### PR TITLE
[codex] Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Check, test, type, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Start test services
+        run: docker compose up --wait -d postgres
+
+      - name: Run checks
+        run: turbo check
+
+      - name: Run type check
+        run: turbo type
+
+      - name: Run tests
+        run: turbo test
+
+      - name: Run build
+        run: turbo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,5 @@ jobs:
       - name: Start test services
         run: docker compose up --wait -d postgres
 
-      - name: Run checks
-        run: turbo check
-
-      - name: Run type check
-        run: turbo type
-
-      - name: Run tests
-        run: turbo test
-
-      - name: Run build
-        run: turbo build
+      - name: Run verification
+        run: turbo check type test build depcruise

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -69,7 +69,10 @@ describe('CreateProjectPage', () => {
 
     expect(await screen.findByRole('heading', {name: 'Project Detail'})).toBeInTheDocument();
     await waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
-    const [connectionBody, projectBody] = requestBodies as Array<Record<string, unknown>>;
+    const [connectionBody, projectBody] = requestBodies as [
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
     expect(connectionBody.provider).toBe('test');
     expect(projectBody.external_repository_id).toBe('platform');
   });

--- a/libs/shared/node/error-monitoring/tsconfig.json
+++ b/libs/shared/node/error-monitoring/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["src"],
+  "files": [],
   "references": [{ "path": "tsconfig.build.json" }]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@
 strictPeerDependencies: true
 dedupePeerDependents: true
 nodeLinker: isolated
+onlyBuiltDependencies:
+  - "@swc/core"
+  - "esbuild"
+  - "protobufjs"
 
 packages:
   - "apps/*"

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -14,7 +14,7 @@
     },
     "type": {
       "cache": true,
-      "dependsOn": ["@shipfox/typescript#build", "^type:emit"]
+      "dependsOn": ["@shipfox/typescript#build"]
     },
     "type:emit": {
       "cache": true,

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -14,7 +14,7 @@
     },
     "type": {
       "cache": true,
-      "dependsOn": ["@shipfox/typescript#build"]
+      "dependsOn": ["@shipfox/typescript#build", "@shipfox/vitest#type:emit"]
     },
     "type:emit": {
       "cache": true,

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -14,7 +14,7 @@
     },
     "type": {
       "cache": true,
-      "dependsOn": ["@shipfox/typescript#build", "@shipfox/vitest#type:emit"]
+      "dependsOn": ["@shipfox/typescript#build", "^type:emit"]
     },
     "type:emit": {
       "cache": true,


### PR DESCRIPTION
Adds a GitHub Actions CI workflow for PRs and pushes to main that installs the mise toolchain, installs pnpm dependencies, starts Postgres, and runs Turbo check, type, test, and build tasks.

Approves required pnpm dependency build scripts so fresh CI installs can build native tooling consistently.

Fixes an existing client projects test type assertion so the new type-check step passes.

Validated with `mise exec -- pnpm install --frozen-lockfile`, `mise exec -- turbo check`, `mise exec -- turbo type`, `mise exec -- turbo test`, and `mise exec -- turbo build`.