### PR TITLE
[codex] Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @noe-charmet @ThierryAbalea


### PR DESCRIPTION
Adds a GitHub CODEOWNERS file assigning ownership of every path in the repository to @noe-charmet and @ThierryAbalea.

This ensures GitHub can request the intended owners for future changes across the repo.

Validation: reviewed the branch diff against origin/main; no project tests were run because this is metadata only.