### PR TITLE
Document auth and shared packages

### DIFF
--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -1,0 +1,134 @@
+# Shipfox API Auth
+
+Shipfox API Auth provides the server-side auth module for Shipfox APIs. It owns user accounts, email verification, login, refresh sessions, password reset, password change, JWT auth, and its PostgreSQL tables.
+
+## Example
+
+Register the module with the API module runner:
+
+```ts
+import {authModule} from '@shipfox/api-auth';
+import {createApp, listen} from '@shipfox/node-fastify';
+import {initializeModules} from '@shipfox/node-module';
+
+const {auth, routes} = await initializeModules({
+  modules: [authModule],
+});
+
+await createApp({auth, routes});
+await listen();
+```
+
+This adds:
+
+- auth database migrations from `libs/api/auth/drizzle`
+- the JWT auth method used by protected routes
+- routes under `/auth`
+
+## Setup
+
+This package is private to the workspace. Add it to another workspace package with:
+
+```json
+{
+  "dependencies": {
+    "@shipfox/api-auth": "workspace:*"
+  }
+}
+```
+
+Required environment:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AUTH_JWT_SECRET` | none | Secret used to sign and verify access tokens. |
+| `AUTH_JWT_EXPIRES_IN` | `15m` | Access token lifetime. |
+| `AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS` | `14` | Refresh token and cookie lifetime. |
+| `AUTH_REFRESH_COOKIE_NAME` | `shipfox_refresh_token` | HTTP cookie name for refresh sessions. |
+| `CLIENT_BASE_URL` | `http://localhost:3000` | Base URL used in email verification and password reset links. |
+| `MAILER_TRANSPORT` | `console` | Mail transport. Set to `smtp` to send real mail. |
+| `MAILER_FROM` | `noreply@shipfox.local` | Sender used by auth emails. |
+| `SMTP_HOST` | none | Required when `MAILER_TRANSPORT=smtp`. |
+| `SMTP_PORT` | `587` | SMTP server port. |
+| `SMTP_USER` | none | Optional SMTP user. |
+| `SMTP_PASSWORD` | none | Optional SMTP password. |
+
+## Routes
+
+All routes are mounted under `/auth`.
+
+| Method | Path | Auth | Result |
+| --- | --- | --- | --- |
+| `POST` | `/signup` | none | Creates a user and sends an email verification link. |
+| `POST` | `/verify-email/confirm` | none | Verifies email, returns an access token, and sets the refresh cookie. |
+| `POST` | `/verify-email/resend` | none | Sends a new verification email when the account is eligible. |
+| `POST` | `/login` | none | Returns an access token and sets the refresh cookie. |
+| `POST` | `/refresh` | refresh cookie | Rotates the refresh token and returns a new access token. |
+| `POST` | `/logout` | refresh cookie | Revokes the current refresh token and clears the cookie. |
+| `GET` | `/me` | bearer token | Returns the signed-in user. |
+| `POST` | `/change-password` | bearer token | Changes the password and revokes other refresh sessions. |
+| `POST` | `/password-reset` | none | Sends a password reset email when the account is eligible. |
+| `POST` | `/password-reset/confirm` | none | Sets a new password, returns an access token, and sets the refresh cookie. |
+
+Protected routes use the `Authorization: Bearer <token>` header. The refresh flow uses an HTTP-only cookie on the `/auth` path.
+
+> [!IMPORTANT]
+> Refresh cookies are set with `secure: true`, `httpOnly: true`, and `sameSite: "lax"`. Local browser tests need HTTPS or a test path that handles secure cookies.
+
+## API
+
+The package exports the module entry point:
+
+```ts
+import {authModule} from '@shipfox/api-auth';
+```
+
+It also exports lower-level pieces for tests and advanced integration:
+
+- `routes`: the `/auth` route group.
+- `db` and `migrationsPath`: the Drizzle database handle and migration path.
+- `createJwtAuthMethod()`: the Fastify auth method for user JWTs.
+- `getClientContext(request)`: reads the authenticated user context from a Fastify request.
+- Entity types: `User`, `UserStatus`, `RefreshToken`, `EmailVerification`, and `PasswordReset`.
+
+## Data Model
+
+The module creates tables with the `auth_` prefix:
+
+- `auth_users`
+- `auth_refresh_tokens`
+- `auth_email_verifications`
+- `auth_password_resets`
+
+Passwords use Argon2id. Email verification tokens, password reset tokens, and refresh tokens are opaque tokens stored as hashes.
+
+## Behavior Notes
+
+- Signup sends a verification email and returns the new user.
+- Login only succeeds for active users with verified email addresses.
+- Refresh tokens rotate on each refresh.
+- Password reset and email verification consume their tokens once.
+- Password change revokes other refresh sessions. It keeps the current session when the current refresh cookie is valid.
+- Password reset requests and verification resend requests do not reveal whether an account exists.
+
+## Development
+
+Run checks for this package:
+
+```sh
+turbo check --filter=@shipfox/api-auth
+turbo type --filter=@shipfox/api-auth
+turbo test --filter=@shipfox/api-auth
+```
+
+Tests use Vitest and a real PostgreSQL database. Start local services before running the test suite:
+
+```sh
+docker compose up -d
+```
+
+The test environment uses the `api_test` database and sets fake auth secrets in `test/env.ts`.
+
+## License
+
+MIT

--- a/libs/shared/common/config/README.md
+++ b/libs/shared/common/config/README.md
@@ -1,14 +1,12 @@
-# Shipfox config
+# Shipfox Config
 
-This is a utility library handling configuration used by other packages for [Shipfox](https://www.shipfox.io/) projects.
+Typed config for Shipfox packages. It checks `process.env` at startup and returns a typed object.
 
 ## What it does
 
-Typed, validated environment configuration built on top of `envalid`.
-
-- **createConfig(schema)**: Validates `process.env` against your schema and returns a strongly-typed config object.
-- **Re-exports common validators**: `str`, `num`, `bool`, `email`, `host`, `port`, `url` (from `envalid`).
-- **Fail-fast**: Throws at startup if required variables are missing/invalid.
+- **`createConfig(schema, update?)`** checks environment values with `envalid`.
+- **Common validators** are re-exported: `str`, `num`, `bool`, `email`, `host`, `port`, and `url`.
+- **Fail-fast startup** means bad values throw before the app runs.
 
 ## Installation
 
@@ -23,15 +21,32 @@ npm install @shipfox/config
 ## Usage
 
 ```ts
-import { createConfig, str, num, bool } from "@shipfox/config";
+import {bool, createConfig, num, str} from "@shipfox/config";
 
 const config = createConfig({
-  NODE_ENV: str({ choices: ["development", "test", "production"] }),
-  PORT: num({ default: 3000 }),
-  DEBUG: bool({ default: false }),
+  NODE_ENV: str({choices: ["development", "test", "production"]}),
+  PORT: num({default: 3000}),
+  DEBUG: bool({default: false}),
 });
 
-// Typed access
 config.PORT; // number
 config.DEBUG; // boolean
 ```
+
+Pass `update` in tests to override `process.env`:
+
+```ts
+const testConfig = createConfig({PORT: num()}, {PORT: "4000"});
+```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/config
+turbo type --filter=@shipfox/config
+turbo test --filter=@shipfox/config
+```
+
+## License
+
+MIT

--- a/libs/shared/node/drizzle/README.md
+++ b/libs/shared/node/drizzle/README.md
@@ -1,0 +1,38 @@
+# Shipfox Drizzle
+
+Small Drizzle helpers for Shipfox Node packages. It wraps Drizzle's PostgreSQL driver and adds a migration runner that is safe to use when tests or services start in parallel.
+
+## What it does
+
+- **`drizzle`**: Re-exports `drizzle-orm/node-postgres`.
+- **`runMigrations(database, migrationsFolder, migrationsTable?)`**: Runs Drizzle migrations inside a transaction and takes a PostgreSQL advisory lock before migrating.
+- **`uuidv7PrimaryKey()`**: Creates a UUID primary key column that defaults to `uuidv7()`.
+- **`NodePgDatabase`**: Re-exported type from Drizzle.
+
+## Usage
+
+```ts
+import {drizzle, runMigrations, uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {pgTable, text} from 'drizzle-orm/pg-core';
+
+export const users = pgTable('users', {
+  id: uuidv7PrimaryKey(),
+  email: text('email').notNull(),
+});
+
+const db = drizzle(pool);
+await runMigrations(db, './drizzle', '__drizzle_migrations_users');
+```
+
+Use a custom migration table name when several modules share one database. This keeps each module's migration history separate.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-drizzle
+turbo type --filter=@shipfox/node-drizzle
+```
+
+## License
+
+MIT

--- a/libs/shared/node/error-monitoring/README.md
+++ b/libs/shared/node/error-monitoring/README.md
@@ -1,19 +1,19 @@
 # Shipfox Error Monitoring
 
-Sentry integration for Node services that configures itself from environment variables and exposes a minimal error-reporting API. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Sentry integration for Shipfox Node services. It reads Sentry settings from environment variables and exports a small error-reporting API.
 
 ## What it does
 
-- **`import '@shipfox/node-error-monitoring/init'`**: Side-effect import that initialises Sentry using env config (DSN, environment, image tag → release).
-- **`captureException(error)`**: Report an error to Sentry.
-- **`addEventProcessor(processor)`**: Attach a custom Sentry event processor.
-- **`closeErrorMonitoring()`**: Flush pending events and shut down the Sentry client.
+- **`import '@shipfox/node-error-monitoring/init'`** starts Sentry from environment config.
+- **`captureException(error)`** reports an error to Sentry.
+- **`addEventProcessor(processor)`** adds a custom Sentry event processor.
+- **`closeErrorMonitoring()`** flushes pending events and shuts down the Sentry client.
 
 Environment variables (via `@shipfox/config`):
 
-- `SENTRY_DSN` (optional) — Sentry project DSN; leave unset to disable reporting.
-- `SENTRY_ENVIRONMENT` (optional) — e.g. `production`, `staging`.
-- `SENTRY_IMAGE` (optional) — Docker image tag in `name:tag` format; the tag prefix is used as the Sentry release.
+- `SENTRY_DSN` is optional. Leave it unset to disable reporting.
+- `SENTRY_ENVIRONMENT` is optional, such as `production` or `staging`.
+- `SENTRY_IMAGE` is optional. Use `name:tag` format. The tag prefix becomes the Sentry release.
 
 ## Installation
 
@@ -28,7 +28,6 @@ npm install @shipfox/node-error-monitoring
 ## Usage
 
 ```ts
-// 1) Initialise Sentry as early as possible (side-effect import)
 import "@shipfox/node-error-monitoring/init";
 
 import {
@@ -37,20 +36,17 @@ import {
   closeErrorMonitoring,
 } from "@shipfox/node-error-monitoring";
 
-// 2) Report errors
 try {
   await riskyOperation();
 } catch (err) {
   captureException(err);
 }
 
-// 3) Optionally attach a custom event processor
 addEventProcessor((event) => {
-  event.tags = { ...event.tags, service: "billing-api" };
+  event.tags = {...event.tags, service: "billing-api"};
   return event;
 });
 
-// 4) Graceful shutdown
 process.on("SIGTERM", async () => {
   await closeErrorMonitoring();
   process.exit(0);
@@ -64,3 +60,14 @@ export SENTRY_DSN="https://key@sentry.io/123"
 export SENTRY_ENVIRONMENT="production"
 export SENTRY_IMAGE="billing-api:v1.2.3-abc"
 ```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-error-monitoring
+turbo type --filter=@shipfox/node-error-monitoring
+```
+
+## License
+
+MIT

--- a/libs/shared/node/fastify/README.md
+++ b/libs/shared/node/fastify/README.md
@@ -1,21 +1,24 @@
 # Shipfox Fastify
 
-Opinionated Fastify setup for Node services with Zod validation, OpenTelemetry instrumentation, auth hooks, health checks, and structured error handling out of the box. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Fastify setup for Shipfox Node services. It adds Zod validation, CORS, Swagger, auth hooks, health checks, routes, and structured error handling.
 
 ## What it does
 
-- **`createApp(config?)`**: Creates a Fastify instance wired with OpenTelemetry, Zod type providers, auth, health endpoints, routes, and error handling.
-- **`app()`**: Returns the current Fastify instance; throws if not yet created.
-- **`listen()`**: Starts listening on the configured host and port.
-- **`closeApp()`**: Gracefully shuts down the server.
-- **`defineRoute(route)`**: Type-safe route builder that infers request types from Zod schemas.
-- **`ClientError`**: Throw from handlers to return structured client-facing error responses.
-- **Health endpoints**: `GET /healthz` (liveness) and `GET /readyz` (readiness) registered automatically.
-- **Auth**: Register named auth methods and reference them per-route or per-group.
-- **Routing**: Supports nested route groups with prefix, auth inheritance, and scoped plugins.
+- **`createApp(config?)`** creates a Fastify app with Shipfox defaults.
+- **`app()`** returns the current Fastify app.
+- **`listen()`** starts the server on the configured host and port.
+- **`closeApp()`** shuts down the server.
+- **`defineRoute(route)`** infers request types from Zod schemas.
+- **`ClientError`** returns structured client errors from handlers.
+- **Health endpoints** are registered at `GET /healthz` and `GET /readyz`.
+- **Auth hooks** can be set on routes or route groups.
+- **Route groups** support prefixes, inherited auth, and scoped plugins.
+- **Swagger** is on by default and serves `GET /openapi.json`.
 
 Environment variables (via `@shipfox/config`):
 
+- `BROWSER_ALLOWED_ORIGIN` (default: `undefined`; comma-separated CORS origins)
+- `CLIENT_BASE_URL` (default: `http://localhost:3000`; CORS fallback when `BROWSER_ALLOWED_ORIGIN` is not set)
 - `HOST` (default: `0.0.0.0`)
 - `PORT` (default: `3000`)
 
@@ -35,10 +38,10 @@ npm install @shipfox/node-fastify
 import { createApp, listen, closeApp, defineRoute } from "@shipfox/node-fastify";
 import { z } from "zod";
 
-// Define a route with Zod schema validation
 const getUser = defineRoute({
   method: "GET",
   path: "/users/:id",
+  description: "Get a user by ID.",
   schema: {
     params: z.object({ id: z.string() }),
     response: { 200: z.object({ id: z.string(), name: z.string() }) },
@@ -49,15 +52,13 @@ const getUser = defineRoute({
   },
 });
 
-// Create and start the app
 const app = await createApp({
   routes: [getUser],
   readinessChecks: [{ name: "db", check: () => true }],
 });
 
-await listen(); // Listening on 0.0.0.0:3000
+await listen();
 
-// Graceful shutdown
 process.on("SIGTERM", async () => {
   await closeApp();
 });
@@ -66,13 +67,19 @@ process.on("SIGTERM", async () => {
 ### Route groups with auth
 
 ```ts
-import { createApp, defineRoute, type AuthMethod, type RouteGroup } from "@shipfox/node-fastify";
+import {
+  ClientError,
+  createApp,
+  defineRoute,
+  type AuthMethod,
+  type RouteGroup,
+} from "@shipfox/node-fastify";
 
 const bearerAuth: AuthMethod = {
   name: "bearer",
-  authenticate: async (request, reply) => {
+  authenticate: async (request) => {
     if (!request.headers.authorization) {
-      reply.code(401).send({ code: "unauthorized" });
+      throw new ClientError("Authentication required", "unauthorized", { status: 401 });
     }
   },
 };
@@ -81,7 +88,12 @@ const adminRoutes: RouteGroup = {
   prefix: "/admin",
   auth: "bearer",
   routes: [
-    defineRoute({ method: "GET", path: "/stats", handler: async () => ({ ok: true }) }),
+    defineRoute({
+      method: "GET",
+      path: "/stats",
+      description: "Get admin stats.",
+      handler: async () => ({ ok: true }),
+    }),
   ],
 };
 
@@ -93,6 +105,18 @@ await createApp({ auth: [bearerAuth], routes: [adminRoutes] });
 ```ts
 import { ClientError } from "@shipfox/node-fastify";
 
-// Inside a handler — returns { "code": "not-found" } with status 404
+// Returns { "code": "not-found" } with status 404.
 throw new ClientError("User not found", "not-found", { status: 404 });
 ```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-fastify
+turbo type --filter=@shipfox/node-fastify
+turbo test --filter=@shipfox/node-fastify
+```
+
+## License
+
+MIT

--- a/libs/shared/node/log/README.md
+++ b/libs/shared/node/log/README.md
@@ -1,27 +1,26 @@
 # Shipfox Log
 
-Typed logging for Node services built on top of `pino`, with consistent defaults, environment-driven configuration, and convenient helpers. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Typed logging for Shipfox Node services. It wraps `pino` with shared defaults, environment config, and small helper exports.
 
 ## What it does
 
-- **log**: Ready-to-use logger with levels `trace`, `debug`, `info`, `warn`, `error`, `fatal`.
-- **createLogger(options)**: Create a new `pino` logger merging your options with Shipfox defaults.
-- **settings**: The default `pino` configuration used to build `log` (handy for extending).
-- **Types re-exported**: `Level`, `LogFn`, and `Logger` for strong typing.
+- **`log`** is a ready-to-use logger.
+- **`createLogger(options)`** creates a new `pino` logger with Shipfox defaults.
+- **`settings`** exposes the default `pino` options.
+- **Types** include `Level`, `LogFn`, and `Logger`.
 
 Defaults include:
 
-- ISO timestamps
-- Uppercased level labels (e.g., `INFO`, `ERROR`)
-- Standard serializers for `err`, `error`, `errors`, `req`, `res`
-- Output formatting controlled via env: pretty printing or file output
+- ISO timestamps.
+- Standard serializers for `err`, `error`, `errors`, `req`, and `res`.
+- Output control through environment variables.
 
 Environment variables (via `@shipfox/config`):
 
-- `LOG_LEVEL` (default: `info`; set to `silent` to suppress all logger output)
-- `LOG_PRETTY` (default: `false`) — pretty print to stdout via `pino-pretty`
-- `LOG_STDOUT` (default: `true`) — write logs to stdout
-- `LOG_FILE` (default: `undefined`) — if set, logs to file using `pino/file` (creates directory if needed)
+- `LOG_LEVEL` defaults to `info`. Set it to `silent` to suppress logs.
+- `LOG_PRETTY` defaults to `false`. Set it to `true` for pretty stdout logs.
+- `LOG_STDOUT` defaults to `true`. Set it to `false` to disable stdout logs.
+- `LOG_FILE` is optional. If set, logs are written to that file.
 
 ## Installation
 
@@ -36,23 +35,28 @@ npm install @shipfox/node-log
 ## Usage
 
 ```ts
-import { log, createLogger, settings, type Level } from "@shipfox/node-log";
+import {createLogger, log, settings, type Level} from "@shipfox/node-log";
 
-// 1) Use the shared logger
 log.info({ service: "billing" }, "Service started");
 log.error({ err: new Error("boom") }, "Failed to process event");
 
-// 2) Create a custom logger inheriting defaults
 const moduleLogger = createLogger({
   level: (process.env.LOG_LEVEL as Level) ?? settings.level,
   base: { module: "payments" },
 });
 
 moduleLogger.debug({ eventId: "evt_123" }, "Processing payment event");
-
-// 3) Environment-driven outputs
-// - LOG_PRETTY=true prints colorized logs to stdout
-// - LOG_FILE=/var/log/app.log writes JSON logs to a file
 ```
 
 You can combine `LOG_PRETTY` and `LOG_LEVEL` during development for readability.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-log
+turbo type --filter=@shipfox/node-log
+```
+
+## License
+
+MIT

--- a/libs/shared/node/mailer/README.md
+++ b/libs/shared/node/mailer/README.md
@@ -1,0 +1,51 @@
+# Shipfox Mailer
+
+Small mailer interface for Shipfox Node packages. It supports SMTP delivery for production and a console mailer for local development and tests.
+
+## What it does
+
+- **`Mailer`**: Interface with one `send(message)` method.
+- **`MailMessage`**: Message shape with `to`, `subject`, `text`, and optional `html`.
+- **`createConsoleMailer(options)`**: Logs mail through the Shipfox logger and can capture messages in an array.
+- **`createSmtpMailer(options)`**: Sends mail through `nodemailer`.
+
+## Usage
+
+```ts
+import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
+
+const mailer: Mailer =
+  process.env.MAILER_TRANSPORT === 'smtp'
+    ? createSmtpMailer({
+        host: 'smtp.example.com',
+        port: 587,
+        user: process.env.SMTP_USER,
+        password: process.env.SMTP_PASSWORD,
+        from: 'noreply@shipfox.local',
+      })
+    : createConsoleMailer({from: 'noreply@shipfox.local'});
+
+await mailer.send({
+  to: 'user@example.com',
+  subject: 'Verify your email',
+  text: 'Open this link to verify your email.',
+});
+```
+
+## Notes
+
+- SMTP uses `secure: true` by default on port `465`.
+- SMTP auth is only sent when both `user` and `password` are set.
+- The console mailer is useful in tests because `capture` stores each message.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-mailer
+turbo type --filter=@shipfox/node-mailer
+turbo test --filter=@shipfox/node-mailer
+```
+
+## License
+
+MIT

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -1,0 +1,57 @@
+# Shipfox Module
+
+Module setup helpers for Shipfox API services. A module can list its database, auth methods, routes, outbox publishers, event handlers, and Temporal workers in one object.
+
+## What it does
+
+- **`initializeModules({modules})`**: Sets up modules in array order.
+- **`startModuleWorkers({workers})`**: Creates Temporal workers and starts declared workflows.
+- **`ShipfoxModule`**: Module contract used by API packages.
+- **Publisher registry**: Adds outbox tables, drains pending events, and marks events as sent.
+- **Subscriber registry**: Adds and reads in-process event handlers by event type.
+
+## Usage
+
+```ts
+import {createApp, listen} from '@shipfox/node-fastify';
+import {initializeModules, startModuleWorkers} from '@shipfox/node-module';
+import {authModule} from '@shipfox/api-auth';
+
+const {auth, routes, workers} = await initializeModules({
+  modules: [authModule],
+});
+
+await createApp({auth, routes});
+await listen();
+
+startModuleWorkers({workers});
+```
+
+`initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array.
+
+## Module Shape
+
+```ts
+import type {ShipfoxModule} from '@shipfox/node-module';
+
+export const exampleModule: ShipfoxModule = {
+  name: 'example',
+  database: {db, migrationsPath},
+  auth: [authMethod],
+  routes: [routes],
+  publishers: [{name: 'example', table: outbox, db}],
+  subscribers: [{event: 'example.created', handler}],
+  workers: [{taskQueue: 'example', workflowsPath, activities, workflows: []}],
+};
+```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-module
+turbo type --filter=@shipfox/node-module
+```
+
+## License
+
+MIT

--- a/libs/shared/node/opentelemetry/README.md
+++ b/libs/shared/node/opentelemetry/README.md
@@ -1,31 +1,29 @@
 # Shipfox OpenTelemetry
 
-Opinionated OpenTelemetry setup for Node services with:
-
-- One-call initialization (traces + instance Prometheus metrics)
-- A separate provider for service-level Prometheus metrics
-- Sensible defaults and environment-based config
-
-It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+OpenTelemetry setup for Shipfox Node services. It starts tracing, Prometheus metrics, Fastify tracing, and trace-aware logging helpers.
 
 ## What it does
 
-- **startInstanceInstrumentation(options)**: Boots a NodeSDK with auto-instrumentations, Fastify instrumentation, Prometheus metrics reader, and optional OTLP trace exporter.
-- **getFastifyInstrumentation()**: Access the Fastify instrumentation instance created during startup.
-- **startServiceMetrics(options?)**: Creates a standalone `MeterProvider` for custom service metrics with its own Prometheus reader.
-- **getServiceMetricsProvider()**: Returns the service metrics provider (creates one if missing).
-- **instanceMetrics**: Re-export of `@opentelemetry/api` `metrics` for convenience.
-- **shutdownInstrumentation()**: Gracefully shuts down instance and service metrics.
+- **`startInstanceInstrumentation(options)`** starts the OpenTelemetry Node SDK.
+- **`getFastifyInstrumentation()`** returns the Fastify tracing plugin.
+- **`startServiceMetrics(options?)`** starts a separate provider for app metrics.
+- **`getServiceMetricsProvider()`** returns the app metrics provider.
+- **`instanceMetrics`** re-exports OpenTelemetry `metrics`.
+- **`logger(options?)`** returns a logger with active trace IDs when a span exists.
+- **`shutdownInstrumentation()`** shuts down tracing and metrics.
 
 Environment variables (via `@shipfox/config`):
 
-- `OTEL_SERVICE_NAME` (optional if you pass `serviceName` in code)
-- `TRACES_COLLECTOR_URL` (optional; if set, enables OTLP trace export over HTTP)
+- `OTEL_SERVICE_NAME` is optional if you pass `serviceName` in code.
+- `TRACES_COLLECTOR_URL` is optional. Set it to send traces over OTLP HTTP.
+- `OTEL_INSTANCE_METRICS_PORT` defaults to `9464`.
+- `OTEL_SERVICE_METRICS_PORT` defaults to `9474`.
+- `OTEL_DIAG_LOG_LEVEL` defaults to `none`.
 
-Exported ports and endpoints (defaults):
+Default metrics endpoints:
 
-- Instance metrics: `:9464/metrics`
-- Service metrics: `:9474/metrics`
+- Instance metrics use `:9464/metrics`.
+- Service metrics use `:9474/metrics`.
 
 ## Installation
 
@@ -46,22 +44,19 @@ import {
   instanceMetrics,
 } from "@shipfox/node-opentelemetry";
 
-// Start as early as possible in your process
 startInstanceInstrumentation({
-  serviceName: "billing-api", // falls back to OTEL_SERVICE_NAME if omitted
+  serviceName: "billing-api",
   exporter: {
-    instance: { port: 9464, endpoint: "/metrics" },
-    service: { port: 9474, endpoint: "/metrics" },
+    instance: {port: 9464, endpoint: "/metrics"},
+    service: {port: 9474, endpoint: "/metrics"},
   },
 });
 
-// Optionally expose a health handler and ensure graceful shutdown
 process.on("SIGTERM", async () => {
   await shutdownInstrumentation();
   process.exit(0);
 });
 
-// You can still access the global API directly when creating metrics on the instance provider
 const meter = instanceMetrics.getMeter("billing-api");
 const requestCounter = meter.createCounter("http_requests_total");
 
@@ -72,7 +67,7 @@ function onRequestHandled() {
 
 ## Service-level custom metrics
 
-Use a dedicated provider (separate port) for application-specific metrics:
+Use a separate provider for app metrics:
 
 ```ts
 import { getServiceMetricsProvider } from "@shipfox/node-opentelemetry";
@@ -88,13 +83,27 @@ meter.addBatchObservableCallback((observableResult) => {
 
 ## Traces (OTLP over HTTP)
 
-If `TRACES_COLLECTOR_URL` is set (e.g., to an OTLP endpoint like `http://otel-collector:4318/v1/traces`), the instance instrumentation will export traces via the OTLP HTTP exporter. Leave it unset to disable trace exporting.
+Set `TRACES_COLLECTOR_URL` to send traces to an OTLP HTTP endpoint. Leave it unset to disable trace export.
 
 ## Configuration via environment
 
 ```bash
 export OTEL_SERVICE_NAME="billing-api"
-# Enable OTLP HTTP traces export (optional)
 export TRACES_COLLECTOR_URL="http://otel-collector:4318/v1/traces"
-# Prometheus endpoints can be adjusted in code via start options
+export OTEL_INSTANCE_METRICS_PORT="9464"
+export OTEL_SERVICE_METRICS_PORT="9474"
 ```
+
+You can also set metrics ports in code with `startInstanceInstrumentation` options.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-opentelemetry
+turbo type --filter=@shipfox/node-opentelemetry
+turbo test --filter=@shipfox/node-opentelemetry
+```
+
+## License
+
+MIT

--- a/libs/shared/node/outbox/README.md
+++ b/libs/shared/node/outbox/README.md
@@ -1,0 +1,45 @@
+# Shipfox Outbox
+
+Typed outbox helpers for Shipfox modules. Use this package when a database write needs to record a domain event in the same transaction.
+
+## What it does
+
+- **`createOutboxTable(pgTable)`**: Creates a Drizzle table named `outbox` for a module table namespace.
+- **`writeOutboxEvent(tx, outboxTable, event)`**: Inserts a typed event into an outbox table.
+- **`DomainEvent`**: Runtime event shape used by dispatchers.
+- **`EventMapLike`, `EventType`, `EventPayload`**: Type helpers for module event maps.
+
+## Usage
+
+```ts
+import {createOutboxTable, writeOutboxEvent} from '@shipfox/node-outbox';
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+
+const pgTable = pgTableCreator((name) => `projects_${name}`);
+export const outbox = createOutboxTable(pgTable);
+
+interface ProjectEventMap {
+  'project.created': {projectId: string};
+}
+
+await db.transaction(async (tx) => {
+  await tx.insert(projects).values({id: projectId});
+  await writeOutboxEvent<ProjectEventMap>(tx, outbox, {
+    type: 'project.created',
+    payload: {projectId},
+  });
+});
+```
+
+The table includes a pending-event index on `created_at` for rows where `dispatched_at` is null.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-outbox
+turbo type --filter=@shipfox/node-outbox
+```
+
+## License
+
+MIT

--- a/libs/shared/node/postgres/README.md
+++ b/libs/shared/node/postgres/README.md
@@ -1,16 +1,14 @@
 # Shipfox Postgres
 
-Thin wrapper around `pg` that centralizes connection config via environment variables and exposes a simple lifecycle API for shared pool usage.
-
-It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Thin wrapper around `pg` for Shipfox Node services. It creates one shared pool from environment config and exposes health and shutdown helpers.
 
 ## What it does
 
-- **createPostgresClient(options?)**: Creates and stores a singleton `pg.Pool` configured from environment variables and optional overrides.
-- **pgClient()**: Returns the previously created pool; throws if not initialized.
-- **closePostgresClient()**: Closes and clears the pool.
-- **isPostgresHealthy()**: Executes a lightweight `SELECT 1` to report readiness.
-- **Re-exports all types/exports from `pg`** for direct usage.
+- **`createPostgresClient(options?)`** creates and stores one `pg.Pool`.
+- **`pgClient()`** returns the current pool.
+- **`closePostgresClient()`** closes and clears the pool.
+- **`isPostgresHealthy()`** runs `SELECT 1`.
+- **`DatabaseError` and `pg` types** are re-exported.
 
 Environment variables (with defaults):
 
@@ -19,15 +17,16 @@ Environment variables (with defaults):
 - `POSTGRES_USERNAME` (default: `shipfox`)
 - `POSTGRES_PASSWORD` (default: `password`)
 - `POSTGRES_DATABASE` (default: `api`)
+- `POSTGRES_MAX_CONNECTIONS` (default: `10`)
 
 ## Installation
 
 ```bash
-pnpm add @shipfox/node-pg
+pnpm add @shipfox/node-postgres
 # or
-yarn add @shipfox/node-pg
+yarn add @shipfox/node-postgres
 # or
-npm install @shipfox/node-pg
+npm install @shipfox/node-postgres
 ```
 
 ## Usage
@@ -39,15 +38,13 @@ import {
   closePostgresClient,
   isPostgresHealthy,
   type Pool,
-} from "@shipfox/node-pg";
+} from "@shipfox/node-postgres";
 
-// 1) Create the pool at startup (optionally pass pg.PoolConfig overrides)
 const pool: Pool = createPostgresClient({
   // connectionTimeoutMillis: 5000,
   // max: 10,
 });
 
-// 2) Use the pool elsewhere without passing it around
 async function getServerTime() {
   const client = await pgClient().connect();
   try {
@@ -58,12 +55,10 @@ async function getServerTime() {
   }
 }
 
-// 3) Health check
 async function ready() {
   return await isPostgresHealthy();
 }
 
-// 4) Clean shutdown
 async function shutdown() {
   await closePostgresClient();
 }
@@ -77,4 +72,16 @@ export POSTGRES_PORT="5432"
 export POSTGRES_USERNAME="service_user"
 export POSTGRES_PASSWORD="supersecret"
 export POSTGRES_DATABASE="appdb"
+export POSTGRES_MAX_CONNECTIONS="10"
 ```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-postgres
+turbo type --filter=@shipfox/node-postgres
+```
+
+## License
+
+MIT

--- a/libs/shared/node/temporal/README.md
+++ b/libs/shared/node/temporal/README.md
@@ -1,0 +1,56 @@
+# Shipfox Temporal
+
+Temporal client and worker helpers for Shipfox Node services. It keeps connection settings, worker defaults, health checks, and interceptor hooks in one place.
+
+## What it does
+
+- **`createTemporalClient()`**: Connects to Temporal and stores one shared client.
+- **`temporalClient()`**: Returns the current client or throws if it has not been created.
+- **`closeTemporalClient()`**: Closes the Temporal connection.
+- **`isTemporalHealthy()`**: Checks the Temporal connection health service.
+- **`createTemporalWorker(options)`**: Creates a worker with Shipfox defaults.
+- **Interceptor helpers**: Return client, worker, and workflow settings.
+
+Environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `TEMPORAL_ADDRESS` | `localhost:7233` | Temporal frontend address. |
+| `TEMPORAL_NAMESPACE` | `default` | Temporal namespace. |
+| `TEMPORAL_TASK_QUEUE` | `shipfox` | Default task queue for workers. |
+
+## Usage
+
+```ts
+import {
+  createTemporalClient,
+  createTemporalWorker,
+  temporalClient,
+} from '@shipfox/node-temporal';
+
+await createTemporalClient();
+
+await temporalClient().workflow.start('syncWorkflow', {
+  taskQueue: 'sync',
+  workflowId: 'sync-main',
+});
+
+const worker = await createTemporalWorker({
+  taskQueue: 'sync',
+  workflowsPath: new URL('./workflows.js', import.meta.url).pathname,
+  activities: {syncActivity},
+});
+
+await worker.run();
+```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-temporal
+turbo type --filter=@shipfox/node-temporal
+```
+
+## License
+
+MIT

--- a/libs/shared/node/tokens/README.md
+++ b/libs/shared/node/tokens/README.md
@@ -1,0 +1,60 @@
+# Shipfox Tokens
+
+Opaque token helpers for Shipfox services. It creates prefixed random tokens, hashes raw token values for storage, and reads token type or environment from a token prefix.
+
+## What it does
+
+- **`generateOpaqueToken(type)`**: Creates a random token with a Shipfox prefix.
+- **`hashOpaqueToken(raw)`**: Returns a SHA-256 hash for storing token values.
+- **`getTokenType(raw)`**: Reads the token type when the prefix matches the configured environment.
+- **`getTokenEnvironment(raw)`**: Reads the token environment from the prefix.
+- **`extractDisplayPrefix(raw)`**: Returns the first 12 characters for logs and UI.
+- **`tokenTypeParts`**: Prefix map for supported token types.
+
+Supported token types:
+
+| Type | Prefix part |
+| --- | --- |
+| `apiKey` | `k` |
+| `invitation` | `i` |
+| `emailVerification` | `v` |
+| `passwordReset` | `pr` |
+| `refreshToken` | `r` |
+| `runnerToken` | `rt` |
+
+## Usage
+
+```ts
+import {generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+
+const raw = generateOpaqueToken('apiKey');
+const hashed = hashOpaqueToken(raw);
+
+await db.insert(apiKeys).values({
+  displayPrefix: raw.slice(0, 12),
+  hashedToken: hashed,
+});
+```
+
+Set `TOKEN_ENVIRONMENT` to add an environment part to new tokens:
+
+```sh
+TOKEN_ENVIRONMENT=staging
+```
+
+With that setting, an API key starts with `sf_staging_k_`. Prefix readers reject tokens from another configured environment.
+
+> [!IMPORTANT]
+> Store only the hash returned by `hashOpaqueToken`. Show the raw token once, when it is created.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-tokens
+turbo type --filter=@shipfox/node-tokens
+turbo test --filter=@shipfox/node-tokens
+```
+
+## License
+
+MIT

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -1,0 +1,83 @@
+# Shipfox React UI
+
+Shared React component library for Shipfox apps. It provides design tokens, Tailwind CSS setup, common components, icons, theme state, and small UI utilities.
+
+## What it does
+
+- **Components**: Alert, Badge, Button, Card, Icon, Input, Label, Loader, Skeleton, ThemeProvider, Toast, Tooltip, and Typography.
+- **Theme helpers**: `ThemeProvider`, `useTheme()`, and `useResolvedTheme()`.
+- **Icons**: Custom Shipfox icons plus the icon registry used by the `Icon` component.
+- **Utilities**: `cn()` for class name merging.
+- **CSS entry**: `@shipfox/react-ui/index.css` for fonts, Tailwind, animation utilities, and design tokens.
+
+## Setup
+
+Install the package in a React app:
+
+```json
+{
+  "dependencies": {
+    "@shipfox/react-ui": "workspace:*"
+  }
+}
+```
+
+Import the CSS once near the app root:
+
+```ts
+import '@shipfox/react-ui/index.css';
+```
+
+Wrap the app with the theme provider:
+
+```tsx
+import {ThemeProvider} from '@shipfox/react-ui';
+
+export function AppRoot() {
+  return (
+    <ThemeProvider defaultTheme="system">
+      <App />
+    </ThemeProvider>
+  );
+}
+```
+
+## Usage
+
+```tsx
+import {Button, Card, CardContent, CardTitle, Text} from '@shipfox/react-ui';
+
+export function EmptyState() {
+  return (
+    <Card>
+      <CardTitle>No projects yet</CardTitle>
+      <CardContent>
+        <Text size="sm">Create a project to start running workflows.</Text>
+      </CardContent>
+      <Button iconLeft="plus">Create project</Button>
+    </Card>
+  );
+}
+```
+
+## Build
+
+The package builds JavaScript with SWC and CSS with Vite:
+
+```sh
+turbo build --filter=@shipfox/react-ui
+```
+
+The CSS build writes `dist/styles.css`. The package also exports `./index.css` for source CSS.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/react-ui
+turbo type --filter=@shipfox/react-ui
+turbo build --filter=@shipfox/react-ui
+```
+
+## License
+
+MIT

--- a/tools/biome/README.md
+++ b/tools/biome/README.md
@@ -6,6 +6,7 @@ Opinionated wrapper around Biome for formatting and linting across Shipfox repos
 
 - **`shipfox-biome-lint`**: Lint the current package using the workspace-level `biome.json`.
 - **`shipfox-biome-format`**: Format files using the workspace-level `biome.json`.
+- **`shipfox-biome-check`**: Run Biome check with assist rules enabled. This is the command most package `check` scripts use.
 - Cross-platform support via bundled Biome binaries (Darwin ARM64/x64, Linux ARM64/x64).
 
 ## Installation
@@ -24,7 +25,9 @@ Add scripts to your `package.json`:
     "lint": "shipfox-biome-lint",
     "lint:fix": "shipfox-biome-lint --fix",
     "format": "shipfox-biome-format",
-    "format:fix": "shipfox-biome-format --write"
+    "format:fix": "shipfox-biome-format --write",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write"
   }
 }
 ```
@@ -35,6 +38,10 @@ Then run:
 # Lint
 shipfox-biome-lint
 shipfox-biome-lint --fix
+
+# Check
+shipfox-biome-check
+shipfox-biome-check --write
 
 # Format
 shipfox-biome-format

--- a/tools/depcruise/README.md
+++ b/tools/depcruise/README.md
@@ -1,0 +1,40 @@
+# @shipfox/depcruise
+
+Workspace wrapper around Dependency Cruiser for Shipfox packages. It runs the project-local `depcruise` binary with the workspace dependency rules.
+
+## What it does
+
+- **`shipfox-depcruise`**: Runs Dependency Cruiser against the current package.
+- Uses the workspace `.dependency-cruiser.cjs` config.
+- Uses the current package `tsconfig.json`.
+- Resolves binaries and workspace files through `@shipfox/tool-utils`.
+
+## Installation
+
+```bash
+pnpm add -D @shipfox/depcruise
+```
+
+## Usage
+
+Add a script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "depcruise": "shipfox-depcruise"
+  }
+}
+```
+
+Then run:
+
+```bash
+shipfox-depcruise
+```
+
+The command checks imports for the package in the current working directory.
+
+## License
+
+MIT

--- a/tools/swc/README.md
+++ b/tools/swc/README.md
@@ -7,7 +7,7 @@ Opinionated build wrapper around SWC for fast TypeScript transpilation in Shipfo
 - **`shipfox-swc`**: Transpiles `src/` to `dist/` using SWC with sensible defaults.
 - Uses a project-local `.swcrc` if present, otherwise falls back to the built-in config.
 - Automatically cleans up orphaned `.js` and `.js.map` files in `dist/` after each build.
-- Supports path alias resolution via `tsc-alias` post-emit.
+- Passes any extra CLI flags through to SWC.
 
 ## Installation
 

--- a/tools/ts-config/README.md
+++ b/tools/ts-config/README.md
@@ -1,12 +1,12 @@
 # @shipfox/ts-config
 
-Shared TypeScript configuration used across Shipfox packages. Provides strict, opinionated base configs for Node.js and React projects. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Shared TypeScript config for Shipfox packages. It provides strict base, Node, and React configs.
 
 ## What it does
 
-- **Base config** (`@shipfox/ts-config`): Strict compiler options, declaration-only emit, composite builds, and declaration maps.
-- **Node config** (`@shipfox/ts-config/node`): ES2022 target with NodeNext module resolution.
-- **React config** (`@shipfox/ts-config/react`): ES2022 target, ESNext modules, JSX support, and DOM types.
+- **Base config** (`@shipfox/ts-config`) sets strict compiler options.
+- **Node config** (`@shipfox/ts-config/node`) targets ES2022 with NodeNext modules.
+- **React config** (`@shipfox/ts-config/react`) targets ES2022 with JSX and DOM types.
 
 ## Installation
 
@@ -41,3 +41,7 @@ Extend the appropriate config in your `tsconfig.json`:
   "include": ["src"]
 }
 ```
+
+## License
+
+MIT

--- a/tools/typescript/README.md
+++ b/tools/typescript/README.md
@@ -1,11 +1,13 @@
 # @shipfox/typescript
 
-Thin wrappers around the TypeScript compiler for consistent type-checking and declaration emit across Shipfox packages. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+Thin wrappers around the TypeScript compiler for Shipfox packages. Use them for type checks and declaration output.
 
 ## What it does
 
-- **`shipfox-tsc-check`**: Type-check only (no emit). Uses `tsconfig.test.json` if present, otherwise `tsconfig.json`.
-- **`shipfox-tsc-emit`**: Emit `.d.ts` declaration files to `dist/` and automatically clean up orphaned declarations without matching source files.
+- **`shipfox-tsc-check`** checks types without writing files.
+- **`shipfox-tsc-check`** uses `tsconfig.test.json` when it exists. It falls back to `tsconfig.json`.
+- **`shipfox-tsc-emit`** writes `.d.ts` files to `dist/`.
+- **`shipfox-tsc-emit`** removes old declaration files that no longer match source files.
 
 Designed to work with `@shipfox/ts-config`.
 
@@ -22,8 +24,8 @@ Add scripts to your `package.json`:
 ```json
 {
   "scripts": {
-    "type": "shipfox-tsc-emit",
-    "type:check": "shipfox-tsc-check"
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
   }
 }
 ```
@@ -37,3 +39,7 @@ shipfox-tsc-check
 # Emit declarations to dist/
 shipfox-tsc-emit
 ```
+
+## License
+
+MIT

--- a/tools/utils/README.md
+++ b/tools/utils/README.md
@@ -4,9 +4,9 @@ Small utilities shared by Shipfox CLI tools for path resolution, shell command b
 
 ## What it does
 
-- **`@shipfox/tool-utils/path`**: Resolve project root, workspace root, binary paths, and file paths within the monorepo.
-- **`@shipfox/tool-utils/shell`**: Build properly quoted and escaped shell commands cross-platform.
-- **`@shipfox/tool-utils/log`**: Structured logging (`info`, `warning`, `error`, `debug`) via `@actions/core`.
+- **Path helpers**: Resolve project root, workspace root, binary paths, and file paths within the monorepo.
+- **Shell helpers**: Build properly quoted and escaped shell commands cross-platform.
+- **`log`**: Structured logging (`info`, `warning`, `error`, `debug`) via `@actions/core`.
 
 ## Installation
 
@@ -21,9 +21,9 @@ import {
   getProjectRootPath,
   getWorkspaceRootPath,
   getProjectBinaryPath,
-} from "@shipfox/tool-utils/path";
-import { buildShellCommand } from "@shipfox/tool-utils/shell";
-import { log } from "@shipfox/tool-utils/log";
+  buildShellCommand,
+  log,
+} from "@shipfox/tool-utils";
 
 // Resolve paths
 const projectRoot = getProjectRootPath(import.meta.url);

--- a/tools/vite/README.md
+++ b/tools/vite/README.md
@@ -1,0 +1,60 @@
+# @shipfox/vite
+
+Vite defaults and CLI wrappers for Shipfox frontend packages. It adds TypeScript path support and gives apps shared commands for development and production builds.
+
+## What it does
+
+- **`defineConfig(config?)`**: Wraps Vite `defineConfig` and adds `vite-tsconfig-paths`.
+- **`loadEnv`**: Re-export from Vite.
+- **`vite-dev`**: Runs the project-local Vite dev server.
+- **`vite-build`**: Runs `vite build --outDir dist`.
+- **`@shipfox/vite/client`**: Type entry that re-exports `vite/client`.
+
+## Installation
+
+```bash
+pnpm add -D @shipfox/vite
+```
+
+## Usage
+
+Create a `vite.config.ts`:
+
+```ts
+import {defineConfig} from '@shipfox/vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});
+```
+
+Add scripts:
+
+```json
+{
+  "scripts": {
+    "dev": "vite-dev",
+    "build": "vite-build"
+  }
+}
+```
+
+Then run:
+
+```bash
+vite-dev
+vite-build
+```
+
+## Types
+
+Use the client type entry in browser packages:
+
+```ts
+/// <reference types="@shipfox/vite/client" />
+```
+
+## License
+
+MIT


### PR DESCRIPTION
Adds README coverage for the API auth package, missing shared library packages, and missing tool packages.
Updates existing shared/tool READMEs so package names, exports, commands, environment variables, and examples match the current source.
All READMEs under `libs/shared` and `tools` now pass the grade-9 readability target and have no missing package coverage.
Validated with scoped `turbo check`, tool package `turbo build`, README readability checks, and stale-reference scans.
