### PR TITLE
[codex] Add Storybook for shared React UI

### DIFF
--- a/libs/shared/react/ui/.gitignore
+++ b/libs/shared/react/ui/.gitignore
@@ -1,0 +1,2 @@
+storybook-static/
+screenshots/

--- a/libs/shared/react/ui/.storybook/main.ts
+++ b/libs/shared/react/ui/.storybook/main.ts
@@ -1,0 +1,35 @@
+import type {StorybookConfig} from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  framework: '@storybook/react-vite',
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  addons: ['storybook-addon-pseudo-states'],
+  viteFinal: async (config) => {
+    const [{default: react}, {default: tailwindcss}, {dirname, resolve}, {fileURLToPath}] =
+      await Promise.all([
+        import('@vitejs/plugin-react'),
+        import('@tailwindcss/vite'),
+        import('node:path'),
+        import('node:url'),
+      ]);
+
+    config.plugins = config.plugins ?? [];
+    config.plugins.push(react(), tailwindcss());
+
+    const currentFile = fileURLToPath(import.meta.url);
+    const currentDir = dirname(currentFile);
+
+    config.resolve = config.resolve ?? {};
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '#components': resolve(currentDir, '../src/components'),
+      '#hooks': resolve(currentDir, '../src/hooks'),
+      '#state': resolve(currentDir, '../src/state'),
+      '#utils': resolve(currentDir, '../src/utils'),
+    };
+
+    return config;
+  },
+};
+
+export default config;

--- a/libs/shared/react/ui/.storybook/preview.tsx
+++ b/libs/shared/react/ui/.storybook/preview.tsx
@@ -1,0 +1,66 @@
+import '../index.css';
+import type {Decorator, Preview} from '@storybook/react';
+import {ThemeProvider} from '#components/theme/index.js';
+
+const withTheme: Decorator = (Story, context) => (
+  <ThemeProvider defaultTheme={context.globals.theme}>{Story()}</ThemeProvider>
+);
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    viewport: {
+      viewports: {
+        large: {
+          name: 'Large Viewport',
+          styles: {
+            width: '1280px',
+            height: '2000px',
+          },
+        },
+        extraLarge: {
+          name: 'Extra Large Viewport',
+          styles: {
+            width: '1920px',
+            height: '2000px',
+          },
+        },
+      },
+    },
+    options: {
+      storySort: {
+        method: 'alphabetical',
+      },
+    },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'system',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {
+            value: 'light',
+            icon: 'sun',
+            title: 'Light',
+          },
+          {
+            value: 'dark',
+            icon: 'moon',
+            title: 'Dark',
+          },
+          {
+            value: 'system',
+            icon: 'info',
+            title: 'System',
+          },
+        ],
+        showName: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/libs/shared/react/ui/.swcrc
+++ b/libs/shared/react/ui/.swcrc
@@ -1,0 +1,42 @@
+{
+  "jsc": {
+    "target": "es2023",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true,
+      "tsx": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true,
+      "react": {
+        "runtime": "automatic"
+      }
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true,
+    "experimental": {
+      "keepImportAttributes": true
+    }
+  },
+  "module": {
+    "type": "es6",
+    "strict": true,
+    "strictMode": true,
+    "noInterop": true,
+    "resolveFully": true
+  },
+  "sourceMaps": true,
+  "minify": false,
+  "exclude": [
+    "node_modules",
+    "jest.config.ts",
+    "^.*\\.spec\\.tsx?$",
+    "^.*\\.test\\.tsx?$",
+    "^.*\\.stories\\.tsx?$",
+    ".*/jest-setup\\.ts$",
+    "^.*\\.js$"
+  ]
+}

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -33,6 +33,8 @@
     "build:css": "vite build --config vite.css.config.ts && rm -f dist/css-entry.js dist/css-entry.js.map",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "storybook": "storybook dev",
+    "storybook:build": "storybook build -o storybook-static",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -61,10 +63,14 @@
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vite": "workspace:*",
+    "@storybook/react": "^10.0.0",
+    "@storybook/react-vite": "^10.0.0",
     "@tailwindcss/vite": "^4.1.13",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
+    "storybook": "^10.0.0",
+    "storybook-addon-pseudo-states": "^10.0.0",
     "vite": "^8.0.3"
   }
 }

--- a/libs/shared/react/ui/src/components/alert/alert.stories.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.stories.tsx
@@ -1,0 +1,91 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Header} from '#components/typography/index.js';
+import {
+  Alert,
+  AlertAction,
+  AlertActions,
+  AlertClose,
+  AlertContent,
+  AlertDescription,
+  AlertTitle,
+} from './alert.js';
+
+const variants = ['default', 'info', 'success', 'warning', 'error'] as const;
+
+const meta = {
+  title: 'Components/Alert',
+  component: Alert,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: variants,
+    },
+    animated: {control: 'boolean'},
+  },
+  args: {
+    variant: 'default',
+    animated: false,
+  },
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Alert {...args}>
+      <AlertContent>
+        <AlertTitle>Deployment queued</AlertTitle>
+        <AlertDescription>Your build will start as soon as a runner is available.</AlertDescription>
+        <AlertActions>
+          <AlertAction>View build</AlertAction>
+          <AlertAction>Dismiss</AlertAction>
+        </AlertActions>
+      </AlertContent>
+      <AlertClose />
+    </Alert>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex min-w-500 flex-col gap-16">
+      {variants.map((variant) => (
+        <Alert key={variant} variant={variant} animated={false}>
+          <AlertContent>
+            <AlertTitle>{variant}</AlertTitle>
+            <AlertDescription>Short message explaining the current status.</AlertDescription>
+          </AlertContent>
+          <AlertClose />
+        </Alert>
+      ))}
+    </div>
+  ),
+};
+
+export const DesignMock: Story = {
+  render: () => (
+    <div className="flex flex-col gap-32 bg-background-neutral-base px-32 py-32">
+      <Header variant="h3" className="text-foreground-neutral-subtle">
+        Alerts
+      </Header>
+      <div className="flex min-w-500 flex-col gap-16">
+        {variants.map((variant) => (
+          <Alert key={variant} variant={variant} animated={false}>
+            <AlertContent>
+              <AlertTitle>Title</AlertTitle>
+              <AlertDescription>Description</AlertDescription>
+              <AlertActions>
+                <AlertAction>Download</AlertAction>
+                <AlertAction>View</AlertAction>
+              </AlertActions>
+            </AlertContent>
+            <AlertClose />
+          </Alert>
+        ))}
+      </div>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/badge/badge.stories.tsx
+++ b/libs/shared/react/ui/src/components/badge/badge.stories.tsx
@@ -1,0 +1,118 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Code} from '#components/typography/index.js';
+import {Badge} from './badge.js';
+import {StatusBadge} from './status-badge.js';
+
+const variants = ['neutral', 'info', 'feature', 'success', 'warning', 'error'] as const;
+const sizes = ['2xs', 'xs'] as const;
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: variants,
+    },
+    size: {
+      control: 'select',
+      options: sizes,
+    },
+    radius: {
+      control: 'select',
+      options: ['default', 'rounded'],
+    },
+  },
+  args: {
+    children: 'Badge',
+    variant: 'neutral',
+    size: '2xs',
+    radius: 'default',
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-32">
+      <div>
+        <Code variant="label" className="mb-16 text-foreground-neutral-subtle">
+          Status badge
+        </Code>
+        <div className="flex gap-16">
+          {variants.map((variant) => (
+            <StatusBadge key={variant} variant={variant}>
+              {variant}
+            </StatusBadge>
+          ))}
+        </div>
+      </div>
+
+      {sizes.map((size) => (
+        <div key={size}>
+          <Code variant="label" className="mb-16 text-foreground-neutral-subtle">
+            Badge {size}
+          </Code>
+          <div className="flex flex-col gap-16">
+            <div className="flex gap-16">
+              {variants.map((variant) => (
+                <Badge key={variant} variant={variant} size={size}>
+                  {variant}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex gap-16">
+              {variants.map((variant) => (
+                <Badge key={variant} variant={variant} size={size} iconLeft="check">
+                  {variant}
+                </Badge>
+              ))}
+            </div>
+            <div className="flex gap-16">
+              {variants.map((variant) => (
+                <Badge key={variant} variant={variant} size={size} iconRight="close">
+                  {variant}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const InteractiveBadges: Story = {
+  render: () => (
+    <div className="flex gap-16">
+      <Badge
+        variant="info"
+        iconRight="close"
+        onIconRightClick={() => undefined}
+        iconRightAriaLabel="Remove info badge"
+      >
+        Removable
+      </Badge>
+      <Badge
+        variant="success"
+        iconLeft="check"
+        iconRight="close"
+        onIconLeftClick={() => undefined}
+        iconLeftAriaLabel="Confirm"
+        onIconRightClick={() => undefined}
+        iconRightAriaLabel="Dismiss"
+      >
+        Actions
+      </Badge>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/button/button-link.stories.tsx
+++ b/libs/shared/react/ui/src/components/button/button-link.stories.tsx
@@ -1,0 +1,87 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {ButtonLink} from './button-link.js';
+
+const meta = {
+  title: 'Components/Button/ButtonLink',
+  component: ButtonLink,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['base', 'interactive', 'muted', 'subtle'],
+    },
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'xl'],
+    },
+    underline: {control: 'boolean'},
+    asChild: {control: 'boolean'},
+  },
+  args: {
+    children: 'Label',
+    variant: 'base',
+    size: 'sm',
+    underline: false,
+    href: '#',
+  },
+} satisfies Meta<typeof ButtonLink>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-16">
+      <ButtonLink {...args} variant="base">
+        Base
+      </ButtonLink>
+      <ButtonLink {...args} variant="interactive">
+        Interactive
+      </ButtonLink>
+      <ButtonLink {...args} variant="muted">
+        Muted
+      </ButtonLink>
+      <ButtonLink {...args} variant="subtle">
+        Subtle
+      </ButtonLink>
+    </div>
+  ),
+};
+
+export const WithUnderline: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-16">
+      <ButtonLink {...args} variant="base" underline>
+        Base
+      </ButtonLink>
+      <ButtonLink {...args} variant="interactive" underline>
+        Interactive
+      </ButtonLink>
+      <ButtonLink {...args} variant="muted" underline>
+        Muted
+      </ButtonLink>
+      <ButtonLink {...args} variant="subtle" underline>
+        Subtle
+      </ButtonLink>
+    </div>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-16">
+      <ButtonLink {...args} iconLeft="addLine">
+        Icon left
+      </ButtonLink>
+      <ButtonLink {...args} iconRight="chevronRight">
+        Icon right
+      </ButtonLink>
+      <ButtonLink {...args} iconLeft="addLine" iconRight="chevronRight">
+        Both icons
+      </ButtonLink>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/button/button.stories.tsx
+++ b/libs/shared/react/ui/src/components/button/button.stories.tsx
@@ -1,0 +1,128 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Code} from '#components/typography/index.js';
+import {Button} from './button.js';
+
+const variantOptions = [
+  'primary',
+  'secondary',
+  'danger',
+  'success',
+  'transparent',
+  'transparentMuted',
+] as const;
+const sizeOptions = ['2xs', 'xs', 'sm', 'md', 'lg', 'xl'] as const;
+
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: variantOptions,
+    },
+    size: {
+      control: 'select',
+      options: sizeOptions,
+    },
+    asChild: {control: 'boolean'},
+    isLoading: {control: 'boolean'},
+  },
+  args: {
+    children: 'Click me',
+    variant: 'primary',
+    size: 'md',
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-32">
+      {sizeOptions.map((size) => (
+        <table key={size} className="w-fit border-separate border-spacing-x-32 border-spacing-y-16">
+          <thead>
+            <tr>
+              <th>{size}</th>
+              <th>Default</th>
+              <th>Hover</th>
+              <th>Focus</th>
+              <th>Disabled</th>
+            </tr>
+          </thead>
+          <tbody>
+            {variantOptions.map((variant) => (
+              <tr key={variant}>
+                <td>
+                  <Code variant="label" className="text-foreground-neutral-subtle">
+                    {variant}
+                  </Code>
+                </td>
+                <td>
+                  <Button {...args} variant={variant} size={size}>
+                    Click me
+                  </Button>
+                </td>
+                <td>
+                  <Button {...args} variant={variant} className="hover" size={size}>
+                    Click me
+                  </Button>
+                </td>
+                <td>
+                  <Button {...args} variant={variant} className="focus" size={size}>
+                    Click me
+                  </Button>
+                </td>
+                <td>
+                  <Button {...args} variant={variant} disabled size={size}>
+                    Click me
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ))}
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      hover: '.hover',
+      focusVisible: '.focus',
+    },
+  },
+};
+
+export const Icons: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-16">
+      <Button {...args} iconLeft="google">
+        Google
+      </Button>
+      <Button {...args} iconRight="microsoft">
+        Microsoft
+      </Button>
+      <Button {...args} iconLeft="google" iconRight="microsoft">
+        Both icons
+      </Button>
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-16">
+      <Button {...args} isLoading>
+        Loading
+      </Button>
+      <Button {...args} isLoading iconLeft="google">
+        Loading with icon
+      </Button>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/button/icon-button.stories.tsx
+++ b/libs/shared/react/ui/src/components/button/icon-button.stories.tsx
@@ -1,0 +1,132 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Code} from '#components/typography/index.js';
+import {IconButton} from './icon-button.js';
+
+const variantOptions = ['primary', 'transparent'] as const;
+const sizeOptions = ['2xs', 'xs', 'sm', 'md', 'lg', 'xl'] as const;
+const radiusOptions = ['rounded', 'full'] as const;
+
+const meta = {
+  title: 'Components/Button/IconButton',
+  component: IconButton,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: variantOptions,
+    },
+    size: {
+      control: 'select',
+      options: sizeOptions,
+    },
+    radius: {
+      control: 'select',
+      options: radiusOptions,
+    },
+    muted: {control: 'boolean'},
+    isLoading: {control: 'boolean'},
+    asChild: {control: 'boolean'},
+  },
+  args: {
+    icon: 'addLine',
+    variant: 'primary',
+    size: 'md',
+    radius: 'rounded',
+    muted: false,
+    'aria-label': 'Add',
+  },
+} satisfies Meta<typeof IconButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-32">
+      {sizeOptions.map((size) => (
+        <div key={size} className="flex flex-col gap-16">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            Size: {size}
+          </Code>
+          {radiusOptions.map((radius) => (
+            <table
+              key={radius}
+              className="w-fit border-separate border-spacing-x-32 border-spacing-y-16"
+            >
+              <thead>
+                <tr>
+                  <th>{radius}</th>
+                  <th>Default</th>
+                  <th>Hover</th>
+                  <th>Focus</th>
+                  <th>Disabled</th>
+                </tr>
+              </thead>
+              <tbody>
+                {variantOptions.map((variant) => (
+                  <tr key={variant}>
+                    <td>
+                      <Code variant="label" className="text-foreground-neutral-subtle">
+                        {variant}
+                      </Code>
+                    </td>
+                    <td>
+                      <IconButton {...args} variant={variant} size={size} radius={radius} />
+                    </td>
+                    <td>
+                      <IconButton
+                        {...args}
+                        variant={variant}
+                        className="hover"
+                        size={size}
+                        radius={radius}
+                      />
+                    </td>
+                    <td>
+                      <IconButton
+                        {...args}
+                        variant={variant}
+                        className="focus"
+                        size={size}
+                        radius={radius}
+                      />
+                    </td>
+                    <td>
+                      <IconButton
+                        {...args}
+                        variant={variant}
+                        disabled
+                        size={size}
+                        radius={radius}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      hover: '.hover',
+      focusVisible: '.focus',
+    },
+  },
+};
+
+export const States: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-16">
+      <IconButton {...args} icon="addLine" aria-label="Add" />
+      <IconButton {...args} icon="addLine" aria-label="Add muted" muted />
+      <IconButton {...args} icon="spinner" aria-label="Loading" isLoading />
+      <IconButton {...args} icon="addLine" aria-label="Disabled" disabled />
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/card/card.stories.tsx
+++ b/libs/shared/react/ui/src/components/card/card.stories.tsx
@@ -1,0 +1,73 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Button} from '#components/button/index.js';
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from './card.js';
+
+const meta = {
+  title: 'Components/Card',
+  component: Card,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="w-360">
+      <CardHeader>
+        <CardTitle>Project usage</CardTitle>
+        <CardDescription>Track this workspace usage for the current billing cycle.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="h-80 rounded-6 bg-background-neutral-subtle" />
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => (
+    <Card className="w-360">
+      <div className="flex items-start gap-16">
+        <CardHeader>
+          <CardTitle>Runner pool</CardTitle>
+          <CardDescription>Autoscaling is enabled for production jobs.</CardDescription>
+        </CardHeader>
+        <CardAction>
+          <Button size="sm" variant="secondary">
+            Manage
+          </Button>
+        </CardAction>
+      </div>
+      <CardContent>
+        <div className="h-80 rounded-6 bg-background-neutral-subtle" />
+      </CardContent>
+    </Card>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <Card className="w-360">
+      <CardHeader>
+        <CardTitle>Invite teammate</CardTitle>
+        <CardDescription>Add someone to help configure the workspace.</CardDescription>
+      </CardHeader>
+      <CardFooter>
+        <Button size="sm">Invite</Button>
+        <Button size="sm" variant="secondary">
+          Cancel
+        </Button>
+      </CardFooter>
+    </Card>
+  ),
+};

--- a/libs/shared/react/ui/src/components/icon/icon.stories.tsx
+++ b/libs/shared/react/ui/src/components/icon/icon.stories.tsx
@@ -1,0 +1,51 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Icon, iconNames} from './icon.js';
+
+const meta = {
+  title: 'Components/Icon',
+  component: Icon,
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'select',
+      options: iconNames,
+    },
+    size: {control: 'number'},
+  },
+  args: {
+    name: 'shipfox',
+    size: 24,
+  },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CommonIcons: Story = {
+  render: () => (
+    <div className="grid grid-cols-6 gap-16">
+      {[
+        'shipfox',
+        'spinner',
+        'addLine',
+        'close',
+        'check',
+        'copy',
+        'info',
+        'github',
+        'google',
+        'microsoft',
+        'slack',
+        'stripe',
+      ].map((name) => (
+        <div key={name} className="flex flex-col items-center gap-8 text-foreground-neutral-base">
+          <Icon name={name} size={24} />
+          <span className="text-xs text-foreground-neutral-muted">{name}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/input/input.stories.tsx
+++ b/libs/shared/react/ui/src/components/input/input.stories.tsx
@@ -1,0 +1,60 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Icon} from '#components/icon/index.js';
+import {Label} from '#components/label/index.js';
+import {Input} from './input.js';
+
+const meta = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['base', 'component'],
+    },
+    size: {
+      control: 'select',
+      options: ['base', 'small'],
+    },
+  },
+  args: {
+    placeholder: 'Placeholder',
+    variant: 'base',
+    size: 'base',
+  },
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const States: Story = {
+  render: (args) => (
+    <div className="grid w-360 gap-16">
+      <div className="grid gap-8">
+        <Label htmlFor="default-input">Default</Label>
+        <Input {...args} id="default-input" placeholder="default@example.com" />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="icon-input">With icons</Label>
+        <Input
+          {...args}
+          id="icon-input"
+          iconLeft={<Icon name="github" className="size-16 text-foreground-neutral-muted" />}
+          iconRight={<Icon name="check" className="size-16 text-tag-success-icon" />}
+          defaultValue="shipfox"
+        />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="invalid-input">Invalid</Label>
+        <Input {...args} id="invalid-input" aria-invalid defaultValue="not an email" />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="disabled-input">Disabled</Label>
+        <Input {...args} id="disabled-input" disabled defaultValue="Disabled value" />
+      </div>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/label/label.stories.tsx
+++ b/libs/shared/react/ui/src/components/label/label.stories.tsx
@@ -1,0 +1,27 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Input} from '#components/input/index.js';
+import {Label} from './label.js';
+
+const meta = {
+  title: 'Components/Label',
+  component: Label,
+  tags: ['autodocs'],
+  args: {
+    children: 'Email address',
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithInput: Story = {
+  render: (args) => (
+    <div className="grid w-320 gap-8">
+      <Label {...args} htmlFor="email" />
+      <Input id="email" type="email" placeholder="you@example.com" />
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/loader/loader.stories.tsx
+++ b/libs/shared/react/ui/src/components/loader/loader.stories.tsx
@@ -1,0 +1,56 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {FullPageLoader} from './full-page-loader.js';
+import {ShipfoxLoader} from './shipfox-loader.js';
+
+const meta = {
+  title: 'Components/Loader',
+  component: ShipfoxLoader,
+  tags: ['autodocs'],
+  argTypes: {
+    animation: {
+      control: 'select',
+      options: ['random', 'circular', 'linear'],
+    },
+    color: {
+      control: 'select',
+      options: ['orange', 'white', 'black'],
+    },
+    background: {
+      control: 'select',
+      options: ['dark', 'light', 'transparent'],
+    },
+    size: {control: 'number'},
+    speed: {control: 'number'},
+    showControls: {control: 'boolean'},
+    autoPlay: {control: 'boolean'},
+  },
+  args: {
+    size: 80,
+    animation: 'random',
+    color: 'orange',
+    background: 'dark',
+    autoPlay: true,
+    showControls: false,
+    speed: 1,
+  },
+} satisfies Meta<typeof ShipfoxLoader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex items-center gap-32">
+      <ShipfoxLoader size={80} animation="random" color="orange" background="dark" />
+      <ShipfoxLoader size={80} animation="circular" color="white" background="dark" />
+      <ShipfoxLoader size={80} animation="leftright" color="black" background="light" />
+    </div>
+  ),
+};
+
+export const FullPage: Story = {
+  render: () => <FullPageLoader className="h-320 w-560 rounded-8" />,
+};

--- a/libs/shared/react/ui/src/components/skeleton/skeleton.stories.tsx
+++ b/libs/shared/react/ui/src/components/skeleton/skeleton.stories.tsx
@@ -1,0 +1,31 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Skeleton} from './skeleton.js';
+
+const meta = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <Skeleton className="h-24 w-240" />,
+};
+
+export const CardLoading: Story = {
+  render: () => (
+    <div className="flex w-360 flex-col gap-16 rounded-8 border border-border-neutral-base p-16">
+      <div className="flex items-center gap-12">
+        <Skeleton className="size-40 rounded-full" />
+        <div className="flex flex-1 flex-col gap-8">
+          <Skeleton className="h-16 w-160" />
+          <Skeleton className="h-12 w-120" />
+        </div>
+      </div>
+      <Skeleton className="h-120 w-full" />
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/toast/toast.stories.tsx
+++ b/libs/shared/react/ui/src/components/toast/toast.stories.tsx
@@ -1,0 +1,60 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Button} from '#components/button/index.js';
+import {Toaster, toast} from './toast.js';
+import {ToastCustom} from './toast-custom.js';
+
+const meta = {
+  title: 'Components/Toast',
+  component: Toaster,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex gap-12">
+      <Toaster />
+      <Button onClick={() => toast.success('Project created')}>Success</Button>
+      <Button onClick={() => toast.info('Runner is warming up')} variant="secondary">
+        Info
+      </Button>
+      <Button onClick={() => toast.warning('Usage is near the limit')} variant="secondary">
+        Warning
+      </Button>
+      <Button onClick={() => toast.error('Deployment failed')} variant="danger">
+        Error
+      </Button>
+    </div>
+  ),
+};
+
+export const Custom: Story = {
+  render: () => (
+    <div className="flex gap-12">
+      <Toaster />
+      <Button
+        onClick={() =>
+          toast.custom((id) => (
+            <ToastCustom
+              variant="info"
+              title="Build ready"
+              description="The preview deployment is available."
+              actions={[
+                {
+                  label: 'Open',
+                  onClick: () => toast.dismiss(id),
+                },
+              ]}
+              onClose={() => toast.dismiss(id)}
+            />
+          ))
+        }
+      >
+        Custom toast
+      </Button>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/tooltip/tooltip.stories.tsx
+++ b/libs/shared/react/ui/src/components/tooltip/tooltip.stories.tsx
@@ -1,0 +1,109 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Button} from '#components/button/index.js';
+import {Code} from '#components/typography/index.js';
+import {Tooltip, TooltipContent, type TooltipContentProps, TooltipTrigger} from './tooltip.js';
+
+type TooltipStoryArgs = {
+  defaultOpen?: boolean;
+  delayDuration?: number;
+  variant?: TooltipContentProps['variant'];
+  size?: TooltipContentProps['size'];
+  side?: TooltipContentProps['side'];
+  align?: TooltipContentProps['align'];
+  sideOffset?: TooltipContentProps['sideOffset'];
+  animated?: TooltipContentProps['animated'];
+};
+
+const meta = {
+  title: 'Components/Tooltip',
+  tags: ['autodocs'],
+  argTypes: {
+    defaultOpen: {control: 'boolean'},
+    delayDuration: {control: 'number'},
+    variant: {
+      control: 'select',
+      options: ['default', 'inverted', 'muted'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    side: {
+      control: 'select',
+      options: ['top', 'bottom', 'left', 'right'],
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+    },
+    sideOffset: {control: 'number'},
+    animated: {control: 'boolean'},
+  },
+  args: {
+    defaultOpen: false,
+    delayDuration: 0,
+    variant: 'default',
+    size: 'md',
+    side: 'top',
+    align: 'center',
+    sideOffset: 8,
+    animated: true,
+  },
+} satisfies Meta<TooltipStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<TooltipStoryArgs>;
+
+export const Default: Story = {
+  render: (args: TooltipStoryArgs) => {
+    const defaultOpen = args.defaultOpen ?? false;
+    const delayDuration = args.delayDuration ?? 0;
+    const variant = args.variant ?? 'default';
+    const size = args.size ?? 'md';
+    const side = args.side ?? 'top';
+    const align = args.align ?? 'center';
+    const sideOffset = args.sideOffset ?? 8;
+    const animated = args.animated ?? true;
+
+    return (
+      <div className="flex items-center justify-center p-64">
+        <Tooltip defaultOpen={defaultOpen} delayDuration={delayDuration}>
+          <TooltipTrigger asChild>
+            <Button>Hover me</Button>
+          </TooltipTrigger>
+          <TooltipContent
+            variant={variant}
+            size={size}
+            side={side}
+            align={align}
+            sideOffset={sideOffset}
+            animated={animated}
+          >
+            Tooltip text
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-32 p-64">
+      {(['default', 'inverted', 'muted'] as const).map((variant) => (
+        <div key={variant} className="flex items-center gap-16">
+          <Code variant="label" className="w-80 text-foreground-neutral-subtle">
+            {variant}
+          </Code>
+          <Tooltip defaultOpen>
+            <TooltipTrigger asChild>
+              <Button variant={variant === 'inverted' ? 'primary' : 'secondary'}>{variant}</Button>
+            </TooltipTrigger>
+            <TooltipContent variant={variant}>Tooltip text</TooltipContent>
+          </Tooltip>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/typography/code.stories.tsx
+++ b/libs/shared/react/ui/src/components/typography/code.stories.tsx
@@ -1,0 +1,39 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Code} from './code.js';
+
+const meta = {
+  title: 'Typography/Code',
+  component: Code,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Code>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const variants = ['label', 'paragraph'] as const;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      {variants.map((variant) => (
+        <div key={variant} className="grid grid-cols-2 gap-8">
+          <div className="flex flex-col gap-4">
+            <Code variant="label" className="text-foreground-neutral-subtle">
+              {variant}
+            </Code>
+            <Code variant={variant}>The quick brown fox jumps over the lazy dog</Code>
+          </div>
+          <div className="flex flex-col gap-4">
+            <Code variant="label" className="text-foreground-neutral-subtle">
+              {variant} bold
+            </Code>
+            <Code variant={variant} bold>
+              The quick brown fox jumps over the lazy dog
+            </Code>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/typography/header.stories.tsx
+++ b/libs/shared/react/ui/src/components/typography/header.stories.tsx
@@ -1,0 +1,30 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Code} from './code.js';
+import {Header} from './header.js';
+
+const meta = {
+  title: 'Typography/Header',
+  component: Header,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Header>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const variants = ['h1', 'h2', 'h3', 'h4'] as const;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      {variants.map((variant) => (
+        <div key={variant} className="flex flex-col gap-4">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            {variant}
+          </Code>
+          <Header variant={variant}>The quick brown fox jumps over the lazy dog</Header>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/typography/text.stories.tsx
+++ b/libs/shared/react/ui/src/components/typography/text.stories.tsx
@@ -1,0 +1,67 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Code} from './code.js';
+import {Text} from './text.js';
+
+const meta = {
+  title: 'Typography/Text',
+  component: Text,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Text>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+const textParagraph =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      {sizes.map((size) => (
+        <div key={size} className="grid grid-cols-2 gap-8">
+          <div className="flex flex-col gap-4">
+            <Code variant="label" className="text-foreground-neutral-subtle">
+              {size}
+            </Code>
+            <Text size={size}>The quick brown fox jumps over the lazy dog</Text>
+          </div>
+          <div className="flex flex-col gap-4">
+            <Code variant="label" className="text-foreground-neutral-subtle">
+              {size} bold
+            </Code>
+            <Text size={size} bold>
+              The quick brown fox jumps over the lazy dog
+            </Text>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const Paragraph: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      {sizes.map((size) => (
+        <div key={size} className="grid grid-cols-2 gap-8">
+          <div className="flex flex-col gap-4">
+            <Code variant="label" className="text-foreground-neutral-subtle">
+              {size} regular
+            </Code>
+            <Text size={size} compact={false}>
+              {textParagraph}
+            </Text>
+          </div>
+          <div className="flex flex-col gap-4">
+            <Code variant="label" className="text-foreground-neutral-subtle">
+              {size} compact
+            </Code>
+            <Text size={size}>{textParagraph}</Text>
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/tsconfig.build.json
+++ b/libs/shared/react/ui/tsconfig.build.json
@@ -5,5 +5,5 @@
     "outDir": "dist"
   },
   "include": ["src"],
-  "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/build-css-entry.ts"]
+  "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.stories.tsx", "**/build-css-entry.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1582,6 +1582,12 @@ importers:
       '@shipfox/vite':
         specifier: workspace:*
         version: link:../../../../tools/vite
+      '@storybook/react':
+        specifier: ^10.0.0
+        version: 10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.0.0
+        version: 10.3.6(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.2.4(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -1594,6 +1600,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.0.0
         version: 5.2.0(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      storybook:
+        specifier: ^10.0.0
+        version: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      storybook-addon-pseudo-states:
+        specifier: ^10.0.0
+        version: 10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       vite:
         specifier: ^8.0.3
         version: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
@@ -2515,6 +2527,15 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
+    resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -3803,6 +3824,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -3857,6 +3887,65 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@storybook/builder-vite@10.3.6':
+    resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
+    peerDependencies:
+      storybook: ^10.3.6
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.3.6':
+    resolution: {integrity: sha512-9kBf7VRdRqTSIYo+rPtVn5yjYYyK8kP2QhEYx3oiXvfwy4RexmbJnhk/tXa/lNiTqukA1TqaWQ2+5MqF4fu6YQ==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.6
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.1':
+    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.3.6':
+    resolution: {integrity: sha512-/Tu1gPu+Fw+zOnAGmxRmOD30FX3a04LxcTAKflEtdpmtIMVR5bA3qpjy+f5YhoyDCecbXyKmL1OeIU2FIIZHqQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.6
+
+  '@storybook/react-vite@10.3.6':
+    resolution: {integrity: sha512-tySQRc+8q7V2NkylQMNJjDV8zXy6tkxb8oDqw/DIhHhI9Xn77MTKVZ8Cihbo5NMm7HYTB6xDKr6wqdSMgdufYQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.6
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/react@10.3.6':
+    resolution: {integrity: sha512-oZQZ6xayWe5IdHmFUTL0TL8rX/gpNNh9gWhT2vzW5eeUvlkVG/RBKdsja6Ndrk2s1D9vcnwiI6r6CNXy3IEEmg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.6
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@swc/cli@0.8.1':
     resolution: {integrity: sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ==}
@@ -4200,6 +4289,12 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -4239,6 +4334,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
@@ -4293,6 +4391,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/resolve@1.20.6':
+    resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
@@ -4301,6 +4402,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
   '@vitest/expect@4.1.4':
     resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
@@ -4316,6 +4420,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.1.4':
     resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
 
@@ -4325,8 +4432,14 @@ packages:
   '@vitest/snapshot@4.1.4':
     resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.1.4':
     resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
@@ -4375,6 +4488,9 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@xhmikosr/archive-type@8.0.1':
     resolution: {integrity: sha512-toXuiWChyfOpEiCPsIw6HGHaNji5LVkvB6EREL548vGWr+hGaehwxG4LzN20vm9aGFXwnA/Jty8yW2/SmV+1zQ==}
@@ -4526,6 +4642,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -4610,6 +4730,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   byte-counter@0.1.0:
     resolution: {integrity: sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==}
     engines: {node: '>=20'}
@@ -4625,6 +4749,10 @@ packages:
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -4632,6 +4760,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -4742,6 +4874,22 @@ packages:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
     engines: {node: '>=20'}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
   dependency-cruiser@17.3.10:
     resolution: {integrity: sha512-jF5WaIb+O+wLabXrQE7iBY2zYBEW8VlnuuL0+iZPvZHGhTaAYdLk31DI0zkwhcGE8CiHcDwGhMnn3PfOAYnVdQ==}
     engines: {node: ^20.12||^22||>=24}
@@ -4758,6 +4906,10 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -4867,6 +5019,10 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
@@ -4916,6 +5072,11 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -4928,8 +5089,15 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -5133,6 +5301,10 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
@@ -5238,6 +5410,11 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -5249,6 +5426,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-installed-globally@1.0.0:
     resolution: {integrity: sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==}
@@ -5284,6 +5466,10 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isbot@5.1.39:
     resolution: {integrity: sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw==}
@@ -5473,6 +5659,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5537,6 +5726,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
@@ -5612,6 +5805,10 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -5645,8 +5842,16 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -5788,6 +5993,15 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
+
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -5811,6 +6025,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -5866,6 +6084,10 @@ packages:
     resolution: {integrity: sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -6002,6 +6224,23 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  storybook-addon-pseudo-states@10.3.6:
+    resolution: {integrity: sha512-0ue+X3FmteLuZLWdqrdJbfKv8u4WlUPz34KuUQfSAuBWkW0xeAcMwOWCbnTU7GQHtNHivGBtOqSoTch4AxkZJg==}
+    peerDependencies:
+      storybook: ^10.3.6
+
+  storybook@10.3.6:
+    resolution: {integrity: sha512-vbSz7g/1rGMC1uAULqMZjALkIuLu2QABqfhRYhyr/11kzyesi+vAmwyJLukZP1FfecxGOgMwOh6GS0YsGpHAvQ==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -6031,6 +6270,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -6119,6 +6362,9 @@ packages:
     resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
     engines: {node: '>=12'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -6130,8 +6376,16 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.28:
@@ -6166,6 +6420,10 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -6236,6 +6494,10 @@ packages:
 
   unionfs@4.6.0:
     resolution: {integrity: sha512-fJAy3gTHjFi5S3TP5EGdjs/OUMFFvI/ady3T8qVuZfkv8Qi8prV/Q8BuFEgODJslhZTT2z2qdD2lGdee9qjEnA==}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@3.0.0:
     resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
@@ -6410,6 +6672,22 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -7021,6 +7299,14 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.5
       yargs: 17.7.2
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -8376,6 +8662,12 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
+  '@rollup/pluginutils@5.3.0':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sentry/core@10.49.0': {}
@@ -8444,6 +8736,75 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))':
+    dependencies:
+      '@storybook/csf-plugin': 10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      ts-dedent: 2.2.0
+      vite: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))':
+    dependencies:
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      vite: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      webpack: 5.106.2(esbuild@0.27.7)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@storybook/react-dom-shim@10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))':
+    dependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  '@storybook/react-vite@10.3.6(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0
+      '@storybook/builder-vite': 10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.106.2(esbuild@0.27.7))
+      '@storybook/react': 10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)
+      empathic: 2.0.0
+      magic-string: 0.30.21
+      react: 19.2.5
+      react-docgen: 8.0.3
+      react-dom: 19.2.5(react@19.2.5)
+      resolve: 1.22.12
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      tsconfig-paths: 4.2.0
+      vite: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react@10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.3.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+      react: 19.2.5
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      react-dom: 19.2.5(react@19.2.5)
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.30(@swc/helpers@0.5.21))':
     dependencies:
@@ -8818,6 +9179,10 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -8871,6 +9236,8 @@ snapshots:
       '@types/node': 24.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/doctrine@0.0.9': {}
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -8938,6 +9305,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/resolve@1.20.6': {}
+
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 24.1.0
@@ -8953,6 +9322,14 @@ snapshots:
       vite: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -8971,6 +9348,10 @@ snapshots:
     optionalDependencies:
       vite: 8.0.9(@types/node@25.5.2)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.4':
     dependencies:
       tinyrainbow: 3.1.0
@@ -8987,7 +9368,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -9070,6 +9461,8 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  '@webcontainer/env@1.1.1': {}
 
   '@xhmikosr/archive-type@8.0.1':
     dependencies:
@@ -9248,6 +9641,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   atomic-sleep@1.0.0: {}
 
   avvio@9.2.0:
@@ -9324,6 +9721,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   byte-counter@0.1.0: {}
 
   cacheable-lookup@7.0.0: {}
@@ -9340,12 +9741,22 @@ snapshots:
 
   caniuse-lite@1.0.30001791: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -9439,6 +9850,17 @@ snapshots:
     dependencies:
       mimic-response: 4.0.0
 
+  deep-eql@5.0.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
   dependency-cruiser@17.3.10:
     dependencies:
       acorn: 8.16.0
@@ -9466,6 +9888,10 @@ snapshots:
 
   diff@8.0.4: {}
 
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
@@ -9486,6 +9912,8 @@ snapshots:
   electron-to-chromium@1.5.344: {}
 
   emoji-regex@8.0.0: {}
+
+  empathic@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -9601,6 +10029,8 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  esprima@4.0.1: {}
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
@@ -9609,9 +10039,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   event-target-shim@5.0.1: {}
 
@@ -9836,6 +10270,12 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
@@ -9939,6 +10379,8 @@ snapshots:
     dependencies:
       hasown: 2.0.3
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -9946,6 +10388,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-installed-globally@1.0.0:
     dependencies:
@@ -9967,6 +10413,10 @@ snapshots:
   is-stream@4.0.1: {}
 
   is-unicode-supported@2.1.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isbot@5.1.39: {}
 
@@ -10120,6 +10570,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  loupe@3.2.1: {}
+
   lowercase-keys@3.0.0: {}
 
   lru-cache@11.3.5: {}
@@ -10183,6 +10635,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   module-details-from-path@1.0.4: {}
 
   motion-dom@12.38.0:
@@ -10238,6 +10692,13 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   openapi-types@12.1.3: {}
 
   p-cancelable@4.0.1: {}
@@ -10260,7 +10721,14 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -10420,6 +10888,25 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -10436,6 +10923,14 @@ snapshots:
       picomatch: 2.3.2
 
   real-require@0.2.0: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   rechoir@0.8.0:
     dependencies:
@@ -10500,6 +10995,8 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.16
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.16
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.16
+
+  run-applescript@7.1.0: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -10608,6 +11105,34 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  storybook-addon-pseudo-states@10.3.6(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+    dependencies:
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+
+  storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.27.7
+      open: 10.2.0
+      recast: 0.23.11
+      semver: 7.7.4
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      ws: 8.20.0
+    optionalDependencies:
+      prettier: 3.8.3
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
+
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -10641,6 +11166,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-indent@4.1.1: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -10735,6 +11262,8 @@ snapshots:
     dependencies:
       convert-hrtime: 5.0.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
@@ -10744,7 +11273,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@2.0.0: {}
+
   tinyrainbow@3.1.0: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.28: {}
 
@@ -10775,6 +11308,8 @@ snapshots:
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
+
+  ts-dedent@2.2.0: {}
 
   tsconfck@3.1.6: {}
 
@@ -10828,6 +11363,13 @@ snapshots:
   unionfs@4.6.0:
     dependencies:
       fs-monkey: 1.1.0
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
 
   unplugin@3.0.0:
     dependencies:
@@ -11012,6 +11554,12 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
 
   xml-name-validator@5.0.0: {}
 

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -29,6 +29,11 @@
       "cache": false,
       "dependsOn": ["^build"]
     },
+    "storybook:build": {
+      "cache": true,
+      "outputs": ["storybook-static/**/*"],
+      "dependsOn": ["^build"]
+    },
     "depcruise": {
       "cache": true,
       "dependsOn": ["@shipfox/depcruise#build"]


### PR DESCRIPTION
## Summary

Adds Storybook back to `@shipfox/react-ui` so shared React UI components can be developed and reviewed in isolation.

## Changes

- Adds Storybook React/Vite config with Tailwind, pseudo-state support, and the existing theme provider toolbar.
- Adds `storybook` and `storybook:build` package scripts plus the Turbo task wiring.
- Adds focused stories for the components currently present in `libs/shared/react/ui`.
- Excludes story files from the library build output and ignores generated Storybook artifacts.

## Validation

- `mise exec -- turbo check --filter=@shipfox/react-ui`
- `mise exec -- turbo type --filter=@shipfox/react-ui`
- `mise exec -- turbo build --filter=@shipfox/react-ui`
- `mise exec -- turbo storybook:build --filter=@shipfox/react-ui`
- `git diff --check`