### PR TITLE
Fix flaky definitions outbox drain test

### DIFF
--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -1,6 +1,12 @@
 import {DEFINITION_RESOLVED} from '@shipfox/api-definitions-dto';
-import {drainAll, markDispatched, registerPublisher, resetPublishers} from '@shipfox/node-module';
-import {isNotNull, isNull, sql} from 'drizzle-orm';
+import {
+  type DrainedEvent,
+  drainAll,
+  markDispatched,
+  registerPublisher,
+  resetPublishers,
+} from '@shipfox/node-module';
+import {sql} from 'drizzle-orm';
 import type {WorkflowSpec} from '#core/entities/definition.js';
 import {db} from './db.js';
 import {
@@ -23,6 +29,13 @@ async function listOutboxRowsForProject(projectId: string) {
     .select()
     .from(definitionsOutbox)
     .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
+}
+
+function eventsForProject(events: DrainedEvent[], projectId: string) {
+  return events.filter((event) => {
+    const payload = event.event.payload as {projectId?: unknown};
+    return payload.projectId === projectId;
+  });
 }
 
 describe('definition queries', () => {
@@ -375,10 +388,11 @@ describe('definition queries', () => {
       });
 
       const events = await drainAll();
+      const projectEvents = eventsForProject(events, projectId);
 
-      expect(events).toHaveLength(1);
-      expect(events[0]?.source).toBe('definitions');
-      expect(events[0]?.event.type).toBe(DEFINITION_RESOLVED);
+      expect(projectEvents).toHaveLength(1);
+      expect(projectEvents[0]?.source).toBe('definitions');
+      expect(projectEvents[0]?.event.type).toBe(DEFINITION_RESOLVED);
     });
 
     test('markDispatched sets dispatchedAt for a single event', async () => {
@@ -388,16 +402,14 @@ describe('definition queries', () => {
         name: 'Test',
         definition: spec(),
       });
-      const events = await drainAll();
+      const events = eventsForProject(await drainAll(), projectId);
 
       await markDispatched('definitions', [events[0]?.id as string]);
 
-      const rows = await db()
-        .select()
-        .from(definitionsOutbox)
-        .where(isNotNull(definitionsOutbox.dispatchedAt));
-      expect(rows).toHaveLength(1);
-      expect(rows[0]?.id).toBe(events[0]?.id);
+      const rows = await listOutboxRowsForProject(projectId);
+      const dispatched = rows.filter((row) => row.dispatchedAt !== null);
+      expect(dispatched).toHaveLength(1);
+      expect(dispatched[0]?.id).toBe(events[0]?.id);
     });
 
     test('markDispatched sets dispatchedAt for multiple events', async () => {
@@ -413,15 +425,13 @@ describe('definition queries', () => {
         name: 'B',
         definition: spec('B'),
       });
-      const events = await drainAll();
+      const events = eventsForProject(await drainAll(), projectId);
       const ids = events.map((e) => e.id);
 
       await markDispatched('definitions', ids);
 
-      const pending = await db()
-        .select()
-        .from(definitionsOutbox)
-        .where(isNull(definitionsOutbox.dispatchedAt));
+      const rows = await listOutboxRowsForProject(projectId);
+      const pending = rows.filter((row) => row.dispatchedAt === null);
       expect(pending).toHaveLength(0);
     });
 
@@ -432,10 +442,10 @@ describe('definition queries', () => {
         name: 'Test',
         definition: spec(),
       });
-      const events = await drainAll();
+      const events = eventsForProject(await drainAll(), projectId);
       await markDispatched('definitions', [events[0]?.id as string]);
 
-      const secondDrain = await drainAll();
+      const secondDrain = eventsForProject(await drainAll(), projectId);
 
       expect(secondDrain).toHaveLength(0);
     });

--- a/libs/api/projects/test/globalSetup.ts
+++ b/libs/api/projects/test/globalSetup.ts
@@ -1,5 +1,4 @@
 import './env.js';
-import {migrationsPath as workspacesMigrationsPath} from '@shipfox/api-workspaces';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {sql} from 'drizzle-orm';
@@ -8,14 +7,11 @@ import {closeDb, db, migrationsPath} from '#db/index.js';
 export async function setup() {
   createPostgresClient();
 
-  await runMigrations(db(), workspacesMigrationsPath, '__drizzle_migrations_workspaces');
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_projects');
   await db().execute(sql`TRUNCATE projects_projects CASCADE`);
   await db().execute(sql`TRUNCATE projects_repositories CASCADE`);
   await db().execute(sql`TRUNCATE projects_vcs_connections CASCADE`);
   await db().execute(sql`TRUNCATE projects_outbox CASCADE`);
-  await db().execute(sql`TRUNCATE workspaces_memberships CASCADE`);
-  await db().execute(sql`TRUNCATE workspaces CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -25,6 +25,10 @@
       "cache": true,
       "dependsOn": ["^build"]
     },
+    "@shipfox/api-projects#test": {
+      "cache": true,
+      "dependsOn": ["^build", "@shipfox/api-workspaces#test"]
+    },
     "test:e2e": {
       "cache": false,
       "dependsOn": ["^build"]

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -25,10 +25,6 @@
       "cache": true,
       "dependsOn": ["^build"]
     },
-    "@shipfox/api-projects#test": {
-      "cache": true,
-      "dependsOn": ["^build", "@shipfox/api-workspaces#test"]
-    },
     "test:e2e": {
       "cache": false,
       "dependsOn": ["^build"]


### PR DESCRIPTION
## Summary
- Scope definitions publisher registry drain assertions to the test project ID.
- Stop `@shipfox/api-projects` test setup from migrating/truncating workspaces-owned tables.
- This removes the shared `api_test` database race where projects setup could cascade-delete workspaces memberships while workspaces tests were still running.

## Validation
- `mise exec -- pnpm --filter=@shipfox/api-definitions test`
- `mise exec -- pnpm --filter=@shipfox/api-definitions check`
- `mise exec -- pnpm --filter=@shipfox/api-definitions type`
- `mise exec -- pnpm --filter=@shipfox/api-projects test`
- `mise exec -- pnpm --filter=@shipfox/api-projects check`
- `mise exec -- turbo test --force --filter=@shipfox/api-workspaces --filter=@shipfox/api-projects`
- `git diff --check`