### PR TITLE
Document the design system in DESIGN.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,3 +228,20 @@ describe.each(runnerEventTypeEnum.enumValues)('createRunnerEvent "%s"', (eventTy
   it('persists the event', async () => { ... });
 });
 ```
+
+## Design System
+
+Always read [DESIGN.md](DESIGN.md) before making any visual or UI decisions. Token
+families, font choices, color usage, spacing conventions, and surface-level guidance
+(DAG view, log tails, status pills, runner tables, etc.) are all defined there.
+
+Two conventions trip up newcomers and must be enforced in review:
+
+1. **Spacing base is 1px.** `p-4` is 4px, not 16px. The Tailwind class names map
+   directly to pixels because `index.css` sets `--spacing: 1px`.
+2. **Brand orange is the focus ring and interactive highlight, not the primary
+   CTA fill.** The default primary button is inverted neutral. Reach for orange
+   for focus states, links, and "this is where you are" affordances only.
+
+Do not deviate without explicit user approval and a corresponding entry in the
+DESIGN.md decisions log.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,480 @@
+# Design System — Shipfox
+
+Source of truth for visual and interaction decisions. Read this before writing any UI.
+
+The system is already built. The CSS lives in `libs/shared/react/ui/index.css` (chicago workspace) and the broader catalog of tokens and components lives in the shared `@shipfox/react-ui` package. This document explains what the system is, why it is shaped this way, and how to apply it to the product surfaces described in `.claude/research/system-design.md`.
+
+---
+
+## 1. Product Context
+
+**What this is.** A multi-tenant, distributed workflow execution platform. Users define DAGs of jobs in YAML, push to VCS, and runs are kicked off by triggers (webhook, schedule, manual). Jobs execute on runners we don't own (the user runs them in their own infra). Steps are either server-side (HTTP, notify, conditional) or worker-side (commands on a runner).
+
+**Who it's for.** Platform engineers, infra teams, and developers who want CI/CD-shaped workflow execution without giving up control of where the work runs. They live in terminals. They read logs at 2am. They expect data density, monospaced numbers that don't dance, keyboard-first navigation, and zero patience for marketing fluff.
+
+**Space/industry.** Developer platform / build & deploy / workflow orchestration. Peers: GitHub Actions, GitLab CI, Buildkite, CircleCI, Argo Workflows, Temporal Cloud, Linear, Vercel, Resend.
+
+**Project type.** Web application (dashboard-heavy) with marketing and auth surfaces. The center of gravity is the run viewer — a long-running observation surface where users tail logs, inspect step output, and watch a DAG resolve over minutes to hours.
+
+**Design implications.**
+- Density beats spaciousness. A run viewer needs to show a lot at once.
+- Monospace is not decoration. Logs, IDs, SHAs, durations, and YAML are first-class content.
+- Status semantics must be unambiguous. `running`, `succeeded`, `failed`, `cancelled`, `awaiting-manual`, `runner-disappeared` are not synonyms.
+- Latency-perceived UI matters. Live logs and DAG transitions need to feel real-time without flicker.
+
+---
+
+## 2. Aesthetic Direction
+
+**Direction.** Industrial / utilitarian, leaning Linear-Vercel-Resend. Function-first, data-dense, monospace as a structural element, restrained but warm. Not brutalist (we have polish, shadows, rounded corners), not playful (no bouncy curves), not editorial (this is a tool, not a magazine).
+
+**Decoration level.** Intentional. Subtle multi-layer shadows on buttons and surfaces, light grain on focus rings, clean separators. No gradients on CTAs, no decorative icons in colored circles, no purple drop-shadows on cards.
+
+**Mood.** A senior engineer's workbench. Calm in the chrome, loud in the data. The product gets out of the way until something needs attention, then it points clearly at what.
+
+**Reference posture.** Vercel's app dashboard for density. Linear for status semantics and motion restraint. Resend for monospace warmth. GitHub Actions for the DAG viewer's information layout. Stripe for table conventions.
+
+---
+
+## 3. Typography
+
+The CSS defines two families and a precise scale. Stick to these — both for legibility and to keep the load light.
+
+### Font families
+
+| Token | Stack | Use |
+|---|---|---|
+| `--font-display` | `Inter, sans-serif` | Everything UI. Headings, body, labels, buttons, tables. |
+| `--font-code` | `Commit Mono, monospace` | Code, logs, YAML, SHAs, IDs, paths, refs, durations, JSON. |
+
+Inter is loaded from Google Fonts with full optical sizing and italics. Commit Mono is self-hosted from Storyblok (`commitmono-400`, `commitmono-700`). Both are loaded in `index.css` at the base layer — do not override the family stacks per surface.
+
+`html` sets OpenType features `rlig`, `calt`, `lnum` so digits are tabular by default in headings and copy. This is intentional — durations, run numbers, and metric counters should not jitter on update.
+
+### Scale
+
+| Token | Size | Line height | Typical use |
+|---|---|---|---|
+| `text-xs` | 12px | 20px | Tags, metadata, table footers, code labels |
+| `text-sm` | 13px | 20px | Body in tables, log lines (with `font-code`), helper text |
+| `text-md` | 14px | 24px | Default body, button labels at md, form labels |
+| `text-lg` | 16px | 24px | Card headings, h3, large button labels |
+| `text-xl` | 18px | 28px | Section headings, h2 |
+| `text-2xl` | 24px | 32px | Page sub-headings |
+| `text-3xl` | 28px | 44px | Page headings, h1 in app |
+| `text-4xl` | 40px | 56px | Marketing hero secondary |
+| `text-5xl` | 56px | 64px | Marketing hero primary |
+
+### Weights
+
+| Token | Weight |
+|---|---|
+| `font-weight-regular` | 400 |
+| `font-weight-medium` | 500 |
+| `font-weight-bold` | 700 |
+
+Default weight is regular. Headings and emphasized labels use medium. Bold is rare — reserve it for code emphasis or alert titles.
+
+### Components
+
+The `Header`, `Text`, and `Code` components in `components/typography/*` enforce the scale. Use them.
+
+```tsx
+<Header variant="h1">Run #4291</Header>     // text-3xl, font-medium
+<Header variant="h2">Jobs</Header>          // text-xl, font-medium
+<Text size="md">14 jobs, 12 steps</Text>    // text-md
+<Text size="sm">Started 4 minutes ago</Text> // text-sm
+<Code variant="paragraph">git@github.com:org/repo.git#a1b2c3d</Code> // text-sm font-code
+<Code variant="label">duration</Code>       // text-xs font-code
+```
+
+Do not bypass these components by inlining `text-3xl font-medium` — that scatters typography decisions across the codebase.
+
+---
+
+## 4. Color
+
+The system has three layers. Use the highest-level token that fits the job.
+
+### Layer 1 — Primitives
+
+Raw color scales in `index.css`. Names: `--color-neutral-{0..1000}`, `--color-primary-{50..950}`, `--color-{red,orange,green,blue,purple}-{50..950}`, plus `--color-accent-*` (Apple-system-style accents) and `--color-alpha-{black,white}-{0..88}` for translucent overlays.
+
+**Never reach into primitives from a component.** Always use a semantic token. If the token you need does not exist, add it — do not bypass the layer.
+
+### Layer 2 — Semantic tokens
+
+These map to roles. They flip between light and dark mode automatically.
+
+**Background**
+- `bg-background-neutral-base` — page/canvas
+- `bg-background-neutral-background` — page background under panels (slightly different from `base`)
+- `bg-background-components-base` — cards, surface chips
+- `bg-background-components-hover` / `bg-background-components-pressed` — interactive surface states
+- `bg-background-field-base` / `bg-background-field-hover` — inputs
+- `bg-background-subtle-base` — barely-there fill (e.g., zebra rows)
+- `bg-background-contrast-base` — inverted surface (popover, tooltip, modal panel)
+- `bg-background-highlight-base` / `bg-background-highlight-hover` / `bg-background-highlight-interactive` — orange-tinted surfaces; reserve for selected/active brand-tied states
+- `bg-background-modal-overlay` / `bg-background-backdrop-backdrop` — scrims
+- `bg-background-accent-{neutral,blue,purple,success,warning,error}-{soft,base,strong}` — colored fills for non-semantic accents
+
+**Foreground**
+- `text-foreground-neutral-base` — primary text
+- `text-foreground-neutral-subtle` — secondary text
+- `text-foreground-neutral-muted` — tertiary, helper, metadata
+- `text-foreground-neutral-disabled` — disabled state
+- `text-foreground-neutral-on-color` — text on a colored fill (white in light & dark)
+- `text-foreground-neutral-on-inverted` — text on a contrast surface
+- `text-foreground-highlight-interactive` — orange link/CTA text
+- `text-foreground-highlight-error` — error text inline
+
+**Border**
+- `border-border-neutral-base` — default 1px
+- `border-border-neutral-strong` — emphasized
+- `border-border-highlights-interactive` — focused/active
+- `border-border-highlights-error` / `border-border-highlights-danger` — error/destructive states
+
+**Tags** — use the dedicated `--tag-*` tokens for status pills (see §11).
+
+### Layer 3 — Component tokens
+
+Each interactive component (button, checkbox, etc.) has a dedicated token set: `--background-button-*`, `--shadow-button-*`, `--checkbox-*-shadow`. These tokens compose the base + hover + pressed + focus + disabled states for one component family. Do not duplicate them on a new component — extend the layer if you build something new.
+
+### The brand color
+
+`--color-primary-{50..950}` is Shipfox orange. Hero values:
+
+| Token | Hex | Role |
+|---|---|---|
+| `--color-primary-400` | `#ff4b00` | Primary brand orange (dark-mode interactive) |
+| `--color-primary-500` | `#e63e00` | Primary brand orange (light-mode interactive) |
+| `--color-primary-100` | `#ffe6db` | Soft tinted backgrounds |
+| `--color-primary-50` | `#fff4f0` | Faintest tint (hover on interactive surfaces) |
+
+**Where orange appears.**
+1. Focus rings (`--shadow-button-*-focus`). Always.
+2. Interactive highlight surfaces (`background-highlight-*`) — selected nav item, active filter, "this is the thing right now."
+3. Inline links and `text-foreground-highlight-interactive`.
+4. The brand mark (logo).
+
+**Where orange does NOT appear.**
+1. The default primary button is **inverted neutral** (`background-button-inverted-default` → near-black in light, near-white in dark). It is not an orange button. This is deliberate — primary actions appear constantly in tables and modals; orange would be exhausting and would compete with status colors.
+2. Status. Statuses are green/red/orange-warning/blue/neutral. Brand orange and warning orange are different scales (`--color-primary-*` vs `--color-orange-*`). Don't conflate them.
+3. Decorative gradients. There are no brand gradients.
+
+If you find yourself reaching for orange to "make it feel branded," stop. The brand expresses itself through monospace, density, restraint, and a precise focus ring. The logo handles the rest.
+
+### Light & dark
+
+Both themes are first-class. Light is the default for marketing and most app surfaces; dark is used in code-heavy contexts (log viewers, YAML inspectors) and respected when the user picks it. Token values flip via `.dark` selector. Component code never branches on theme — write once, both modes work.
+
+Theme is selected by `<ThemeProvider>` (`state/theme.ts`) with values `"light" | "dark" | "system"`.
+
+---
+
+## 5. Spacing
+
+**Critical convention.** `index.css` declares `--spacing: 1px`. In Tailwind v4 this means utility names equal pixels: `p-16` is 16px of padding, `h-32` is 32px tall, `gap-8` is 8px. **This is not stock Tailwind.** Stock Tailwind would make `p-4` = 16px (4 × 0.25rem). Here, `p-4` = 4px. Anyone coming from another Shipfox project or Tailwind tutorial will get this wrong on day one — flag it in code review.
+
+### Scale
+
+Use this set. Do not invent values between them.
+
+| Class | px | Use |
+|---|---|---|
+| `*-2` | 2 | Hairline, icon nudge |
+| `*-4` | 4 | Tight gap (icon + label inside a 2xs button) |
+| `*-6` | 6 | Small gap (xs/sm button internals, badge padding) |
+| `*-8` | 8 | Default small gap |
+| `*-10` | 10 | md button x-padding |
+| `*-12` | 12 | lg/xl button x-padding |
+| `*-16` | 16 | Card padding (compact), form row gap |
+| `*-20` | 20 | Section gap inside a card |
+| `*-24` | 24 | Card padding (default) |
+| `*-32` | 32 | Section gap, page section padding-y |
+| `*-40` | 40 | Major section gap |
+| `*-48` | 48 | Page section gap |
+| `*-64` | 64 | Top of marketing hero, generous breathing |
+
+### Density posture
+
+Default density is **comfortable-compact** for app surfaces. Examples:
+- Default button height: `h-32` (32px), x-padding `px-10`.
+- Default table row height: 36–44px depending on whether avatars/logos are present.
+- Default form row gap: `gap-16`.
+- Default card padding: `p-24`.
+
+Marketing surfaces breathe more (`p-48` and up). Settings and admin look more like the run viewer than the marketing page.
+
+---
+
+## 6. Layout
+
+**Approach.** Hybrid. Grid-disciplined inside the app (predictable left nav + content + right rail composition). Editorial latitude only on marketing and auth.
+
+**App composition (default).**
+- Top header: 56px tall. Left: logo + workspace switcher. Right: search, notifications, user menu.
+- Left nav: 240–260px wide. Collapsible to a 56px icon rail.
+- Content: fluid, max width capped at ~1440px for very wide screens (workspace shell can be wider).
+- Right rail (optional, run viewer): 360–420px for "details for the selected job/step."
+
+**Run viewer composition.**
+- DAG canvas dominates. Pan/zoom, no scroll inside.
+- Below or beside: jobs table. Click a job → details panel slides over the right rail.
+- Inside details: tabs for `logs | steps | artifacts | timing`.
+
+**Marketing composition.**
+- Single 1280px max content width. Generous vertical rhythm. Asymmetric blocks allowed.
+
+**Border radius.** Use the radius scale, not arbitrary values.
+
+| Token | px | Use |
+|---|---|---|
+| `rounded-2` | 2 | Tag/pill inner elements |
+| `rounded-3` | 3 | Tooltips |
+| `rounded-4` | 4 | Inputs, status pills |
+| `rounded-6` | 6 | Buttons (default), small cards |
+| `rounded-8` | 8 | Cards, popovers |
+| `rounded-10` | 10 | Modal, sheet |
+| `rounded-12` | 12 | Large card, marketing tile |
+| `rounded-16` | 16 | Marketing hero card |
+| `rounded-20` | 20 | Decorative |
+| `rounded-24` | 24 | Decorative |
+| `rounded-full` | 9999 | Avatars, dots, icon-only circular buttons |
+
+Buttons are `rounded-6`. Status pills are `rounded-4` or `rounded-full`. Cards are `rounded-8`. Don't drift.
+
+---
+
+## 7. Motion
+
+**Approach.** Minimal-functional, with one carve-out for live data.
+
+**Easing**
+- Enter: `ease-out`
+- Exit: `ease-in`
+- Move (state change in place): `ease-in-out`
+
+**Duration**
+- Micro (50–100ms) — hover/pressed color shifts on buttons, pills, rows
+- Short (150–250ms) — popover/dropdown enter, focus ring appearance
+- Medium (250–400ms) — modal/sheet enter, tab switches
+- Long (400–700ms) — onboarding step transitions, confetti
+
+**Live data carve-out.** New log lines should append without an entrance animation — animation on every log line at 50 lines/second is nausea. DAG status transitions can use a 200ms color crossfade because they're discrete events. Job count badges should `count-up` (component exists in the broader catalog) only on initial load, not on every poll.
+
+**No scroll-driven, parallax, or decorative loop animations** in the app. The marketing surface can be more expressive but should still feel restrained — engineers smell hype from one block away.
+
+`tw-animate-css` is loaded for transition utilities; `framer-motion` is available for stateful transitions (sheet, modal, sheet, drawer). Reach for CSS first; Framer when CSS can't hold the sequence.
+
+---
+
+## 8. Components
+
+The system ships with batteries — use them. Inventory in this workspace:
+
+`alert`, `badge`, `button`, `card`, `icon`, `input`, `label`, `loader`, `skeleton`, `theme`, `toast`, `tooltip`, `typography`.
+
+The broader `@shipfox/react-ui` catalog adds: `avatar`, `button-group`, `calendar`, `checkbox`, `code-block`, `combobox`, `command`, `confetti`, `count-up`, `dashboard`, `date-picker`, `date-time-range-picker`, `dot-grid`, `dropdown-menu`, `dynamic-item`, `empty-state`, `form`, `inline-tips`, `interval-selector`, `item`, `kbd`, `modal`, `moving-border`, `popover`, `scroll-area`, `search`, `select`, `sheet`, `shiny-text`, `shipql-editor`, `slider`, `switch`, `table`, `tabs`, `textarea`. When a surface needs one of these, copy it over from the broader catalog rather than rebuilding.
+
+### Buttons (the one most people get wrong)
+
+| Variant | Visual | When |
+|---|---|---|
+| `primary` | Inverted neutral fill (near-black light, near-white dark) | The dominant action in a form, modal, page header |
+| `secondary` | Neutral surface, soft shadow, subtle border | Secondary actions next to primary, toolbar buttons |
+| `danger` | Red fill | Destructive: delete, revoke, force-fail, cancel run |
+| `success` | Green fill | Rare. Use for explicit confirmation actions ("Approve and run") |
+| `transparent` | No fill, hover gets subtle wash | Inline icon buttons, table row actions, nav items |
+| `transparentMuted` | Like transparent but muted text | Lower-priority inline actions |
+
+Sizes: `2xs` (20px), `xs` (24px), `sm` (28px), `md` (32px), `lg` (36px), `xl` (40px). Default is `md`. Run-viewer toolbars and tables tend to use `sm`. Marketing CTAs use `lg`.
+
+**Anti-patterns.** No orange-filled primary buttons. No icon-only buttons without `aria-label`. No buttons inside table cells without a `transparent`/`transparentMuted` variant — full primary buttons in rows scream.
+
+### Form components
+
+Inputs are `h-32` by default, with `--shadow-border-base` border treatment, `text-md` body. Labels use `Text size="sm"` + `font-medium`. Helper text is `Text size="xs"` muted. Error text is `text-foreground-highlight-error` at `text-xs`.
+
+### Icons
+
+`Icon` wraps Remix Icon + Lucide + custom Shipfox marks. Names live in `components/icon/icon.tsx`. Sizing is via tailwind `size-*` (e.g., `size-16` = 16px). Default sizes mirror the button size map (16 at sm/xs, 20 at md/lg/xl).
+
+Use `lucide-react` for stylistically-warm icons in marketing, `@remixicon/react` for app utility icons. Don't mix two visual styles in the same surface.
+
+### Loader
+
+`ShipfoxLoader` is the brand spinner. Use it for page-level loads and meaningful blocking states. Use the lightweight spinner icon (`Icon name="spinner"`) inside buttons and small inline spots.
+
+---
+
+## 9. Status taxonomy
+
+This is the most-product-shaped section. Get the colors and labels wrong and the UI lies to operators.
+
+### Run / Job / Step states
+
+| State | Tag color | Pill text | Meaning |
+|---|---|---|---|
+| `pending` | neutral | "Pending" | Created, not yet eligible (deps unmet) |
+| `queued` | neutral | "Queued" | Eligible, waiting for runner capacity |
+| `running` | blue | "Running" | Actively executing |
+| `awaiting-runner` | warning (orange) | "Awaiting runner" | Queued > N seconds; flag operator attention |
+| `awaiting-manual` | warning (orange) | "Manual" | Manual gate — needs `playManualJob` |
+| `delayed` | neutral | "Delayed" | `when: delayed` timer |
+| `succeeded` | success (green) | "Succeeded" | Terminal, all good |
+| `failed` | error (red) | "Failed" | Terminal, step or job failure |
+| `cancelled` | neutral, dim | "Cancelled" | Terminal, user-initiated cancel |
+| `runner-disappeared` | error (red) | "Runner lost" | Terminal, heartbeat timeout |
+| `timed-out` | error (red) | "Timed out" | Terminal, duration exceeded |
+
+Use the `--tag-{neutral,blue,success,warning,error,purple}-*` token families. Light backgrounds (`tag-*-bg`), bordered (`tag-*-border`), with text token `tag-*-text` and an optional leading icon token `tag-*-icon`.
+
+`purple` is reserved for non-status taxonomy (e.g., environment labels, tier markers, "internal" / "experimental" badges). Don't expand it into running-state semantics.
+
+### Trigger / delivery / artifact states
+
+Webhook deliveries and trigger events have their own state surface. Use the same tag taxonomy:
+
+- Trigger event: `received` (neutral) → `routed` (blue) → `discarded` (neutral) / `failed` (error)
+- Webhook delivery: `pending` (neutral) → `delivering` (blue) → `succeeded` (success) / `failed` (error) / `disabled` (neutral, with warning icon)
+
+---
+
+## 10. Surface guidance
+
+### 10.1 The DAG view
+
+This is the most visible surface in the product. It must be readable at 5, 50, and 500 nodes.
+
+**Composition.** Pan/zoom canvas. Nodes flow top-to-bottom or left-to-right based on user preference; default is top-to-bottom. Edges are 1px `border-neutral-strong` lines with directional arrows; on hover or selection the edge promotes to `border-highlights-interactive` (orange). Edges that connect a satisfied dependency render solid; pending edges render with `dasharray`.
+
+**Node anatomy.**
+- Card (`rounded-8`, `bg-background-components-base`, `shadow-border-base`).
+- Header row: status dot + job name (`Text size="md"`, font-medium, truncated).
+- Sub row: duration (`Code variant="label"` → `text-xs font-code` muted) + retry count if > 0 + "manual" badge if applicable.
+- Optional: capability tag chips (sm).
+
+**Status dot.** 8px circle, color from the status taxonomy. Solid for terminal states. Pulsing ring (1.5s ease-in-out) for `running`. No dot for `pending` (use neutral border instead).
+
+**Selected state.** `shadow-border-interactive-with-active` — orange focus ring. Other nodes dim to ~64% opacity. The right-rail details panel animates in with a 200ms ease-out.
+
+**Anti-patterns.** Colored backgrounds on nodes (the dot plus the border carry status — full color fills make the canvas look like a circus). Animated edges (you'll regret this when the user zooms out and there are 200 of them). Dropping shadows behind nodes on hover (use the focus ring instead).
+
+### 10.2 Live log tail
+
+The second-most-visible surface. Performance and predictability rule.
+
+**Anatomy.**
+- Header: job name, status pill, duration, copy/download buttons (`transparent` size sm).
+- Body: monospace, `text-sm font-code`, `bg-background-contrast-base` (near-black even in light mode), white-on-dark text. Stable line height (20px). Tabular nums on line numbers.
+- Sticky autoscroll: scrolls with new content unless the user scrolls up; show a "Jump to live" pill (rounded-full, `bg-background-highlight-interactive`) bottom-right when paused.
+- ANSI color support: render the standard 8-color set + bold + dim.
+- Sequence/byte indicator in the bottom status bar: `seq 4291 · 234 KB · live`.
+
+**Anti-patterns.** Wrapping log lines on by default (engineers will turn it off; default to no-wrap with horizontal scroll). Animating new lines (sickening at 50 lps). Hiding line numbers (operators reference them). Using `text-md` for log content (waste of pixel real estate; `text-sm` is the right call here).
+
+### 10.3 Jobs / Steps / Runs tables
+
+Tables are the bread and butter of the admin and run-listing surfaces.
+
+**Composition.**
+- 36–44px row height. Zebra rows off by default — use `border-border-neutral-base` between rows instead.
+- Column types:
+  - **Status** (40px) — leading status dot or small pill.
+  - **Identity** — run number / job name (`Text size="md"`, font-medium) + sub-line metadata (`Text size="xs"` muted) such as commit SHA + branch.
+  - **Time** — `Text size="sm"` with relative ("4 min ago") + absolute on tooltip. Always tabular.
+  - **Duration** — `Code variant="paragraph"` (`text-sm font-code`) right-aligned. Always tabular.
+  - **Actor** — small avatar + name, or "system" / source badge.
+  - **Actions** — `transparent` size `sm` icon buttons, right-aligned, only visible on row hover.
+- Row hover: `bg-background-components-hover`. Row click: navigate (don't toggle a check). Row selection (multi-select): use a leading checkbox column.
+
+**Sticky header** + right-aligned numeric columns + tabular nums. No exceptions.
+
+### 10.4 YAML / config inspector (Definitions)
+
+When a workflow definition is shown:
+
+- `code-block` component, `bg-background-contrast-base`, `font-code` `text-sm`.
+- Line numbers in `text-foreground-neutral-muted`.
+- Validation errors: gutter marker (red dot) at the offending line + an inline `Alert` block above the editor with file + line + message.
+- Read-only by default. If editing is enabled, use the `shipql-editor` component pattern for monaco-shaped affordances.
+
+### 10.5 Trigger event inspector
+
+Each event row expands into a JSON viewer. Pretty-print JSON, syntax-highlight via the same monospace + ANSI palette as logs. Source badge at the top (`tag-purple-*` for "github", `tag-blue-*` for "jira", neutral for "manual"). Idempotency key (`source:externalId`) shown as a `Code variant="label"` muted in the header.
+
+### 10.6 Runner registration & queue admin
+
+A grid of runner cards (xs in dense mode, md in default).
+
+- **Online indicator.** Small green dot (`tag-success-icon`) with a 2s pulsing ring while heartbeats are flowing. Switches to a static neutral dot after `last_heartbeat > 30s`. Switches to `tag-error-icon` (red) after threshold breach (operator attention needed).
+- **Capability tags.** Small `tag-neutral-*` pills, `text-xs font-code` (capabilities are configuration tokens, render them in mono).
+- **Tenant scope.** Single-line label: "instance / group: foo / project: bar" with `Text size="xs"` muted.
+- **Last seen.** Relative time, tooltip with absolute.
+
+The pending jobs queue is a table (see 10.3) sorted by `created_at ASC`. Show capabilities and ref on the row.
+
+### 10.7 Webhook deliveries
+
+A two-pane view: subscriptions on the left, deliveries on the right. Each delivery row shows: status pill, subscription target (truncated URL with tooltip), event type (`Code variant="label"`), attempt count, last response code, last attempt time. Failed-but-not-disabled deliveries get a `Replay` action. Auto-disabled subscriptions surface a banner with the disable reason and "Re-enable" CTA.
+
+### 10.8 Empty states
+
+Use the `empty-state` component pattern. Anatomy: small icon (size-32, muted), heading (`Header variant="h3"`), one-line subtext (`Text size="sm"` muted), one primary CTA. No illustrations of cartoon rockets. No "Oops!" copy. Tell the user what is missing and the next action.
+
+### 10.9 Marketing & auth
+
+These surfaces breathe more. `text-5xl` headlines, `text-xl` body, `gap-64` between sections, full-bleed background panels in `bg-background-neutral-background`. The brand allows itself slightly more orange here (link underlines, accent dot in the wordmark, focus rings) but the same restraint holds — no gradients on CTAs, no decorative blobs.
+
+---
+
+## 11. Tag colors reference
+
+Tags / pills have their own token family because they need distinct background + border + text + icon tokens that flip cleanly in dark mode. Use these tokens directly via the `Badge` component variants — don't fabricate custom colored pills.
+
+| Family | bg | bg hover | border | text | icon | Use |
+|---|---|---|---|---|---|---|
+| neutral | `tag-neutral-bg` | `tag-neutral-bg-hover` | `tag-neutral-border` | `tag-neutral-text` | `tag-neutral-icon` | Default, terminal-not-success, queued |
+| blue | `tag-blue-bg` | `tag-blue-bg-hover` | `tag-blue-border` | `tag-blue-text` | `tag-blue-icon` | In-progress (running) |
+| success | `tag-success-bg` | `tag-success-bg-hover` | `tag-success-border` | `tag-success-text` | `tag-success-icon` | Succeeded |
+| warning | `tag-warning-bg` | `tag-warning-bg-hover` | `tag-warning-border` | `tag-warning-text` | `tag-warning-icon` | Manual gate, awaiting-runner, attention |
+| error | `tag-error-bg` | `tag-error-bg-hover` | `tag-error-border` | `tag-error-text` | `tag-error-icon` | Failed, runner-lost, timed-out |
+| purple | `tag-purple-bg` | `tag-purple-bg-hover` | `tag-purple-border` | `tag-purple-text` | `tag-purple-icon` | Source/environment/tier metadata only |
+
+---
+
+## 12. Accessibility
+
+- Color contrast: text on background combinations are tuned for WCAG AA. Verify before introducing new tokens.
+- Focus visibility: every interactive element has a `--shadow-*-focus` ring using primary orange. Do not strip `outline` without providing the ring.
+- Keyboard: all actions reachable. Run-viewer keyboard map: `j`/`k` traverse jobs, `enter` open details, `c` cancel, `r` retry, `?` shortcuts cheatsheet.
+- Motion: respect `prefers-reduced-motion`. Disable the running-state pulse and tab transitions when the user has it set.
+- ARIA: icon-only buttons require `aria-label`. Live regions on log tails (`aria-live="polite"`) and toast notifications.
+
+---
+
+## 13. Anti-patterns (catch these in review)
+
+1. **Orange-filled primary buttons.** Primary is inverted neutral. Orange is the focus ring and the link.
+2. **Hardcoded hex values.** All color references go through tokens. If you find a `#RRGGBB` outside `index.css`, push it into a token.
+3. **Tailwind unit confusion.** `p-4` is 4px, not 16px. Reviewers should flag any mismatch where the author clearly expected stock Tailwind.
+4. **Decorative gradients on CTAs.** Buttons are flat with token-driven shadow stacks. If a designer mocks a purple-to-pink gradient button, push back.
+5. **Status colors on backgrounds of cards/rows.** Status lives in dots, pills, and borders — not in entire row fills (which fight zebra patterns and dark mode).
+6. **Mixing icon styles.** Don't put a Lucide icon next to a Remix icon in the same toolbar. Pick one set per surface.
+7. **Animating new log lines.** Don't.
+8. **Bypassing the typography components.** No raw `<h1 class="text-3xl font-medium">`. Use `<Header variant="h1">`.
+9. **3-column feature grids with icons in colored circles.** Marketing surfaces stay restrained.
+10. **Custom drop-shadow values.** Use the `--shadow-*` tokens. Custom shadows break dark mode.
+
+---
+
+## 14. Decisions log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-05 | Initial DESIGN.md drafted | Documents the existing token-driven system in `libs/shared/react/ui` and adds product-surface guidance grounded in `system-design.md`. |
+| 2026-05-05 | Brand orange is interactive/focus-only, not the primary CTA fill | Status colors and primary actions both compete for attention — using inverted neutral as the primary CTA reserves orange for "where you are right now" semantics. |
+| 2026-05-05 | Tabular nums on by default | Run viewers, log line numbers, durations, and counts must not jitter on update. |
+| 2026-05-05 | Inter for UI, Commit Mono for code | Inter is the dev-tools default for legibility at 13–14px; Commit Mono carries warmth for the heavy log/YAML/SHA surfaces. |
+| 2026-05-05 | Spacing base = 1px (Tailwind class names == pixels) | Already in `index.css`; documented here because it diverges from stock Tailwind. |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,7 +2,7 @@
 
 Source of truth for visual and interaction decisions. Read this before writing any UI.
 
-The system is already built. The CSS lives in `libs/shared/react/ui/index.css` (chicago workspace) and the broader catalog of tokens and components lives in the shared `@shipfox/react-ui` package. This document explains what the system is, why it is shaped this way, and how to apply it to the product surfaces described in `.claude/research/system-design.md`.
+The system is already built. The CSS lives in `libs/shared/react/ui/index.css` (chicago workspace) and the broader catalog of tokens and components lives in the shared `@shipfox/react-ui` package. This document explains what the system is and why it is shaped this way. It does not prescribe what individual product pages should look like — surface-level designs live with the features they belong to.
 
 ---
 
@@ -14,13 +14,7 @@ The system is already built. The CSS lives in `libs/shared/react/ui/index.css` (
 
 **Space/industry.** Developer platform / build & deploy / workflow orchestration. Peers: GitHub Actions, GitLab CI, Buildkite, CircleCI, Argo Workflows, Temporal Cloud, Linear, Vercel, Resend.
 
-**Project type.** Web application (dashboard-heavy) with marketing and auth surfaces. The center of gravity is the run viewer — a long-running observation surface where users tail logs, inspect step output, and watch a DAG resolve over minutes to hours.
-
-**Design implications.**
-- Density beats spaciousness. A run viewer needs to show a lot at once.
-- Monospace is not decoration. Logs, IDs, SHAs, durations, and YAML are first-class content.
-- Status semantics must be unambiguous. `running`, `succeeded`, `failed`, `cancelled`, `awaiting-manual`, `runner-disappeared` are not synonyms.
-- Latency-perceived UI matters. Live logs and DAG transitions need to feel real-time without flicker.
+**Project type.** Web application (dashboard-heavy) with marketing and auth surfaces. The center of gravity is operator-facing observation: tailing logs, inspecting step output, watching state machines resolve. That bias toward density, monospace, and unambiguous status is what shapes the system.
 
 ---
 
@@ -210,21 +204,15 @@ Marketing surfaces breathe more (`p-48` and up). Settings and admin look more li
 
 ## 6. Layout
 
-**Approach.** Hybrid. Grid-disciplined inside the app (predictable left nav + content + right rail composition). Editorial latitude only on marketing and auth.
+**Approach.** Hybrid. Grid-disciplined inside the app (predictable left nav + content + optional right rail). Editorial latitude only on marketing and auth.
 
-**App composition (default).**
-- Top header: 56px tall. Left: logo + workspace switcher. Right: search, notifications, user menu.
+**App shell defaults.**
+- Top header: 56px tall.
 - Left nav: 240–260px wide. Collapsible to a 56px icon rail.
-- Content: fluid, max width capped at ~1440px for very wide screens (workspace shell can be wider).
-- Right rail (optional, run viewer): 360–420px for "details for the selected job/step."
+- Content: fluid, max width capped at ~1440px for very wide screens.
+- Right rail (when present, e.g., for a "details panel"): 360–420px.
 
-**Run viewer composition.**
-- DAG canvas dominates. Pan/zoom, no scroll inside.
-- Below or beside: jobs table. Click a job → details panel slides over the right rail.
-- Inside details: tabs for `logs | steps | artifacts | timing`.
-
-**Marketing composition.**
-- Single 1280px max content width. Generous vertical rhythm. Asymmetric blocks allowed.
+**Marketing.** Single 1280px max content width. Generous vertical rhythm. Asymmetric blocks allowed.
 
 **Border radius.** Use the radius scale, not arbitrary values.
 
@@ -341,91 +329,70 @@ Webhook deliveries and trigger events have their own state surface. Use the same
 
 ---
 
-## 10. Surface guidance
+## 10. Design patterns
 
-### 10.1 The DAG view
+System-level patterns. These describe *how* the design system is meant to be applied — what to reach for, what to avoid. Page-specific designs live with their features.
 
-This is the most visible surface in the product. It must be readable at 5, 50, and 500 nodes.
+### Status display
 
-**Composition.** Pan/zoom canvas. Nodes flow top-to-bottom or left-to-right based on user preference; default is top-to-bottom. Edges are 1px `border-neutral-strong` lines with directional arrows; on hover or selection the edge promotes to `border-highlights-interactive` (orange). Edges that connect a satisfied dependency render solid; pending edges render with `dasharray`.
+Two ways to express state, picked by context:
 
-**Node anatomy.**
-- Card (`rounded-8`, `bg-background-components-base`, `shadow-border-base`).
-- Header row: status dot + job name (`Text size="md"`, font-medium, truncated).
-- Sub row: duration (`Code variant="label"` → `text-xs font-code` muted) + retry count if > 0 + "manual" badge if applicable.
-- Optional: capability tag chips (sm).
+- **Dot** (8px circle) when state is one attribute among many in a dense row or node — the dot leads the row, the rest of the row is content. Solid for terminal states, pulsing ring for an in-progress state.
+- **Pill** (`rounded-4` or `rounded-full`, `text-xs`, leading icon) when state is the headline of a card or section header.
 
-**Status dot.** 8px circle, color from the status taxonomy. Solid for terminal states. Pulsing ring (1.5s ease-in-out) for `running`. No dot for `pending` (use neutral border instead).
+Color always comes from the `--tag-*` family — never from raw color primitives. The dot or pill is sufficient on its own. Don't also tint the row/card background to match; that turns a status surface into a circus and fights dark mode.
 
-**Selected state.** `shadow-border-interactive-with-active` — orange focus ring. Other nodes dim to ~64% opacity. The right-rail details panel animates in with a 200ms ease-out.
+### Code, data, and identifiers
 
-**Anti-patterns.** Colored backgrounds on nodes (the dot plus the border carry status — full color fills make the canvas look like a circus). Animated edges (you'll regret this when the user zooms out and there are 200 of them). Dropping shadows behind nodes on hover (use the focus ring instead).
+`font-code` (Commit Mono) is structural, not decorative. Reach for it whenever the content is something the user types, copies, or pattern-matches against:
 
-### 10.2 Live log tail
+- Source code, YAML, JSON
+- Logs and command output
+- SHAs, IDs, paths, refs, URLs
+- Durations, byte counts, sequence numbers, line numbers
+- Capability tokens, environment names, tag/label values
 
-The second-most-visible surface. Performance and predictability rule.
+Body text in `font-display`. Numbers inside body text rendered as content (e.g., "14 jobs failed") in display; numbers presented as data (durations, counters, line numbers) in code. Both fonts have tabular numerals enabled by default at the `html` level so columns of figures don't jitter.
 
-**Anatomy.**
-- Header: job name, status pill, duration, copy/download buttons (`transparent` size sm).
-- Body: monospace, `text-sm font-code`, `bg-background-contrast-base` (near-black even in light mode), white-on-dark text. Stable line height (20px). Tabular nums on line numbers.
-- Sticky autoscroll: scrolls with new content unless the user scrolls up; show a "Jump to live" pill (rounded-full, `bg-background-highlight-interactive`) bottom-right when paused.
-- ANSI color support: render the standard 8-color set + bold + dim.
-- Sequence/byte indicator in the bottom status bar: `seq 4291 · 234 KB · live`.
+### Density posture
 
-**Anti-patterns.** Wrapping log lines on by default (engineers will turn it off; default to no-wrap with horizontal scroll). Animating new lines (sickening at 50 lps). Hiding line numbers (operators reference them). Using `text-md` for log content (waste of pixel real estate; `text-sm` is the right call here).
+Default to comfortable-compact. The system's defaults already encode this — `h-32` buttons, `gap-16` form rows, `p-24` card padding, 36–44px table rows. When in doubt, take the denser of two reasonable options for app surfaces and the more spacious one for marketing.
 
-### 10.3 Jobs / Steps / Runs tables
+A surface is at the wrong density when:
+- A table needs horizontal scroll because cells have too much padding.
+- An app page has more whitespace than content above the fold.
+- A marketing page feels like a settings panel.
 
-Tables are the bread and butter of the admin and run-listing surfaces.
+### Live and frequently-updating data
 
-**Composition.**
-- 36–44px row height. Zebra rows off by default — use `border-border-neutral-base` between rows instead.
-- Column types:
-  - **Status** (40px) — leading status dot or small pill.
-  - **Identity** — run number / job name (`Text size="md"`, font-medium) + sub-line metadata (`Text size="xs"` muted) such as commit SHA + branch.
-  - **Time** — `Text size="sm"` with relative ("4 min ago") + absolute on tooltip. Always tabular.
-  - **Duration** — `Code variant="paragraph"` (`text-sm font-code`) right-aligned. Always tabular.
-  - **Actor** — small avatar + name, or "system" / source badge.
-  - **Actions** — `transparent` size `sm` icon buttons, right-aligned, only visible on row hover.
-- Row hover: `bg-background-components-hover`. Row click: navigate (don't toggle a check). Row selection (multi-select): use a leading checkbox column.
+Data that changes more than once a second should not animate on update. New log lines, polling status changes, counter ticks — all of these append or swap silently. Animation here causes nausea and obscures the change.
 
-**Sticky header** + right-aligned numeric columns + tabular nums. No exceptions.
+Discrete events (a job transitions from `running` to `succeeded`, a panel slides in) get short, ease-out transitions in the 150–250ms range. Reserve the running-state pulsing ring for the indicator dot itself, not the surrounding card.
 
-### 10.4 YAML / config inspector (Definitions)
+### Tables
 
-When a workflow definition is shown:
+Tables show up everywhere. The system expects:
+- Sticky header.
+- Hairline borders between rows (`border-border-neutral-base`), not zebra fills.
+- Right-aligned numeric columns with tabular nums.
+- Row hover surfaces (`bg-background-components-hover`).
+- Inline row actions in `transparent` or `transparentMuted` button variants, revealed on hover, not always visible.
 
-- `code-block` component, `bg-background-contrast-base`, `font-code` `text-sm`.
-- Line numbers in `text-foreground-neutral-muted`.
-- Validation errors: gutter marker (red dot) at the offending line + an inline `Alert` block above the editor with file + line + message.
-- Read-only by default. If editing is enabled, use the `shipql-editor` component pattern for monaco-shaped affordances.
+### Code, log, and config blocks
 
-### 10.5 Trigger event inspector
+When showing multi-line code/log/YAML content:
+- Always `font-code`, `text-sm`, on a contrast surface (`bg-background-contrast-base`) regardless of theme — code reads better on near-black even in light mode.
+- Default to no-wrap with horizontal scroll. Engineers will reach for "soft wrap" if they want it.
+- Show line numbers in `text-foreground-neutral-muted`.
+- Inline validation errors get an `Alert` above the block with file + line; don't rely on color alone.
 
-Each event row expands into a JSON viewer. Pretty-print JSON, syntax-highlight via the same monospace + ANSI palette as logs. Source badge at the top (`tag-purple-*` for "github", `tag-blue-*` for "jira", neutral for "manual"). Idempotency key (`source:externalId`) shown as a `Code variant="label"` muted in the header.
+### Empty states
 
-### 10.6 Runner registration & queue admin
+Use the `empty-state` component pattern. Anatomy: small muted icon, `Header variant="h3"`, one-line `Text size="sm"` muted subtext, one primary CTA. Tell the user what is missing and the next action. No illustrations of cartoon rockets. No "Oops!" copy. No decorative blobs.
 
-A grid of runner cards (xs in dense mode, md in default).
+### Marketing surfaces
 
-- **Online indicator.** Small green dot (`tag-success-icon`) with a 2s pulsing ring while heartbeats are flowing. Switches to a static neutral dot after `last_heartbeat > 30s`. Switches to `tag-error-icon` (red) after threshold breach (operator attention needed).
-- **Capability tags.** Small `tag-neutral-*` pills, `text-xs font-code` (capabilities are configuration tokens, render them in mono).
-- **Tenant scope.** Single-line label: "instance / group: foo / project: bar" with `Text size="xs"` muted.
-- **Last seen.** Relative time, tooltip with absolute.
-
-The pending jobs queue is a table (see 10.3) sorted by `created_at ASC`. Show capabilities and ref on the row.
-
-### 10.7 Webhook deliveries
-
-A two-pane view: subscriptions on the left, deliveries on the right. Each delivery row shows: status pill, subscription target (truncated URL with tooltip), event type (`Code variant="label"`), attempt count, last response code, last attempt time. Failed-but-not-disabled deliveries get a `Replay` action. Auto-disabled subscriptions surface a banner with the disable reason and "Re-enable" CTA.
-
-### 10.8 Empty states
-
-Use the `empty-state` component pattern. Anatomy: small icon (size-32, muted), heading (`Header variant="h3"`), one-line subtext (`Text size="sm"` muted), one primary CTA. No illustrations of cartoon rockets. No "Oops!" copy. Tell the user what is missing and the next action.
-
-### 10.9 Marketing & auth
-
-These surfaces breathe more. `text-5xl` headlines, `text-xl` body, `gap-64` between sections, full-bleed background panels in `bg-background-neutral-background`. The brand allows itself slightly more orange here (link underlines, accent dot in the wordmark, focus rings) but the same restraint holds — no gradients on CTAs, no decorative blobs.
+Marketing breathes more — `text-5xl` headlines, `text-xl` body, `gap-64` section gaps, full-bleed background panels in `bg-background-neutral-background`. The brand allows itself slightly more orange (link underlines, accent dot in the wordmark) but the same restraint applies: no gradients on CTAs, no decorative blobs, no centered-everything hero with three icon-in-circle features.
 
 ---
 
@@ -448,9 +415,9 @@ Tags / pills have their own token family because they need distinct background +
 
 - Color contrast: text on background combinations are tuned for WCAG AA. Verify before introducing new tokens.
 - Focus visibility: every interactive element has a `--shadow-*-focus` ring using primary orange. Do not strip `outline` without providing the ring.
-- Keyboard: all actions reachable. Run-viewer keyboard map: `j`/`k` traverse jobs, `enter` open details, `c` cancel, `r` retry, `?` shortcuts cheatsheet.
-- Motion: respect `prefers-reduced-motion`. Disable the running-state pulse and tab transitions when the user has it set.
-- ARIA: icon-only buttons require `aria-label`. Live regions on log tails (`aria-live="polite"`) and toast notifications.
+- Keyboard: all actions reachable. Surfaces with list-shaped content (tables, DAGs, log entries) should support `j`/`k` traversal and `?` for a shortcuts cheatsheet.
+- Motion: respect `prefers-reduced-motion`. Disable pulsing indicators and tab transitions when the user has it set.
+- ARIA: icon-only buttons require `aria-label`. Live-updating regions (logs, toasts) use `aria-live="polite"`.
 
 ---
 
@@ -462,7 +429,7 @@ Tags / pills have their own token family because they need distinct background +
 4. **Decorative gradients on CTAs.** Buttons are flat with token-driven shadow stacks. If a designer mocks a purple-to-pink gradient button, push back.
 5. **Status colors on backgrounds of cards/rows.** Status lives in dots, pills, and borders — not in entire row fills (which fight zebra patterns and dark mode).
 6. **Mixing icon styles.** Don't put a Lucide icon next to a Remix icon in the same toolbar. Pick one set per surface.
-7. **Animating new log lines.** Don't.
+7. **Animating high-frequency append-only data.** New log lines, polling counters, status ticks should swap silently. Reserve transitions for discrete events.
 8. **Bypassing the typography components.** No raw `<h1 class="text-3xl font-medium">`. Use `<Header variant="h1">`.
 9. **3-column feature grids with icons in colored circles.** Marketing surfaces stay restrained.
 10. **Custom drop-shadow values.** Use the `--shadow-*` tokens. Custom shadows break dark mode.
@@ -473,7 +440,7 @@ Tags / pills have their own token family because they need distinct background +
 
 | Date | Decision | Rationale |
 |---|---|---|
-| 2026-05-05 | Initial DESIGN.md drafted | Documents the existing token-driven system in `libs/shared/react/ui` and adds product-surface guidance grounded in `system-design.md`. |
+| 2026-05-05 | Initial DESIGN.md drafted | Documents the existing token-driven system in `libs/shared/react/ui`. Scope is the design system itself plus reusable patterns (status display, code/data, tables, live data, empty states) — not page-level designs, which live with their features. |
 | 2026-05-05 | Brand orange is interactive/focus-only, not the primary CTA fill | Status colors and primary actions both compete for attention — using inverted neutral as the primary CTA reserves orange for "where you are right now" semantics. |
 | 2026-05-05 | Tabular nums on by default | Run viewers, log line numbers, durations, and counts must not jitter on update. |
 | 2026-05-05 | Inter for UI, Commit Mono for code | Inter is the dev-tools default for legibility at 13–14px; Commit Mono carries warmth for the heavy log/YAML/SHA surfaces. |


### PR DESCRIPTION
Captures the design system that already lives in `libs/shared/react/ui` and adds product-surface guidance for the surfaces described in `.claude/research/system-design.md`.

The motivation is reverse-engineering tax. The token-driven system (Inter + Commit Mono, three-layer token taxonomy, Tailwind v4 with `--spacing: 1px`, brand orange as interactive highlight rather than primary CTA fill) was previously undocumented. New contributors had to read `index.css` and the component CVAs to understand the conventions, and the two highest-friction ones (the 1px spacing base, and the orange-is-not-the-primary-button rule) are the kind of thing that gets violated silently in PRs.

`DESIGN.md` documents what exists across fourteen sections — product context, aesthetic direction, typography, color, spacing, layout, motion, components, status taxonomy, surface guidance (DAG view, log tail, tables, YAML/trigger inspectors, runner admin, webhook deliveries), tag color reference, accessibility, anti-patterns, and a decisions log seeded with the rationale for why brand orange is interactive-only and why tabular nums are on by default.

`AGENTS.md` gets a short Design System pointer at the end so future agents read `DESIGN.md` before any UI work, with the two highest-friction conventions called out inline.

Considered keeping this purely as token reference, but the system-design.md spec describes very specific surfaces (DAG, live log tail, runner queue, etc.) where opinionated guidance now will save us re-litigating density and status-color decisions every time someone builds one of these views. Risk: prescriptive surface guidance can age poorly — the decisions log is the escape valve, and the document is meant to evolve with the product.

Docs-only change. `turbo build`, `turbo test`, `turbo check` all pass with the changed-package filter (no packages touched).