### PR TITLE
Add explicit workspace deps to E2E packages for Turbo DAG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ E2E setup must stay HTTP-first. Add module-owned setup routes under
 `/__e2e/<module>` and wrap them in `@shipfox/e2e-helper-*` helpers; do not create
 E2E data through direct database access.
 
+Each E2E package must also declare an explicit workspace dependency on the package
+it verifies, such as `@shipfox/client-auth` for `@shipfox/e2e-client-auth`, so
+Turbo includes the referenced package in the task DAG.
+
 ## Unit Testing Strategy (Node Apps)
 
 Tests use **Vitest** and run against a real PostgreSQL database, not mocks. The philosophy is to test against real infrastructure where possible and only mock external dependencies (feature flags, cloud provider APIs, etc.).

--- a/e2e/api/auth/package.json
+++ b/e2e/api/auth/package.json
@@ -13,6 +13,7 @@
     "type": "shipfox-tsc-check"
   },
   "devDependencies": {
+    "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",

--- a/e2e/client/auth/package.json
+++ b/e2e/client/auth/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/client-auth": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
     "@shipfox/playwright": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
 
   e2e/api/auth:
     devDependencies:
+      '@shipfox/api-auth':
+        specifier: workspace:*
+        version: link:../../../libs/api/auth
       '@shipfox/api-auth-dto':
         specifier: workspace:*
         version: link:../../../libs/api/auth-dto
@@ -200,6 +203,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/client-auth':
+        specifier: workspace:*
+        version: link:../../../libs/client/auth
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
E2E packages were missing direct workspace dependencies on the packages they verify. Without these, Turbo doesn't include the referenced packages in the task DAG when running scoped builds or tests (e.g. `--filter '...[origin/main]'`), meaning changes to `@shipfox/api-auth` or `@shipfox/client-auth` wouldn't trigger their E2E suites.

Adds `@shipfox/api-auth` to `e2e/api/auth` and `@shipfox/client-auth` to `e2e/client/auth`, and documents the requirement in `AGENTS.md` so it's enforced going forward.