### PR TITLE
Deploy react-ui Storybook to Vercel

### DIFF
--- a/libs/shared/react/ui/vercel.json
+++ b/libs/shared/react/ui/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo build && pnpm run storybook:build",
+  "devCommand": "pnpm run storybook",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
+}


### PR DESCRIPTION
Add a `vercel.json` to `libs/shared/react/ui` so the design system Storybook can be deployed and hosted on Vercel as a static site.

The config points Vercel at the existing `storybook:build` script and `storybook-static` output directory, with no framework override needed for a pure static build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `vercel.json` to deploy the `@shipfox/react-ui` Storybook to Vercel as a static site. Builds with `turbo build` then `pnpm run storybook:build`, disables framework detection (`framework: null`), and serves from `storybook-static`.

<sup>Written for commit e8e93a2ab044629dd22222a4a19dd8b0377d7595. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

