### PR TITLE
[react-ui] Fix Storybook theme switching

### DIFF
--- a/libs/shared/react/ui/.storybook/preview.tsx
+++ b/libs/shared/react/ui/.storybook/preview.tsx
@@ -2,9 +2,14 @@ import '../index.css';
 import type {Decorator, Preview} from '@storybook/react';
 import {ThemeProvider} from '#components/theme/index.js';
 
-const withTheme: Decorator = (Story, context) => (
-  <ThemeProvider defaultTheme={context.globals.theme}>{Story()}</ThemeProvider>
-);
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-theme-${theme}`}>
+      {Story()}
+    </ThemeProvider>
+  );
+};
 
 const preview: Preview = {
   decorators: [withTheme],


### PR DESCRIPTION
Fix Storybook theme switching for React UI component previews.

The Storybook decorator previously passed the selected global theme only as the ThemeProvider default. Once the provider mounted, changing the toolbar theme could leave previews stuck on the original theme because the provider state was not reset. Keying the provider by the selected theme remounts it when the global changes, and using a theme-specific storage key keeps persisted Storybook state from overriding the active toolbar selection.

This keeps light and dark Storybook previews responsive to the selected toolbar theme, including visual regression capture paths that rely on Storybook globals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Storybook theme switching so React UI previews update when the toolbar theme changes. The decorator now keys the `ThemeProvider` by `context.globals.theme` and sets a theme-specific `storageKey` (`shipfox-theme-${theme}`) to prevent persisted state from overriding the active selection.

<sup>Written for commit 156e574af0e8c48782bfad24132cf0dd2a5fb3f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

