### PR TITLE
Add E2E coverage for workspace creation and switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ vite.config.ts.timestamp-*
 # Playwright
 test-results/
 playwright-report/
+
+# Argos visual regression artifacts
+screenshots/

--- a/e2e/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/client/auth/tests/auth-client.e2e.ts
@@ -1,9 +1,7 @@
-import {randomUUID} from 'node:crypto';
 import {argosScreenshot} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const LOGIN_URL_RE = /\/auth\/login$/u;
-const WORKSPACE_INTEGRATIONS_URL_RE = /\/workspaces\/[^/]+\/integrations\/?$/u;
 
 test('redirects guests from the app root to login', async ({page}) => {
   await page.goto('/');
@@ -37,20 +35,4 @@ test('hydrates an E2E browser session from the refresh cookie after reload', asy
 
   await page.reload();
   await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
-});
-
-test('creates a workspace through the real onboarding UI', async ({page, auth}) => {
-  const user = await auth.createUser();
-  await auth.loginAs(page, user);
-  const workspaceName = `E2E Workspace ${randomUUID()}`;
-
-  await page.goto('/');
-  await page.getByLabel('Workspace name').fill(workspaceName);
-  await page.getByRole('button', {name: 'Create workspace'}).click();
-
-  // Fresh workspace has zero source-control connections, so the workspace home
-  // redirects to the scoped integration gallery.
-  await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
-  await expect(page.getByRole('heading', {name: 'Connect source control'})).toBeVisible();
-  await argosScreenshot(page, 'auth/setup-integrations');
 });

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@shipfox/e2e-client-workspaces",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./tests/*"
+  },
+  "scripts": {
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test:e2e": "shipfox-playwright-test",
+    "type": "shipfox-tsc-check"
+  },
+  "devDependencies": {
+    "@shipfox/api-workspaces": "workspace:*",
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/client-auth": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/client/workspaces/playwright.config.ts
+++ b/e2e/client/workspaces/playwright.config.ts
@@ -1,0 +1,32 @@
+import {config} from '@shipfox/e2e-core';
+import {defineConfig, devices} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  globalSetup: './tests/global-setup.ts',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        [
+          '@argos-ci/playwright/reporter',
+          {
+            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
+            buildName: 'client-workspaces',
+            ignoreUploadFailures: true,
+          },
+        ],
+      ]
+    : 'list',
+  use: {
+    baseURL: config.CLIENT_URL,
+    trace: 'retain-on-failure',
+    contextOptions: {reducedMotion: 'reduce'},
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/e2e/client/workspaces/tests/global-setup.ts
+++ b/e2e/client/workspaces/tests/global-setup.ts
@@ -1,0 +1,5 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck();
+}

--- a/e2e/client/workspaces/tests/test.ts
+++ b/e2e/client/workspaces/tests/test.ts
@@ -1,0 +1,9 @@
+import {test as base, expect} from '@shipfox/e2e-core/playwright';
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
+  ...authHelper,
+  ...workspacesHelper,
+});
+export {expect};

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -1,0 +1,166 @@
+import {randomUUID} from 'node:crypto';
+import {argosScreenshot} from '@shipfox/playwright';
+import {expect, test} from './test.js';
+
+const ONBOARDING_URL_RE = /\/setup\/workspaces\/new\/?$/u;
+const WORKSPACE_INTEGRATIONS_URL_RE = /\/workspaces\/[^/]+\/integrations\/?$/u;
+const CREATE_WORKSPACE_LABEL_RE = /Create workspace/u;
+const LAST_WORKSPACE_KEY = 'shipfox.lastWorkspaceId';
+
+function workspaceUrlRe(wid: string): RegExp {
+  return new RegExp(`/workspaces/${wid}(/|$)`, 'u');
+}
+
+async function readLastWorkspaceId(page: import('@shipfox/playwright').Page): Promise<string> {
+  const raw = await page.evaluate((key) => window.localStorage.getItem(key), LAST_WORKSPACE_KEY);
+  expect(raw, `localStorage[${LAST_WORKSPACE_KEY}]`).not.toBeNull();
+  return JSON.parse(raw as string) as string;
+}
+
+test('redirects a no-workspace user from / to onboarding', async ({page, auth}) => {
+  const user = await auth.createUser();
+  await auth.loginAs(page, user);
+
+  await page.goto('/');
+
+  await expect(page).toHaveURL(ONBOARDING_URL_RE);
+  await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
+  await expect(page.getByLabel('Workspace name')).toBeVisible();
+  await argosScreenshot(page, 'workspaces/onboarding-blank');
+});
+
+test('redirects a no-workspace user from a workspace deep-link to onboarding', async ({
+  page,
+  auth,
+}) => {
+  const user = await auth.createUser();
+  await auth.loginAs(page, user);
+
+  await page.goto(`/workspaces/${randomUUID()}`);
+
+  await expect(page).toHaveURL(ONBOARDING_URL_RE);
+  await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
+});
+
+test('creates the first workspace via onboarding and persists lastWorkspaceId', async ({
+  page,
+  auth,
+}) => {
+  const user = await auth.createUser();
+  await auth.loginAs(page, user);
+  const workspaceName = `E2E Workspace ${randomUUID()}`;
+
+  await page.goto('/');
+  await expect(page).toHaveURL(ONBOARDING_URL_RE);
+  await page.getByLabel('Workspace name').fill(workspaceName);
+  await page.getByRole('button', {name: 'Create workspace'}).click();
+
+  await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
+  await expect(page.getByRole('heading', {name: 'Connect source control'})).toBeVisible();
+  const url = new URL(page.url());
+  const wid = url.pathname.split('/')[2];
+  expect(wid).toBeTruthy();
+  expect(await readLastWorkspaceId(page)).toBe(wid);
+  await argosScreenshot(page, 'workspaces/onboarding-complete');
+});
+
+test('switches between workspaces from the top nav', async ({page, auth, workspaces}) => {
+  const user = await auth.createUser();
+  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  const wsB = await workspaces.create({userId: user.user.id, name: `B ${randomUUID()}`});
+  await auth.loginAs(page, user);
+
+  await page.goto(`/workspaces/${wsA.id}`);
+  await expect(page).toHaveURL(workspaceUrlRe(wsA.id));
+
+  await page.getByLabel('Switch workspace').click();
+  await argosScreenshot(page, 'workspaces/switcher-open');
+  await page.getByRole('option', {name: wsB.name}).click();
+
+  await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
+  await expect(page.getByRole('link', {name: wsB.name})).toBeVisible();
+  expect(await readLastWorkspaceId(page)).toBe(wsB.id);
+});
+
+test('persists the active workspace across reload and via /', async ({page, auth, workspaces}) => {
+  const user = await auth.createUser();
+  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  const wsB = await workspaces.create({userId: user.user.id, name: `B ${randomUUID()}`});
+  await auth.loginAs(page, user);
+
+  await page.goto(`/workspaces/${wsB.id}/integrations`);
+  await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
+
+  await page.reload();
+  await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
+
+  await page.goto('/');
+  await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
+  // Sanity: never landed on wsA.
+  expect(page.url()).not.toMatch(workspaceUrlRe(wsA.id));
+});
+
+test('creates a second workspace from the switcher mid-session', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  await auth.loginAs(page, user);
+
+  await page.goto(`/workspaces/${wsA.id}`);
+  await page.getByLabel('Switch workspace').click();
+  await expect(page.getByRole('option', {name: wsA.name})).toBeVisible();
+  await expect(page.getByRole('option', {name: CREATE_WORKSPACE_LABEL_RE})).toBeVisible();
+  await argosScreenshot(page, 'workspaces/switcher-single-with-create');
+
+  await page.getByRole('option', {name: CREATE_WORKSPACE_LABEL_RE}).click();
+  await expect(page).toHaveURL(ONBOARDING_URL_RE);
+
+  const newName = `B ${randomUUID()}`;
+  await page.getByLabel('Workspace name').fill(newName);
+  await page.getByRole('button', {name: 'Create workspace'}).click();
+
+  await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
+  const newWid = new URL(page.url()).pathname.split('/')[2];
+  expect(newWid).toBeTruthy();
+  expect(newWid).not.toBe(wsA.id);
+
+  // Switcher now lists both workspaces.
+  await page.getByLabel('Switch workspace').click();
+  await expect(page.getByRole('option', {name: wsA.name})).toBeVisible();
+  await expect(page.getByRole('option', {name: newName})).toBeVisible();
+  expect(await readLastWorkspaceId(page)).toBe(newWid);
+});
+
+test('routes a returning user with workspaces straight to /workspaces/$wid', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  await auth.loginAs(page, user);
+
+  // Record every URL the page transits through. The PR #23 regression was a
+  // brief flash of /setup/workspaces/new while auth-refresh resolved
+  // memberships; asserting only the final URL would let that flash slip
+  // past Playwright auto-wait.
+  const urlsSeen: string[] = [];
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      urlsSeen.push(frame.url());
+    }
+  });
+
+  await page.goto('/');
+  await expect(page).toHaveURL(workspaceUrlRe(wsA.id));
+
+  for (const url of urlsSeen) {
+    expect(url, `transit URL must not flash through onboarding: ${url}`).not.toMatch(
+      ONBOARDING_URL_RE,
+    );
+  }
+  await argosScreenshot(page, 'workspaces/returning-user-home');
+});

--- a/e2e/client/workspaces/tsconfig.json
+++ b/e2e/client/workspaces/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/e2e/helpers/workspaces/package.json
+++ b/e2e/helpers/workspaces/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@shipfox/e2e-helper-workspaces",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-workspaces": "workspace:*",
+    "@shipfox/api-workspaces-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/helpers/workspaces/src/index.ts
+++ b/e2e/helpers/workspaces/src/index.ts
@@ -1,0 +1,52 @@
+import type {
+  E2eCreateWorkspaceBodyDto,
+  E2eCreateWorkspaceResponseDto,
+} from '@shipfox/api-workspaces-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+export type {
+  E2eCreateWorkspaceBodyDto,
+  E2eCreateWorkspaceResponseDto,
+} from '@shipfox/api-workspaces-dto';
+
+export interface CreateWorkspaceParams {
+  userId: string;
+  name?: string;
+}
+
+function generateName(): string {
+  return `E2E Workspace ${crypto.randomUUID()}`;
+}
+
+export async function createWorkspace(
+  params: CreateWorkspaceParams,
+): Promise<E2eCreateWorkspaceResponseDto> {
+  const body: E2eCreateWorkspaceBodyDto = {
+    user_id: params.userId,
+    name: params.name ?? generateName(),
+  };
+  return await requestJson<E2eCreateWorkspaceResponseDto>('post', '/__e2e/workspaces', {
+    json: body,
+  });
+}
+
+export function createWorkspacesHelper() {
+  return {
+    create: createWorkspace,
+  };
+}
+
+export type WorkspacesHelper = ReturnType<typeof createWorkspacesHelper>;
+
+export interface WorkspacesFixtures {
+  workspaces: WorkspacesHelper;
+}
+
+export const workspacesHelper = {
+  workspaces: async (
+    {request: _request}: {request: unknown},
+    use: (helper: WorkspacesHelper) => Promise<void>,
+  ) => {
+    await use(createWorkspacesHelper());
+  },
+};

--- a/e2e/helpers/workspaces/tsconfig.build.json
+++ b/e2e/helpers/workspaces/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/workspaces/tsconfig.json
+++ b/e2e/helpers/workspaces/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/libs/api/workspaces-dto/src/schemas/e2e.ts
+++ b/libs/api/workspaces-dto/src/schemas/e2e.ts
@@ -1,0 +1,13 @@
+import {z} from 'zod';
+import {workspaceResponseSchema} from './workspace.js';
+
+export const e2eCreateWorkspaceBodySchema = z.object({
+  user_id: z.string().uuid(),
+  name: z.string().min(1).max(255),
+});
+
+export type E2eCreateWorkspaceBodyDto = z.infer<typeof e2eCreateWorkspaceBodySchema>;
+
+export const e2eCreateWorkspaceResponseSchema = workspaceResponseSchema;
+
+export type E2eCreateWorkspaceResponseDto = z.infer<typeof e2eCreateWorkspaceResponseSchema>;

--- a/libs/api/workspaces-dto/src/schemas/index.ts
+++ b/libs/api/workspaces-dto/src/schemas/index.ts
@@ -9,6 +9,12 @@ export {
   revokeApiKeyResponseSchema,
 } from './api-key.js';
 export {
+  type E2eCreateWorkspaceBodyDto,
+  type E2eCreateWorkspaceResponseDto,
+  e2eCreateWorkspaceBodySchema,
+  e2eCreateWorkspaceResponseSchema,
+} from './e2e.js';
+export {
   type AcceptInvitationBodyDto,
   type AcceptInvitationResponseDto,
   acceptInvitationBodySchema,

--- a/libs/api/workspaces/src/index.ts
+++ b/libs/api/workspaces/src/index.ts
@@ -1,6 +1,7 @@
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath} from '#db/index.js';
 import {createApiKeyAuthMethod} from '#presentation/auth/api-key-auth.js';
+import {workspacesE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {workspacesRoutes} from '#presentation/routes/index.js';
 
 export type {ApiKey} from '#core/entities/api-key.js';
@@ -19,4 +20,5 @@ export const workspacesModule: ShipfoxModule = {
   database: {db, migrationsPath},
   auth: [createApiKeyAuthMethod()],
   routes: workspacesRoutes,
+  e2eRoutes: [workspacesE2eRoutes],
 };

--- a/libs/api/workspaces/src/presentation/e2eRoutes/create-workspace.ts
+++ b/libs/api/workspaces/src/presentation/e2eRoutes/create-workspace.ts
@@ -1,0 +1,28 @@
+import {
+  e2eCreateWorkspaceBodySchema,
+  e2eCreateWorkspaceResponseSchema,
+} from '@shipfox/api-workspaces-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+import {createWorkspaceForUser} from '#core/index.js';
+import {toWorkspaceDto} from '#presentation/dto/index.js';
+
+export const createE2eWorkspaceRoute = defineRoute({
+  method: 'POST',
+  path: '/',
+  description: 'Create a workspace for an existing user for E2E tests.',
+  schema: {
+    body: e2eCreateWorkspaceBodySchema,
+    response: {
+      201: e2eCreateWorkspaceResponseSchema,
+    },
+  },
+  handler: async (request, reply) => {
+    const workspace = await createWorkspaceForUser({
+      name: request.body.name,
+      userId: request.body.user_id,
+    });
+
+    reply.code(201);
+    return toWorkspaceDto(workspace);
+  },
+});

--- a/libs/api/workspaces/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/workspaces/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,7 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createE2eWorkspaceRoute} from './create-workspace.js';
+
+export const workspacesE2eRoutes: RouteGroup = {
+  prefix: '/workspaces',
+  routes: [createE2eWorkspaceRoute],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,36 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/client/workspaces:
+    devDependencies:
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../../../libs/api/workspaces
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/client-auth':
+        specifier: workspace:*
+        version: link:../../../libs/client/auth
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../../helpers/auth
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/core:
     dependencies:
       '@shipfox/config':
@@ -258,6 +288,34 @@ importers:
       '@shipfox/api-auth-dto':
         specifier: workspace:*
         version: link:../../../libs/api/auth-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/helpers/workspaces:
+    dependencies:
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../../../libs/api/workspaces
+      '@shipfox/api-workspaces-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/workspaces-dto
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
PR #23 introduced the top-nav workspace switcher, last-workspace
persistence, workspace-scoped routing, and an atomic-membership
auth-refresh fix. None of those green paths were exercised end-to-end.

Stand up a new `@shipfox/e2e-client-workspaces` package that owns this
coverage (its own `client-workspaces` Argos build) with seven tests:

- No-workspace user redirected from `/` to `/setup/workspaces/new`.
- No-workspace user redirected from a workspace deep-link to onboarding
  (workspace `_layout.tsx` `beforeLoad` guard).
- Onboarding form green path, including `lastWorkspaceId` persistence
  after creation.
- Switching workspaces from the top nav (URL change + crumb update +
  `lastWorkspaceId` write).
- Persistence across reload and via `/` (returns to last-active
  workspace, not first membership).
- Creating a second workspace mid-session via the switcher's "Create
  workspace" entry.
- Returning-user regression catch: records the full URL transit
  history with `page.on('framenavigated')` and asserts the user with
  existing workspaces never flashes through `/setup/workspaces/new`.
  This pins PR #23's atomic-membership fix in `refresh-auth.ts`. A
  plain `.not.toBeVisible()` after the URL settles would be too weak
  for that brief-flash regression class.

To stage users with multiple workspaces without driving the onboarding
UI for every prereq, add a module-owned `POST /__e2e/workspaces` admin
route on `libs/api/workspaces` plus a `@shipfox/e2e-helper-workspaces`
package mirroring `@shipfox/e2e-helper-auth`. The seed path delegates
to the same core `createWorkspaceForUser` provider as the user-facing
endpoint, so seed and user paths produce identical state (outbox
events, defaults, membership row).

Considered driving everything through the onboarding UI to avoid new
infra, but tests that need 2 pre-seeded workspaces would have walked
the form twice each, multiplying flake surface and runtime. Also
considered putting the new tests inside `e2e/client/auth`; that's
where workspace UI components currently live as imports, but workspace
creation and switching are not auth concerns. Keeping them in their
own package keeps Argos buildName scoped per surface and lets
`auth-client.e2e.ts` stay focused on guest-redirect / login /
refresh-cookie hydration. The misplaced "creates a workspace through
the real onboarding UI" test is removed from auth as part of this PR.

Areas worth reviewing closely:

- `e2e/client/workspaces/tests/workspace-flows.e2e.ts:135` — the
  `framenavigated` URL-history capture in T7. The listener must be
  attached **before** `page.goto('/')`, otherwise the regression flash
  would not be recorded.
- `libs/api/workspaces/src/presentation/e2eRoutes/create-workspace.ts`
  — confirm the seed path's userEmail default
  (`createWorkspaceForUser` falls back to `user-${userId}@example.local`
  when omitted) is acceptable for E2E test fixtures. The auth user
  table has the real email; the membership row gets the placeholder.
- `e2e/client/workspaces/tsconfig.json` adds `DOM` to `lib` so
  Playwright `page.evaluate(() => window.localStorage.getItem(...))`
  type-checks. The other E2E packages didn't need this; this one does
  because T3, T4, and T6 read `localStorage` from the page.

Two scenarios remain documented as deferred in
`TODOS.md` "Projects Playwright E2E (incl. layout journey)":

- cmd+K opens the workspace switcher.
- `/` redirect with a stale `lastWorkspaceId` (membership lost) falls
  back to the first workspace, not `/setup/workspaces/new`.

Five Argos screenshots ship with the new package, one per distinct
page state: `workspaces/onboarding-blank`,
`workspaces/onboarding-complete`, `workspaces/switcher-open`,
`workspaces/switcher-single-with-create`, and
`workspaces/returning-user-home`. The plan's full visual-regression
coverage rationale (including what is intentionally **not**
snapshotted) lives in
`.claude/plans/system-instruction-you-are-working-lazy-comet.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end coverage for workspace onboarding, switching, and last-workspace routing, plus a lightweight seeding API to keep tests fast and stable. Pins the returning-user flow so it never flashes through onboarding.

- **New Features**
  - New `@shipfox/e2e-client-workspaces` package with Playwright + Argos build `client-workspaces`.
  - Seven tests cover: onboarding redirects, deep-link guard, first-workspace creation with `lastWorkspaceId`, top-nav switching, persistence across reload and `/`, creating a second workspace via the switcher, and returning-user routing with no `/setup/workspaces/new` flash.
  - New `@shipfox/e2e-helper-workspaces` and module-owned `POST /__e2e/workspaces` route to seed workspaces using the same `createWorkspaceForUser` provider; DTOs added in `@shipfox/api-workspaces-dto`.

- **Refactors**
  - Removed the workspace-creation test from `e2e/client/auth`; workspace flows now live in `@shipfox/e2e-client-workspaces`.
  - Wired E2E routes into `@shipfox/api-workspaces`; added `DOM` lib to the workspaces E2E `tsconfig` for `localStorage` reads.
  - Ignored Argos artifacts by adding `screenshots/` to `.gitignore`.

<sup>Written for commit 8bf7e0f77d5fd25affb6b9d06b013438c1467dfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

