### PR TITLE
Redesign projects hub as a Vercel-style searchable card grid

### DIFF
--- a/libs/api/projects-dto/src/schemas/project.ts
+++ b/libs/api/projects-dto/src/schemas/project.ts
@@ -36,6 +36,7 @@ export const listProjectsQuerySchema = z.object({
   workspace_id: z.string().uuid(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
   cursor: z.string().optional(),
+  search: z.string().min(1).max(100).optional(),
 });
 
 export type ListProjectsQueryDto = z.infer<typeof listProjectsQuerySchema>;

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -1,4 +1,4 @@
-import {and, desc, eq, lt, or, type SQL} from 'drizzle-orm';
+import {and, desc, eq, ilike, lt, or, type SQL} from 'drizzle-orm';
 import type {Project} from '#core/entities/project.js';
 import {ProjectAlreadyExistsError, ProjectNotFoundError} from '#core/errors.js';
 import {db} from './db.js';
@@ -20,6 +20,11 @@ export interface ListProjectsParams {
   workspaceId: string;
   limit: number;
   cursor?: ProjectCursor | undefined;
+  search?: string | undefined;
+}
+
+function escapeIlikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (char) => `\\${char}`);
 }
 
 export interface ListProjectsResult {
@@ -97,6 +102,9 @@ export async function listProjects(params: ListProjectsParams): Promise<ListProj
   const conditions = [eq(projects.workspaceId, params.workspaceId)];
   const cursorCondition = cursorWhere(params);
   if (cursorCondition) conditions.push(cursorCondition);
+  if (params.search) {
+    conditions.push(ilike(projects.name, `%${escapeIlikePattern(params.search)}%`));
+  }
 
   const rows = await db()
     .select()

--- a/libs/api/projects/src/presentation/routes/list-projects.ts
+++ b/libs/api/projects/src/presentation/routes/list-projects.ts
@@ -18,14 +18,14 @@ export const listProjectsRoute = defineRoute({
     },
   },
   handler: async (request) => {
-    const {workspace_id: workspaceId, limit, cursor} = request.query;
+    const {workspace_id: workspaceId, limit, cursor, search} = request.query;
     const decodedCursor = decodeProjectCursor(cursor);
     if (cursor && !decodedCursor) {
       throw new ClientError('Invalid cursor', 'invalid-cursor', {status: 400});
     }
 
     await requireMembership({request, workspaceId});
-    const result = await listProjects({workspaceId, limit, cursor: decodedCursor});
+    const result = await listProjects({workspaceId, limit, cursor: decodedCursor, search});
 
     return {
       projects: result.projects.map(toProjectDto),

--- a/libs/api/projects/src/presentation/routes/projects.test.ts
+++ b/libs/api/projects/src/presentation/routes/projects.test.ts
@@ -145,6 +145,57 @@ describe('project routes', () => {
     expect(res.json().projects[0].source.connection_id).toBe(sourceConnectionId);
   });
 
+  test('filters projects by `search` (case-insensitive substring on name)', async () => {
+    const names = ['Platform', 'Runner', 'Notifier'];
+    for (const [index, name] of names.entries()) {
+      vi.mocked(sourceControl.resolveRepository).mockResolvedValueOnce({
+        connection: {
+          id: sourceConnectionId,
+          workspaceId,
+          provider: 'debug',
+          externalAccountId: 'debug',
+          displayName: 'Debug',
+          lifecycleStatus: 'active',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        repository: {
+          externalRepositoryId: `debug:${name.toLowerCase()}-${index}`,
+          owner: 'debug-owner',
+          name: name.toLowerCase(),
+          fullName: `debug-owner/${name.toLowerCase()}`,
+          defaultBranch: 'main',
+          visibility: 'private',
+          cloneUrl: `https://debug.local/debug-owner/${name.toLowerCase()}.git`,
+          htmlUrl: `https://debug.local/debug-owner/${name.toLowerCase()}`,
+        },
+      });
+      await app.inject({
+        method: 'POST',
+        url: '/projects',
+        headers: {authorization: 'Bearer user'},
+        payload: {
+          workspace_id: workspaceId,
+          name,
+          source: {
+            connection_id: sourceConnectionId,
+            external_repository_id: `debug:${name.toLowerCase()}-${index}`,
+          },
+        },
+      });
+    }
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/projects?workspace_id=${workspaceId}&search=runn`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const returned = res.json().projects.map((project: {name: string}) => project.name);
+    expect(returned).toEqual(['Runner']);
+  });
+
   test('returns 409 when the source repository already has a project', async () => {
     const payload = {
       workspace_id: workspaceId,

--- a/libs/client/app-shell/src/components/nav-bar.tsx
+++ b/libs/client/app-shell/src/components/nav-bar.tsx
@@ -21,18 +21,14 @@ export function NavBar() {
       </Link>
       <span className="h-20 w-px bg-border-neutral-base" aria-hidden="true" />
       <WorkspaceCrumb workspace={workspace} />
-      {params.pid && project ? (
-        <>
-          <span className="text-foreground-neutral-muted" aria-hidden="true">
-            /
-          </span>
-          <ProjectCrumb
-            workspaceId={workspace.id}
-            projectId={project.id}
-            projectName={project.name}
-          />
-        </>
-      ) : null}
+      <span className="text-foreground-neutral-muted" aria-hidden="true">
+        /
+      </span>
+      <ProjectCrumb
+        workspaceId={workspace.id}
+        projectId={project?.id}
+        projectName={project?.name}
+      />
       <div className="flex-1" />
       <UserMenu />
     </header>

--- a/libs/client/app-shell/src/components/project-tabs.tsx
+++ b/libs/client/app-shell/src/components/project-tabs.tsx
@@ -11,6 +11,17 @@ export function ProjectTabs() {
   const params = useParams({strict: false}) as {wid?: string; pid?: string};
   const reduced = useReducedMotion();
   const inProject = Boolean(params.wid && params.pid);
+  const inWorkspace = Boolean(params.wid && !params.pid);
+
+  const tabClassName = `h-40 inline-flex items-center px-4 text-sm font-medium transition-colors ${
+    reduced ? '' : 'transition-[border-color]'
+  }`;
+  const activeProps = {
+    className: 'border-b-2 border-border-highlights-interactive text-foreground-neutral-base',
+  };
+  const inactiveProps = {
+    className: 'border-b-2 border-transparent text-foreground-neutral-muted',
+  };
 
   return (
     <div
@@ -18,23 +29,28 @@ export function ProjectTabs() {
       aria-label="Project sections"
       className="sticky top-56 z-20 h-40 px-16 flex items-end gap-12 bg-background-subtle-base border-b border-border-neutral-base"
     >
+      {inWorkspace && params.wid ? (
+        <Link
+          to="/workspaces/$wid"
+          params={{wid: params.wid}}
+          role="tab"
+          activeOptions={{exact: true}}
+          activeProps={activeProps}
+          inactiveProps={inactiveProps}
+          className={tabClassName}
+        >
+          Projects
+        </Link>
+      ) : null}
       {inProject && params.wid && params.pid ? (
         <Link
           to="/workspaces/$wid/projects/$pid"
           params={{wid: params.wid, pid: params.pid}}
           role="tab"
-          aria-selected="true"
           activeOptions={{exact: true}}
-          activeProps={{
-            className:
-              'border-b-2 border-border-highlights-interactive text-foreground-neutral-base',
-          }}
-          inactiveProps={{
-            className: 'border-b-2 border-transparent text-foreground-neutral-muted',
-          }}
-          className={`h-40 inline-flex items-center px-4 text-sm font-medium transition-colors ${
-            reduced ? '' : 'transition-[border-color]'
-          }`}
+          activeProps={activeProps}
+          inactiveProps={inactiveProps}
+          className={tabClassName}
         >
           Overview
         </Link>

--- a/libs/client/app-shell/src/components/project-tabs.tsx
+++ b/libs/client/app-shell/src/components/project-tabs.tsx
@@ -18,9 +18,11 @@ export function ProjectTabs() {
   }`;
   const activeProps = {
     className: 'border-b-2 border-border-highlights-interactive text-foreground-neutral-base',
+    'aria-selected': 'true' as const,
   };
   const inactiveProps = {
     className: 'border-b-2 border-transparent text-foreground-neutral-muted',
+    'aria-selected': 'false' as const,
   };
 
   return (

--- a/libs/client/projects/src/components/project-crumb.tsx
+++ b/libs/client/projects/src/components/project-crumb.tsx
@@ -5,43 +5,65 @@ import {ProjectSwitcher} from './project-switcher.js';
 
 export interface ProjectCrumbProps {
   workspaceId: string;
-  projectId: string;
-  projectName: string;
+  projectId?: string | undefined;
+  projectName?: string | undefined;
 }
 
 export function ProjectCrumb({workspaceId, projectId, projectName}: ProjectCrumbProps) {
   const [open, setOpen] = useState(false);
 
+  if (projectId && projectName) {
+    return (
+      <div className="flex items-center">
+        <Link
+          to="/workspaces/$wid/projects/$pid"
+          params={{wid: workspaceId, pid: projectId}}
+          aria-current="page"
+          className="text-md font-medium text-foreground-neutral-base px-6 py-4 rounded-6 hover:bg-background-components-hover transition-colors max-w-[240px] truncate"
+        >
+          {projectName}
+        </Link>
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Switch project"
+              aria-haspopup="listbox"
+              aria-expanded={open}
+              className="ml-2 grid place-items-center size-24 rounded-4 text-foreground-neutral-muted hover:bg-background-components-hover hover:text-foreground-neutral-base transition-colors"
+            >
+              <Icon name="arrowDownSLine" className="size-16" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[320px] p-0" align="start" sideOffset={8}>
+            <ProjectSwitcher
+              workspaceId={workspaceId}
+              activeProjectId={projectId}
+              onSelect={() => setOpen(false)}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center">
-      <Link
-        to="/workspaces/$wid/projects/$pid"
-        params={{wid: workspaceId, pid: projectId}}
-        aria-current="page"
-        className="text-md font-medium text-foreground-neutral-base px-6 py-4 rounded-6 hover:bg-background-components-hover transition-colors max-w-[240px] truncate"
-      >
-        {projectName}
-      </Link>
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            aria-label="Switch project"
-            aria-haspopup="listbox"
-            aria-expanded={open}
-            className="ml-2 grid place-items-center size-24 rounded-4 text-foreground-neutral-muted hover:bg-background-components-hover hover:text-foreground-neutral-base transition-colors"
-          >
-            <Icon name="arrowDownSLine" className="size-16" />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent className="w-[320px] p-0" align="start" sideOffset={8}>
-          <ProjectSwitcher
-            workspaceId={workspaceId}
-            activeProjectId={projectId}
-            onSelect={() => setOpen(false)}
-          />
-        </PopoverContent>
-      </Popover>
-    </div>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Switch project"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          className="flex items-center gap-2 text-md font-medium text-foreground-neutral-base px-6 py-4 rounded-6 hover:bg-background-components-hover transition-colors"
+        >
+          <span className="max-w-[240px] truncate">All projects</span>
+          <Icon name="arrowDownSLine" className="size-16 text-foreground-neutral-muted" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0" align="start" sideOffset={8}>
+        <ProjectSwitcher workspaceId={workspaceId} onSelect={() => setOpen(false)} />
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/libs/client/projects/src/components/project-switcher.tsx
+++ b/libs/client/projects/src/components/project-switcher.tsx
@@ -15,7 +15,7 @@ import {useProjectsInfiniteQuery} from '#hooks/api/projects.js';
 
 export interface ProjectSwitcherProps {
   workspaceId: string;
-  activeProjectId: string | undefined;
+  activeProjectId?: string | undefined;
   onSelect?: () => void;
 }
 
@@ -41,11 +41,25 @@ export function ProjectSwitcher({workspaceId, activeProjectId, onSelect}: Projec
     onSelect?.();
   };
 
+  const handleSelectAll = () => {
+    navigate({to: '/workspaces/$wid', params: {wid: workspaceId}});
+    onSelect?.();
+  };
+
   return (
     <Command>
       <CommandInput placeholder="Search projects..." />
       <ScrollArea>
         <CommandList className="max-h-300">
+          <CommandGroup>
+            <CommandItem value="__all" keywords={['all projects']} onSelect={handleSelectAll}>
+              <Icon
+                name="check"
+                className={`size-16 mr-8 ${activeProjectId ? 'opacity-0' : 'opacity-100'}`}
+              />
+              All projects
+            </CommandItem>
+          </CommandGroup>
           {query.isError ? (
             <CommandEmpty>Couldn&apos;t load projects.</CommandEmpty>
           ) : query.isLoading ? (

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -4,11 +4,12 @@ import type {
   ProjectResponseDto,
 } from '@shipfox/api-projects-dto';
 import {apiRequest} from '@shipfox/client-api';
-import {useInfiniteQuery, useMutation, useQuery} from '@tanstack/react-query';
+import {keepPreviousData, useInfiniteQuery, useMutation, useQuery} from '@tanstack/react-query';
 
 export const projectsQueryKeys = {
   all: ['projects'] as const,
-  list: (workspaceId: string) => [...projectsQueryKeys.all, 'list', workspaceId] as const,
+  list: (workspaceId: string, search?: string) =>
+    [...projectsQueryKeys.all, 'list', workspaceId, search ?? ''] as const,
   detail: (projectId: string) => [...projectsQueryKeys.all, 'detail', projectId] as const,
 };
 
@@ -16,17 +17,20 @@ export async function listProjects({
   workspaceId,
   limit = 50,
   cursor,
+  search,
   signal,
 }: {
   workspaceId: string;
   limit?: number;
   cursor?: string | undefined;
+  search?: string | undefined;
   signal?: AbortSignal;
 }) {
-  const search = new URLSearchParams({workspace_id: workspaceId, limit: String(limit)});
-  if (cursor) search.set('cursor', cursor);
+  const params = new URLSearchParams({workspace_id: workspaceId, limit: String(limit)});
+  if (cursor) params.set('cursor', cursor);
+  if (search) params.set('search', search);
 
-  return await apiRequest<ListProjectsResponseDto>(`/projects?${search.toString()}`, {signal});
+  return await apiRequest<ListProjectsResponseDto>(`/projects?${params.toString()}`, {signal});
 }
 
 export async function getProject(projectId: string) {
@@ -37,16 +41,21 @@ export async function createProject(body: CreateProjectBodyDto) {
   return await apiRequest<ProjectResponseDto>('/projects', {method: 'POST', body});
 }
 
-export function useProjectsInfiniteQuery(workspaceId: string | undefined, limit = 50) {
+export function useProjectsInfiniteQuery(
+  workspaceId: string | undefined,
+  search?: string,
+  limit = 50,
+) {
   return useInfiniteQuery({
     queryKey: workspaceId
-      ? projectsQueryKeys.list(workspaceId)
+      ? projectsQueryKeys.list(workspaceId, search)
       : [...projectsQueryKeys.all, 'list'],
     enabled: Boolean(workspaceId),
     initialPageParam: undefined as string | undefined,
     queryFn: ({pageParam, signal}) =>
-      listProjects({workspaceId: workspaceId ?? '', limit, cursor: pageParam, signal}),
+      listProjects({workspaceId: workspaceId ?? '', limit, cursor: pageParam, search, signal}),
     getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -24,13 +24,15 @@ import {projectErrorCopy} from '#project-error.js';
 export function ProjectsHubPage() {
   const workspace = useActiveWorkspace();
   const [searchInput, setSearchInput] = useState('');
-  const debouncedSearch = useDebouncedValue(searchInput, 250).trim();
+  const trimmedInput = searchInput.trim();
+  const debouncedSearch = useDebouncedValue(trimmedInput, 250);
   const query = useProjectsInfiniteQuery(workspace.id, debouncedSearch || undefined);
   const projects = query.data?.pages.flatMap((page) => page.projects) ?? [];
   const errorCopy = query.error ? projectErrorCopy(query.error) : undefined;
 
   const isInitialLoading = query.isPending;
-  const isSearching = Boolean(debouncedSearch && query.isFetching);
+  const isDebouncePending = trimmedInput !== debouncedSearch;
+  const isSearching = Boolean(trimmedInput) && (isDebouncePending || query.isFetching);
   const hasNoData = !query.data;
 
   return (
@@ -52,7 +54,8 @@ export function ProjectsHubPage() {
               isSearching ? (
                 <Icon
                   name="spinner"
-                  className="size-16 animate-spin text-foreground-neutral-muted"
+                  size={16}
+                  className="text-foreground-neutral-muted"
                   aria-hidden="true"
                 />
               ) : undefined

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -32,7 +32,8 @@ export function ProjectsHubPage() {
 
   const isInitialLoading = query.isPending;
   const isDebouncePending = trimmedInput !== debouncedSearch;
-  const isSearching = Boolean(trimmedInput) && (isDebouncePending || query.isFetching);
+  const isSearching =
+    Boolean(trimmedInput) && (isDebouncePending || (query.isFetching && !query.isFetchingNextPage));
   const hasNoData = !query.data;
 
   return (

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -8,36 +8,69 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Code,
   Header,
   Icon,
+  Input,
   Skeleton,
   StatusBadge,
   Text,
 } from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
+import {useEffect, useState} from 'react';
 import {useProjectsInfiniteQuery} from '#hooks/api/projects.js';
 import {projectErrorCopy} from '#project-error.js';
 
 export function ProjectsHubPage() {
   const workspace = useActiveWorkspace();
-  const query = useProjectsInfiniteQuery(workspace.id);
+  const [searchInput, setSearchInput] = useState('');
+  const debouncedSearch = useDebouncedValue(searchInput, 250).trim();
+  const query = useProjectsInfiniteQuery(workspace.id, debouncedSearch || undefined);
   const projects = query.data?.pages.flatMap((page) => page.projects) ?? [];
   const errorCopy = query.error ? projectErrorCopy(query.error) : undefined;
 
+  const isInitialLoading = query.isPending;
+  const isSearching = Boolean(debouncedSearch && query.isFetching);
+  const hasNoData = !query.data;
+
   return (
     <div className="flex w-full flex-col gap-24">
-      <header className="flex items-start justify-between gap-24 max-[640px]:flex-col">
-        <Header variant="h2">Projects</Header>
-        <Button asChild iconLeft="addLine">
-          <Link to="/workspaces/$wid/projects/new" params={{wid: workspace.id}}>
-            New project
-          </Link>
-        </Button>
+      <header className="flex flex-col gap-16">
+        <div className="flex items-start justify-between gap-24 max-[640px]:flex-col">
+          <Header variant="h2">Projects</Header>
+        </div>
+        <div className="flex items-center gap-12 max-[640px]:flex-col max-[640px]:items-stretch">
+          <Input
+            type="search"
+            value={searchInput}
+            onChange={(event) => setSearchInput(event.target.value)}
+            placeholder="Search projects…"
+            aria-label="Search projects"
+            className="flex-1"
+            iconLeft={<Icon name="searchLine" className="size-16" />}
+            iconRight={
+              isSearching ? (
+                <Icon
+                  name="spinner"
+                  className="size-16 animate-spin text-foreground-neutral-muted"
+                  aria-hidden="true"
+                />
+              ) : undefined
+            }
+          />
+          <Button asChild iconLeft="addLine" className="shrink-0 max-[640px]:w-full">
+            <Link to="/workspaces/$wid/projects/new" params={{wid: workspace.id}}>
+              New project
+            </Link>
+          </Button>
+        </div>
       </header>
 
-      {query.isPending ? <ProjectsSkeleton /> : null}
+      {isInitialLoading || (debouncedSearch && hasNoData && query.isFetching) ? (
+        <ProjectsSkeleton />
+      ) : null}
 
-      {query.isError && !query.data ? (
+      {query.isError && hasNoData ? (
         <Alert variant="error">
           <div className="flex flex-col gap-8">
             <Text size="sm" bold>
@@ -51,30 +84,38 @@ export function ProjectsHubPage() {
         </Alert>
       ) : null}
 
-      {!query.isPending && !query.isError && projects.length === 0 ? (
+      {!isInitialLoading && !query.isError && projects.length === 0 && !debouncedSearch ? (
         <EmptyProjects workspaceId={workspace.id} />
       ) : null}
 
+      {!query.isFetching && !query.isError && projects.length === 0 && debouncedSearch ? (
+        <NoSearchResults search={debouncedSearch} onClear={() => setSearchInput('')} />
+      ) : null}
+
       {projects.length > 0 ? (
-        <section className="flex flex-col gap-12" aria-label="Projects list">
-          {projects.map((project) => (
-            <ProjectRow project={project} key={project.id} workspaceId={workspace.id} />
-          ))}
+        <section aria-label="Projects list">
+          <ul className="grid gap-16 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {projects.map((project) => (
+              <ProjectCard project={project} key={project.id} workspaceId={workspace.id} />
+            ))}
+          </ul>
           {query.error && query.data ? (
-            <Alert variant="warning">
+            <Alert variant="warning" className="mt-16">
               <Text size="sm">
                 Could not load the next page. Existing projects are still shown.
               </Text>
             </Alert>
           ) : null}
           {query.hasNextPage ? (
-            <Button
-              variant="secondary"
-              isLoading={query.isFetchingNextPage}
-              onClick={() => query.fetchNextPage()}
-            >
-              Load more
-            </Button>
+            <div className="mt-16 flex justify-center">
+              <Button
+                variant="secondary"
+                isLoading={query.isFetchingNextPage}
+                onClick={() => query.fetchNextPage()}
+              >
+                Load more
+              </Button>
+            </div>
           ) : null}
         </section>
       ) : null}
@@ -82,16 +123,34 @@ export function ProjectsHubPage() {
   );
 }
 
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+  return debounced;
+}
+
 function ProjectsSkeleton() {
   return (
-    <div className="flex flex-col gap-12" role="status" aria-label="Loading projects">
-      {[0, 1, 2].map((row) => (
-        <Card className="p-18" key={row}>
-          <Skeleton className="h-20 w-1/3" />
-          <Skeleton className="h-16 w-2/3" />
-        </Card>
+    <ul
+      role="status"
+      aria-label="Loading projects"
+      className="grid gap-16 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+    >
+      {[0, 1, 2, 3, 4, 5].map((row) => (
+        <li key={row}>
+          <Card className="p-20 h-full gap-12">
+            <div className="flex items-center justify-between gap-12">
+              <Skeleton className="h-20 w-1/2" />
+              <Skeleton className="h-20 w-72 shrink-0" />
+            </div>
+            <Skeleton className="h-16 w-2/3" />
+          </Card>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }
 
@@ -116,26 +175,47 @@ function EmptyProjects({workspaceId}: {workspaceId: string}) {
   );
 }
 
-function ProjectRow({project, workspaceId}: {project: ProjectResponseDto; workspaceId: string}) {
+function NoSearchResults({search, onClear}: {search: string; onClear: () => void}) {
   return (
-    <Card className="p-18">
+    <Card className="items-center gap-18 p-32 text-center">
+      <div className="flex size-44 items-center justify-center rounded-8 border border-border-neutral-base bg-background-neutral-base">
+        <Icon name="searchLine" className="size-24 text-foreground-neutral-muted" />
+      </div>
+      <CardHeader className="items-center">
+        <CardTitle variant="h3">No projects match “{search}”</CardTitle>
+        <CardDescription>Try a different search, or clear it to see all projects.</CardDescription>
+      </CardHeader>
+      <Button size="sm" variant="secondary" onClick={onClear}>
+        Clear search
+      </Button>
+    </Card>
+  );
+}
+
+function ProjectCard({project, workspaceId}: {project: ProjectResponseDto; workspaceId: string}) {
+  return (
+    <li className="contents">
       <Link
         to="/workspaces/$wid/projects/$pid"
         params={{wid: workspaceId, pid: project.id}}
-        className="block"
+        className="block h-full rounded-8 focus-visible:outline-none focus-visible:shadow-button-secondary-focus"
       >
-        <CardContent className="flex items-center justify-between gap-18 max-[640px]:flex-col max-[640px]:items-start">
-          <div className="min-w-0">
-            <Text size="lg" bold className="truncate">
-              {project.name}
-            </Text>
-            <Text size="sm" className="text-foreground-neutral-muted truncate">
+        <Card className="p-20 h-full gap-12 hover:bg-background-components-hover transition-colors">
+          <CardContent className="flex flex-col gap-8 p-0">
+            <div className="flex items-center justify-between gap-12">
+              <Text size="lg" bold className="truncate">
+                {project.name}
+              </Text>
+              <StatusBadge variant="success" className="shrink-0">
+                Connected
+              </StatusBadge>
+            </div>
+            <Code variant="paragraph" className="text-foreground-neutral-muted truncate">
               {project.source.external_repository_id}
-            </Text>
-          </div>
-          <StatusBadge variant="success">Connected</StatusBadge>
-        </CardContent>
+            </Code>
+          </CardContent>
+        </Card>
       </Link>
-    </Card>
+    </li>
   );
 }


### PR DESCRIPTION
The projects hub previously rendered a single-column list of rows with no search and no top-nav tab affordance. This brings it closer to Vercel's project picker: a responsive card grid with a debounced server-side search, a workspace-level "Projects" tab, and a project crumb that stays visible in an "All projects" mode when no project is selected.

## What changed

- **Backend (`@shipfox/api-projects`)**: `GET /projects` accepts an optional `search` param that applies a case-insensitive `ilike` on `projects.name` (with `%`, `_`, and `\` escaped). Cursor pagination semantics are unchanged because the predicate is part of the `WHERE` clause and orderBy stays on `(created_at desc, id desc)`.
- **Client query hook**: `useProjectsInfiniteQuery` accepts an optional `search` (in the query key) and uses `keepPreviousData` so prior results stay visible while the next query loads.
- **Hub page**: search `Input` with `searchLine` icon left and inline `spinner` while fetching; responsive card grid (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`); `ProjectCard` token-grounded against DESIGN.md (`p-20`, `rounded-8`, `h-full`, hover surface, focus ring); a new `NoSearchResults` state distinct from the genuine no-projects empty state; the toolbar stacks vertically below 640px with the button full-width.
- **Project card typography fix**: the external repository id now uses the `Code` typography component (`font-code`), correcting a DESIGN.md §10 miss where pattern-matched identifiers were rendered in the display font.
- **Top nav**: `ProjectTabs` adds a single "Projects" tab when no project is selected. `ProjectCrumb` is always rendered; in "All projects" mode the whole crumb is the popover trigger (single hit area). `ProjectSwitcher` exposes an "All projects" item at the top so users can return to the hub from any project.

## Why these decisions

- **Server-side search over client-side filter**: matches the existing `list-repositories` pattern and scales beyond the first page once a workspace has many projects. The existing `ProjectSwitcher` keeps using the no-search variant — its cmdk client filter is fine for the dropdown.
- **Keep the in-page `Header h2 Projects` even though the tab strip says the same**: deliberate decision to preserve scannability and match the rest of the app's page-header convention.
- **Whole-crumb trigger in "All projects" mode**: there is nothing to link to (we're already at the route), so the label and chevron collapse into one button.

## Plan and design review

Plan and design review live at `.claude/plans/system-instruction-you-are-working-eager-snail.md` (design score 5/10 → 8/10 after 5 decisions; no unresolved gaps).

## Follow-ups

Visual regression baselines for the hub, breadcrumb, and tab strip will need to be accepted in Argos after this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Projects hub into a Vercel-style, responsive card grid with debounced server-side search. Improves workspace navigation with a “Projects” tab and an “All projects” crumb/switcher.

- **New Features**
  - Backend (`@shipfox/api-projects`): `GET /projects` adds optional `search` (1–100 chars, case-insensitive `ilike` on `projects.name`, with `%`, `_`, `\` escaped); cursor pagination unchanged.
  - Client: `useProjectsInfiniteQuery(workspaceId, search)` keeps previous data while searching; query key includes `search`.
  - Hub: search input with inline spinner during typing/debounce and search fetches; distinct “No results” state with Clear; 1/2/3‑column card grid.
  - Navigation: workspace-level “Projects” tab when no project is selected; Project crumb always visible with an “All projects” mode; `ProjectSwitcher` adds an “All projects” item.

- **Bug Fixes**
  - Accessibility/UX: tabs now set `aria-selected` correctly; the search field spinner no longer appears during pagination (“Load more”).
  - Project cards render external repository IDs with `Code` typography for correct monospace styling.

<sup>Written for commit 6fe5eab9f08915e8a56d6711dc8692081b53345c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

