### PR TITLE
Stabilize workspace visual test data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
           wait_for "$API_URL/readyz"
           wait_for "$CLIENT_URL"
-          turbo test:e2e --filter=@shipfox/e2e-api-auth --filter=@shipfox/e2e-client-auth
+          turbo test:e2e
 
       - name: Upload E2E API logs
         if: failure() && steps.e2e.outcome == 'failure'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,10 @@ Conventions:
 - Name snapshots `<surface>/<state>` (e.g. `auth/login`,
   `projects/empty-state`). The directory-style prefix groups related shots in
   the Argos UI.
+- Keep any generated entity data that is visible in a screenshot deterministic.
+  Random users, IDs, and hidden setup data are fine for isolation, but names,
+  titles, and other rendered text should use fixed values so Argos only reports
+  meaningful UI drift.
 
 New `e2e/client/*` packages register their own Argos reporter in their
 `playwright.config.ts` with a `buildName` that matches the package suffix

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/biome": "workspace:*",
-    "@shipfox/client-auth": "workspace:*",
+    "@shipfox/client-router": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -48,7 +48,7 @@ test('creates the first workspace via onboarding and persists lastWorkspaceId', 
 }) => {
   const user = await auth.createUser();
   await auth.loginAs(page, user);
-  const workspaceName = `E2E Workspace ${randomUUID()}`;
+  const workspaceName = 'E2E Onboarding Workspace';
 
   await page.goto('/');
   await expect(page).toHaveURL(ONBOARDING_URL_RE);
@@ -66,8 +66,10 @@ test('creates the first workspace via onboarding and persists lastWorkspaceId', 
 
 test('switches between workspaces from the top nav', async ({page, auth, workspaces}) => {
   const user = await auth.createUser();
-  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
-  const wsB = await workspaces.create({userId: user.user.id, name: `B ${randomUUID()}`});
+  const workspaceAName = 'Alpha Workspace';
+  const workspaceBName = 'Beta Workspace';
+  const wsA = await workspaces.create({userId: user.user.id, name: workspaceAName});
+  const wsB = await workspaces.create({userId: user.user.id, name: workspaceBName});
   await auth.loginAs(page, user);
 
   await page.goto(`/workspaces/${wsA.id}`);
@@ -75,17 +77,17 @@ test('switches between workspaces from the top nav', async ({page, auth, workspa
 
   await page.getByLabel('Switch workspace').click();
   await argosScreenshot(page, 'workspaces/switcher-open');
-  await page.getByRole('option', {name: wsB.name}).click();
+  await page.getByRole('option', {name: workspaceBName}).click();
 
   await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
-  await expect(page.getByRole('link', {name: wsB.name})).toBeVisible();
+  await expect(page.getByRole('link', {name: workspaceBName})).toBeVisible();
   expect(await readLastWorkspaceId(page)).toBe(wsB.id);
 });
 
 test('persists the active workspace across reload and via /', async ({page, auth, workspaces}) => {
   const user = await auth.createUser();
-  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
-  const wsB = await workspaces.create({userId: user.user.id, name: `B ${randomUUID()}`});
+  const wsA = await workspaces.create({userId: user.user.id, name: 'Alpha Workspace'});
+  const wsB = await workspaces.create({userId: user.user.id, name: 'Beta Workspace'});
   await auth.loginAs(page, user);
 
   await page.goto(`/workspaces/${wsB.id}/integrations`);
@@ -106,20 +108,21 @@ test('creates a second workspace from the switcher mid-session', async ({
   workspaces,
 }) => {
   const user = await auth.createUser();
-  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  const workspaceAName = 'Alpha Workspace';
+  const workspaceBName = 'Beta Workspace';
+  const wsA = await workspaces.create({userId: user.user.id, name: workspaceAName});
   await auth.loginAs(page, user);
 
   await page.goto(`/workspaces/${wsA.id}`);
   await page.getByLabel('Switch workspace').click();
-  await expect(page.getByRole('option', {name: wsA.name})).toBeVisible();
+  await expect(page.getByRole('option', {name: workspaceAName})).toBeVisible();
   await expect(page.getByRole('option', {name: CREATE_WORKSPACE_LABEL_RE})).toBeVisible();
   await argosScreenshot(page, 'workspaces/switcher-single-with-create');
 
   await page.getByRole('option', {name: CREATE_WORKSPACE_LABEL_RE}).click();
   await expect(page).toHaveURL(ONBOARDING_URL_RE);
 
-  const newName = `B ${randomUUID()}`;
-  await page.getByLabel('Workspace name').fill(newName);
+  await page.getByLabel('Workspace name').fill(workspaceBName);
   await page.getByRole('button', {name: 'Create workspace'}).click();
 
   await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
@@ -129,8 +132,8 @@ test('creates a second workspace from the switcher mid-session', async ({
 
   // Switcher now lists both workspaces.
   await page.getByLabel('Switch workspace').click();
-  await expect(page.getByRole('option', {name: wsA.name})).toBeVisible();
-  await expect(page.getByRole('option', {name: newName})).toBeVisible();
+  await expect(page.getByRole('option', {name: workspaceAName})).toBeVisible();
+  await expect(page.getByRole('option', {name: workspaceBName})).toBeVisible();
   expect(await readLastWorkspaceId(page)).toBe(newWid);
 });
 
@@ -140,7 +143,7 @@ test('switcher keeps Create workspace visible when search filters every workspac
   workspaces,
 }) => {
   const user = await auth.createUser();
-  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  const wsA = await workspaces.create({userId: user.user.id, name: 'Alpha Workspace'});
   await auth.loginAs(page, user);
 
   await page.goto(`/workspaces/${wsA.id}`);
@@ -168,7 +171,7 @@ test('routes a returning user with workspaces straight to /workspaces/$wid', asy
   workspaces,
 }) => {
   const user = await auth.createUser();
-  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+  const wsA = await workspaces.create({userId: user.user.id, name: 'Alpha Workspace'});
   await auth.loginAs(page, user);
 
   // Record every URL the page transits through. The PR #23 regression was a

--- a/libs/client/auth/src/components/workspace-switcher.tsx
+++ b/libs/client/auth/src/components/workspace-switcher.tsx
@@ -41,34 +41,36 @@ export function WorkspaceSwitcher({activeWorkspaceId, onSelect}: WorkspaceSwitch
   return (
     <Command>
       <CommandInput placeholder="Search workspaces..." />
-      <CommandList>
-        <CommandEmpty>No workspaces found.</CommandEmpty>
-        <CommandGroup heading="Workspaces">
-          {workspaces.map((workspace) => (
-            <CommandItem
-              key={workspace.id}
-              value={workspace.id}
-              keywords={[workspace.name]}
-              onSelect={() => handleSelect(workspace.id)}
-            >
-              <Icon
-                name="check"
-                className={`size-16 mr-8 ${
-                  activeWorkspaceId === workspace.id ? 'opacity-100' : 'opacity-0'
-                }`}
-              />
-              {workspace.name}
-            </CommandItem>
-          ))}
+      <CommandList className="max-h-none overflow-visible overflow-y-visible p-0">
+        <div className="max-h-300 overflow-y-auto overflow-x-hidden p-4 scrollbar">
+          <CommandEmpty>No workspaces found.</CommandEmpty>
+          <CommandGroup heading="Workspaces">
+            {workspaces.map((workspace) => (
+              <CommandItem
+                key={workspace.id}
+                value={workspace.id}
+                keywords={[workspace.name]}
+                onSelect={() => handleSelect(workspace.id)}
+              >
+                <Icon
+                  name="check"
+                  className={`size-16 mr-8 ${
+                    activeWorkspaceId === workspace.id ? 'opacity-100' : 'opacity-0'
+                  }`}
+                />
+                {workspace.name}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </div>
+        <CommandSeparator alwaysRender className="mx-0" />
+        <CommandGroup forceMount className="p-4">
+          <CommandItem value="__create" onSelect={handleCreate} forceMount>
+            <Icon name="addLine" className="size-16" />
+            Create workspace
+          </CommandItem>
         </CommandGroup>
       </CommandList>
-      <CommandSeparator />
-      <CommandGroup forceMount>
-        <CommandItem value="__create" onSelect={handleCreate} forceMount>
-          <Icon name="addLine" className="size-16" />
-          Create workspace
-        </CommandItem>
-      </CommandGroup>
     </Command>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,9 +236,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
-      '@shipfox/client-auth':
+      '@shipfox/client-router':
         specifier: workspace:*
-        version: link:../../../libs/client/auth
+        version: link:../../../libs/client/router
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
Make workspace E2E screenshots use deterministic workspace names while preserving generated users and IDs for isolation.

The workspace Argos snapshots were built from randomly named workspaces, so screenshot diffs could reflect fixture text changes instead of UI drift. This fixes visible workspace names inline and documents the convention for future client-page screenshots.

The `client-workspaces` Argos build was also missing because CI only ran a hardcoded subset of E2E packages. CI now runs `turbo test:e2e` so new E2E packages with that task are picked up automatically, and the workspaces E2E package now depends on the client router package that owns the workspace route surfaces.