### PR TITLE
Fix post-login redirect flashing through workspace onboarding

### DIFF
--- a/e2e/client/auth/package.json
+++ b/e2e/client/auth/package.json
@@ -17,6 +17,7 @@
     "@shipfox/client-auth": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/client/auth/tests/auth-client.e2e.ts
@@ -1,7 +1,13 @@
+import {randomUUID} from 'node:crypto';
 import {argosScreenshot} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const LOGIN_URL_RE = /\/auth\/login$/u;
+const ONBOARDING_URL_RE = /\/setup\/workspaces\/new\/?$/u;
+
+function workspaceUrlRe(wid: string): RegExp {
+  return new RegExp(`/workspaces/${wid}(/|$)`, 'u');
+}
 
 test('redirects guests from the app root to login', async ({page}) => {
   await page.goto('/');
@@ -21,6 +27,38 @@ test('logs in through the UI with an E2E-created verified user', async ({page, a
 
   await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
   await argosScreenshot(page, 'auth/post-login-workspace');
+});
+
+test('form login routes a user with workspaces straight to /workspaces/$wid', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const wsA = await workspaces.create({userId: user.user.id, name: `A ${randomUUID()}`});
+
+  // Record every URL the page transits through. Asserting only the final URL
+  // would let a brief flash through /setup/workspaces/new slip past
+  // Playwright auto-wait — that flash is the bug we're guarding against.
+  const urlsSeen: string[] = [];
+  page.on('framenavigated', (frame) => {
+    if (frame === page.mainFrame()) {
+      urlsSeen.push(frame.url());
+    }
+  });
+
+  await page.goto('/auth/login');
+  await page.getByLabel('Email').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', {name: 'Log in'}).click();
+
+  await expect(page).toHaveURL(workspaceUrlRe(wsA.id));
+
+  for (const url of urlsSeen) {
+    expect(url, `transit URL must not flash through onboarding: ${url}`).not.toMatch(
+      ONBOARDING_URL_RE,
+    );
+  }
 });
 
 test('hydrates an E2E browser session from the refresh cookie after reload', async ({

--- a/e2e/client/auth/tests/test.ts
+++ b/e2e/client/auth/tests/test.ts
@@ -1,5 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
 
-export const test = base.extend<AuthFixtures>(authHelper);
+export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
+  ...authHelper,
+  ...workspacesHelper,
+});
 export {expect};

--- a/libs/client/auth/src/hooks/api/login-auth.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.ts
@@ -17,8 +17,12 @@ export function useLoginAuth() {
   return useMutation({
     mutationFn: loginAuth,
     onSuccess: async (result) => {
-      setState(toAuthenticatedState(result));
       queryClient.setQueryData(authRefreshQueryKey, result);
+      // Resolve workspaces before flipping auth state to authenticated. A
+      // single atomic setState avoids the intermediate window where the user
+      // appears authenticated with zero workspaces, which sent users with
+      // workspaces straight to `/setup/workspaces/new` after form login.
+      let memberships: Awaited<ReturnType<typeof listUserWorkspaces>>['memberships'] = [];
       try {
         const workspaces = await queryClient.fetchQuery({
           queryKey: userWorkspacesQueryKey,
@@ -26,11 +30,12 @@ export function useLoginAuth() {
           retry: false,
           staleTime: 0,
         });
-        setState(toAuthenticatedState(result, workspaces.memberships));
+        memberships = workspaces.memberships;
         queryClient.setQueryData(userWorkspacesQueryKey, workspaces);
       } catch {
         // The user is authenticated even if workspace hydration fails.
       }
+      setState(toAuthenticatedState(result, memberships));
     },
   });
 }

--- a/libs/client/auth/src/pages/login-page.test.tsx
+++ b/libs/client/auth/src/pages/login-page.test.tsx
@@ -1,5 +1,6 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {fireEvent, screen} from '@testing-library/react';
+import {GuestGuard} from '#components/auth-guard.js';
 import {pageUserFactory} from '#test/factories/user.js';
 import {renderAuthPage} from '#test/pages.js';
 import {jsonResponse} from '#test/utils.js';
@@ -75,7 +76,12 @@ describe('LoginPage', () => {
       });
     configureApiClient({fetchImpl});
 
-    renderAuthPage('/auth/login', <LoginPage />);
+    renderAuthPage(
+      '/auth/login',
+      <GuestGuard>
+        <LoginPage />
+      </GuestGuard>,
+    );
     fireEvent.change(await screen.findByLabelText('Email'), {
       target: {value: 'login@example.com'},
     });

--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -1,6 +1,6 @@
 import {loginBodySchema} from '@shipfox/api-auth-dto';
 import {Alert, Button, ButtonLink, Input, Label, Text} from '@shipfox/react-ui';
-import {Link, useNavigate} from '@tanstack/react-router';
+import {Link} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {type FormEvent, useState} from 'react';
 import {AuthShell} from '#/components/auth-shell.js';
@@ -12,7 +12,6 @@ type LoginField = 'email' | 'password';
 
 export function LoginPage() {
   const login = useLoginAuth();
-  const navigate = useNavigate();
   const [authFormDraft, setAuthFormDraft] = useAtom(authFormDraftAtom);
   const [fieldErrors, setFieldErrors] = useState<FieldErrors<LoginField>>({});
   const [formError, setFormError] = useState<string | undefined>();
@@ -31,7 +30,10 @@ export function LoginPage() {
     try {
       await login.mutateAsync(parsed.data);
       setAuthFormDraft(initialAuthFormDraft);
-      await navigate({to: '/', replace: true});
+      // The route's GuestGuard redirects authenticated users to `/`. Letting
+      // the guard fire from the auth-state-driven re-render guarantees the
+      // router sees the freshly-hydrated workspace memberships before `/`
+      // evaluates its redirect — explicit navigate races the React render.
     } catch (error) {
       setFormError(authErrorMessage(error));
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@shipfox/e2e-helper-auth':
         specifier: workspace:*
         version: link:../../helpers/auth
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright


### PR DESCRIPTION
Form login flipped auth state to `authenticated` with empty workspaces
before fetching memberships, then issued an explicit `navigate('/')`
that raced the React render of the new auth context. Returning users
with a workspace consistently bounced to `/setup/workspaces/new` even
though manually visiting `/` afterwards landed on the right project.

Mirrors the `refresh-auth.ts` pattern: fetch workspaces first, run a
single atomic `setState`, and let the route's `GuestGuard` fire the
redirect from the auth-state-driven re-render so the router context
is guaranteed fresh when `/`'s `beforeLoad` evaluates.

The new E2E test in `@shipfox/e2e-client-auth` drives the actual login
form (not the cookie shortcut) for a user with a pre-existing workspace
and asserts the page never transits through `/setup/workspaces/new` —
the existing workspace-flows regression test only covered the
refresh-cookie path.

Note: `verify-email-auth.ts` and `password-reset-auth.ts` have the same
two-phase setState anti-pattern; left out of scope for this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race after form login that briefly sent users with existing workspaces to onboarding. We now hydrate memberships before setting auth and let the route `GuestGuard` handle the redirect.

- **Bug Fixes**
  - In `useLoginAuth`, fetch workspace memberships first and then set authenticated state atomically; update `authRefresh` and workspace queries.
  - Remove explicit `navigate('/')` from `LoginPage`; rely on `GuestGuard` to redirect on re-render.
  - Add E2E test in `@shipfox/e2e-client-auth` to log in via the form and assert no transit through `/setup/workspaces/new`; update unit test to render `LoginPage` under `GuestGuard`.

- **Dependencies**
  - Add `@shipfox/e2e-helper-workspaces` to `@shipfox/e2e-client-auth`.

<sup>Written for commit fac955863b2bb9024ee4564a5c11b7da49c9c9a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

