### PR TITLE
Fix Debug source-control connect leaving the user on /integrations

### DIFF
--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@shipfox/e2e-client-integrations",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./tests/*"
+  },
+  "scripts": {
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test:e2e": "shipfox-playwright-test",
+    "type": "shipfox-tsc-check"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/client-integrations": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/client/integrations/playwright.config.ts
+++ b/e2e/client/integrations/playwright.config.ts
@@ -1,0 +1,32 @@
+import {config} from '@shipfox/e2e-core';
+import {defineConfig, devices} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  globalSetup: './tests/global-setup.ts',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        [
+          '@argos-ci/playwright/reporter',
+          {
+            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
+            buildName: 'client-integrations',
+            ignoreUploadFailures: true,
+          },
+        ],
+      ]
+    : 'list',
+  use: {
+    baseURL: config.CLIENT_URL,
+    trace: 'retain-on-failure',
+    contextOptions: {reducedMotion: 'reduce'},
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/e2e/client/integrations/tests/global-setup.ts
+++ b/e2e/client/integrations/tests/global-setup.ts
@@ -1,0 +1,5 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck();
+}

--- a/e2e/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/client/integrations/tests/integration-flows.e2e.ts
@@ -1,0 +1,37 @@
+import {randomUUID} from 'node:crypto';
+import {expect, test} from './test.js';
+
+const WORKSPACE_INTEGRATIONS_URL_RE = /\/workspaces\/[^/]+\/integrations\/?$/u;
+const DEBUG_INSTALL_URL_RE = /\/workspaces\/[^/]+\/integrations\/debug\/?$/u;
+
+function projectsNewUrlRe(wid: string): RegExp {
+  return new RegExp(`/workspaces/${wid}/projects/new/?$`, 'u');
+}
+
+test('connecting Debug from onboarding flows into project creation', async ({page, auth}) => {
+  const user = await auth.createUser();
+  await auth.loginAs(page, user);
+
+  // Reproduces the user-reported flow: a fresh user lands on Connect source
+  // control via the onboarding handoff (so HomeRouter has already populated
+  // the projects + source-connections caches with empty data for this
+  // workspace), then clicks Debug to create their first connection.
+  await page.goto('/');
+  await page.getByLabel('Workspace name').fill(`E2E Workspace ${randomUUID()}`);
+  await page.getByRole('button', {name: 'Create workspace'}).click();
+  await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
+  await expect(page.getByRole('heading', {name: 'Connect source control'})).toBeVisible();
+
+  const wid = new URL(page.url()).pathname.split('/')[2];
+  expect(wid).toBeTruthy();
+
+  await page.locator(`a[href$="/workspaces/${wid}/integrations/debug"]`).click();
+
+  // DebugInstallPage creates the connection on mount, fires the success toast,
+  // then navigates back to /workspaces/$wid — HomeRouter should see the new
+  // connection plus zero projects and forward the user to /projects/new.
+  await expect(page.getByText('Debug source control connected.')).toBeVisible();
+  await expect(page).not.toHaveURL(DEBUG_INSTALL_URL_RE);
+  await expect(page).not.toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
+  await expect(page).toHaveURL(projectsNewUrlRe(wid as string));
+});

--- a/e2e/client/integrations/tests/test.ts
+++ b/e2e/client/integrations/tests/test.ts
@@ -1,0 +1,9 @@
+import {test as base, expect} from '@shipfox/e2e-core/playwright';
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
+  ...authHelper,
+  ...workspacesHelper,
+});
+export {expect};

--- a/e2e/client/integrations/tsconfig.json
+++ b/e2e/client/integrations/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/libs/client/integrations/src/pages/debug-install-page.tsx
+++ b/libs/client/integrations/src/pages/debug-install-page.tsx
@@ -23,6 +23,10 @@ export function DebugInstallPage() {
       .then(async () => {
         await queryClient.invalidateQueries({
           queryKey: integrationsQueryKeys.sourceConnections(workspaceId),
+          // HomeRouter is the next active observer, not this page, so the
+          // default 'active' refetch would no-op and leave the cache stale
+          // until after HomeRouter's first render redirects back here.
+          refetchType: 'all',
         });
         toast.success('Debug source control connected.');
         await navigate({to: '/workspaces/$wid', params: {wid: workspaceId}});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,33 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/client/integrations:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/client-integrations':
+        specifier: workspace:*
+        version: link:../../../libs/client/integrations
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../../helpers/auth
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/client/workspaces:
     devDependencies:
       '@shipfox/api-workspaces':


### PR DESCRIPTION
After clicking Connect on Debug from the onboarding flow, the success toast
fires but the user lands back on /workspaces/<wid>/integrations instead of
being routed onward to project creation.

`DebugInstallPage` invalidated the source-connections query and awaited it
before navigating to the workspace home, but the install page is not an
observer of that query. With the default `refetchType: 'active'`,
`invalidateQueries` only marked the cache stale and resolved immediately
— no refetch was triggered. `HomeRouter` then mounted with the empty
connections cached during the onboarding redirect through /, saw
`connections.length === 0`, and bounced the user back to /integrations
before the background refetch landed. The bug only reproduces via the
onboarding handoff because that path is what primes the projects query
cache, removing the `FullPageLoader` gate that would otherwise give the
refetch time to complete.

Fix: pass `refetchType: 'all'` so the cache is fresh by the time
`navigate` runs. Considered `refetchQueries` and direct `setQueryData`
on the mutation response — `invalidateQueries` keeps the verb matching
what happened (data changed) and stays one line. The GitHub install
page does not have this pattern (it `window.location.assign`s to OAuth)
so no parallel change is needed there.

Adds a new `@shipfox/e2e-client-integrations` Playwright package
mirroring `e2e-client-workspaces`, with one regression test that walks
the onboarding → Debug connect → /projects/new flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Debug integration onboarding redirect so users go to project creation after Connect instead of landing back on /integrations. Ensures the source-connections cache refetches before navigation by using `refetchType: 'all'`.

- **Bug Fixes**
  - Set `refetchType: 'all'` on `invalidateQueries` in `DebugInstallPage` so `HomeRouter` sees the new connection and forwards to `/projects/new`.

- **New Features**
  - Added `@shipfox/e2e-client-integrations` Playwright package with a regression test for onboarding → Debug connect → `/projects/new`.

<sup>Written for commit c3bea4f69fdf091c61ce23f271740676560cc88a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

