### PR TITLE
Add VRT snapshots for workspace switcher overflow

### DIFF
--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -165,6 +165,44 @@ test('switcher keeps Create workspace visible when search filters every workspac
   await expect(page).toHaveURL(ONBOARDING_URL_RE);
 });
 
+test('switcher list scrolls while Create workspace stays pinned', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const first = await workspaces.create({userId: user.user.id, name: 'Workspace 01'});
+  for (let i = 2; i <= 20; i++) {
+    const name = `Workspace ${String(i).padStart(2, '0')}`;
+    await workspaces.create({userId: user.user.id, name});
+  }
+  await auth.loginAs(page, user);
+
+  await page.goto(`/workspaces/${first.id}`);
+  await expect(page).toHaveURL(workspaceUrlRe(first.id));
+
+  await page.getByLabel('Switch workspace').click();
+  await expect(page.getByRole('option', {name: 'Workspace 01'})).toBeVisible();
+  await expect(page.getByRole('option', {name: CREATE_WORKSPACE_LABEL_RE})).toBeVisible();
+  await argosScreenshot(page, 'workspaces/switcher-many-overflow');
+
+  // Scroll the inner max-h-300 container to the bottom. Walk up from a
+  // workspace option until we hit the first ancestor whose content overflows
+  // its box — that is the scrollable div wrapping the Workspaces CommandGroup.
+  // The Create workspace footer is a sibling of that div, so scrolling it
+  // cannot move the footer; the second snapshot proves that.
+  await page.evaluate(() => {
+    let el = document.querySelector('[role="option"]')?.parentElement ?? null;
+    while (el && el.scrollHeight <= el.clientHeight) {
+      el = el.parentElement;
+    }
+    if (el) el.scrollTop = el.scrollHeight;
+  });
+  await expect(page.getByRole('option', {name: 'Workspace 20'})).toBeInViewport();
+  await expect(page.getByRole('option', {name: CREATE_WORKSPACE_LABEL_RE})).toBeVisible();
+  await argosScreenshot(page, 'workspaces/switcher-many-overflow-scrolled');
+});
+
 test('routes a returning user with workspaces straight to /workspaces/$wid', async ({
   page,
   auth,

--- a/libs/api/workspaces/src/db/memberships.test.ts
+++ b/libs/api/workspaces/src/db/memberships.test.ts
@@ -49,6 +49,21 @@ describe('memberships db', () => {
     expect(list[0]?.workspaceName).toBe(workspace.name);
   });
 
+  test('lists memberships sorted by workspace name ascending', async () => {
+    const user = await createUser({email: emailFor('order'), hashedPassword: 'h'});
+    const suffix = crypto.randomUUID();
+    const charlie = await createWorkspace({name: `order-${suffix}-Charlie`});
+    const alpha = await createWorkspace({name: `order-${suffix}-Alpha`});
+    const bravo = await createWorkspace({name: `order-${suffix}-Bravo`});
+    await createMembership({userId: user.userId, workspaceId: charlie.id});
+    await createMembership({userId: user.userId, workspaceId: alpha.id});
+    await createMembership({userId: user.userId, workspaceId: bravo.id});
+
+    const list = await listMembershipsByUser({userId: user.userId});
+
+    expect(list.map((m) => m.workspaceName)).toEqual([alpha.name, bravo.name, charlie.name]);
+  });
+
   test('lists memberships by workspace joined with user info', async () => {
     const user = await createUser({email: emailFor('listt'), hashedPassword: 'h', name: 'Listy'});
     const workspace = await createWorkspace({name: `Workspace ${crypto.randomUUID()}`});

--- a/libs/api/workspaces/src/db/memberships.ts
+++ b/libs/api/workspaces/src/db/memberships.ts
@@ -42,7 +42,8 @@ export async function listMembershipsByUser(params: {
     })
     .from(memberships)
     .innerJoin(workspaces, eq(workspaces.id, memberships.workspaceId))
-    .where(eq(memberships.userId, params.userId));
+    .where(eq(memberships.userId, params.userId))
+    .orderBy(workspaces.name);
 
   return rows.map((row) => ({...toMembership(row.membership), workspaceName: row.workspaceName}));
 }


### PR DESCRIPTION
Existing `workspaces/switcher-*` Argos snapshots cover the open / single-with-create / empty-search states with at most 2 workspaces, so the `max-h-300` + pinned-footer layout in `WorkspaceSwitcher` had no regression coverage. A change that re-pinned the footer inside the scroll container, removed `overflow-y-auto`, or dropped the height cap would not be caught.

This adds two snapshots seeded with 20 workspaces:

- `workspaces/switcher-many-overflow` — captures scroll-top: list clipped at `max-h-300`, footer rendered below the clipped region.
- `workspaces/switcher-many-overflow-scrolled` — after scrolling the inner container to the bottom, proves the footer stays put (it's a sibling of the scroll region, not nested inside it).

While writing the test, the surfaced precondition was that `listMembershipsByUser` had no `ORDER BY` clause, so any test seeding many workspaces is non-deterministic by construction — and product-side a returning user could see their switcher re-shuffle between page loads. Split into a separate first commit so the ordering fix is reviewable on its own.

Considered a single `expect(scrollHeight > clientHeight)` assertion instead of the second snapshot, but a regression that re-pins the footer with `position:absolute` inside the scroll container would pass that assertion and still break pinning under scroll. Two snapshots catch the actual claim.

Reviewer notes:
- The `gh pr` will diff against new Argos baselines on first run; both need approval in Argos.
- The two commits are independently reviewable: the ordering fix (with unit test asserting alphabetical readback) stands alone even if the VRT addition is split out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add VRT snapshots for workspace switcher overflow to confirm the list scrolls and the Create workspace footer stays pinned. Sort memberships by workspace name to stabilize the switcher order and make tests deterministic.

- **New Features**
  - Added Argos snapshots: `workspaces/switcher-many-overflow` (top) and `workspaces/switcher-many-overflow-scrolled` (scrolled) to verify clipping and footer pinning.

- **Bug Fixes**
  - `listMembershipsByUser` now orders by `workspaces.name` ascending; added a unit test asserting alphabetical results.

<sup>Written for commit a523176914de7e7f69ba4ed365d228e9bf813f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

