### PR TITLE
[client-projects] Stabilize project switcher empty search test

### DIFF
--- a/libs/client/projects/src/components/project-switcher.test.tsx
+++ b/libs/client/projects/src/components/project-switcher.test.tsx
@@ -1,4 +1,3 @@
-import {configureApiClient} from '@shipfox/client-api';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {
   createMemoryHistory,
@@ -9,7 +8,8 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {jsonResponse, PROJECT_TEST_WID} from '#test/pages.js';
+import {projectsQueryKeys} from '#hooks/api/projects.js';
+import {PROJECT_TEST_WID} from '#test/pages.js';
 import {ProjectSwitcher} from './project-switcher.js';
 
 const CREATE_PROJECT_LABEL_RE = /Create project/u;
@@ -17,17 +17,9 @@ const CREATE_PROJECT_LABEL_RE = /Create project/u;
 describe('ProjectSwitcher', () => {
   test('keeps Create project pinned and keyboard-selectable under empty search', async () => {
     const onSelect = vi.fn();
-    configureApiClient({
-      baseUrl: 'https://api.example.test',
-      fetchImpl: vi.fn().mockResolvedValue(
-        jsonResponse({
-          projects: [projectDto({id: 'project-1', name: 'Platform'})],
-          next_cursor: null,
-        }),
-      ),
-    });
+    const projects = [projectDto({id: 'project-1', name: 'Platform'})];
 
-    renderProjectSwitcher({onSelect});
+    renderProjectSwitcher({onSelect, projects});
     await screen.findByRole('option', {name: 'Platform'});
     const createOption = screen.getByRole('option', {name: CREATE_PROJECT_LABEL_RE});
     const searchInput = screen.getByPlaceholderText('Search projects...');
@@ -47,8 +39,20 @@ describe('ProjectSwitcher', () => {
   });
 });
 
-function renderProjectSwitcher({onSelect}: {onSelect: () => void}) {
-  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+function renderProjectSwitcher({
+  onSelect,
+  projects,
+}: {
+  onSelect: () => void;
+  projects: ReturnType<typeof projectDto>[];
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false, staleTime: Number.POSITIVE_INFINITY}},
+  });
+  queryClient.setQueryData(projectsQueryKeys.list(PROJECT_TEST_WID), {
+    pages: [{projects, next_cursor: null}],
+    pageParams: [undefined],
+  });
   const rootRoute = createRootRoute({component: Outlet});
   const workspaceRoute = createRoute({
     getParentRoute: () => rootRoute,


### PR DESCRIPTION
Stabilize the project switcher empty-search test by seeding the React Query cache directly instead of waiting on mocked API data.

The test is meant to verify command-menu behavior: Create project stays pinned outside the filtered list and Enter routes to the create page when the search has no project matches. In CI, the assertion for the seeded project could run before API-backed query data finished rendering, leaving only the static pinned items in the DOM.

This keeps the test focused on the UI behavior under test and removes the network/query timing dependency from setup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilize the ProjectSwitcher empty-search test by seeding the `@tanstack/react-query` cache instead of waiting on mocked API data. This removes timing flakiness and ensures “Create project” stays pinned and keyboard-selectable.

<sup>Written for commit b09e57f03efef5379243a51bd60196324dcb08ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

