### PR TITLE
[client-auth] Mark auth sentence links as interactive

### DIFF
--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -91,7 +91,10 @@ export function LoginPage() {
         </Button>
       </form>
       <Text size="sm" className="text-center text-foreground-neutral-subtle">
-        New to Shipfox? <Link to="/auth/signup">Create an account</Link>
+        New to Shipfox?{' '}
+        <ButtonLink asChild variant="interactive" underline>
+          <Link to="/auth/signup">Create an account</Link>
+        </ButtonLink>
       </Text>
     </AuthShell>
   );

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -73,7 +73,10 @@ function PasswordResetRequest() {
           Use another email
         </Button>
         <Text size="sm" className="text-center text-foreground-neutral-subtle">
-          Remembered it? <Link to="/auth/login">Log in</Link>
+          Remembered it?{' '}
+          <ButtonLink asChild variant="interactive" underline>
+            <Link to="/auth/login">Log in</Link>
+          </ButtonLink>
         </Text>
       </AuthShell>
     );
@@ -108,7 +111,10 @@ function PasswordResetRequest() {
         </Button>
       </form>
       <Text size="sm" className="text-center text-foreground-neutral-subtle">
-        Remembered it? <Link to="/auth/login">Log in</Link>
+        Remembered it?{' '}
+        <ButtonLink asChild variant="interactive" underline>
+          <Link to="/auth/login">Log in</Link>
+        </ButtonLink>
       </Text>
     </AuthShell>
   );

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -1,5 +1,5 @@
 import {signupBodySchema} from '@shipfox/api-auth-dto';
-import {Alert, Button, Input, Label, Text} from '@shipfox/react-ui';
+import {Alert, Button, ButtonLink, Input, Label, Text} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {type FormEvent, useState} from 'react';
@@ -60,7 +60,10 @@ export function SignupPage() {
           Use another email
         </Button>
         <Text size="sm" className="text-center text-foreground-neutral-subtle">
-          Already verified? <Link to="/auth/login">Log in</Link>
+          Already verified?{' '}
+          <ButtonLink asChild variant="interactive" underline>
+            <Link to="/auth/login">Log in</Link>
+          </ButtonLink>
         </Text>
       </AuthShell>
     );
@@ -136,7 +139,10 @@ export function SignupPage() {
         </Button>
       </form>
       <Text size="sm" className="text-center text-foreground-neutral-subtle">
-        Already have an account? <Link to="/auth/login">Log in</Link>
+        Already have an account?{' '}
+        <ButtonLink asChild variant="interactive" underline>
+          <Link to="/auth/login">Log in</Link>
+        </ButtonLink>
       </Text>
     </AuthShell>
   );


### PR DESCRIPTION
Mark inline auth sentence links with the design-system interactive link treatment.

The auth pages used muted surrounding text and plain router links, so only part of each sentence was clickable while the full sentence looked visually identical. This wraps the actionable phrases in `ButtonLink` with the interactive, underlined variant so users can distinguish the clickable area without introducing bespoke styling.

Also applies the same treatment to matching password reset prompts for consistency across the auth surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the design-system `ButtonLink` (interactive + underline) for inline auth prompts so the actionable text is clearly clickable. Applied to Login, Signup, and Password Reset pages for a consistent treatment.

<sup>Written for commit 9ad2c52df6c9b5b50c7087bb6e16ba5b24ea231e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

