### PR TITLE
Report per-step runtime results in runner protocol

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -46,19 +46,19 @@
 
 **Depends on:** Nothing. Can be built independently.
 
-## Add per-step status reporting to runner protocol
+## Single-statement `applyStepResults` for many-step jobs
 
-**What:** Extend the runner completion protocol to report per-step results instead of a single job-level status. Update `CompleteJobBodyDto` to accept an array of `{ stepId, status, output }` alongside the job status. Update `jobOrchestration` to use per-step statuses instead of `bulkSetStepStatuses`.
+**What:** Collapse the N-update + 1-cancellation-sweep pattern in `applyStepResults` (`libs/api/workflows/src/db/workflow-runs.ts`) into a single `UPDATE steps SET status = CASE id WHEN ... END, error = CASE id WHEN ... END WHERE job_id = ?` for jobs with many reported steps.
 
-**Why:** Currently, the runner knows which steps succeeded and which failed (fail-fast execution), but the protocol only sends a single `{status, output}` for the entire job. The backend's `bulkSetStepStatuses` marks ALL steps with the same terminal status. If step 2 of 5 fails, steps 3-5 show as "failed" even though they were never executed. This makes debugging harder and the UI misleading.
+**Why:** The current implementation does N+1 UPDATEs per transaction. Fine for typical jobs (<20 steps). At 100+ steps, the round-trip overhead becomes the dominant cost.
 
-**Pros:** Accurate per-step status in the UI. Steps that were never executed show as "cancelled" or "skipped" instead of "failed." Step-level output for debugging.
+**Pros:** Single round-trip, atomic by construction.
 
-**Cons:** Protocol change requires coordinated runner + backend update. Adds complexity to the completion flow.
+**Cons:** SQL gets noisier; harder to read. Premature for current step counts.
 
-**Context:** The runner's executor already tracks per-step results internally. The change is mostly about widening the protocol to carry that data through. The `output` field in `CompleteJobBodyDto` is `z.unknown()` so a structured object could be sent today, but the backend ignores step-level detail. Both the DTO schema and the `jobOrchestration` signal handler need updates.
+**Context:** Tracked in the per-step-runtime-reporting plan. The terminal-state guard and canonical-set semantics must be preserved in the rewrite. Defer until typical jobs exceed ~20 steps.
 
-**Depends on:** Runner POC (needs a working runner to iterate on the protocol).
+**Depends on:** Nothing.
 
 ## Workspaces
 

--- a/apps/runner/src/api-client.ts
+++ b/apps/runner/src/api-client.ts
@@ -38,7 +38,7 @@ export async function completeJob(
   const response = await api.post(`runners/jobs/${params.jobId}/complete`, {
     json: {
       status: params.status,
-      output: params.output,
+      steps: params.steps,
     } satisfies CompleteJobBodyDto,
   });
   return completeJobResponseSchema.parse(await response.json());

--- a/apps/runner/src/executor.test.ts
+++ b/apps/runner/src/executor.test.ts
@@ -18,7 +18,7 @@ describe('executeJob', () => {
     const callOrder: number[] = [];
     mockExecuteRunStep.mockImplementation((step) => {
       callOrder.push(step.position);
-      return Promise.resolve({success: true, output: ''});
+      return Promise.resolve({success: true, output: '', error: null});
     });
 
     const job = buildJob([
@@ -32,41 +32,72 @@ describe('executeJob', () => {
     expect(callOrder).toEqual([0, 1, 2]);
   });
 
-  it('returns succeeded when all steps pass', async () => {
-    mockExecuteRunStep.mockResolvedValue({success: true, output: 'ok\n'});
+  it('returns succeeded with one entry per step when all pass', async () => {
+    mockExecuteRunStep.mockResolvedValue({success: true, output: 'ok\n', error: null});
 
     const job = buildJob([{position: 0}, {position: 1}]);
 
     const result = await executeJob(job);
 
     expect(result.status).toBe('succeeded');
-    expect(result.output).toBe('ok\nok\n');
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0]).toEqual({step_id: job.steps[0]?.id, status: 'succeeded', error: null});
+    expect(result.steps[1]).toEqual({step_id: job.steps[1]?.id, status: 'succeeded', error: null});
   });
 
-  it('stops on first failure and returns failed', async () => {
+  it('stops on first failure and only reports up to the failed step', async () => {
     mockExecuteRunStep
-      .mockResolvedValueOnce({success: true, output: 'step1\n'})
-      .mockResolvedValueOnce({success: false, output: 'step2-err\n'})
-      .mockResolvedValueOnce({success: true, output: 'step3\n'});
+      .mockResolvedValueOnce({success: true, output: 'step1\n', error: null})
+      .mockResolvedValueOnce({
+        success: false,
+        output: 'step2-err\n',
+        error: {message: 'Command exited with code 1', exitCode: 1},
+      })
+      .mockResolvedValueOnce({success: true, output: 'step3\n', error: null});
 
     const job = buildJob([{position: 0}, {position: 1}, {position: 2}]);
 
     const result = await executeJob(job);
 
     expect(result.status).toBe('failed');
-    expect(result.output).toBe('step1\nstep2-err\n');
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0]?.status).toBe('succeeded');
+    expect(result.steps[1]).toEqual({
+      step_id: job.steps[1]?.id,
+      status: 'failed',
+      error: {message: 'Command exited with code 1', exitCode: 1},
+    });
     expect(mockExecuteRunStep).toHaveBeenCalledTimes(2);
   });
 
+  it('propagates signal-kill error shape from a failed step', async () => {
+    mockExecuteRunStep.mockResolvedValueOnce({
+      success: false,
+      output: '',
+      error: {message: 'Killed by signal SIGKILL', exitCode: null, signal: 'SIGKILL'},
+    });
+
+    const job = buildJob([{position: 0}]);
+
+    const result = await executeJob(job);
+
+    expect(result.status).toBe('failed');
+    expect(result.steps[0]?.error).toEqual({
+      message: 'Killed by signal SIGKILL',
+      exitCode: null,
+      signal: 'SIGKILL',
+    });
+  });
+
   it('handles a single step job', async () => {
-    mockExecuteRunStep.mockResolvedValue({success: true, output: 'done\n'});
+    mockExecuteRunStep.mockResolvedValue({success: true, output: 'done\n', error: null});
 
     const job = buildJob([{position: 0}]);
 
     const result = await executeJob(job);
 
     expect(result.status).toBe('succeeded');
-    expect(result.output).toBe('done\n');
+    expect(result.steps).toHaveLength(1);
   });
 
   it('handles a job with no steps', async () => {
@@ -75,7 +106,7 @@ describe('executeJob', () => {
     const result = await executeJob(job);
 
     expect(result.status).toBe('succeeded');
-    expect(result.output).toBe('');
+    expect(result.steps).toEqual([]);
     expect(mockExecuteRunStep).not.toHaveBeenCalled();
   });
 });

--- a/apps/runner/src/executor.test.ts
+++ b/apps/runner/src/executor.test.ts
@@ -51,7 +51,7 @@ describe('executeJob', () => {
       .mockResolvedValueOnce({
         success: false,
         output: 'step2-err\n',
-        error: {message: 'Command exited with code 1', exitCode: 1},
+        error: {message: 'Command exited with code 1', exit_code: 1},
       })
       .mockResolvedValueOnce({success: true, output: 'step3\n', error: null});
 
@@ -65,7 +65,7 @@ describe('executeJob', () => {
     expect(result.steps[1]).toEqual({
       step_id: job.steps[1]?.id,
       status: 'failed',
-      error: {message: 'Command exited with code 1', exitCode: 1},
+      error: {message: 'Command exited with code 1', exit_code: 1},
     });
     expect(mockExecuteRunStep).toHaveBeenCalledTimes(2);
   });
@@ -74,7 +74,7 @@ describe('executeJob', () => {
     mockExecuteRunStep.mockResolvedValueOnce({
       success: false,
       output: '',
-      error: {message: 'Killed by signal SIGKILL', exitCode: null, signal: 'SIGKILL'},
+      error: {message: 'Killed by signal SIGKILL', exit_code: null, signal: 'SIGKILL'},
     });
 
     const job = buildJob([{position: 0}]);
@@ -84,7 +84,7 @@ describe('executeJob', () => {
     expect(result.status).toBe('failed');
     expect(result.steps[0]?.error).toEqual({
       message: 'Killed by signal SIGKILL',
-      exitCode: null,
+      exit_code: null,
       signal: 'SIGKILL',
     });
   });
@@ -98,16 +98,6 @@ describe('executeJob', () => {
 
     expect(result.status).toBe('succeeded');
     expect(result.steps).toHaveLength(1);
-  });
-
-  it('handles a job with no steps', async () => {
-    const job = buildJob([]);
-
-    const result = await executeJob(job);
-
-    expect(result.status).toBe('succeeded');
-    expect(result.steps).toEqual([]);
-    expect(mockExecuteRunStep).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/runner/src/executor.ts
+++ b/apps/runner/src/executor.ts
@@ -1,10 +1,10 @@
-import type {JobPayloadDto} from '@shipfox/api-runners-dto';
+import type {JobPayloadDto, StepResultDto} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {executeRunStep} from '#run-step.js';
 
 export interface ExecuteJobResult {
   status: 'succeeded' | 'failed';
-  output: string;
+  steps: StepResultDto[];
 }
 
 export async function executeJob(
@@ -12,7 +12,7 @@ export async function executeJob(
   options: {signal?: AbortSignal} = {},
 ): Promise<ExecuteJobResult> {
   const steps = [...job.steps].sort((a, b) => a.position - b.position);
-  let output = '';
+  const reported: StepResultDto[] = [];
 
   for (const step of steps) {
     const stepLabel = step.name ?? `step #${step.position}`;
@@ -22,15 +22,16 @@ export async function executeJob(
     );
 
     const result = await executeRunStep(step, options);
-    output += result.output;
 
     if (!result.success) {
       logger().error({stepId: step.id, stepName: step.name}, `Step ${stepLabel} failed`);
-      return {status: 'failed', output};
+      reported.push({step_id: step.id, status: 'failed', error: result.error});
+      return {status: 'failed', steps: reported};
     }
 
     logger().info({stepId: step.id, stepName: step.name}, `Step ${stepLabel} succeeded`);
+    reported.push({step_id: step.id, status: 'succeeded', error: null});
   }
 
-  return {status: 'succeeded', output};
+  return {status: 'succeeded', steps: reported};
 }

--- a/apps/runner/src/run-step.test.ts
+++ b/apps/runner/src/run-step.test.ts
@@ -13,12 +13,13 @@ describe('executeRunStep', () => {
     expect(result.output).toContain('hello');
   });
 
-  it('fails with non-zero exit code', async () => {
+  it('fails with non-zero exit code and reports it on result.error', async () => {
     const step = buildStep({config: {run: 'exit 1'}});
 
     const result = await executeRunStep(step);
 
     expect(result.success).toBe(false);
+    expect(result.error).toEqual({message: 'Command exited with code 1', exitCode: 1});
   });
 
   it('captures both stdout and stderr', async () => {
@@ -31,22 +32,40 @@ describe('executeRunStep', () => {
     expect(result.output).toContain('err');
   });
 
-  it('returns failure for unsupported step type', async () => {
+  it('returns failure for unsupported step type with the reason on error.message', async () => {
     const step = buildStep({type: 'docker', config: {image: 'node:20'}});
 
     const result = await executeRunStep(step);
 
     expect(result.success).toBe(false);
-    expect(result.output).toContain('Unsupported step type: docker');
+    expect(result.error?.message).toContain('Unsupported step type: docker');
+    expect(result.error?.exitCode).toBeUndefined();
+    expect(result.output).toBe('');
   });
 
-  it('returns failure when config.run is missing', async () => {
+  it('returns failure when config.run is missing with the reason on error.message', async () => {
     const step = buildStep({config: {}});
 
     const result = await executeRunStep(step);
 
     expect(result.success).toBe(false);
-    expect(result.output).toContain('missing or empty');
+    expect(result.error?.message).toContain('missing or empty');
+    expect(result.error?.exitCode).toBeUndefined();
+  });
+
+  it('reports signal kill on result.error when aborted', async () => {
+    const step = buildStep({config: {run: 'sleep 30'}});
+    const ac = new AbortController();
+    const promise = executeRunStep(step, {signal: ac.signal});
+
+    await new Promise((r) => setTimeout(r, 50));
+    ac.abort();
+
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error?.exitCode).toBeNull();
+    expect(result.error?.signal).toBe('SIGKILL');
+    expect(result.error?.message).toContain('SIGKILL');
   });
 
   it('handles multi-line scripts', async () => {

--- a/apps/runner/src/run-step.test.ts
+++ b/apps/runner/src/run-step.test.ts
@@ -19,7 +19,7 @@ describe('executeRunStep', () => {
     const result = await executeRunStep(step);
 
     expect(result.success).toBe(false);
-    expect(result.error).toEqual({message: 'Command exited with code 1', exitCode: 1});
+    expect(result.error).toEqual({message: 'Command exited with code 1', exit_code: 1});
   });
 
   it('captures both stdout and stderr', async () => {
@@ -39,7 +39,7 @@ describe('executeRunStep', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.message).toContain('Unsupported step type: docker');
-    expect(result.error?.exitCode).toBeUndefined();
+    expect(result.error?.exit_code).toBeUndefined();
     expect(result.output).toBe('');
   });
 
@@ -50,7 +50,7 @@ describe('executeRunStep', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.message).toContain('missing or empty');
-    expect(result.error?.exitCode).toBeUndefined();
+    expect(result.error?.exit_code).toBeUndefined();
   });
 
   it('reports signal kill on result.error when aborted', async () => {
@@ -63,7 +63,7 @@ describe('executeRunStep', () => {
 
     const result = await promise;
     expect(result.success).toBe(false);
-    expect(result.error?.exitCode).toBeNull();
+    expect(result.error?.exit_code).toBeNull();
     expect(result.error?.signal).toBe('SIGKILL');
     expect(result.error?.message).toContain('SIGKILL');
   });

--- a/apps/runner/src/run-step.ts
+++ b/apps/runner/src/run-step.ts
@@ -136,10 +136,10 @@ function spawnAndCapture(scriptPath: string, options: {signal?: AbortSignal}): P
         code === null
           ? {
               message: `Killed by signal ${signal ?? 'unknown'}`,
-              exitCode: null,
+              exit_code: null,
               ...(signal ? {signal} : {}),
             }
-          : {message: `Command exited with code ${code}`, exitCode: code};
+          : {message: `Command exited with code ${code}`, exit_code: code};
       resolve({success: false, output: finalOutput, error});
     });
 

--- a/apps/runner/src/run-step.ts
+++ b/apps/runner/src/run-step.ts
@@ -3,12 +3,17 @@ import {randomUUID} from 'node:crypto';
 import {unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
-import type {JobPayloadStepDto} from '@shipfox/api-runners-dto';
+import type {JobPayloadStepDto, StepErrorDto} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 
 export interface StepResult {
   success: boolean;
+  // Captured stdout/stderr for runner-side observability and tests (the
+  // grandchild-PID extraction in run-step.test.ts depends on this). Never sent
+  // to the API: per-step logs are a separate concern (future S3-backed logs).
   output: string;
+  // Populated when success is false. Null on success.
+  error: StepErrorDto;
 }
 
 const MAX_OUTPUT_BYTES = 1024 * 1024; // 1MB
@@ -20,7 +25,8 @@ export function executeRunStep(
   if (step.type !== 'run') {
     return Promise.resolve({
       success: false,
-      output: `Unsupported step type: ${step.type}`,
+      output: '',
+      error: {message: `Unsupported step type: ${step.type}`},
     });
   }
 
@@ -28,7 +34,8 @@ export function executeRunStep(
   if (!command) {
     return Promise.resolve({
       success: false,
-      output: 'Step config.run is missing or empty',
+      output: '',
+      error: {message: 'Step config.run is missing or empty'},
     });
   }
 
@@ -116,13 +123,24 @@ function spawnAndCapture(scriptPath: string, options: {signal?: AbortSignal}): P
       }
     };
 
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
       cleanupAbortListener();
       const finalOutput = truncated ? `[output truncated]\n${output}` : output;
-      resolve({
-        success: code === 0,
-        output: finalOutput,
-      });
+      if (code === 0) {
+        resolve({success: true, output: finalOutput, error: null});
+        return;
+      }
+      // code === null when the child was terminated by a signal (e.g. SIGKILL
+      // from killGroup() on abort). Otherwise code is the non-zero exit code.
+      const error: StepErrorDto =
+        code === null
+          ? {
+              message: `Killed by signal ${signal ?? 'unknown'}`,
+              exitCode: null,
+              ...(signal ? {signal} : {}),
+            }
+          : {message: `Command exited with code ${code}`, exitCode: code};
+      resolve({success: false, output: finalOutput, error});
     });
 
     child.on('error', (err) => {
@@ -130,7 +148,8 @@ function spawnAndCapture(scriptPath: string, options: {signal?: AbortSignal}): P
       logger().error({err}, 'Failed to spawn shell process');
       resolve({
         success: false,
-        output: `Failed to spawn process: ${err.message}`,
+        output: '',
+        error: {message: `Failed to spawn process: ${err.message}`},
       });
     });
   });

--- a/apps/runner/src/runner.ts
+++ b/apps/runner/src/runner.ts
@@ -64,7 +64,9 @@ async function runJob(job: Awaited<ReturnType<typeof requestJob>> & object): Pro
     logger().info({jobId: job.job_id, status: result.status}, 'Job execution finished');
   } catch (execError) {
     logger().error({err: execError, jobId: job.job_id}, 'Job execution failed');
-    result = {status: 'failed', output: String(execError)};
+    // Empty steps[] tells the API "we don't know which step crashed"; the
+    // workflow falls back to bulk-failing every step.
+    result = {status: 'failed', steps: []};
   } finally {
     heartbeatLoop.stop();
     if (currentJobAbortController === ac) currentJobAbortController = undefined;
@@ -73,7 +75,7 @@ async function runJob(job: Awaited<ReturnType<typeof requestJob>> & object): Pro
   // 404 here is the expected signal that the backend already finalized this
   // job; do not retry, do not fall through to the outer catch (would re-attempt).
   try {
-    await completeJob({jobId: job.job_id, status: result.status, output: result.output});
+    await completeJob({jobId: job.job_id, status: result.status, steps: result.steps});
     logger().info({jobId: job.job_id, status: result.status}, 'Job completed');
   } catch (reportError) {
     if (reportError instanceof HTTPError && reportError.response.status === 404) {

--- a/libs/api/runners-dto/src/events.ts
+++ b/libs/api/runners-dto/src/events.ts
@@ -1,10 +1,12 @@
+import type {StepResultDto} from '#schemas/complete-job.js';
+
 export const RUNNER_JOB_COMPLETED = 'runners.job.completed' as const;
 
 export interface RunnerJobCompletedEvent {
   jobId: string;
   runId: string;
   status: 'succeeded' | 'failed';
-  output?: unknown;
+  steps: StepResultDto[];
 }
 
 export interface RunnersEventMap {

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -21,6 +21,10 @@ export {
   type RunnerTokenDto,
   revokeRunnerTokenResponseSchema,
   runnerTokenDtoSchema,
+  type StepErrorDto,
+  type StepResultDto,
+  stepErrorSchema,
+  stepResultSchema,
 } from '#schemas/index.js';
 export {
   RUNNER_JOB_COMPLETED,

--- a/libs/api/runners-dto/src/schemas/complete-job.ts
+++ b/libs/api/runners-dto/src/schemas/complete-job.ts
@@ -10,11 +10,15 @@ export const stepErrorSchema = z
 
 export type StepErrorDto = z.infer<typeof stepErrorSchema>;
 
-export const stepResultSchema = z.object({
-  step_id: z.string().uuid(),
-  status: z.enum(['succeeded', 'failed']),
-  error: stepErrorSchema,
-});
+export const stepResultSchema = z
+  .object({
+    step_id: z.string().uuid(),
+    status: z.enum(['succeeded', 'failed']),
+    error: stepErrorSchema,
+  })
+  .refine((step) => (step.status === 'succeeded' ? step.error === null : step.error !== null), {
+    message: 'succeeded steps must have error=null and failed steps must include an error',
+  });
 
 export type StepResultDto = z.infer<typeof stepResultSchema>;
 

--- a/libs/api/runners-dto/src/schemas/complete-job.ts
+++ b/libs/api/runners-dto/src/schemas/complete-job.ts
@@ -3,7 +3,7 @@ import {z} from 'zod';
 export const stepErrorSchema = z
   .object({
     message: z.string(),
-    exitCode: z.number().int().nullable().optional(),
+    exit_code: z.number().int().nullable().optional(),
     signal: z.string().optional(),
   })
   .nullable();

--- a/libs/api/runners-dto/src/schemas/complete-job.ts
+++ b/libs/api/runners-dto/src/schemas/complete-job.ts
@@ -1,9 +1,37 @@
 import {z} from 'zod';
 
-export const completeJobBodySchema = z.object({
+export const stepErrorSchema = z
+  .object({
+    message: z.string(),
+    exitCode: z.number().int().nullable().optional(),
+    signal: z.string().optional(),
+  })
+  .nullable();
+
+export type StepErrorDto = z.infer<typeof stepErrorSchema>;
+
+export const stepResultSchema = z.object({
+  step_id: z.string().uuid(),
   status: z.enum(['succeeded', 'failed']),
-  output: z.unknown().optional(),
+  error: stepErrorSchema,
 });
+
+export type StepResultDto = z.infer<typeof stepResultSchema>;
+
+export const completeJobBodySchema = z
+  .object({
+    status: z.enum(['succeeded', 'failed']),
+    steps: z.array(stepResultSchema),
+  })
+  .refine(
+    (body) =>
+      body.status !== 'succeeded' ||
+      (body.steps.length > 0 && body.steps.every((s) => s.status === 'succeeded')),
+    {
+      message:
+        'succeeded jobs must report at least one step and all reported steps must be succeeded',
+    },
+  );
 
 export type CompleteJobBodyDto = z.infer<typeof completeJobBodySchema>;
 

--- a/libs/api/runners-dto/src/schemas/index.ts
+++ b/libs/api/runners-dto/src/schemas/index.ts
@@ -3,6 +3,10 @@ export {
   type CompleteJobResponseDto,
   completeJobBodySchema,
   completeJobResponseSchema,
+  type StepErrorDto,
+  type StepResultDto,
+  stepErrorSchema,
+  stepResultSchema,
 } from './complete-job.js';
 export {type HeartbeatResponseDto, heartbeatResponseSchema} from './heartbeat.js';
 export {

--- a/libs/api/runners-dto/src/schemas/request-job.ts
+++ b/libs/api/runners-dto/src/schemas/request-job.ts
@@ -14,7 +14,7 @@ export const jobPayloadSchema = z.object({
   job_id: z.string().uuid(),
   run_id: z.string().uuid(),
   job_name: z.string(),
-  steps: z.array(jobPayloadStepSchema),
+  steps: z.array(jobPayloadStepSchema).min(1),
 });
 
 export type JobPayloadDto = z.infer<typeof jobPayloadSchema>;

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -1,15 +1,16 @@
+import type {StepResultDto} from '@shipfox/api-runners-dto';
 import {finalizeRunningJob, findStuckJobs} from '#db/jobs.js';
 import {RunningJobNotFoundError} from './errors.js';
 
 export async function completeJob(
   params: {jobId: string; runnerTokenId: string},
-  result: {status: 'succeeded' | 'failed'; output?: unknown},
+  result: {status: 'succeeded' | 'failed'; steps: StepResultDto[]},
 ): Promise<{runId: string}> {
   const finalized = await finalizeRunningJob({
     jobId: params.jobId,
     runnerTokenId: params.runnerTokenId,
     status: result.status,
-    output: result.output,
+    steps: result.steps,
     onMissing: 'throw',
   });
   if (!finalized) throw new RunningJobNotFoundError(params.jobId);
@@ -26,11 +27,15 @@ export async function detectAndFailStuckJobs(params: {
 
   let failed = 0;
   for (const candidate of candidates) {
+    // Empty steps[] flows into the workflow's empty-fallback path, which
+    // bulk-fails every step. The "runner_disappeared" reason previously stored
+    // here was transport-only (never persisted) and the heartbeat audit log
+    // remains the source of truth for why a job went stuck.
     const finalized = await finalizeRunningJob({
       jobId: candidate.jobId,
       staleBeforeMs: params.thresholdSeconds * 1000,
       status: 'failed',
-      output: {reason: 'runner_disappeared'},
+      steps: [],
       onMissing: 'noop',
     });
     if (finalized) failed += 1;

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -141,13 +141,21 @@ describe('completeJob', () => {
     runnerTokenId = runnerToken.id;
   });
 
+  function succeededResult(stepId: string) {
+    return {
+      status: 'succeeded' as const,
+      steps: [{step_id: stepId, status: 'succeeded' as const, error: null}],
+    };
+  }
+
   it('deletes the running job and writes an outbox event', async () => {
-    await pendingJobFactory.create({workspaceId});
+    const pending = await pendingJobFactory.create({workspaceId});
     const claimed = await claimJob({workspaceId, runnerTokenId});
+    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
 
     const result = await completeJob(
       {jobId: claimed?.jobId as string, runnerTokenId},
-      {status: 'succeeded'},
+      succeededResult(stepId),
     );
 
     expect(result.runId).toBe(claimed?.runId as string);
@@ -162,23 +170,28 @@ describe('completeJob', () => {
     expect(payload.jobId).toBe(claimed?.jobId as string);
     expect(payload.runId).toBe(claimed?.runId as string);
     expect(payload.status).toBe('succeeded');
+    expect(payload.steps).toHaveLength(1);
   });
 
   it('throws RunningJobNotFoundError when job is not running', async () => {
     await expect(
-      completeJob({jobId: crypto.randomUUID(), runnerTokenId}, {status: 'succeeded'}),
+      completeJob(
+        {jobId: crypto.randomUUID(), runnerTokenId},
+        succeededResult(crypto.randomUUID()),
+      ),
     ).rejects.toThrow('Running job not found');
   });
 
   it('does not complete a job owned by another runner token', async () => {
     const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
-    await pendingJobFactory.create({workspaceId});
+    const pending = await pendingJobFactory.create({workspaceId});
     const claimed = await claimJob({workspaceId, runnerTokenId});
+    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
 
     await expect(
       completeJob(
         {jobId: claimed?.jobId as string, runnerTokenId: otherRunnerToken.id},
-        {status: 'succeeded'},
+        succeededResult(stepId),
       ),
     ).rejects.toThrow('Running job not found');
 
@@ -346,7 +359,7 @@ describe('detectAndFailStuckJobs', () => {
     });
   }
 
-  it('fails a stuck job and writes a runners.job.completed event with reason runner_disappeared', async () => {
+  it('fails a stuck job and writes a runners.job.completed event with empty steps[]', async () => {
     const {jobId, runId} = await makeStaleJob(600);
 
     const result = await detectAndFailStuckJobs({thresholdSeconds: 180});
@@ -361,7 +374,10 @@ describe('detectAndFailStuckJobs', () => {
     expect(payload.jobId).toBe(jobId);
     expect(payload.runId).toBe(runId);
     expect(payload.status).toBe('failed');
-    expect(payload.output).toEqual({reason: 'runner_disappeared'});
+    // Stuck-job detection has no per-step detail; the workflow falls back to
+    // bulk-failing every step via the empty-steps path.
+    expect(payload.steps).toEqual([]);
+    expect(payload.output).toBeUndefined();
   });
 
   it('does not fail a job whose heartbeat is still inside the threshold window', async () => {

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -2,6 +2,7 @@ import {
   type JobPayloadDto,
   RUNNER_JOB_COMPLETED,
   type RunnersEventMap,
+  type StepResultDto,
 } from '@shipfox/api-runners-dto';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, eq, lt, sql} from 'drizzle-orm';
@@ -77,7 +78,7 @@ export interface FinalizeRunningJobParams {
   /** When provided, only delete the row if its heartbeat is older than this. */
   staleBeforeMs?: number;
   status: 'succeeded' | 'failed';
-  output?: unknown;
+  steps: StepResultDto[];
   /** Whether to throw `RunningJobNotFoundError` when no row matches the filters. */
   onMissing: 'throw' | 'noop';
 }
@@ -126,7 +127,7 @@ export async function finalizeRunningJob(
         jobId: params.jobId,
         runId: row.runId,
         status: params.status,
-        output: params.output,
+        steps: params.steps,
       },
     });
 

--- a/libs/api/runners/src/presentation/routes/complete-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/complete-job.test.ts
@@ -52,11 +52,18 @@ describe('POST /runners/jobs/:jobId/complete', () => {
     runnerTokenId = token.id;
   });
 
+  function buildSucceededBody(stepId: string) {
+    return {
+      status: 'succeeded' as const,
+      steps: [{step_id: stepId, status: 'succeeded' as const, error: null}],
+    };
+  }
+
   it('returns 401 without authorization', async () => {
     const res = await app.inject({
       method: 'POST',
       url: `/runners/jobs/${crypto.randomUUID()}/complete`,
-      payload: {status: 'succeeded'},
+      payload: buildSucceededBody(crypto.randomUUID()),
     });
 
     expect(res.statusCode).toBe(401);
@@ -67,21 +74,22 @@ describe('POST /runners/jobs/:jobId/complete', () => {
       method: 'POST',
       url: `/runners/jobs/${crypto.randomUUID()}/complete`,
       headers: {authorization: 'Bearer invalid'},
-      payload: {status: 'succeeded'},
+      payload: buildSucceededBody(crypto.randomUUID()),
     });
 
     expect(res.statusCode).toBe(401);
   });
 
-  it('returns 200 on successful completion by the owning runner token', async () => {
+  it('returns 200 on successful completion and outbox event carries steps', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
     const claimed = await claimJob({workspaceId, runnerTokenId});
+    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',
       url: `/runners/jobs/${pending.jobId}/complete`,
       headers: {authorization: `Bearer ${rawToken}`},
-      payload: {status: 'succeeded'},
+      payload: buildSucceededBody(stepId),
     });
 
     expect(res.statusCode).toBe(200);
@@ -92,18 +100,21 @@ describe('POST /runners/jobs/:jobId/complete', () => {
     expect(claimed?.jobId).toBe(pending.jobId);
     expect(running).toHaveLength(0);
     expect(outboxRows[0]?.eventType).toBe(RUNNER_JOB_COMPLETED);
+    const payload = outboxRows[0]?.payload as {steps: unknown[]};
+    expect(payload.steps).toHaveLength(1);
   });
 
   it('allows a revoked token to complete a job it already owns', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
     await claimJob({workspaceId, runnerTokenId});
     await revokeRunnerToken({tokenId: runnerTokenId, workspaceId});
+    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',
       url: `/runners/jobs/${pending.jobId}/complete`,
       headers: {authorization: `Bearer ${rawToken}`},
-      payload: {status: 'succeeded'},
+      payload: buildSucceededBody(stepId),
     });
 
     expect(res.statusCode).toBe(200);
@@ -114,12 +125,13 @@ describe('POST /runners/jobs/:jobId/complete', () => {
     const otherRawToken = `sf_r_${crypto.randomUUID()}`;
     await runnerTokenFactory.create({workspaceId}, {transient: {rawToken: otherRawToken}});
     await claimJob({workspaceId, runnerTokenId});
+    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',
       url: `/runners/jobs/${pending.jobId}/complete`,
       headers: {authorization: `Bearer ${otherRawToken}`},
-      payload: {status: 'succeeded'},
+      payload: buildSucceededBody(stepId),
     });
 
     const running = await db()
@@ -140,5 +152,76 @@ describe('POST /runners/jobs/:jobId/complete', () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects status=succeeded with empty steps[] (strict refine)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${crypto.randomUUID()}/complete`,
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {status: 'succeeded', steps: []},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects status=succeeded with a failed step (strict refine)', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${crypto.randomUUID()}/complete`,
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {
+        status: 'succeeded',
+        steps: [
+          {step_id: crypto.randomUUID(), status: 'succeeded', error: null},
+          {
+            step_id: crypto.randomUUID(),
+            status: 'failed',
+            error: {message: 'boom', exitCode: 1},
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('accepts status=failed with empty steps[] (executor-throws / stuck path)', async () => {
+    const pending = await pendingJobFactory.create({workspaceId});
+    await claimJob({workspaceId, runnerTokenId});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${pending.jobId}/complete`,
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {status: 'failed', steps: []},
+    });
+
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('accepts status=failed with mixed step statuses (mid-job failure)', async () => {
+    const pending = await pendingJobFactory.create({workspaceId});
+    await claimJob({workspaceId, runnerTokenId});
+    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${pending.jobId}/complete`,
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {
+        status: 'failed',
+        steps: [
+          {step_id: stepId, status: 'succeeded', error: null},
+          {
+            step_id: crypto.randomUUID(),
+            status: 'failed',
+            error: {message: 'Command exited with code 1', exitCode: 1},
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/libs/api/runners/src/presentation/routes/complete-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/complete-job.test.ts
@@ -177,7 +177,7 @@ describe('POST /runners/jobs/:jobId/complete', () => {
           {
             step_id: crypto.randomUUID(),
             status: 'failed',
-            error: {message: 'boom', exitCode: 1},
+            error: {message: 'boom', exit_code: 1},
           },
         ],
       },
@@ -216,7 +216,7 @@ describe('POST /runners/jobs/:jobId/complete', () => {
           {
             step_id: crypto.randomUUID(),
             status: 'failed',
-            error: {message: 'Command exited with code 1', exitCode: 1},
+            error: {message: 'Command exited with code 1', exit_code: 1},
           },
         ],
       },

--- a/libs/api/runners/src/presentation/routes/complete-job.ts
+++ b/libs/api/runners/src/presentation/routes/complete-job.ts
@@ -24,10 +24,10 @@ export const completeJobRoute = defineRoute({
   },
   handler: async (request) => {
     const {jobId} = request.params;
-    const {status, output} = request.body;
+    const {status, steps} = request.body;
     const runner = getRunnerContext(request);
 
-    await completeJob({jobId, runnerTokenId: runner.runnerTokenId}, {status, output});
+    await completeJob({jobId, runnerTokenId: runner.runnerTokenId}, {status, steps});
 
     return {ok: true};
   },

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -43,8 +43,7 @@ describe('detectAndFailStuckJobsActivity', () => {
       (row) => (row.payload as Record<string, unknown>).jobId === claimed?.jobId,
     );
     expect(matching).toHaveLength(1);
-    expect((matching[0]?.payload as Record<string, unknown>).output).toEqual({
-      reason: 'runner_disappeared',
-    });
+    expect((matching[0]?.payload as Record<string, unknown>).steps).toEqual([]);
+    expect((matching[0]?.payload as Record<string, unknown>).output).toBeUndefined();
   });
 });

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -10,7 +10,9 @@ export {
   runListResponseSchema,
   runResponseSchema,
   type StepDto,
+  type StepErrorDtoShape,
   stepDtoSchema,
+  stepErrorDtoSchema,
 } from '#schemas/index.js';
 export {
   WORKFLOW_RUN_CREATED,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -9,4 +9,9 @@ export {
   runListResponseSchema,
   runResponseSchema,
 } from './run.js';
-export {type StepDto, stepDtoSchema} from './step.js';
+export {
+  type StepDto,
+  type StepErrorDtoShape,
+  stepDtoSchema,
+  stepErrorDtoSchema,
+} from './step.js';

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -1,5 +1,15 @@
 import {z} from 'zod';
 
+export const stepErrorDtoSchema = z
+  .object({
+    message: z.string(),
+    exit_code: z.number().int().nullable().optional(),
+    signal: z.string().optional(),
+  })
+  .nullable();
+
+export type StepErrorDtoShape = z.infer<typeof stepErrorDtoSchema>;
+
 export const stepDtoSchema = z.object({
   id: z.string().uuid(),
   job_id: z.string().uuid(),
@@ -7,6 +17,7 @@ export const stepDtoSchema = z.object({
   status: z.string(),
   type: z.string(),
   config: z.record(z.unknown()),
+  error: stepErrorDtoSchema,
   position: z.number(),
   created_at: z.string(),
   updated_at: z.string(),

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -22,6 +22,7 @@ export {
   getStepsByJobIds,
   getWorkflowRunById,
   listWorkflowRunsByProject,
+  StepResultsContractViolationError,
   updateJobStatus,
   updateWorkflowRunStatus,
 } from './workflow-runs.js';

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -4,13 +4,16 @@ import {fileURLToPath} from 'node:url';
 export {closeDb, db, schema} from './db.js';
 export {workflowsOutbox} from './schema/outbox.js';
 export type {
+  ApplyStepResultsParams,
   BulkUpdateStepStatusesParams,
   CreateWorkflowRunParams,
   FailJobAsTimedOutParams,
+  ReportedStepResult,
   UpdateJobStatusParams,
   UpdateWorkflowRunStatusParams,
 } from './workflow-runs.js';
 export {
+  applyStepResults,
   bulkUpdateStepStatuses,
   createWorkflowRun,
   failJobAsTimedOut,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -4,7 +4,9 @@ import {eq, sql} from 'drizzle-orm';
 import {db} from './db.js';
 import {jobs} from './schema/jobs.js';
 import {workflowsOutbox} from './schema/outbox.js';
+import {steps as stepsTable} from './schema/steps.js';
 import {
+  applyStepResults,
   bulkUpdateStepStatuses,
   createWorkflowRun,
   failJobAsTimedOut,
@@ -572,6 +574,229 @@ describe('workflow run queries', () => {
       expect(jobSteps).toHaveLength(3);
       for (const step of jobSteps) {
         expect(step.status).toBe('succeeded');
+      }
+    });
+
+    test('does not downgrade a terminal step (terminal-state guard)', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        definition: spec({jobs: {build: {steps: [{run: 'a'}, {run: 'b'}]}}}),
+        triggerContext: {type: 'manual'},
+      });
+      const runJobs = await getJobsByRunId(run.id);
+      const jobId = runJobs[0]?.id ?? '';
+      const seeded = await getStepsByJobId(jobId);
+
+      await db()
+        .update(stepsTable)
+        .set({status: 'succeeded'})
+        .where(eq(stepsTable.id, seeded[0]?.id as string));
+
+      await bulkUpdateStepStatuses({jobId, status: 'failed'});
+
+      const final = await getStepsByJobId(jobId);
+      expect(final[0]?.status).toBe('succeeded');
+      expect(final[1]?.status).toBe('failed');
+    });
+  });
+
+  describe('applyStepResults', () => {
+    async function seedJob(stepCount: number) {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        definition: spec({
+          jobs: {
+            build: {
+              steps: Array.from({length: stepCount}, (_, i) => ({run: `step${i + 1}`})),
+            },
+          },
+        }),
+        triggerContext: {type: 'manual'},
+      });
+      const runJobs = await getJobsByRunId(run.id);
+      const jobId = runJobs[0]?.id ?? '';
+      const jobSteps = await getStepsByJobId(jobId);
+      return {jobId, jobSteps};
+    }
+
+    test('REGRESSION: mid-job failure marks unreached steps as cancelled, not failed', async () => {
+      const {jobId, jobSteps} = await seedJob(4);
+
+      await applyStepResults({
+        jobId,
+        reportedSteps: [
+          {stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null},
+          {
+            stepId: jobSteps[1]?.id as string,
+            status: 'failed',
+            error: {message: 'Command exited with code 1', exitCode: 1},
+          },
+        ],
+      });
+
+      const final = await getStepsByJobId(jobId);
+      expect(final[0]?.status).toBe('succeeded');
+      expect(final[0]?.error).toBeNull();
+      expect(final[1]?.status).toBe('failed');
+      expect(final[1]?.error).toEqual({message: 'Command exited with code 1', exitCode: 1});
+      expect(final[2]?.status).toBe('cancelled');
+      expect(final[3]?.status).toBe('cancelled');
+    });
+
+    test('writes status=succeeded with null error when every step succeeds', async () => {
+      const {jobId, jobSteps} = await seedJob(2);
+
+      await applyStepResults({
+        jobId,
+        reportedSteps: jobSteps.map((s) => ({
+          stepId: s.id,
+          status: 'succeeded' as const,
+          error: null,
+        })),
+      });
+
+      const final = await getStepsByJobId(jobId);
+      for (const step of final) {
+        expect(step.status).toBe('succeeded');
+        expect(step.error).toBeNull();
+      }
+    });
+
+    test('terminal-state guard blocks downgrade on reported updates', async () => {
+      const {jobId, jobSteps} = await seedJob(2);
+      await db()
+        .update(stepsTable)
+        .set({status: 'failed'})
+        .where(eq(stepsTable.id, jobSteps[0]?.id as string));
+
+      await applyStepResults({
+        jobId,
+        reportedSteps: [
+          {stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null},
+          {stepId: jobSteps[1]?.id as string, status: 'succeeded', error: null},
+        ],
+      });
+
+      const final = await getStepsByJobId(jobId);
+      expect(final[0]?.status).toBe('failed');
+      expect(final[1]?.status).toBe('succeeded');
+    });
+
+    test('terminal-state guard blocks cancellation of an already-succeeded step', async () => {
+      const {jobId, jobSteps} = await seedJob(3);
+      await db()
+        .update(stepsTable)
+        .set({status: 'succeeded'})
+        .where(eq(stepsTable.id, jobSteps[2]?.id as string));
+
+      await applyStepResults({
+        jobId,
+        reportedSteps: [{stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null}],
+      });
+
+      const final = await getStepsByJobId(jobId);
+      expect(final[2]?.status).toBe('succeeded');
+    });
+
+    test('empty reportedSteps[] falls back to bulk-fail (executor-throws path)', async () => {
+      const {jobId} = await seedJob(3);
+
+      await applyStepResults({jobId, reportedSteps: []});
+
+      const final = await getStepsByJobId(jobId);
+      for (const step of final) {
+        expect(step.status).toBe('failed');
+      }
+    });
+
+    test('Temporal-retry idempotency: re-running with the same payload is a no-op', async () => {
+      const {jobId, jobSteps} = await seedJob(3);
+      const payload = {
+        jobId,
+        reportedSteps: [
+          {stepId: jobSteps[0]?.id as string, status: 'succeeded' as const, error: null},
+          {
+            stepId: jobSteps[1]?.id as string,
+            status: 'failed' as const,
+            error: {message: 'boom', exitCode: 1},
+          },
+        ],
+      };
+
+      await applyStepResults(payload);
+      const afterFirst = await getStepsByJobId(jobId);
+      const updatedAtAfterFirst = afterFirst.map((s) => s.updatedAt.toISOString());
+
+      await applyStepResults(payload);
+      const afterSecond = await getStepsByJobId(jobId);
+
+      expect(afterSecond.map((s) => s.status)).toEqual(['succeeded', 'failed', 'cancelled']);
+      // Already-terminal rows are guarded; updatedAt should not move.
+      expect(afterSecond.map((s) => s.updatedAt.toISOString())).toEqual(updatedAtAfterFirst);
+    });
+
+    test('hostile: bogus stepId does not corrupt real steps (cancels every real step instead)', async () => {
+      const {jobId, jobSteps} = await seedJob(3);
+
+      await applyStepResults({
+        jobId,
+        reportedSteps: [
+          {
+            stepId: '00000000-0000-0000-0000-000000000999',
+            status: 'failed',
+            error: {message: 'bogus'},
+          },
+        ],
+      });
+
+      const final = await getStepsByJobId(jobId);
+      // Every real step ends cancelled; no real step has 'failed' or the bogus error written.
+      for (const step of final) {
+        expect(step.status).toBe('cancelled');
+        expect(step.error).toBeNull();
+      }
+      // Sanity check: the bogus id never matched a real row.
+      expect(final.map((s) => s.id)).toEqual(jobSteps.map((s) => s.id));
+    });
+
+    test('hostile: duplicate stepId is idempotent (terminal guard absorbs the second write)', async () => {
+      const {jobId, jobSteps} = await seedJob(2);
+      const stepId = jobSteps[0]?.id as string;
+
+      await applyStepResults({
+        jobId,
+        reportedSteps: [
+          {stepId, status: 'succeeded', error: null},
+          {stepId, status: 'failed', error: {message: 'should not apply', exitCode: 1}},
+        ],
+      });
+
+      const final = await getStepsByJobId(jobId);
+      // The first write wins because the terminal guard then blocks the second.
+      expect(final[0]?.status).toBe('succeeded');
+      expect(final[0]?.error).toBeNull();
+    });
+
+    test('hostile: cross-job stepId is filtered out by the canonical-set check', async () => {
+      const seedA = await seedJob(2);
+      const seedB = await seedJob(2);
+
+      await applyStepResults({
+        jobId: seedA.jobId,
+        reportedSteps: [
+          {stepId: seedA.jobSteps[0]?.id as string, status: 'succeeded', error: null},
+          {stepId: seedB.jobSteps[0]?.id as string, status: 'succeeded', error: null},
+        ],
+      });
+
+      // The cross-job step should not have been touched.
+      const finalB = await getStepsByJobId(seedB.jobId);
+      for (const step of finalB) {
+        expect(step.status).toBe('pending');
       }
     });
   });

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -14,6 +14,7 @@ import {
   getStepsByJobId,
   getWorkflowRunById,
   listWorkflowRunsByProject,
+  StepResultsContractViolationError,
   updateJobStatus,
   updateWorkflowRunStatus,
 } from './workflow-runs.js';
@@ -628,6 +629,7 @@ describe('workflow run queries', () => {
 
       await applyStepResults({
         jobId,
+        completionStatus: 'failed',
         reportedSteps: [
           {stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null},
           {
@@ -652,6 +654,7 @@ describe('workflow run queries', () => {
 
       await applyStepResults({
         jobId,
+        completionStatus: 'succeeded',
         reportedSteps: jobSteps.map((s) => ({
           stepId: s.id,
           status: 'succeeded' as const,
@@ -675,6 +678,7 @@ describe('workflow run queries', () => {
 
       await applyStepResults({
         jobId,
+        completionStatus: 'succeeded',
         reportedSteps: [
           {stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null},
           {stepId: jobSteps[1]?.id as string, status: 'succeeded', error: null},
@@ -695,6 +699,7 @@ describe('workflow run queries', () => {
 
       await applyStepResults({
         jobId,
+        completionStatus: 'failed',
         reportedSteps: [{stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null}],
       });
 
@@ -702,10 +707,10 @@ describe('workflow run queries', () => {
       expect(final[2]?.status).toBe('succeeded');
     });
 
-    test('empty reportedSteps[] falls back to bulk-fail (executor-throws path)', async () => {
+    test('empty reportedSteps[] with completionStatus=failed falls back to bulk-fail', async () => {
       const {jobId} = await seedJob(3);
 
-      await applyStepResults({jobId, reportedSteps: []});
+      await applyStepResults({jobId, completionStatus: 'failed', reportedSteps: []});
 
       const final = await getStepsByJobId(jobId);
       for (const step of final) {
@@ -717,6 +722,7 @@ describe('workflow run queries', () => {
       const {jobId, jobSteps} = await seedJob(3);
       const payload = {
         jobId,
+        completionStatus: 'failed' as const,
         reportedSteps: [
           {stepId: jobSteps[0]?.id as string, status: 'succeeded' as const, error: null},
           {
@@ -739,11 +745,12 @@ describe('workflow run queries', () => {
       expect(afterSecond.map((s) => s.updatedAt.toISOString())).toEqual(updatedAtAfterFirst);
     });
 
-    test('hostile: bogus stepId does not corrupt real steps (cancels every real step instead)', async () => {
+    test('hostile (failed): bogus stepId does not corrupt real steps', async () => {
       const {jobId, jobSteps} = await seedJob(3);
 
       await applyStepResults({
         jobId,
+        completionStatus: 'failed',
         reportedSteps: [
           {
             stepId: '00000000-0000-0000-0000-000000000999',
@@ -759,16 +766,16 @@ describe('workflow run queries', () => {
         expect(step.status).toBe('cancelled');
         expect(step.error).toBeNull();
       }
-      // Sanity check: the bogus id never matched a real row.
       expect(final.map((s) => s.id)).toEqual(jobSteps.map((s) => s.id));
     });
 
-    test('hostile: duplicate stepId is idempotent (terminal guard absorbs the second write)', async () => {
+    test('hostile (failed): duplicate stepId is idempotent (terminal guard absorbs the second write)', async () => {
       const {jobId, jobSteps} = await seedJob(2);
       const stepId = jobSteps[0]?.id as string;
 
       await applyStepResults({
         jobId,
+        completionStatus: 'failed',
         reportedSteps: [
           {stepId, status: 'succeeded', error: null},
           {stepId, status: 'failed', error: {message: 'should not apply', exitCode: 1}},
@@ -781,12 +788,13 @@ describe('workflow run queries', () => {
       expect(final[0]?.error).toBeNull();
     });
 
-    test('hostile: cross-job stepId is filtered out by the canonical-set check', async () => {
+    test('hostile (failed): cross-job stepId is filtered out by the canonical-set check', async () => {
       const seedA = await seedJob(2);
       const seedB = await seedJob(2);
 
       await applyStepResults({
         jobId: seedA.jobId,
+        completionStatus: 'failed',
         reportedSteps: [
           {stepId: seedA.jobSteps[0]?.id as string, status: 'succeeded', error: null},
           {stepId: seedB.jobSteps[0]?.id as string, status: 'succeeded', error: null},
@@ -798,6 +806,74 @@ describe('workflow run queries', () => {
       for (const step of finalB) {
         expect(step.status).toBe('pending');
       }
+    });
+
+    describe('strict mode (completionStatus=succeeded)', () => {
+      test('throws when reportedSteps is empty', async () => {
+        const {jobId} = await seedJob(2);
+
+        await expect(
+          applyStepResults({jobId, completionStatus: 'succeeded', reportedSteps: []}),
+        ).rejects.toThrow(StepResultsContractViolationError);
+      });
+
+      test('throws when a reported stepId is unknown to the job (bogus uuid)', async () => {
+        const {jobId, jobSteps} = await seedJob(2);
+
+        await expect(
+          applyStepResults({
+            jobId,
+            completionStatus: 'succeeded',
+            reportedSteps: [
+              {stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null},
+              {
+                stepId: '00000000-0000-0000-0000-000000000999',
+                status: 'succeeded',
+                error: null,
+              },
+            ],
+          }),
+        ).rejects.toThrow(StepResultsContractViolationError);
+
+        // No DB writes leaked: every real step still pending.
+        const final = await getStepsByJobId(jobId);
+        for (const step of final) {
+          expect(step.status).toBe('pending');
+        }
+      });
+
+      test('throws when a canonical stepId is missing from the report', async () => {
+        const {jobId, jobSteps} = await seedJob(3);
+
+        await expect(
+          applyStepResults({
+            jobId,
+            completionStatus: 'succeeded',
+            reportedSteps: [
+              {stepId: jobSteps[0]?.id as string, status: 'succeeded', error: null},
+              {stepId: jobSteps[1]?.id as string, status: 'succeeded', error: null},
+              // jobSteps[2] missing
+            ],
+          }),
+        ).rejects.toThrow(StepResultsContractViolationError);
+      });
+
+      test('throws on duplicate stepIds in the report', async () => {
+        const {jobId, jobSteps} = await seedJob(2);
+        const stepId = jobSteps[0]?.id as string;
+
+        await expect(
+          applyStepResults({
+            jobId,
+            completionStatus: 'succeeded',
+            reportedSteps: [
+              {stepId, status: 'succeeded', error: null},
+              {stepId, status: 'succeeded', error: null},
+              {stepId: jobSteps[1]?.id as string, status: 'succeeded', error: null},
+            ],
+          }),
+        ).rejects.toThrow(StepResultsContractViolationError);
+      });
     });
   });
 });

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -290,7 +290,21 @@ export interface ReportedStepResult {
 
 export interface ApplyStepResultsParams {
   jobId: string;
+  /**
+   * Job-level completion status. When 'succeeded', the activity enforces strict
+   * consistency: reported step ids must be the canonical set, with no
+   * duplicates and no unknowns. Violations throw — the workflow surfaces the
+   * failure and the job stays running until the timeout path catches it.
+   */
+  completionStatus: 'succeeded' | 'failed';
   reportedSteps: ReportedStepResult[];
+}
+
+export class StepResultsContractViolationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StepResultsContractViolationError';
+  }
 }
 
 /**
@@ -315,6 +329,11 @@ export interface ApplyStepResultsParams {
  */
 export async function applyStepResults(params: ApplyStepResultsParams): Promise<void> {
   if (params.reportedSteps.length === 0) {
+    if (params.completionStatus === 'succeeded') {
+      throw new StepResultsContractViolationError(
+        'completionStatus=succeeded with no reported steps',
+      );
+    }
     await bulkUpdateStepStatuses({jobId: params.jobId, status: 'failed'});
     return;
   }
@@ -326,6 +345,30 @@ export async function applyStepResults(params: ApplyStepResultsParams): Promise<
       .where(eq(steps.jobId, params.jobId));
     const canonicalIds = new Set(canonical.map((row) => row.id));
     const reportedIdSet = new Set(params.reportedSteps.map((r) => r.stepId));
+
+    if (params.completionStatus === 'succeeded') {
+      // Strict mode: every reported id must be canonical, every canonical id
+      // must be reported, and the reported list must have no duplicates. A
+      // bogus or missing id with status=succeeded would otherwise corrupt the
+      // run history (job marked succeeded while real steps end cancelled).
+      if (params.reportedSteps.length !== reportedIdSet.size) {
+        throw new StepResultsContractViolationError(
+          'duplicate stepId in reportedSteps with completionStatus=succeeded',
+        );
+      }
+      const unknown = params.reportedSteps.find((r) => !canonicalIds.has(r.stepId));
+      if (unknown) {
+        throw new StepResultsContractViolationError(
+          `unknown stepId ${unknown.stepId} with completionStatus=succeeded`,
+        );
+      }
+      const missing = canonical.filter((row) => !reportedIdSet.has(row.id));
+      if (missing.length > 0) {
+        throw new StepResultsContractViolationError(
+          `unreported canonical stepIds with completionStatus=succeeded: ${missing.map((r) => r.id).join(', ')}`,
+        );
+      }
+    }
 
     const updatedAt = new Date();
 

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -274,5 +274,90 @@ export async function bulkUpdateStepStatuses(params: BulkUpdateStepStatusesParam
       status: params.status,
       updatedAt: new Date(),
     })
-    .where(eq(steps.jobId, params.jobId));
+    .where(
+      and(
+        eq(steps.jobId, params.jobId),
+        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+      ),
+    );
+}
+
+export interface ReportedStepResult {
+  stepId: string;
+  status: 'succeeded' | 'failed';
+  error: Record<string, unknown> | null;
+}
+
+export interface ApplyStepResultsParams {
+  jobId: string;
+  reportedSteps: ReportedStepResult[];
+}
+
+/**
+ * Persists per-step results from the runner, marks any unreported step in the
+ * job as `cancelled`, and never downgrades an already-terminal row.
+ *
+ *   reportedSteps[] ──► ┌──────────────────────────────────────┐
+ *                       │ canonical = SELECT id WHERE job_id=? │
+ *                       └──────────────────────────────────────┘
+ *                                       │
+ *                       ┌───────────────┴───────────────┐
+ *                       ▼                               ▼
+ *                 reported ∩ canonical          canonical \ reported
+ *                  status + error                  status='cancelled'
+ *                       │                               │
+ *                       ▼                               ▼
+ *                   one UPDATE per row,         one UPDATE id IN (...)
+ *                   guarded by terminal         guarded by terminal
+ *
+ * Unknown / cross-job step ids get filtered out by the canonical-set
+ * intersection so they cannot leak into either branch.
+ */
+export async function applyStepResults(params: ApplyStepResultsParams): Promise<void> {
+  if (params.reportedSteps.length === 0) {
+    await bulkUpdateStepStatuses({jobId: params.jobId, status: 'failed'});
+    return;
+  }
+
+  await db().transaction(async (tx) => {
+    const canonical = await tx
+      .select({id: steps.id})
+      .from(steps)
+      .where(eq(steps.jobId, params.jobId));
+    const canonicalIds = new Set(canonical.map((row) => row.id));
+    const reportedIdSet = new Set(params.reportedSteps.map((r) => r.stepId));
+
+    const updatedAt = new Date();
+
+    for (const reported of params.reportedSteps) {
+      if (!canonicalIds.has(reported.stepId)) continue;
+      await tx
+        .update(steps)
+        .set({
+          status: reported.status,
+          error: reported.error ?? null,
+          updatedAt,
+        })
+        .where(
+          and(
+            eq(steps.id, reported.stepId),
+            eq(steps.jobId, params.jobId),
+            sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+          ),
+        );
+    }
+
+    const cancelIds = canonical.map((row) => row.id).filter((id) => !reportedIdSet.has(id));
+    if (cancelIds.length > 0) {
+      await tx
+        .update(steps)
+        .set({status: 'cancelled', updatedAt})
+        .where(
+          and(
+            inArray(steps.id, cancelIds),
+            sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+          ),
+        );
+    }
+  });
 }

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -1,5 +1,20 @@
-import type {StepDto} from '@shipfox/api-workflows-dto';
+import type {StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
 import type {Step} from '#core/entities/step.js';
+
+// Domain `error` is loosely typed (jsonb), but the runner contract writes
+// {message, exitCode?, signal?}. Map known camelCase fields to snake_case for
+// the wire DTO; pass everything else through unchanged.
+function toStepErrorDto(error: Record<string, unknown> | null): StepErrorDtoShape {
+  if (error === null) return null;
+  const message = typeof error.message === 'string' ? error.message : '';
+  const exitCode = error.exitCode;
+  const signal = typeof error.signal === 'string' ? error.signal : undefined;
+  return {
+    message,
+    ...(exitCode === null || typeof exitCode === 'number' ? {exit_code: exitCode} : {}),
+    ...(signal ? {signal} : {}),
+  };
+}
 
 export function toStepDto(step: Step): StepDto {
   return {
@@ -9,6 +24,7 @@ export function toStepDto(step: Step): StepDto {
     status: step.status,
     type: step.type,
     config: step.config,
+    error: toStepErrorDto(step.error),
     position: step.position,
     created_at: step.createdAt.toISOString(),
     updated_at: step.updatedAt.toISOString(),

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -120,6 +120,7 @@ describe('GET /api/workflows/runs/:id', () => {
 
     await applyStepResults({
       jobId,
+      completionStatus: 'failed',
       reportedSteps: [
         {stepId: steps[0]?.id as string, status: 'succeeded', error: null},
         {

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -4,7 +4,12 @@ import {ClientError} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
-import {createWorkflowRun} from '#db/workflow-runs.js';
+import {
+  applyStepResults,
+  createWorkflowRun,
+  getJobsByRunId,
+  getStepsByJobId,
+} from '#db/workflow-runs.js';
 import {getRunRoute} from './get-run.js';
 
 const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
@@ -92,6 +97,59 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(body.jobs[0].steps).toHaveLength(2);
     expect(body.jobs[0].steps[0].name).toBe('Install');
     expect(body.jobs[0].steps[1].name).toBeNull();
+  });
+
+  test('exposes per-step error and cancelled status after applyStepResults', async () => {
+    const projectId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      definition: {
+        name: 'Test',
+        jobs: {build: {steps: [{run: 'a'}, {run: 'b'}, {run: 'c'}]}},
+      },
+      triggerContext: {type: 'manual'},
+    });
+
+    const runJobs = await getJobsByRunId(run.id);
+    const jobId = runJobs[0]?.id ?? '';
+    const steps = await getStepsByJobId(jobId);
+
+    await applyStepResults({
+      jobId,
+      reportedSteps: [
+        {stepId: steps[0]?.id as string, status: 'succeeded', error: null},
+        {
+          stepId: steps[1]?.id as string,
+          status: 'failed',
+          error: {message: 'Command exited with code 1', exitCode: 1},
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${run.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const responseSteps = body.jobs[0].steps as Array<{
+      status: string;
+      error: {message: string; exit_code?: number | null} | null;
+    }>;
+    expect(responseSteps[0]?.status).toBe('succeeded');
+    expect(responseSteps[0]?.error).toBeNull();
+    expect(responseSteps[1]?.status).toBe('failed');
+    expect(responseSteps[1]?.error).toEqual({
+      message: 'Command exited with code 1',
+      exit_code: 1,
+    });
+    expect(responseSteps[2]?.status).toBe('cancelled');
+    expect(responseSteps[2]?.error).toBeNull();
   });
 
   test('returns 404 for non-existent run', async () => {

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-completed.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-completed.ts
@@ -16,7 +16,7 @@ export async function onRunnerJobCompleted(event: DomainEvent): Promise<void> {
   try {
     await handle.signal('job-completed', {
       status: payload.status,
-      output: payload.output,
+      steps: payload.steps,
     });
   } catch (err) {
     // Workflow already terminated (e.g. timeout path); its status is

--- a/libs/api/workflows/src/temporal/activities/index.ts
+++ b/libs/api/workflows/src/temporal/activities/index.ts
@@ -1,4 +1,5 @@
 import {
+  applyStepResultsActivity,
   bulkSetStepStatuses,
   enqueueJobForRunner,
   failJobAsTimedOutActivity,
@@ -13,6 +14,7 @@ export function createOrchestrationActivities() {
     setRunStatus,
     setJobStatus,
     bulkSetStepStatuses,
+    applyStepResultsActivity,
     enqueueJobForRunner,
     failJobAsTimedOutActivity,
   };

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,9 +1,10 @@
 import {enqueueJob} from '@shipfox/api-runners';
-import type {JobPayloadDto} from '@shipfox/api-runners-dto';
+import type {JobPayloadDto, StepResultDto} from '@shipfox/api-runners-dto';
 import type {JobStatus} from '#core/entities/job.js';
 import type {StepStatus} from '#core/entities/step.js';
 import type {WorkflowRunStatus} from '#core/entities/workflow-run.js';
 import {
+  applyStepResults,
   bulkUpdateStepStatuses,
   failJobAsTimedOut,
   getJobsByRunId,
@@ -102,6 +103,22 @@ export async function bulkSetStepStatuses(params: {
   status: StepStatus;
 }): Promise<void> {
   await bulkUpdateStepStatuses(params);
+}
+
+// Snake_case `step_id` from the wire DTO converts to camel `stepId` here so
+// domain code never sees the external shape.
+export async function applyStepResultsActivity(params: {
+  jobId: string;
+  reportedSteps: StepResultDto[];
+}): Promise<void> {
+  await applyStepResults({
+    jobId: params.jobId,
+    reportedSteps: params.reportedSteps.map((s) => ({
+      stepId: s.step_id,
+      status: s.status,
+      error: s.error as Record<string, unknown> | null,
+    })),
+  });
 }
 
 export async function enqueueJobForRunner(params: {

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -105,18 +105,28 @@ export async function bulkSetStepStatuses(params: {
   await bulkUpdateStepStatuses(params);
 }
 
-// Snake_case `step_id` from the wire DTO converts to camel `stepId` here so
-// domain code never sees the external shape.
+// Wire (snake_case) → domain (camelCase) at the activity boundary so DB code
+// never sees the external shape. The completionStatus is forwarded so the
+// activity can enforce strict consistency for succeeded jobs.
 export async function applyStepResultsActivity(params: {
   jobId: string;
+  completionStatus: 'succeeded' | 'failed';
   reportedSteps: StepResultDto[];
 }): Promise<void> {
   await applyStepResults({
     jobId: params.jobId,
+    completionStatus: params.completionStatus,
     reportedSteps: params.reportedSteps.map((s) => ({
       stepId: s.step_id,
       status: s.status,
-      error: s.error as Record<string, unknown> | null,
+      error:
+        s.error == null
+          ? null
+          : {
+              message: s.error.message,
+              ...(s.error.exit_code !== undefined ? {exitCode: s.error.exit_code} : {}),
+              ...(s.error.signal !== undefined ? {signal: s.error.signal} : {}),
+            },
     })),
   });
 }

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
@@ -48,6 +48,9 @@ beforeAll(async () => {
       bulkSetStepStatuses: (params: unknown) => {
         calls.push({name: 'bulkSetStepStatuses', params});
       },
+      applyStepResultsActivity: (params: unknown) => {
+        calls.push({name: 'applyStepResultsActivity', params});
+      },
       enqueueJobForRunner: (params: unknown) => {
         // No-op — we want the workflow to block on the signal until the timeout fires.
         calls.push({name: 'enqueueJobForRunner', params});
@@ -90,9 +93,7 @@ const defaultJobInput = {
   steps: [{id: 'step-1', name: null, type: 'run', config: {cmd: 'echo hi'}, position: 0}],
 };
 
-function executeJob(
-  input: typeof defaultJobInput,
-): Promise<{status: string; jobVersion: number; output?: unknown}> {
+function executeJob(input: typeof defaultJobInput): Promise<{status: string; jobVersion: number}> {
   return testEnv.client.workflow.execute('jobOrchestration', {
     taskQueue: TASK_QUEUE,
     workflowId: `job:${input.jobId}-${Math.random()}`,
@@ -101,11 +102,10 @@ function executeJob(
 }
 
 describe('jobOrchestration timeout path', () => {
-  test('times out after JOB_MAX_DURATION; calls failJobAsTimedOutActivity once', async () => {
+  test('times out after JOB_MAX_DURATION; calls failJobAsTimedOutActivity then bulkSetStepStatuses', async () => {
     const result = await executeJob(defaultJobInput);
 
     expect(result.status).toBe('failed');
-    expect(result.output).toEqual({reason: 'job_timeout'});
 
     expect(callsNamed('failJobAsTimedOutActivity')).toHaveLength(1);
 
@@ -114,8 +114,11 @@ describe('jobOrchestration timeout path', () => {
     );
     expect(setJobStatuses).toEqual(['running']);
 
+    // Timeout path uses the bulk activity (no per-step detail available),
+    // NOT applyStepResultsActivity.
     const stepCall = callsNamed('bulkSetStepStatuses')[0];
     expect((stepCall?.params as {status: string})?.status).toBe('failed');
+    expect(callsNamed('applyStepResultsActivity')).toHaveLength(0);
   }, 60_000);
 
   test('failJobAsTimedOutActivity throws → workflow surfaces the error', async () => {

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
@@ -31,9 +31,7 @@ const defaultJobInput = {
   steps: [{id: 'step-1', name: null, type: 'run', config: {cmd: 'echo hi'}, position: 0}],
 };
 
-function executeJob(
-  input: typeof defaultJobInput,
-): Promise<{status: string; jobVersion: number; output?: unknown}> {
+function executeJob(input: typeof defaultJobInput): Promise<{status: string; jobVersion: number}> {
   return testEnv.client.workflow.execute('jobOrchestration', {
     taskQueue: TASK_QUEUE,
     workflowId: `job:${input.jobId}`,
@@ -42,7 +40,7 @@ function executeJob(
 }
 
 describe('jobOrchestration', () => {
-  test('signal succeeded — job and steps marked succeeded', async () => {
+  test('signal succeeded — workflow forwards reported steps to applyStepResultsActivity', async () => {
     setCfg({dag: makeDag([]), jobResults: new Map([['job-1', 'succeeded']])});
 
     const result = await executeJob(defaultJobInput);
@@ -53,14 +51,16 @@ describe('jobOrchestration', () => {
     const statuses = setJobStatusCalls().map((c) => c.params.status);
     expect(statuses).toEqual(['running', 'succeeded']);
 
-    const stepCalls = callsNamed('bulkSetStepStatuses') as Array<{
-      params: {jobId: string; status: string};
+    const applyCalls = callsNamed('applyStepResultsActivity') as Array<{
+      params: {jobId: string; reportedSteps: Array<{status: string}>};
     }>;
-    expect(stepCalls).toHaveLength(1);
-    expect(stepCalls[0]?.params.status).toBe('succeeded');
+    expect(applyCalls).toHaveLength(1);
+    expect(applyCalls[0]?.params.reportedSteps[0]?.status).toBe('succeeded');
+    // Completion path must NOT use the bulk activity.
+    expect(callsNamed('bulkSetStepStatuses')).toHaveLength(0);
   });
 
-  test('signal failed — job and steps marked failed', async () => {
+  test('signal failed — workflow forwards the failed step to applyStepResultsActivity', async () => {
     setCfg({dag: makeDag([]), jobResults: new Map([['job-2', 'failed']])});
 
     const result = await executeJob({...defaultJobInput, jobId: 'job-2'});
@@ -70,10 +70,12 @@ describe('jobOrchestration', () => {
     const statuses = setJobStatusCalls().map((c) => c.params.status);
     expect(statuses).toEqual(['running', 'failed']);
 
-    const stepCalls = callsNamed('bulkSetStepStatuses') as Array<{
-      params: {status: string};
+    const applyCalls = callsNamed('applyStepResultsActivity') as Array<{
+      params: {reportedSteps: Array<{status: string}>};
     }>;
-    expect(stepCalls[0]?.params.status).toBe('failed');
+    expect(applyCalls).toHaveLength(1);
+    expect(applyCalls[0]?.params.reportedSteps[0]?.status).toBe('failed');
+    expect(callsNamed('bulkSetStepStatuses')).toHaveLength(0);
   });
 
   test('duplicate signal is ignored', async () => {
@@ -111,7 +113,7 @@ describe('jobOrchestration', () => {
 
     // Clean up: signal it so it completes and doesn't leak
     setCfg({dag: makeDag([]), jobResults: new Map()});
-    await handle.signal('job-completed', {status: 'failed'});
+    await handle.signal('job-completed', {status: 'failed', steps: []});
     await handle.result();
   }, 15_000);
 });

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
@@ -92,13 +92,21 @@ export async function jobOrchestration(
     }
     const {status, steps} = signalPayload;
 
+    // Apply step results FIRST: the activity validates strict consistency for
+    // succeeded jobs (no bogus/missing/duplicate stepIds) and throws on
+    // violation. Only mark the job final if the per-step state is consistent;
+    // otherwise the job stays running and the timeout path will catch it.
+    await applyStepResultsActivity({
+      jobId: input.jobId,
+      completionStatus: status,
+      reportedSteps: steps,
+    });
+
     const {newVersion: finalVersion} = await setJobStatus({
       jobId: input.jobId,
       status,
       version: runningVersion,
     });
-
-    await applyStepResultsActivity({jobId: input.jobId, reportedSteps: steps});
 
     return {status, jobVersion: finalVersion};
   }

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
@@ -1,3 +1,4 @@
+import type {StepResultDto} from '@shipfox/api-runners-dto';
 import {condition, defineSignal, proxyActivities, setHandler} from '@temporalio/workflow';
 
 import type {CompletionStatus} from '#core/dag.js';
@@ -10,8 +11,8 @@ import type {createOrchestrationActivities} from '../activities/index.js';
  *   ┌─ runner POST /complete arrives ──► signal payload set
  *   │                                     ▼
  *   │                                  setJobStatus(status from signal)
- *   │                                  bulkSetStepStatuses(status)
- *   │                                  return {status, output}
+ *   │                                  applyStepResultsActivity(reportedSteps)
+ *   │                                  return {status}
  *   │
  *   └─ JOB_MAX_DURATION elapses with no signal ──► condition() returns false
  *                                                  ▼
@@ -20,19 +21,23 @@ import type {createOrchestrationActivities} from '../activities/index.js';
  *                                                 workflows_outbox INSERT)
  *                                                  ▼
  *                                              bulkSetStepStatuses('failed')
- *                                              return {status:'failed',
- *                                                      output:{reason:'job_timeout'}}
+ *                                              return {status:'failed'}
  */
 
-const {setJobStatus, enqueueJobForRunner, bulkSetStepStatuses, failJobAsTimedOutActivity} =
-  proxyActivities<ReturnType<typeof createOrchestrationActivities>>({
-    startToCloseTimeout: '30s',
-  });
+const {
+  setJobStatus,
+  enqueueJobForRunner,
+  bulkSetStepStatuses,
+  applyStepResultsActivity,
+  failJobAsTimedOutActivity,
+} = proxyActivities<ReturnType<typeof createOrchestrationActivities>>({
+  startToCloseTimeout: '30s',
+});
 
 const JOB_MAX_DURATION = '60 minutes';
 
 export const jobCompletedSignal =
-  defineSignal<[{status: CompletionStatus; output?: unknown}]>('job-completed');
+  defineSignal<[{status: CompletionStatus; steps: StepResultDto[]}]>('job-completed');
 
 export interface JobOrchestrationInput {
   workspaceId: string;
@@ -52,7 +57,6 @@ export interface JobOrchestrationInput {
 export interface JobOrchestrationResult {
   status: CompletionStatus;
   jobVersion: number;
-  output?: unknown;
 }
 
 export async function jobOrchestration(
@@ -72,7 +76,7 @@ export async function jobOrchestration(
     steps: input.steps,
   });
 
-  let signalPayload: {status: CompletionStatus; output?: unknown} | undefined;
+  let signalPayload: {status: CompletionStatus; steps: StepResultDto[]} | undefined;
 
   setHandler(jobCompletedSignal, (r) => {
     if (!signalPayload) {
@@ -86,7 +90,7 @@ export async function jobOrchestration(
     if (!signalPayload) {
       throw new Error('Unreachable: condition() returned true so signalPayload is set');
     }
-    const {status, output} = signalPayload;
+    const {status, steps} = signalPayload;
 
     const {newVersion: finalVersion} = await setJobStatus({
       jobId: input.jobId,
@@ -94,9 +98,9 @@ export async function jobOrchestration(
       version: runningVersion,
     });
 
-    await bulkSetStepStatuses({jobId: input.jobId, status});
+    await applyStepResultsActivity({jobId: input.jobId, reportedSteps: steps});
 
-    return {status, jobVersion: finalVersion, output};
+    return {status, jobVersion: finalVersion};
   }
 
   // Timeout path. The activity is the critical path for the failure decision:
@@ -111,5 +115,5 @@ export async function jobOrchestration(
 
   await bulkSetStepStatuses({jobId: input.jobId, status: 'failed'});
 
-  return {status: 'failed', jobVersion: finalVersion, output: {reason: 'job_timeout'}};
+  return {status: 'failed', jobVersion: finalVersion};
 }

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -142,12 +142,16 @@ function createMockActivities() {
       calls.push({name: 'bulkSetStepStatuses', params});
     },
 
+    applyStepResultsActivity: (params: {jobId: string; reportedSteps: unknown[]}) => {
+      calls.push({name: 'applyStepResultsActivity', params});
+    },
+
     enqueueJobForRunner: async (params: {
       workspaceId: string;
       jobId: string;
       runId: string;
       jobName: string;
-      steps: unknown[];
+      steps: Array<{id: string}>;
     }) => {
       calls.push({name: 'enqueueJobForRunner', params});
 
@@ -159,11 +163,30 @@ function createMockActivities() {
       if (cfg.skipSignal) return;
 
       const status = cfg.jobResults.get(params.jobId) ?? 'succeeded';
+      // Mirror what the runner reports: per-step entries for every step in the
+      // payload, all marked succeeded for status='succeeded'; for failures, the
+      // first step is failed and the rest are omitted (the activity cancels
+      // them).
+      const steps =
+        status === 'succeeded'
+          ? params.steps.map((s) => ({step_id: s.id, status: 'succeeded' as const, error: null}))
+          : params.steps[0]
+            ? [
+                {
+                  step_id: params.steps[0].id,
+                  status: 'failed' as const,
+                  error: {message: 'mock failure', exitCode: 1},
+                },
+              ]
+            : [];
       const handle = testEnv.client.workflow.getHandle(`job:${params.jobId}`);
-      await handle.signal('job-completed', {status});
+      await handle.signal('job-completed', {status, steps});
 
       if (cfg.duplicateSignal) {
-        await handle.signal('job-completed', {status: 'failed', output: 'duplicate'});
+        await handle.signal('job-completed', {
+          status: 'failed',
+          steps: [],
+        });
       }
     },
 

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -142,7 +142,11 @@ function createMockActivities() {
       calls.push({name: 'bulkSetStepStatuses', params});
     },
 
-    applyStepResultsActivity: (params: {jobId: string; reportedSteps: unknown[]}) => {
+    applyStepResultsActivity: (params: {
+      jobId: string;
+      completionStatus: 'succeeded' | 'failed';
+      reportedSteps: unknown[];
+    }) => {
       calls.push({name: 'applyStepResultsActivity', params});
     },
 
@@ -175,7 +179,7 @@ function createMockActivities() {
                 {
                   step_id: params.steps[0].id,
                   status: 'failed' as const,
-                  error: {message: 'mock failure', exitCode: 1},
+                  error: {message: 'mock failure', exit_code: 1},
                 },
               ]
             : [];


### PR DESCRIPTION
The runner already executes steps sequentially and knows which one failed and why, but it only reported a single `{status, output}` for the whole job. The orchestration workflow then bulk-set every step in the job to that same status, so when step 2 of 4 failed, steps 3 and 4 were also marked `failed` even though they never ran. This change makes the run history faithful: each step that actually ran gets its own status and structured error; steps that never ran are marked `cancelled`.

## What changed

- **Wire contract**: `POST /runners/jobs/:jobId/complete` body becomes `{status, steps: [{step_id, status, error}]}`. Job-level `output` is fully cleaned up (request body → outbox event payload → Temporal signal → workflow return).
- **Shared error schema** lives in `runners-dto/src/schemas/complete-job.ts`: `{message, exitCode?, signal?}`. Captures SIGKILL exits (where `code === null` in `child.on('close')`) so the failure reason is preserved.
- **Strict refine** at the route boundary: `status='succeeded'` requires `steps.length > 0` and every reported step `succeeded`. Inconsistent payloads return 400.
- **New `applyStepResults` activity** computes the cancellation set from the canonical job step ids (intersected with reported ids) instead of `NOT IN (reported_ids)`. A bogus/unknown `step_id` from the runner can't trigger "cancel every real step".
- **Terminal-state guard everywhere** (`status NOT IN ('succeeded','failed','cancelled')`): both reported updates and the cancellation sweep in `applyStepResults`, plus `bulkUpdateStepStatuses` for the timeout path. Activities are idempotent under Temporal retries.
- **Empty-steps fallback** (`steps: []`) covers executor crashes and the stuck-job detector. Falls through to bulk-fail every step. `detectAndFailStuckJobs` no longer emits `output: {reason: 'runner_disappeared'}`; the heartbeat audit log is the source of truth for stuck reasons.
- **Run detail DTO** (`GET /runs/:id`) now exposes `error: {message, exit_code?, signal?} | null` per step.

## Why these specific shapes

The plan went through `/plan-eng-review` and an independent `/codex review`. The codex review caught several real bugs in the original design that this PR fixes from the start:

- bogus `step_id` triggering `NOT IN` cancellation of every real step (fixed via canonical-set intersection)
- `detectAndFailStuckJobs` was an unhandled producer of `finalizeRunningJob`'s `output` field (now passes `steps: []`)
- `bulkUpdateStepStatuses` had no terminal guard despite the "everywhere" claim (now does)
- `run-step.test.ts:88-108` PID-extraction depends on `result.output`; `StepResult.output` retained internally
- `child.on('close')` gives `code === null` on signal kill (now handled with `signal: 'SIGKILL'`)

Out of scope: per-step log persistence (stdout/stderr). Tracked as future S3-backed work; the existing `output` jsonb column on `steps` is left in place for that.

## Coverage

- **Critical regression test**: `applyStepResults` with step 2 of 4 failing → step 1 succeeded, step 2 failed with error, steps 3-4 cancelled.
- Hostile payloads: unknown `stepId`, duplicate `stepId`, cross-job `stepId`.
- Idempotency: re-running activity with same payload is a no-op (`updatedAt` unchanged).
- Strict-refine cases: `status='succeeded'` with empty steps / failed step → 400.
- `GET /runs/:id` integration test asserts `error` shape end-to-end.
- Timeout path regression: still calls `bulkSetStepStatuses`, NOT `applyStepResultsActivity`.

## Reviewer focus

- Per CLAUDE.md, public HTTP DTOs are snake_case at the boundary; domain code uses camelCase. The mapping happens at `applyStepResultsActivity` (`step_id` → `stepId`).
- `applyStepResults` and `bulkSetStepStatuses` coexist intentionally — see `## Notes` in `.claude/plans/system-instruction-you-are-working-wise-pnueli.md` for the rationale.
- Performance footnote: `applyStepResults` is N updates + 1 cancellation sweep per transaction. Fine for typical step counts (<20). A single-statement `CASE` rewrite is tracked in `TODOS.md`.

## Manual verification not run

I did not run the full `docker compose up -d` end-to-end. Unit + integration tests cover every path in the test diagram, but a live runner-against-live-API smoke is worth doing before merging if you want to see the new per-step statuses surface in `GET /runs/:id`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report per-step runtime results so each executed step gets its own status and structured error; unreached steps are cancelled. Tightened contract: succeeded jobs must report the exact canonical step set, the workflow applies step results before finalizing the job, zero-step jobs are no longer dispatched, and job-level `output` is removed.

- **New Features**
  - `POST /runners/jobs/:jobId/complete` now accepts `{status, steps: [{step_id, status, error}]}`; job-level `output` is removed from the request, the `RUNNER_JOB_COMPLETED` event, the Temporal signal, and the workflow result.
  - Shared error shape uses snake_case `{message, exit_code?, signal?}` in `@shipfox/api-runners-dto`; `GET /runs/:id` exposes per-step `error` in snake_case via `@shipfox/api-workflows-dto`. Schema enforces: succeeded steps must have `error=null`; failed steps must include `error`.
  - New `applyStepResults` activity writes reported statuses/errors, cancels the rest via the canonical step set, guards terminal states, and is idempotent. For `status='succeeded'`, it requires an exact canonical step-id match (no unknown, missing, or duplicate ids) and runs before `setJobStatus`; violations throw. The timeout path still uses `bulkUpdateStepStatuses` with a terminal-state guard.
  - Runner job payload now requires at least one step (`steps.min(1)`), so zero-step jobs are never sent to runners. Empty `steps: []` on completion is still accepted for executor crashes or stuck jobs; stuck-job detection now emits `steps: []`.

- **Migration**
  - Update the runner to send `steps` when completing and report errors with `error.exit_code` using `@shipfox/api-runners-dto`.
  - Ensure every job has at least one step; zero-step jobs are rejected earlier.
  - If anything consumed job-level `output`, switch to per-step `steps[].error` or read from `GET /runs/:id`.

<sup>Written for commit 733da3e85b0c0ae5d6d3ffac97676663dc92080d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

