### PR TITLE
Restrict CI remote cache writes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ jobs:
     name: Check, test, type, and build
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: shipfox
+      # Only approved code on main may publish remote cache artifacts. Pull
+      # requests can restore trusted artifacts from main, but cannot poison cache.
+      TURBO_CACHE: ${{ github.ref == 'refs/heads/main' && 'local:rw,remote:rw' || 'local:rw,remote:r' }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Enable Turborepo remote caching in CI using the Shipfox team token configuration while keeping cache publication restricted to approved code.

Pull request runs can restore existing trusted artifacts to speed up CI, but they use a read-only remote cache mode so unreviewed changes cannot publish cache artifacts. Runs on main keep read/write access so merged code refreshes the shared cache for future branches.

This keeps the performance benefit of remote caching without allowing PR branches to poison the cache used by later CI runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Turborepo remote caching in CI with writes restricted to `main`. PR runs can read from the remote cache but cannot publish, preventing cache poisoning while keeping builds fast.

<sup>Written for commit d5653e9afeea4317e5b54618cfc3a8ea6f918a54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

