### PR TITLE
Configure Renovate update grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,64 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "group:recommended",
+    "monorepo:turbo",
+    "monorepo:vitest",
+    "monorepo:react",
+    "packages:react",
+    "packages:vite",
+    "packages:unitTest",
+    "helpers:pinGitHubActionDigests",
+    "customManagers:biomeVersions",
+    "customManagers:dockerfileVersions",
+    "replacements:all",
+    "security:openssf-scorecard",
+    "abandonments:recommended",
+    ":configMigration",
+    ":gitSignOff",
+    "schedule:daily"
+  ],
+  "prHourlyLimit": 5,
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates into one PR",
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Group all Docker image updates into one PR",
+      "groupName": "Docker images",
+      "groupSlug": "docker-images",
+      "matchDatasources": ["docker"]
+    },
+    {
+      "description": "Group NPM patch and minor updates into one PR",
+      "groupName": "NPM patch and minor",
+      "groupSlug": "npm-patch-minor",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch", "minor"]
+    },
+    {
+      "description": "Keep shipfox internal packages in their own group",
+      "groupName": "shipfox packages",
+      "groupSlug": "shipfox",
+      "matchPackageNames": ["@shipfox/**"]
+    },
+    {
+      "description": "TanStack Query: group related packages together and bump ranges to keep deps and peerDeps in sync across the monorepo",
+      "groupName": "tanstack-query",
+      "groupSlug": "tanstack-query",
+      "matchPackageNames": ["@tanstack/react-query", "@tanstack/query-core", "@tanstack/react-query-devtools"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "TanStack Router: group runtime and plugin packages together and bump ranges to avoid route typegen/runtime drift",
+      "groupName": "tanstack-router",
+      "groupSlug": "tanstack-router",
+      "matchPackageNames": ["@tanstack/react-router", "@tanstack/router-plugin"],
+      "rangeStrategy": "bump"
+    }
   ]
 }


### PR DESCRIPTION
Configure Renovate with the shared Shipfox update policy that fits this pnpm/Turbo monorepo.

The initial config only used Renovate's recommended baseline, which would leave dependency updates more fragmented and miss repo-specific dependency surfaces like GitHub Actions, Docker images, Biome, React, Vite, Vitest, TanStack Query, and TanStack Router. This adds grouping and preset behavior to make Renovate PRs easier to review while keeping tightly coupled packages in sync.

This intentionally does not enable TypeScript RC following because this repo should stay on non-RC TypeScript versions. The TanStack Router rule adapts the reference project's React Router grouping to this repo's router stack so runtime and plugin updates land together.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures Renovate with the shared Shipfox policy for this pnpm/Turbo monorepo. Groups updates across npm, GitHub Actions, Docker, and TanStack stacks to reduce noise and keep related packages in sync.

- **New Features**
  - Extends presets for monorepo and ecosystem coverage: `group:recommended`, `monorepo:{turbo,vitest,react}`, `packages:{react,vite,unitTest}`, `helpers:pinGitHubActionDigests`, `customManagers:{biomeVersions,dockerfileVersions}`, `replacements:all`, `security:openssf-scorecard`, `abandonments:recommended`, `:configMigration`, `:gitSignOff`, `schedule:daily`.
  - Adds grouping rules: GitHub Actions, Docker images, npm patch/minor, and internal `@shipfox/**`; also groups TanStack Query (`@tanstack/react-query`, `@tanstack/query-core`, `@tanstack/react-query-devtools`) and TanStack Router (`@tanstack/react-router`, `@tanstack/router-plugin`) with `rangeStrategy: "bump"`.
  - Sets `prHourlyLimit` to 5.

<sup>Written for commit 58f07de3501ab89a8bc88c6b76867954982c173e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

