### PR TITLE
[api/auth] Stabilize E2E session route test

### DIFF
--- a/libs/api/auth/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/auth/src/presentation/e2eRoutes/index.test.ts
@@ -2,6 +2,10 @@ import {createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance} from 'fastify';
 import {authE2eRoutes} from './index.js';
 
+vi.mock('@shipfox/api-workspaces', () => ({
+  listMembershipsByUser: vi.fn(() => Promise.resolve([])),
+}));
+
 describe('auth E2E routes', () => {
   let app: FastifyInstance;
 


### PR DESCRIPTION
Mock `@shipfox/api-workspaces` in the auth E2E route tests so the suite no longer depends on cross-package DB state.

The `creates a browser session for an E2E-created user` test was flaking with a 500 in CI. The handler under test (`POST /auth/sessions`) calls `signAccessToken`, which calls `listMembershipsByUser` from `@shipfox/api-workspaces`. That query joins `workspaces_memberships` and `workspaces`, which are not migrated by the auth package's `test/globalSetup.ts` — only the auth migrations run there. The test only passed when the workspaces package's tests had already migrated those tables into `api_test`, an ordering Turbo doesn't guarantee.

The other route tests (`test/routes.ts`, `core/auth.test.ts`) already hoist a `vi.mock('@shipfox/api-workspaces', ...)` to avoid this coupling. This applies the same pattern to the E2E route test file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilize the auth E2E session route test by mocking `@shipfox/api-workspaces` to remove a cross-package DB dependency. This eliminates CI flakes (500s) in `POST /auth/sessions` by stubbing `listMembershipsByUser` to resolve to an empty array.

<sup>Written for commit 2722c628ecc2fc10a9a73549f6fe09e0d0640e86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

