### PR TITLE
[auth] Add verification email resend cooldown

### DIFF
--- a/libs/api/auth-dto/src/schemas/auth.ts
+++ b/libs/api/auth-dto/src/schemas/auth.ts
@@ -1,6 +1,8 @@
 import {z} from 'zod';
 import {userDtoSchema} from './user.js';
 
+export const EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS = 60;
+
 export const passwordSchema = z.string().min(12).max(128);
 export const emailSchema = z
   .string()
@@ -89,3 +91,9 @@ export const verifyEmailResendBodySchema = z.object({
 });
 
 export type VerifyEmailResendBodyDto = z.infer<typeof verifyEmailResendBodySchema>;
+
+export const verifyEmailResendResponseSchema = z.object({
+  next_resend_available_at: z.string().datetime(),
+});
+
+export type VerifyEmailResendResponseDto = z.infer<typeof verifyEmailResendResponseSchema>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -1,6 +1,7 @@
 export {
   type ChangePasswordBodyDto,
   changePasswordBodySchema,
+  EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
   emailSchema,
   type LoginBodyDto,
   type LoginResponseDto,
@@ -26,9 +27,11 @@ export {
   type VerifyEmailConfirmBodyDto,
   type VerifyEmailConfirmResponseDto,
   type VerifyEmailResendBodyDto,
+  type VerifyEmailResendResponseDto,
   verifyEmailConfirmBodySchema,
   verifyEmailConfirmResponseSchema,
   verifyEmailResendBodySchema,
+  verifyEmailResendResponseSchema,
 } from './auth.js';
 export {
   type E2eCreateSessionBodyDto,

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -221,11 +221,14 @@ describe('auth core', () => {
       .set({createdAt: existingCreatedAt})
       .where(eq(emailVerifications.userId, user.id));
 
+    const beforeCall = Date.now();
     const result = await resendEmailVerification({email: user.email});
     const verified = await confirmEmailVerification({token});
 
-    expect(result.nextResendAvailableAt.getTime()).toBeGreaterThan(
-      existingCreatedAt.getTime() + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000,
+    // The cooldown branch must return the generic `now + cooldown` estimate, not
+    // `latest.createdAt + cooldown`, so the response cannot leak prior timing.
+    expect(result.nextResendAvailableAt.getTime()).toBeGreaterThanOrEqual(
+      beforeCall + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000,
     );
     expect(captured).toHaveLength(1);
     expect(verified.user.id).toBe(user.id);

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -1,3 +1,4 @@
+import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import {eq} from 'drizzle-orm';
@@ -24,6 +25,7 @@ import {
 import {verifyUserToken} from '#core/jwt.js';
 import {db} from '#db/db.js';
 import {findActiveRefreshTokenByHash} from '#db/refresh-tokens.js';
+import {emailVerifications} from '#db/schema/email-verifications.js';
 import {users} from '#db/schema/users.js';
 import {findUserByEmail, findUserById} from '#db/users.js';
 import {userFactory} from '#test/index.js';
@@ -187,13 +189,70 @@ describe('auth core', () => {
   test('resendEmailVerification only sends for active unverified users', async () => {
     const unverified = await userFactory.create();
     const verified = await userFactory.create({emailVerifiedAt: new Date()});
+    const inactive = await userFactory.create();
+    await db().update(users).set({status: 'suspended'}).where(eq(users.id, inactive.id));
 
-    await resendEmailVerification({email: unverified.email});
-    await resendEmailVerification({email: verified.email});
-    await resendEmailVerification({email: `missing-${crypto.randomUUID()}@example.com`});
+    const sent = await resendEmailVerification({email: unverified.email});
+    const verifiedResult = await resendEmailVerification({email: verified.email});
+    const inactiveResult = await resendEmailVerification({email: inactive.email});
+    const missingResult = await resendEmailVerification({
+      email: `missing-${crypto.randomUUID()}@example.com`,
+    });
 
     expect(captured).toHaveLength(1);
     expect(captured[0]?.to).toBe(unverified.email);
+    expect(sent.nextResendAvailableAt).toBeInstanceOf(Date);
+    expect(verifiedResult.nextResendAvailableAt).toBeInstanceOf(Date);
+    expect(inactiveResult.nextResendAvailableAt).toBeInstanceOf(Date);
+    expect(missingResult.nextResendAvailableAt).toBeInstanceOf(Date);
+  });
+
+  test('resendEmailVerification respects cooldown without invalidating the current token', async () => {
+    const user = await signup({
+      email: `resend-cooldown-${crypto.randomUUID()}@example.com`,
+      password: 'correct horse battery staple',
+    });
+    const token = extractToken(captured[0]);
+
+    const result = await resendEmailVerification({email: user.email});
+    const verified = await confirmEmailVerification({token});
+
+    expect(result.nextResendAvailableAt).toBeInstanceOf(Date);
+    expect(captured).toHaveLength(1);
+    expect(verified.user.id).toBe(user.id);
+  });
+
+  test('resendEmailVerification sends again after cooldown', async () => {
+    const user = await signup({
+      email: `resend-after-cooldown-${crypto.randomUUID()}@example.com`,
+      password: 'correct horse battery staple',
+    });
+    const staleCreatedAt = new Date(
+      Date.now() - (EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS + 1) * 1000,
+    );
+    await db()
+      .update(emailVerifications)
+      .set({createdAt: staleCreatedAt})
+      .where(eq(emailVerifications.userId, user.id));
+
+    const result = await resendEmailVerification({email: user.email});
+
+    expect(result.nextResendAvailableAt).toBeInstanceOf(Date);
+    expect(captured).toHaveLength(2);
+    expect(captured[1]?.to).toBe(user.email);
+  });
+
+  test('resendEmailVerification serializes duplicate requests for one user', async () => {
+    const user = await userFactory.create();
+
+    const results = await Promise.all([
+      resendEmailVerification({email: user.email}),
+      resendEmailVerification({email: user.email}),
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.to).toBe(user.email);
   });
 
   test('password reset request and confirm update the password and invalidate the token', async () => {

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -213,11 +213,20 @@ describe('auth core', () => {
       password: 'correct horse battery staple',
     });
     const token = extractToken(captured[0]);
+    const existingCreatedAt = new Date(
+      Date.now() - (EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS / 2) * 1000,
+    );
+    await db()
+      .update(emailVerifications)
+      .set({createdAt: existingCreatedAt})
+      .where(eq(emailVerifications.userId, user.id));
 
     const result = await resendEmailVerification({email: user.email});
     const verified = await confirmEmailVerification({token});
 
-    expect(result.nextResendAvailableAt).toBeInstanceOf(Date);
+    expect(result.nextResendAvailableAt.getTime()).toBeGreaterThan(
+      existingCreatedAt.getTime() + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000,
+    );
     expect(captured).toHaveLength(1);
     expect(verified.user.id).toBe(user.id);
   });

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -1,7 +1,12 @@
+import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
 import {listMembershipsByUser} from '@shipfox/api-workspaces';
 import {generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
 import {config, mailer} from '#config.js';
-import {consumeEmailVerification, createEmailVerification} from '#db/email-verifications.js';
+import {
+  consumeEmailVerification,
+  createEmailVerification,
+  createResendEmailVerification,
+} from '#db/email-verifications.js';
 import {consumePasswordReset, createPasswordReset} from '#db/password-resets.js';
 import {
   createRefreshToken,
@@ -249,6 +254,10 @@ export interface ConfirmEmailVerificationResult {
   user: User;
 }
 
+export interface ResendEmailVerificationResult {
+  nextResendAvailableAt: Date;
+}
+
 export async function confirmEmailVerification(params: {
   token: string;
 }): Promise<ConfirmEmailVerificationResult> {
@@ -268,13 +277,22 @@ export async function confirmEmailVerification(params: {
   return {token, refreshToken, user};
 }
 
-export async function resendEmailVerification(params: {email: string}): Promise<void> {
-  const user = await findUserByEmail({email: params.email});
-  if (!user || user.status !== 'active' || user.emailVerifiedAt !== null) {
-    return;
+export async function resendEmailVerification(params: {
+  email: string;
+}): Promise<ResendEmailVerificationResult> {
+  const rawToken = generateOpaqueToken('emailVerification');
+  const result = await createResendEmailVerification({
+    email: params.email,
+    hashedToken: hashOpaqueToken(rawToken),
+    expiresAt: hoursFromNow(VERIFICATION_TTL_HOURS),
+    cooldownSeconds: EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+  });
+
+  if (result.user && result.verification) {
+    await sendVerificationEmail(result.user, rawToken);
   }
 
-  await createAndSendEmailVerification(user);
+  return {nextResendAvailableAt: result.nextResendAvailableAt};
 }
 
 export async function requestPasswordReset(params: {email: string}): Promise<void> {

--- a/libs/api/auth/src/db/email-verifications.ts
+++ b/libs/api/auth/src/db/email-verifications.ts
@@ -1,7 +1,9 @@
-import {and, eq, gt, isNull, sql} from 'drizzle-orm';
+import {and, desc, eq, gt, isNull, sql} from 'drizzle-orm';
 import type {EmailVerification} from '#core/entities/email-verification.js';
+import type {User} from '#core/entities/user.js';
 import {db} from './db.js';
 import {emailVerifications, toEmailVerification} from './schema/email-verifications.js';
+import {toUser, users} from './schema/users.js';
 
 export interface CreateEmailVerificationParams {
   userId: string;
@@ -30,6 +32,83 @@ export async function createEmailVerification(
     const row = rows[0];
     if (!row) throw new Error('Insert returned no rows');
     return toEmailVerification(row);
+  });
+}
+
+export interface CreateResendEmailVerificationParams {
+  email: string;
+  hashedToken: string;
+  expiresAt: Date;
+  cooldownSeconds: number;
+  now?: Date | undefined;
+}
+
+export interface CreateResendEmailVerificationResult {
+  user?: User | undefined;
+  verification?: EmailVerification | undefined;
+  nextResendAvailableAt: Date;
+}
+
+function secondsAfter(date: Date, seconds: number): Date {
+  return new Date(date.getTime() + seconds * 1000);
+}
+
+export async function createResendEmailVerification(
+  params: CreateResendEmailVerificationParams,
+): Promise<CreateResendEmailVerificationResult> {
+  const now = params.now ?? new Date();
+  const genericNextResendAvailableAt = secondsAfter(now, params.cooldownSeconds);
+
+  return await db().transaction(async (tx) => {
+    const userRows = await tx
+      .select()
+      .from(users)
+      .where(eq(users.email, params.email))
+      .limit(1)
+      .for('update');
+    const userRow = userRows[0];
+    if (!userRow) {
+      return {nextResendAvailableAt: genericNextResendAvailableAt};
+    }
+
+    const user = toUser(userRow);
+    if (user.status !== 'active' || user.emailVerifiedAt !== null) {
+      return {nextResendAvailableAt: genericNextResendAvailableAt};
+    }
+
+    const latestRows = await tx
+      .select()
+      .from(emailVerifications)
+      .where(and(eq(emailVerifications.userId, user.id), isNull(emailVerifications.usedAt)))
+      .orderBy(desc(emailVerifications.createdAt))
+      .limit(1);
+    const latest = latestRows[0] ? toEmailVerification(latestRows[0]) : undefined;
+    if (latest && secondsAfter(latest.createdAt, params.cooldownSeconds) > now) {
+      return {user, nextResendAvailableAt: genericNextResendAvailableAt};
+    }
+
+    await tx
+      .update(emailVerifications)
+      .set({usedAt: sql`now()`})
+      .where(and(eq(emailVerifications.userId, user.id), isNull(emailVerifications.usedAt)));
+
+    const rows = await tx
+      .insert(emailVerifications)
+      .values({
+        userId: user.id,
+        hashedToken: params.hashedToken,
+        expiresAt: params.expiresAt,
+      })
+      .returning();
+
+    const row = rows[0];
+    if (!row) throw new Error('Insert returned no rows');
+    const verification = toEmailVerification(row);
+    return {
+      user,
+      verification,
+      nextResendAvailableAt: secondsAfter(verification.createdAt, params.cooldownSeconds),
+    };
   });
 }
 

--- a/libs/api/auth/src/db/email-verifications.ts
+++ b/libs/api/auth/src/db/email-verifications.ts
@@ -84,6 +84,8 @@ export async function createResendEmailVerification(
       .limit(1);
     const latest = latestRows[0] ? toEmailVerification(latestRows[0]) : undefined;
     if (latest && secondsAfter(latest.createdAt, params.cooldownSeconds) > now) {
+      // Return the same public retry estimate as no-op cases so the endpoint does
+      // not expose existing account state or prior verification timing.
       return {user, nextResendAvailableAt: genericNextResendAvailableAt};
     }
 

--- a/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.test.ts
+++ b/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.test.ts
@@ -1,4 +1,8 @@
+import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
+import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
+import {db} from '#db/db.js';
+import {emailVerifications} from '#db/schema/email-verifications.js';
 import {
   capturedMail,
   createAuthTestApp,
@@ -23,7 +27,7 @@ describe('POST /auth/verify-email/resend', () => {
     await app.close();
   });
 
-  test('returns 204 and sends a new token for an unverified account', async () => {
+  test('returns 200 without sending during cooldown for an unverified account', async () => {
     const email = uniqueEmail('verify-resend');
     await signup(app, {email, password: 'correct horse battery staple'});
 
@@ -33,11 +37,34 @@ describe('POST /auth/verify-email/resend', () => {
       payload: {email: email.toUpperCase()},
     });
 
-    expect(res.statusCode).toBe(204);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().next_resend_available_at).toEqual(expect.any(String));
+    expect(capturedMail().filter((message) => message.to === email)).toHaveLength(1);
+  });
+
+  test('returns 200 and sends a new token after cooldown', async () => {
+    const email = uniqueEmail('verify-resend-ready');
+    const signupRes = await signup(app, {email, password: 'correct horse battery staple'});
+    const staleCreatedAt = new Date(
+      Date.now() - (EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS + 1) * 1000,
+    );
+    await db()
+      .update(emailVerifications)
+      .set({createdAt: staleCreatedAt})
+      .where(eq(emailVerifications.userId, signupRes.json().user.id));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/verify-email/resend',
+      payload: {email},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().next_resend_available_at).toEqual(expect.any(String));
     expect(capturedMail().filter((message) => message.to === email)).toHaveLength(2);
   });
 
-  test('returns 204 without sending mail for a verified account', async () => {
+  test('returns 200 without sending mail for a verified account', async () => {
     const email = uniqueEmail('verify-resend-verified');
     await signup(app, {email, password: 'correct horse battery staple'});
     await verifyEmail(app, email);
@@ -49,7 +76,20 @@ describe('POST /auth/verify-email/resend', () => {
       payload: {email},
     });
 
-    expect(res.statusCode).toBe(204);
+    expect(res.statusCode).toBe(200);
+    expect(res.json().next_resend_available_at).toEqual(expect.any(String));
+    expect(capturedMail()).toHaveLength(0);
+  });
+
+  test('returns the same response shape for a missing account', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/verify-email/resend',
+      payload: {email: uniqueEmail('verify-resend-missing')},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({next_resend_available_at: expect.any(String)});
     expect(capturedMail()).toHaveLength(0);
   });
 });

--- a/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.ts
+++ b/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.ts
@@ -1,6 +1,5 @@
-import {verifyEmailResendBodySchema} from '@shipfox/api-auth-dto';
+import {verifyEmailResendBodySchema, verifyEmailResendResponseSchema} from '@shipfox/api-auth-dto';
 import {defineRoute} from '@shipfox/node-fastify';
-import {z} from 'zod';
 import {resendEmailVerification} from '#core/auth.js';
 
 export const verifyEmailResendRoute = defineRoute({
@@ -10,14 +9,16 @@ export const verifyEmailResendRoute = defineRoute({
   schema: {
     body: verifyEmailResendBodySchema,
     response: {
-      204: z.void(),
+      200: verifyEmailResendResponseSchema,
     },
   },
   handler: async (request, reply) => {
     const {email} = request.body;
 
-    await resendEmailVerification({email});
+    const result = await resendEmailVerification({email});
 
-    reply.code(204);
+    reply.code(200).send({
+      next_resend_available_at: result.nextResendAvailableAt.toISOString(),
+    });
   },
 });

--- a/libs/client/auth/src/hooks/api/verify-email-auth.ts
+++ b/libs/client/auth/src/hooks/api/verify-email-auth.ts
@@ -1,4 +1,9 @@
-import type {VerifyEmailConfirmBodyDto, VerifyEmailConfirmResponseDto} from '@shipfox/api-auth-dto';
+import type {
+  VerifyEmailConfirmBodyDto,
+  VerifyEmailConfirmResponseDto,
+  VerifyEmailResendBodyDto,
+  VerifyEmailResendResponseDto,
+} from '@shipfox/api-auth-dto';
 import {apiRequest} from '@shipfox/client-api';
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 import {useSetAtom} from 'jotai';
@@ -11,6 +16,17 @@ async function verifyEmailAuth(body: VerifyEmailConfirmBodyDto) {
     method: 'POST',
     body,
   });
+}
+
+async function resendEmailVerificationAuth(body: VerifyEmailResendBodyDto) {
+  return await apiRequest<VerifyEmailResendResponseDto>('/auth/verify-email/resend', {
+    method: 'POST',
+    body,
+  });
+}
+
+export function useResendEmailVerificationAuth() {
+  return useMutation({mutationFn: resendEmailVerificationAuth});
 }
 
 export function useVerifyEmailAuth() {

--- a/libs/client/auth/src/hooks/index.ts
+++ b/libs/client/auth/src/hooks/index.ts
@@ -6,7 +6,7 @@ export {
 } from './api/password-reset-auth.js';
 export {useRefreshAuth} from './api/refresh-auth.js';
 export {useSignupAuth} from './api/signup-auth.js';
-export {useVerifyEmailAuth} from './api/verify-email-auth.js';
+export {useResendEmailVerificationAuth, useVerifyEmailAuth} from './api/verify-email-auth.js';
 export {useCreateWorkspaceAuth} from './api/workspace-auth.js';
 export {useActiveWorkspace, useMaybeActiveWorkspace} from './use-active-workspace.js';
 export type {AuthStateValue} from './use-auth-state.js';

--- a/libs/client/auth/src/pages/email-verification-resend-model.test.ts
+++ b/libs/client/auth/src/pages/email-verification-resend-model.test.ts
@@ -1,0 +1,52 @@
+import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
+import {
+  getLocalResendAvailableAt,
+  getResendRemainingSeconds,
+  parseNextResendAvailableAt,
+} from './email-verification-resend-model.js';
+
+describe('email verification resend model', () => {
+  test('creates local cooldown targets from the shared cooldown', () => {
+    const now = Date.UTC(2026, 4, 11, 12, 0, 0);
+
+    const result = getLocalResendAvailableAt(now);
+
+    expect(result).toBe(now + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000);
+  });
+
+  test('rounds remaining cooldown seconds up for display', () => {
+    const now = Date.UTC(2026, 4, 11, 12, 0, 0);
+
+    const result = getResendRemainingSeconds({
+      nextResendAvailableAt: now + 1_001,
+      now,
+    });
+
+    expect(result).toBe(2);
+  });
+
+  test('does not return negative remaining cooldown seconds', () => {
+    const now = Date.UTC(2026, 4, 11, 12, 0, 0);
+
+    const result = getResendRemainingSeconds({
+      nextResendAvailableAt: now - 1_000,
+      now,
+    });
+
+    expect(result).toBe(0);
+  });
+
+  test('parses valid server cooldown timestamps', () => {
+    const timestamp = '2026-05-11T12:01:00.000Z';
+
+    const result = parseNextResendAvailableAt(timestamp);
+
+    expect(result).toBe(Date.parse(timestamp));
+  });
+
+  test('ignores invalid server cooldown timestamps', () => {
+    const result = parseNextResendAvailableAt('not-a-date');
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/libs/client/auth/src/pages/email-verification-resend-model.ts
+++ b/libs/client/auth/src/pages/email-verification-resend-model.ts
@@ -1,0 +1,21 @@
+import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
+
+export function getLocalResendAvailableAt(now: number): number {
+  return now + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000;
+}
+
+export function getResendRemainingSeconds(params: {
+  nextResendAvailableAt: number | undefined;
+  now: number;
+}): number {
+  if (!params.nextResendAvailableAt) return 0;
+
+  return Math.max(0, Math.ceil((params.nextResendAvailableAt - params.now) / 1000));
+}
+
+export function parseNextResendAvailableAt(value: string): number | undefined {
+  const nextAvailableAt = Date.parse(value);
+  if (!Number.isFinite(nextAvailableAt)) return undefined;
+
+  return nextAvailableAt;
+}

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -86,6 +86,7 @@ describe('SignupPage', () => {
 
   test('enables resend after the signup cooldown expires', async () => {
     vi.useFakeTimers({toFake: ['Date', 'setInterval', 'clearInterval']});
+    const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
     const user = pageUserFactory.build({email: 'new@example.com', name: 'New User'});
     const fetchImpl = vi
       .fn()
@@ -111,6 +112,7 @@ describe('SignupPage', () => {
     expect(screen.getByRole('button', {name: 'Resend verification email'})).not.toHaveAttribute(
       'aria-disabled',
     );
+    expect(clearIntervalSpy).toHaveBeenCalled();
   });
 
   test('resends verification email and restarts cooldown from the server response', async () => {

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -1,14 +1,16 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {fireEvent, screen} from '@testing-library/react';
+import {act, fireEvent, screen, waitFor} from '@testing-library/react';
 import {pageUserFactory} from '#test/factories/user.js';
 import {renderAuthPage} from '#test/pages.js';
-import {jsonResponse} from '#test/utils.js';
+import {jsonResponse, requestUrl} from '#test/utils.js';
 import {SignupPage} from './signup-page.js';
 
 const SUBMITTED_EMAIL_RE = /new@example.com/;
+const RESEND_COUNTDOWN_RE = /^Resend in \d+s$/;
 
 describe('SignupPage', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     configureApiClient({baseUrl: 'https://api.example.test', getAccessToken: undefined});
   });
 
@@ -30,6 +32,11 @@ describe('SignupPage', () => {
 
     expect(await screen.findByRole('heading', {name: 'Check your email'})).toBeInTheDocument();
     expect(screen.getByText(SUBMITTED_EMAIL_RE)).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: RESEND_COUNTDOWN_RE})).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+    expect(screen.getByRole('button', {name: 'Use another email'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Log in'})).toHaveAttribute('href', '/auth/login');
   });
 
@@ -75,5 +82,123 @@ describe('SignupPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Email already exists');
+  });
+
+  test('enables resend after the signup cooldown expires', async () => {
+    vi.useFakeTimers({toFake: ['Date', 'setInterval', 'clearInterval']});
+    const user = pageUserFactory.build({email: 'new@example.com', name: 'New User'});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
+      )
+      .mockResolvedValueOnce(jsonResponse({user}, {status: 201}));
+    configureApiClient({fetchImpl});
+
+    renderAuthPage('/auth/signup', <SignupPage />);
+    fireEvent.change(await screen.findByLabelText('Email'), {target: {value: 'new@example.com'}});
+    fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'long secure password'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
+    expect(await screen.findByRole('button', {name: RESEND_COUNTDOWN_RE})).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(screen.getByRole('button', {name: 'Resend verification email'})).not.toHaveAttribute(
+      'aria-disabled',
+    );
+  });
+
+  test('resends verification email and restarts cooldown from the server response', async () => {
+    vi.useFakeTimers({toFake: ['Date', 'setInterval', 'clearInterval']});
+    const user = pageUserFactory.build({email: 'new@example.com', name: 'New User'});
+    const nextResendAvailableAt = new Date(Date.now() + 120_000).toISOString();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
+      )
+      .mockResolvedValueOnce(jsonResponse({user}, {status: 201}))
+      .mockResolvedValueOnce(
+        jsonResponse({next_resend_available_at: nextResendAvailableAt}, {status: 200}),
+      );
+    configureApiClient({fetchImpl});
+
+    renderAuthPage('/auth/signup', <SignupPage />);
+    fireEvent.change(await screen.findByLabelText('Email'), {target: {value: 'new@example.com'}});
+    fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'long secure password'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
+    await screen.findByRole('heading', {name: 'Check your email'});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Resend verification email'}));
+
+    await waitFor(() => {
+      expect(
+        fetchImpl.mock.calls.some(([input]) =>
+          requestUrl(input).endsWith('/auth/verify-email/resend'),
+        ),
+      ).toBe(true);
+    });
+    expect(
+      await screen.findByText('If another verification email can be sent, it will arrive shortly.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: RESEND_COUNTDOWN_RE})).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+
+  test('surfaces resend failures without leaving the check-email state', async () => {
+    vi.useFakeTimers({toFake: ['Date', 'setInterval', 'clearInterval']});
+    const user = pageUserFactory.build({email: 'new@example.com', name: 'New User'});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
+      )
+      .mockResolvedValueOnce(jsonResponse({user}, {status: 201}))
+      .mockResolvedValueOnce(
+        jsonResponse({code: 'server-error', message: 'Server error'}, {status: 500}),
+      );
+    configureApiClient({fetchImpl});
+
+    renderAuthPage('/auth/signup', <SignupPage />);
+    fireEvent.change(await screen.findByLabelText('Email'), {target: {value: 'new@example.com'}});
+    fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'long secure password'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
+    await screen.findByRole('heading', {name: 'Check your email'});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    fireEvent.click(screen.getByRole('button', {name: 'Resend verification email'}));
+
+    expect(await screen.findByText('Server error')).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Check your email'})).toBeInTheDocument();
+  });
+
+  test('returns to the signup form when choosing another email', async () => {
+    const user = pageUserFactory.build({email: 'new@example.com', name: 'New User'});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
+      )
+      .mockResolvedValueOnce(jsonResponse({user}, {status: 201}));
+    configureApiClient({fetchImpl});
+
+    renderAuthPage('/auth/signup', <SignupPage />);
+    fireEvent.change(await screen.findByLabelText('Email'), {target: {value: 'new@example.com'}});
+    fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'long secure password'}});
+    fireEvent.click(screen.getByRole('button', {name: 'Create account'}));
+    await screen.findByRole('heading', {name: 'Check your email'});
+    fireEvent.click(screen.getByRole('button', {name: 'Use another email'}));
+
+    expect(screen.getByRole('heading', {name: 'Create your Shipfox account'})).toBeInTheDocument();
   });
 });

--- a/libs/client/auth/src/pages/signup-page.test.tsx
+++ b/libs/client/auth/src/pages/signup-page.test.tsx
@@ -1,8 +1,8 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {act, fireEvent, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, screen} from '@testing-library/react';
 import {pageUserFactory} from '#test/factories/user.js';
 import {renderAuthPage} from '#test/pages.js';
-import {jsonResponse, requestUrl} from '#test/utils.js';
+import {jsonResponse} from '#test/utils.js';
 import {SignupPage} from './signup-page.js';
 
 const SUBMITTED_EMAIL_RE = /new@example.com/;
@@ -140,13 +140,6 @@ describe('SignupPage', () => {
     });
     fireEvent.click(screen.getByRole('button', {name: 'Resend verification email'}));
 
-    await waitFor(() => {
-      expect(
-        fetchImpl.mock.calls.some(([input]) =>
-          requestUrl(input).endsWith('/auth/verify-email/resend'),
-        ),
-      ).toBe(true);
-    });
     expect(
       await screen.findByText('If another verification email can be sent, it will arrive shortly.'),
     ).toBeInTheDocument();

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -1,4 +1,3 @@
-import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
 import {Alert, Button, ButtonLink, Input, Label, Text, toast} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
@@ -8,6 +7,11 @@ import {useSignupAuth} from '#hooks/api/signup-auth.js';
 import {useResendEmailVerificationAuth} from '#hooks/api/verify-email-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
 import {parseSignupForm} from './auth-form-model.js';
+import {
+  getLocalResendAvailableAt,
+  getResendRemainingSeconds,
+  parseNextResendAvailableAt,
+} from './email-verification-resend-model.js';
 import {authErrorMessage, type FieldErrors} from './form-utils.js';
 
 type SignupField = 'email' | 'password' | 'name';
@@ -24,9 +28,7 @@ export function SignupPage() {
   const [formError, setFormError] = useState<string | undefined>();
   const [resendError, setResendError] = useState<string | undefined>();
   const {email, password} = authFormDraft;
-  const resendRemainingSeconds = nextResendAvailableAt
-    ? Math.max(0, Math.ceil((nextResendAvailableAt - now) / 1000))
-    : 0;
+  const resendRemainingSeconds = getResendRemainingSeconds({nextResendAvailableAt, now});
   const isResendCoolingDown = resendRemainingSeconds > 0;
 
   useEffect(() => {
@@ -51,9 +53,9 @@ export function SignupPage() {
   }, [nextResendAvailableAt, submittedEmail]);
 
   function restartLocalCooldown() {
-    const nextAvailableAt = Date.now() + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000;
-    setNow(Date.now());
-    setNextResendAvailableAt(nextAvailableAt);
+    const current = Date.now();
+    setNow(current);
+    setNextResendAvailableAt(getLocalResendAvailableAt(current));
   }
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
@@ -83,9 +85,9 @@ export function SignupPage() {
     setResendError(undefined);
     try {
       const result = await resendEmailVerification.mutateAsync({email: submittedEmail});
-      const nextAvailableAt = Date.parse(result.next_resend_available_at);
+      const nextAvailableAt = parseNextResendAvailableAt(result.next_resend_available_at);
       setNow(Date.now());
-      if (Number.isFinite(nextAvailableAt)) {
+      if (nextAvailableAt !== undefined) {
         setNextResendAvailableAt(nextAvailableAt);
       } else {
         restartLocalCooldown();

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -1,9 +1,11 @@
-import {Alert, Button, ButtonLink, Input, Label, Text} from '@shipfox/react-ui';
+import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
+import {Alert, Button, ButtonLink, Input, Label, Text, toast} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
-import {type FormEvent, useState} from 'react';
+import {type FormEvent, useEffect, useState} from 'react';
 import {AuthShell} from '#/components/auth-shell.js';
 import {useSignupAuth} from '#hooks/api/signup-auth.js';
+import {useResendEmailVerificationAuth} from '#hooks/api/verify-email-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
 import {parseSignupForm} from './auth-form-model.js';
 import {authErrorMessage, type FieldErrors} from './form-utils.js';
@@ -12,12 +14,47 @@ type SignupField = 'email' | 'password' | 'name';
 
 export function SignupPage() {
   const signup = useSignupAuth();
+  const resendEmailVerification = useResendEmailVerificationAuth();
   const [authFormDraft, setAuthFormDraft] = useAtom(authFormDraftAtom);
   const [name, setName] = useState('');
   const [submittedEmail, setSubmittedEmail] = useState<string | undefined>();
+  const [now, setNow] = useState(() => Date.now());
+  const [nextResendAvailableAt, setNextResendAvailableAt] = useState<number | undefined>();
   const [fieldErrors, setFieldErrors] = useState<FieldErrors<SignupField>>({});
   const [formError, setFormError] = useState<string | undefined>();
+  const [resendError, setResendError] = useState<string | undefined>();
   const {email, password} = authFormDraft;
+  const resendRemainingSeconds = nextResendAvailableAt
+    ? Math.max(0, Math.ceil((nextResendAvailableAt - now) / 1000))
+    : 0;
+  const isResendCoolingDown = resendRemainingSeconds > 0;
+
+  useEffect(() => {
+    if (!submittedEmail || !nextResendAvailableAt) {
+      return;
+    }
+
+    const current = Date.now();
+    setNow(current);
+    if (nextResendAvailableAt <= current) {
+      return;
+    }
+
+    const handle = window.setInterval(() => {
+      const tickNow = Date.now();
+      setNow(tickNow);
+      if (nextResendAvailableAt <= tickNow) {
+        window.clearInterval(handle);
+      }
+    }, 1000);
+    return () => window.clearInterval(handle);
+  }, [nextResendAvailableAt, submittedEmail]);
+
+  function restartLocalCooldown() {
+    const nextAvailableAt = Date.now() + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000;
+    setNow(Date.now());
+    setNextResendAvailableAt(nextAvailableAt);
+  }
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -33,8 +70,29 @@ export function SignupPage() {
       const result = await signup.mutateAsync(parsed.body);
       setAuthFormDraft(initialAuthFormDraft);
       setSubmittedEmail(result.user.email);
+      setResendError(undefined);
+      restartLocalCooldown();
     } catch (error) {
       setFormError(authErrorMessage(error));
+    }
+  }
+
+  async function onResendVerificationEmail() {
+    if (!submittedEmail || isResendCoolingDown || resendEmailVerification.isPending) return;
+
+    setResendError(undefined);
+    try {
+      const result = await resendEmailVerification.mutateAsync({email: submittedEmail});
+      const nextAvailableAt = Date.parse(result.next_resend_available_at);
+      setNow(Date.now());
+      if (Number.isFinite(nextAvailableAt)) {
+        setNextResendAvailableAt(nextAvailableAt);
+      } else {
+        restartLocalCooldown();
+      }
+      toast.success('If another verification email can be sent, it will arrive shortly.');
+    } catch (error) {
+      setResendError(authErrorMessage(error));
     }
   }
 
@@ -44,14 +102,32 @@ export function SignupPage() {
         title="Check your email"
         description={`We sent a verification link to ${submittedEmail}.`}
       >
+        {resendError ? <Alert variant="error">{resendError}</Alert> : null}
         <Alert variant="success">
           Click the verification link to activate your account, then come back to log in.
         </Alert>
         <Button
-          className="w-full"
+          aria-disabled={isResendCoolingDown ? true : undefined}
+          className="w-full aria-disabled:cursor-not-allowed aria-disabled:opacity-70"
           variant="secondary"
           type="button"
-          onClick={() => setSubmittedEmail(undefined)}
+          isLoading={resendEmailVerification.isPending}
+          onClick={onResendVerificationEmail}
+        >
+          {resendEmailVerification.isPending
+            ? 'Sending email...'
+            : isResendCoolingDown
+              ? `Resend in ${resendRemainingSeconds}s`
+              : 'Resend verification email'}
+        </Button>
+        <Button
+          className="w-full"
+          variant="transparent"
+          type="button"
+          onClick={() => {
+            setSubmittedEmail(undefined);
+            setResendError(undefined);
+          }}
         >
           Use another email
         </Button>

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -108,31 +108,33 @@ export function SignupPage() {
         <Alert variant="success">
           Click the verification link to activate your account, then come back to log in.
         </Alert>
-        <Button
-          aria-disabled={isResendCoolingDown ? true : undefined}
-          className="w-full aria-disabled:cursor-not-allowed aria-disabled:opacity-70"
-          variant="secondary"
-          type="button"
-          isLoading={resendEmailVerification.isPending}
-          onClick={onResendVerificationEmail}
-        >
-          {resendEmailVerification.isPending
-            ? 'Sending email...'
-            : isResendCoolingDown
-              ? `Resend in ${resendRemainingSeconds}s`
-              : 'Resend verification email'}
-        </Button>
-        <Button
-          className="w-full"
-          variant="transparent"
-          type="button"
-          onClick={() => {
-            setSubmittedEmail(undefined);
-            setResendError(undefined);
-          }}
-        >
-          Use another email
-        </Button>
+        <div className="flex flex-col gap-8">
+          <Button
+            aria-disabled={isResendCoolingDown ? true : undefined}
+            className="w-full aria-disabled:cursor-not-allowed aria-disabled:opacity-70"
+            variant="secondary"
+            type="button"
+            isLoading={resendEmailVerification.isPending}
+            onClick={onResendVerificationEmail}
+          >
+            {resendEmailVerification.isPending
+              ? 'Sending email...'
+              : isResendCoolingDown
+                ? `Resend in ${resendRemainingSeconds}s`
+                : 'Resend verification email'}
+          </Button>
+          <Button
+            className="w-full"
+            variant="transparent"
+            type="button"
+            onClick={() => {
+              setSubmittedEmail(undefined);
+              setResendError(undefined);
+            }}
+          >
+            Use another email
+          </Button>
+        </div>
         <Text size="sm" className="text-center text-foreground-neutral-subtle">
           Already verified?{' '}
           <ButtonLink asChild variant="interactive" underline>


### PR DESCRIPTION
[auth] Add verification email resend cooldown

Signup currently sends the initial verification email but leaves users without an in-flow recovery action if delivery is delayed or lost. This adds a 60-second resend flow on the post-signup check-email screen and updates the resend endpoint to return a generic next-available timestamp for every public outcome.

The API keeps address enumeration safety by returning the same response shape for eligible users, cooldown hits, missing users, inactive users, and already verified users. Eligible resend creation is serialized with a user-row lock inside the transaction so rapid duplicate requests can create at most one new verification email.

Considered exposing exact eligibility state to make the UI more specific, but that would leak account state. The UI instead mirrors the cooldown locally after signup, then follows the server timestamp after resend attempts while using generic toast copy.

Review focus: the cooldown transaction in `email-verifications.ts`, the public DTO shape for `POST /auth/verify-email/resend`, and the focusable `aria-disabled` resend button behavior in the signup check-email state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 60‑second, privacy‑safe verification email resend flow with a generic “next available” timestamp and a countdown after signup. Prevents address enumeration, serializes duplicate requests, and keeps the current token valid until a new one is issued after cooldown.

- **New Features**
  - API: `POST /auth/verify-email/resend` returns 200 with `{next_resend_available_at}`; uses a generic `now + cooldown` estimate for privacy; only sends a new email after cooldown.
  - DB: enforces a per‑user cooldown with row locks; at most one email per window; keeps the current token valid during cooldown and replaces it after cooldown.
  - DTOs: added `EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS` and `verifyEmailResendResponseSchema` (plus types) in `@shipfox/api-auth-dto`.
  - UI: signup “Check your email” adds a resend button with an `aria-disabled` countdown, a “Use another email” action, a generic success toast, and inline resend errors; mirrors local cooldown post‑signup, syncs to the server timestamp on resend, and stops the timer after expiry.

- **Migration**
  - Expect 200 JSON from `POST /auth/verify-email/resend` and read `next_resend_available_at` (was 204).
  - Use `useResendEmailVerificationAuth` to call the new resend endpoint.

<sup>Written for commit 71f469f8b0754cf9588e5b84571c46b019394434. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

