### PR TITLE
[client-auth] Split pure auth tests from DOM tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,69 @@ Each E2E package must also declare an explicit workspace dependency on the packa
 it verifies, such as `@shipfox/client-auth` for `@shipfox/e2e-client-auth`, so
 Turbo includes the referenced package in the task DAG.
 
+## Unit Testing Strategy (Client Apps)
+
+Client tests should default to the cheapest environment that can prove the
+behavior under test. React Testing Library is useful for DOM behavior, but it is
+too expensive for schema validation, request payload shaping, error-copy mapping,
+redirect sanitization, cache key generation, or other pure decisions.
+
+When adding or refactoring client tests:
+
+1. Put pure behavior in plain TypeScript helpers and test it in Vitest's `node`
+   environment. Examples include form parsing, DTO normalization, auth error
+   copy, URL sanitization, and token timing helpers.
+2. Keep React Testing Library for behavior that requires rendered React state:
+   provider wiring, hooks interacting with React Query/Jotai, focus/portal/menu
+   behavior, StrictMode idempotency, and a small number of page smoke tests.
+3. Move full user journeys to Playwright E2E instead of reproducing them through
+   a memory router, auth provider, query client, API mocks, and toast container in
+   every unit test.
+4. Avoid asserting schema details or exact request payloads in RTL page tests when
+   a Node helper test can cover the same branch directly.
+5. Avoid real timers in unit tests. Prefer immediate promises, fake timers, or
+   explicitly controlled promises over `setTimeout` sleeps.
+6. Use `fireEvent.change` for simple final-value form setup. Use
+   `userEvent.type` only when keyboard-level interaction semantics are the thing
+   being tested.
+
+Client packages that mix pure tests and DOM tests should split Vitest projects so
+`.test.ts` files can run in `node` without `test/setup.ts`, while `.test.tsx`
+files and browser-storage tests run in `jsdom`:
+
+```typescript
+export default defineConfig(
+  {
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+            exclude: ['src/state/local-storage-backed.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx', 'src/state/local-storage-backed.test.ts'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
+    },
+  },
+  import.meta.url,
+);
+```
+
+The target shape is many fast Node tests for branch-heavy behavior, a small RTL
+suite for React integration, and Playwright for user-visible journeys.
+
 ## Unit Testing Strategy (Node Apps)
 
 Tests use **Vitest** and run against a real PostgreSQL database, not mocks. The philosophy is to test against real infrastructure where possible and only mock external dependencies (feature flags, cloud provider APIs, etc.).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,66 +113,10 @@ Turbo includes the referenced package in the task DAG.
 
 ## Unit Testing Strategy (Client Apps)
 
-Client tests should default to the cheapest environment that can prove the
-behavior under test. React Testing Library is useful for DOM behavior, but it is
-too expensive for schema validation, request payload shaping, error-copy mapping,
-redirect sanitization, cache key generation, or other pure decisions.
-
-When adding or refactoring client tests:
-
-1. Put pure behavior in plain TypeScript helpers and test it in Vitest's `node`
-   environment. Examples include form parsing, DTO normalization, auth error
-   copy, URL sanitization, and token timing helpers.
-2. Keep React Testing Library for behavior that requires rendered React state:
-   provider wiring, hooks interacting with React Query/Jotai, focus/portal/menu
-   behavior, StrictMode idempotency, and a small number of page smoke tests.
-3. Move full user journeys to Playwright E2E instead of reproducing them through
-   a memory router, auth provider, query client, API mocks, and toast container in
-   every unit test.
-4. Avoid asserting schema details or exact request payloads in RTL page tests when
-   a Node helper test can cover the same branch directly.
-5. Avoid real timers in unit tests. Prefer immediate promises, fake timers, or
-   explicitly controlled promises over `setTimeout` sleeps.
-6. Use `fireEvent.change` for simple final-value form setup. Use
-   `userEvent.type` only when keyboard-level interaction semantics are the thing
-   being tested.
-
-Client packages that mix pure tests and DOM tests should split Vitest projects so
-`.test.ts` files can run in `node` without `test/setup.ts`, while `.test.tsx`
-files and browser-storage tests run in `jsdom`:
-
-```typescript
-export default defineConfig(
-  {
-    test: {
-      projects: [
-        {
-          extends: true,
-          test: {
-            name: 'node',
-            environment: 'node',
-            include: ['src/**/*.test.ts'],
-            exclude: ['src/state/local-storage-backed.test.ts'],
-          },
-        },
-        {
-          extends: true,
-          test: {
-            name: 'dom',
-            environment: 'jsdom',
-            include: ['src/**/*.test.tsx', 'src/state/local-storage-backed.test.ts'],
-            setupFiles: ['test/setup.ts'],
-          },
-        },
-      ],
-    },
-  },
-  import.meta.url,
-);
-```
-
-The target shape is many fast Node tests for branch-heavy behavior, a small RTL
-suite for React integration, and Playwright for user-visible journeys.
+The detailed client testing strategy lives in
+[CONTRIBUTING.md](CONTRIBUTING.md#unit-testing-strategy-client-apps). In short:
+keep pure behavior in Vitest `node` tests, reserve React Testing Library for
+rendered React behavior, and move full user journeys to Playwright E2E.
 
 ## Unit Testing Strategy (Node Apps)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,69 @@ E2E setup APIs are module-owned routes under `/__e2e/<module>`. They are mounted
 when both `E2E_ENABLED=true` and `E2E_ADMIN_API_KEY` are set. Tests must create data
 through these HTTP APIs, not through direct database access.
 
+## Unit Testing Strategy (Client Apps)
+
+Client tests should default to the cheapest environment that can prove the
+behavior under test. React Testing Library is useful for DOM behavior, but it is
+too expensive for schema validation, request payload shaping, error-copy mapping,
+redirect sanitization, cache key generation, or other pure decisions.
+
+When adding or refactoring client tests:
+
+1. Put pure behavior in plain TypeScript helpers and test it in Vitest's `node`
+   environment. Examples include form parsing, DTO normalization, auth error
+   copy, URL sanitization, and token timing helpers.
+2. Keep React Testing Library for behavior that requires rendered React state:
+   provider wiring, hooks interacting with React Query/Jotai, focus/portal/menu
+   behavior, StrictMode idempotency, and a small number of page smoke tests.
+3. Move full user journeys to Playwright E2E instead of reproducing them through
+   a memory router, auth provider, query client, API mocks, and toast container in
+   every unit test.
+4. Avoid asserting schema details or exact request payloads in RTL page tests when
+   a Node helper test can cover the same branch directly.
+5. Avoid real timers in unit tests. Prefer immediate promises, fake timers, or
+   explicitly controlled promises over `setTimeout` sleeps.
+6. Use `fireEvent.change` for simple final-value form setup. Use
+   `userEvent.type` only when keyboard-level interaction semantics are the thing
+   being tested.
+
+Client packages that mix pure tests and DOM tests should split Vitest projects so
+`.test.ts` files can run in `node` without `test/setup.ts`, while `.test.tsx`
+files and browser-storage tests run in `jsdom`:
+
+```typescript
+export default defineConfig(
+  {
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+            exclude: ['src/state/local-storage-backed.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx', 'src/state/local-storage-backed.test.ts'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
+    },
+  },
+  import.meta.url,
+);
+```
+
+The target shape is many fast Node tests for branch-heavy behavior, a small RTL
+suite for React integration, and Playwright for user-visible journeys.
+
 ## Visual Regression Testing
 
 Visual drift is caught on every PR via [Argos](https://argos-ci.com/). One Argos

--- a/libs/client/auth/src/components/auth-provider.test.tsx
+++ b/libs/client/auth/src/components/auth-provider.test.tsx
@@ -24,12 +24,6 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   });
 }
 
-function delayedJsonResponse(body: unknown): Promise<Response> {
-  return new Promise((resolve) => {
-    setTimeout(() => resolve(jsonResponse(body)), 5);
-  });
-}
-
 function StatusProbe() {
   const auth = useAuthState();
   const logout = useLogoutAuth();
@@ -125,7 +119,7 @@ describe('AuthProvider', () => {
   test('deduplicates concurrent refresh calls', async () => {
     const fetchImpl = vi
       .fn()
-      .mockImplementation(() => delayedJsonResponse({token: 'access-token', user}));
+      .mockImplementation(() => Promise.resolve(jsonResponse({token: 'access-token', user})));
     configureApiClient({fetchImpl});
     const onDone = vi.fn();
 

--- a/libs/client/auth/src/pages/auth-form-model.test.ts
+++ b/libs/client/auth/src/pages/auth-form-model.test.ts
@@ -1,0 +1,106 @@
+import {
+  parseLoginForm,
+  parsePasswordResetConfirmForm,
+  parsePasswordResetRequestForm,
+  parseSignupForm,
+} from './auth-form-model.js';
+
+describe('auth form model', () => {
+  test('normalizes a valid login payload', () => {
+    const result = parseLoginForm({
+      email: 'Login@Example.com',
+      password: 'correct horse',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      body: {
+        email: 'login@example.com',
+        password: 'correct horse',
+      },
+    });
+  });
+
+  test('returns login field errors without rendering the login page', () => {
+    const result = parseLoginForm({email: '', password: ''});
+
+    expect(result).toEqual({
+      ok: false,
+      fieldErrors: {
+        email: 'Invalid email',
+        password: 'String must contain at least 1 character(s)',
+      },
+    });
+  });
+
+  test('trims optional signup names and normalizes email', () => {
+    const result = parseSignupForm({
+      email: 'New@Example.com',
+      password: 'long secure password',
+      name: '  New User  ',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      body: {
+        email: 'new@example.com',
+        password: 'long secure password',
+        name: 'New User',
+      },
+    });
+  });
+
+  test('omits blank signup names', () => {
+    const result = parseSignupForm({
+      email: 'new@example.com',
+      password: 'long secure password',
+      name: '   ',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      body: {
+        email: 'new@example.com',
+        password: 'long secure password',
+      },
+    });
+  });
+
+  test('normalizes password reset request emails', () => {
+    const result = parsePasswordResetRequestForm({email: 'Reset@Example.com'});
+
+    expect(result).toEqual({
+      ok: true,
+      body: {email: 'reset@example.com'},
+    });
+  });
+
+  test('returns password reset confirmation field errors', () => {
+    const result = parsePasswordResetConfirmForm({
+      token: 'reset-token',
+      newPassword: 'short',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      fieldErrors: {
+        new_password: 'String must contain at least 12 character(s)',
+      },
+    });
+  });
+
+  test('normalizes password reset confirmation payloads', () => {
+    const result = parsePasswordResetConfirmForm({
+      token: 'reset-token',
+      newPassword: 'new password is long',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      body: {
+        token: 'reset-token',
+        new_password: 'new password is long',
+      },
+    });
+  });
+});

--- a/libs/client/auth/src/pages/auth-form-model.ts
+++ b/libs/client/auth/src/pages/auth-form-model.ts
@@ -1,0 +1,70 @@
+import {
+  type LoginBodyDto,
+  loginBodySchema,
+  type PasswordResetConfirmBodyDto,
+  type PasswordResetRequestBodyDto,
+  passwordResetConfirmBodySchema,
+  passwordResetRequestBodySchema,
+  type SignupBodyDto,
+  signupBodySchema,
+} from '@shipfox/api-auth-dto';
+import {type FieldErrors, fieldErrorsFromZod} from './form-utils.js';
+
+type FormResult<TBody, TField extends string> =
+  | {ok: true; body: TBody}
+  | {ok: false; fieldErrors: FieldErrors<TField>};
+
+export function parseLoginForm(input: {
+  email: string;
+  password: string;
+}): FormResult<LoginBodyDto, 'email' | 'password'> {
+  const parsed = loginBodySchema.safeParse(input);
+  if (!parsed.success) {
+    return {ok: false, fieldErrors: fieldErrorsFromZod(parsed.error)};
+  }
+
+  return {ok: true, body: parsed.data};
+}
+
+export function parseSignupForm(input: {
+  email: string;
+  password: string;
+  name: string;
+}): FormResult<SignupBodyDto, 'email' | 'password' | 'name'> {
+  const parsed = signupBodySchema.safeParse({
+    email: input.email,
+    password: input.password,
+    name: input.name.trim() ? input.name.trim() : undefined,
+  });
+  if (!parsed.success) {
+    return {ok: false, fieldErrors: fieldErrorsFromZod(parsed.error)};
+  }
+
+  return {ok: true, body: parsed.data};
+}
+
+export function parsePasswordResetRequestForm(input: {
+  email: string;
+}): FormResult<PasswordResetRequestBodyDto, 'email'> {
+  const parsed = passwordResetRequestBodySchema.safeParse(input);
+  if (!parsed.success) {
+    return {ok: false, fieldErrors: fieldErrorsFromZod(parsed.error)};
+  }
+
+  return {ok: true, body: parsed.data};
+}
+
+export function parsePasswordResetConfirmForm(input: {
+  token: string;
+  newPassword: string;
+}): FormResult<PasswordResetConfirmBodyDto, 'new_password'> {
+  const parsed = passwordResetConfirmBodySchema.safeParse({
+    token: input.token,
+    new_password: input.newPassword,
+  });
+  if (!parsed.success) {
+    return {ok: false, fieldErrors: fieldErrorsFromZod(parsed.error)};
+  }
+
+  return {ok: true, body: parsed.data};
+}

--- a/libs/client/auth/src/pages/form-utils.test.ts
+++ b/libs/client/auth/src/pages/form-utils.test.ts
@@ -1,0 +1,50 @@
+import {ApiError} from '@shipfox/client-api';
+import {authErrorMessage, fieldErrorsFromZod} from './form-utils.js';
+
+describe('fieldErrorsFromZod', () => {
+  test('keeps the first message for each field', () => {
+    const result = fieldErrorsFromZod<'email' | 'password'>({
+      issues: [
+        {path: ['email'], message: 'Invalid email'},
+        {path: ['email'], message: 'Email required'},
+        {path: ['password'], message: 'Password required'},
+        {path: [0], message: 'Ignored'},
+      ],
+    });
+
+    expect(result).toEqual({
+      email: 'Invalid email',
+      password: 'Password required',
+    });
+  });
+});
+
+describe('authErrorMessage', () => {
+  test.each([
+    ['invalid-credentials', 'Email or password is incorrect.'],
+    ['email-not-verified', 'Verify your email before signing in.'],
+    ['email-taken', 'An account already exists for this email.'],
+    ['token-invalid', 'This link is invalid or expired.'],
+    ['network-error', 'We could not reach the API. Check your connection and try again.'],
+  ])('maps %s to client copy', (code, message) => {
+    const error = new ApiError({code, message: 'Server copy', status: 400});
+
+    const result = authErrorMessage(error);
+
+    expect(result).toBe(message);
+  });
+
+  test('falls back to API error messages', () => {
+    const error = new ApiError({code: 'rate-limited', message: 'Try later', status: 429});
+
+    const result = authErrorMessage(error);
+
+    expect(result).toBe('Try later');
+  });
+
+  test('uses generic copy for unknown errors', () => {
+    const result = authErrorMessage(new Error('boom'));
+
+    expect(result).toBe('Something went wrong. Try again.');
+  });
+});

--- a/libs/client/auth/src/pages/login-page.test.tsx
+++ b/libs/client/auth/src/pages/login-page.test.tsx
@@ -11,7 +11,7 @@ describe('LoginPage', () => {
     configureApiClient({baseUrl: 'https://api.example.test', getAccessToken: undefined});
   });
 
-  test('validates fields and links to signup', async () => {
+  test('renders account recovery and signup links', async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(
@@ -20,10 +20,8 @@ describe('LoginPage', () => {
     configureApiClient({fetchImpl});
 
     renderAuthPage('/auth/login', <LoginPage />);
-    fireEvent.click(await screen.findByRole('button', {name: 'Log in'}));
 
-    expect(await screen.findByText('Invalid email')).toBeInTheDocument();
-    expect(screen.getByText('String must contain at least 1 character(s)')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', {name: 'Connect to Shipfox'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Create an account'})).toHaveAttribute(
       'href',
       '/auth/signup',
@@ -60,15 +58,12 @@ describe('LoginPage', () => {
 
   test('posts valid credentials and navigates home', async () => {
     const user = pageUserFactory.build({email: 'login@example.com'});
-    let requestBody: unknown;
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(
         jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
       )
-      .mockImplementationOnce(async (input: RequestInfo | URL) => {
-        requestBody = await (input as Request).json();
-
+      .mockImplementationOnce(() => {
         return jsonResponse({
           token: 'access-token',
           user,
@@ -91,9 +86,5 @@ describe('LoginPage', () => {
     expect(await screen.findByRole('heading', {name: 'Authenticated home'})).toBeInTheDocument();
     const request = fetchImpl.mock.calls[1]?.[0] as Request;
     expect(request.url).toBe('https://api.example.test/auth/login');
-    expect(requestBody).toEqual({
-      email: 'login@example.com',
-      password: 'correct horse',
-    });
   });
 });

--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -1,4 +1,3 @@
-import {loginBodySchema} from '@shipfox/api-auth-dto';
 import {Alert, Button, ButtonLink, Input, Label, Text} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
@@ -6,7 +5,8 @@ import {type FormEvent, useState} from 'react';
 import {AuthShell} from '#/components/auth-shell.js';
 import {useLoginAuth} from '#hooks/api/login-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
-import {authErrorMessage, type FieldErrors, fieldErrorsFromZod} from './form-utils.js';
+import {parseLoginForm} from './auth-form-model.js';
+import {authErrorMessage, type FieldErrors} from './form-utils.js';
 
 type LoginField = 'email' | 'password';
 
@@ -20,15 +20,15 @@ export function LoginPage() {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFormError(undefined);
-    const parsed = loginBodySchema.safeParse({email, password});
-    if (!parsed.success) {
-      setFieldErrors(fieldErrorsFromZod<LoginField>(parsed.error));
+    const parsed = parseLoginForm({email, password});
+    if (!parsed.ok) {
+      setFieldErrors(parsed.fieldErrors);
       return;
     }
 
     setFieldErrors({});
     try {
-      await login.mutateAsync(parsed.data);
+      await login.mutateAsync(parsed.body);
       setAuthFormDraft(initialAuthFormDraft);
       // The route's GuestGuard redirects authenticated users to `/`. Letting
       // the guard fire from the auth-state-driven re-render guarantees the

--- a/libs/client/auth/src/pages/password-reset-page.test.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.test.tsx
@@ -10,7 +10,7 @@ describe('PasswordResetPage', () => {
     configureApiClient({baseUrl: 'https://api.example.test', getAccessToken: undefined});
   });
 
-  test('validates the request email and links back to login', async () => {
+  test('renders the reset request form and links back to login', async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValue(
@@ -19,19 +19,15 @@ describe('PasswordResetPage', () => {
     configureApiClient({fetchImpl});
 
     renderAuthPage('/auth/reset', <PasswordResetPage />);
-    fireEvent.click(await screen.findByRole('button', {name: 'Send reset link'}));
 
-    expect(await screen.findByText('Invalid email')).toBeInTheDocument();
+    expect(await screen.findByRole('heading', {name: 'Reset your password'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Log in'})).toHaveAttribute('href', '/auth/login');
   });
 
   test('requests a reset link for a valid email', async () => {
-    let requestBody: unknown;
-    const fetchImpl = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+    const fetchImpl = vi.fn().mockImplementation((input: RequestInfo | URL) => {
       const url = requestUrl(input);
       if (url.endsWith('/auth/password-reset')) {
-        requestBody = await (input as Request).json();
-
         return new Response(null, {status: 204});
       }
       if (url.endsWith('/auth/refresh')) {
@@ -59,34 +55,14 @@ describe('PasswordResetPage', () => {
     );
     const request = resetCall?.[0] as Request;
     expect(request.url).toBe('https://api.example.test/auth/password-reset');
-    expect(requestBody).toEqual({email: 'reset@example.com'});
-  });
-
-  test('validates the new password for reset confirmation', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValue(
-        jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
-      );
-    configureApiClient({fetchImpl});
-
-    renderAuthPage('/auth/reset?token=reset-token', <PasswordResetPage />);
-    fireEvent.click(await screen.findByRole('button', {name: 'Update password'}));
-
-    expect(
-      await screen.findByText('String must contain at least 12 character(s)'),
-    ).toBeInTheDocument();
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   test('confirms a password reset token', async () => {
     const user = pageUserFactory.build({email: 'reset@example.com'});
-    let requestBody: unknown;
     let didConfirm = false;
-    const fetchImpl = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+    const fetchImpl = vi.fn().mockImplementation((input: RequestInfo | URL) => {
       const url = requestUrl(input);
       if (url.endsWith('/auth/password-reset/confirm')) {
-        requestBody = await (input as Request).json();
         didConfirm = true;
         return jsonResponse({token: 'reset-access-token', user});
       }
@@ -115,10 +91,6 @@ describe('PasswordResetPage', () => {
     );
     const request = confirmCall?.[0] as Request;
     expect(request.url).toBe('https://api.example.test/auth/password-reset/confirm');
-    expect(requestBody).toEqual({
-      token: 'reset-token',
-      new_password: 'new password is long',
-    });
   });
 
   test('reports invalid reset tokens', async () => {

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -1,7 +1,3 @@
-import {
-  passwordResetConfirmBodySchema,
-  passwordResetRequestBodySchema,
-} from '@shipfox/api-auth-dto';
 import {Alert, Button, ButtonLink, Input, Label, Text, toast} from '@shipfox/react-ui';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
@@ -13,7 +9,8 @@ import {
 } from '#hooks/api/password-reset-auth.js';
 import {useRefreshAuth} from '#hooks/api/refresh-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
-import {authErrorMessage, type FieldErrors, fieldErrorsFromZod} from './form-utils.js';
+import {parsePasswordResetConfirmForm, parsePasswordResetRequestForm} from './auth-form-model.js';
+import {authErrorMessage, type FieldErrors} from './form-utils.js';
 
 type RequestField = 'email';
 type ConfirmField = 'new_password';
@@ -40,16 +37,16 @@ function PasswordResetRequest() {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFormError(undefined);
-    const parsed = passwordResetRequestBodySchema.safeParse({email});
-    if (!parsed.success) {
-      setFieldErrors(fieldErrorsFromZod<RequestField>(parsed.error));
+    const parsed = parsePasswordResetRequestForm({email});
+    if (!parsed.ok) {
+      setFieldErrors(parsed.fieldErrors);
       return;
     }
 
     setFieldErrors({});
     try {
-      await requestPasswordReset.mutateAsync(parsed.data);
-      setSubmittedEmail(parsed.data.email);
+      await requestPasswordReset.mutateAsync(parsed.body);
+      setSubmittedEmail(parsed.body.email);
     } catch (error) {
       setFormError(authErrorMessage(error));
     }
@@ -132,15 +129,15 @@ function PasswordResetConfirm({token}: {token: string}) {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFormError(undefined);
-    const parsed = passwordResetConfirmBodySchema.safeParse({token, new_password: newPassword});
-    if (!parsed.success) {
-      setFieldErrors(fieldErrorsFromZod<ConfirmField>(parsed.error));
+    const parsed = parsePasswordResetConfirmForm({token, newPassword});
+    if (!parsed.ok) {
+      setFieldErrors(parsed.fieldErrors);
       return;
     }
 
     setFieldErrors({});
     try {
-      await confirmPasswordReset.mutateAsync(parsed.data);
+      await confirmPasswordReset.mutateAsync(parsed.body);
       await refreshAuth();
       setAuthFormDraft(initialAuthFormDraft);
       toast.success('Your password has been changed. You are now logged in.');

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -1,4 +1,3 @@
-import {signupBodySchema} from '@shipfox/api-auth-dto';
 import {Alert, Button, ButtonLink, Input, Label, Text} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
@@ -6,7 +5,8 @@ import {type FormEvent, useState} from 'react';
 import {AuthShell} from '#/components/auth-shell.js';
 import {useSignupAuth} from '#hooks/api/signup-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
-import {authErrorMessage, type FieldErrors, fieldErrorsFromZod} from './form-utils.js';
+import {parseSignupForm} from './auth-form-model.js';
+import {authErrorMessage, type FieldErrors} from './form-utils.js';
 
 type SignupField = 'email' | 'password' | 'name';
 
@@ -22,19 +22,15 @@ export function SignupPage() {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFormError(undefined);
-    const parsed = signupBodySchema.safeParse({
-      email,
-      password,
-      name: name.trim() ? name.trim() : undefined,
-    });
-    if (!parsed.success) {
-      setFieldErrors(fieldErrorsFromZod<SignupField>(parsed.error));
+    const parsed = parseSignupForm({email, password, name});
+    if (!parsed.ok) {
+      setFieldErrors(parsed.fieldErrors);
       return;
     }
 
     setFieldErrors({});
     try {
-      const result = await signup.mutateAsync(parsed.data);
+      const result = await signup.mutateAsync(parsed.body);
       setAuthFormDraft(initialAuthFormDraft);
       setSubmittedEmail(result.user.email);
     } catch (error) {

--- a/libs/client/auth/src/pages/verify-email-page.test.tsx
+++ b/libs/client/auth/src/pages/verify-email-page.test.tsx
@@ -10,40 +10,6 @@ describe('VerifyEmailPage', () => {
     configureApiClient({baseUrl: 'https://api.example.test', getAccessToken: undefined});
   });
 
-  test('confirms a valid token', async () => {
-    const user = pageUserFactory.build();
-    let didVerify = false;
-    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
-      const url = requestUrl(input);
-      if (url.endsWith('/auth/verify-email/confirm')) {
-        didVerify = true;
-        return Promise.resolve(jsonResponse({token: 'verified-access-token', user}));
-      }
-      if (url.endsWith('/auth/refresh')) {
-        return Promise.resolve(
-          didVerify
-            ? jsonResponse({token: 'refreshed-access-token', user})
-            : jsonResponse({code: 'unauthorized', message: 'Unauthorized'}, {status: 401}),
-        );
-      }
-      return Promise.resolve(
-        jsonResponse({code: 'not-found', message: 'Not found'}, {status: 404}),
-      );
-    });
-    configureApiClient({fetchImpl});
-
-    renderAuthPage('/auth/verify-email?token=token-123', <VerifyEmailPage />);
-
-    expect(await screen.findByRole('heading', {name: 'Authenticated home'})).toBeInTheDocument();
-    expect(
-      await screen.findByText('Your email is verified. You are now logged in.'),
-    ).toBeInTheDocument();
-    const refreshCalls = fetchImpl.mock.calls.filter(([input]) =>
-      requestUrl(input).endsWith('/auth/refresh'),
-    );
-    expect(refreshCalls.length).toBeGreaterThanOrEqual(1);
-  });
-
   test('only confirms once under StrictMode', async () => {
     const user = pageUserFactory.build();
     let didVerify = false;

--- a/libs/client/auth/vitest.config.ts
+++ b/libs/client/auth/vitest.config.ts
@@ -3,8 +3,26 @@ import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
 export default defineConfig(
   {
     test: {
-      environment: 'jsdom',
-      setupFiles: ['test/setup.ts'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+            exclude: ['src/state/last-workspace.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx', 'src/state/last-workspace.test.ts'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
     },
   },
   import.meta.url,


### PR DESCRIPTION
Split the client auth test suite into fast Node tests for pure behavior and jsdom tests for React integration behavior.

React Testing Library was being used for branch-heavy form parsing and request-shaping checks, which made simple schema and copy assertions pay for the full router, auth provider, query client, and toast harness. This extracts auth form parsing into plain TypeScript helpers, adds Node coverage for those helpers and auth error copy, and trims duplicate assertions from page-level RTL tests.

This also documents the client testing strategy in the repo guides so future client modules can follow the same pattern: pure tests in Node, small RTL coverage for React wiring, and full user journeys in Playwright.

Reviewers should pay closest attention to the new `client-auth` Vitest project split and the preserved page-level coverage after moving validation details into Node tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the `client-auth` tests into fast Node tests for pure auth logic and focused `jsdom`/RTL tests for React wiring to speed up the suite while keeping page-level coverage. Extracted form parsing into helpers and updated pages and tests accordingly.

- **Refactors**
  - Added `auth-form-model.ts` with `parseLoginForm`, `parseSignupForm`, `parsePasswordResetRequestForm`, and `parsePasswordResetConfirmForm`, plus Node tests for these and `fieldErrorsFromZod`/`authErrorMessage` (from `@shipfox/client-api`).
  - Updated login, signup, and password reset pages to use the helpers; trimmed RTL tests to focus on UI, links, and navigation; retained the StrictMode verify-email test.
  - Removed timer delays from `AuthProvider` tests in favor of promise-based `fetch` responses.
  - Split Vitest into `node` and `dom` projects (`.test.ts` in Node; `.test.tsx` and `src/state/last-workspace.test.ts` in `jsdom`). Moved detailed client testing strategy to `CONTRIBUTING.md` and linked from `AGENTS.md` to avoid duplication.

<sup>Written for commit 93b51d2debb70e642bd08a03282d2e0f2035ca9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

