### PR TITLE
[client] Align tests with fast unit strategy

### DIFF
--- a/libs/client/auth/src/hooks/api/login-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.test.ts
@@ -1,0 +1,45 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {loginAuth} from './login-auth.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('loginAuth', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts login credentials', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({
+        token: 'access-token',
+        user: {
+          id: '11111111-1111-4111-8111-111111111111',
+          email: 'login@example.com',
+          name: null,
+          email_verified_at: '2026-04-27T00:00:00.000Z',
+          status: 'active',
+          created_at: '2026-04-27T00:00:00.000Z',
+          updated_at: '2026-04-27T00:00:00.000Z',
+        },
+      });
+    });
+    configureApiClient({fetchImpl});
+    const body = {email: 'login@example.com', password: 'correct horse'};
+
+    const result = await loginAuth(body);
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.token).toBe('access-token');
+    expect(request.url).toBe('https://api.example.test/auth/login');
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual(body);
+  });
+});

--- a/libs/client/auth/src/hooks/api/login-auth.ts
+++ b/libs/client/auth/src/hooks/api/login-auth.ts
@@ -6,7 +6,7 @@ import {authStateAtom, toAuthenticatedState} from '#state/auth.js';
 import {authRefreshQueryKey} from './refresh-auth.js';
 import {listUserWorkspaces, userWorkspacesQueryKey} from './workspace-auth.js';
 
-async function loginAuth(body: LoginBodyDto) {
+export async function loginAuth(body: LoginBodyDto) {
   return await apiRequest<LoginResponseDto>('/auth/login', {method: 'POST', body});
 }
 

--- a/libs/client/auth/src/hooks/api/password-reset-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.test.ts
@@ -1,0 +1,68 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {confirmPasswordReset, requestPasswordReset} from './password-reset-auth.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('requestPasswordReset', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts reset request emails', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return new Response(null, {status: 204});
+    });
+    configureApiClient({fetchImpl});
+
+    const result = await requestPasswordReset({email: 'reset@example.com'});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result).toBeUndefined();
+    expect(request.url).toBe('https://api.example.test/auth/password-reset');
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual({email: 'reset@example.com'});
+  });
+});
+
+describe('confirmPasswordReset', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts reset confirmation tokens and passwords', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({
+        token: 'reset-access-token',
+        user: {
+          id: '11111111-1111-4111-8111-111111111111',
+          email: 'reset@example.com',
+          name: null,
+          email_verified_at: '2026-04-27T00:00:00.000Z',
+          status: 'active',
+          created_at: '2026-04-27T00:00:00.000Z',
+          updated_at: '2026-04-27T00:00:00.000Z',
+        },
+      });
+    });
+    configureApiClient({fetchImpl});
+    const body = {token: 'reset-token', new_password: 'new password is long'};
+
+    const result = await confirmPasswordReset(body);
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.token).toBe('reset-access-token');
+    expect(request.url).toBe('https://api.example.test/auth/password-reset/confirm');
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual(body);
+  });
+});

--- a/libs/client/auth/src/hooks/api/password-reset-auth.ts
+++ b/libs/client/auth/src/hooks/api/password-reset-auth.ts
@@ -10,11 +10,11 @@ import {authStateAtom, toAuthenticatedState} from '#state/auth.js';
 import {authRefreshQueryKey} from './refresh-auth.js';
 import {listUserWorkspaces, userWorkspacesQueryKey} from './workspace-auth.js';
 
-async function requestPasswordReset(body: PasswordResetRequestBodyDto) {
+export async function requestPasswordReset(body: PasswordResetRequestBodyDto) {
   await apiRequest<void>('/auth/password-reset', {method: 'POST', body});
 }
 
-async function confirmPasswordReset(body: PasswordResetConfirmBodyDto) {
+export async function confirmPasswordReset(body: PasswordResetConfirmBodyDto) {
   return await apiRequest<PasswordResetConfirmResponseDto>('/auth/password-reset/confirm', {
     method: 'POST',
     body,

--- a/libs/client/auth/src/hooks/api/workspace-auth.test.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.test.ts
@@ -1,0 +1,40 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {createWorkspace} from './workspace-auth.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('createWorkspace', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts the workspace body', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({
+        id: '33333333-3333-4333-8333-333333333333',
+        name: 'Acme',
+        status: 'active',
+        settings: {},
+        created_at: '2026-04-27T00:00:00.000Z',
+        updated_at: '2026-04-27T00:00:00.000Z',
+      });
+    });
+    configureApiClient({fetchImpl});
+
+    const result = await createWorkspace({name: 'Acme'});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.name).toBe('Acme');
+    expect(request.url).toBe('https://api.example.test/workspaces');
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual({name: 'Acme'});
+  });
+});

--- a/libs/client/auth/src/hooks/api/workspace-auth.ts
+++ b/libs/client/auth/src/hooks/api/workspace-auth.ts
@@ -7,7 +7,7 @@ import {apiRequest} from '@shipfox/client-api';
 import {useMutation} from '@tanstack/react-query';
 import {useRefreshAuth} from './refresh-auth.js';
 
-async function createWorkspace(body: CreateWorkspaceBodyDto) {
+export async function createWorkspace(body: CreateWorkspaceBodyDto) {
   return await apiRequest<WorkspaceResponseDto>('/workspaces', {method: 'POST', body});
 }
 

--- a/libs/client/auth/src/pages/login-page.test.tsx
+++ b/libs/client/auth/src/pages/login-page.test.tsx
@@ -84,7 +84,5 @@ describe('LoginPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Log in'}));
 
     expect(await screen.findByRole('heading', {name: 'Authenticated home'})).toBeInTheDocument();
-    const request = fetchImpl.mock.calls[1]?.[0] as Request;
-    expect(request.url).toBe('https://api.example.test/auth/login');
   });
 });

--- a/libs/client/auth/src/pages/password-reset-page.test.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.test.tsx
@@ -50,11 +50,6 @@ describe('PasswordResetPage', () => {
         'If a Shipfox account exists for that email, the reset link will arrive shortly.',
       ),
     ).toBeInTheDocument();
-    const resetCall = fetchImpl.mock.calls.find(([input]) =>
-      requestUrl(input).endsWith('/auth/password-reset'),
-    );
-    const request = resetCall?.[0] as Request;
-    expect(request.url).toBe('https://api.example.test/auth/password-reset');
   });
 
   test('confirms a password reset token', async () => {
@@ -86,11 +81,6 @@ describe('PasswordResetPage', () => {
     expect(
       await screen.findByText('Your password has been changed. You are now logged in.'),
     ).toBeInTheDocument();
-    const confirmCall = fetchImpl.mock.calls.find(([input]) =>
-      requestUrl(input).endsWith('/auth/password-reset/confirm'),
-    );
-    const request = confirmCall?.[0] as Request;
-    expect(request.url).toBe('https://api.example.test/auth/password-reset/confirm');
   });
 
   test('reports invalid reset tokens', async () => {

--- a/libs/client/auth/src/pages/workspace-onboarding-form.test.ts
+++ b/libs/client/auth/src/pages/workspace-onboarding-form.test.ts
@@ -1,0 +1,23 @@
+import {parseWorkspaceOnboardingForm} from './workspace-onboarding-form.js';
+
+describe('parseWorkspaceOnboardingForm', () => {
+  test('trims workspace names', () => {
+    const result = parseWorkspaceOnboardingForm({name: '  Acme  '});
+
+    expect(result).toEqual({
+      ok: true,
+      body: {name: 'Acme'},
+    });
+  });
+
+  test('returns field errors for blank names', () => {
+    const result = parseWorkspaceOnboardingForm({name: '   '});
+
+    expect(result).toEqual({
+      ok: false,
+      fieldErrors: {
+        name: 'String must contain at least 1 character(s)',
+      },
+    });
+  });
+});

--- a/libs/client/auth/src/pages/workspace-onboarding-form.ts
+++ b/libs/client/auth/src/pages/workspace-onboarding-form.ts
@@ -1,0 +1,17 @@
+import {type CreateWorkspaceBodyDto, createWorkspaceBodySchema} from '@shipfox/api-workspaces-dto';
+import {type FieldErrors, fieldErrorsFromZod} from './form-utils.js';
+
+type WorkspaceField = 'name';
+
+export type WorkspaceOnboardingFormResult =
+  | {ok: true; body: CreateWorkspaceBodyDto}
+  | {ok: false; fieldErrors: FieldErrors<WorkspaceField>};
+
+export function parseWorkspaceOnboardingForm(input: {name: string}): WorkspaceOnboardingFormResult {
+  const parsed = createWorkspaceBodySchema.safeParse({name: input.name.trim()});
+  if (!parsed.success) {
+    return {ok: false, fieldErrors: fieldErrorsFromZod<WorkspaceField>(parsed.error)};
+  }
+
+  return {ok: true, body: parsed.data};
+}

--- a/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.test.tsx
@@ -17,9 +17,8 @@ describe('WorkspaceOnboardingPage', () => {
 
   test('creates a workspace before showing the signed-in app', async () => {
     const user = pageUserFactory.build({email: 'workspace@example.com'});
-    let requestBody: unknown;
     let didCreateWorkspace = false;
-    const fetchImpl = vi.fn().mockImplementation(async (input: RequestInfo | URL) => {
+    const fetchImpl = vi.fn().mockImplementation((input: RequestInfo | URL) => {
       const url = requestUrl(input);
       const method = input instanceof Request ? input.method : 'GET';
       if (url.endsWith('/auth/refresh')) {
@@ -45,7 +44,6 @@ describe('WorkspaceOnboardingPage', () => {
         });
       }
       if (url.endsWith('/workspaces') && method === 'POST') {
-        requestBody = await (input as Request).json();
         didCreateWorkspace = true;
         return jsonResponse(
           {
@@ -77,12 +75,7 @@ describe('WorkspaceOnboardingPage', () => {
     });
     fireEvent.click(screen.getByRole('button', {name: 'Create workspace'}));
 
-    await waitFor(() => {
-      expect(requestBody).toEqual({name: 'Acme'});
-      expect(JSON.parse(window.localStorage.getItem('shipfox.lastWorkspaceId') ?? 'null')).toBe(
-        '33333333-3333-4333-8333-333333333333',
-      );
-    });
+    await waitFor(() => expect(didCreateWorkspace).toBe(true));
   });
 
   test('validates the workspace name locally', async () => {
@@ -112,8 +105,6 @@ describe('WorkspaceOnboardingPage', () => {
     );
     fireEvent.click(await screen.findByRole('button', {name: 'Create workspace'}));
 
-    expect(
-      await screen.findByText('String must contain at least 1 character(s)'),
-    ).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('Workspace name')).toBeInvalid());
   });
 });

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -1,4 +1,3 @@
-import {createWorkspaceBodySchema} from '@shipfox/api-workspaces-dto';
 import {
   Alert,
   Button,
@@ -18,7 +17,8 @@ import {useSetAtom} from 'jotai';
 import {type FormEvent, useState} from 'react';
 import {useCreateWorkspaceAuth} from '#hooks/api/workspace-auth.js';
 import {lastWorkspaceIdAtom} from '#state/last-workspace.js';
-import {authErrorMessage, type FieldErrors, fieldErrorsFromZod} from './form-utils.js';
+import {authErrorMessage, type FieldErrors} from './form-utils.js';
+import {parseWorkspaceOnboardingForm} from './workspace-onboarding-form.js';
 
 type WorkspaceField = 'name';
 
@@ -50,15 +50,15 @@ export function WorkspaceOnboardingPage() {
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setFormError(undefined);
-    const parsed = createWorkspaceBodySchema.safeParse({name: name.trim()});
-    if (!parsed.success) {
-      setFieldErrors(fieldErrorsFromZod<WorkspaceField>(parsed.error));
+    const parsed = parseWorkspaceOnboardingForm({name});
+    if (!parsed.ok) {
+      setFieldErrors(parsed.fieldErrors);
       return;
     }
 
     setFieldErrors({});
     try {
-      const created = await createWorkspace.mutateAsync(parsed.data);
+      const created = await createWorkspace.mutateAsync(parsed.body);
       toast.success('Workspace created.');
       // Pin the new workspace as the last-active one so a page refresh and
       // future visits to `/` land on it. Going through `/` directly would

--- a/libs/client/integrations/vitest.config.ts
+++ b/libs/client/integrations/vitest.config.ts
@@ -3,8 +3,7 @@ import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
 export default defineConfig(
   {
     test: {
-      environment: 'jsdom',
-      setupFiles: ['test/setup.ts'],
+      environment: 'node',
     },
   },
   import.meta.url,

--- a/libs/client/projects/src/hooks/api/projects.test.ts
+++ b/libs/client/projects/src/hooks/api/projects.test.ts
@@ -1,0 +1,78 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {createProject, listProjects} from './projects.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('listProjects', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('includes workspace, limit, cursor, and search params', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({projects: [], next_cursor: null}));
+    configureApiClient({fetchImpl});
+
+    const result = await listProjects({
+      workspaceId: '11111111-1111-4111-8111-111111111111',
+      limit: 25,
+      cursor: 'cursor-1',
+      search: 'platform api',
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    const url = new URL(request.url);
+    expect(result.projects).toEqual([]);
+    expect(url.pathname).toBe('/projects');
+    expect(url.searchParams.get('workspace_id')).toBe('11111111-1111-4111-8111-111111111111');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('cursor')).toBe('cursor-1');
+    expect(url.searchParams.get('search')).toBe('platform api');
+  });
+});
+
+describe('createProject', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts the project body', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({
+        id: '44444444-4444-4444-8444-444444444444',
+        workspace_id: '11111111-1111-4111-8111-111111111111',
+        name: 'Platform',
+        source: {
+          connection_id: '33333333-3333-4333-8333-333333333333',
+          external_repository_id: 'platform',
+        },
+        created_at: '2026-05-07T01:00:00.000Z',
+        updated_at: '2026-05-07T01:00:00.000Z',
+      });
+    });
+    configureApiClient({fetchImpl});
+    const body = {
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+      name: 'Platform',
+      source: {
+        connection_id: '33333333-3333-4333-8333-333333333333',
+        external_repository_id: 'platform',
+      },
+    };
+
+    const result = await createProject(body);
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.name).toBe('Platform');
+    expect(request.url).toBe('https://api.example.test/projects');
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual(body);
+  });
+});

--- a/libs/client/projects/src/hooks/api/workflow-runs.test.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.test.ts
@@ -1,0 +1,49 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {createWorkflowRun} from './workflow-runs.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('createWorkflowRun', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts project and definition ids', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse(
+        {
+          id: '66666666-6666-4666-8666-666666666666',
+          project_id: '44444444-4444-4444-8444-444444444444',
+          definition_id: '55555555-5555-4555-8555-555555555555',
+          status: 'pending',
+          trigger_context: {type: 'manual'},
+          inputs: null,
+          created_at: '2026-05-07T01:01:00.000Z',
+          updated_at: '2026-05-07T01:01:00.000Z',
+        },
+        {status: 201},
+      );
+    });
+    configureApiClient({fetchImpl});
+    const body = {
+      project_id: '44444444-4444-4444-8444-444444444444',
+      definition_id: '55555555-5555-4555-8555-555555555555',
+    };
+
+    const result = await createWorkflowRun(body);
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.status).toBe('pending');
+    expect(request.url).toBe('https://api.example.test/workflows/runs');
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual(body);
+  });
+});

--- a/libs/client/projects/src/pages/create-project-page.test.tsx
+++ b/libs/client/projects/src/pages/create-project-page.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {fireEvent, screen, waitFor} from '@testing-library/react';
+import {fireEvent, screen} from '@testing-library/react';
 import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
 import {CreateProjectPage} from './create-project-page.js';
 
@@ -10,22 +10,22 @@ const DEBUG_RADIO_LABEL_RE = /^Debug debug · debug$/;
 
 describe('CreateProjectPage', () => {
   test('with a single connection: pre-selects, renders repos, creates a project', async () => {
-    const requestBodies: unknown[] = [];
-    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       const request = input as Request;
-      if (request.method !== 'GET') {
-        requestBodies.push(await request.json());
-      }
       if (request.url.includes('/integration-connections?')) {
-        return jsonResponse({connections: [connectionDto()]});
+        return Promise.resolve(jsonResponse({connections: [connectionDto()]}));
       }
       if (request.url.includes(`/integration-connections/${CONNECTION_ID}/repositories`)) {
-        return jsonResponse({repositories: [repositoryDto()], next_cursor: null});
+        return Promise.resolve(jsonResponse({repositories: [repositoryDto()], next_cursor: null}));
       }
       if (request.url.endsWith('/projects')) {
-        return jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'}));
+        return Promise.resolve(
+          jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'})),
+        );
       }
-      return jsonResponse({});
+      return Promise.resolve(
+        jsonResponse(projectDto({id: '44444444-4444-4444-8444-444444444444'})),
+      );
     });
     configureApiClient({fetchImpl});
 
@@ -35,17 +35,7 @@ describe('CreateProjectPage', () => {
     expect((await screen.findAllByText('debug-owner/platform')).length).toBeGreaterThan(0);
     fireEvent.click(screen.getByRole('button', {name: 'Create project'}));
 
-    await waitFor(() =>
-      expect(requestBodies).toContainEqual(
-        expect.objectContaining({
-          name: 'Platform',
-          source: {
-            connection_id: CONNECTION_ID,
-            external_repository_id: 'platform',
-          },
-        }),
-      ),
-    );
+    expect(await screen.findByRole('heading', {name: 'Source identity'})).toBeInTheDocument();
   });
 
   test('with multiple connections: hides repo picker until a connection is selected', async () => {

--- a/libs/client/projects/src/pages/project-detail-page.test.tsx
+++ b/libs/client/projects/src/pages/project-detail-page.test.tsx
@@ -94,10 +94,8 @@ describe('ProjectDetailPage', () => {
     });
   });
 
-  test('Run posts project_id and definition_id', async () => {
-    const requests: RecordedRequest[] = [];
-    const fetchImpl = createProjectDetailFetch({requests});
-    configureApiClient({fetchImpl});
+  test('queues a run from a workflow definition', async () => {
+    configureApiClient({fetchImpl: createProjectDetailFetch()});
 
     renderProjectPage(
       `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}`,
@@ -109,16 +107,7 @@ describe('ProjectDetailPage', () => {
 
     fireEvent.click(runButton);
 
-    await waitFor(() => {
-      expect(requests).toContainEqual({
-        url: 'https://api.example.test/workflows/runs',
-        method: 'POST',
-        body: JSON.stringify({
-          project_id: PROJECT_ID,
-          definition_id: '55555555-5555-4555-8555-555555555555',
-        }),
-      });
-    });
+    expect(await screen.findByText('Run queued')).toBeInTheDocument();
   });
 
   test('renders not found state', async () => {
@@ -141,34 +130,18 @@ describe('ProjectDetailPage', () => {
   });
 });
 
-interface RecordedRequest {
-  url: string;
-  method: string;
-  body: string | undefined;
-}
-
 function createProjectDetailFetch({
   project = jsonResponse(projectDto()),
   definitions = jsonResponse(definitionsDto()),
   run = jsonResponse(runDto(), {status: 201}),
-  requests,
 }: {
   project?: Response;
   definitions?: Response;
   run?: Response;
-  requests?: RecordedRequest[];
 } = {}) {
-  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
     const url = new URL(requestInputUrl(input));
     const method = init?.method ?? (input instanceof Request ? input.method : 'GET');
-    const body =
-      typeof init?.body === 'string'
-        ? init.body
-        : input instanceof Request
-          ? await input.clone().text()
-          : undefined;
-
-    requests?.push({url: url.toString(), method, body});
 
     if (url.pathname === `/projects/${PROJECT_ID}`) {
       return Promise.resolve(project.clone());
@@ -176,7 +149,7 @@ function createProjectDetailFetch({
     if (url.pathname === '/definitions') {
       return Promise.resolve(definitions.clone());
     }
-    if (url.pathname === '/workflows/runs' && init?.method === 'POST') {
+    if (url.pathname === '/workflows/runs' && method === 'POST') {
       return Promise.resolve(run.clone());
     }
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -74,8 +74,6 @@ describe('ProjectsHubPage', () => {
     fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
 
     expect(await screen.findByText('API')).toBeInTheDocument();
-    const secondRequest = fetchImpl.mock.calls[1]?.[0] as Request;
-    expect(secondRequest.url).toContain('cursor=cursor-1');
   });
 
   test('renders an error alert with retry', async () => {

--- a/libs/client/projects/vitest.config.ts
+++ b/libs/client/projects/vitest.config.ts
@@ -3,8 +3,25 @@ import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
 export default defineConfig(
   {
     test: {
-      environment: 'jsdom',
-      setupFiles: ['test/setup.ts'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
     },
   },
   import.meta.url,

--- a/libs/client/runners/src/components/runner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/runner-tokens-settings-section.test.tsx
@@ -1,14 +1,12 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {ReactElement} from 'react';
 import {WorkspaceRunnerTokensSettingsSection} from './runner-tokens-settings-section.js';
 
 const RUNNERS_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
-const tokensPath = `/workspaces/${RUNNERS_TEST_WORKSPACE_ID}/runners/tokens`;
-
 function jsonResponse(body: unknown, init: ResponseInit = {}) {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -40,15 +38,6 @@ function renderRunnerTokens(element: ReactElement) {
       <Toaster />
     </QueryClientProvider>,
   );
-}
-
-function requestPath(input: RequestInfo | URL): string {
-  const url = input instanceof Request ? input.url : input.toString();
-  return new URL(url).pathname;
-}
-
-function requestMethod(input: RequestInfo | URL): string {
-  return input instanceof Request ? input.method : 'GET';
 }
 
 function firstButton(name: string): HTMLElement {
@@ -104,16 +93,13 @@ describe('WorkspaceRunnerTokensSettingsSection', () => {
     );
     await screen.findByText('No usable runner tokens');
     await user.click(screen.getByRole('button', {name: 'Create token'}));
-    await user.type(await screen.findByLabelText('Token name'), 'Local runner');
+    fireEvent.change(await screen.findByLabelText('Token name'), {
+      target: {value: 'Local runner'},
+    });
     await user.click(lastButton('Create token'));
 
     expect(await screen.findByText('Token created')).toBeVisible();
     expect(screen.getByText('sf_rt_raw-created-token')).toBeVisible();
-    expect(
-      fetchImpl.mock.calls.some(
-        ([input]) => requestPath(input) === tokensPath && requestMethod(input) === 'POST',
-      ),
-    ).toBe(true);
   });
 
   test('surfaces create errors without clearing the form', async () => {
@@ -131,7 +117,9 @@ describe('WorkspaceRunnerTokensSettingsSection', () => {
     );
     await screen.findByText('No usable runner tokens');
     await user.click(screen.getByRole('button', {name: 'Create token'}));
-    await user.type(await screen.findByLabelText('Token name'), 'Local runner');
+    fireEvent.change(await screen.findByLabelText('Token name'), {
+      target: {value: 'Local runner'},
+    });
     await user.click(lastButton('Create token'));
 
     expect(await screen.findByText('Could not create token')).toBeVisible();
@@ -157,9 +145,6 @@ describe('WorkspaceRunnerTokensSettingsSection', () => {
 
     await waitFor(() => expect(screen.queryByText('Deploy runner')).not.toBeInTheDocument());
     expect(screen.getByText('No usable runner tokens')).toBeVisible();
-    expect(fetchImpl.mock.calls.map(([input]) => requestPath(input))).toContain(
-      `${tokensPath}/33333333-3333-4333-8333-333333333333/revoke`,
-    );
   });
 
   test('shows a recoverable revoke error', async () => {

--- a/libs/client/runners/src/hooks/api/runner-tokens.test.ts
+++ b/libs/client/runners/src/hooks/api/runner-tokens.test.ts
@@ -1,0 +1,84 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {createRunnerToken, revokeRunnerToken} from './runner-tokens.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('createRunnerToken', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts token creation body', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse(
+        {
+          id: '44444444-4444-4444-8444-444444444444',
+          raw_token: 'sf_rt_raw-created-token',
+          prefix: 'sf_rt_raw-c',
+          name: 'Local runner',
+          workspace_id: '11111111-1111-4111-8111-111111111111',
+          expires_at: '2026-05-09T00:00:00.000Z',
+          created_at: '2026-05-08T00:00:00.000Z',
+        },
+        {status: 201},
+      );
+    });
+    configureApiClient({fetchImpl});
+    const body = {name: 'Local runner', ttl_seconds: 86_400};
+
+    const result = await createRunnerToken({
+      workspaceId: '11111111-1111-4111-8111-111111111111',
+      body,
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.raw_token).toBe('sf_rt_raw-created-token');
+    expect(request.url).toBe(
+      'https://api.example.test/workspaces/11111111-1111-4111-8111-111111111111/runners/tokens',
+    );
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual(body);
+  });
+});
+
+describe('revokeRunnerToken', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('posts to the token revoke endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: '33333333-3333-4333-8333-333333333333',
+        workspace_id: '11111111-1111-4111-8111-111111111111',
+        prefix: 'sf_r_abcdefg',
+        name: 'Deploy runner',
+        expires_at: '2026-05-09T00:00:00.000Z',
+        revoked_at: '2026-05-08T01:00:00.000Z',
+        created_at: '2026-05-08T00:00:00.000Z',
+        updated_at: '2026-05-08T01:00:00.000Z',
+      }),
+    );
+    configureApiClient({fetchImpl});
+
+    const result = await revokeRunnerToken({
+      workspaceId: '11111111-1111-4111-8111-111111111111',
+      tokenId: '33333333-3333-4333-8333-333333333333',
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.revoked_at).toBe('2026-05-08T01:00:00.000Z');
+    expect(request.url).toBe(
+      'https://api.example.test/workspaces/11111111-1111-4111-8111-111111111111/runners/tokens/33333333-3333-4333-8333-333333333333/revoke',
+    );
+    expect(request.method).toBe('POST');
+  });
+});

--- a/libs/client/runners/vitest.config.ts
+++ b/libs/client/runners/vitest.config.ts
@@ -3,8 +3,25 @@ import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
 export default defineConfig(
   {
     test: {
-      environment: 'jsdom',
-      setupFiles: ['test/setup.ts'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
     },
   },
   import.meta.url,

--- a/libs/client/workspace-settings/src/pages/runners-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/runners-settings-page.test.tsx
@@ -1,6 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {screen, waitFor} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import {screen} from '@testing-library/react';
 import {
   jsonResponse,
   renderWorkspaceSettingsPage,
@@ -8,46 +7,8 @@ import {
 } from '#test/pages.js';
 import {RunnersSettingsPage} from './runners-settings-page.js';
 
-const tokensPath = `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/runners/tokens`;
-
-function runnerToken(overrides: Partial<Record<string, string | null>> = {}) {
-  return {
-    id: '33333333-3333-4333-8333-333333333333',
-    workspace_id: WORKSPACE_SETTINGS_TEST_WID,
-    prefix: 'sf_r_abcdefg',
-    name: 'Deploy runner',
-    expires_at: '2026-05-09T00:00:00.000Z',
-    revoked_at: null,
-    created_at: '2026-05-08T00:00:00.000Z',
-    updated_at: '2026-05-08T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function requestPath(input: RequestInfo | URL): string {
-  const url = input instanceof Request ? input.url : input.toString();
-  return new URL(url).pathname;
-}
-
-function requestMethod(input: RequestInfo | URL): string {
-  return input instanceof Request ? input.method : 'GET';
-}
-
-function firstButton(name: string): HTMLElement {
-  const button = screen.getAllByRole('button', {name})[0];
-  if (!button) throw new Error(`Button not found: ${name}`);
-  return button;
-}
-
-function lastButton(name: string): HTMLElement {
-  const buttons = screen.getAllByRole('button', {name});
-  const button = buttons.at(-1);
-  if (!button) throw new Error(`Button not found: ${name}`);
-  return button;
-}
-
 describe('RunnersSettingsPage', () => {
-  test('renders an empty usable-token state', async () => {
+  test('renders the settings shell and runner token section', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({tokens: []}));
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
@@ -56,117 +17,8 @@ describe('RunnersSettingsPage', () => {
       <RunnersSettingsPage />,
     );
 
+    expect(await screen.findByRole('heading', {name: 'Workspace settings'})).toBeVisible();
     expect(await screen.findByText('No usable runner tokens')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Create token'})).toBeVisible();
-  });
-
-  test('creates a token and reveals the raw token inline once', async () => {
-    const user = userEvent.setup();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({tokens: []}))
-      .mockResolvedValueOnce(
-        jsonResponse(
-          {
-            id: '44444444-4444-4444-8444-444444444444',
-            raw_token: 'sf_rt_raw-created-token',
-            prefix: 'sf_rt_raw-c',
-            name: 'Local runner',
-            workspace_id: WORKSPACE_SETTINGS_TEST_WID,
-            expires_at: '2026-05-09T00:00:00.000Z',
-            created_at: '2026-05-08T00:00:00.000Z',
-          },
-          {status: 201},
-        ),
-      )
-      .mockResolvedValueOnce(jsonResponse({tokens: [runnerToken({name: 'Local runner'})]}));
-    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
-
-    renderWorkspaceSettingsPage(
-      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/runners`,
-      <RunnersSettingsPage />,
-    );
-    await screen.findByText('No usable runner tokens');
-    await user.click(screen.getByRole('button', {name: 'Create token'}));
-    await user.type(await screen.findByLabelText('Token name'), 'Local runner');
-    await user.click(lastButton('Create token'));
-
-    expect(await screen.findByText('Token created')).toBeVisible();
-    expect(screen.getByText('sf_rt_raw-created-token')).toBeVisible();
-    expect(
-      fetchImpl.mock.calls.some(
-        ([input]) => requestPath(input) === tokensPath && requestMethod(input) === 'POST',
-      ),
-    ).toBe(true);
-  });
-
-  test('surfaces create errors without clearing the form', async () => {
-    const user = userEvent.setup();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({tokens: []}))
-      .mockResolvedValueOnce(
-        jsonResponse({message: 'Token quota reached', code: 'quota-reached'}, {status: 422}),
-      );
-    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
-
-    renderWorkspaceSettingsPage(
-      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/runners`,
-      <RunnersSettingsPage />,
-    );
-    await screen.findByText('No usable runner tokens');
-    await user.click(screen.getByRole('button', {name: 'Create token'}));
-    await user.type(await screen.findByLabelText('Token name'), 'Local runner');
-    await user.click(lastButton('Create token'));
-
-    expect(await screen.findByText('Could not create token')).toBeVisible();
-    expect(screen.getByText('Token quota reached')).toBeVisible();
-    expect(screen.getByLabelText('Token name')).toHaveValue('Local runner');
-  });
-
-  test('revokes a token after row confirmation and removes it from the list', async () => {
-    const user = userEvent.setup();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({tokens: [runnerToken()]}))
-      .mockResolvedValueOnce(jsonResponse(runnerToken({revoked_at: '2026-05-08T01:00:00.000Z'})))
-      .mockResolvedValueOnce(jsonResponse({tokens: []}));
-    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
-
-    renderWorkspaceSettingsPage(
-      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/runners`,
-      <RunnersSettingsPage />,
-    );
-    expect((await screen.findAllByText('Deploy runner')).length).toBeGreaterThan(0);
-    await user.click(firstButton('Revoke Deploy runner'));
-    await user.click(lastButton('Revoke'));
-
-    await waitFor(() => expect(screen.queryByText('Deploy runner')).not.toBeInTheDocument());
-    expect(screen.getByText('No usable runner tokens')).toBeVisible();
-    expect(fetchImpl.mock.calls.map(([input]) => requestPath(input))).toContain(
-      `${tokensPath}/33333333-3333-4333-8333-333333333333/revoke`,
-    );
-  });
-
-  test('shows a recoverable revoke error', async () => {
-    const user = userEvent.setup();
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({tokens: [runnerToken()]}))
-      .mockResolvedValueOnce(
-        jsonResponse({message: 'Runner token not found', code: 'not-found'}, {status: 404}),
-      );
-    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
-
-    renderWorkspaceSettingsPage(
-      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/runners`,
-      <RunnersSettingsPage />,
-    );
-    expect((await screen.findAllByText('Deploy runner')).length).toBeGreaterThan(0);
-    await user.click(firstButton('Revoke Deploy runner'));
-    await user.click(lastButton('Revoke'));
-
-    expect(await screen.findByText('Runner token not found')).toBeVisible();
-    expect(screen.getAllByText('Deploy runner').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
Align client library tests with the testing principles introduced in PR #52.

Several client packages still used jsdom/RTL tests for pure transport and request-shaping behavior, which made small branch-heavy checks pay for full React rendering. This moves those assertions into Node tests for the owning API helpers, splits mixed Vitest configs into node and dom projects, and trims page-level tests back to rendered behavior and React wiring.

The workspace settings runner page now stays as a page smoke test, while runner token CRUD behavior remains covered in the client-runners package. Reviewers should pay closest attention to the newly exported auth transport helpers and the workspace onboarding form parsing extraction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns client tests with the fast unit strategy by moving transport/request-shaping checks into fast Node tests and trimming page tests to rendered behavior. Also splits mixed Vitest configs into Node/DOM projects and extracts small helpers for direct testing.

- **Refactors**
  - Moved API request-shaping tests to Node for auth (login/password reset/workspace), projects, workflow runs, and runner tokens.
  - Split Vitest setups: `libs/client/projects` and `libs/client/runners` now have Node + DOM projects; `libs/client/integrations` runs in Node.
  - Simplified RTL tests to verify UI flow and wiring; the workspace settings runner page remains a smoke test while token CRUD is covered in `libs/client/runners` API tests.

- **New Features**
  - Exported `loginAuth`, `requestPasswordReset`, `confirmPasswordReset`, and `createWorkspace` for direct unit testing.
  - Added `parseWorkspaceOnboardingForm` for local validation with unit tests; onboarding page now uses this parser.

<sup>Written for commit caf2c0a9f24b47471b06839e3e3293321d9d5ce2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

