### PR TITLE
Add Renovate release age gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,9 @@
     ":gitSignOff",
     "schedule:daily"
   ],
+  "minimumReleaseAge": "48 hours",
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "prHourlyLimit": 5,
   "packageRules": [
     {


### PR DESCRIPTION
Add a repository-wide 48-hour minimum release age gate to Renovate updates.

New package versions can be compromised shortly after publication and removed once the ecosystem catches them. This config delays Renovate dependency branches and PRs until the candidate release is at least 48 hours old, reducing the chance that automation introduces a freshly published malicious dependency.

The PR also sets Renovate to wait for non-pending internal checks with strict filtering so dependency PRs are not opened during the cooldown window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repository-wide 48-hour minimum release age for Renovate so dependency branches and PRs wait until a release is at least 48 hours old. Sets `minimumReleaseAge: "48 hours"`, `prCreation: "not-pending"`, and `internalChecksFilter: "strict"` to delay PRs and avoid opening them while internal checks are pending.

<sup>Written for commit 4f0bed7d7ff4b5bc85330a622b2fa7c7b7b1025d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

