### PR TITLE
[e2e/client-workspaces] Mask member dates in invitation screenshots

### DIFF
--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -7,6 +7,8 @@ const PENDING_INVITATION_RE = /open invitation already exists/u;
 const VISUAL_OWNER_EMAIL = 'owner@example.test';
 const VISUAL_INVITEE_EMAIL = 'invitee@example.test';
 const VISUAL_PENDING_EMAIL = 'pending-invitee@example.test';
+const VISUAL_JOINED_DATE = 'May 1, 2026';
+const VISUAL_EXPIRES_DATE = 'May 20, 2026';
 
 function workspaceUrlRe(wid: string): RegExp {
   return new RegExp(`/workspaces/${wid}(/|$)`, 'u');
@@ -154,9 +156,17 @@ test('accepts an invitation from the public landing page via login', async ({
   await expect(page.getByText(owner.email)).toBeVisible();
   await expect(page.getByText(invitee.email)).toBeVisible();
   await expect(page.getByText('No pending invitations.')).toBeVisible();
+  const memberJoinedText = (
+    await page
+      .getByRole('row', {name: textRe(invitee.email)})
+      .getByRole('cell')
+      .nth(2)
+      .innerText()
+  ).trim();
   await stableArgosScreenshot(page, 'members/populated-with-empty-invitations', [
     [owner.email, VISUAL_OWNER_EMAIL],
     [invitee.email, VISUAL_INVITEE_EMAIL],
+    [memberJoinedText, VISUAL_JOINED_DATE],
   ]);
 });
 
@@ -235,28 +245,31 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
   await expect(page.getByText(`Invitation sent to ${pendingEmail}.`)).toBeVisible();
   const pendingInvitationRow = page.getByRole('row', {name: textRe(pendingEmail)});
   await expect(pendingInvitationRow).toBeVisible();
-  await stableArgosScreenshot(page, 'members/pending-invitations-populated', [
+  const pendingExpiresText = (
+    await pendingInvitationRow.getByRole('cell').nth(2).innerText()
+  ).trim();
+  const pendingRowReplacements = [
     [owner.email, VISUAL_OWNER_EMAIL],
     [pendingEmail, VISUAL_PENDING_EMAIL],
-  ]);
+    [pendingExpiresText, VISUAL_EXPIRES_DATE],
+  ] as const;
+  await stableArgosScreenshot(
+    page,
+    'members/pending-invitations-populated',
+    pendingRowReplacements,
+  );
 
   await page.getByRole('button', {name: 'Invite member'}).click();
   await page.getByLabel('Email').fill(pendingEmail);
   await page.getByRole('button', {name: 'Send invitation'}).click();
   await expect(page.getByText(PENDING_INVITATION_RE)).toBeVisible();
-  await stableArgosScreenshot(page, 'members/invite-member-modal-conflict', [
-    [owner.email, VISUAL_OWNER_EMAIL],
-    [pendingEmail, VISUAL_PENDING_EMAIL],
-  ]);
+  await stableArgosScreenshot(page, 'members/invite-member-modal-conflict', pendingRowReplacements);
   await page.keyboard.press('Escape');
 
   await pendingInvitationRow.hover();
   await page.getByRole('button', {name: 'Revoke invitation'}).click();
   await expect(page.getByText(`Revoke invitation to ${pendingEmail}?`)).toBeVisible();
-  await stableArgosScreenshot(page, 'members/revoke-invitation-confirm', [
-    [owner.email, VISUAL_OWNER_EMAIL],
-    [pendingEmail, VISUAL_PENDING_EMAIL],
-  ]);
+  await stableArgosScreenshot(page, 'members/revoke-invitation-confirm', pendingRowReplacements);
   await page.getByRole('button', {name: 'Revoke'}).click();
 
   await expect(page.getByText(`Invitation to ${pendingEmail} revoked.`)).toBeVisible();


### PR DESCRIPTION
Workspace members and pending invitations both render today-relative dates through `formatDate(...)` — the Joined column for members and the Expires column for invitations — so Argos saw a fresh diff on every run for `members/populated-with-empty-invitations`, `members/pending-invitations-populated`, `members/invite-member-modal-conflict`, and `members/revoke-invitation-confirm`.

`stableArgosScreenshot` does plain string replacement and can't mask values it isn't told about. The test now reads the displayed date text out of the relevant row before each screenshot and feeds it into the replacement list with a stable literal (`May 1, 2026` for Joined, `May 20, 2026` for Expires). The third test captures the Expires text once and reuses a shared replacement tuple across all three screenshots that show the pending row.

`members/populated-with-empty-invitations` wasn't in the original report but has the same root cause through the Joined column, so it's fixed here proactively before it starts flaking too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops daily Argos diffs by masking today-relative "Joined" and "Expires" dates in workspace members and invitations screenshots. Stabilizes visual tests and prevents flaky failures.

- **Bug Fixes**
  - Reads rendered date text in the target row and replaces it with stable literals (`May 1, 2026` for Joined, `May 20, 2026` for Expires) before calling `stableArgosScreenshot`.
  - Reuses a shared replacement tuple across all screenshots that include the pending invitation row.
  - Fixes these tests: `members/populated-with-empty-invitations`, `members/pending-invitations-populated`, `members/invite-member-modal-conflict`, `members/revoke-invitation-confirm`.

<sup>Written for commit c2c3f107526f3f8cc43abb82da3ef947a7151ff6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

