### PR TITLE
Wait for modal readiness on second invite open in members e2e

### DIFF
--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -260,6 +260,8 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
   );
 
   await page.getByRole('button', {name: 'Invite member'}).click();
+  await expect(page.getByRole('heading', {name: 'Invite a member'})).toBeVisible();
+  await expect(page.getByLabel('Email')).toBeFocused();
   await page.getByLabel('Email').fill(pendingEmail);
   await page.getByRole('button', {name: 'Send invitation'}).click();
   await expect(page.getByText(PENDING_INVITATION_RE)).toBeVisible();


### PR DESCRIPTION
Stabilize the duplicate-invitation step of the members invitation e2e test.

The test reopened the Invite member modal and immediately filled the email
and clicked Send invitation, without waiting for the freshly mounted
dialog. The modal is Radix Dialog wrapped in `Presence` with a 150ms
close animation (`libs/shared/react/ui/src/components/modal/modal.tsx`),
so the prior instance's form nodes can still be in the DOM while the new
instance mounts and autofocuses. That window lets Playwright's fill /
submit race against the open transition and occasionally swallow the
POST, in which case the expected "An open invitation already exists"
conflict alert never renders and the assertion at line 246 times out at
5s — exactly what Argos builds 451 and 460 captured.

The first open of the same modal in this test already guards on
`heading visible` + `email focused`. Mirror those gates on the second
open so the form is fully ready before fill / submit.

Server logic (`libs/api/workspaces/src/db/invitations.ts`,
`libs/api/workspaces/src/presentation/routes/invitations/create.ts`)
and client error handling
(`libs/client/workspace-settings/.../workspace-members-section.tsx`)
are unchanged — only the e2e test is updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for the Invite member modal to be fully ready (heading visible, Email focused) before filling/sending on the second open in the members invitation e2e. This stabilizes the duplicate-invitation step by avoiding a race with the Radix `Presence` close animation that sometimes swallowed the POST and hid the conflict alert.

<sup>Written for commit 0c49e1993f254e520546f0b213fa25eeb44bebb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

