### PR TITLE
[client-auth] Stabilize login test

### DIFF
--- a/libs/client/auth/src/pages/login-page.test.tsx
+++ b/libs/client/auth/src/pages/login-page.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {fireEvent, screen} from '@testing-library/react';
+import {act, fireEvent, screen} from '@testing-library/react';
 import {GuestGuard} from '#components/auth-guard.js';
 import {pageUserFactory} from '#test/factories/user.js';
 import {renderAuthPage} from '#test/pages.js';
@@ -103,6 +103,9 @@ describe('LoginPage', () => {
           token: 'access-token',
           user,
         });
+      })
+      .mockImplementationOnce(() => {
+        return jsonResponse({memberships: []});
       });
     configureApiClient({fetchImpl});
 
@@ -116,6 +119,8 @@ describe('LoginPage', () => {
       target: {value: 'login@example.com'},
     });
     fireEvent.change(screen.getByLabelText('Password'), {target: {value: 'correct horse'}});
+    // Let TanStack Form publish field changes before submit validation reads them.
+    await act(() => Promise.resolve());
     fireEvent.click(screen.getByRole('button', {name: 'Log in'}));
 
     expect(await screen.findByRole('heading', {name: 'Authenticated home'})).toBeInTheDocument();


### PR DESCRIPTION
Stabilize the client auth login page test by waiting for TanStack Form to publish field updates before submitting, and by explicitly mocking the workspace hydration request made after a successful login.

The CI flake showed the DOM inputs containing the intended credentials while submit validation still reported empty-field errors. That points to the test racing React/Form state propagation rather than a product behavior regression.

The PR intentionally excludes the local `mise.lock` change in this workspace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the client auth login page test by waiting for form state to settle and by mocking the post-login workspace fetch. Removes a CI flake where validation read empty fields even though inputs were filled.

- **Bug Fixes**
  - Flush field updates before submit using `act` from `@testing-library/react`.
  - Mock the workspace hydration request after successful login to avoid unexpected network calls.

<sup>Written for commit 365cc9c28e80f37d8201d8bc79b5b5f1632ffa86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

