### PR TITLE
Group @argos-ci Renovate updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,10 +50,21 @@
       "matchPackageNames": ["@shipfox/**"]
     },
     {
+      "description": "Group all @argos-ci NPM updates into one PR",
+      "groupName": "argos-ci",
+      "groupSlug": "argos-ci",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@argos-ci/**"]
+    },
+    {
       "description": "TanStack Query: group related packages together and bump ranges to keep deps and peerDeps in sync across the monorepo",
       "groupName": "tanstack-query",
       "groupSlug": "tanstack-query",
-      "matchPackageNames": ["@tanstack/react-query", "@tanstack/query-core", "@tanstack/react-query-devtools"],
+      "matchPackageNames": [
+        "@tanstack/react-query",
+        "@tanstack/query-core",
+        "@tanstack/react-query-devtools"
+      ],
       "rangeStrategy": "bump"
     },
     {


### PR DESCRIPTION
Add a Renovate `packageRules` entry that groups all `@argos-ci/**` npm
updates under a single `argos-ci` group.

The CLI (`@argos-ci/cli`) and the Storybook plugin (`@argos-ci/storybook`)
track the same release cadence, so per-package PRs were just noise — one
grouped PR is easier to review and land together.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group all `@argos-ci/**` npm updates into a single Renovate PR to reduce noise and keep related changes synced. Adds a `packageRules` entry in `renovate.json` that creates an `argos-ci` group for the npm manager.

<sup>Written for commit 3264e7840121d64dc706d1ec95e40bb0aed7e456. Summary will update on new commits. <a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/77?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

