### PR TITLE
Group pnpm Renovate updates into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -73,6 +73,12 @@
       "groupSlug": "tanstack-router",
       "matchPackageNames": ["@tanstack/react-router", "@tanstack/router-plugin"],
       "rangeStrategy": "bump"
+    },
+    {
+      "description": "Group pnpm updates across managers (packageManager field + npm:pnpm) into one PR",
+      "groupName": "pnpm",
+      "groupSlug": "pnpm",
+      "matchPackageNames": ["pnpm"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry matching `pnpm` by package name so Renovate's `pnpm` and `npm` managers (both of which parse the `packageManager` field) produce a single grouped PR instead of duplicates like #82 + #79.

## Test plan
- [ ] Renovate dry-run / next scheduled run produces one PR for the pending pnpm v11 bump instead of two.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Group `pnpm` updates into a single Renovate PR by matching `pnpm` by package name. This prevents duplicate PRs from the `pnpm` and `npm` managers when both parse the `packageManager` field.

<sup>Written for commit ff3f3e64161bd5e83bb006d84ebfcb932950e801. Summary will update on new commits. <a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/83?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

