### PR TITLE
[integrations] Add API E2E tests for the GitHub webhook flow

### DIFF
--- a/e2e/api/integrations/package.json
+++ b/e2e/api/integrations/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@shipfox/e2e-api-integrations",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./tests/*"
+  },
+  "scripts": {
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test:e2e": "shipfox-playwright-test",
+    "type": "shipfox-tsc-check"
+  },
+  "devDependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
+    "@shipfox/api-integration-github": "workspace:*",
+    "@shipfox/api-integration-github-dto": "workspace:*",
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-integration-github": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/api/integrations/playwright.config.ts
+++ b/e2e/api/integrations/playwright.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  globalSetup: './tests/global-setup.ts',
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    trace: 'retain-on-failure',
+  },
+});

--- a/e2e/api/integrations/tests/global-setup.ts
+++ b/e2e/api/integrations/tests/global-setup.ts
@@ -1,0 +1,5 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck({requireClient: false});
+}

--- a/e2e/api/integrations/tests/integrations-api.e2e.ts
+++ b/e2e/api/integrations/tests/integrations-api.e2e.ts
@@ -1,0 +1,105 @@
+import {randomUUID} from 'node:crypto';
+import {INTEGRATION_REPOSITORY_PUSHED} from '@shipfox/api-integration-core-dto';
+import {expect, test} from './test.js';
+
+test('signed push writes an INTEGRATION_REPOSITORY_PUSHED outbox row visible via /__e2e/integration/events', async ({
+  auth,
+  workspaces,
+  integrationGithub,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({userId: user.user.id});
+  const github = await integrationGithub.connect({workspaceId: workspace.id});
+
+  const push = await integrationGithub.sendSignedPush({installationId: github.installationId});
+
+  expect(push.status).toBe(204);
+  const {events} = await integrationGithub.readEvents({deliveryId: push.deliveryId});
+  expect(events).toHaveLength(1);
+  expect(events[0]?.event_type).toBe(INTEGRATION_REPOSITORY_PUSHED);
+  expect(events[0]?.payload).toMatchObject({
+    provider: 'github',
+    deliveryId: push.deliveryId,
+    headCommitSha: push.headCommitSha,
+    ref: 'main',
+    isDefaultBranch: true,
+    externalRepositoryId: `github:${push.repositoryId}`,
+  });
+});
+
+test('rejects an invalid signature with 401 and writes no outbox row', async ({
+  auth,
+  workspaces,
+  integrationGithub,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({userId: user.user.id});
+  const github = await integrationGithub.connect({workspaceId: workspace.id});
+  const deliveryId = randomUUID();
+
+  const push = await integrationGithub.sendRawSignedPush({
+    rawBody: JSON.stringify({
+      ref: 'refs/heads/main',
+      after: 'abc',
+      repository: {id: 1, default_branch: 'main'},
+      installation: {id: Number(github.installationId)},
+    }),
+    deliveryId,
+    repositoryId: 1,
+    headCommitSha: 'abc',
+    signature: 'sha256=deadbeef',
+  });
+
+  expect(push.status).toBe(401);
+  const {events} = await integrationGithub.readEvents({deliveryId});
+  expect(events).toEqual([]);
+});
+
+test('deduplicates a repeated x-github-delivery to a single outbox row', async ({
+  auth,
+  workspaces,
+  integrationGithub,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({userId: user.user.id});
+  const github = await integrationGithub.connect({workspaceId: workspace.id});
+  const deliveryId = randomUUID();
+
+  const first = await integrationGithub.sendSignedPush({
+    installationId: github.installationId,
+    deliveryId,
+  });
+  const second = await integrationGithub.sendSignedPush({
+    installationId: github.installationId,
+    deliveryId,
+  });
+
+  expect(first.status).toBe(204);
+  expect(second.status).toBe(204);
+  const {events} = await integrationGithub.readEvents({deliveryId});
+  expect(events).toHaveLength(1);
+});
+
+test('non-push events return 204 and write no INTEGRATION_REPOSITORY_PUSHED outbox row', async ({
+  auth,
+  workspaces,
+  integrationGithub,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({userId: user.user.id});
+  await integrationGithub.connect({workspaceId: workspace.id});
+  const deliveryId = randomUUID();
+  const rawBody = JSON.stringify({zen: 'Practicality beats purity.'});
+
+  const push = await integrationGithub.sendRawSignedPush({
+    rawBody,
+    deliveryId,
+    repositoryId: 0,
+    headCommitSha: '',
+    eventHeader: 'ping',
+  });
+
+  expect(push.status).toBe(204);
+  const {events} = await integrationGithub.readEvents({deliveryId});
+  expect(events).toEqual([]);
+});

--- a/e2e/api/integrations/tests/test.ts
+++ b/e2e/api/integrations/tests/test.ts
@@ -1,0 +1,17 @@
+import {test as base, expect} from '@shipfox/e2e-core/playwright';
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {
+  type IntegrationGithubFixtures,
+  integrationGithubHelper,
+} from '@shipfox/e2e-helper-integration-github';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+type Fixtures = AuthFixtures & WorkspacesFixtures & IntegrationGithubFixtures;
+
+export const test = base.extend<Fixtures>({
+  ...authHelper,
+  ...workspacesHelper,
+  ...integrationGithubHelper,
+});
+
+export {expect};

--- a/e2e/api/integrations/tsconfig.json
+++ b/e2e/api/integrations/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/e2e/helpers/integration-github/package.json
+++ b/e2e/helpers/integration-github/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@shipfox/e2e-helper-integration-github",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
+    "@shipfox/api-integration-github-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/helpers/integration-github/src/index.ts
+++ b/e2e/helpers/integration-github/src/index.ts
@@ -1,0 +1,177 @@
+import {randomInt, randomUUID} from 'node:crypto';
+import type {
+  E2eCreateIntegrationConnectionResponseDto,
+  E2eListIntegrationEventsResponseDto,
+} from '@shipfox/api-integration-core-dto';
+import type {E2eCreateGithubInstallationResponseDto} from '@shipfox/api-integration-github-dto';
+import {request, requestJson} from '@shipfox/e2e-core';
+import {signGithubWebhookBody} from './sign.js';
+
+export {signGithubWebhookBody} from './sign.js';
+
+const WEBHOOK_SECRET = process.env.GITHUB_APP_WEBHOOK_SECRET ?? 'test-webhook-secret';
+
+export interface ConnectGithubParams {
+  workspaceId: string;
+  installationId?: string;
+  externalAccountId?: string;
+  displayName?: string;
+  accountLogin?: string;
+}
+
+export interface ConnectedGithub {
+  connectionId: string;
+  installationId: string;
+  externalAccountId: string;
+}
+
+export async function connectGithub(params: ConnectGithubParams): Promise<ConnectedGithub> {
+  const installationId = params.installationId ?? String(randomInt(1_000_000, 99_999_999));
+  const externalAccountId = params.externalAccountId ?? installationId;
+
+  const connectionResponse = await requestJson<E2eCreateIntegrationConnectionResponseDto>(
+    'post',
+    '/__e2e/integration/connections',
+    {
+      json: {
+        workspace_id: params.workspaceId,
+        provider: 'github',
+        external_account_id: externalAccountId,
+        display_name: params.displayName ?? `e2e-${externalAccountId}`,
+      },
+    },
+  );
+
+  await requestJson<E2eCreateGithubInstallationResponseDto>(
+    'post',
+    '/__e2e/integration/github/installations',
+    {
+      json: {
+        connection_id: connectionResponse.connection.id,
+        installation_id: installationId,
+        account_login: params.accountLogin ?? 'e2e-account',
+      },
+    },
+  );
+
+  return {
+    connectionId: connectionResponse.connection.id,
+    installationId,
+    externalAccountId,
+  };
+}
+
+export interface GithubPushCommit {
+  id?: string;
+  message?: string;
+}
+
+export interface SendSignedPushParams {
+  installationId: string;
+  repositoryId?: number;
+  ref?: string;
+  defaultBranch?: string;
+  headCommitSha?: string;
+  deliveryId?: string;
+  commits?: GithubPushCommit[];
+}
+
+export interface SendSignedPushResult {
+  status: number;
+  deliveryId: string;
+  headCommitSha: string;
+  repositoryId: number;
+}
+
+export async function sendSignedPush(params: SendSignedPushParams): Promise<SendSignedPushResult> {
+  const deliveryId = params.deliveryId ?? randomUUID();
+  const headCommitSha = params.headCommitSha ?? randomUUID().replaceAll('-', '');
+  const ref = params.ref ?? 'refs/heads/main';
+  const defaultBranch = params.defaultBranch ?? 'main';
+  const repositoryId = params.repositoryId ?? randomInt(1, 1_000_000);
+
+  const payload = {
+    ref,
+    after: headCommitSha,
+    repository: {id: repositoryId, default_branch: defaultBranch},
+    installation: {id: Number(params.installationId)},
+    commits: params.commits ?? [],
+  };
+  const rawBody = JSON.stringify(payload);
+
+  return await sendRawSignedPush({deliveryId, rawBody, repositoryId, headCommitSha});
+}
+
+export interface SendRawSignedPushParams {
+  rawBody: string;
+  deliveryId: string;
+  repositoryId: number;
+  headCommitSha: string;
+  signature?: string;
+  eventHeader?: string;
+}
+
+export async function sendRawSignedPush(
+  params: SendRawSignedPushParams,
+): Promise<SendSignedPushResult> {
+  const signature = params.signature ?? signGithubWebhookBody(params.rawBody, WEBHOOK_SECRET);
+  const response = await request('post', '/webhooks/integrations/github', {
+    body: params.rawBody,
+    headers: {
+      'content-type': 'application/json',
+      'x-hub-signature-256': signature,
+      'x-github-event': params.eventHeader ?? 'push',
+      'x-github-delivery': params.deliveryId,
+    },
+    throwHttpErrors: false,
+  });
+
+  return {
+    status: response.status,
+    deliveryId: params.deliveryId,
+    repositoryId: params.repositoryId,
+    headCommitSha: params.headCommitSha,
+  };
+}
+
+export interface ReadEventsParams {
+  deliveryId?: string;
+  eventType?: string;
+}
+
+export async function readEvents(
+  params: ReadEventsParams = {},
+): Promise<E2eListIntegrationEventsResponseDto> {
+  const search = new URLSearchParams();
+  if (params.deliveryId) search.set('delivery_id', params.deliveryId);
+  if (params.eventType) search.set('event_type', params.eventType);
+
+  const query = search.toString();
+  const path = query ? `/__e2e/integration/events?${query}` : '/__e2e/integration/events';
+  return await requestJson<E2eListIntegrationEventsResponseDto>('get', path, {});
+}
+
+export function createIntegrationGithubHelper() {
+  return {
+    connect: connectGithub,
+    sendSignedPush,
+    sendRawSignedPush,
+    readEvents,
+    webhookSecret: WEBHOOK_SECRET,
+  };
+}
+
+export type IntegrationGithubHelper = ReturnType<typeof createIntegrationGithubHelper>;
+
+export interface IntegrationGithubFixtures {
+  integrationGithub: IntegrationGithubHelper;
+}
+
+export const integrationGithubHelper = {
+  integrationGithub: async (
+    {request: _request}: {request: unknown},
+    use: (helper: IntegrationGithubHelper) => Promise<void>,
+  ) => {
+    await use(createIntegrationGithubHelper());
+  },
+};

--- a/e2e/helpers/integration-github/src/sign.ts
+++ b/e2e/helpers/integration-github/src/sign.ts
@@ -1,0 +1,5 @@
+import {createHmac} from 'node:crypto';
+
+export function signGithubWebhookBody(rawBody: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+}

--- a/e2e/helpers/integration-github/tsconfig.build.json
+++ b/e2e/helpers/integration-github/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/integration-github/tsconfig.json
+++ b/e2e/helpers/integration-github/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -116,6 +116,7 @@ export interface IntegrationProvider<
   displayName: string;
   adapters?: IntegrationProviderAdapters<Connection> | undefined;
   routes?: Route[] | undefined;
+  e2eRoutes?: Route[] | undefined;
 }
 
 export interface RegisteredIntegrationProvider<

--- a/libs/api/integration/core-dto/src/schemas/e2e.ts
+++ b/libs/api/integration/core-dto/src/schemas/e2e.ts
@@ -1,0 +1,53 @@
+import {z} from 'zod';
+import {integrationConnectionLifecycleStatusSchema} from './integrations.js';
+
+export const e2eCreateIntegrationConnectionBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  provider: z.string().min(1),
+  external_account_id: z.string().min(1),
+  display_name: z.string().min(1).optional(),
+  lifecycle_status: integrationConnectionLifecycleStatusSchema.optional(),
+});
+
+export type E2eCreateIntegrationConnectionBodyDto = z.infer<
+  typeof e2eCreateIntegrationConnectionBodySchema
+>;
+
+export const e2eCreateIntegrationConnectionResponseSchema = z.object({
+  connection: z.object({
+    id: z.string().uuid(),
+    workspace_id: z.string().uuid(),
+    provider: z.string(),
+    external_account_id: z.string(),
+    display_name: z.string(),
+    lifecycle_status: integrationConnectionLifecycleStatusSchema,
+  }),
+});
+
+export type E2eCreateIntegrationConnectionResponseDto = z.infer<
+  typeof e2eCreateIntegrationConnectionResponseSchema
+>;
+
+export const e2eListIntegrationEventsQuerySchema = z.object({
+  delivery_id: z.string().min(1).optional(),
+  event_type: z.string().min(1).optional(),
+});
+
+export type E2eListIntegrationEventsQueryDto = z.infer<typeof e2eListIntegrationEventsQuerySchema>;
+
+export const e2eIntegrationOutboxEventSchema = z.object({
+  id: z.string().uuid(),
+  event_type: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+  created_at: z.string(),
+});
+
+export type E2eIntegrationOutboxEventDto = z.infer<typeof e2eIntegrationOutboxEventSchema>;
+
+export const e2eListIntegrationEventsResponseSchema = z.object({
+  events: z.array(e2eIntegrationOutboxEventSchema),
+});
+
+export type E2eListIntegrationEventsResponseDto = z.infer<
+  typeof e2eListIntegrationEventsResponseSchema
+>;

--- a/libs/api/integration/core-dto/src/schemas/index.ts
+++ b/libs/api/integration/core-dto/src/schemas/index.ts
@@ -1,4 +1,16 @@
 export {
+  type E2eCreateIntegrationConnectionBodyDto,
+  type E2eCreateIntegrationConnectionResponseDto,
+  type E2eIntegrationOutboxEventDto,
+  type E2eListIntegrationEventsQueryDto,
+  type E2eListIntegrationEventsResponseDto,
+  e2eCreateIntegrationConnectionBodySchema,
+  e2eCreateIntegrationConnectionResponseSchema,
+  e2eIntegrationOutboxEventSchema,
+  e2eListIntegrationEventsQuerySchema,
+  e2eListIntegrationEventsResponseSchema,
+} from './e2e.js';
+export {
   type IntegrationCapabilityDto,
   type IntegrationConnectionDto,
   type IntegrationConnectionLifecycleStatusDto,

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -18,6 +18,7 @@ import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
 import {publishRepositoryPushed, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import {createIntegrationE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
 import {createIntegrationsMaintenanceActivities} from '#temporal/activities/index.js';
 import {INTEGRATIONS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
@@ -193,10 +194,13 @@ export async function createIntegrationsContext(
     getIntegrationConnectionById,
   });
 
+  const providerE2eRoutes = registry.list().flatMap((provider) => provider.e2eRoutes ?? []);
+
   const module: ShipfoxModule = {
     name: 'integrations',
     database: github ? [{db, migrationsPath}, github.database] : {db, migrationsPath},
     routes: createIntegrationRoutes(registry, sourceControl),
+    e2eRoutes: [createIntegrationE2eRoutes(providerE2eRoutes)],
     publishers: [{name: 'integrations', table: integrationsOutbox, db}],
     workers: [
       {

--- a/libs/api/integration/core/src/presentation/e2eRoutes/connections.ts
+++ b/libs/api/integration/core/src/presentation/e2eRoutes/connections.ts
@@ -1,0 +1,39 @@
+import {
+  e2eCreateIntegrationConnectionBodySchema,
+  e2eCreateIntegrationConnectionResponseSchema,
+} from '@shipfox/api-integration-core-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+import {upsertIntegrationConnection} from '#db/connections.js';
+
+export const createE2eIntegrationConnectionRoute = defineRoute({
+  method: 'POST',
+  path: '/connections',
+  description: 'Seed an integration connection for E2E tests.',
+  schema: {
+    body: e2eCreateIntegrationConnectionBodySchema,
+    response: {
+      201: e2eCreateIntegrationConnectionResponseSchema,
+    },
+  },
+  handler: async (request, reply) => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId: request.body.workspace_id,
+      provider: request.body.provider,
+      externalAccountId: request.body.external_account_id,
+      displayName: request.body.display_name ?? `e2e-${request.body.external_account_id}`,
+      lifecycleStatus: request.body.lifecycle_status ?? 'active',
+    });
+
+    reply.code(201);
+    return {
+      connection: {
+        id: connection.id,
+        workspace_id: connection.workspaceId,
+        provider: connection.provider,
+        external_account_id: connection.externalAccountId,
+        display_name: connection.displayName,
+        lifecycle_status: connection.lifecycleStatus,
+      },
+    };
+  },
+});

--- a/libs/api/integration/core/src/presentation/e2eRoutes/events.ts
+++ b/libs/api/integration/core/src/presentation/e2eRoutes/events.ts
@@ -1,0 +1,51 @@
+import {
+  e2eListIntegrationEventsQuerySchema,
+  e2eListIntegrationEventsResponseSchema,
+} from '@shipfox/api-integration-core-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+import {and, asc, eq, type SQL, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {integrationsOutbox} from '#db/schema/outbox.js';
+
+export const createE2eIntegrationEventsRoute = defineRoute({
+  method: 'GET',
+  path: '/events',
+  description: 'Read integration outbox rows for E2E assertions.',
+  schema: {
+    querystring: e2eListIntegrationEventsQuerySchema,
+    response: {
+      200: e2eListIntegrationEventsResponseSchema,
+    },
+  },
+  handler: async (request) => {
+    const conditions: SQL[] = [];
+    if (request.query.event_type) {
+      conditions.push(eq(integrationsOutbox.eventType, request.query.event_type));
+    }
+    if (request.query.delivery_id) {
+      conditions.push(
+        sql`${integrationsOutbox.payload} ->> 'deliveryId' = ${request.query.delivery_id}`,
+      );
+    }
+
+    const rows = await db()
+      .select({
+        id: integrationsOutbox.id,
+        eventType: integrationsOutbox.eventType,
+        payload: integrationsOutbox.payload,
+        createdAt: integrationsOutbox.createdAt,
+      })
+      .from(integrationsOutbox)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(asc(integrationsOutbox.createdAt));
+
+    return {
+      events: rows.map((row) => ({
+        id: row.id,
+        event_type: row.eventType,
+        payload: row.payload as Record<string, unknown>,
+        created_at: row.createdAt.toISOString(),
+      })),
+    };
+  },
+});

--- a/libs/api/integration/core/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/core/src/presentation/e2eRoutes/index.test.ts
@@ -1,0 +1,158 @@
+import {randomUUID} from 'node:crypto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {sql} from 'drizzle-orm';
+import type {FastifyInstance} from 'fastify';
+import {db} from '#db/db.js';
+import {integrationsOutbox} from '#db/schema/outbox.js';
+import {createIntegrationE2eRoutes} from './index.js';
+
+const UUID_RE = /^[0-9a-f-]{36}$/u;
+
+async function createTestApp(): Promise<FastifyInstance> {
+  const routes = createIntegrationE2eRoutes([]);
+  const app = await createApp({routes: [routes], swagger: false});
+  await app.ready();
+  return app;
+}
+
+async function truncateState(): Promise<void> {
+  await db().execute(sql`TRUNCATE integrations_connections CASCADE`);
+  await db().execute(sql`TRUNCATE integrations_outbox CASCADE`);
+}
+
+describe('integration E2E routes', () => {
+  beforeEach(async () => {
+    await closeApp();
+    await truncateState();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  describe('POST /integration/connections', () => {
+    it('seeds an active integration connection', async () => {
+      const app = await createTestApp();
+      const workspaceId = randomUUID();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/integration/connections',
+        payload: {
+          workspace_id: workspaceId,
+          provider: 'github',
+          external_account_id: 'installation-42',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.connection).toMatchObject({
+        workspace_id: workspaceId,
+        provider: 'github',
+        external_account_id: 'installation-42',
+        display_name: 'e2e-installation-42',
+        lifecycle_status: 'active',
+      });
+      expect(body.connection.id).toMatch(UUID_RE);
+    });
+
+    it('honors lifecycle_status and display_name overrides', async () => {
+      const app = await createTestApp();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/integration/connections',
+        payload: {
+          workspace_id: randomUUID(),
+          provider: 'github',
+          external_account_id: 'installation-99',
+          display_name: 'Custom name',
+          lifecycle_status: 'disabled',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().connection).toMatchObject({
+        display_name: 'Custom name',
+        lifecycle_status: 'disabled',
+      });
+    });
+
+    it('rejects a missing body field with 400', async () => {
+      const app = await createTestApp();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/integration/connections',
+        payload: {workspace_id: randomUUID(), provider: 'github'},
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('GET /integration/events', () => {
+    it('returns rows filtered by deliveryId', async () => {
+      const app = await createTestApp();
+      const deliveryId = randomUUID();
+      await db()
+        .insert(integrationsOutbox)
+        .values([
+          {
+            eventType: 'integrations.repository.pushed',
+            payload: {deliveryId, headCommitSha: 'abc'},
+          },
+          {
+            eventType: 'integrations.repository.pushed',
+            payload: {deliveryId: randomUUID(), headCommitSha: 'other'},
+          },
+        ]);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/integration/events?delivery_id=${deliveryId}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      const events = res.json().events;
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        event_type: 'integrations.repository.pushed',
+        payload: {deliveryId, headCommitSha: 'abc'},
+      });
+    });
+
+    it('filters by event_type', async () => {
+      const app = await createTestApp();
+      await db()
+        .insert(integrationsOutbox)
+        .values([
+          {eventType: 'integrations.repository.pushed', payload: {deliveryId: 'a'}},
+          {eventType: 'integrations.other', payload: {deliveryId: 'b'}},
+        ]);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/integration/events?event_type=integrations.repository.pushed',
+      });
+
+      expect(res.statusCode).toBe(200);
+      const events = res.json().events;
+      expect(events).toHaveLength(1);
+      expect(events[0].event_type).toBe('integrations.repository.pushed');
+    });
+
+    it('returns an empty list (not 404) when nothing matches', async () => {
+      const app = await createTestApp();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/integration/events?delivery_id=${randomUUID()}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().events).toEqual([]);
+    });
+  });
+});

--- a/libs/api/integration/core/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/integration/core/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,14 @@
+import type {RouteExport, RouteGroup} from '@shipfox/node-fastify';
+import {createE2eIntegrationConnectionRoute} from './connections.js';
+import {createE2eIntegrationEventsRoute} from './events.js';
+
+export function createIntegrationE2eRoutes(providerE2eRoutes: RouteExport[]): RouteGroup {
+  return {
+    prefix: '/integration',
+    routes: [
+      createE2eIntegrationConnectionRoute,
+      createE2eIntegrationEventsRoute,
+      ...providerE2eRoutes,
+    ],
+  };
+}

--- a/libs/api/integration/github-dto/src/schemas/e2e.ts
+++ b/libs/api/integration/github-dto/src/schemas/e2e.ts
@@ -1,0 +1,25 @@
+import {z} from 'zod';
+
+export const e2eCreateGithubInstallationBodySchema = z.object({
+  connection_id: z.string().uuid(),
+  installation_id: z.string().min(1),
+  account_login: z.string().min(1).optional(),
+  account_type: z.string().min(1).optional(),
+  repository_selection: z.enum(['all', 'selected']).optional(),
+});
+
+export type E2eCreateGithubInstallationBodyDto = z.infer<
+  typeof e2eCreateGithubInstallationBodySchema
+>;
+
+export const e2eCreateGithubInstallationResponseSchema = z.object({
+  installation: z.object({
+    id: z.string().uuid(),
+    connection_id: z.string().uuid(),
+    installation_id: z.string(),
+  }),
+});
+
+export type E2eCreateGithubInstallationResponseDto = z.infer<
+  typeof e2eCreateGithubInstallationResponseSchema
+>;

--- a/libs/api/integration/github-dto/src/schemas/index.ts
+++ b/libs/api/integration/github-dto/src/schemas/index.ts
@@ -1,2 +1,3 @@
+export * from './e2e.js';
 export * from './github.js';
 export * from './webhooks.js';

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '#core/webhook.js';
 import {closeDb, db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
+import {githubE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {
   type CreateGithubIntegrationRoutesOptions,
   createGithubIntegrationRoutes,
@@ -60,5 +61,6 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
         getIntegrationConnectionById: options.getIntegrationConnectionById,
       }),
     ],
+    e2eRoutes: [githubE2eRoutes],
   };
 }

--- a/libs/api/integration/github/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/index.test.ts
@@ -1,0 +1,74 @@
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance} from 'fastify';
+import {insertConnection, truncateIntegrationsState} from '#test/core-fixtures.js';
+import {githubE2eRoutes} from './index.js';
+
+async function createTestApp(): Promise<FastifyInstance> {
+  const app = await createApp({routes: [githubE2eRoutes], swagger: false});
+  await app.ready();
+  return app;
+}
+
+describe('GitHub E2E routes', () => {
+  beforeEach(async () => {
+    await closeApp();
+    await truncateIntegrationsState();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  describe('POST /github/installations', () => {
+    it('seeds an installation tied to a connection', async () => {
+      const app = await createTestApp();
+      const connection = await insertConnection({externalAccountId: '424242'});
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/github/installations',
+        payload: {
+          connection_id: connection.id,
+          installation_id: '424242',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.json().installation).toMatchObject({
+        connection_id: connection.id,
+        installation_id: '424242',
+      });
+    });
+
+    it('honors optional account fields', async () => {
+      const app = await createTestApp();
+      const connection = await insertConnection({externalAccountId: '111'});
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/github/installations',
+        payload: {
+          connection_id: connection.id,
+          installation_id: '111',
+          account_login: 'shipfox',
+          account_type: 'User',
+          repository_selection: 'selected',
+        },
+      });
+
+      expect(res.statusCode).toBe(201);
+    });
+
+    it('rejects a missing installation_id with 400', async () => {
+      const app = await createTestApp();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/github/installations',
+        payload: {connection_id: '00000000-0000-0000-0000-000000000000'},
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+});

--- a/libs/api/integration/github/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,7 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createE2eGithubInstallationRoute} from './installations.js';
+
+export const githubE2eRoutes: RouteGroup = {
+  prefix: '/github',
+  routes: [createE2eGithubInstallationRoute],
+};

--- a/libs/api/integration/github/src/presentation/e2eRoutes/installations.ts
+++ b/libs/api/integration/github/src/presentation/e2eRoutes/installations.ts
@@ -1,0 +1,37 @@
+import {
+  e2eCreateGithubInstallationBodySchema,
+  e2eCreateGithubInstallationResponseSchema,
+} from '@shipfox/api-integration-github-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+import {upsertGithubInstallation} from '#db/installations.js';
+
+export const createE2eGithubInstallationRoute = defineRoute({
+  method: 'POST',
+  path: '/installations',
+  description: 'Seed a GitHub App installation for E2E tests.',
+  schema: {
+    body: e2eCreateGithubInstallationBodySchema,
+    response: {
+      201: e2eCreateGithubInstallationResponseSchema,
+    },
+  },
+  handler: async (request, reply) => {
+    const installation = await upsertGithubInstallation({
+      connectionId: request.body.connection_id,
+      installationId: request.body.installation_id,
+      accountLogin: request.body.account_login ?? 'e2e-account',
+      accountType: request.body.account_type ?? 'Organization',
+      repositorySelection: request.body.repository_selection ?? 'all',
+      latestEvent: {source: 'e2e'},
+    });
+
+    reply.code(201);
+    return {
+      installation: {
+        id: installation.id,
+        connection_id: installation.connectionId,
+        installation_id: installation.installationId,
+      },
+    };
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,42 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/api/integrations:
+    devDependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/core-dto
+      '@shipfox/api-integration-github':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/github
+      '@shipfox/api-integration-github-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/github-dto
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../../helpers/auth
+      '@shipfox/e2e-helper-integration-github':
+        specifier: workspace:*
+        version: link:../../helpers/integration-github
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/client/auth:
     devDependencies:
       '@shipfox/biome':
@@ -354,6 +390,34 @@ importers:
       '@shipfox/api-auth-dto':
         specifier: workspace:*
         version: link:../../../libs/api/auth-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/helpers/integration-github:
+    dependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/core-dto
+      '@shipfox/api-integration-github-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/github-dto
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core


### PR DESCRIPTION
First iteration of API-level E2E coverage for the GitHub integration: signed push payloads are POSTed at the booted API and the resulting integrations_outbox row is asserted through a new admin-gated readback route. The four specs (happy push, invalid signature, duplicate delivery, non-push event) live in a new `e2e/api/integrations` package that mirrors `e2e/api/auth`.

We do not currently exercise the integration through a running app. The in-process tests at `libs/api/integration/github/src/presentation/routes/webhooks.test.ts` cover the webhook handler's internals well, but they don't catch wiring bugs (modules not composed in `run.ts`, dispatcher loop not running, cross-module subscriber registration broken, admin auth misconfigured on `/__e2e/*`, env secrets diverging between API and test process). API E2E closes that gap without duplicating the unit coverage.

This iteration deliberately stops at the integrations outbox. The full chain — `INTEGRATION_REPOSITORY_PUSHED` → `PROJECT_SOURCE_COMMIT_OBSERVED` → Temporal `DEFINITION_SYNC_WORKFLOW` → outbound `fetchRepositoryFile` → definitions DB — requires outbound GitHub stubbing and a Temporal worker in the E2E env. The approach is locked (in-process `StubGithubApiClient` controlled via `/__e2e/integration/github/fixtures`) and the design is captured in `.claude/plans/system-instruction-you-are-working-wild-crescent.md`, but the implementation is deferred to a follow-up.

Worth a careful look:
- The new optional `e2eRoutes` field on `IntegrationProvider` (in `libs/api/integration/core-dto/src/contracts/integrations.ts`). Each provider now contributes its own E2E surface; the GitHub installation seed route lives in the GitHub package and is collected in `createIntegrationsContext` alongside `integration/core`'s own routes.
- HMAC signing is duplicated between `webhooks.test.ts` (existing inline `signedHeaders` helper) and `e2e/helpers/integration-github/src/sign.ts`. The plan originally called for extracting once; moving it to a shared location would force `libs/api/integration/github` to devDep on an `e2e/helpers/*` package, which inverts the usual layering. Six lines of HMAC felt cheaper to duplicate than to absorb that coupling.
- Webhook secret is shared via env (`GITHUB_APP_WEBHOOK_SECRET`) — both the booted API and the test process read from the same value, with `'test-webhook-secret'` as the local default.

The pre-existing `@shipfox/api-workflows` test failures on `origin/main` (NOT NULL violation on `workflows_workflow_runs.name`) are unrelated to this branch — verified by running the suite against a clean `origin/main` checkout of that directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add API-level E2E tests for the GitHub webhook flow. Sends signed push payloads to the running API and asserts an INTEGRATION_REPOSITORY_PUSHED outbox row via new admin E2E routes.

- New Features
  - E2E routes under /__e2e/integration: POST /connections (seed a connection) and GET /events (read outbox; filter by delivery_id, event_type).
  - GitHub routes: POST /__e2e/integration/github/installations (seed a GitHub App installation).
  - `IntegrationProvider` adds `e2eRoutes`; core collects provider routes in `createIntegrationsContext`.
  - New `@shipfox/e2e-helper-integration-github` and `@shipfox/e2e-api-integrations` tests cover: happy push, invalid signature, duplicate delivery, and non-push events.

- Notes
  - Webhook secret comes from `GITHUB_APP_WEBHOOK_SECRET` (default `test-webhook-secret`).
  - HMAC signing helper is duplicated locally to avoid cross-layer deps.
  - This iteration stops at the integrations outbox; full sync flow is planned for a follow-up.

<sup>Written for commit 8fd0d14432bf1911b1f5c1b7ef25250d7c28b1ef. Summary will update on new commits. <a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/84?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

