### PR TITLE
Fix flaky workspace updatedAt assertion under clock drift

### DIFF
--- a/libs/api/workspaces/src/db/workspaces.ts
+++ b/libs/api/workspaces/src/db/workspaces.ts
@@ -1,4 +1,4 @@
-import {eq} from 'drizzle-orm';
+import {eq, sql} from 'drizzle-orm';
 import type {Workspace, WorkspaceStatus} from '#core/entities/workspace.js';
 import {db} from './db.js';
 import {toWorkspace, workspaces} from './schema/workspaces.js';
@@ -30,7 +30,7 @@ export interface UpdateWorkspaceParams {
 export async function updateWorkspace(
   params: UpdateWorkspaceParams,
 ): Promise<Workspace | undefined> {
-  const set: Record<string, unknown> = {updatedAt: new Date()};
+  const set: Record<string, unknown> = {updatedAt: sql`NOW()`};
   if (params.name !== undefined) set.name = params.name;
   if (params.status !== undefined) set.status = params.status;
   if (params.settings !== undefined) set.settings = params.settings;


### PR DESCRIPTION
Use `sql\`NOW()\`` in `updateWorkspace` so both the create and update paths
sample the same Postgres clock for `updated_at`.

`createWorkspace` lets Postgres populate `updated_at` via `defaultNow()`
(server clock), while `updateWorkspace` was setting `updatedAt: new Date()`
(host Node clock). When the database container clock runs ahead of the
host clock — which routinely happens with Docker on macOS — an update
issued *after* a create can yield an earlier `updated_at` than the create
row. This made `libs/api/workspaces/src/db/workspaces.test.ts`
intermittently fail the `updatedAt >= created.updatedAt` assertion in
`updateWorkspace > updates only provided fields` with the actual value
trailing the expected one by several seconds.

Switching the update set to `sql\`NOW()\`` keeps the timestamp generated
on the server side in both code paths, so the monotonic comparison holds
regardless of host/container drift. No schema or API behaviour changes.

Other domain modules (auth, triggers, workflows, runners) use the same
`new Date()` pattern in their update statements, but none of their tests
assert a `updatedAt >= createdAt` ordering today; leaving those for a
follow-up to keep this PR scoped to the failing test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the database clock for workspace updates to fix flaky updatedAt ordering under host/container clock drift. This aligns update timestamps with creates and stabilizes tests.

- **Bug Fixes**
  - Set updatedAt via `sql\`NOW()\`` in `updateWorkspace` so create and update use the same Postgres clock.
  - Fixes flaky `updatedAt >= createdAt` assertion under clock skew. No schema or API changes.

<sup>Written for commit 5541770fa32f9629381427f23ef21eb6433d733d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

