### PR TITLE
Mask owner joined date in members settings screenshots

### DIFF
--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -229,16 +229,23 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
   await page.goto(`/workspaces/${workspace.id}/settings/members`);
   await expect(page.getByRole('heading', {name: 'Pending invitations'})).toBeVisible();
   await expect(page.getByText('No pending invitations.')).toBeVisible();
-  await stableArgosScreenshot(page, 'members/pending-invitations-empty', [
+  const ownerJoinedText = (
+    await page
+      .getByRole('row', {name: textRe(owner.email)})
+      .getByRole('cell')
+      .nth(2)
+      .innerText()
+  ).trim();
+  const ownerRowReplacements = [
     [owner.email, VISUAL_OWNER_EMAIL],
-  ]);
+    [ownerJoinedText, VISUAL_JOINED_DATE],
+  ] as const;
+  await stableArgosScreenshot(page, 'members/pending-invitations-empty', ownerRowReplacements);
 
   await page.getByRole('button', {name: 'Invite member'}).click();
   await expect(page.getByRole('heading', {name: 'Invite a member'})).toBeVisible();
   await expect(page.getByLabel('Email')).toBeFocused();
-  await stableArgosScreenshot(page, 'members/invite-member-modal-idle', [
-    [owner.email, VISUAL_OWNER_EMAIL],
-  ]);
+  await stableArgosScreenshot(page, 'members/invite-member-modal-idle', ownerRowReplacements);
 
   await page.getByLabel('Email').fill(pendingEmail);
   await page.getByRole('button', {name: 'Send invitation'}).click();
@@ -251,6 +258,7 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
   const pendingRowReplacements = [
     [owner.email, VISUAL_OWNER_EMAIL],
     [pendingEmail, VISUAL_PENDING_EMAIL],
+    [ownerJoinedText, VISUAL_JOINED_DATE],
     [pendingExpiresText, VISUAL_EXPIRES_DATE],
   ] as const;
   await stableArgosScreenshot(


### PR DESCRIPTION
Stabilize three Argos screenshots in `invitations-members.e2e` that drift
on every run because the owner's "Joined" cell renders `member.created_at`
unmasked.

`pending-invitations-empty`, `invite-member-modal-idle`, and
`invite-member-modal-conflict` previously only replaced `owner.email`,
so the owner row's date column produced a fresh pixel diff each day
even though no UI behavior had changed. Argos flagged these as visual
regressions on PR #97 despite the diff being purely temporal.

The fix mirrors the invitee-row pattern already used a few lines above:
capture the owner's joined-cell text once when the members page first
loads (when only the owner is present), and add it as a replacement
alongside `owner.email` for every subsequent screenshot that has the
owner row in frame. The pending invitation's expires-date masking is
unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks the owner’s “Joined” date in members settings screenshots to stop daily pixel diffs and stabilize three Argos snapshots in `invitations-members.e2e`.

- **Bug Fixes**
  - Capture the owner’s joined-cell text once and replace it with `VISUAL_JOINED_DATE` across screenshots that include the owner row.
  - Apply shared replacements to `pending-invitations-empty`, `invite-member-modal-idle`, and `invite-member-modal-conflict`; pending invitation expires-date masking is unchanged.

<sup>Written for commit edcdcbfaac2a7d42387c5b5f757eb292c18dd0e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

