### PR TITLE
Switch publish flow to changesets/action with release PR

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,13 +1,14 @@
 name: Publish packages
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       package_name:
-        description: Name of the package to publish (leave empty to publish all eligible packages)
-        required: false
+        description: Name of a single package to republish from current main (escape hatch)
+        required: true
         type: string
-        default: ""
 
 permissions:
   contents: write
@@ -19,10 +20,48 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Version + publish
+  release:
+    name: Open release PR or publish
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+
+    steps:
+      - name: Mint App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Open release PR or publish
+        uses: changesets/action@v1
+        with:
+          version: pnpm exec changeset version
+          publish: turbo build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm exec changeset publish
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_CONFIG_PROVENANCE: "true"
+
+  publish-single:
+    name: Publish ${{ inputs.package_name }}
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
@@ -36,42 +75,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Bump versions and update changelogs
-        if: inputs.package_name == ''
-        run: pnpm exec changeset version
+      - name: Build target package
+        env:
+          PACKAGE_NAME: ${{ inputs.package_name }}
+        run: turbo build type:emit --filter "$PACKAGE_NAME"
 
-      - name: Build publishable packages
-        run: turbo build type:emit --filter='./libs/**' --filter='./tools/**'
-
-      - name: Publish a specific package
-        if: inputs.package_name != ''
+      - name: Publish package
         env:
           PACKAGE_NAME: ${{ inputs.package_name }}
         run: pnpm publish --access public --no-git-checks --provenance --filter "$PACKAGE_NAME"
-
-      - name: Publish bumped packages
-        if: inputs.package_name == ''
-        run: pnpm exec changeset publish
-
-      - name: Mint App installation token
-        if: inputs.package_name == ''
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
-
-      - name: Open version-bump PR
-        if: inputs.package_name == ''
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
-        with:
-          token: ${{ steps.app-token.outputs.token }}
-          sign-commits: true
-          commit-message: "chore(publish): version packages"
-          title: "chore(publish): version packages"
-          body: |
-            Version bumps and changelog updates from the most recent `Publish packages` workflow run.
-
-            Packages have already been published to npm with provenance via trusted publishing.
-          branch: publish-packages
-          branch-suffix: short-commit-hash

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -3,12 +3,6 @@ name: Publish packages
 on:
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      package_name:
-        description: Name of a single package to republish from current main (escape hatch)
-        required: true
-        type: string
 
 permissions:
   contents: write
@@ -22,7 +16,6 @@ concurrency:
 jobs:
   release:
     name: Open release PR or publish
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 25
 
@@ -56,31 +49,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
-
-  publish-single:
-    name: Publish ${{ inputs.package_name }}
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
-
-      - name: Build target package
-        env:
-          PACKAGE_NAME: ${{ inputs.package_name }}
-        run: turbo build type:emit --filter "$PACKAGE_NAME"
-
-      - name: Publish package
-        env:
-          PACKAGE_NAME: ${{ inputs.package_name }}
-        run: pnpm publish --access public --no-git-checks --provenance --filter "$PACKAGE_NAME"

--- a/libs/api/auth-context/package.json
+++ b/libs/api/auth-context/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-auth-context",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/auth-dto/package.json
+++ b/libs/api/auth-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-auth-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-auth",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/definitions-dto/package.json
+++ b/libs/api/definitions-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-definitions-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-definitions",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/dispatcher/package.json
+++ b/libs/api/dispatcher/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-dispatcher",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/integration/core-dto/package.json
+++ b/libs/api/integration/core-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-integration-core-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-integration-core",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/integration/debug-dto/package.json
+++ b/libs/api/integration/debug-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-integration-debug-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/integration/debug/package.json
+++ b/libs/api/integration/debug/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-integration-debug",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/integration/github-dto/package.json
+++ b/libs/api/integration/github-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-integration-github-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-integration-github",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/projects-dto/package.json
+++ b/libs/api/projects-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-projects-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/projects/package.json
+++ b/libs/api/projects/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-projects",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/runners-dto/package.json
+++ b/libs/api/runners-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-runners-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-runners",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/triggers-dto/package.json
+++ b/libs/api/triggers-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-triggers-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-triggers",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/workflows-dto/package.json
+++ b/libs/api/workflows-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-workflows-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-workflows",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/workspaces-dto/package.json
+++ b/libs/api/workspaces-dto/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-workspaces-dto",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api-workspaces",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/api/package.json
+++ b/libs/client/api/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-api",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/app-shell/package.json
+++ b/libs/client/app-shell/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-app-shell",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-auth",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/integrations/package.json
+++ b/libs/client/integrations/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-integrations",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/invitations/package.json
+++ b/libs/client/invitations/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-invitations",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/projects/package.json
+++ b/libs/client/projects/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-projects",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/router/package.json
+++ b/libs/client/router/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-router",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/runners/package.json
+++ b/libs/client/runners/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-runners",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/client/workspace-settings/package.json
+++ b/libs/client/workspace-settings/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client-workspace-settings",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/drizzle/package.json
+++ b/libs/shared/node/drizzle/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/node-drizzle",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/node-module",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/node-outbox",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/tokens/package.json
+++ b/libs/shared/node/tokens/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/node-tokens",
   "license": "MIT",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Replaces the manual `workflow_dispatch` publish flow with the
`changesets/action@v1` release-PR pattern, and stops the 35 unpublished
lib packages from attempting first-publish.

## Why

The previous flow ran `changeset version` + `changeset publish` first
and only then opened a PR with the version bumps. Two problems:

1. **npm led git.** The new versions were on the registry before the
   bump commits landed on `main`. Anyone reading the repo saw stale
   versions until someone merged the catch-up PR.
2. **Retries weren't safe.** If publish died partway, re-clicking the
   workflow ran `changeset version` again from the still-unbumped
   `main`. If new changesets had landed in the meantime, the second
   run produced *different* versions for the same packages —
   half-published at version A, attempting version B on retry.

The release-PR flow inverts the order: bumps land on `main` first via
a reviewable PR, then merging that PR is what triggers publish. Retries
are idempotent because `changeset publish` skips packages whose
current `package.json` version is already on npm.

## What changed

- `publish-packages.yml` rewritten to use `changesets/action@v1` on
  `push: main`. The build step is embedded in the action's `publish`
  script so update-PR runs stay cheap (build only runs when actually
  publishing).
- Single-package `workflow_dispatch` escape hatch preserved in the
  same file. Keeping the filename matters: the npm Trusted Publisher
  rules are bound to `publish-packages.yml`, so this avoids
  reconfiguring 18 packages on npmjs.com.
- `NPM_CONFIG_PROVENANCE=true` threads provenance through every
  underlying `npm publish` call. `id-token: write` permission is kept
  for OIDC.
- Workflow-level concurrency (`cancel-in-progress: false`) serializes
  back-to-back runs so the action always operates on the latest
  `main`.
- 35 lib packages still at `0.0.0` marked `private: true`. They had no
  Trusted Publisher rules and would E404 on every release. They can
  be re-opened individually once they're ready to ship.

## Notes for reviewers

- `changesets/action@v1` is unpinned; Renovate will pin to a SHA on
  its next pass to match the rest of the file.
- The two outstanding changesets (`react-ui` + tools) will fire the
  release-PR flow as soon as this lands on `main`. Review and merge
  the auto-opened "chore(release): version packages" PR to actually
  publish.
- If your Trusted Publisher rules specify a GitHub environment, both
  jobs need a matching `environment:` key; left blank intentionally
  for now.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches package publishing to a release-PR flow using `changesets/action@v1`, so version bumps land on `main` before publish and retries are safe. Removes the manual single-package `workflow_dispatch` path, and marks 35 `0.0.0` lib packages as `private` to stop failing first-publish attempts.

- **Refactors**
  - Publish flow runs on `push` to `main`: opens a release PR; merging it triggers publish.
  - Builds only when publishing via the action’s `publish` script; PR updates stay fast.
  - Uses a GitHub App token for repo access; provenance enabled with `NPM_CONFIG_PROVENANCE=true` and `id-token: write`.
  - Drops manual single-package publish to keep changesets as the source of truth and resolve ref guard and `PACKAGE_NAME` validation findings.
  - Serializes runs with workflow-level concurrency to always act on the latest `main`.

- **Migration**
  - After this merges, an auto "chore(release): version packages" PR will open; merge it to publish.
  - The 35 libs at `0.0.0` are now `private`; flip to `false` individually once they have Trusted Publisher rules and are ready to ship.
  - If your npm Trusted Publisher requires a GitHub environment, add a matching `environment:` to the job.

<sup>Written for commit c6f1539bad65252a06fed7d8d2df172f03bf88f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

