### PR TITLE
Use client-id for release bot App token

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -24,7 +24,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          client-id: ${{ vars.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
 
       - name: Check out repository


### PR DESCRIPTION
Switch the publish workflow's `actions/create-github-app-token` step from the
deprecated `app-id` input to `client-id`, reading the value from a new
`RELEASE_BOT_CLIENT_ID` repository variable.

`actions/create-github-app-token@v3` started emitting a deprecation warning on
every push to `main` ("Use 'client-id' instead"). The action accepts either an
App ID or a Client ID as the issuer, but the input name had to change to keep
the warning quiet. The matching `RELEASE_BOT_CLIENT_ID` variable has already
been added in GitHub; the old `RELEASE_BOT_APP_ID` variable can be removed once
this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update publish workflow to use `client-id` with `actions/create-github-app-token@v3`, pulling from `vars.RELEASE_BOT_CLIENT_ID`. Replaces the deprecated `app-id` input and removes the deprecation warning on pushes to `main`.

- **Migration**
  - Remove `RELEASE_BOT_APP_ID` repo variable after merge; `RELEASE_BOT_CLIENT_ID` is already set.

<sup>Written for commit dbe7069cd5dcf331a63ab913036723a8ab9abf09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

