### PR TITLE
Remove pnpm vitest override, pin via @shipfox/vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,5 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.10",
     "@types/node": "^24.1.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "vitest": "^4.1.5"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2818,7 +2818,7 @@ importers:
         specifier: workspace:*
         version: link:../utils
       vitest:
-        specifier: ^4.0.8
+        specifier: ^4.1.5
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.3))
     devDependencies:
       '@shipfox/swc':

--- a/tools/vitest/package.json
+++ b/tools/vitest/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@shipfox/tool-utils": "workspace:*",
-    "vitest": "^4.0.8"
+    "vitest": "^4.1.5"
   },
   "devDependencies": {
     "@shipfox/swc": "workspace:*",


### PR DESCRIPTION
pnpm v11 stopped reading the `pnpm` field in `package.json` and prints a
warning on every install that `pnpm.overrides` is ignored:

> [WARN] The "pnpm" field in package.json is no longer read by pnpm.
> The following keys were ignored: "pnpm.overrides".

Rather than relocate the override to `pnpm-workspace.yaml`, this drops it
entirely and aligns the workspace on a single `vitest` version through
the shared `@shipfox/vitest` tool.

`@shipfox/vitest` becomes the canonical version source: its `vitest`
dependency is bumped from `^4.0.8` to `^4.1.5` so it matches
`@shipfox/react-ui`, the only other package that declares `vitest`
directly. react-ui has to keep its own `vitest` entry because the
storybook addon emits story-test files that `import "vitest"`, which
under `nodeLinker: isolated` must resolve from react-ui's own
`node_modules` — the transitive copy inside `@shipfox/vitest` does not
cover it.

With both specifiers at `^4.1.5`, `vitest` resolves to a single version
(`4.1.7`) workspace-wide and the override is no longer needed. Verified
that react-ui's browser-mode/Argos tests (83 tests) still pass, install
is clean under `strictPeerDependencies`, and `@vitest/browser-playwright`'s
exact `vitest: 4.1.7` peer is satisfied.