### PR TITLE
Sign release PR commits via the GitHub API

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,12 +40,13 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Open release PR or publish
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm exec changeset version
           publish: turbo build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm exec changeset publish
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
The changesets release PR (e.g. #101) cannot be merged because branch protection on `main` requires verified signatures, but `changesets/action` was using the default `git-cli` commit mode, which produces unsigned commits.

Switching to `commitMode: github-api` makes the action push the version commit through the GitHub API, which signs it with GitHub's internal GPG key and attributes it to the owner of `GITHUB_TOKEN` (our `shipfox-release-bot[bot]` app). The commit then shows as verified, satisfying the rule. This option was introduced in changesets/action v1.5.0.

GPG key management was not an option since the committer is a GitHub App, which cannot own a GPG key — the API commit mode is the supported path.

Also pinned `changesets/action` to a commit SHA (v1.8.0) to match the SHA-pinning convention used by every other action in this workflow.

The existing release PR keeps its unsigned commit; the next release run will regenerate the branch with a verified commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch release PR commits to be created via the GitHub API so they are GPG-signed and pass `main`’s verified-signature rule. Also pin `changesets/action` to v1.8.0.

- **Migration**
  - The existing release PR stays unsigned; the next run will regenerate the branch with a verified commit.

<sup>Written for commit 86d8aaf1bc19e9bb2e622050ccd731705dcefdd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

