### PR TITLE
Fix duplicate "You joined" toast on invitation-via-login accept

### DIFF
--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -1,26 +1,13 @@
 import {loginBodySchema} from '@shipfox/api-auth-dto';
-import type {AcceptInvitationResponseDto} from '@shipfox/api-workspaces-dto';
-import {apiRequest} from '@shipfox/client-api';
-import {
-  Alert,
-  Button,
-  ButtonLink,
-  FormField,
-  FormFieldInput,
-  Icon,
-  Text,
-  toast,
-} from '@shipfox/react-ui';
+import {Alert, Button, ButtonLink, FormField, FormFieldInput, Icon, Text} from '@shipfox/react-ui';
 import {useForm} from '@tanstack/react-form';
-import {Link, useNavigate, useSearch} from '@tanstack/react-router';
+import {Link, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
 import {AuthShell} from '#/components/auth-shell.js';
 import {useLoginAuth} from '#hooks/api/login-auth.js';
-import {useRefreshAuth} from '#hooks/api/refresh-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
 import {loginErrorToFormError} from './form-errors.js';
-import {authErrorMessage} from './form-utils.js';
 import {
   extractInvitationToken,
   pendingInvitation,
@@ -29,8 +16,6 @@ import {
 
 export function LoginPage() {
   const login = useLoginAuth();
-  const refreshAuth = useRefreshAuth();
-  const navigate = useNavigate();
   const search = useSearch({strict: false}) as {redirect?: unknown};
   const invitationToken = extractInvitationToken(search.redirect);
   const invitationPreview = useInvitationContext(invitationToken);
@@ -48,30 +33,9 @@ export function LoginPage() {
     onSubmit: async ({value}) => {
       setFormError(undefined);
       try {
-        const session = await login.mutateAsync(value);
+        await login.mutateAsync(value);
         skipDraftPersistRef.current = true;
         setAuthFormDraft(initialAuthFormDraft);
-
-        if (invitationToken && invitationPending) {
-          try {
-            const result = await apiRequest<AcceptInvitationResponseDto>('/invitations/accept', {
-              method: 'POST',
-              body: {token: invitationToken},
-              headers: {authorization: `Bearer ${session.token}`},
-            });
-            await refreshAuth();
-            toast.success(`You joined ${invitationPending.workspace_name}.`);
-            await navigate({
-              to: '/workspaces/$wid',
-              params: {wid: result.membership.workspace_id},
-            });
-          } catch (error) {
-            toast.error(authErrorMessage(error));
-            await navigate({to: '/invitations/accept', search: {token: invitationToken}});
-          }
-        }
-        // The route's GuestGuard redirects authenticated users to `/` from the
-        // auth-state-driven re-render — explicit navigate would race the render.
       } catch (error) {
         const mapped = loginErrorToFormError(error);
         if (mapped.kind === 'field') {


### PR DESCRIPTION
Logging in from an invitation link accepted the invitation twice and fired the "You joined …" success toast twice. The flaky e2e (`accepts an invitation from the public landing page via login`) caught it as a Playwright strict-mode violation: the toast text resolved to two elements.

Two code paths each accepted and toasted:

1. `LoginPage.onSubmit` did its own inline `POST /invitations/accept` → `toast.success` → navigate to the workspace.
2. The login route's `GuestGuard` redirects the now-authenticated user back to the `redirect` target (`/invitations/accept?token=…`), where `InvitationAcceptPage`'s auto-accept effect — authenticated, email-matched, preview already React-Query-cached — accepts again and fires a second identical toast via `completeInvitationAcceptance`.

Whether both toasts were alive within the 5s assertion window depended on which navigation unmounted first, hence the flake. Signup doesn't hit this because it accepts the invitation server-side in the signup request, so the redirect lands on an `already_used` invitation and the auto-accept effect bails.

Fix: remove the redundant inline accept from the login page. `InvitationAcceptPage` is the single canonical owner of acceptance — it already has the StrictMode/in-flight guards (`inFlightAccepts`, `hasKickedAccept`) and the error UI. The login page now just authenticates and lets `GuestGuard` drive the redirect. This deletes the duplicate POST, the duplicate toast, and the navigation race.

No changeset: `@shipfox/client-auth` is `private: true`, so changesets for it are dropped at release time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate invitation acceptance and the double "You joined" toast when logging in from an invitation link by removing inline acceptance from the login flow. Acceptance now happens only on `InvitationAcceptPage` after `GuestGuard` redirects, which also stabilizes the flaky e2e test.

- **Bug Fixes**
  - Removed inline `/invitations/accept` call, toast, and navigation from `LoginPage.onSubmit`.
  - `InvitationAcceptPage` is the sole owner of acceptance with existing guards and error UI, eliminating the double POST, duplicate toast, and navigation race.

<sup>Written for commit 97d994fa6417e1bcd99aa596aa114fd6eb7a4882. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

