### PR TITLE
Pin changesets/action to v1.7.0 to stop release PR auto-close

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Open release PR or publish
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm exec changeset version
           publish: turbo build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm exec changeset publish

--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,12 @@
       "groupName": "pnpm",
       "groupSlug": "pnpm",
       "matchPackageNames": ["pnpm"]
+    },
+    {
+      "description": "Hold changesets/action at v1.7.x: v1.8.0 regressed commitMode:github-api so it closes the release PR without reopening it (changesets/action#615). Drop this rule once a fixed v1.8.x ships.",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["changesets/action"],
+      "allowedVersions": "<1.8.0"
     }
   ]
 }


### PR DESCRIPTION
Pins `changesets/action` back to v1.7.0 in the publish workflow and adds a Renovate rule holding it below v1.8.0.

On the last publish run, the release ("version packages") PR was closed and never reopened, stranding the release. Root cause: v1.8.0 changed the existing-PR update from the REST `pulls.update({state:"open"})` call to a GraphQL mutation. With `commitMode: github-api`, the action force-pushes the release branch before updating the PR — that force-push makes GitHub auto-close the PR, and the GraphQL `state: OPEN` that runs immediately after is a no-op because the API still reports the PR as open (propagation delay). The PR stays closed permanently. This is a known v1.8.0 regression, [changesets/action#615](https://github.com/changesets/action/issues/615), still open and not fixed on `main`.

v1.7.0 is the last release before the regression; its REST-based update reliably reopens the PR. Pinning back keeps `commitMode: github-api`, so release-PR commits remain signed by the App.

Renovate pins Actions to the latest release and would bump straight back to the broken v1.8.0, so a `packageRules` entry caps `changesets/action` at `<1.8.0`. The rule's description records why and the condition to remove it (a fixed v1.8.x).

Considered instead dropping `commitMode: github-api` to stay on v1.8.0, but that would lose the signed release commits set up by #100/#102/#104.

Note: the currently-open release PR is already closed; the next push to `main` after this lands will recreate it under v1.7.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `changesets/action` to v1.7.0 to stop the release PR from being auto-closed with `commitMode: github-api`. Added a Renovate rule to keep it below v1.8.0 until the upstream regression is fixed.

- **Bug Fixes**
  - v1.8.0 changed the PR update to GraphQL; after the force-push, GitHub auto-closes the PR and it never reopens.
  - v1.7.0 uses the REST update, which reliably reopens the PR and keeps App-signed release commits; Renovate holds `changesets/action` at <1.8.0 until a fixed v1.8.x ships.
  - If the current release PR is closed, the next push to `main` will recreate it.

<sup>Written for commit f8be6ea44386e16e5e2b96e19cf5c1e6f29fdb0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

