### PR TITLE
Fix package publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -43,10 +43,14 @@ jobs:
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm exec changeset version
-          publish: turbo build type:emit --filter='./libs/**' --filter='./tools/**' && pnpm exec changeset publish
-          commit: "chore(release): version packages"
-          title: "chore(release): version packages"
+          publish: pnpm run release:publish
+          commit: "Version packages"
+          title: "Version packages"
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: "true"
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: shipfox
+          # Publish must never populate the shared cache — only read what CI built.
+          TURBO_CACHE: local:rw,remote:r

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "packageManager": "pnpm@11.5.0",
   "type": "module",
+  "scripts": {
+    "release:publish": "turbo build type:emit --filter='./libs/**' --filter='./tools/**' && changeset publish"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.27.10",
     "@types/node": "^24.1.0"


### PR DESCRIPTION
Fixes the release publish job, which has been failing on every version-PR merge.

The `publish` input chained two commands with `&&`, but `changesets/action` does not run that string through a shell — it splits on whitespace and execs the first token directly. So `turbo` was handed `&&`, `pnpm`, `exec`, `changeset`, `publish` as task names and failed with `Missing tasks in project`. The chaining never worked. This moves the command into a `release:publish` root script and points the action at `pnpm run release:publish`, so pnpm runs the `&&` chain in a real shell. `changeset publish` stays a single global invocation (it owns "which packages to publish" via the npm registry; turbo owns build order via its task graph).

While here, two smaller fixes:

- The publish job now reads the shared turbo remote cache without writing to it (`TURBO_CACHE: local:rw,remote:r`). It can reuse artifacts CI built instead of rebuilding cold, and the release runner never seeds the shared cache. Best-effort, since CI and publish trigger off the same push and run in parallel.
- The release PR `commit`/`title` drop the `chore(release):` conventional-commit prefix (now `Version packages`) to match our commit/PR title conventions. This only affects future release PRs.

The `--filter='./libs/**' --filter='./tools/**'` scoping is kept intentionally: it builds exactly the publishable set, and there is no remote cache write here to make building the unpublished apps free.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix package publish workflow by moving the chained publish command into a root script so `changesets/action` executes it correctly. Publishing now reuses the shared `turbo` remote cache in read-only mode and no longer seeds it.

- **Bug Fixes**
  - Run `pnpm run release:publish` to execute `turbo build type:emit --filter='./libs/**' --filter='./tools/**' && changeset publish` in a real shell.
  - Configure `TURBO_CACHE: local:rw,remote:r` with `TURBO_TOKEN` and `TURBO_TEAM` to read CI-built artifacts without writing to the remote cache.
  - Change release PR commit/title to "Version packages" to match our conventions.

<sup>Written for commit 9e6d102b5576d544f2e3e8a1b2ed8c42d4ccb759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

