### PR TITLE
Add repository metadata to fix provenance publishing

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/api",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "apps/api"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/client",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "apps/client"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/runner",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "apps/runner"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/api/auth/package.json
+++ b/e2e/api/auth/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-api-auth",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/api/auth"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/client/auth/package.json
+++ b/e2e/client/auth/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-client-auth",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/client/auth"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-client-integrations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/client/integrations"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/client/runners/package.json
+++ b/e2e/client/runners/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-client-runners",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/client/runners"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-client-workspaces",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/client/workspaces"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/core/package.json
+++ b/e2e/core/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-core",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/core"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/helpers/auth/package.json
+++ b/e2e/helpers/auth/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-helper-auth",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/helpers/auth"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/e2e/helpers/workspaces/package.json
+++ b/e2e/helpers/workspaces/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@shipfox/e2e-helper-workspaces",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/helpers/workspaces"
+  },
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/libs/api/auth-context/package.json
+++ b/libs/api/auth-context/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-auth-context",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/auth-context"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/auth-dto/package.json
+++ b/libs/api/auth-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-auth-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/auth-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-auth",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/auth"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/definitions-dto/package.json
+++ b/libs/api/definitions-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-definitions-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/definitions-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-definitions",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/definitions"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/dispatcher/package.json
+++ b/libs/api/dispatcher/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-dispatcher",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/dispatcher"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/integration/core-dto/package.json
+++ b/libs/api/integration/core-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-integration-core-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/integration/core-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-integration-core",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/integration/core"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/integration/debug-dto/package.json
+++ b/libs/api/integration/debug-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-integration-debug-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/integration/debug-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/integration/debug/package.json
+++ b/libs/api/integration/debug/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-integration-debug",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/integration/debug"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/integration/github-dto/package.json
+++ b/libs/api/integration/github-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-integration-github-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/integration/github-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-integration-github",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/integration/github"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/projects-dto/package.json
+++ b/libs/api/projects-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-projects-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/projects-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/projects/package.json
+++ b/libs/api/projects/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-projects",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/projects"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/runners-dto/package.json
+++ b/libs/api/runners-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-runners-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/runners-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-runners",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/runners"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/triggers-dto/package.json
+++ b/libs/api/triggers-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-triggers-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/triggers-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-triggers",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/triggers"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/workflows-dto/package.json
+++ b/libs/api/workflows-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-workflows-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/workflows-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-workflows",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/workflows"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/workspaces-dto/package.json
+++ b/libs/api/workspaces-dto/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-workspaces-dto",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/workspaces-dto"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/api-workspaces",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/api/workspaces"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/api/package.json
+++ b/libs/client/api/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-api",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/api"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/app-shell/package.json
+++ b/libs/client/app-shell/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-app-shell",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/app-shell"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-auth",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/auth"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/integrations/package.json
+++ b/libs/client/integrations/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-integrations",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/integrations"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/invitations/package.json
+++ b/libs/client/invitations/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-invitations",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/invitations"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/projects/package.json
+++ b/libs/client/projects/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-projects",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/projects"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/router/package.json
+++ b/libs/client/router/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-router",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/router"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/runners/package.json
+++ b/libs/client/runners/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-runners",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/runners"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/client/workspace-settings/package.json
+++ b/libs/client/workspace-settings/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/client-workspace-settings",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/workspace-settings"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/shared/common/config/package.json
+++ b/libs/shared/common/config/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "1.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/common/config"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/drizzle/package.json
+++ b/libs/shared/node/drizzle/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/node-drizzle",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/drizzle"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/shared/node/error-monitoring/package.json
+++ b/libs/shared/node/error-monitoring/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/error-monitoring"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/fastify/package.json
+++ b/libs/shared/node/fastify/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/fastify"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/log/package.json
+++ b/libs/shared/node/log/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.3.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/log"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/mailer/package.json
+++ b/libs/shared/node/mailer/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/mailer"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/node-module",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/module"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/shared/node/opentelemetry/package.json
+++ b/libs/shared/node/opentelemetry/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.4.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/opentelemetry"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/node-outbox",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/outbox"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/shared/node/postgres/package.json
+++ b/libs/shared/node/postgres/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.3.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/postgres"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/temporal/package.json
+++ b/libs/shared/node/temporal/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/temporal"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/libs/shared/node/tokens/package.json
+++ b/libs/shared/node/tokens/package.json
@@ -2,6 +2,11 @@
   "name": "@shipfox/node-tokens",
   "license": "MIT",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/node/tokens"
+  },
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -3,6 +3,11 @@
   "license": "MIT",
   "private": false,
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/react/ui"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@shipfox/workspace",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git"
+  },
   "license": "MIT",
   "private": true,
   "packageManager": "pnpm@11.5.0",

--- a/tools/biome/package.json
+++ b/tools/biome/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/biome",
   "version": "1.8.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/biome"
+  },
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/tools/depcruise/package.json
+++ b/tools/depcruise/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/depcruise",
   "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/depcruise"
+  },
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/playwright",
   "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/playwright"
+  },
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/tools/swc/package.json
+++ b/tools/swc/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/swc",
   "version": "1.2.4",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/swc"
+  },
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/tools/ts-config/package.json
+++ b/tools/ts-config/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/ts-config",
   "version": "1.3.5",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/ts-config"
+  },
   "license": "MIT",
   "private": false,
   "files": [

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/typescript",
   "version": "1.1.4",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/typescript"
+  },
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/tool-utils",
   "version": "1.1.2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/utils"
+  },
   "license": "MIT",
   "private": false,
   "main": "src/index.js",

--- a/tools/vite/package.json
+++ b/tools/vite/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/vite",
   "version": "1.2.2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/vite"
+  },
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/tools/vitest/package.json
+++ b/tools/vitest/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@shipfox/vitest",
   "version": "1.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/vitest"
+  },
   "license": "MIT",
   "private": false,
   "main": "dist/index.js",


### PR DESCRIPTION
Publishing packages from `main` has been failing for every package with an `E422` provenance error:

```
422 Unprocessable Entity - PUT .../@shipfox%2freact-ui - Error verifying sigstore
provenance bundle: Failed to validate repository information: package.json:
"repository.url" is "", expected to match "https://github.com/ShipfoxHQ/platform"
```

The publish workflow sets `NPM_CONFIG_PROVENANCE: "true"`. With provenance on, npm builds a signed bundle from the GitHub Actions environment and then refuses to publish unless each package's `repository.url` matches the repo in that bundle. No package declared a `repository` field, so npm read it as `""` and rejected all of them — taking down the whole release run. (The `404` lines in that run are benign: changesets just checking whether new package names exist yet.)

This adds a `repository` block pointing at `ShipfoxHQ/platform`, with each package's monorepo `directory`, to **every** `package.json` in the workspace — not only the publishable ones — so the metadata stays consistent across apps, e2e, and internal libs. The root `package.json` gets the field without a `directory`.

### No changeset on purpose

This is a publishing/CI metadata fix, not a consumer-facing behavior change. The package versions that failed to publish are still unpublished, so once this lands the existing publish flow republishes them at their current versions (now with provenance passing) — adding a changeset would only re-bump them needlessly. The four already-published packages will pick up the field on their next real version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `repository` block to every workspace package to satisfy npm provenance and unblock publishing from `main`. Fixes `E422` errors by ensuring each `repository.url` points to `git+https://github.com/ShipfoxHQ/platform.git`.

- **Bug Fixes**
  - Added `repository` metadata (with monorepo `directory`) to all `package.json` files; root gets the repo without `directory`.
  - Publishing with `NPM_CONFIG_PROVENANCE=true` now passes and the release workflow succeeds.
  - No changeset; no runtime or API changes.

<sup>Written for commit 6349b419f36a38d2209cf8a29f422b89c5416443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

