### PR TITLE
[ts-config] Publish referenced tsconfig files in the npm tarball

### DIFF
--- a/.changeset/swift-pumas-ship.md
+++ b/.changeset/swift-pumas-ship.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/ts-config": patch
+---
+
+Publishes the referenced tsconfig files so `@shipfox/ts-config/node` and `/react` resolve from the npm tarball.

--- a/tools/ts-config/package.json
+++ b/tools/ts-config/package.json
@@ -9,9 +9,11 @@
   "license": "MIT",
   "private": false,
   "files": [
-    "tsconfig.json"
+    "tsconfig.base.json",
+    "tsconfig.node.json",
+    "tsconfig.react.json"
   ],
-  "main": "tsconfig.json",
+  "main": "tsconfig.base.json",
   "exports": {
     ".": "./tsconfig.base.json",
     "./node": "./tsconfig.node.json",


### PR DESCRIPTION
Fix `@shipfox/ts-config` shipping an empty config set to npm.

`tools/ts-config/package.json` exported three subpath entry points
(`.`, `./node`, `./react`) pointing at `tsconfig.base.json`,
`tsconfig.node.json`, and `tsconfig.react.json` — all present in the
repo — but its `files` allowlist contained only `"tsconfig.json"`, a
file that does not exist. As a result `npm pack` produced a tarball with
just `package.json`, `README.md`, and `LICENSE`, and any consumer doing
`extends: "@shipfox/ts-config/react"` (e.g. `apps/landing`) failed with:

```
error TS6053: File '@shipfox/ts-config/react' not found.
```

This change lists the three real config files in `files` and repoints
`main` from the non-existent `tsconfig.json` to `tsconfig.base.json` so
it matches the `.` export. A patch changeset is included to publish the
corrected tarball.

Note: the broken `1.3.6` is already on npm. Consumers pinned to an exact
version will need to bump to the new patch; caret ranges pick it up
automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the actual TypeScript config files in `@shipfox/ts-config` so `@shipfox/ts-config`, `/node`, and `/react` resolve from the npm tarball. Fixes TS6053 errors caused by the empty package.

- **Bug Fixes**
  - Include `tsconfig.base.json`, `tsconfig.node.json`, and `tsconfig.react.json` in `files`.
  - Set `main` to `tsconfig.base.json` to match the `.` export.

- **Migration**
  - If pinned to `1.3.6`, bump to the new patch release; caret ranges pick it up automatically.

<sup>Written for commit 1e20efe56edfde64567f25411470cec86b126e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

