### PR TITLE
[react-ui] Add "use client" directives for Next.js App Router compatibility

### DIFF
--- a/.changeset/swift-foxes-render.md
+++ b/.changeset/swift-foxes-render.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds "use client" directives to interactive components, hooks, and theme state so the library renders correctly in Next.js App Router and other React Server Components consumers.

--- a/libs/shared/react/ui/src/components/alert/alert.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {cva, type VariantProps} from 'class-variance-authority';
 import {AnimatePresence, motion, type Transition} from 'framer-motion';
 import {

--- a/libs/shared/react/ui/src/components/avatar/avatar-group.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar-group.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import {cva, type VariantProps} from 'class-variance-authority';
 import {

--- a/libs/shared/react/ui/src/components/avatar/avatar.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps, ReactNode} from 'react';

--- a/libs/shared/react/ui/src/components/badge/badge.tsx
+++ b/libs/shared/react/ui/src/components/badge/badge.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {Slot} from '@radix-ui/react-slot';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps, MouseEvent} from 'react';

--- a/libs/shared/react/ui/src/components/button/button-link.tsx
+++ b/libs/shared/react/ui/src/components/button/button-link.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {Slot, Slottable} from '@radix-ui/react-slot';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/button/button.tsx
+++ b/libs/shared/react/ui/src/components/button/button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {Slot, Slottable} from '@radix-ui/react-slot';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/button/icon-button.tsx
+++ b/libs/shared/react/ui/src/components/button/icon-button.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {Slot} from '@radix-ui/react-slot';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/combobox/combobox.tsx
+++ b/libs/shared/react/ui/src/components/combobox/combobox.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from 'react';
 import {cn} from '#utils/cn.js';
 import {

--- a/libs/shared/react/ui/src/components/command/command.tsx
+++ b/libs/shared/react/ui/src/components/command/command.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {cva, type VariantProps} from 'class-variance-authority';
 import {Command as CommandPrimitive} from 'cmdk';
 import {type ComponentProps, forwardRef, useCallback, useState} from 'react';

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/form-field/form-field.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   type ComponentProps,
   createContext,

--- a/libs/shared/react/ui/src/components/icon/custom/spinner.tsx
+++ b/libs/shared/react/ui/src/components/icon/custom/spinner.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type {RemixiconComponentType} from '@remixicon/react';
 import {motion, type SVGMotionProps, type Variants} from 'framer-motion';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/input/input.tsx
+++ b/libs/shared/react/ui/src/components/input/input.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps, ReactNode} from 'react';
 import {forwardRef} from 'react';

--- a/libs/shared/react/ui/src/components/label/label.tsx
+++ b/libs/shared/react/ui/src/components/label/label.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as LabelPrimitive from '@radix-ui/react-label';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/loader/shipfox-loader.tsx
+++ b/libs/shared/react/ui/src/components/loader/shipfox-loader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   type CSSProperties,
   type MouseEvent,

--- a/libs/shared/react/ui/src/components/logo/logo.tsx
+++ b/libs/shared/react/ui/src/components/logo/logo.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type {ComponentProps} from 'react';
 import {useResolvedTheme} from '#hooks/useResolvedTheme.js';
 import {cn} from '#utils/cn.js';

--- a/libs/shared/react/ui/src/components/modal/modal.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {cva} from 'class-variance-authority';
 import {type ComponentProps, createContext, type ReactNode, useContext} from 'react';

--- a/libs/shared/react/ui/src/components/popover/popover.tsx
+++ b/libs/shared/react/ui/src/components/popover/popover.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 import type {ComponentProps} from 'react';
 import {cn} from '#utils/cn.js';

--- a/libs/shared/react/ui/src/components/scroll-area/scroll-area.tsx
+++ b/libs/shared/react/ui/src/components/scroll-area/scroll-area.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import type {ComponentProps} from 'react';
 import {cn} from '#utils/cn.js';

--- a/libs/shared/react/ui/src/components/select/select.tsx
+++ b/libs/shared/react/ui/src/components/select/select.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as SelectPrimitive from '@radix-ui/react-select';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/sheet/sheet.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';

--- a/libs/shared/react/ui/src/components/tabs/tabs.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {type HTMLMotionProps, motion, type Transition} from 'framer-motion';
 import {
   Children,

--- a/libs/shared/react/ui/src/components/theme/theme-provider.tsx
+++ b/libs/shared/react/ui/src/components/theme/theme-provider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {type ReactNode, useEffect, useState} from 'react';
 import {type Theme, ThemeProviderContext} from '#state/theme.js';
 

--- a/libs/shared/react/ui/src/components/toast/toast-custom.tsx
+++ b/libs/shared/react/ui/src/components/toast/toast-custom.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ReactNode} from 'react';
 import {Icon} from '#components/icon/icon.js';

--- a/libs/shared/react/ui/src/components/toast/toast.tsx
+++ b/libs/shared/react/ui/src/components/toast/toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import {AlertTriangle, CheckCircle2, Info, Loader2, XCircle} from 'lucide-react';
 import {
   Toaster as SonnerToaster,

--- a/libs/shared/react/ui/src/components/tooltip/tooltip.tsx
+++ b/libs/shared/react/ui/src/components/tooltip/tooltip.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 import {cva, type VariantProps} from 'class-variance-authority';
 import {motion, type Transition} from 'framer-motion';

--- a/libs/shared/react/ui/src/hooks/useMediaQuery.ts
+++ b/libs/shared/react/ui/src/hooks/useMediaQuery.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {useEffect, useState} from 'react';
 
 class MediaQueryManager {

--- a/libs/shared/react/ui/src/hooks/useResolvedTheme.ts
+++ b/libs/shared/react/ui/src/hooks/useResolvedTheme.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {useSyncExternalStore} from 'react';
 import {useTheme} from './useTheme.js';
 

--- a/libs/shared/react/ui/src/hooks/useTheme.ts
+++ b/libs/shared/react/ui/src/hooks/useTheme.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {useContext} from 'react';
 import {ThemeProviderContext} from '#state/theme.js';
 

--- a/libs/shared/react/ui/src/state/theme.ts
+++ b/libs/shared/react/ui/src/state/theme.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {createContext} from 'react';
 
 export type Theme = 'dark' | 'light' | 'system';


### PR DESCRIPTION
`@shipfox/react-ui` is published and consumed by Next.js App Router apps, but none of its modules carried `"use client"` directives. Under React Server Components, any component that uses hooks, context, browser APIs, or third-party client primitives throws at build/runtime the moment a server component imports it.

This adds `"use client"` to every module that *intrinsically* requires the client runtime:

- **Hooks / context / browser APIs**: `useTheme`, `useResolvedTheme`, `useMediaQuery`, `state/theme`, `theme-provider`.
- **Radix / cmdk / vaul / sonner / framer-motion wrappers**: button (+ link/icon), input, label, tabs, tooltip, dropdown-menu, combobox, form-field, popover, scroll-area, command, select, modal, sheet, toast (+ custom), avatar (+ group), alert, spinner, shipfox-loader.
- **In-module event handlers**: `badge` (renders an internal `<button onClick>`), `logo` (`useResolvedTheme`).

Purely presentational modules are deliberately left **unmarked** so they remain shared modules that Next.js can still render on the server (zero JS): typography, card, kbd, skeleton, table, inline-tips, icon + static SVG icons, status-badge, full-page-loader, and the `utils/*`. Barrel `index.ts` files are also left alone — the directive belongs on the leaf module, and marking a barrel would force the entire library client-side.

Verified that SWC preserves `'use client';` as the literal first statement in the published `dist/` output (it hoists the jsx-runtime import beneath it), so the directives actually ship to consumers. `turbo build`, `check`, and the full `test` suite (incl. the react-ui browser/Storybook tests) pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add "use client" to client-only modules in `@shipfox/react-ui` so Next.js App Router and other RSC consumers render interactive components without build/runtime errors. Presentational components stay server-rendered.

- **New Features**
  - Marked modules that use hooks, context, browser APIs, or client libs (`@radix-ui/*`, `cmdk`, `sonner`, `framer-motion`, etc.) with "use client".
  - Left presentational modules and barrel files unmarked to keep zero-JS SSR and avoid forcing the whole library client-side.
  - Verified the build keeps the directive as the first statement in `dist/` so consumers get correct client boundaries.

<sup>Written for commit b7f2a86d6692e4e80fbcf1beb88140744051bca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/platform/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

