### PR TITLE
Raise Renovate minimum release age to 7 days; add pnpm policy at 48h

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,4 +11,4 @@ _.path = ['{{config_root}}/node_modules/.bin']
 
 [settings]
 lockfile       = true
-install_before = "48h"
+minimum_release_age = "48h"

--- a/mise.toml
+++ b/mise.toml
@@ -11,4 +11,4 @@ _.path = ['{{config_root}}/node_modules/.bin']
 
 [settings]
 lockfile       = true
-install_before = "48h"
+install_before = "7d"

--- a/mise.toml
+++ b/mise.toml
@@ -11,4 +11,4 @@ _.path = ['{{config_root}}/node_modules/.bin']
 
 [settings]
 lockfile       = true
-install_before = "7d"
+install_before = "48h"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 strictPeerDependencies: true
 dedupePeerDependents: true
 nodeLinker: isolated
+minimumReleaseAge: 2880
 allowBuilds:
   '@swc/core': true
   esbuild: true

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
     ":gitSignOff",
     "schedule:daily"
   ],
-  "minimumReleaseAge": "48 hours",
+  "minimumReleaseAge": "7 days",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "prHourlyLimit": 5,


### PR DESCRIPTION
Raise Renovate's `minimumReleaseAge` to 7 days so freshly published
packages soak for a week before we adopt them. Reduces exposure to
supply-chain attacks (typosquats, compromised maintainer accounts) and
unstable initial releases.

Also enable pnpm's own `minimumReleaseAge` as a defense-in-depth check
at install time, so a freshly committed lockfile that somehow bypassed
Renovate still gets rejected locally and in CI.

`pnpm-workspace.yaml` is held at 48 hours, and `mise.toml` stays at its
existing 48h, because several pinned versions are themselves less than
7 days old and would otherwise break installs:

- `@biomejs/biome@2.4.16`, `@tanstack/react-router@^1.170.10`,
  `@tanstack/router-plugin@^1.168.13` — block `pnpm install`
- `pnpm@11.5.0`, `turbo@2.9.16` (mise) — block `mise install`

Renovate's `tanstack-router` group has `rangeStrategy: "bump"` and
Renovate itself manages the mise tool versions, so once those pins age
past 7 days we can raise pnpm and mise to match without further
intervention.

Verified `pnpm install --frozen-lockfile` succeeds against the existing
lockfile under the 48h policy, so no lockfile churn in this PR.