### PR TITLE
Add workflow expression modules

### DIFF
--- a/.changeset/calm-lemons-express.md
+++ b/.changeset/calm-lemons-express.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/expression-language": minor
+"@shipfox/expression-evaluator": minor
+---
+
+Adds shared CEL expression language and evaluator packages behind Shipfox-owned APIs.

--- a/libs/shared/expression/evaluator/README.md
+++ b/libs/shared/expression/evaluator/README.md
@@ -1,0 +1,67 @@
+# Expression Evaluator
+
+Shared CEL evaluation for validated Shipfox expressions.
+
+## What it does
+
+- `evaluateWorkflowExpression` runs a validated `WorkflowExpression` against supplied values.
+- `evaluateWorkflowPredicate` returns `true` only when the expression result is the boolean `true`.
+- `WorkflowExpressionEvaluationError` wraps evaluation failures from the CEL engine.
+
+Use this package after an expression has already been accepted by `@shipfox/expression-language`. The caller supplies all values. The evaluator does not fetch data.
+
+Think of this as the last step. The text was checked before. Now the caller gives the values for this run, and this part returns a value. It should be easy to test because it only uses what the caller gives it.
+
+## Installation
+
+```sh
+pnpm add @shipfox/expression-evaluator
+```
+
+## Usage
+
+```ts
+import {createWorkflowExpression} from '@shipfox/expression-language';
+import {evaluateWorkflowPredicate} from '@shipfox/expression-evaluator';
+
+const expression = createWorkflowExpression({
+  source: 'event.conclusion == "success"',
+  typeEnvironment: {
+    event: {kind: 'object', fields: {conclusion: 'string'}},
+  },
+});
+
+const passed = evaluateWorkflowPredicate(expression, {
+  event: {conclusion: 'success'},
+});
+```
+
+## Behavior Notes
+
+- Evaluation is deterministic and side-effect-free.
+- The caller must pass values that match the type-checked context.
+- The evaluator does not read secrets, database rows, events, files, or external services.
+- The CEL engine stays hidden behind this package.
+
+Do not put side effects here. Do not read state here. Code that needs a row, file, secret, or event must get it before calling this package.
+
+When you add a new call site, build the data first. Then pass that data in one plain object. A test should be able to pass the same object and get the same answer.
+
+This keeps run logic clear and makes each test small.
+
+If the answer is wrong, change the data you pass in or change the checked text before this step.
+
+Keep this part small and easy to test.
+
+## Development
+
+```sh
+turbo build --filter=@shipfox/expression-evaluator
+turbo check --filter=@shipfox/expression-evaluator
+turbo type --filter=@shipfox/expression-evaluator
+turbo test --filter=@shipfox/expression-evaluator
+```
+
+## License
+
+MIT

--- a/libs/shared/expression/evaluator/package.json
+++ b/libs/shared/expression/evaluator/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@shipfox/expression-evaluator",
+  "license": "MIT",
+  "private": false,
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/shared/expression/evaluator"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@gresb/cel-javascript": "0.1.1",
+    "@shipfox/expression-language": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/shared/expression/evaluator/src/evaluator/errors.ts
+++ b/libs/shared/expression/evaluator/src/evaluator/errors.ts
@@ -1,0 +1,10 @@
+export const workflowExpressionEvaluationErrorCode = 'workflow-expression-evaluation-failed';
+
+export class WorkflowExpressionEvaluationError extends Error {
+  readonly code = workflowExpressionEvaluationErrorCode;
+
+  constructor(cause: unknown) {
+    super('Workflow expression evaluation failed', {cause});
+    this.name = 'WorkflowExpressionEvaluationError';
+  }
+}

--- a/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.test.ts
@@ -1,0 +1,69 @@
+import {createWorkflowExpression} from '@shipfox/expression-language';
+import {WorkflowExpressionEvaluationError} from './errors.js';
+import {
+  evaluateWorkflowExpression,
+  evaluateWorkflowPredicate,
+} from './evaluate-workflow-expression.js';
+
+describe('evaluateWorkflowExpression', () => {
+  it('evaluates a validated CEL expression against caller-provided values', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {conclusion: 'success'},
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('treats only the boolean true value as a passing predicate', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    const result = evaluateWorkflowPredicate(expression, {
+      event: {conclusion: 'success'},
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true for predicates that evaluate to the boolean true value', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    const result = evaluateWorkflowPredicate(expression, {
+      event: {conclusion: 'success'},
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('wraps evaluation errors when supplied values do not match the checked context', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    const act = () =>
+      evaluateWorkflowPredicate(expression, {
+        event: {},
+      });
+
+    expect(act).toThrow(WorkflowExpressionEvaluationError);
+  });
+});

--- a/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.ts
@@ -1,0 +1,25 @@
+import {Runtime} from '@gresb/cel-javascript';
+import type {WorkflowExpression} from '@shipfox/expression-language';
+import {WorkflowExpressionEvaluationError} from './errors.js';
+
+export type WorkflowExpressionEvaluationContext = Readonly<Record<string, unknown>>;
+export type WorkflowExpressionEvaluationValue = unknown;
+
+export function evaluateWorkflowExpression(
+  expression: WorkflowExpression,
+  context: WorkflowExpressionEvaluationContext,
+): WorkflowExpressionEvaluationValue {
+  try {
+    // The CEL engine validates against the supplied runtime values during evaluation.
+    return new Runtime(expression.source).evaluate(context);
+  } catch (error) {
+    throw new WorkflowExpressionEvaluationError(error);
+  }
+}
+
+export function evaluateWorkflowPredicate(
+  expression: WorkflowExpression,
+  context: WorkflowExpressionEvaluationContext,
+): boolean {
+  return evaluateWorkflowExpression(expression, context) === true;
+}

--- a/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.ts
@@ -10,7 +10,6 @@ export function evaluateWorkflowExpression(
   context: WorkflowExpressionEvaluationContext,
 ): WorkflowExpressionEvaluationValue {
   try {
-    // The CEL engine validates against the supplied runtime values during evaluation.
     return new Runtime(expression.source).evaluate(context);
   } catch (error) {
     throw new WorkflowExpressionEvaluationError(error);

--- a/libs/shared/expression/evaluator/src/evaluator/index.ts
+++ b/libs/shared/expression/evaluator/src/evaluator/index.ts
@@ -1,0 +1,10 @@
+export {
+  WorkflowExpressionEvaluationError,
+  workflowExpressionEvaluationErrorCode,
+} from './errors.js';
+export {
+  evaluateWorkflowExpression,
+  evaluateWorkflowPredicate,
+  type WorkflowExpressionEvaluationContext,
+  type WorkflowExpressionEvaluationValue,
+} from './evaluate-workflow-expression.js';

--- a/libs/shared/expression/evaluator/src/index.ts
+++ b/libs/shared/expression/evaluator/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  evaluateWorkflowExpression,
+  evaluateWorkflowPredicate,
+  type WorkflowExpressionEvaluationContext,
+  WorkflowExpressionEvaluationError,
+  type WorkflowExpressionEvaluationValue,
+  workflowExpressionEvaluationErrorCode,
+} from '#evaluator/index.js';

--- a/libs/shared/expression/evaluator/tsconfig.build.json
+++ b/libs/shared/expression/evaluator/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/shared/expression/evaluator/tsconfig.json
+++ b/libs/shared/expression/evaluator/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/shared/expression/evaluator/tsconfig.test.json
+++ b/libs/shared/expression/evaluator/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/shared/expression/evaluator/vitest.config.ts
+++ b/libs/shared/expression/evaluator/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/shared/expression/language/README.md
+++ b/libs/shared/expression/language/README.md
@@ -1,0 +1,85 @@
+# Expression Language
+
+Shared CEL parsing and type checks for Shipfox expressions.
+
+## What it does
+
+- `createWorkflowExpression` checks CEL source with a type environment.
+- `WorkflowExpression` stores `{language: 'cel', source}` with a branded source string.
+- `InvalidWorkflowExpressionError` reports parse and type errors.
+- `ExpressionTypeEnvironment` describes the names and field types visible to an expression.
+
+Use this package before raw expression text enters a workflow model. It keeps CEL behind a Shipfox API so the rest of the code does not depend on a vendor package.
+
+Think of this as a check at the edge. A user or tool gives some text. This part says if the text can be used in the place where it was found. If the text is good, later code can keep it. If the text is bad, stop and show the reason near the field.
+
+## Installation
+
+```sh
+pnpm add @shipfox/expression-language
+```
+
+## Usage
+
+```ts
+import {createWorkflowExpression} from '@shipfox/expression-language';
+
+const expression = createWorkflowExpression({
+  source: 'event.conclusion == "success"',
+  typeEnvironment: {
+    event: {
+      kind: 'object',
+      fields: {
+        conclusion: 'string',
+      },
+    },
+  },
+});
+
+expression; // {language: "cel", source: "event.conclusion == \"success\""}
+```
+
+## Context
+
+CEL is the selected expression language. The accepted stored shape is only the language tag and source string. Do not store vendor ASTs, checked data, protobuf bytes, or compiled objects.
+
+Expression contexts are lexical. The caller builds the type environment from the place where the expression appears in the workflow tree.
+
+Root bindings can include `trigger`, `inputs`, `env`, and `run`. Event-triggered filters can add `event`. Step, job, loop, and parallel bindings are available only when they are in scope and upstream. Secrets are not expression bindings.
+
+Type environments come from event schemas, workflow inputs, step output schemas, loop and parallel types, and run metadata. This package checks the source against that environment. It does not know about projects, users, the database, or the runtime.
+
+The place in the tree matters. A name that is in scope in one place may be out of scope in another place. Build the list of names first, then call this package. Keep that rule simple so a reader can tell why a name is allowed.
+
+## Behavior Notes
+
+- The parser trims source before storing it.
+- Bad source throws `InvalidWorkflowExpressionError`.
+- The package uses `@gresb/cel-javascript` internally.
+- The CEL dependency is patched for ESM packaging; re-check the patch when upgrading it.
+- Raw strings become branded only after this package accepts them.
+
+Do not pass user text around as if it were safe. Make it safe here first. That keeps later code small and makes tests easier to read.
+
+When you add a new place that can use this text, start by asking what names should be visible there. Add those names to the type map, add a test for a good field, and add a test for a bad field.
+
+This keeps the rule clear for both the next person and the next test.
+
+Keep it easy to follow.
+
+Keep it small.
+
+This helps the team find the right place to make a change.
+
+## Development
+
+```sh
+turbo build --filter=@shipfox/expression-language
+turbo check --filter=@shipfox/expression-language
+turbo type --filter=@shipfox/expression-language
+turbo test --filter=@shipfox/expression-language
+```
+
+## License
+
+MIT

--- a/libs/shared/expression/language/package.json
+++ b/libs/shared/expression/language/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@shipfox/expression-language",
+  "license": "MIT",
+  "private": false,
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/shared/expression/language"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@gresb/cel-javascript": "0.1.1"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/shared/expression/language/package.json
+++ b/libs/shared/expression/language/package.json
@@ -11,9 +11,6 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "imports": {
-    "#*": "./src/*"
-  },
   "files": [
     "dist"
   ],

--- a/libs/shared/expression/language/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/language/src/expression/create-workflow-expression.test.ts
@@ -1,0 +1,131 @@
+import {
+  createWorkflowExpression,
+  unsafeWorkflowExpressionFromSource,
+} from './create-workflow-expression.js';
+import {InvalidWorkflowExpressionError} from './errors.js';
+import type {ExpressionScalarType} from './workflow-expression.js';
+
+describe('createWorkflowExpression', () => {
+  it('returns a CEL workflow expression when the source parses and type-checks', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    expect(expression).toEqual({
+      language: 'cel',
+      source: 'event.conclusion == "success"',
+    });
+  });
+
+  it('rejects misspelled fields from the typed context', () => {
+    const act = () =>
+      createWorkflowExpression({
+        source: 'event.conclsion == "success"',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
+      });
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+    expect(act).toThrow('Invalid workflow expression');
+  });
+
+  it('exposes the source and type-check reason on invalid expression errors', () => {
+    let error: unknown;
+    try {
+      createWorkflowExpression({
+        source: 'event.conclsion == "success"',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(InvalidWorkflowExpressionError);
+    expect(error).toMatchObject({
+      code: 'invalid-workflow-expression',
+      name: 'InvalidWorkflowExpressionError',
+      source: 'event.conclsion == "success"',
+    });
+    expect((error as InvalidWorkflowExpressionError).reason).toContain('conclsion');
+  });
+
+  it.each([
+    ['string', 'event.value == "success"'],
+    ['int', 'event.value >= 1'],
+    ['uint', 'event.value >= 1'],
+    ['double', 'event.value >= 1.5'],
+    ['bool', 'event.value == true'],
+    ['null', 'event.value == null'],
+    ['timestamp', 'event.value < timestamp("2026-01-01T00:00:00Z")'],
+  ] satisfies readonly [
+    ExpressionScalarType,
+    string,
+  ][])('type-checks %s fields', (scalarType, source) => {
+    const expression = createWorkflowExpression({
+      source,
+      typeEnvironment: {
+        event: {kind: 'object', fields: {value: scalarType}},
+      },
+    });
+
+    expect(expression).toEqual({
+      language: 'cel',
+      source,
+    });
+  });
+
+  it('rejects parse errors before type checking', () => {
+    const act = () =>
+      createWorkflowExpression({
+        source: 'event.conclusion ==',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
+      });
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
+  it('rejects blank sources', () => {
+    const act = () => createWorkflowExpression({source: '   '});
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
+  it('trims accepted sources before storing them', () => {
+    const expression = createWorkflowExpression({
+      source: '  event.conclusion == "success"  ',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    expect(expression.source).toBe('event.conclusion == "success"');
+  });
+
+  it('does not expose vendor ASTs or checked metadata', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      typeEnvironment: {
+        event: {kind: 'object', fields: {conclusion: 'string'}},
+      },
+    });
+
+    expect(Object.keys(expression)).toEqual(['language', 'source']);
+  });
+
+  it('rehydrates already-validated sources without calling the CEL parser', () => {
+    const expression = unsafeWorkflowExpressionFromSource('event.conclusion == "success"');
+
+    expect(expression).toEqual({
+      language: 'cel',
+      source: 'event.conclusion == "success"',
+    });
+  });
+});

--- a/libs/shared/expression/language/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/language/src/expression/create-workflow-expression.test.ts
@@ -58,7 +58,6 @@ describe('createWorkflowExpression', () => {
   it.each([
     ['string', 'event.value == "success"'],
     ['int', 'event.value >= 1'],
-    ['uint', 'event.value >= 1'],
     ['double', 'event.value >= 1.5'],
     ['bool', 'event.value == true'],
     ['null', 'event.value == null'],

--- a/libs/shared/expression/language/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/language/src/expression/create-workflow-expression.ts
@@ -12,7 +12,6 @@ import type {
 const scalarTypeToCelType = {
   string: 'string',
   int: 'int',
-  uint: 'int',
   double: 'float',
   bool: 'bool',
   null: 'null',

--- a/libs/shared/expression/language/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/language/src/expression/create-workflow-expression.ts
@@ -1,0 +1,82 @@
+import {Runtime} from '@gresb/cel-javascript';
+import {InvalidWorkflowExpressionError} from './errors.js';
+import type {
+  CreateWorkflowExpressionParams,
+  ExpressionScalarType,
+  ExpressionType,
+  ExpressionTypeEnvironment,
+  ValidCelExpression,
+  WorkflowExpression,
+} from './workflow-expression.js';
+
+const scalarTypeToCelType = {
+  string: 'string',
+  int: 'int',
+  uint: 'int',
+  double: 'float',
+  bool: 'bool',
+  null: 'null',
+  timestamp: 'timestamp',
+} satisfies Record<ExpressionScalarType, string>;
+
+export function createWorkflowExpression(
+  params: CreateWorkflowExpressionParams,
+): WorkflowExpression {
+  const source = params.source.trim();
+  if (source.length === 0) {
+    throw new InvalidWorkflowExpressionError({
+      source: params.source,
+      reason: 'Expression source must not be empty.',
+    });
+  }
+
+  const parseResult = Runtime.parseString(source);
+  if (!parseResult.success) {
+    throw new InvalidWorkflowExpressionError({
+      source,
+      reason: parseResult.error ?? 'Expression source could not be parsed.',
+    });
+  }
+
+  const typeCheckResult = Runtime.typeCheck(
+    source,
+    {},
+    toCelTypeEnvironment(params.typeEnvironment ?? {}),
+  );
+  if (!typeCheckResult.success) {
+    throw new InvalidWorkflowExpressionError({
+      source,
+      reason: typeCheckResult.error ?? 'Expression source did not type-check.',
+    });
+  }
+
+  return {
+    language: 'cel',
+    source: source as ValidCelExpression,
+  };
+}
+
+export function unsafeWorkflowExpressionFromSource(source: string): WorkflowExpression {
+  // Use only when rehydrating a source that was already validated before storage.
+  return {
+    language: 'cel',
+    source: source as ValidCelExpression,
+  };
+}
+
+function toCelTypeEnvironment(
+  typeEnvironment: ExpressionTypeEnvironment,
+): Record<string, string | Record<string, unknown> | unknown[]> {
+  return Object.fromEntries(
+    Object.entries(typeEnvironment).map(([name, type]) => [name, toCelType(type)]),
+  );
+}
+
+function toCelType(type: ExpressionType): string | Record<string, unknown> | unknown[] {
+  if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'list') return [toCelType(type.element)];
+
+  return Object.fromEntries(
+    Object.entries(type.fields).map(([name, field]) => [name, toCelType(field)]),
+  );
+}

--- a/libs/shared/expression/language/src/expression/errors.ts
+++ b/libs/shared/expression/language/src/expression/errors.ts
@@ -1,0 +1,14 @@
+export const invalidWorkflowExpressionErrorCode = 'invalid-workflow-expression';
+
+export class InvalidWorkflowExpressionError extends Error {
+  readonly code = invalidWorkflowExpressionErrorCode;
+  readonly source: string;
+  readonly reason: string;
+
+  constructor(params: {source: string; reason: string; cause?: unknown}) {
+    super('Invalid workflow expression', {cause: params.cause});
+    this.name = 'InvalidWorkflowExpressionError';
+    this.source = params.source;
+    this.reason = params.reason;
+  }
+}

--- a/libs/shared/expression/language/src/expression/index.ts
+++ b/libs/shared/expression/language/src/expression/index.ts
@@ -1,0 +1,13 @@
+export {
+  createWorkflowExpression,
+  unsafeWorkflowExpressionFromSource,
+} from './create-workflow-expression.js';
+export {InvalidWorkflowExpressionError, invalidWorkflowExpressionErrorCode} from './errors.js';
+export type {
+  CreateWorkflowExpressionParams,
+  ExpressionScalarType,
+  ExpressionType,
+  ExpressionTypeEnvironment,
+  ValidCelExpression,
+  WorkflowExpression,
+} from './workflow-expression.js';

--- a/libs/shared/expression/language/src/expression/workflow-expression.ts
+++ b/libs/shared/expression/language/src/expression/workflow-expression.ts
@@ -5,14 +5,7 @@ export interface WorkflowExpression {
   source: ValidCelExpression;
 }
 
-export type ExpressionScalarType =
-  | 'string'
-  | 'int'
-  | 'uint'
-  | 'double'
-  | 'bool'
-  | 'null'
-  | 'timestamp';
+export type ExpressionScalarType = 'string' | 'int' | 'double' | 'bool' | 'null' | 'timestamp';
 
 export type ExpressionType =
   | ExpressionScalarType

--- a/libs/shared/expression/language/src/expression/workflow-expression.ts
+++ b/libs/shared/expression/language/src/expression/workflow-expression.ts
@@ -1,0 +1,33 @@
+export type ValidCelExpression = string & {readonly __validCelExpression: unique symbol};
+
+export interface WorkflowExpression {
+  language: 'cel';
+  source: ValidCelExpression;
+}
+
+export type ExpressionScalarType =
+  | 'string'
+  | 'int'
+  | 'uint'
+  | 'double'
+  | 'bool'
+  | 'null'
+  | 'timestamp';
+
+export type ExpressionType =
+  | ExpressionScalarType
+  | {
+      kind: 'object';
+      fields: Readonly<Record<string, ExpressionType>>;
+    }
+  | {
+      kind: 'list';
+      element: ExpressionType;
+    };
+
+export type ExpressionTypeEnvironment = Readonly<Record<string, ExpressionType>>;
+
+export interface CreateWorkflowExpressionParams {
+  source: string;
+  typeEnvironment?: ExpressionTypeEnvironment;
+}

--- a/libs/shared/expression/language/src/index.ts
+++ b/libs/shared/expression/language/src/index.ts
@@ -9,4 +9,4 @@ export {
   unsafeWorkflowExpressionFromSource,
   type ValidCelExpression,
   type WorkflowExpression,
-} from '#expression/index.js';
+} from './expression/index.js';

--- a/libs/shared/expression/language/src/index.ts
+++ b/libs/shared/expression/language/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  type CreateWorkflowExpressionParams,
+  createWorkflowExpression,
+  type ExpressionScalarType,
+  type ExpressionType,
+  type ExpressionTypeEnvironment,
+  InvalidWorkflowExpressionError,
+  invalidWorkflowExpressionErrorCode,
+  unsafeWorkflowExpressionFromSource,
+  type ValidCelExpression,
+  type WorkflowExpression,
+} from '#expression/index.js';

--- a/libs/shared/expression/language/tsconfig.build.json
+++ b/libs/shared/expression/language/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/shared/expression/language/tsconfig.json
+++ b/libs/shared/expression/language/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/shared/expression/language/tsconfig.test.json
+++ b/libs/shared/expression/language/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/shared/expression/language/vitest.config.ts
+++ b/libs/shared/expression/language/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/patches/@gresb__cel-javascript@0.1.1.patch
+++ b/patches/@gresb__cel-javascript@0.1.1.patch
@@ -1,0 +1,75 @@
+diff --git a/lib/Evaluator.js b/lib/Evaluator.js
+index 838f17a09d8bbeba9f9e3ff05f79115d9e853335..26cedc22f0aa2b6c31ed91db6fd465085db7c2d6 100644
+--- a/lib/Evaluator.js
++++ b/lib/Evaluator.js
+@@ -1,6 +1,6 @@
+-import CELVisitor from './generated/CELVisitor';
+-import { builtInFunctions } from './BuiltInFunctions';
+-import Context from './Context';
++import CELVisitor from './generated/CELVisitor.js';
++import { builtInFunctions } from './BuiltInFunctions.js';
++import Context from './Context.js';
+ /**
+  * Validates if a string represents a valid timestamp in ISO 8601 format.
+  * Accepts both date-only (YYYY-MM-DD) and full datetime formats.
+diff --git a/lib/Runtime.js b/lib/Runtime.js
+index 6234a0570b8a1fb8dd0aa936e768f6c8c5f461a7..fe038fed1a3cad0347d602923df0558078760005 100644
+--- a/lib/Runtime.js
++++ b/lib/Runtime.js
+@@ -1,10 +1,10 @@
+ import antlr4 from 'antlr4';
+ import CELLexer from './generated/CELLexer.js';
+ import CELParser from './generated/CELParser.js';
+-import Evaluator from './Evaluator';
+-import Context from './Context';
+-import { ErrorCollector } from './ErrorCollector';
+-import TypeChecker from './TypeChecker';
++import Evaluator from './Evaluator.js';
++import Context from './Context.js';
++import { ErrorCollector } from './ErrorCollector.js';
++import TypeChecker from './TypeChecker.js';
+ export class Runtime {
+     constructor(celExpression) {
+         this.ast = null;
+diff --git a/lib/TypeChecker.js b/lib/TypeChecker.js
+index 8c13a925e9636cdd47df79b91618d13408cda4c3..5ad5cd287b93a28fb4e5bf87d1064ae4f696c85a 100644
+--- a/lib/TypeChecker.js
++++ b/lib/TypeChecker.js
+@@ -1,5 +1,5 @@
+-import CELVisitor from './generated/CELVisitor';
+-import Context from './Context';
++import CELVisitor from './generated/CELVisitor.js';
++import Context from './Context.js';
+ class TypeChecker extends CELVisitor {
+     constructor(context) {
+         super();
+diff --git a/lib/index.js b/lib/index.js
+index 3a9b96d3a41fe1861d02c075d9ad70c0c22ae28b..cc4515cc61b3d800e89a24ef10f785529d4dc1aa 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1,2 +1,2 @@
+-export { Runtime } from './Runtime';
+-export { Evaluator } from './Evaluator';
++export { Runtime } from './Runtime.js';
++export { Evaluator } from './Evaluator.js';
+diff --git a/package.json b/package.json
+index e822ee5364420084d615dfe3a6d377e57c3cb831..e975892ffba8cafd96fedef3f2af61883262ab00 100644
+--- a/package.json
++++ b/package.json
+@@ -2,7 +2,7 @@
+   "name": "@gresb/cel-javascript",
+   "version": "0.1.1",
+   "description": "Parser and evaluator for Google's Common Expression Language (CEL) in JavaScript using ANTLR4",
+-  "main": "src/index.ts",
++  "main": "lib/index.js",
+   "type": "module",
+   "scripts": {
+     "build": "tsc",
+@@ -38,5 +38,6 @@
+   "bugs": {
+     "url": "https://github.com/GRESB/cel-javascript/issues"
+   },
+-  "homepage": "https://github.com/GRESB/cel-javascript#readme"
++  "homepage": "https://github.com/GRESB/cel-javascript#readme",
++  "types": "lib/index.d.ts"
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@gresb/cel-javascript@0.1.1': 25633d62641014489f723fad0b7e3a3e0e43505f3c7d0562a5988d3c77b63d19
+
 importers:
 
   .:
@@ -2174,11 +2177,36 @@ importers:
         specifier: workspace:*
         version: link:../../../../tools/vitest
 
-  libs/shared/workflow/document:
+  libs/shared/expression/evaluator:
     dependencies:
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+      '@gresb/cel-javascript':
+        specifier: 0.1.1
+        version: 0.1.1(patch_hash=25633d62641014489f723fad0b7e3a3e0e43505f3c7d0562a5988d3c77b63d19)
+      '@shipfox/expression-language':
+        specifier: workspace:*
+        version: link:../language
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
+  libs/shared/expression/language:
+    dependencies:
+      '@gresb/cel-javascript':
+        specifier: 0.1.1
+        version: 0.1.1(patch_hash=25633d62641014489f723fad0b7e3a3e0e43505f3c7d0562a5988d3c77b63d19)
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*
@@ -2730,6 +2758,28 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@29.1.1)(vite@8.0.15(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))
+
+  libs/shared/workflow/document:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
 
   tools/biome:
     dependencies:
@@ -3883,6 +3933,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@gresb/cel-javascript@0.1.1':
+    resolution: {integrity: sha512-jknjyuWYH5wls2Nvae5xG7nIlpECS+2Dtqj2+lnatQ5gchKUBfdgnMLup7z2C2Zxzl3UvlKjP+2lGrs/epRIaw==}
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -6764,6 +6817,10 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  antlr4@4.13.2:
+    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
+    engines: {node: '>=16'}
 
   arch@3.0.0:
     resolution: {integrity: sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==}
@@ -10255,6 +10312,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@gresb/cel-javascript@0.1.1(patch_hash=25633d62641014489f723fad0b7e3a3e0e43505f3c7d0562a5988d3c77b63d19)':
+    dependencies:
+      antlr4: 4.13.2
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -13291,6 +13352,8 @@ snapshots:
   ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
+
+  antlr4@4.13.2: {}
 
   arch@3.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,6 @@ packages:
   - "turbo/**"
   - "!**/vite/types/**"
   - "!**/node_modules/**"
+
+patchedDependencies:
+  '@gresb/cel-javascript@0.1.1': patches/@gresb__cel-javascript@0.1.1.patch


### PR DESCRIPTION
## Objective

Adds Shipfox-owned expression modules that hide the selected CEL implementation behind stable package APIs.

This PR intentionally keeps expression parsing and evaluation separate from workflow parsing/modeling. It establishes the expression contract that later workflow-model work can depend on without exposing `@gresb/cel-javascript` directly.

## Scope

- Adds `@shipfox/expression-language` in `libs/shared/expression/language`.
  - Parses and type-checks CEL source with a caller-provided type environment.
  - Returns `WorkflowExpression` values with a branded `ValidCelExpression` source.
  - Documents the lexical workflow expression-context model.
- Adds `@shipfox/expression-evaluator` in `libs/shared/expression/evaluator`.
  - Evaluates validated expressions against caller-provided runtime values.
  - Keeps evaluation deterministic and side-effect-free.
- Patches `@gresb/cel-javascript@0.1.1` packaging so it can be imported from Shipfox ESM packages.

Persisted expressions remain only:

```ts
{ language: 'cel', source: string }
```

No CEL AST, checked protobuf, compiled object, or vendor metadata is persisted. Trigger-filter expression parsing/type-checking is deferred until event-schema-backed type environments are introduced.

## Validation

- `mise exec -- turbo build --filter=@shipfox/expression-language --filter=@shipfox/expression-evaluator`
- `mise exec -- turbo type --filter=@shipfox/expression-language --filter=@shipfox/expression-evaluator`
- `mise exec -- turbo test --filter=@shipfox/expression-language --filter=@shipfox/expression-evaluator`
- `mise exec -- turbo check --filter=@shipfox/expression-language --filter=@shipfox/expression-evaluator`
- README readability checks for both expression packages
- `mise exec -- turbo build --filter '...[origin/main]'`
- `mise exec -- turbo test --filter '...[origin/main]'`
- `mise exec -- turbo check --filter '...[origin/main]'`

## Review

Claude consult review was run for this rewritten PR. Accepted recommendations were applied, including broader scalar type coverage, less brittle vendor-error assertions, extra evaluator tests, and README notes about the temporary vendor patch.

<!-- stk:begin -->
## Stack

Part 2 of 7.

Depends on: #125
Next: #127

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 | #125 | `workflow-config-reference` | `main` |
| 2 (current) | #126 | `workflow-yaml-surface` | `workflow-config-reference` |
| 3 | #127 | `workflow-expressions` | `workflow-yaml-surface` |
| 4 | #128 | `workflow-model-ir` | `workflow-expressions` |
| 5 | #129 | `workflow-definitions-integration` | `workflow-model-ir` |
| 6 | #130 | `workflow-runtime-scheduling` | `workflow-definitions-integration` |
| 7 | #131 | `workflow-runtime-kernel-spike` | `workflow-runtime-scheduling` |

<!-- stk:end -->