### PR TITLE
Add workflow step gates

### DIFF
--- a/.changeset/gentle-gates-open.md
+++ b/.changeset/gentle-gates-open.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": minor
+---
+
+Adds step gates with `success_if` and `on_failure` to the workflow document shape.

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -42,6 +42,7 @@
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-projects": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
+    "@shipfox/expression-language": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/definitions/src/core/entities/workflow-model.ts
+++ b/libs/api/definitions/src/core/entities/workflow-model.ts
@@ -1,3 +1,5 @@
+import type {WorkflowExpression} from '@shipfox/expression-language';
+
 export interface WorkflowModel {
   readonly kind: 'workflow';
   readonly name: string;
@@ -28,11 +30,22 @@ export interface WorkflowModelStep {
   readonly sourceName?: string;
   readonly kind: 'run';
   readonly command: WorkflowModelRunCommand;
+  readonly gate?: WorkflowModelStepGate;
 }
 
 export interface WorkflowModelRunCommand {
   readonly kind: 'shell';
   readonly value: string;
+}
+
+export interface WorkflowModelStepGate {
+  readonly successIf?: WorkflowExpression;
+  readonly onFailure?: WorkflowModelStepFailureAction;
+}
+
+export interface WorkflowModelStepFailureAction {
+  readonly restartFrom: string;
+  readonly output?: string;
 }
 
 export interface WorkflowModelDependency {

--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -8,6 +8,9 @@ Code that turns a checked workflow document into the model used by definitions.
   parsing.
 - **`normalizeWorkflowDocument(document)`**: Applies defaults, expands
   shorthand fields, assigns stable ids, and builds graph edges.
+- **Step gates**: Parse run-step `gate.success_if` as CEL with `exit_code` in
+  scope and check `gate.on_failure.restart_from` against earlier named steps in
+  the same job.
 - **`InvalidWorkflowModelError`**: Reports semantic workflow errors found during
   normalization.
 
@@ -67,12 +70,31 @@ file paths. Those fields belong to `WorkflowDefinition`.
 Trigger filters stay as source strings in this module for now. A later change
 will type-check them when event schemas define the expression context.
 
+Run-step gate expressions are different. They have a small local result context,
+so this module can parse and type-check `success_if` now. The accepted model
+stores a `WorkflowExpression` with `language: 'cel'` and the original source
+string.
+
+For now, run-step gates can use `exit_code`. Fields such as `step.output.pass`
+need a declared output schema, so they belong to later agent-step work.
+
+`on_failure.restart_from` must name an earlier step in the same job. The runtime
+host does not execute restart semantics yet. This module only records the
+accepted meaning in the model.
+
 If a rule needs project data or database state, put that rule in another layer.
 This module should stay pure and easy to test.
 
 If a rule can be checked from the document alone, it can live here. If a rule
-needs a project, a user, a commit, or a row from the database, it should live
-with that data.
+needs a project, a user, a commit, or a database row, it should live with that
+data.
+
+Run this step before saving a new definition. That way bad links, bad ids, and
+bad gate rules stop early, while the caller still knows which file field caused
+the problem.
+
+This also makes the next step simpler. The next step can read one clear shape
+instead of checking many short forms again.
 
 ## Development
 

--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -72,8 +72,8 @@ will type-check them when event schemas define the expression context.
 
 Run-step gate expressions are different. They have a small local result context,
 so this module can parse and type-check `success_if` now. The accepted model
-stores a `WorkflowExpression` with `language: 'cel'` and the original source
-string.
+stores a typed `WorkflowExpression` with `language: 'cel'`, the original source
+string, and `check: 'typed'`.
 
 For now, run-step gates can use `exit_code`. Fields such as `step.output.pass`
 need a declared output schema, so they belong to later agent-step work.

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -4,6 +4,8 @@ export type WorkflowModelValidationIssueCode =
   | 'duplicate-job-id'
   | 'duplicate-step-id'
   | 'duplicate-trigger-id'
+  | 'invalid-step-gate-restart-from'
+  | 'invalid-step-gate-success-if'
   | 'job-dependency-cycle'
   | 'multiple-manual-triggers'
   | 'self-job-dependency'

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -196,6 +196,7 @@ describe('normalizeWorkflowDocument', () => {
         successIf: {
           language: 'cel',
           source: 'exit_code == 0',
+          check: 'typed',
         },
         onFailure: {
           restartFrom: 'producer',
@@ -220,6 +221,7 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.jobs[0]?.steps[0]?.gate?.successIf).toEqual({
       language: 'cel',
       source: 'exit_code == 0',
+      check: 'typed',
     });
   });
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -163,6 +163,192 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.dependencies).toEqual([{from: 'build', to: 'test'}]);
   });
 
+  it('normalizes step gates with success conditions and failure actions', () => {
+    const reviewOutput = 'Agent rejected the PR $' + '{{ step.output.review }}';
+    const document: WorkflowDocument = {
+      name: 'review loop',
+      jobs: {
+        review: {
+          steps: [
+            {name: 'producer', run: 'npm run build'},
+            {
+              name: 'reviewer',
+              run: 'npm run review',
+              gate: {
+                success_if: 'exit_code == 0',
+                on_failure: {
+                  restart_from: 'producer',
+                  output: reviewOutput,
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[1]).toMatchObject({
+      id: 'review-reviewer',
+      sourceName: 'reviewer',
+      gate: {
+        successIf: {
+          language: 'cel',
+          source: 'exit_code == 0',
+        },
+        onFailure: {
+          restartFrom: 'producer',
+          output: reviewOutput,
+        },
+      },
+    });
+  });
+
+  it('normalizes run step exit-code gates', () => {
+    const document: WorkflowDocument = {
+      name: 'simple build',
+      jobs: {
+        build: {
+          steps: [{name: 'build', run: 'npm run build', gate: {success_if: 'exit_code == 0'}}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]?.gate?.successIf).toEqual({
+      language: 'cel',
+      source: 'exit_code == 0',
+    });
+  });
+
+  it('normalizes on_failure-only gates', () => {
+    const document: WorkflowDocument = {
+      name: 'retry build',
+      jobs: {
+        build: {
+          steps: [
+            {name: 'install', run: 'npm install'},
+            {name: 'build', run: 'npm run build', gate: {on_failure: {restart_from: 'install'}}},
+          ],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[1]?.gate).toEqual({
+      onFailure: {restartFrom: 'install'},
+    });
+  });
+
+  it('reports invalid gate success_if expressions', () => {
+    const document: WorkflowDocument = {
+      name: 'invalid gate',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build', gate: {success_if: 'step.output.pass == true'}}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid-step-gate-success-if',
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
+        details: expect.objectContaining({source: 'step.output.pass == true'}),
+      }),
+    ]);
+  });
+
+  it('reports gate restart_from references to unknown steps', () => {
+    const document: WorkflowDocument = {
+      name: 'invalid gate',
+      jobs: {
+        build: {
+          steps: [
+            {
+              name: 'review',
+              run: 'npm run review',
+              gate: {on_failure: {restart_from: 'producer'}},
+            },
+          ],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code: 'invalid-step-gate-restart-from',
+        message: 'Step "build-review" must restart from an earlier named step; found "producer".',
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'on_failure'],
+        details: {stepId: 'build-review', restartFrom: 'producer'},
+      },
+    ]);
+  });
+
+  it('reports gate restart_from references to the same step', () => {
+    const document: WorkflowDocument = {
+      name: 'invalid gate',
+      jobs: {
+        build: {
+          steps: [
+            {
+              name: 'review',
+              run: 'npm run review',
+              gate: {on_failure: {restart_from: 'review'}},
+            },
+          ],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code: 'invalid-step-gate-restart-from',
+        message: 'Step "build-review" must restart from an earlier named step; found "review".',
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'on_failure'],
+        details: {stepId: 'build-review', restartFrom: 'review'},
+      },
+    ]);
+  });
+
+  it('reports gate restart_from references to later steps', () => {
+    const document: WorkflowDocument = {
+      name: 'invalid gate',
+      jobs: {
+        build: {
+          steps: [
+            {
+              name: 'review',
+              run: 'npm run review',
+              gate: {on_failure: {restart_from: 'producer'}},
+            },
+            {name: 'producer', run: 'npm run build'},
+          ],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code: 'invalid-step-gate-restart-from',
+        message: 'Step "build-review" must restart from an earlier named step; found "producer".',
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'on_failure'],
+        details: {stepId: 'build-review', restartFrom: 'producer'},
+      },
+    ]);
+  });
+
   it('reports unknown dependencies', () => {
     const document: WorkflowDocument = {
       name: 'unknown dependency',

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -257,8 +257,11 @@ function normalizeGateSuccessIf(params: {
   try {
     return createWorkflowExpression({
       source: params.source,
-      typeEnvironment: {
-        exit_code: 'int',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          exit_code: 'int',
+        },
       },
     });
   } catch (error) {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -1,9 +1,19 @@
-import type {WorkflowDocument, WorkflowDocumentJob} from '@shipfox/workflow-document';
+import {
+  createWorkflowExpression,
+  InvalidWorkflowExpressionError,
+  type WorkflowExpression,
+} from '@shipfox/expression-language';
+import type {
+  WorkflowDocument,
+  WorkflowDocumentJob,
+  WorkflowDocumentRunStep,
+} from '@shipfox/workflow-document';
 import type {
   WorkflowModel,
   WorkflowModelDependency,
   WorkflowModelJob,
   WorkflowModelStep,
+  WorkflowModelStepGate,
   WorkflowModelTrigger,
 } from '../entities/workflow-model.js';
 import {
@@ -155,11 +165,25 @@ function normalizeJobs(
         usedStepIds.set(stepId, index);
       }
 
+      const gate = normalizeStepGate({
+        step,
+        sourceName,
+        stepIndex: index,
+        stepId,
+        previousStepSourceNames: new Set(
+          job.steps
+            .slice(0, index)
+            .flatMap((candidate) => (candidate.name ? [candidate.name] : [])),
+        ),
+        issues,
+      });
+
       return {
         id: stepId,
         ...(stepSourceName === undefined ? {} : {sourceName: stepSourceName}),
         kind: 'run',
         command: {kind: 'shell', value: step.run},
+        ...(gate === undefined ? {} : {gate}),
       };
     });
 
@@ -173,6 +197,87 @@ function normalizeJobs(
       },
     ];
   });
+}
+
+function normalizeStepGate(params: {
+  step: WorkflowDocumentRunStep;
+  sourceName: string;
+  stepIndex: number;
+  stepId: string;
+  previousStepSourceNames: ReadonlySet<string>;
+  issues: WorkflowModelValidationIssue[];
+}): WorkflowModelStepGate | undefined {
+  const gate = params.step.gate;
+  if (gate === undefined) return undefined;
+
+  const successIf = normalizeGateSuccessIf({
+    source: gate.success_if,
+    sourceName: params.sourceName,
+    stepIndex: params.stepIndex,
+    issues: params.issues,
+  });
+  const onFailure =
+    gate.on_failure === undefined
+      ? undefined
+      : {
+          restartFrom: gate.on_failure.restart_from,
+          ...(gate.on_failure.output === undefined ? {} : {output: gate.on_failure.output}),
+        };
+
+  if (
+    gate.on_failure !== undefined &&
+    !params.previousStepSourceNames.has(gate.on_failure.restart_from)
+  ) {
+    params.issues.push(
+      issue({
+        code: 'invalid-step-gate-restart-from',
+        message: `Step "${params.stepId}" must restart from an earlier named step; found "${gate.on_failure.restart_from}".`,
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'gate', 'on_failure'],
+        details: {stepId: params.stepId, restartFrom: gate.on_failure.restart_from},
+      }),
+    );
+  }
+
+  if (successIf === undefined && onFailure === undefined) return undefined;
+
+  return {
+    ...(successIf === undefined ? {} : {successIf}),
+    ...(onFailure === undefined ? {} : {onFailure}),
+  };
+}
+
+function normalizeGateSuccessIf(params: {
+  source: string | undefined;
+  sourceName: string;
+  stepIndex: number;
+  issues: WorkflowModelValidationIssue[];
+}): WorkflowExpression | undefined {
+  if (params.source === undefined) return undefined;
+
+  try {
+    return createWorkflowExpression({
+      source: params.source,
+      typeEnvironment: {
+        exit_code: 'int',
+      },
+    });
+  } catch (error) {
+    params.issues.push(
+      issue({
+        code: 'invalid-step-gate-success-if',
+        message: 'Step gate success_if must be a valid CEL boolean expression.',
+        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'gate', 'success_if'],
+        details: {
+          source: params.source,
+          reason:
+            error instanceof InvalidWorkflowExpressionError
+              ? error.reason
+              : 'Expression source did not parse or type-check.',
+        },
+      }),
+    );
+    return undefined;
+  }
 }
 
 function normalizeDependencies(

--- a/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.document.json
+++ b/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.document.json
@@ -15,7 +15,10 @@
         },
         {
           "name": "build",
-          "run": "npm run build"
+          "run": "npm run build",
+          "gate": {
+            "success_if": "exit_code == 0"
+          }
         }
       ]
     }

--- a/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.yaml
+++ b/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.yaml
@@ -10,3 +10,5 @@ jobs:
       - run: npm install
       - name: build
         run: npm run build
+        gate:
+          success_if: exit_code == 0

--- a/libs/api/workflows/src/core/workflow-runtime/README.md
+++ b/libs/api/workflows/src/core/workflow-runtime/README.md
@@ -36,6 +36,11 @@ For example, a run can have one build job and one test job. If the build job has
 
 The scheduler also accepts a `running` set. Jobs in that set have already been started by the host but have not completed yet. The scheduler will not start them again, and it will return no command when it must wait for a running job before more jobs can be scheduled.
 
+`materializeWorkflowModel` also serializes step gates into step config. It keeps
+the accepted `success_if` expression and `on_failure` action with the step that
+will run. It does not evaluate the expression or restart jobs. That work belongs
+to a later host change.
+
 ## Development
 
 ```sh

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -2,13 +2,30 @@ import type {WorkflowModel} from '@shipfox/api-definitions';
 import {workflowModel} from '#test/index.js';
 import {materializeWorkflowModel} from './materialize-workflow-model.js';
 
+type TestWorkflowExpression = NonNullable<
+  NonNullable<WorkflowModel['jobs'][number]['steps'][number]['gate']>['successIf']
+>;
+
+function expression(source: string): TestWorkflowExpression {
+  return {language: 'cel', source: source as TestWorkflowExpression['source']};
+}
+
 describe('materializeWorkflowModel', () => {
   it('converts workflow model jobs and steps to runtime rows', () => {
     const model = workflowModel({
       runner: 'ubuntu-latest',
       jobs: {
         build: {
-          steps: [{name: 'install', run: 'npm install'}, {run: 'npm run build'}],
+          steps: [
+            {name: 'install', run: 'npm install'},
+            {
+              run: 'npm run build',
+              gate: {
+                successIf: expression('exit_code == 0'),
+                onFailure: {restartFrom: 'install', output: 'Build failed'},
+              },
+            },
+          ],
         },
         test: {
           needs: 'build',
@@ -38,7 +55,13 @@ describe('materializeWorkflowModel', () => {
             sourceName: null,
             status: 'pending',
             type: 'run',
-            config: {run: 'npm run build'},
+            config: {
+              run: 'npm run build',
+              gate: {
+                success_if: {language: 'cel', source: 'exit_code == 0'},
+                on_failure: {restart_from: 'install', output: 'Build failed'},
+              },
+            },
             position: 1,
           },
         ],

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -7,7 +7,7 @@ type TestWorkflowExpression = NonNullable<
 >;
 
 function expression(source: string): TestWorkflowExpression {
-  return {language: 'cel', source: source as TestWorkflowExpression['source']};
+  return {language: 'cel', check: 'typed', source: source as TestWorkflowExpression['source']};
 }
 
 describe('materializeWorkflowModel', () => {
@@ -58,7 +58,7 @@ describe('materializeWorkflowModel', () => {
             config: {
               run: 'npm run build',
               gate: {
-                success_if: {language: 'cel', source: 'exit_code == 0'},
+                success_if: {language: 'cel', check: 'typed', source: 'exit_code == 0'},
                 on_failure: {restart_from: 'install', output: 'Build failed'},
               },
             },

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -51,5 +51,29 @@ function dependencySourceNames(
 }
 
 function stepConfig(step: WorkflowModelStep): Record<string, unknown> {
-  return {run: step.command.value};
+  return {
+    run: step.command.value,
+    ...(step.gate === undefined ? {} : {gate: stepGateConfig(step.gate)}),
+  };
+}
+
+function stepGateConfig(gate: NonNullable<WorkflowModelStep['gate']>): Record<string, unknown> {
+  return {
+    ...(gate.successIf === undefined
+      ? {}
+      : {
+          success_if: {
+            language: gate.successIf.language,
+            source: gate.successIf.source,
+          },
+        }),
+    ...(gate.onFailure === undefined
+      ? {}
+      : {
+          on_failure: {
+            restart_from: gate.onFailure.restartFrom,
+            ...(gate.onFailure.output === undefined ? {} : {output: gate.onFailure.output}),
+          },
+        }),
+  };
 }

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -64,6 +64,7 @@ function stepGateConfig(gate: NonNullable<WorkflowModelStep['gate']>): Record<st
       : {
           success_if: {
             language: gate.successIf.language,
+            check: gate.successIf.check,
             source: gate.successIf.source,
           },
         }),

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -3,6 +3,7 @@ import type {WorkflowModel} from '@shipfox/api-definitions';
 interface TestWorkflowStep {
   readonly name?: string | undefined;
   readonly run: string;
+  readonly gate?: WorkflowModel['jobs'][number]['steps'][number]['gate'] | undefined;
 }
 
 interface TestWorkflowJob {
@@ -38,6 +39,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
         ...(step.name === undefined ? {} : {sourceName: step.name}),
         kind: 'run' as const,
         command: {kind: 'shell' as const, value: step.run},
+        ...(step.gate === undefined ? {} : {gate: step.gate}),
       })),
     };
   });

--- a/libs/shared/expression/evaluator/README.md
+++ b/libs/shared/expression/evaluator/README.md
@@ -26,8 +26,11 @@ import {evaluateWorkflowPredicate} from '@shipfox/expression-evaluator';
 
 const expression = createWorkflowExpression({
   source: 'event.conclusion == "success"',
-  typeEnvironment: {
-    event: {kind: 'object', fields: {conclusion: 'string'}},
+  check: {
+    mode: 'typed',
+    typeEnvironment: {
+      event: {kind: 'object', fields: {conclusion: 'string'}},
+    },
   },
 });
 

--- a/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/evaluator/src/evaluator/evaluate-workflow-expression.test.ts
@@ -9,8 +9,11 @@ describe('evaluateWorkflowExpression', () => {
   it('evaluates a validated CEL expression against caller-provided values', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion == "success"',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 
@@ -24,8 +27,11 @@ describe('evaluateWorkflowExpression', () => {
   it('treats only the boolean true value as a passing predicate', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 
@@ -39,8 +45,11 @@ describe('evaluateWorkflowExpression', () => {
   it('returns true for predicates that evaluate to the boolean true value', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion == "success"',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 
@@ -54,8 +63,11 @@ describe('evaluateWorkflowExpression', () => {
   it('wraps evaluation errors when supplied values do not match the checked context', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion == "success"',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 

--- a/libs/shared/expression/language/README.md
+++ b/libs/shared/expression/language/README.md
@@ -1,19 +1,21 @@
 # Expression Language
 
-Shared CEL parsing and type checks for Shipfox expressions.
+Shared CEL parsing and type checks for Shipfox workflow expressions.
 
 ## What it does
 
-- `createWorkflowExpression` checks CEL source with a type environment.
-- `WorkflowExpression` stores `{language: 'cel', source}` with a branded source string.
-- `InvalidWorkflowExpressionError` reports parse and type errors.
-- `ExpressionTypeEnvironment` describes the names and field types visible to an expression.
+- **`createWorkflowExpression`**: Checks CEL source in either `syntax` or
+  `typed` mode and returns a stored Shipfox expression.
+- **`WorkflowExpression`**: Stores the CEL language tag, the checked source, and
+  the check level that was applied.
+- **`ExpressionTypeEnvironment`**: Describes the names and field types visible to
+  a typed expression.
+- **`InvalidWorkflowExpressionError`**: Reports parse and type-check failures.
 
-Use this package before raw expression text enters a workflow model. It keeps CEL behind a Shipfox API so the rest of the code does not depend on a vendor package.
+Use this package before raw expression text enters a workflow model. It keeps
+CEL behind a Shipfox API, so other packages do not depend on a vendor parser.
 
-Think of this as a check at the edge. A user or tool gives some text. This part says if the text can be used in the place where it was found. If the text is good, later code can keep it. If the text is bad, stop and show the reason near the field.
-
-## Installation
+## Installation / Setup
 
 ```sh
 pnpm add @shipfox/expression-language
@@ -24,52 +26,69 @@ pnpm add @shipfox/expression-language
 ```ts
 import {createWorkflowExpression} from '@shipfox/expression-language';
 
-const expression = createWorkflowExpression({
-  source: 'event.conclusion == "success"',
-  typeEnvironment: {
-    event: {
-      kind: 'object',
-      fields: {
-        conclusion: 'string',
-      },
+const triggerFilter = createWorkflowExpression({
+  source: 'event.ref == "refs/heads/main"',
+  check: {mode: 'syntax'},
+});
+
+const stepGate = createWorkflowExpression({
+  source: 'exit_code == 0',
+  check: {
+    mode: 'typed',
+    typeEnvironment: {
+      exit_code: 'int',
     },
   },
 });
 
-expression; // {language: "cel", source: "event.conclusion == \"success\""}
+console.log(triggerFilter.check); // "syntax"
+console.log(stepGate.check); // "typed"
 ```
-
-## Context
-
-CEL is the selected expression language. The accepted stored shape is only the language tag and source string. Do not store vendor ASTs, checked data, protobuf bytes, or compiled objects.
-
-Expression contexts are lexical. The caller builds the type environment from the place where the expression appears in the workflow tree.
-
-Root bindings can include `trigger`, `inputs`, `env`, and `run`. Event-triggered filters can add `event`. Step, job, loop, and parallel bindings are available only when they are in scope and upstream. Secrets are not expression bindings.
-
-Type environments come from event schemas, workflow inputs, step output schemas, loop and parallel types, and run metadata. This package checks the source against that environment. It does not know about projects, users, the database, or the runtime.
-
-The place in the tree matters. A name that is in scope in one place may be out of scope in another place. Build the list of names first, then call this package. Keep that rule simple so a reader can tell why a name is allowed.
 
 ## Behavior Notes
 
+- Use `syntax` when CEL syntax should be checked but fields are not known yet.
+- Use `typed` when the caller knows the names and field types in scope.
 - The parser trims source before storing it.
 - Bad source throws `InvalidWorkflowExpressionError`.
 - The package uses `@gresb/cel-javascript` internally.
-- The CEL dependency is patched for ESM packaging; re-check the patch when upgrading it.
-- Raw strings become branded only after this package accepts them.
+- The CEL dependency is patched for ESM packaging; re-check the patch when
+  upgrading it.
 
-Do not pass user text around as if it were safe. Make it safe here first. That keeps later code small and makes tests easier to read.
+Trigger filters can use `syntax` while integration event payloads are still
+open. Gate expressions can use `typed` because their local fields are known.
 
-When you add a new place that can use this text, start by asking what names should be visible there. Add those names to the type map, add a test for a good field, and add a test for a bad field.
+Choose the mode from the place where the text appears. If the caller does not
+know the event shape yet, use `syntax`. This checks that the text is valid CEL
+and saves it with that mark. It does not check names or fields.
 
-This keeps the rule clear for both the next person and the next test.
+If the caller knows the names that are in scope, use `typed`. Pass those names
+and their field types in `typeEnvironment`. This lets the package catch a bad
+field name before the workflow is saved.
 
-Keep it easy to follow.
+Most call sites need one simple choice. If data can come from many outside
+services, and the code cannot know every part of it, use `syntax`. If the data
+shape is set by our code and can be put in a small map, use `typed`. A bad value
+at run time can still fail later. This package checks the text before save time.
 
-Keep it small.
+Tests should stay close to the rule that owns the text. Give the function a good
+case and a bad case. The same input should give the same result each time. This
+code should not read files, call the network, or load data from a store.
 
-This helps the team find the right place to make a change.
+When a new area needs this feature, start with the user text and the values that
+can be seen from that place. Pick the mode first. Add only the values that are
+known there. Then add a test that proves a wrong path is caught or left open on
+purpose.
+
+This keeps the first save fast and clear. It also lets later code show a clear
+message near the part that a person wrote.
+
+Keep the call small. Put the rule near the place that owns it, and make the test
+read like the case a user would send. Keep it clear.
+
+The stored expression does not include vendor ASTs, checked data, protobuf bytes,
+or compiled objects. It stores only the CEL language tag, checked source, and the
+check level.
 
 ## Development
 

--- a/libs/shared/expression/language/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/language/src/expression/create-workflow-expression.test.ts
@@ -3,29 +3,49 @@ import {
   unsafeWorkflowExpressionFromSource,
 } from './create-workflow-expression.js';
 import {InvalidWorkflowExpressionError} from './errors.js';
-import type {ExpressionScalarType} from './workflow-expression.js';
+import type {CreateWorkflowExpressionParams, ExpressionScalarType} from './workflow-expression.js';
 
 describe('createWorkflowExpression', () => {
-  it('returns a CEL workflow expression when the source parses and type-checks', () => {
+  it('returns a typed CEL workflow expression when the source parses and type-checks', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion == "success"',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 
     expect(expression).toEqual({
       language: 'cel',
       source: 'event.conclusion == "success"',
+      check: 'typed',
     });
   });
 
-  it('rejects misspelled fields from the typed context', () => {
+  it('returns a syntax CEL workflow expression when unknown fields parse', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.ref == "refs/heads/main"',
+      check: {mode: 'syntax'},
+    });
+
+    expect(expression).toEqual({
+      language: 'cel',
+      source: 'event.ref == "refs/heads/main"',
+      check: 'syntax',
+    });
+  });
+
+  it('rejects misspelled fields from the typed environment', () => {
     const act = () =>
       createWorkflowExpression({
         source: 'event.conclsion == "success"',
-        typeEnvironment: {
-          event: {kind: 'object', fields: {conclusion: 'string'}},
+        check: {
+          mode: 'typed',
+          typeEnvironment: {
+            event: {kind: 'object', fields: {conclusion: 'string'}},
+          },
         },
       });
 
@@ -33,13 +53,26 @@ describe('createWorkflowExpression', () => {
     expect(act).toThrow('Invalid workflow expression');
   });
 
+  it('rejects unknown variables from an empty typed environment', () => {
+    const act = () =>
+      createWorkflowExpression({
+        source: 'event.ref == "refs/heads/main"',
+        check: {mode: 'typed'},
+      });
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
   it('exposes the source and type-check reason on invalid expression errors', () => {
     let error: unknown;
     try {
       createWorkflowExpression({
         source: 'event.conclsion == "success"',
-        typeEnvironment: {
-          event: {kind: 'object', fields: {conclusion: 'string'}},
+        check: {
+          mode: 'typed',
+          typeEnvironment: {
+            event: {kind: 'object', fields: {conclusion: 'string'}},
+          },
         },
       });
     } catch (caught) {
@@ -68,14 +101,18 @@ describe('createWorkflowExpression', () => {
   ][])('type-checks %s fields', (scalarType, source) => {
     const expression = createWorkflowExpression({
       source,
-      typeEnvironment: {
-        event: {kind: 'object', fields: {value: scalarType}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {value: scalarType}},
+        },
       },
     });
 
     expect(expression).toEqual({
       language: 'cel',
       source,
+      check: 'typed',
     });
   });
 
@@ -83,48 +120,97 @@ describe('createWorkflowExpression', () => {
     const act = () =>
       createWorkflowExpression({
         source: 'event.conclusion ==',
-        typeEnvironment: {
-          event: {kind: 'object', fields: {conclusion: 'string'}},
+        check: {
+          mode: 'typed',
+          typeEnvironment: {
+            event: {kind: 'object', fields: {conclusion: 'string'}},
+          },
         },
       });
 
     expect(act).toThrow(InvalidWorkflowExpressionError);
   });
 
-  it('rejects blank sources', () => {
-    const act = () => createWorkflowExpression({source: '   '});
+  it('rejects parse errors in syntax mode', () => {
+    const act = () =>
+      createWorkflowExpression({
+        source: 'event.conclusion ==',
+        check: {mode: 'syntax'},
+      });
 
     expect(act).toThrow(InvalidWorkflowExpressionError);
   });
 
-  it('trims accepted sources before storing them', () => {
+  it('rejects blank sources in syntax mode', () => {
+    const act = () => createWorkflowExpression({source: '   ', check: {mode: 'syntax'}});
+
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
+  it('trims accepted syntax sources before storing them', () => {
+    const expression = createWorkflowExpression({
+      source: '  event.ref == "refs/heads/main"  ',
+      check: {mode: 'syntax'},
+    });
+
+    expect(expression.source).toBe('event.ref == "refs/heads/main"');
+    expect(expression.check).toBe('syntax');
+  });
+
+  it('trims accepted typed sources before storing them', () => {
     const expression = createWorkflowExpression({
       source: '  event.conclusion == "success"  ',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 
     expect(expression.source).toBe('event.conclusion == "success"');
+    expect(expression.check).toBe('typed');
   });
 
   it('does not expose vendor ASTs or checked metadata', () => {
     const expression = createWorkflowExpression({
       source: 'event.conclusion == "success"',
-      typeEnvironment: {
-        event: {kind: 'object', fields: {conclusion: 'string'}},
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
       },
     });
 
-    expect(Object.keys(expression)).toEqual(['language', 'source']);
+    expect(Object.keys(expression)).toEqual(['language', 'source', 'check']);
   });
 
-  it('rehydrates already-validated sources without calling the CEL parser', () => {
-    const expression = unsafeWorkflowExpressionFromSource('event.conclusion == "success"');
+  it('requires typed environments to be attached to typed checks', () => {
+    const params = {
+      source: 'event.conclusion == "success"',
+      check: {
+        mode: 'syntax',
+        // @ts-expect-error typeEnvironment is only valid for typed checks.
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
+      },
+    } satisfies CreateWorkflowExpressionParams;
+
+    expect(params.check.mode).toBe('syntax');
+  });
+
+  it('rehydrates already-validated sources with their persisted check level', () => {
+    const expression = unsafeWorkflowExpressionFromSource({
+      source: 'event.conclusion == "success"',
+      check: 'typed',
+    });
 
     expect(expression).toEqual({
       language: 'cel',
       source: 'event.conclusion == "success"',
+      check: 'typed',
     });
   });
 });

--- a/libs/shared/expression/language/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/language/src/expression/create-workflow-expression.ts
@@ -37,29 +37,36 @@ export function createWorkflowExpression(
     });
   }
 
-  const typeCheckResult = Runtime.typeCheck(
-    source,
-    {},
-    toCelTypeEnvironment(params.typeEnvironment ?? {}),
-  );
-  if (!typeCheckResult.success) {
-    throw new InvalidWorkflowExpressionError({
+  if (params.check.mode === 'typed') {
+    const typeCheckResult = Runtime.typeCheck(
       source,
-      reason: typeCheckResult.error ?? 'Expression source did not type-check.',
-    });
+      {},
+      toCelTypeEnvironment(params.check.typeEnvironment ?? {}),
+    );
+    if (!typeCheckResult.success) {
+      throw new InvalidWorkflowExpressionError({
+        source,
+        reason: typeCheckResult.error ?? 'Expression source did not type-check.',
+      });
+    }
   }
 
   return {
     language: 'cel',
     source: source as ValidCelExpression,
+    check: params.check.mode,
   };
 }
 
-export function unsafeWorkflowExpressionFromSource(source: string): WorkflowExpression {
+export function unsafeWorkflowExpressionFromSource(params: {
+  source: string;
+  check: WorkflowExpression['check'];
+}): WorkflowExpression {
   // Use only when rehydrating a source that was already validated before storage.
   return {
     language: 'cel',
-    source: source as ValidCelExpression,
+    source: params.source as ValidCelExpression,
+    check: params.check,
   };
 }
 

--- a/libs/shared/expression/language/src/expression/index.ts
+++ b/libs/shared/expression/language/src/expression/index.ts
@@ -10,4 +10,6 @@ export type {
   ExpressionTypeEnvironment,
   ValidCelExpression,
   WorkflowExpression,
+  WorkflowExpressionCheck,
+  WorkflowExpressionCheckOptions,
 } from './workflow-expression.js';

--- a/libs/shared/expression/language/src/expression/workflow-expression.ts
+++ b/libs/shared/expression/language/src/expression/workflow-expression.ts
@@ -3,7 +3,10 @@ export type ValidCelExpression = string & {readonly __validCelExpression: unique
 export interface WorkflowExpression {
   language: 'cel';
   source: ValidCelExpression;
+  check: WorkflowExpressionCheck;
 }
+
+export type WorkflowExpressionCheck = 'syntax' | 'typed';
 
 export type ExpressionScalarType = 'string' | 'int' | 'double' | 'bool' | 'null' | 'timestamp';
 
@@ -20,7 +23,16 @@ export type ExpressionType =
 
 export type ExpressionTypeEnvironment = Readonly<Record<string, ExpressionType>>;
 
+export type WorkflowExpressionCheckOptions =
+  | {
+      mode: 'syntax';
+    }
+  | {
+      mode: 'typed';
+      typeEnvironment?: ExpressionTypeEnvironment;
+    };
+
 export interface CreateWorkflowExpressionParams {
   source: string;
-  typeEnvironment?: ExpressionTypeEnvironment;
+  check: WorkflowExpressionCheckOptions;
 }

--- a/libs/shared/expression/language/src/index.ts
+++ b/libs/shared/expression/language/src/index.ts
@@ -9,4 +9,6 @@ export {
   unsafeWorkflowExpressionFromSource,
   type ValidCelExpression,
   type WorkflowExpression,
+  type WorkflowExpressionCheck,
+  type WorkflowExpressionCheckOptions,
 } from './expression/index.js';

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -1,18 +1,21 @@
 # Workflow Document
 
-Workflow document input shape for Shipfox tools.
+Input shape for Shipfox workflow authoring.
 
 ## What it does
 
 - `workflowDocumentSchema` defines the accepted Zod shape for a workflow document.
 - `parseWorkflowDocument` parses unknown input into a typed `WorkflowDocument`.
 - `InvalidWorkflowDocumentError` reports invalid input with the original Zod error as `cause`.
+- `WorkflowDocumentRunStepGate` describes the step `gate` block with `success_if`
+  and `on_failure`.
 
-Use this package where Shipfox accepts a workflow object from a file, tool, or API call. It checks the shape only. It does not add defaults, pick runners, check job links, save data, or run jobs.
+Use this package where Shipfox accepts a workflow object from a file, tool, or
+API call. It checks the shape only. It does not add defaults, pick runners,
+check job links, save data, or run jobs.
 
-Keep it near the edge of the system. If the value is good, pass it to the next layer. If the value is bad, show the fields from the Zod error to the user.
-
-Use it when a file, form, or tool may send data that is wrong. The call gives one clear yes or no. Good data can move on. Bad data stops here, close to the place where it came in.
+Keep it near the edge of the system. If the value is good, pass it to the next
+layer. If the value is bad, show the fields from the Zod error to the user.
 
 ## Installation
 
@@ -38,7 +41,7 @@ try {
     jobs: {
       build: {
         runner: 'ubuntu-latest',
-        steps: [{run: 'npm run build'}],
+        steps: [{run: 'npm run build', gate: {success_if: 'exit_code == 0'}}],
       },
     },
   });
@@ -58,17 +61,25 @@ try {
 
 - The public contract is the Zod schema and the TypeScript types built from it.
 - Bad input throws a typed `Error`; UI or API code can read `validationError.issues` for field details.
-- Rules about what a workflow means belong to definitions-owned code, not this package.
+- The `gate` block is checked as input shape here. CEL parsing and restart
+  target checks belong to definitions-owned model code.
+- Rules that need a project, user, runner, database row, or saved state belong
+  outside this package.
 
-This package should stay small. Add only fields that are part of the input shape. Put rules that need a project, user, runner, or saved state in another module.
+This package answers one question: does this value have the right fields. The
+next layer can then decide what those fields mean. Keeping that split clear
+makes errors easier to show and tests easier to read.
 
-That split keeps each part easy to test. This part checks form. Other parts can check meaning.
+A file can come from a person, a tool, or a form. This part checks it before any
+other part uses it. Good data moves on. Bad data stops close to where it came
+from. That gives the caller a clear place to show what must change.
 
-Test shape here. Test meaning with the code that gives the value meaning. That way each test has one job.
+This keeps the first step fast and easy to use. It also lets later code work
+with a value that has already passed the basic shape check.
 
-Keep that line clear as the system grows.
-
-It is better to stop bad things early than to let them move through many parts.
+Use it at the start of a flow. Do not wait until save time. The sooner this
+part runs, the easier it is to tell the caller what is wrong and ask for a
+small fix.
 
 ## Development
 

--- a/libs/shared/workflow/document/src/document/index.ts
+++ b/libs/shared/workflow/document/src/document/index.ts
@@ -2,6 +2,7 @@ export {
   type WorkflowDocument,
   type WorkflowDocumentJob,
   type WorkflowDocumentRunStep,
+  type WorkflowDocumentRunStepGate,
   type WorkflowDocumentTrigger,
   workflowDocumentJobSchema,
   workflowDocumentRunStepSchema,

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -82,6 +82,34 @@ describe('workflowDocumentSchema', () => {
     expect(result.triggers?.main_push?.filter).toBe('event.ref == "refs/heads/main"');
   });
 
+  it('accepts a step gate with success_if and on_failure', () => {
+    const workflowDocument = {
+      name: 'review loop',
+      jobs: {
+        review: {
+          steps: [
+            {name: 'producer', run: 'npm run build'},
+            {
+              name: 'reviewer',
+              run: 'npm run review',
+              gate: {
+                success_if: 'step.output.pass == true',
+                on_failure: {
+                  restart_from: 'producer',
+                  output: 'Review failed',
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    const result = workflowDocumentSchema.safeParse(workflowDocument);
+
+    expect(result.success).toBe(true);
+  });
+
   it.each([
     ['missing required top-level fields', {}],
     ['empty jobs map', {name: 'simple build', jobs: {}}],
@@ -113,6 +141,21 @@ describe('workflowDocumentSchema', () => {
     [
       'unknown fields',
       {name: 'simple build', jobs: {build: {steps: [{run: 'npm test', shell: 'bash'}]}}},
+    ],
+    ['empty gate', {name: 'simple build', jobs: {build: {steps: [{run: 'npm test', gate: {}}]}}}],
+    [
+      'gate unknown field',
+      {
+        name: 'simple build',
+        jobs: {build: {steps: [{run: 'npm test', gate: {if: 'exit_code == 0'}}]}},
+      },
+    ],
+    [
+      'gate on_failure without restart_from',
+      {
+        name: 'simple build',
+        jobs: {build: {steps: [{run: 'npm test', gate: {on_failure: {}}}]}},
+      },
     ],
   ])('rejects %s', (_label, workflowDocument) => {
     const result = workflowDocumentSchema.safeParse(workflowDocument);

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -20,6 +20,20 @@ export const workflowDocumentTriggerSchema = z.strictObject({
 export const workflowDocumentRunStepSchema = z.strictObject({
   name: z.string().min(1).optional(),
   run: z.string().min(1),
+  gate: z
+    .strictObject({
+      success_if: z.string().min(1).optional(),
+      on_failure: z
+        .strictObject({
+          restart_from: z.string().min(1),
+          output: z.string().min(1).optional(),
+        })
+        .optional(),
+    })
+    .refine((value) => value.success_if !== undefined || value.on_failure !== undefined, {
+      message: 'Expected success_if or on_failure',
+    })
+    .optional(),
 });
 
 export const workflowDocumentJobSchema = z.strictObject({
@@ -37,5 +51,8 @@ export const workflowDocumentSchema = z.strictObject({
 
 export type WorkflowDocument = z.infer<typeof workflowDocumentSchema>;
 export type WorkflowDocumentJob = z.infer<typeof workflowDocumentJobSchema>;
+export type WorkflowDocumentRunStepGate = NonNullable<
+  z.infer<typeof workflowDocumentRunStepSchema>['gate']
+>;
 export type WorkflowDocumentRunStep = z.infer<typeof workflowDocumentRunStepSchema>;
 export type WorkflowDocumentTrigger = z.infer<typeof workflowDocumentTriggerSchema>;

--- a/libs/shared/workflow/document/src/index.ts
+++ b/libs/shared/workflow/document/src/index.ts
@@ -5,6 +5,7 @@ export {
   type WorkflowDocument,
   type WorkflowDocumentJob,
   type WorkflowDocumentRunStep,
+  type WorkflowDocumentRunStepGate,
   type WorkflowDocumentTrigger,
   workflowDocumentSchema,
 } from '#document/index.js';

--- a/libs/shared/workflow/document/test/data/simple-build.json
+++ b/libs/shared/workflow/document/test/data/simple-build.json
@@ -15,7 +15,10 @@
         },
         {
           "name": "build",
-          "run": "npm run build"
+          "run": "npm run build",
+          "gate": {
+            "success_if": "exit_code == 0"
+          }
         }
       ]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,9 @@ importers:
       '@shipfox/api-projects-dto':
         specifier: workspace:*
         version: link:../projects-dto
+      '@shipfox/expression-language':
+        specifier: workspace:*
+        version: link:../../shared/expression/language
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle


### PR DESCRIPTION
<!-- stk:begin -->
## Stack

Part 1 of 1.

Depends on: none
Next: none

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #131 | `workflow-runtime-kernel-spike` | `main` |

<!-- stk:end -->

## Summary

Adds the workflow step `gate` block with `success_if` and `on_failure` support across the document, model, and runtime materialization layers.

This PR does not implement durable restart execution in the host. It records accepted gate semantics in `WorkflowModel` and serializes them into step config so the later host work has a stable shape to consume.

## Notable Changes

- Adds `gate` to `@shipfox/workflow-document` run steps.
- Parses run-step `gate.success_if` as CEL during `WorkflowModel` normalization.
- Keeps the current run-step expression context grounded to `exit_code` only.
- Validates `gate.on_failure.restart_from` against earlier named steps in the same job.
- Stores accepted gates in `WorkflowModel` as `successIf` / `onFailure`.
- Materializes accepted gate metadata into workflow runtime step config.
- Updates simple-build YAML fixtures and examples to use `gate.success_if: exit_code == 0`.
- Updates module READMEs with the gate boundary and deferrals.

## Tests

Passed:

- `mise exec -- turbo type --filter=@shipfox/workflow-document --filter=@shipfox/api-definitions --filter=@shipfox/api-workflows`
- `mise exec -- turbo check --filter=@shipfox/workflow-document --filter=@shipfox/api-definitions --filter=@shipfox/api-workflows`
- `mise exec -- turbo test --filter=@shipfox/workflow-document --filter=@shipfox/expression-language`
- README readability for workflow document, workflow model, and workflow runtime READMEs
- DB-free definitions Vitest lane through a temporary config: 2 files, 30 tests passed
- DB-free workflow-runtime Vitest lane through a temporary config: 2 files, 12 tests passed

Blocked locally:

- `mise exec -- turbo test --filter=@shipfox/api-definitions --filter=@shipfox/api-workflows`
- Reason: package global setup requires local Postgres and fails with `ECONNREFUSED ::1:5432` / `127.0.0.1:5432` before tests run.

## Deferrals

- Durable host restart execution is deferred.
- `step.output.*` gate expressions are deferred until a step kind with declared output schemas exists, such as future agent steps.
- Trigger-filter CEL parsing/type-checking remains deferred.
- Post-#136 runtime host reconciliation remains deferred.
