### PR TITLE
[api/runners] Use Drizzle query builder for job claim

### DIFF
--- a/.changeset/lazy-foxes-claim.md
+++ b/.changeset/lazy-foxes-claim.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Rewrites the pending-job claim query with the Drizzle query builder instead of raw SQL, keeping the same FOR UPDATE SKIP LOCKED locking behavior.

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -5,7 +5,7 @@ import {
   type StepResultDto,
 } from '@shipfox/api-runners-dto';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
-import {and, eq, lt, sql} from 'drizzle-orm';
+import {and, asc, eq, lt, sql} from 'drizzle-orm';
 import {RunningJobNotFoundError} from '#core/errors.js';
 import {db} from './db.js';
 import {runnersOutbox} from './schema/outbox.js';
@@ -39,33 +39,28 @@ export async function claimJob(params: {
   runnerTokenId: string;
 }): Promise<ClaimedJob | null> {
   return await db().transaction(async (tx) => {
-    const rows = await tx.execute(
-      sql`SELECT id, workspace_id, job_id, run_id, payload
-          FROM runners_pending_jobs
-          WHERE workspace_id = ${params.workspaceId}
-          ORDER BY created_at ASC
-          LIMIT 1
-          FOR UPDATE SKIP LOCKED`,
-    );
-
-    const row = rows.rows[0] as
-      | {id: string; workspace_id: string; job_id: string; run_id: string; payload: unknown}
-      | undefined;
+    const [row] = await tx
+      .select()
+      .from(pendingJobs)
+      .where(eq(pendingJobs.workspaceId, params.workspaceId))
+      .orderBy(asc(pendingJobs.createdAt))
+      .limit(1)
+      .for('update', {skipLocked: true});
 
     if (!row) return null;
 
     await tx.delete(pendingJobs).where(eq(pendingJobs.id, row.id));
 
     await tx.insert(runningJobs).values({
-      workspaceId: row.workspace_id,
-      jobId: row.job_id,
-      runId: row.run_id,
+      workspaceId: row.workspaceId,
+      jobId: row.jobId,
+      runId: row.runId,
       runnerTokenId: params.runnerTokenId,
     });
 
     return {
-      jobId: row.job_id,
-      runId: row.run_id,
+      jobId: row.jobId,
+      runId: row.runId,
       payload: row.payload as JobPayloadDto,
     };
   });


### PR DESCRIPTION
Replaces the raw SQL in `claimJob` with the Drizzle query builder. The pending-job claim now reads as a typed `.select()` chain using `.for('update', {skipLocked: true})` for the `FOR UPDATE SKIP LOCKED` lock, instead of a hand-written SQL string plus a manual row cast and snake_case→camelCase remapping.

This was prompted by [drizzle-orm#2875](https://github.com/drizzle-team/drizzle-orm/issues/2875). Row-level locking with `skipLocked` is stable in our `drizzle-orm@0.45.2`, so the raw SQL is no longer needed. The generated query and locking semantics are identical — this is a behavior-preserving refactor that drops the untyped escape hatch.

The existing `claimJob` tests in `jobs.test.ts` already cover the contract this must preserve: FIFO ordering, the concurrent two-runner claim that relies on `SKIP LOCKED`, and the pending→running row move. Build and `turbo check` pass locally; the DB-backed tests were not run here (Docker unavailable in this environment) and will run in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor `claimJob` to use the Drizzle query builder instead of raw SQL, keeping the same `FOR UPDATE SKIP LOCKED` semantics. Improves type safety and readability with no behavior change.

- **Refactors**
  - Replace raw SQL with `.select().orderBy(asc(pendingJobs.createdAt)).limit(1).for('update', {skipLocked: true})`.
  - Remove manual row casting and snake_case→camelCase remapping by returning typed rows.
  - Preserve FIFO ordering, concurrent claim via `SKIP LOCKED`, and the pending→running move.

<sup>Written for commit 68184b4056941183cea29c117a575e3fc2b0e505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

