### PR TITLE
[api/workflows] Add per-step progression domain service

### DIFF
--- a/.changeset/eng-396-step-progression.md
+++ b/.changeset/eng-396-step-progression.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Add the per-step progression domain service (`nextStepForJob`, `recordStepResult`) and its guarded DB primitives over the existing `steps` table. Dormant until the per-step runner protocol is wired into the HTTP and orchestration layers; no runtime behavior changes yet.

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -13,3 +13,24 @@ export class ProjectMismatchError extends Error {
     this.name = 'ProjectMismatchError';
   }
 }
+
+export class JobNotFoundError extends Error {
+  constructor(jobId: string) {
+    super(`Job not found or has no steps: ${jobId}`);
+    this.name = 'JobNotFoundError';
+  }
+}
+
+export class StepNotFoundError extends Error {
+  constructor(stepId: string, jobId: string) {
+    super(`Step ${stepId} not found in job ${jobId}`);
+    this.name = 'StepNotFoundError';
+  }
+}
+
+export class StepNotRunningError extends Error {
+  constructor(stepId: string, jobId: string) {
+    super(`Step ${stepId} in job ${jobId} is not running and cannot accept a result`);
+    this.name = 'StepNotRunningError';
+  }
+}

--- a/libs/api/workflows/src/core/index.ts
+++ b/libs/api/workflows/src/core/index.ts
@@ -3,6 +3,14 @@ export {findBlockedNodes, findReadyNodes} from './dag.js';
 export type {Job, JobStatus} from './entities/job.js';
 export type {Step, StepStatus} from './entities/step.js';
 export type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from './entities/workflow-run.js';
-export {DefinitionNotFoundError, ProjectMismatchError} from './errors.js';
+export {
+  DefinitionNotFoundError,
+  JobNotFoundError,
+  ProjectMismatchError,
+  StepNotFoundError,
+  StepNotRunningError,
+} from './errors.js';
+export type {NextStep, RecordStepResultOutcome, RecordStepResultParams} from './job-execution.js';
+export {nextStepForJob, recordStepResult} from './job-execution.js';
 export type {RunWorkflowParams} from './run-workflow.js';
 export {runWorkflow} from './run-workflow.js';

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -1,0 +1,254 @@
+import type {WorkflowSpec} from '@shipfox/api-definitions';
+import type {Step} from '#core/entities/step.js';
+import {
+  bulkUpdateStepStatuses,
+  createWorkflowRun,
+  getJobsByRunId,
+  getStepsByJobId,
+} from '#db/workflow-runs.js';
+import {JobNotFoundError, StepNotFoundError, StepNotRunningError} from './errors.js';
+import {nextStepForJob, recordStepResult} from './job-execution.js';
+
+// Jobs/steps are materialized from a WorkflowSpec by createWorkflowRun (there is
+// no step/job factory), so arrange a single `build` job with `stepCount` steps
+// and read back its persisted, position-ordered steps.
+async function arrangeJobWithSteps(stepCount: number): Promise<{jobId: string; steps: Step[]}> {
+  const definition: WorkflowSpec = {
+    name: 'Test Workflow',
+    jobs: {
+      build: {steps: Array.from({length: stepCount}, (_, i) => ({run: `echo step-${i}`}))},
+    },
+  };
+
+  const run = await createWorkflowRun({
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    definitionId: crypto.randomUUID(),
+    definition,
+    triggerPayload: {
+      source: 'manual',
+      event: 'fire',
+      subscriptionId: crypto.randomUUID(),
+      userId: crypto.randomUUID(),
+    },
+  });
+
+  const jobs = await getJobsByRunId(run.id);
+  const jobId = jobs[0]?.id as string;
+  const steps = await getStepsByJobId(jobId);
+  return {jobId, steps};
+}
+
+describe('nextStepForJob', () => {
+  test('returns the lowest-position pending step and marks it running', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+
+    const result = await nextStepForJob(jobId);
+
+    expect(result).toEqual({kind: 'step', step: expect.objectContaining({id: steps[0]?.id})});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('running');
+    expect(after[1]?.status).toBe('pending');
+    expect(after[2]?.status).toBe('pending');
+  });
+
+  test('idempotent re-delivery: a second pull returns the same running step', async () => {
+    const {jobId} = await arrangeJobWithSteps(3);
+    const first = await nextStepForJob(jobId);
+
+    const second = await nextStepForJob(jobId);
+
+    expect(first.kind).toBe('step');
+    expect(second.kind).toBe('step');
+    const firstId = first.kind === 'step' ? first.step.id : null;
+    const secondId = second.kind === 'step' ? second.step.id : null;
+    expect(secondId).toBe(firstId);
+    const running = (await getStepsByJobId(jobId)).filter((s) => s.status === 'running');
+    expect(running).toHaveLength(1);
+  });
+
+  test('after a step succeeds, the next pull returns the next pending step', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded'});
+
+    const next = await nextStepForJob(jobId);
+
+    expect(next).toEqual({kind: 'step', step: expect.objectContaining({id: steps[1]?.id})});
+  });
+
+  test('all steps succeeded → {done, succeeded}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    for (const step of steps) {
+      await nextStepForJob(jobId);
+      await recordStepResult({jobId, stepId: step.id, status: 'succeeded'});
+    }
+
+    const result = await nextStepForJob(jobId);
+
+    expect(result).toEqual({kind: 'done', status: 'succeeded'});
+  });
+
+  test('unknown jobId → JobNotFoundError (not a vacuous done)', async () => {
+    await expect(nextStepForJob(crypto.randomUUID())).rejects.toBeInstanceOf(JobNotFoundError);
+  });
+
+  test('all terminal with a failure → {done, failed}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'failed'});
+
+    const result = await nextStepForJob(jobId);
+
+    expect(result).toEqual({kind: 'done', status: 'failed'});
+  });
+
+  test('all cancelled, none failed → {done, failed}', async () => {
+    const {jobId} = await arrangeJobWithSteps(2);
+    // A cancelled job with no failure must still report 'failed', not a vacuous
+    // success.
+    await bulkUpdateStepStatuses({jobId, status: 'cancelled'});
+
+    const result = await nextStepForJob(jobId);
+
+    expect(result).toEqual({kind: 'done', status: 'failed'});
+  });
+});
+
+describe('recordStepResult', () => {
+  test('succeeded on a non-final step → {jobFinished:false}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'succeeded',
+    });
+
+    expect(outcome).toEqual({jobFinished: false});
+    expect((await getStepsByJobId(jobId))[0]?.status).toBe('succeeded');
+  });
+
+  test('succeeded on the final step → {jobFinished:true, succeeded}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'succeeded',
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+  });
+
+  test('failed step → step failed, remaining cancelled, {jobFinished:true, failed}', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+      error: {message: 'boom'},
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('failed');
+    expect(after[0]?.error).toEqual({message: 'boom'});
+    expect(after[1]?.status).toBe('cancelled');
+    expect(after[2]?.status).toBe('cancelled');
+  });
+
+  test('never downgrades an already-terminal row', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded'});
+
+    // A late 'failed' report for the already-succeeded step must not downgrade it.
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'failed'});
+
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('succeeded');
+    expect(after[1]?.status).toBe('pending');
+  });
+
+  test('unknown stepId → StepNotFoundError', async () => {
+    const {jobId} = await arrangeJobWithSteps(1);
+
+    await expect(
+      recordStepResult({jobId, stepId: crypto.randomUUID(), status: 'succeeded'}),
+    ).rejects.toBeInstanceOf(StepNotFoundError);
+  });
+
+  test('cross-job stepId → StepNotFoundError', async () => {
+    const a = await arrangeJobWithSteps(1);
+    const b = await arrangeJobWithSteps(1);
+
+    await expect(
+      recordStepResult({jobId: a.jobId, stepId: b.steps[0]?.id as string, status: 'succeeded'}),
+    ).rejects.toBeInstanceOf(StepNotFoundError);
+  });
+
+  test('result for a pending (never-dispatched) step → StepNotRunningError', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    // Skip nextStepForJob so the step stays pending (never handed out).
+
+    await expect(
+      recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded'}),
+    ).rejects.toBeInstanceOf(StepNotRunningError);
+  });
+
+  test('duplicate succeeded report is a no-op', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded'});
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'succeeded',
+    });
+
+    expect(outcome).toEqual({jobFinished: false});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('succeeded');
+    expect(after[1]?.status).toBe('pending');
+  });
+
+  test('duplicate failed report is a no-op and job stays fully terminal', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(3);
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'failed'});
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('failed');
+    expect(after[1]?.status).toBe('cancelled');
+    expect(after[2]?.status).toBe('cancelled');
+  });
+});
+
+describe('nextStepForJob concurrency', () => {
+  test('concurrent pulls return the same step', async () => {
+    const {jobId} = await arrangeJobWithSteps(3);
+
+    const [a, b] = await Promise.all([nextStepForJob(jobId), nextStepForJob(jobId)]);
+
+    expect(a.kind).toBe('step');
+    expect(b.kind).toBe('step');
+    const idA = a.kind === 'step' ? a.step.id : null;
+    const idB = b.kind === 'step' ? b.step.id : null;
+    expect(idA).toBe(idB);
+    const running = (await getStepsByJobId(jobId)).filter((s) => s.status === 'running');
+    expect(running).toHaveLength(1);
+  });
+});

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1,0 +1,97 @@
+import {withTransaction} from '#db/db.js';
+import {
+  applyStepResult,
+  cancelRemainingSteps,
+  getStepsByJobIdForUpdate,
+  markStepRunning,
+} from '#db/workflow-runs.js';
+import type {CompletionStatus} from './dag.js';
+import type {Step, StepStatus} from './entities/step.js';
+import {JobNotFoundError, StepNotFoundError, StepNotRunningError} from './errors.js';
+
+const TERMINAL_STATUSES: ReadonlySet<StepStatus> = new Set(['succeeded', 'failed', 'cancelled']);
+
+function isTerminal(status: StepStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+// Anything other than an all-succeeded job is a failure, so an externally
+// cancelled job never reads as a vacuous success.
+function deriveCompletion(steps: Step[]): CompletionStatus {
+  return steps.every((step) => step.status === 'succeeded') ? 'succeeded' : 'failed';
+}
+
+export type NextStep = {kind: 'step'; step: Step} | {kind: 'done'; status: CompletionStatus};
+
+export function nextStepForJob(jobId: string): Promise<NextStep> {
+  // FOR UPDATE serializes concurrent pulls so a step is never dispatched twice.
+  return withTransaction(async (tx) => {
+    const steps = await getStepsByJobIdForUpdate(jobId, tx);
+
+    // An unknown or step-less job has nothing to progress; rejecting it stops a
+    // bad id from deriving a vacuous 'succeeded' completion below.
+    if (steps.length === 0) throw new JobNotFoundError(jobId);
+
+    // Re-deliver the in-flight step rather than advancing, so a retried pull
+    // cannot skip a step.
+    const running = steps.find((step) => step.status === 'running');
+    if (running) return {kind: 'step', step: running};
+
+    const pending = steps.find((step) => step.status === 'pending');
+    if (pending) {
+      const marked = await markStepRunning({jobId, stepId: pending.id}, tx);
+      return {kind: 'step', step: marked ?? pending};
+    }
+
+    return {kind: 'done', status: deriveCompletion(steps)};
+  });
+}
+
+export interface RecordStepResultParams {
+  jobId: string;
+  stepId: string;
+  status: 'succeeded' | 'failed';
+  error?: Record<string, unknown> | null;
+}
+
+export type RecordStepResultOutcome =
+  | {jobFinished: false}
+  | {jobFinished: true; status: CompletionStatus};
+
+export function recordStepResult(params: RecordStepResultParams): Promise<RecordStepResultOutcome> {
+  // The failed result and its sibling cancellations are two writes; one
+  // transaction keeps them atomic, so a crashed-then-retried report can never
+  // leave siblings stranded once the step itself is terminal.
+  return withTransaction(async (tx) => {
+    const steps = await getStepsByJobIdForUpdate(params.jobId, tx);
+    const target = steps.find((step) => step.id === params.stepId);
+
+    if (!target) throw new StepNotFoundError(params.stepId, params.jobId);
+
+    if (!isTerminal(target.status)) {
+      // A result may only land on a step that was actually handed out.
+      if (target.status === 'pending') {
+        throw new StepNotRunningError(params.stepId, params.jobId);
+      }
+      await applyStepResult(
+        {
+          jobId: params.jobId,
+          stepId: params.stepId,
+          status: params.status,
+          error: params.error ?? null,
+        },
+        tx,
+      );
+      if (params.status === 'failed') {
+        await cancelRemainingSteps({jobId: params.jobId}, tx);
+      }
+    }
+    // A terminal target is a duplicate report, left untouched.
+
+    const after = await getStepsByJobIdForUpdate(params.jobId, tx);
+    if (after.every((step) => isTerminal(step.status))) {
+      return {jobFinished: true, status: deriveCompletion(after)};
+    }
+    return {jobFinished: false};
+  });
+}

--- a/libs/api/workflows/src/db/db.ts
+++ b/libs/api/workflows/src/db/db.ts
@@ -17,3 +17,11 @@ export function db() {
 export function closeDb(): void {
   _db = undefined;
 }
+
+export type Tx = Parameters<Parameters<NodePgDatabase<typeof schema>['transaction']>[0]>[0];
+
+// Lets callers express a unit of work to run atomically without depending on the
+// db() singleton or drizzle's transaction API directly.
+export function withTransaction<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
+  return db().transaction(fn);
+}

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -9,7 +9,7 @@ import {and, asc, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql} fro
 import type {Job, JobStatus} from '#core/entities/job.js';
 import type {Step, StepStatus} from '#core/entities/step.js';
 import type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from '#core/entities/workflow-run.js';
-import {db} from './db.js';
+import {db, type Tx} from './db.js';
 import {jobs, toJob} from './schema/jobs.js';
 import {workflowsOutbox} from './schema/outbox.js';
 import {steps, toStep} from './schema/steps.js';
@@ -352,8 +352,6 @@ export async function updateWorkflowRunStatus(
   return toWorkflowRun(row);
 }
 
-type Tx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
-
 export interface UpdateJobStatusAtVersionParams {
   jobId: string;
   status: JobStatus;
@@ -446,8 +444,12 @@ export interface BulkUpdateStepStatusesParams {
   status: StepStatus;
 }
 
-export async function bulkUpdateStepStatuses(params: BulkUpdateStepStatusesParams): Promise<void> {
-  await db()
+export async function bulkUpdateStepStatuses(
+  params: BulkUpdateStepStatusesParams,
+  tx?: Tx,
+): Promise<void> {
+  const executor = tx ?? db();
+  await executor
     .update(steps)
     .set({
       status: params.status,
@@ -582,4 +584,75 @@ export async function applyStepResults(params: ApplyStepResultsParams): Promise<
         );
     }
   });
+}
+
+// Per-step progression primitives. They take a mandatory `tx` because they only
+// run inside the job-execution service's transaction, and every write guards on
+// the never-downgrade predicate so a late or duplicate write cannot overwrite an
+// already-terminal row.
+
+// Locking in position order gives both entry points one lock order, so they
+// never deadlock and the failed-report apply+cancel pair commits atomically.
+export async function getStepsByJobIdForUpdate(jobId: string, tx: Tx): Promise<Step[]> {
+  const rows = await tx
+    .select()
+    .from(steps)
+    .where(eq(steps.jobId, jobId))
+    .orderBy(asc(steps.position))
+    .for('update');
+  return rows.map(toStep);
+}
+
+export interface MarkStepRunningParams {
+  jobId: string;
+  stepId: string;
+}
+
+export async function markStepRunning(params: MarkStepRunningParams, tx: Tx): Promise<Step | null> {
+  const rows = await tx
+    .update(steps)
+    .set({status: 'running', updatedAt: new Date()})
+    .where(
+      and(
+        eq(steps.id, params.stepId),
+        eq(steps.jobId, params.jobId),
+        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+      ),
+    )
+    .returning();
+  const row = rows[0];
+  return row ? toStep(row) : null;
+}
+
+export interface ApplyStepResultParams {
+  jobId: string;
+  stepId: string;
+  status: 'succeeded' | 'failed';
+  error: Record<string, unknown> | null;
+}
+
+export async function applyStepResult(params: ApplyStepResultParams, tx: Tx): Promise<void> {
+  await tx
+    .update(steps)
+    .set({status: params.status, error: params.error ?? null, updatedAt: new Date()})
+    .where(
+      and(
+        eq(steps.id, params.stepId),
+        eq(steps.jobId, params.jobId),
+        sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
+      ),
+    );
+}
+
+export interface CancelRemainingStepsParams {
+  jobId: string;
+}
+
+// The just-failed step is already terminal, so the shared guarded sweep leaves
+// it alone and only the still-pending siblings are cancelled.
+export async function cancelRemainingSteps(
+  params: CancelRemainingStepsParams,
+  tx: Tx,
+): Promise<void> {
+  await bulkUpdateStepStatuses({jobId: params.jobId, status: 'cancelled'}, tx);
 }


### PR DESCRIPTION
Introduces the single source of step-advance logic for the per-step runner protocol (T2), operating directly on the existing `steps` table with no HTTP, token, or Temporal coupling:

- `nextStepForJob(jobId)` — returns the lowest-position non-terminal step and marks it `running`. Idempotent: a retried pull returns the already-`running` step rather than skipping ahead.
- `recordStepResult({jobId, stepId, status, error})` — guarded never-downgrade report; on `failed` it cancels the remaining steps, and it signals `{jobFinished, status}` once every step is terminal.

## Why

The runner protocol is moving from job-atomic (ship a whole job, run all steps locally, report once via `/complete`) to per-step pull/report, so steps transition `pending → running → terminal` one at a time for live status and so some steps can be decided at run time. T2 is the pure domain core of that flip.

## Notes for review

- **Atomicity / crash-safety:** a `failed` report is two writes (mark step failed, then cancel siblings). Both `nextStepForJob` and `recordStepResult` wrap their work in one `db().transaction()` and open with a `SELECT … ORDER BY position FOR UPDATE` locked read (shared lock order). This makes the failed path atomic — a crashed-then-retried report can never strand the remaining steps `pending` — and prevents concurrent double-dispatch. The one-runner-per-leased-job invariant is the primary serialization; `FOR UPDATE` is defense-in-depth (covered by a concurrent-pull race test).
- **Protocol guard:** `recordStepResult` rejects a result for a never-dispatched (`pending`) step (`StepNotRunningError`) and for unknown/cross-job step ids (`StepNotFoundError`); a duplicate/retried report on a terminal step is an idempotent no-op.
- **DRY:** `cancelRemainingSteps` delegates to the existing guarded sweep `bulkUpdateStepStatuses` (now `tx`-aware). The new DB primitives are intentionally **not** exported from the `db` barrel — callers go through the core service.
- **Dormant:** nothing wires these into a runtime path yet (routes/auth → T3, Temporal cutover → T6), so this is safe and reversible. Changeset is `patch` (internal, no consumer impact yet).

Refs ENG-396

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-step progression domain service to `@shipfox/api-workflows` for the T2 runner protocol. It provides idempotent step pull/report with atomic failure handling and stays dormant until wired; supports ENG-396.

- **New Features**
  - `nextStepForJob(jobId)` returns the in-flight or next pending step and marks it running; serialized with `SELECT … FOR UPDATE`. Unknown job → `JobNotFoundError`.
  - `recordStepResult({jobId, stepId, status, error})` applies results, cancels remaining steps on failure, never downgrades, and returns `{jobFinished:false}` or `{jobFinished:true, status}`.
  - Completion: all steps succeeded → `succeeded`; any failure or all-cancelled → `failed` (no vacuous success).
  - Infra/exports: `withTransaction`; tx-only DB primitives (`getStepsByJobIdForUpdate`, `markStepRunning`, `applyStepResult`, `cancelRemainingSteps`); `bulkUpdateStepStatuses` is tx-aware; export `nextStepForJob`, `recordStepResult`, and types; add `JobNotFoundError`, `StepNotFoundError`, `StepNotRunningError`. Tests cover idempotency and concurrent pulls.

<sup>Written for commit 0b925ad59dbb7c0c1436768f7bb1c98a1b67780e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

