### PR TITLE
Fix release PR flapping by bumping changesets/action to v1.9.0

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Open release PR or publish
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm exec changeset version
           publish: pnpm run release:publish


### PR DESCRIPTION
The `Publish packages` workflow opens a "Version packages" PR on one push to `main` and closes it on the next, then reopens it again — flapping every other run.

## Cause

The workflow uses `changesets/action` with `commitMode: github-api` (required because releases run under a GitHub App token with provenance, not the default `GITHUB_TOKEN`). On the pinned `v1.7.0`, that mode had a force-push bug: when updating the existing release branch it momentarily reset the branch to the base commit. GitHub reads that as the branch being fully merged/empty and **auto-closes the open PR**, which only reopens on the next push to `main`.

This is tracked upstream in [changesets/action#550](https://github.com/changesets/action/issues/550) (related: [#487](https://github.com/changesets/action/issues/487), [#474](https://github.com/changesets/action/issues/474)).

## Fix

Bump `changesets/action` from v1.7.0 to **v1.9.0**, which includes [PR #645](https://github.com/changesets/action/pull/645):

> Improved force-push handling when using `commitMode: "github-api"` so updating an existing branch no longer temporarily resets the target branch to the base commit, avoiding cases where GitHub closes open pull requests during the update.

The bump is backward-compatible with our config: v1.8.0/v1.9.0 only add opt-in sub-actions (`pr-comment`, `pr-status`) and a `prDraft` input — no existing inputs changed. The action stays pinned by commit SHA (`a45c4d5`, the dereferenced `v1.9.0` tag).

Refs changesets/action#550

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the “Version packages” release PR from closing and reopening every other run. Bump `changesets/action` from v1.7.0 to v1.9.0 to fix a `commitMode: github-api` force-push issue that temporarily reset the branch and triggered PR auto-close.

<sup>Written for commit d7ff5f32d6090e8e87ee1f1982b8479930803f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

