### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ playwright-report/
 
 # Argos visual regression artifacts
 screenshots/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Adds `.DS_Store` to the repo `.gitignore` under a new `# macOS` section.

The file kept appearing in `git status` for macOS developers because there
was no OS-level entry in the ignore file. Ignoring it at the project level
covers all collaborators without each contributor needing a global gitignore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.DS_Store` to the repo `.gitignore` to stop macOS Finder files from showing up in git status and being committed. This keeps the repo clean and removes the need for contributors to set a global ignore.

<sup>Written for commit d306427b58b916c96161d1d21a9b29a502348b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

