### PR TITLE
Make runner scheduling step-less

### DIFF
--- a/.changeset/eng-398-claim-grants-token.md
+++ b/.changeset/eng-398-claim-grants-token.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-runners-dto": minor
+"@shipfox/api-runners": minor
+"@shipfox/api-workflows": patch
+---
+
+Reshape Scheduling around runner job leases. Jobs are now enqueued via `scheduleJob({jobId, workspaceId, runId})`, and the claim route mints a job lease token and returns `{job_id, run_id, lease_token}`. The stuck-job detector now emits a new `runners.job.lease_expired` event (`RUNNER_JOB_LEASE_EXPIRED`, payload `{jobId, runId}`) when a lease expires.

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,19 +46,9 @@
 
 **Depends on:** Nothing. Can be done as a standalone PR.
 
-## Add runner authentication
+## Capability-scoped / registration runner tokens
 
-**What:** Add authentication to runner protocol endpoints (`POST /runners/jobs/request` and `POST /runners/jobs/:id/complete`).
-
-**Why:** Runner protocol is a public API surface. Without auth, anyone can claim and complete jobs. Required before any non-local deployment.
-
-**Pros:** Security baseline for runner protocol.
-
-**Cons:** Requires runner registration flow, token management.
-
-**Context:** The system design spec describes a `POST /api/runners/register` endpoint that issues `RunnerCredentials` via a registration token. Runner protocol endpoints should validate these credentials. For production, consider runner-scoped tokens with workspace and capability restrictions.
-
-**Depends on:** Nothing. Can be built independently.
+Runner-token auth already guards the runner protocol endpoints. Future hardening: a `POST /api/runners/register` registration flow issuing runner-scoped tokens with workspace and capability restrictions.
 
 ## Single-statement `applyStepResults` for many-step jobs
 
@@ -102,10 +92,10 @@
 
 - [ ] **Per-job-type configurable timeout** — `jobOrchestration` currently hardcodes `JOB_MAX_DURATION = '60 minutes'`. Add a `timeout` field on the step/job spec parsed by Definitions, persisted on the `jobs` row, and read by `jobOrchestration` via input. Default to 60min when unset. Necessary for mixed quick/long-running jobs (notify steps don't need 60min; nightly ETL steps need more). Schema-additive on `jobs`.
 
-- [ ] **Bulk DELETE…RETURNING + bulk outbox in `detectAndFailStuckJobs`** — Today the function is N+1: SELECT stuck rows, then per-row `finalizeRunningJob` (atomic `DELETE … WHERE last_heartbeat_at < cutoff RETURNING run_id` + 1-row outbox insert). Total ~1 SELECT + N DELETEs per cron tick. Acceptable at handful-of-runners scale; revisit with a single transaction `DELETE FROM running_jobs WHERE last_heartbeat_at < $threshold RETURNING job_id, run_id` plus a multi-row outbox insert when concurrent-job counts demand it. Likely depends on a `writeOutboxEvents` (plural) helper in `@shipfox/node-outbox`.
+- [ ] **Bulk DELETE…RETURNING + bulk outbox in `detectAndExpireStuckJobs`** — Today the function is N+1: SELECT stuck rows, then per-row `expireStuckJob` (atomic `DELETE … WHERE last_heartbeat_at < cutoff RETURNING run_id` + 1-row `runners.job.lease_expired` outbox insert). Total ~1 SELECT + N DELETEs per cron tick. Acceptable at handful-of-runners scale; revisit with a single transaction `DELETE FROM running_jobs WHERE last_heartbeat_at < $threshold RETURNING job_id, run_id` plus a multi-row outbox insert when concurrent-job counts demand it. Likely depends on a `writeOutboxEvents` (plural) helper in `@shipfox/node-outbox`.
 
 - [ ] **`cancelRun(runId)` + DAG-wide cancellation propagation** — The heartbeat-cancel plumbing is wired (cancellation_requested_at column + heartbeat response field) but only consumed by `jobOrchestration`'s timeout. Add a `cancelRun` command in Workflows that walks the DAG, calls `requestJobCancellation` for each running job in the run, and signals `WorkflowRunOrchestration`/child `JobOrchestration`s to abort. Spec context: `.claude/research/system-design.md:341`. Closes the user-facing "stop this run" UX gap without protocol change on the runner side.
 
-- [ ] **Calibrate stuck-job threshold + failure observability** — The detector uses a 180s threshold (≈18× the 10s heartbeat interval). Under a 3-minute Postgres or network blip, healthy long-running jobs whose heartbeats are silently failing will be killed. Two follow-ups: (1) emit a Prometheus/OpenTelemetry counter for "jobs failed by detector" so we can detect calibration mismatches in production; (2) consider raising the default to 300s (or making it configurable per-tenant) once we have load data. Couple this with a runner-side warning log when consecutive heartbeat failures exceed `intervalMs * N` so disconnects are visible before the detector fires.
+- [ ] **Calibrate stuck-job threshold + failure observability** — The detector uses a 180s threshold (≈18× the 10s heartbeat interval). Under a 3-minute Postgres or network blip, healthy long-running jobs whose heartbeats are silently failing will be killed. Two follow-ups: (1) emit a Prometheus/OpenTelemetry counter for "job leases expired by detector" so we can detect calibration mismatches in production; (2) consider raising the default to 300s (or making it configurable per-tenant) once we have load data. Couple this with a runner-side warning log when consecutive heartbeat failures exceed `intervalMs * N` so disconnects are visible before the detector fires.
 
 - [ ] **Worker-boot failures should fail the app, not log a warning** — `startModuleWorkers` at `libs/shared/node/module/src/initialize.ts:103-138` catches per-worker creation/start errors and only logs a warning. `apps/api/src/core/run.ts:54` calls it without `await`. A typo in `workflowsPath`, a missing dist file, or a Temporal connection issue at startup means a registered worker silently fails to start — and we lose the safety net (e.g. the `runners-maintenance` cron that fails stuck jobs). Two-line fix: re-throw in `startModuleWorkers`, `await` in `run.ts`. Defer because it touches an app-boot critical path that should be tested carefully (which other modules depend on this catch-and-warn behavior?). Surfaced by codex on the workflows↔runners decoupling PR.

--- a/TODOS.md
+++ b/TODOS.md
@@ -46,10 +46,6 @@
 
 **Depends on:** Nothing. Can be done as a standalone PR.
 
-## Capability-scoped / registration runner tokens
-
-Runner-token auth already guards the runner protocol endpoints. Future hardening: a `POST /api/runners/register` registration flow issuing runner-scoped tokens with workspace and capability restrictions.
-
 ## Single-statement `applyStepResults` for many-step jobs
 
 **What:** Collapse the N-update + 1-cancellation-sweep pattern in `applyStepResults` (`libs/api/workflows/src/db/workflow-runs.ts`) into a single `UPDATE steps SET status = CASE id WHEN ... END, error = CASE id WHEN ... END WHERE job_id = ?` for jobs with many reported steps.

--- a/libs/api/runners-dto/src/events.ts
+++ b/libs/api/runners-dto/src/events.ts
@@ -9,6 +9,14 @@ export interface RunnerJobCompletedEvent {
   steps: StepResultDto[];
 }
 
+export const RUNNER_JOB_LEASE_EXPIRED = 'runners.job.lease_expired' as const;
+
+export interface RunnerJobLeaseExpiredEvent {
+  jobId: string;
+  runId: string;
+}
+
 export interface RunnersEventMap {
   [RUNNER_JOB_COMPLETED]: RunnerJobCompletedEvent;
+  [RUNNER_JOB_LEASE_EXPIRED]: RunnerJobLeaseExpiredEvent;
 }

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -1,8 +1,10 @@
 export {
+  type ClaimedJobResponseDto,
   type CompleteJobBodyDto,
   type CompleteJobResponseDto,
   type CreateRunnerTokenBodyDto,
   type CreateRunnerTokenResponseDto,
+  claimedJobResponseSchema,
   completeJobBodySchema,
   completeJobResponseSchema,
   createRunnerTokenBodySchema,
@@ -31,6 +33,8 @@ export {
 } from '#schemas/index.js';
 export {
   RUNNER_JOB_COMPLETED,
+  RUNNER_JOB_LEASE_EXPIRED,
   type RunnerJobCompletedEvent,
+  type RunnerJobLeaseExpiredEvent,
   type RunnersEventMap,
 } from './events.js';

--- a/libs/api/runners-dto/src/schemas/claim-job.ts
+++ b/libs/api/runners-dto/src/schemas/claim-job.ts
@@ -1,0 +1,9 @@
+import {z} from 'zod';
+
+export const claimedJobResponseSchema = z.object({
+  job_id: z.string().uuid(),
+  run_id: z.string().uuid(),
+  lease_token: z.string().min(1),
+});
+
+export type ClaimedJobResponseDto = z.infer<typeof claimedJobResponseSchema>;

--- a/libs/api/runners-dto/src/schemas/index.ts
+++ b/libs/api/runners-dto/src/schemas/index.ts
@@ -1,3 +1,4 @@
+export {type ClaimedJobResponseDto, claimedJobResponseSchema} from './claim-job.js';
 export {
   type CompleteJobBodyDto,
   type CompleteJobResponseDto,

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -11,7 +11,6 @@ CREATE TABLE "runners_pending_jobs" (
 	"workspace_id" uuid NOT NULL,
 	"job_id" uuid NOT NULL,
 	"run_id" uuid NOT NULL,
-	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "runners_pending_jobs_job_id_unique" UNIQUE("job_id")
 );

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -95,12 +95,6 @@
           "primaryKey": false,
           "notNull": true
         },
-        "payload": {
-          "name": "payload",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": true
-        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -1,6 +1,6 @@
 export type {RunnerToken} from './entities/runner-token.js';
 export {RunnerTokenNotFoundError, RunningJobNotFoundError} from './errors.js';
-export {completeJob} from './jobs.js';
+export {type ClaimJobResult, claimJob, completeJob} from './jobs.js';
 export {
   createWorkspaceRunnerToken,
   listUsableRunnerTokens,

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -1,44 +1,57 @@
 import type {StepResultDto} from '@shipfox/api-runners-dto';
-import {finalizeRunningJob, findStuckJobs} from '#db/jobs.js';
-import {RunningJobNotFoundError} from './errors.js';
+import {issueJobLeaseToken} from '#core/job-lease-token.js';
+import {claimPendingJob, expireStuckJob, finalizeRunningJob, findStuckJobs} from '#db/jobs.js';
 
 export async function completeJob(
   params: {jobId: string; runnerTokenId: string},
   result: {status: 'succeeded' | 'failed'; steps: StepResultDto[]},
 ): Promise<{runId: string}> {
-  const finalized = await finalizeRunningJob({
+  return await finalizeRunningJob({
     jobId: params.jobId,
     runnerTokenId: params.runnerTokenId,
     status: result.status,
     steps: result.steps,
-    onMissing: 'throw',
   });
-  if (!finalized) throw new RunningJobNotFoundError(params.jobId);
-  return finalized;
+}
+
+export interface ClaimJobResult {
+  jobId: string;
+  runId: string;
+  leaseToken: string;
+}
+
+export async function claimJob(params: {
+  workspaceId: string;
+  runnerTokenId: string;
+}): Promise<ClaimJobResult | null> {
+  const claimed = await claimPendingJob(params);
+  if (!claimed) return null;
+
+  const leaseToken = await issueJobLeaseToken({
+    jobId: claimed.jobId,
+    runId: claimed.runId,
+    workspaceId: params.workspaceId,
+    runnerTokenId: params.runnerTokenId,
+  });
+
+  return {jobId: claimed.jobId, runId: claimed.runId, leaseToken};
 }
 
 // N+1 by design (~1 SELECT + N DELETEs per tick). Bulk DELETE…RETURNING +
 // multi-row outbox insert is the documented scale path; deferred until load
 // signals demand it.
-export async function detectAndFailStuckJobs(params: {
+export async function detectAndExpireStuckJobs(params: {
   thresholdSeconds: number;
-}): Promise<{failed: number}> {
+}): Promise<{expired: number}> {
   const candidates = await findStuckJobs({thresholdSeconds: params.thresholdSeconds});
 
-  let failed = 0;
+  let expired = 0;
   for (const candidate of candidates) {
-    // Empty steps[] flows into the workflow's empty-fallback path, which
-    // bulk-fails every step. The "runner_disappeared" reason previously stored
-    // here was transport-only (never persisted) and the heartbeat audit log
-    // remains the source of truth for why a job went stuck.
-    const finalized = await finalizeRunningJob({
+    const result = await expireStuckJob({
       jobId: candidate.jobId,
       staleBeforeMs: params.thresholdSeconds * 1000,
-      status: 'failed',
-      steps: [],
-      onMissing: 'noop',
     });
-    if (finalized) failed += 1;
+    if (result) expired += 1;
   }
-  return {failed};
+  return {expired};
 }

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -2,8 +2,15 @@ import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 export {closeDb, db, schema} from './db.js';
-export type {ClaimedJob, EnqueueJobParams, FinalizeRunningJobParams} from './jobs.js';
-export {claimJob, enqueueJob, finalizeRunningJob, findStuckJobs, recordHeartbeat} from './jobs.js';
+export type {ClaimedJob, FinalizeRunningJobParams, ScheduleJobParams} from './jobs.js';
+export {
+  claimPendingJob,
+  expireStuckJob,
+  finalizeRunningJob,
+  findStuckJobs,
+  recordHeartbeat,
+  scheduleJob,
+} from './jobs.js';
 export type {CreateRunnerTokenParams} from './runner-tokens.js';
 export {
   createRunnerToken,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -1,57 +1,123 @@
-import {RUNNER_JOB_COMPLETED} from '@shipfox/api-runners-dto';
+import {RUNNER_JOB_COMPLETED, RUNNER_JOB_LEASE_EXPIRED} from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
-import {completeJob, detectAndFailStuckJobs} from '#core/jobs.js';
+import {verifyJobLeaseToken} from '#core/job-lease-token.js';
+import {claimJob, completeJob, detectAndExpireStuckJobs} from '#core/jobs.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {db} from './db.js';
-import {claimJob, enqueueJob, recordHeartbeat, requestJobCancellation} from './jobs.js';
+import {
+  claimPendingJob,
+  expireStuckJob,
+  recordHeartbeat,
+  requestJobCancellation,
+  scheduleJob,
+} from './jobs.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
 import {runningJobs} from './schema/running-jobs.js';
 
-describe('enqueueJob', () => {
+describe('scheduleJob', () => {
   beforeEach(async () => {
     await db().execute(
       sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_outbox CASCADE`,
     );
   });
 
-  it('inserts a row into pending_jobs with correct payload', async () => {
+  it('stores a pending assignment row', async () => {
     const jobId = crypto.randomUUID();
     const runId = crypto.randomUUID();
     const workspaceId = crypto.randomUUID();
-    const payload = {
-      job_id: jobId,
-      run_id: runId,
-      job_name: 'build',
-      steps: [
-        {
-          id: crypto.randomUUID(),
-          name: 'hello',
-          type: 'run',
-          config: {run: 'echo hello'},
-          position: 0,
-        },
-      ],
-    };
 
-    await enqueueJob({workspaceId, jobId, runId, payload});
+    await scheduleJob({workspaceId, jobId, runId});
 
     const rows = await db().select().from(pendingJobs);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.jobId).toBe(jobId);
     expect(rows[0]?.runId).toBe(runId);
     expect(rows[0]?.workspaceId).toBe(workspaceId);
-    expect(rows[0]?.payload).toEqual(payload);
+    expect(rows[0]).not.toHaveProperty('payload');
   });
 
-  it('throws on duplicate job_id', async () => {
+  it('is idempotent: scheduling the same jobId twice is a no-op', async () => {
     const jobId = crypto.randomUUID();
-    const attrs = {workspaceId: crypto.randomUUID(), runId: crypto.randomUUID(), jobId};
-    const payload = {job_id: jobId, run_id: attrs.runId, job_name: 'build', steps: []};
+    const params = {workspaceId: crypto.randomUUID(), runId: crypto.randomUUID(), jobId};
 
-    await enqueueJob({...attrs, payload});
+    await scheduleJob(params);
+    await expect(scheduleJob(params)).resolves.toBeUndefined();
 
-    await expect(enqueueJob({...attrs, payload})).rejects.toThrow();
+    const rows = await db().select().from(pendingJobs);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('claimPendingJob', () => {
+  let workspaceId: string;
+  let runnerTokenId: string;
+
+  beforeEach(async () => {
+    await db().execute(
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens CASCADE`,
+    );
+    workspaceId = crypto.randomUUID();
+    const runnerToken = await runnerTokenFactory.create({workspaceId});
+    runnerTokenId = runnerToken.id;
+  });
+
+  it('returns the job ids when a job is available', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+
+    expect(claimed).not.toBeNull();
+    expect(claimed?.jobId).toBe(created.jobId);
+    expect(claimed?.runId).toBe(created.runId);
+  });
+
+  it('returns null when no jobs are pending', async () => {
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+
+    expect(claimed).toBeNull();
+  });
+
+  it('only one caller wins when two claim concurrently', async () => {
+    const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
+    await pendingJobFactory.create({workspaceId});
+
+    const [claim1, claim2] = await Promise.all([
+      claimPendingJob({workspaceId, runnerTokenId}),
+      claimPendingJob({workspaceId, runnerTokenId: otherRunnerToken.id}),
+    ]);
+
+    const claimed = [claim1, claim2].filter(Boolean);
+    expect(claimed).toHaveLength(1);
+  });
+
+  it('claims the oldest job first', async () => {
+    const older = await pendingJobFactory.create({workspaceId});
+    await pendingJobFactory.create({workspaceId});
+
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+
+    expect(claimed?.jobId).toBe(older.jobId);
+  });
+
+  it('moves the job from pending to running', async () => {
+    await pendingJobFactory.create({workspaceId});
+
+    await claimPendingJob({workspaceId, runnerTokenId});
+
+    const pending = await db().select().from(pendingJobs);
+    const running = await db().select().from(runningJobs);
+    expect(pending).toHaveLength(0);
+    expect(running).toHaveLength(1);
+    expect(running[0]?.runnerTokenId).toBe(runnerTokenId);
+  });
+
+  it('does not claim jobs from another workspace', async () => {
+    await pendingJobFactory.create({workspaceId: crypto.randomUUID()});
+
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+
+    expect(claimed).toBeNull();
   });
 });
 
@@ -68,7 +134,7 @@ describe('claimJob', () => {
     runnerTokenId = runnerToken.id;
   });
 
-  it('returns the job payload when a job is available', async () => {
+  it('mints a lease token whose claims match the claimed job', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
     const claimed = await claimJob({workspaceId, runnerTokenId});
@@ -76,52 +142,18 @@ describe('claimJob', () => {
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
     expect(claimed?.runId).toBe(created.runId);
-    expect(claimed?.payload.job_name).toBe(created.payload.job_name);
+    expect(claimed).not.toHaveProperty('steps');
+
+    const claims = await verifyJobLeaseToken(claimed?.leaseToken as string);
+    expect(claims).toMatchObject({
+      jobId: created.jobId,
+      runId: created.runId,
+      workspaceId,
+      runnerTokenId,
+    });
   });
 
-  it('returns null when no jobs are pending', async () => {
-    const claimed = await claimJob({workspaceId, runnerTokenId});
-
-    expect(claimed).toBeNull();
-  });
-
-  it('only one caller wins when two claim concurrently', async () => {
-    const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
-    await pendingJobFactory.create({workspaceId});
-
-    const [claim1, claim2] = await Promise.all([
-      claimJob({workspaceId, runnerTokenId}),
-      claimJob({workspaceId, runnerTokenId: otherRunnerToken.id}),
-    ]);
-
-    const claimed = [claim1, claim2].filter(Boolean);
-    expect(claimed).toHaveLength(1);
-  });
-
-  it('claims the oldest job first', async () => {
-    const older = await pendingJobFactory.create({workspaceId});
-    await pendingJobFactory.create({workspaceId});
-
-    const claimed = await claimJob({workspaceId, runnerTokenId});
-
-    expect(claimed?.jobId).toBe(older.jobId);
-  });
-
-  it('moves the job from pending to running', async () => {
-    await pendingJobFactory.create({workspaceId});
-
-    await claimJob({workspaceId, runnerTokenId});
-
-    const pending = await db().select().from(pendingJobs);
-    const running = await db().select().from(runningJobs);
-    expect(pending).toHaveLength(0);
-    expect(running).toHaveLength(1);
-    expect(running[0]?.runnerTokenId).toBe(runnerTokenId);
-  });
-
-  it('does not claim jobs from another workspace', async () => {
-    await pendingJobFactory.create({workspaceId: crypto.randomUUID()});
-
+  it('returns null and mints no token when the queue is empty', async () => {
     const claimed = await claimJob({workspaceId, runnerTokenId});
 
     expect(claimed).toBeNull();
@@ -149,13 +181,12 @@ describe('completeJob', () => {
   }
 
   it('deletes the running job and writes an outbox event', async () => {
-    const pending = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
-    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+    await pendingJobFactory.create({workspaceId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     const result = await completeJob(
       {jobId: claimed?.jobId as string, runnerTokenId},
-      succeededResult(stepId),
+      succeededResult(crypto.randomUUID()),
     );
 
     expect(result.runId).toBe(claimed?.runId as string);
@@ -184,14 +215,13 @@ describe('completeJob', () => {
 
   it('does not complete a job owned by another runner token', async () => {
     const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
-    const pending = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
-    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+    await pendingJobFactory.create({workspaceId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     await expect(
       completeJob(
         {jobId: claimed?.jobId as string, runnerTokenId: otherRunnerToken.id},
-        succeededResult(stepId),
+        succeededResult(crypto.randomUUID()),
       ),
     ).rejects.toThrow('Running job not found');
 
@@ -214,7 +244,7 @@ describe('recordHeartbeat', () => {
 
   it('returns cancel:false on a fresh row and bumps last_heartbeat_at', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     const before = await db()
       .select()
@@ -244,7 +274,7 @@ describe('recordHeartbeat', () => {
 
   it('returns cancel:true after requestJobCancellation', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
 
@@ -265,7 +295,7 @@ describe('recordHeartbeat', () => {
   it('throws when jobId belongs to a different runner token', async () => {
     const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     await expect(
       recordHeartbeat({
@@ -288,7 +318,7 @@ describe('requestJobCancellation', () => {
 
   it('sets cancellation_requested_at on a fresh row', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
 
@@ -301,7 +331,7 @@ describe('requestJobCancellation', () => {
 
   it('is idempotent: second call preserves the first timestamp', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
     const after1 = await db()
@@ -325,7 +355,7 @@ describe('requestJobCancellation', () => {
   });
 });
 
-describe('detectAndFailStuckJobs', () => {
+describe('detectAndExpireStuckJobs', () => {
   let workspaceId: string;
   let runnerTokenId: string;
 
@@ -337,7 +367,7 @@ describe('detectAndFailStuckJobs', () => {
 
   async function makeStaleJob(staleSeconds: number): Promise<{jobId: string; runId: string}> {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
     await db()
       .update(runningJobs)
       .set({
@@ -359,42 +389,40 @@ describe('detectAndFailStuckJobs', () => {
     });
   }
 
-  it('fails a stuck job and writes a runners.job.completed event with empty steps[]', async () => {
+  it('expires a stuck job and writes a runners.job.lease_expired event', async () => {
     const {jobId, runId} = await makeStaleJob(600);
 
-    const result = await detectAndFailStuckJobs({thresholdSeconds: 180});
+    const result = await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
-    expect(result.failed).toBeGreaterThanOrEqual(1);
+    expect(result.expired).toBeGreaterThanOrEqual(1);
     expect(await runningJobsForTest()).toHaveLength(0);
 
     const outbox = await outboxForJobs([jobId]);
     expect(outbox).toHaveLength(1);
-    expect(outbox[0]?.eventType).toBe(RUNNER_JOB_COMPLETED);
+    expect(outbox[0]?.eventType).toBe(RUNNER_JOB_LEASE_EXPIRED);
     const payload = outbox[0]?.payload as Record<string, unknown>;
     expect(payload.jobId).toBe(jobId);
     expect(payload.runId).toBe(runId);
-    expect(payload.status).toBe('failed');
-    // Stuck-job detection has no per-step detail; the workflow falls back to
-    // bulk-failing every step via the empty-steps path.
-    expect(payload.steps).toEqual([]);
-    expect(payload.output).toBeUndefined();
+    // The lease-expired event carries only the assignment identifiers.
+    expect(payload.status).toBeUndefined();
+    expect(payload.steps).toBeUndefined();
   });
 
-  it('does not fail a job whose heartbeat is still inside the threshold window', async () => {
+  it('does not expire a job whose heartbeat is still inside the threshold window', async () => {
     const {jobId} = await makeStaleJob(60);
 
-    await detectAndFailStuckJobs({thresholdSeconds: 180});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
     expect(await runningJobsForTest()).toHaveLength(1);
     expect(await outboxForJobs([jobId])).toHaveLength(0);
   });
 
-  it('only fails the stuck rows in a mixed batch', async () => {
+  it('only expires the stuck rows in a mixed batch', async () => {
     const stuck1 = await makeStaleJob(600);
     const stuck2 = await makeStaleJob(600);
     const fresh = await makeStaleJob(30);
 
-    await detectAndFailStuckJobs({thresholdSeconds: 180});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
     const remaining = await runningJobsForTest();
     expect(remaining.map((r) => r.jobId)).toEqual([fresh.jobId]);
@@ -402,8 +430,8 @@ describe('detectAndFailStuckJobs', () => {
   });
 
   it('returns zero when there are no stuck jobs', async () => {
-    const result = await detectAndFailStuckJobs({thresholdSeconds: 180});
-    expect(result.failed).toBe(0);
+    const result = await detectAndExpireStuckJobs({thresholdSeconds: 180});
+    expect(result.expired).toBe(0);
   });
 
   it('skips a row whose heartbeat refreshed before the atomic DELETE re-evaluates the predicate', async () => {
@@ -415,9 +443,20 @@ describe('detectAndFailStuckJobs', () => {
       .set({lastHeartbeatAt: sql`now()`})
       .where(eq(runningJobs.jobId, jobId));
 
-    await detectAndFailStuckJobs({thresholdSeconds: 180});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
     expect(await runningJobsForTest()).toHaveLength(1);
     expect(await outboxForJobs([jobId])).toHaveLength(0);
+  });
+
+  it('double-expiring the same stuck job emits exactly one event', async () => {
+    const {jobId} = await makeStaleJob(600);
+
+    const first = await expireStuckJob({jobId, staleBeforeMs: 180_000});
+    const second = await expireStuckJob({jobId, staleBeforeMs: 180_000});
+
+    expect(first).toBeDefined();
+    expect(second).toBeUndefined();
+    expect(await outboxForJobs([jobId])).toHaveLength(1);
   });
 });

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -18,9 +18,12 @@ export interface ScheduleJobParams {
   runId: string;
 }
 
-// Idempotent: a duplicate jobId means the job is already scheduled. Temporal
-// retries the enqueue activity at-least-once, so a unique-violation throw on a
-// retry-after-lost-result would permanently fail a healthy job's workflow.
+// Idempotent while the job is still pending: a duplicate jobId already in
+// `runners_pending_jobs` is a no-op. Temporal retries the enqueue activity
+// at-least-once, so a unique-violation throw on a retry-after-lost-result
+// would permanently fail a healthy job's workflow. This does not cover a retry
+// after the job has been claimed and moved to `runners_running_jobs`; that
+// window is owned by ENG-400.
 export async function scheduleJob(params: ScheduleJobParams): Promise<void> {
   await db()
     .insert(pendingJobs)

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -21,9 +21,10 @@ export interface ScheduleJobParams {
 // Idempotent while the job is still pending: a duplicate jobId already in
 // `runners_pending_jobs` is a no-op. Temporal retries the enqueue activity
 // at-least-once, so a unique-violation throw on a retry-after-lost-result
-// would permanently fail a healthy job's workflow. This does not cover a retry
-// after the job has been claimed and moved to `runners_running_jobs`; that
-// window is owned by ENG-400.
+// would permanently fail a healthy job's workflow. The guard does not extend
+// past the claim: once the job has moved to `runners_running_jobs`, a retry
+// can reinsert a pending row that a later claim then rejects on the
+// running-job unique constraint.
 export async function scheduleJob(params: ScheduleJobParams): Promise<void> {
   await db()
     .insert(pendingJobs)
@@ -126,8 +127,9 @@ export async function finalizeRunningJob(
  * written in the same transaction only when a row was deleted, so a heartbeat
  * landing between an outer `findStuckJobs` read and this call leaves the live
  * job untouched, and overlapping detector runs cannot double-emit. `runId`
- * comes from `RETURNING`. (Duplicates `finalizeRunningJob`'s shape on purpose;
- * `finalizeRunningJob` is removed in ENG-400.)
+ * comes from `RETURNING`. Intentionally not shared with `finalizeRunningJob`:
+ * the two guard on different predicates and emit different events, so the
+ * resemblance is shallow.
  */
 export async function expireStuckJob(params: {
   jobId: string;

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -1,6 +1,6 @@
 import {
-  type JobPayloadDto,
   RUNNER_JOB_COMPLETED,
+  RUNNER_JOB_LEASE_EXPIRED,
   type RunnersEventMap,
   type StepResultDto,
 } from '@shipfox/api-runners-dto';
@@ -12,38 +12,43 @@ import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
 import {runningJobs} from './schema/running-jobs.js';
 
-export interface EnqueueJobParams {
+export interface ScheduleJobParams {
   workspaceId: string;
   jobId: string;
   runId: string;
-  payload: JobPayloadDto;
 }
 
-export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
-  await db().insert(pendingJobs).values({
-    workspaceId: params.workspaceId,
-    jobId: params.jobId,
-    runId: params.runId,
-    payload: params.payload,
-  });
+// Idempotent: a duplicate jobId means the job is already scheduled. Temporal
+// retries the enqueue activity at-least-once, so a unique-violation throw on a
+// retry-after-lost-result would permanently fail a healthy job's workflow.
+export async function scheduleJob(params: ScheduleJobParams): Promise<void> {
+  await db()
+    .insert(pendingJobs)
+    .values({
+      workspaceId: params.workspaceId,
+      jobId: params.jobId,
+      runId: params.runId,
+    })
+    .onConflictDoNothing({target: pendingJobs.jobId});
 }
 
 export interface ClaimedJob {
   jobId: string;
   runId: string;
-  payload: JobPayloadDto;
 }
 
-export async function claimJob(params: {
+export async function claimPendingJob(params: {
   workspaceId: string;
   runnerTokenId: string;
 }): Promise<ClaimedJob | null> {
   return await db().transaction(async (tx) => {
+    // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
+    // for rows sharing a created_at within a batch.
     const [row] = await tx
       .select()
       .from(pendingJobs)
       .where(eq(pendingJobs.workspaceId, params.workspaceId))
-      .orderBy(asc(pendingJobs.createdAt))
+      .orderBy(asc(pendingJobs.createdAt), asc(pendingJobs.id))
       .limit(1)
       .for('update', {skipLocked: true});
 
@@ -61,60 +66,40 @@ export async function claimJob(params: {
     return {
       jobId: row.jobId,
       runId: row.runId,
-      payload: row.payload as JobPayloadDto,
     };
   });
 }
 
 export interface FinalizeRunningJobParams {
   jobId: string;
-  /** When provided, only delete the row if it belongs to this runner token. */
-  runnerTokenId?: string;
-  /** When provided, only delete the row if its heartbeat is older than this. */
-  staleBeforeMs?: number;
+  runnerTokenId: string;
   status: 'succeeded' | 'failed';
   steps: StepResultDto[];
-  /** Whether to throw `RunningJobNotFoundError` when no row matches the filters. */
-  onMissing: 'throw' | 'noop';
 }
 
 /**
- * Race-safe by construction: all guard predicates (token scope, stale
- * heartbeat) live inside the DELETE's WHERE, and the outbox event is written
- * in the same transaction only when a row was actually deleted. So a heartbeat
- * arriving between an outer "is this stuck?" check and this call cannot cause
- * a live job to be finalized, and two concurrent finalizers cannot both emit
- * the same `runners.job.completed` event.
+ * Race-safe by construction: the token-scope guard lives inside the DELETE's
+ * WHERE, and the outbox event is written in the same transaction only when a
+ * row was actually deleted. So two concurrent finalizers cannot both emit the
+ * same `runners.job.completed` event. Throws `RunningJobNotFoundError` when no
+ * row matches.
  */
 export async function finalizeRunningJob(
   params: FinalizeRunningJobParams,
-): Promise<{runId: string} | undefined> {
+): Promise<{runId: string}> {
   return await db().transaction(async (tx) => {
-    const conditions = [eq(runningJobs.jobId, params.jobId)];
-    if (params.runnerTokenId !== undefined) {
-      conditions.push(eq(runningJobs.runnerTokenId, params.runnerTokenId));
-    }
-    if (params.staleBeforeMs !== undefined) {
-      conditions.push(
-        lt(
-          runningJobs.lastHeartbeatAt,
-          sql`now() - (${params.staleBeforeMs} || ' milliseconds')::interval`,
-        ),
-      );
-    }
-
     const deleted = await tx
       .delete(runningJobs)
-      .where(and(...conditions))
+      .where(
+        and(
+          eq(runningJobs.jobId, params.jobId),
+          eq(runningJobs.runnerTokenId, params.runnerTokenId),
+        ),
+      )
       .returning({runId: runningJobs.runId});
 
     const row = deleted[0];
-    if (!row) {
-      if (params.onMissing === 'throw') {
-        throw new RunningJobNotFoundError(params.jobId);
-      }
-      return undefined;
-    }
+    if (!row) throw new RunningJobNotFoundError(params.jobId);
 
     await writeOutboxEvent<RunnersEventMap>(tx, runnersOutbox, {
       type: RUNNER_JOB_COMPLETED,
@@ -123,6 +108,50 @@ export async function finalizeRunningJob(
         runId: row.runId,
         status: params.status,
         steps: params.steps,
+      },
+    });
+
+    return {runId: row.runId};
+  });
+}
+
+/**
+ * Deletes a stuck running-job lease and emits `runners.job.lease_expired`.
+ *
+ * Race-safe by the same contract as `finalizeRunningJob` (see above): the
+ * stale-heartbeat guard lives inside the DELETE's WHERE and the outbox event is
+ * written in the same transaction only when a row was deleted, so a heartbeat
+ * landing between an outer `findStuckJobs` read and this call leaves the live
+ * job untouched, and overlapping detector runs cannot double-emit. `runId`
+ * comes from `RETURNING`. (Duplicates `finalizeRunningJob`'s shape on purpose;
+ * `finalizeRunningJob` is removed in ENG-400.)
+ */
+export async function expireStuckJob(params: {
+  jobId: string;
+  staleBeforeMs: number;
+}): Promise<{runId: string} | undefined> {
+  return await db().transaction(async (tx) => {
+    const deleted = await tx
+      .delete(runningJobs)
+      .where(
+        and(
+          eq(runningJobs.jobId, params.jobId),
+          lt(
+            runningJobs.lastHeartbeatAt,
+            sql`now() - (${params.staleBeforeMs} || ' milliseconds')::interval`,
+          ),
+        ),
+      )
+      .returning({runId: runningJobs.runId});
+
+    const row = deleted[0];
+    if (!row) return undefined;
+
+    await writeOutboxEvent<RunnersEventMap>(tx, runnersOutbox, {
+      type: RUNNER_JOB_LEASE_EXPIRED,
+      payload: {
+        jobId: params.jobId,
+        runId: row.runId,
       },
     });
 

--- a/libs/api/runners/src/db/schema/pending-jobs.ts
+++ b/libs/api/runners/src/db/schema/pending-jobs.ts
@@ -1,5 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, jsonb, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {index, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 
 export const pendingJobs = pgTable(
@@ -9,7 +9,6 @@ export const pendingJobs = pgTable(
     workspaceId: uuid('workspace_id').notNull(),
     jobId: uuid('job_id').notNull().unique(),
     runId: uuid('run_id').notNull(),
-    payload: jsonb('payload').notNull(),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
   },
   (table) => [

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -9,7 +9,7 @@ import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
 export type {JobLeaseTokenClaims} from '@shipfox/api-runners-dto';
 export {verifyJobLeaseToken} from '#core/job-lease-token.js';
-export {enqueueJob} from '#db/index.js';
+export {type ScheduleJobParams, scheduleJob} from '#db/index.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');

--- a/libs/api/runners/src/presentation/routes/complete-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/complete-job.test.ts
@@ -5,7 +5,7 @@ import {closeApp, createApp} from '@shipfox/node-fastify';
 import {eq, sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
-import {claimJob} from '#db/jobs.js';
+import {claimPendingJob} from '#db/jobs.js';
 import {revokeRunnerToken} from '#db/runner-tokens.js';
 import {runnersOutbox} from '#db/schema/outbox.js';
 import {runningJobs} from '#db/schema/running-jobs.js';
@@ -82,8 +82,8 @@ describe('POST /runners/jobs/:jobId/complete', () => {
 
   it('returns 200 on successful completion and outbox event carries steps', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
-    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const stepId = crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',
@@ -106,9 +106,9 @@ describe('POST /runners/jobs/:jobId/complete', () => {
 
   it('allows a revoked token to complete a job it already owns', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
-    await claimJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerTokenId});
     await revokeRunnerToken({tokenId: runnerTokenId, workspaceId});
-    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+    const stepId = crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',
@@ -124,8 +124,8 @@ describe('POST /runners/jobs/:jobId/complete', () => {
     const pending = await pendingJobFactory.create({workspaceId});
     const otherRawToken = `sf_r_${crypto.randomUUID()}`;
     await runnerTokenFactory.create({workspaceId}, {transient: {rawToken: otherRawToken}});
-    await claimJob({workspaceId, runnerTokenId});
-    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+    await claimPendingJob({workspaceId, runnerTokenId});
+    const stepId = crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',
@@ -188,7 +188,7 @@ describe('POST /runners/jobs/:jobId/complete', () => {
 
   it('accepts status=failed with empty steps[] (executor-throws / stuck path)', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
-    await claimJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerTokenId});
 
     const res = await app.inject({
       method: 'POST',
@@ -202,8 +202,8 @@ describe('POST /runners/jobs/:jobId/complete', () => {
 
   it('accepts status=failed with mixed step statuses (mid-job failure)', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
-    await claimJob({workspaceId, runnerTokenId});
-    const stepId = pending.payload.steps[0]?.id ?? crypto.randomUUID();
+    await claimPendingJob({workspaceId, runnerTokenId});
+    const stepId = crypto.randomUUID();
 
     const res = await app.inject({
       method: 'POST',

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -4,7 +4,7 @@ import {closeApp, createApp} from '@shipfox/node-fastify';
 import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
-import {claimJob, requestJobCancellation} from '#db/jobs.js';
+import {claimPendingJob, requestJobCancellation} from '#db/jobs.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
@@ -59,7 +59,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
 
   it('returns 200 + cancel:false on a fresh row', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
-    await claimJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerTokenId});
 
     const res = await app.inject({
       method: 'POST',
@@ -73,7 +73,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
 
   it('returns 200 + cancel:true after requestJobCancellation', async () => {
     const pending = await pendingJobFactory.create({workspaceId});
-    await claimJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerTokenId});
     await requestJobCancellation({jobId: pending.jobId});
 
     const res = await app.inject({
@@ -101,7 +101,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
     const pending = await pendingJobFactory.create({workspaceId});
     const otherRawToken = `sf_r_${crypto.randomUUID()}`;
     await runnerTokenFactory.create({workspaceId}, {transient: {rawToken: otherRawToken}});
-    await claimJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerTokenId});
 
     const res = await app.inject({
       method: 'POST',

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -3,6 +3,7 @@ import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
+import {verifyJobLeaseToken} from '#core/job-lease-token.js';
 import {db} from '#db/db.js';
 import {revokeRunnerToken} from '#db/runner-tokens.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
@@ -23,6 +24,7 @@ describe('POST /runners/jobs/request', () => {
   let app: FastifyInstance;
   let rawToken: string;
   let workspaceId: string;
+  let runnerTokenId: string;
 
   beforeAll(async () => {
     app = await createApp({
@@ -43,7 +45,8 @@ describe('POST /runners/jobs/request', () => {
     );
     rawToken = `sf_r_${crypto.randomUUID()}`;
     workspaceId = crypto.randomUUID();
-    await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+    const token = await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+    runnerTokenId = token.id;
   });
 
   it('returns 401 without authorization', async () => {
@@ -65,8 +68,8 @@ describe('POST /runners/jobs/request', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it('returns 200 with a workspace-scoped job payload when a job is available', async () => {
-    await pendingJobFactory.create({workspaceId});
+  it('returns 200 with the job ids and a verifiable lease token when a job is available', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
 
     const res = await app.inject({
       method: 'POST',
@@ -76,10 +79,19 @@ describe('POST /runners/jobs/request', () => {
 
     expect(res.statusCode).toBe(200);
     const body = res.json();
-    expect(body.job_id).toBeDefined();
-    expect(body.run_id).toBeDefined();
-    expect(body.job_name).toBeDefined();
-    expect(Array.isArray(body.steps)).toBe(true);
+    expect(body.job_id).toBe(created.jobId);
+    expect(body.run_id).toBe(created.runId);
+    expect(typeof body.lease_token).toBe('string');
+    expect(body.job_name).toBeUndefined();
+    expect(body.steps).toBeUndefined();
+
+    const claims = await verifyJobLeaseToken(body.lease_token);
+    expect(claims).toMatchObject({
+      jobId: created.jobId,
+      runId: created.runId,
+      workspaceId,
+      runnerTokenId,
+    });
   });
 
   it('returns 204 when no jobs are available for the token workspace', async () => {

--- a/libs/api/runners/src/presentation/routes/request-job.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.ts
@@ -1,15 +1,15 @@
-import {jobPayloadResponseSchema} from '@shipfox/api-runners-dto';
+import {claimedJobResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
-import {claimJob} from '#db/jobs.js';
+import {claimJob} from '#core/jobs.js';
 import {getRunnerContext} from '#presentation/auth/index.js';
 
 export const requestJobRoute = defineRoute({
   method: 'POST',
   path: '/request',
-  description: 'Get the next available job for the runner to run',
+  description: 'Claim the next available job and receive its lease token',
   schema: {
     response: {
-      200: jobPayloadResponseSchema,
+      200: claimedJobResponseSchema,
     },
   },
   handler: async (_request, reply) => {
@@ -33,8 +33,7 @@ export const requestJobRoute = defineRoute({
     return {
       job_id: job.jobId,
       run_id: job.runId,
-      job_name: job.payload.job_name,
-      steps: job.payload.steps,
+      lease_token: job.leaseToken,
     };
   },
 });

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
@@ -2,7 +2,7 @@ import {WORKFLOWS_JOB_TIMED_OUT} from '@shipfox/api-workflows-dto';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
-import {claimJob} from '#db/jobs.js';
+import {claimPendingJob} from '#db/jobs.js';
 import {runningJobs} from '#db/schema/running-jobs.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {onWorkflowsJobTimedOut} from './on-workflows-job-timed-out.js';
@@ -28,7 +28,7 @@ describe('onWorkflowsJobTimedOut', () => {
 
   it('sets cancellation_requested_at on the matching running_jobs row', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
     expect(claimed).not.toBeNull();
 
     await onWorkflowsJobTimedOut(buildEvent(claimed?.jobId as string, claimed?.runId as string));
@@ -42,7 +42,7 @@ describe('onWorkflowsJobTimedOut', () => {
 
   it('idempotent under double delivery: second call preserves the first timestamp', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
     await onWorkflowsJobTimedOut(buildEvent(claimed?.jobId as string, claimed?.runId as string));
     const after1 = await db()

--- a/libs/api/runners/src/temporal/activities/index.ts
+++ b/libs/api/runners/src/temporal/activities/index.ts
@@ -1,7 +1,7 @@
-import {detectAndFailStuckJobsActivity} from './maintenance-activities.js';
+import {detectAndExpireStuckJobsActivity} from './maintenance-activities.js';
 
 export function createRunnersMaintenanceActivities() {
   return {
-    detectAndFailStuckJobsActivity,
+    detectAndExpireStuckJobsActivity,
   };
 }

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -1,13 +1,13 @@
-import {RUNNER_JOB_COMPLETED} from '@shipfox/api-runners-dto';
+import {RUNNER_JOB_LEASE_EXPIRED} from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
-import {claimJob} from '#db/jobs.js';
+import {claimPendingJob} from '#db/jobs.js';
 import {runnersOutbox} from '#db/schema/outbox.js';
 import {runningJobs} from '#db/schema/running-jobs.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
-import {detectAndFailStuckJobsActivity} from './maintenance-activities.js';
+import {detectAndExpireStuckJobsActivity} from './maintenance-activities.js';
 
-describe('detectAndFailStuckJobsActivity', () => {
+describe('detectAndExpireStuckJobsActivity', () => {
   let workspaceId: string;
   let runnerTokenId: string;
 
@@ -17,17 +17,17 @@ describe('detectAndFailStuckJobsActivity', () => {
     runnerTokenId = runnerToken.id;
   });
 
-  it('delegates to detectAndFailStuckJobs and returns the failed count', async () => {
+  it('delegates to detectAndExpireStuckJobs and returns the expired count', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
     await db()
       .update(runningJobs)
       .set({lastHeartbeatAt: sql`now() - interval '10 minutes'`})
       .where(eq(runningJobs.jobId, claimed?.jobId as string));
 
-    const result = await detectAndFailStuckJobsActivity({thresholdSeconds: 180});
+    const result = await detectAndExpireStuckJobsActivity({thresholdSeconds: 180});
 
-    expect(result.failed).toBeGreaterThanOrEqual(1);
+    expect(result.expired).toBeGreaterThanOrEqual(1);
 
     const stillRunning = await db()
       .select()
@@ -38,12 +38,14 @@ describe('detectAndFailStuckJobsActivity', () => {
     const outbox = await db()
       .select()
       .from(runnersOutbox)
-      .where(eq(runnersOutbox.eventType, RUNNER_JOB_COMPLETED));
+      .where(eq(runnersOutbox.eventType, RUNNER_JOB_LEASE_EXPIRED));
     const matching = outbox.filter(
       (row) => (row.payload as Record<string, unknown>).jobId === claimed?.jobId,
     );
     expect(matching).toHaveLength(1);
-    expect((matching[0]?.payload as Record<string, unknown>).steps).toEqual([]);
-    expect((matching[0]?.payload as Record<string, unknown>).output).toBeUndefined();
+    const payload = matching[0]?.payload as Record<string, unknown>;
+    expect(payload.runId).toBe(claimed?.runId);
+    expect(payload.steps).toBeUndefined();
+    expect(payload.status).toBeUndefined();
   });
 });

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.ts
@@ -1,7 +1,7 @@
-import {detectAndFailStuckJobs} from '#core/jobs.js';
+import {detectAndExpireStuckJobs} from '#core/jobs.js';
 
-export async function detectAndFailStuckJobsActivity(params: {
+export async function detectAndExpireStuckJobsActivity(params: {
   thresholdSeconds: number;
-}): Promise<{failed: number}> {
-  return await detectAndFailStuckJobs(params);
+}): Promise<{expired: number}> {
+  return await detectAndExpireStuckJobs(params);
 }

--- a/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
+++ b/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
@@ -2,7 +2,7 @@ import {log, proxyActivities} from '@temporalio/workflow';
 
 import type {createRunnersMaintenanceActivities} from '../activities/index.js';
 
-const {detectAndFailStuckJobsActivity} = proxyActivities<
+const {detectAndExpireStuckJobsActivity} = proxyActivities<
   ReturnType<typeof createRunnersMaintenanceActivities>
 >({
   startToCloseTimeout: '60s',
@@ -11,12 +11,12 @@ const {detectAndFailStuckJobsActivity} = proxyActivities<
 const STUCK_JOB_THRESHOLD_SECONDS = 180;
 
 export async function stuckJobDetector(): Promise<void> {
-  const {failed} = await detectAndFailStuckJobsActivity({
+  const {expired} = await detectAndExpireStuckJobsActivity({
     thresholdSeconds: STUCK_JOB_THRESHOLD_SECONDS,
   });
-  if (failed > 0) {
-    log.info('Stuck-job detector failed jobs', {
-      failed,
+  if (expired > 0) {
+    log.info('Stuck-job detector expired job leases', {
+      expired,
       thresholdSeconds: STUCK_JOB_THRESHOLD_SECONDS,
     });
   }

--- a/libs/api/runners/test/factories/pending-job.ts
+++ b/libs/api/runners/test/factories/pending-job.ts
@@ -1,25 +1,22 @@
-import type {JobPayloadDto} from '@shipfox/api-runners-dto';
 import {Factory} from 'fishery';
-import {enqueueJob} from '#db/jobs.js';
+import {scheduleJob} from '#db/jobs.js';
 
 interface PendingJobAttrs {
   workspaceId: string;
   jobId: string;
   runId: string;
-  payload: JobPayloadDto;
 }
 
-export const pendingJobFactory = Factory.define<PendingJobAttrs>(({sequence, onCreate}) => {
+export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) => {
   const jobId = crypto.randomUUID();
   const runId = crypto.randomUUID();
   const workspaceId = crypto.randomUUID();
 
   onCreate(async (attrs) => {
-    await enqueueJob({
+    await scheduleJob({
       workspaceId: attrs.workspaceId,
       jobId: attrs.jobId,
       runId: attrs.runId,
-      payload: attrs.payload,
     });
     return attrs;
   });
@@ -28,19 +25,5 @@ export const pendingJobFactory = Factory.define<PendingJobAttrs>(({sequence, onC
     workspaceId,
     jobId,
     runId,
-    payload: {
-      job_id: jobId,
-      run_id: runId,
-      job_name: `test-job-${sequence}`,
-      steps: [
-        {
-          id: crypto.randomUUID(),
-          name: 'hello',
-          type: 'run',
-          config: {run: 'echo hello'},
-          position: 0,
-        },
-      ],
-    },
   };
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -135,14 +135,6 @@ export async function enqueueJobForRunner(params: {
   workspaceId: string;
   jobId: string;
   runId: string;
-  jobName: string;
-  steps: Array<{
-    id: string;
-    name: string | null;
-    type: string;
-    config: Record<string, unknown>;
-    position: number;
-  }>;
 }): Promise<void> {
   await scheduleJob({
     workspaceId: params.workspaceId,

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,5 +1,5 @@
-import {enqueueJob} from '@shipfox/api-runners';
-import type {JobPayloadDto, StepResultDto} from '@shipfox/api-runners-dto';
+import {scheduleJob} from '@shipfox/api-runners';
+import type {StepResultDto} from '@shipfox/api-runners-dto';
 import type {JobStatus} from '#core/entities/job.js';
 import type {StepStatus} from '#core/entities/step.js';
 import type {WorkflowRunStatus} from '#core/entities/workflow-run.js';
@@ -144,18 +144,10 @@ export async function enqueueJobForRunner(params: {
     position: number;
   }>;
 }): Promise<void> {
-  const payload: JobPayloadDto = {
-    job_id: params.jobId,
-    run_id: params.runId,
-    job_name: params.jobName,
-    steps: params.steps,
-  };
-
-  await enqueueJob({
+  await scheduleJob({
     workspaceId: params.workspaceId,
     jobId: params.jobId,
     runId: params.runId,
-    payload,
   });
 }
 

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
@@ -88,9 +88,7 @@ const defaultJobInput = {
   workspaceId: 'workspace-1',
   jobId: 'job-timeout',
   runId: 'run-1',
-  jobName: 'build',
   jobVersion: 1,
-  steps: [{id: 'step-1', name: null, type: 'run', config: {cmd: 'echo hi'}, position: 0}],
 };
 
 function executeJob(input: typeof defaultJobInput): Promise<{status: string; jobVersion: number}> {

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
@@ -1,5 +1,6 @@
 import {
   callsNamed,
+  dagJob,
   makeDag,
   resetCalls,
   setCfg,
@@ -26,9 +27,7 @@ const defaultJobInput = {
   workspaceId: 'workspace-1',
   jobId: 'job-1',
   runId: 'run-1',
-  jobName: 'build',
   jobVersion: 1,
-  steps: [{id: 'step-1', name: null, type: 'run', config: {cmd: 'echo hi'}, position: 0}],
 };
 
 function executeJob(input: typeof defaultJobInput): Promise<{status: string; jobVersion: number}> {
@@ -41,7 +40,10 @@ function executeJob(input: typeof defaultJobInput): Promise<{status: string; job
 
 describe('jobOrchestration', () => {
   test('signal succeeded — workflow forwards reported steps to applyStepResultsActivity', async () => {
-    setCfg({dag: makeDag([]), jobResults: new Map([['job-1', 'succeeded']])});
+    setCfg({
+      dag: makeDag([dagJob('job-1', 'build')]),
+      jobResults: new Map([['job-1', 'succeeded']]),
+    });
 
     const result = await executeJob(defaultJobInput);
 
@@ -61,7 +63,7 @@ describe('jobOrchestration', () => {
   });
 
   test('signal failed — workflow forwards the failed step to applyStepResultsActivity', async () => {
-    setCfg({dag: makeDag([]), jobResults: new Map([['job-2', 'failed']])});
+    setCfg({dag: makeDag([dagJob('job-2', 'build')]), jobResults: new Map([['job-2', 'failed']])});
 
     const result = await executeJob({...defaultJobInput, jobId: 'job-2'});
 
@@ -80,7 +82,7 @@ describe('jobOrchestration', () => {
 
   test('duplicate signal is ignored', async () => {
     setCfg({
-      dag: makeDag([]),
+      dag: makeDag([dagJob('job-3', 'build')]),
       jobResults: new Map([['job-3', 'succeeded']]),
       duplicateSignal: true,
     });

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
@@ -43,15 +43,7 @@ export interface JobOrchestrationInput {
   workspaceId: string;
   jobId: string;
   runId: string;
-  jobName: string;
   jobVersion: number;
-  steps: Array<{
-    id: string;
-    name: string | null;
-    type: string;
-    config: Record<string, unknown>;
-    position: number;
-  }>;
 }
 
 export interface JobOrchestrationResult {
@@ -72,8 +64,6 @@ export async function jobOrchestration(
     workspaceId: input.workspaceId,
     jobId: input.jobId,
     runId: input.runId,
-    jobName: input.jobName,
-    steps: input.steps,
   });
 
   let signalPayload: {status: CompletionStatus; steps: StepResultDto[]} | undefined;

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -113,9 +113,7 @@ function launchJobs(
             workspaceId: input.workspaceId,
             jobId: job.id,
             runId: input.runId,
-            jobName: job.name,
             jobVersion: jobVersions.get(job.id) ?? job.version,
-            steps: job.steps,
           },
         ],
       });

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -150,13 +150,7 @@ function createMockActivities() {
       calls.push({name: 'applyStepResultsActivity', params});
     },
 
-    enqueueJobForRunner: async (params: {
-      workspaceId: string;
-      jobId: string;
-      runId: string;
-      jobName: string;
-      steps: Array<{id: string}>;
-    }) => {
+    enqueueJobForRunner: async (params: {workspaceId: string; jobId: string; runId: string}) => {
       calls.push({name: 'enqueueJobForRunner', params});
 
       if (cfg.enqueueError) {
@@ -167,17 +161,18 @@ function createMockActivities() {
       if (cfg.skipSignal) return;
 
       const status = cfg.jobResults.get(params.jobId) ?? 'succeeded';
-      // Mirror what the runner reports: per-step entries for every step in the
-      // payload, all marked succeeded for status='succeeded'; for failures, the
-      // first step is failed and the rest are omitted (the activity cancels
-      // them).
+      // Scheduling is step-less, so the runner reports steps it resolves on its
+      // own. Mirror that here by reading the job's steps from the DAG: per-step
+      // entries for every step when status='succeeded'; for failures, the first
+      // step is failed and the rest are omitted (the activity cancels them).
+      const jobSteps = cfg.dag.jobs.find((job) => job.id === params.jobId)?.steps ?? [];
       const steps =
         status === 'succeeded'
-          ? params.steps.map((s) => ({step_id: s.id, status: 'succeeded' as const, error: null}))
-          : params.steps[0]
+          ? jobSteps.map((s) => ({step_id: s.id, status: 'succeeded' as const, error: null}))
+          : jobSteps[0]
             ? [
                 {
-                  step_id: params.steps[0].id,
+                  step_id: jobSteps[0].id,
                   status: 'failed' as const,
                   error: {message: 'mock failure', exit_code: 1},
                 },

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -161,10 +161,9 @@ function createMockActivities() {
       if (cfg.skipSignal) return;
 
       const status = cfg.jobResults.get(params.jobId) ?? 'succeeded';
-      // Scheduling is step-less, so the runner reports steps it resolves on its
-      // own. Mirror that here by reading the job's steps from the DAG: per-step
-      // entries for every step when status='succeeded'; for failures, the first
-      // step is failed and the rest are omitted (the activity cancels them).
+      // Scheduling is step-less, so a real runner resolves its own steps and
+      // reports them back. The schedule call no longer carries them, so source
+      // them from the DAG to reproduce that report shape.
       const jobSteps = cfg.dag.jobs.find((job) => job.id === params.jobId)?.steps ?? [];
       const steps =
         status === 'succeeded'


### PR DESCRIPTION
Make scheduling step-less so runner claims bind only a job/run lease instead of transporting step payloads through the runner queue.

This moves pending runner work to `{job_id, run_id, workspace_id}`, exposes `scheduleJob(...)`, and makes the claim route mint and return `{job_id, run_id, lease_token}`. Stuck running jobs now expire the lease and emit `runners.job.lease_expired`, leaving failure handling to ENG-400 rather than fabricating an empty-steps completion.

Review notes: `libs/api/runners/drizzle/0000_initial.sql` and its snapshot were edited in place because no runner migration has shipped. Existing local DBs need to be recreated because the migration hash changes, for example with `docker compose down -v && docker compose up -d` or an equivalent targeted drop.

Until ENG-399, existing runner agents compile but fail runtime parsing of the new claim response. Until ENG-400 wires the lease-expired subscriber, `runners.job.lease_expired` is intentionally zero-subscriber plumbing and stuck jobs are only failed by the 60-minute workflow backstop. There is also still an at-least-once enqueue window where a retry after claim can reinsert a pending row; ENG-400 will document or close that contract.

Fixes ENG-398

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make runner scheduling step-less and token-based: we now queue only ids; runners claim a lease token, and stuck leases emit `runners.job.lease_expired`. Implements ENG-398.

- **New Features**
  - Replaced `enqueueJob` with `scheduleJob({jobId, runId, workspaceId})` in `@shipfox/api-runners` (idempotent on `jobId` while pending).
  - `/runners/jobs/request` now returns `{job_id, run_id, lease_token}` (`claimedJobResponseSchema` in `@shipfox/api-runners-dto`).
  - Added `RUNNER_JOB_LEASE_EXPIRED` (`runners.job.lease_expired`) event; the detector now expires leases and emits this event.
  - Removed `payload` from `runners_pending_jobs`; pending work stores only ids.
  - Workflows: removed step payloads from scheduling (`enqueueJobForRunner`, `JobOrchestrationInput`) to keep scheduling step-less end to end.

- **Migration**
  - Recreate local runner DBs (initial migration edited), e.g. `docker compose down -v && docker compose up -d`.
  - Replace `enqueueJob` calls with `scheduleJob`; update agents to parse the new claim response (no steps; use `lease_token`).
  - Until ENG-399/ENG-400: older agents will fail parsing; `runners.job.lease_expired` has no subscriber and the 60‑min backstop still handles failures.

<sup>Written for commit 93f97319cf8f6459d2a84d2fe2e88a8cead0efda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

