### PR TITLE
[api/integration] Add createCheckoutSpec() for GitHub and Debug

### DIFF
--- a/.changeset/eng-403-checkout-spec.md
+++ b/.changeset/eng-403-checkout-spec.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-core-dto": patch
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-debug": patch
+---
+
+Add `createCheckoutSpec()` to the integration source-control service and the GitHub and Debug providers. GitHub mints a short-lived, repo-scoped installation access token and returns it as structured `CheckoutCredentials` alongside a clean `repositoryUrl` (the secret is never embedded in the URL); Debug returns its static clone URL with no credentials. `ref` defaults to the repository default branch, providers without checkout support raise a typed `IntegrationCheckoutUnsupportedError`, and a `redactCheckoutSpec()` helper masks the token for logging. Dormant until the checkout-token endpoint and runner enrichment are wired in; no runtime behavior changes yet.

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -62,6 +62,7 @@ function sourceControl(
     fetchFile: vi.fn(() =>
       Promise.resolve({path: '.shipfox/workflows/ci.yml', ref: 'main', content: validYaml}),
     ),
+    createCheckoutSpec: vi.fn(),
     ...overrides,
   };
 }

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -61,6 +61,7 @@ function sourceControl(
     fetchFile: vi.fn(() =>
       Promise.resolve({path: '.shipfox/workflows/ci.yml', ref: 'main', content: validYaml}),
     ),
+    createCheckoutSpec: vi.fn(),
     ...overrides,
   };
 }

--- a/libs/api/integration/core-dto/package.json
+++ b/libs/api/integration/core-dto/package.json
@@ -32,6 +32,8 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },

--- a/libs/api/integration/core-dto/src/contracts/index.ts
+++ b/libs/api/integration/core-dto/src/contracts/index.ts
@@ -1,4 +1,5 @@
 export type {
+  CheckoutCredentials,
   CheckoutSpec,
   CreateCheckoutSpecInput,
   FetchFileInput,
@@ -26,4 +27,5 @@ export {
   IntegrationProviderError,
   MAX_REPOSITORY_FILE_BYTES,
   parseProviderRepositoryId,
+  redactCheckoutSpec,
 } from './integrations.js';

--- a/libs/api/integration/core-dto/src/contracts/integrations.test.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.test.ts
@@ -34,7 +34,7 @@ describe('redactCheckoutSpec', () => {
     expect(spec.credentials?.token).toBe('ghs_supersecret');
   });
 
-  it('returns the spec unchanged when there are no credentials', () => {
+  it('returns the spec unchanged when there are no credentials and the url is clean', () => {
     const spec: CheckoutSpec = {
       repositoryUrl: 'https://debug.local/debug-owner/platform.git',
       ref: 'main',
@@ -43,5 +43,35 @@ describe('redactCheckoutSpec', () => {
     const redacted = redactCheckoutSpec(spec);
 
     expect(redacted).toBe(spec);
+  });
+
+  it('strips credentials embedded in repositoryUrl as a defense in depth', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://x-access-token:ghs_supersecret@github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {
+        username: 'x-access-token',
+        token: 'ghs_supersecret',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      },
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted.repositoryUrl).toBe('https://github.com/shipfox/platform.git');
+    expect(redacted.repositoryUrl).not.toContain('ghs_supersecret');
+    expect(redacted.credentials?.token).toBe('***');
+  });
+
+  it('strips embedded credentials even when the spec has no credentials field', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://x-access-token:ghs_supersecret@github.com/shipfox/platform.git',
+      ref: 'main',
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted.repositoryUrl).toBe('https://github.com/shipfox/platform.git');
+    expect(redacted.repositoryUrl).not.toContain('ghs_supersecret');
   });
 });

--- a/libs/api/integration/core-dto/src/contracts/integrations.test.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.test.ts
@@ -1,0 +1,47 @@
+import {type CheckoutSpec, redactCheckoutSpec} from './integrations.js';
+
+describe('redactCheckoutSpec', () => {
+  it('masks the credential token while keeping the other fields intact', () => {
+    const expiresAt = new Date('2026-06-10T12:00:00.000Z');
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {username: 'x-access-token', token: 'ghs_supersecret', expiresAt},
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted).toEqual({
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {username: 'x-access-token', token: '***', expiresAt},
+    });
+  });
+
+  it('does not mutate the original spec', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {
+        username: 'x-access-token',
+        token: 'ghs_supersecret',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      },
+    };
+
+    redactCheckoutSpec(spec);
+
+    expect(spec.credentials?.token).toBe('ghs_supersecret');
+  });
+
+  it('returns the spec unchanged when there are no credentials', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://debug.local/debug-owner/platform.git',
+      ref: 'main',
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted).toBe(spec);
+  });
+});

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -167,11 +167,31 @@ export const MAX_REPOSITORY_FILE_BYTES = 1_000_000;
 const REDACTED_TOKEN = '***';
 
 export function redactCheckoutSpec(spec: CheckoutSpec): CheckoutSpec {
-  if (!spec.credentials) return spec;
+  const repositoryUrl = stripUrlCredentials(spec.repositoryUrl);
+  if (!spec.credentials) {
+    return repositoryUrl === spec.repositoryUrl ? spec : {...spec, repositoryUrl};
+  }
   return {
     ...spec,
+    repositoryUrl,
     credentials: {...spec.credentials, token: REDACTED_TOKEN},
   };
+}
+
+// Defense in depth: providers must keep `repositoryUrl` credential-free, but a
+// helper whose job is to make a spec safe to log must also strip any userinfo
+// (e.g. `https://x-access-token:<token>@host/...`) so a provider mistake cannot
+// leak a token through the URL.
+function stripUrlCredentials(repositoryUrl: string): string {
+  try {
+    const url = new URL(repositoryUrl);
+    if (!url.username && !url.password) return repositoryUrl;
+    url.username = '';
+    url.password = '';
+    return url.toString();
+  } catch {
+    return repositoryUrl;
+  }
 }
 
 export function buildProviderRepositoryId(

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -87,6 +87,12 @@ export interface CheckoutCredentials {
 }
 
 export interface CheckoutSpec {
+  /**
+   * Clone URL that must never embed authentication material. Credentials live
+   * only in `credentials` so `redactCheckoutSpec()` can mask them; a provider
+   * that embeds a token in this URL would bypass redaction and leak it into
+   * logs, `git remote -v`, and persisted job rows.
+   */
   repositoryUrl: string;
   ref: string;
   credentials?: CheckoutCredentials | undefined;

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -80,15 +80,22 @@ export interface FetchFileInput<Connection extends IntegrationConnection = Integ
   path: string;
 }
 
+export interface CheckoutCredentials {
+  username: string;
+  token: string;
+  expiresAt: Date;
+}
+
 export interface CheckoutSpec {
   repositoryUrl: string;
   ref: string;
+  credentials?: CheckoutCredentials | undefined;
 }
 
 export interface CreateCheckoutSpecInput<
   Connection extends IntegrationConnection = IntegrationConnection,
 > extends ResolveRepositoryInput<Connection> {
-  ref: string;
+  ref?: string | undefined;
 }
 
 export interface SourceControlProvider<
@@ -150,6 +157,16 @@ export class IntegrationProviderError extends Error {
 }
 
 export const MAX_REPOSITORY_FILE_BYTES = 1_000_000;
+
+const REDACTED_TOKEN = '***';
+
+export function redactCheckoutSpec(spec: CheckoutSpec): CheckoutSpec {
+  if (!spec.credentials) return spec;
+  return {
+    ...spec,
+    credentials: {...spec.credentials, token: REDACTED_TOKEN},
+  };
+}
 
 export function buildProviderRepositoryId(
   provider: IntegrationProviderKind,

--- a/libs/api/integration/core-dto/vitest.config.ts
+++ b/libs/api/integration/core-dto/vitest.config.ts
@@ -1,1 +1,3 @@
-export {defineConfig as default} from '@shipfox/vitest';
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({test: {}}, import.meta.url) as UserConfigExport;

--- a/libs/api/integration/core/src/core/errors.ts
+++ b/libs/api/integration/core/src/core/errors.ts
@@ -28,6 +28,12 @@ export class IntegrationCapabilityUnavailableError extends Error {
   }
 }
 
+export class IntegrationCheckoutUnsupportedError extends Error {
+  constructor(public readonly provider: IntegrationProviderKind) {
+    super(`Integration provider ${provider} cannot create a checkout spec`);
+  }
+}
+
 export class IntegrationProviderUnavailableError extends Error {
   constructor(provider: IntegrationProviderKind) {
     super(`No integration provider registered for ${provider}`);

--- a/libs/api/integration/core/src/core/providers/source-control.ts
+++ b/libs/api/integration/core/src/core/providers/source-control.ts
@@ -1,4 +1,5 @@
 export type {
+  CheckoutCredentials,
   CheckoutSpec,
   CreateCheckoutSpecInput,
   FetchFileInput,
@@ -13,3 +14,4 @@ export type {
   ResolveRepositoryInput,
   SourceControlProvider,
 } from '@shipfox/api-integration-core-dto';
+export {redactCheckoutSpec} from '@shipfox/api-integration-core-dto';

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -1,4 +1,4 @@
-import {IntegrationProviderError} from './errors.js';
+import {IntegrationCheckoutUnsupportedError, IntegrationProviderError} from './errors.js';
 import {createIntegrationProviderRegistry} from './providers/registry.js';
 import type {RepositorySnapshot, SourceControlProvider} from './providers/source-control.js';
 import {createSourceControlIntegrationService} from './source-control-service.js';
@@ -27,7 +27,10 @@ describe('integration source-control service', () => {
     updatedAt: new Date(),
   };
 
-  function createService(overrides: Partial<SourceControlProvider> = {}) {
+  function createService(
+    overrides: Partial<SourceControlProvider> = {},
+    options: {omitCheckoutSpec?: boolean} = {},
+  ) {
     const sourceControl: SourceControlProvider = {
       listRepositories: async () => {
         await Promise.resolve();
@@ -48,8 +51,15 @@ describe('integration source-control service', () => {
         await Promise.resolve();
         return {path: '.shipfox/workflows/ci.yml', ref: 'main', content: 'name: CI'};
       },
+      createCheckoutSpec: async (input) => {
+        await Promise.resolve();
+        return {repositoryUrl: repository.cloneUrl, ref: input.ref ?? repository.defaultBranch};
+      },
       ...overrides,
     };
+    if (options.omitCheckoutSpec) {
+      delete sourceControl.createCheckoutSpec;
+    }
     return createSourceControlIntegrationService({
       registry: createIntegrationProviderRegistry([
         {
@@ -148,5 +158,62 @@ describe('integration source-control service', () => {
     });
 
     expect(result.content).toBe('name: CI');
+  });
+
+  it('creates a checkout spec through an active source-control connection', async () => {
+    const service = createService();
+
+    const result = await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      externalRepositoryId: 'debug:platform',
+      ref: 'feature/x',
+    });
+
+    expect(result).toEqual({
+      repositoryUrl: 'https://debug.local/debug-owner/platform.git',
+      ref: 'feature/x',
+    });
+  });
+
+  it('rejects a checkout spec for a connection in another workspace', async () => {
+    const service = createService();
+
+    const result = service.createCheckoutSpec({
+      workspaceId: crypto.randomUUID(),
+      connectionId: connection.id,
+      externalRepositoryId: 'debug:platform',
+    });
+
+    await expect(result).rejects.toThrow('requested workspace');
+  });
+
+  it('surfaces provider checkout failures', async () => {
+    const service = createService({
+      createCheckoutSpec: async () => {
+        await Promise.resolve();
+        throw new IntegrationProviderError('access-denied', 'Checkout not permitted');
+      },
+    });
+
+    const result = service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      externalRepositoryId: 'debug:platform',
+    });
+
+    await expect(result).rejects.toMatchObject({reason: 'access-denied'});
+  });
+
+  it('rejects when the provider does not support creating a checkout spec', async () => {
+    const service = createService({}, {omitCheckoutSpec: true});
+
+    const result = service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      externalRepositoryId: 'debug:platform',
+    });
+
+    await expect(result).rejects.toBeInstanceOf(IntegrationCheckoutUnsupportedError);
   });
 });

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -1,11 +1,13 @@
 import type {IntegrationConnection} from './entities/connection.js';
 import {
+  IntegrationCheckoutUnsupportedError,
   IntegrationConnectionInactiveError,
   IntegrationConnectionNotFoundError,
   IntegrationConnectionWorkspaceMismatchError,
 } from './errors.js';
 import type {IntegrationProviderRegistry} from './providers/registry.js';
 import type {
+  CheckoutSpec,
   FilePage,
   FileSnapshot,
   RepositoryPage,
@@ -18,6 +20,7 @@ export interface IntegrationSourceControlService {
   resolveRepository(input: ResolveSourceRepositoryInput): Promise<ResolvedSourceRepository>;
   listFiles(input: ListSourceFilesInput): Promise<FilePage>;
   fetchFile(input: FetchSourceFileInput): Promise<FileSnapshot>;
+  createCheckoutSpec(input: CreateSourceCheckoutSpecInput): Promise<CheckoutSpec>;
 }
 
 export interface ListSourceRepositoriesInput {
@@ -43,6 +46,10 @@ export interface ListSourceFilesInput extends ResolveSourceRepositoryInput {
 export interface FetchSourceFileInput extends ResolveSourceRepositoryInput {
   ref: string;
   path: string;
+}
+
+export interface CreateSourceCheckoutSpecInput extends ResolveSourceRepositoryInput {
+  ref?: string | undefined;
 }
 
 export interface ResolvedSourceRepository {
@@ -128,6 +135,23 @@ export function createSourceControlIntegrationService({
         externalRepositoryId,
         ref,
         path,
+      });
+    },
+
+    async createCheckoutSpec({workspaceId, connectionId, externalRepositoryId, ref}) {
+      const connection = await getConnection(connectionId);
+      if (connection.workspaceId !== workspaceId) {
+        throw new IntegrationConnectionWorkspaceMismatchError(connectionId);
+      }
+      const sourceControl = registry.getAdapter(connection.provider, 'source_control');
+      if (!sourceControl.createCheckoutSpec) {
+        throw new IntegrationCheckoutUnsupportedError(connection.provider);
+      }
+
+      return await sourceControl.createCheckoutSpec({
+        connection,
+        externalRepositoryId,
+        ref,
       });
     },
   };

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -45,6 +45,7 @@ export type {
 export type {IntegrationProviderErrorReason} from '#core/errors.js';
 export {
   IntegrationCapabilityUnavailableError,
+  IntegrationCheckoutUnsupportedError,
   IntegrationConnectionInactiveError,
   IntegrationConnectionNotFoundError,
   IntegrationConnectionWorkspaceMismatchError,
@@ -53,6 +54,9 @@ export {
 } from '#core/errors.js';
 export type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 export type {
+  CheckoutCredentials,
+  CheckoutSpec,
+  CreateCheckoutSpecInput,
   FetchFileInput,
   FileEntry,
   FilePage,
@@ -65,6 +69,7 @@ export type {
   ResolveRepositoryInput,
   SourceControlProvider,
 } from '#core/providers/source-control.js';
+export {redactCheckoutSpec} from '#core/providers/source-control.js';
 export type {IntegrationSourceControlService} from '#core/source-control-service.js';
 export {createSourceControlIntegrationService} from '#core/source-control-service.js';
 export type {GetIntegrationConnectionByIdFn} from '#db/connections.js';

--- a/libs/api/integration/debug/src/core/source-control.test.ts
+++ b/libs/api/integration/debug/src/core/source-control.test.ts
@@ -86,4 +86,31 @@ describe('DebugSourceControlProvider', () => {
 
     expect(result.content).toContain('name: CI');
   });
+
+  it('creates a credential-free checkout spec for the requested ref', async () => {
+    const provider = new DebugSourceControlProvider();
+
+    const result = await provider.createCheckoutSpec({
+      connection,
+      externalRepositoryId: 'debug:platform',
+      ref: 'feature/x',
+    });
+
+    expect(result).toEqual({
+      repositoryUrl: 'https://debug.local/debug-owner/platform.git',
+      ref: 'feature/x',
+    });
+    expect(result.credentials).toBeUndefined();
+  });
+
+  it('defaults the checkout ref to the repository default branch', async () => {
+    const provider = new DebugSourceControlProvider();
+
+    const result = await provider.createCheckoutSpec({
+      connection,
+      externalRepositoryId: 'debug:platform',
+    });
+
+    expect(result.ref).toBe('main');
+  });
 });

--- a/libs/api/integration/debug/src/core/source-control.ts
+++ b/libs/api/integration/debug/src/core/source-control.ts
@@ -1,5 +1,7 @@
 import {
   buildProviderRepositoryId,
+  type CheckoutSpec,
+  type CreateCheckoutSpecInput,
   type FetchFileInput,
   type FilePage,
   type FileSnapshot,
@@ -162,6 +164,14 @@ export class DebugSourceControlProvider implements SourceControlProvider {
       path: input.path,
       ref: input.ref,
       content,
+    };
+  }
+
+  async createCheckoutSpec(input: CreateCheckoutSpecInput): Promise<CheckoutSpec> {
+    const repository = await this.resolveRepository(input);
+    return {
+      repositoryUrl: repository.cloneUrl,
+      ref: input.ref?.trim() || repository.defaultBranch,
     };
   }
 }

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -1,0 +1,71 @@
+import {GithubIntegrationProviderError} from '#core/errors.js';
+import {createGithubApiClient} from './client.js';
+
+const {createInstallationAccessTokenMock} = vi.hoisted(() => ({
+  createInstallationAccessTokenMock: vi.fn(),
+}));
+
+vi.mock('octokit', () => ({
+  App: class App {
+    octokit = {
+      rest: {apps: {createInstallationAccessToken: createInstallationAccessTokenMock}},
+    };
+  },
+  Octokit: class Octokit {},
+  RequestError: class RequestError extends Error {},
+}));
+
+describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
+  beforeEach(() => {
+    createInstallationAccessTokenMock.mockReset();
+  });
+
+  it('mints a repository-scoped, read-only installation token', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const client = createGithubApiClient();
+
+    const result = await client.createInstallationAccessToken({
+      installationId: 1,
+      repositoryId: 42,
+    });
+
+    expect(result).toEqual({
+      token: 'ghs_installationtoken',
+      expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+    });
+    expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
+      installation_id: 1,
+      repository_ids: [42],
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('rejects a response without a token', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const client = createGithubApiClient();
+
+    const result = client.createInstallationAccessToken({installationId: 1, repositoryId: 42});
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+    });
+    await expect(result).rejects.toBeInstanceOf(GithubIntegrationProviderError);
+  });
+
+  it('rejects a response with a missing or unparseable expiry', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken'},
+    });
+    const client = createGithubApiClient();
+
+    const result = client.createInstallationAccessToken({installationId: 1, repositoryId: 42});
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'malformed-provider-response',
+    });
+  });
+});

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -88,6 +88,15 @@ export interface GithubApiClient {
     ref: string;
     path: string;
   }): Promise<GithubFileContent>;
+  createInstallationAccessToken(input: {
+    installationId: number;
+    repositoryId: number;
+  }): Promise<GithubInstallationAccessToken>;
+}
+
+export interface GithubInstallationAccessToken {
+  token: string;
+  expiresAt: Date;
 }
 
 export function createGithubApiClient(): GithubApiClient {
@@ -326,6 +335,31 @@ class OctokitGithubApiClient implements GithubApiClient {
       path: data.path,
       size: data.size,
       content: Buffer.from(data.content, 'base64').toString('utf8'),
+    };
+  }
+
+  async createInstallationAccessToken(input: {
+    installationId: number;
+    repositoryId: number;
+  }): Promise<GithubInstallationAccessToken> {
+    const response = await mapGithubError(() =>
+      this.getApp().octokit.rest.apps.createInstallationAccessToken({
+        installation_id: input.installationId,
+        repository_ids: [input.repositoryId],
+        permissions: {contents: 'read'},
+      }),
+    );
+
+    if (typeof response.data.token !== 'string') {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub installation access token response did not include a token',
+      );
+    }
+
+    return {
+      token: response.data.token,
+      expiresAt: new Date(response.data.expires_at),
     };
   }
 

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -357,9 +357,17 @@ class OctokitGithubApiClient implements GithubApiClient {
       );
     }
 
+    const expiresAt = new Date(response.data.expires_at);
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new GithubIntegrationProviderError(
+        'malformed-provider-response',
+        'GitHub installation access token response did not include a valid expiry',
+      );
+    }
+
     return {
       token: response.data.token,
-      expiresAt: new Date(response.data.expires_at),
+      expiresAt,
     };
   }
 

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -54,6 +54,12 @@ function githubClient(overrides: Partial<GithubApiClient> = {}): GithubApiClient
         size: 58,
       }),
     ),
+    createInstallationAccessToken: vi.fn(() =>
+      Promise.resolve({
+        token: 'ghs_installationtoken',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      }),
+    ),
     ...overrides,
   };
 }
@@ -239,5 +245,77 @@ describe('GithubSourceControlProvider', () => {
     });
 
     await expect(result).rejects.toMatchObject({reason: 'content-too-large'});
+  });
+
+  it('creates a checkout spec with a clean url and short-lived credentials', async () => {
+    await createInstallation();
+    const github = githubClient();
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = await provider.createCheckoutSpec({
+      connection: connection(),
+      externalRepositoryId: 'github:42',
+      ref: 'feature/x',
+    });
+
+    expect(result).toEqual({
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'feature/x',
+      credentials: {
+        username: 'x-access-token',
+        token: 'ghs_installationtoken',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      },
+    });
+    expect(result.repositoryUrl).not.toContain('ghs_installationtoken');
+    expect(github.createInstallationAccessToken).toHaveBeenCalledWith({
+      installationId,
+      repositoryId: 42,
+    });
+  });
+
+  it('defaults the checkout ref to the repository default branch', async () => {
+    await createInstallation();
+    const github = githubClient();
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = await provider.createCheckoutSpec({
+      connection: connection(),
+      externalRepositoryId: 'github:42',
+    });
+
+    expect(result.ref).toBe('main');
+  });
+
+  it('propagates provider errors raised while minting the checkout token', async () => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.reject(new GithubIntegrationProviderError('access-denied', 'token denied')),
+      ),
+    });
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = provider.createCheckoutSpec({
+      connection: connection(),
+      externalRepositoryId: 'github:42',
+    });
+
+    await expect(result).rejects.toMatchObject({reason: 'access-denied'});
+  });
+
+  it('rejects a malformed external repository id before any api call', async () => {
+    await createInstallation();
+    const github = githubClient();
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = provider.createCheckoutSpec({
+      connection: connection(),
+      externalRepositoryId: 'github:not-a-number',
+    });
+
+    await expect(result).rejects.toMatchObject({reason: 'repository-not-found'});
+    expect(github.getRepository).not.toHaveBeenCalled();
+    expect(github.createInstallationAccessToken).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -1,6 +1,8 @@
 import {Buffer} from 'node:buffer';
 import {
   buildProviderRepositoryId,
+  type CheckoutSpec,
+  type CreateCheckoutSpecInput,
   type FetchFileInput,
   type FilePage,
   type FileSnapshot,
@@ -136,6 +138,25 @@ export class GithubSourceControlProvider
       path: file.path,
       ref: input.ref,
       content: file.content,
+    };
+  }
+
+  async createCheckoutSpec(
+    input: CreateCheckoutSpecInput<GithubIntegrationConnection>,
+  ): Promise<CheckoutSpec> {
+    const installationId = await this.installationId(input.connection.id);
+    const {repositoryId} = parseGithubRepositoryLocator(input.externalRepositoryId);
+    const repository = await this.github.getRepository({installationId, repositoryId});
+    const ref = input.ref?.trim() || repository.defaultBranch;
+    const {token, expiresAt} = await this.github.createInstallationAccessToken({
+      installationId,
+      repositoryId,
+    });
+
+    return {
+      repositoryUrl: repository.cloneUrl,
+      ref,
+      credentials: {username: 'x-access-token', token, expiresAt},
     };
   }
 

--- a/libs/api/projects/src/core/projects.test.ts
+++ b/libs/api/projects/src/core/projects.test.ts
@@ -46,6 +46,7 @@ describe('createProjectFromSource', () => {
       }),
       listFiles: vi.fn(),
       fetchFile: vi.fn(),
+      createCheckoutSpec: vi.fn(),
     };
   });
 

--- a/libs/api/projects/src/presentation/routes/projects.test.ts
+++ b/libs/api/projects/src/presentation/routes/projects.test.ts
@@ -81,6 +81,7 @@ describe('project routes', () => {
       }),
       listFiles: vi.fn(),
       fetchFile: vi.fn(),
+      createCheckoutSpec: vi.fn(),
     };
     app = await createApp({
       auth: [fakeUserAuth],


### PR DESCRIPTION
Exposes `createCheckoutSpec()` on `IntegrationSourceControlService` so the backend can resolve checkout data and credential material from the source-control provider and hand a runner a typed, credential-bearing checkout intent. Part of the Runner-managed workspaces project; this PR settles the service contract that the checkout-token endpoint and runner enrichment build on.

## What changed

- **core-dto** — `CheckoutSpec` gains an optional structured `credentials` field (`CheckoutCredentials { username, token, expiresAt }`); `CreateCheckoutSpecInput.ref` is now optional. Adds a pure `redactCheckoutSpec()` helper that masks the token for logging. Wires the package for unit tests (it had none).
- **core** — `createCheckoutSpec()` on the service, following the existing dispatch pattern (connection + workspace guards). New typed `IntegrationCheckoutUnsupportedError` for providers that don't implement the optional method.
- **github** — `createInstallationAccessToken()` on the API client (repo-scoped, `contents: read`); the provider returns a clean `repositoryUrl` plus `credentials { username: 'x-access-token', token, expiresAt }`, defaulting `ref` to the repository default branch.
- **debug** — returns the static clone URL with no credentials.

## Why credentials are a structured field, not embedded in the URL

An inline-token URL (`https://x-access-token:<token>@github.com/...`) is the leakiest representation — it ends up in `git remote -v`, `git clone <url>` process args, and any log/row that serializes the spec, which conflicts with the project's hard "no credentials in logs, API logs, queued/running job rows, or persisted results" criterion. A structured field makes redaction trivial, keeps `repositoryUrl` secret-free, and conveys token expiry. (This decision was made in plan review and is documented on the Linear issue.)

## Notes for reviewers

- This is purely additive and **dormant**: no HTTP route consumes it yet. `redactCheckoutSpec()` has no call site in this PR by design — the dependent checkout-token endpoint and runner enrichment tickets wire it in, compose auth from `credentials`, and respect `expiresAt`.
- The GitHub installation token is GitHub-issued (not a Shipfox-signed token), so it stays in the github package rather than api-auth.
- The Octokit call in `client.ts` is not unit-tested, matching the existing posture (no github client method is unit-tested; it's mocked at the provider level).

Refs ENG-403

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `createCheckoutSpec()` to the source-control service and GitHub/Debug providers to return a clean checkout spec with optional short-lived credentials for runners. Hardens `redactCheckoutSpec()` to also strip any credentials embedded in the `repositoryUrl`. Supports ENG-403; dormant until the checkout-token endpoint and runner enrichment are wired in.

- **New Features**
  - Service: `createCheckoutSpec()` returns a typed `CheckoutSpec` with optional `credentials`; enforces workspace/connection guards; unsupported providers throw `IntegrationCheckoutUnsupportedError`.
  - GitHub: mints a short‑lived, repo‑scoped installation token (`contents: read`), validates a parseable expiry, classifies malformed responses as `malformed-provider-response`, and returns a clean `repositoryUrl` plus `credentials { username: 'x-access-token', token, expiresAt }`; `ref` defaults to the repository’s default branch; adds a client test pinning `repository_ids` scoping and permissions.
  - Debug: returns the static clone URL with no credentials; `ref` defaults to the repository’s default branch.
  - DTO (`@shipfox/api-integration-core-dto`): adds `CheckoutCredentials`, makes `CreateCheckoutSpecInput.ref` optional, adds `redactCheckoutSpec()` to mask tokens and strip URL userinfo as defense in depth, and documents that credentials must never be embedded in `repositoryUrl`; adds test scripts/config and unit tests.
  - Core (`@shipfox/api-integration-core`): exports `CheckoutSpec`, `CheckoutCredentials`, `CreateCheckoutSpecInput`, `redactCheckoutSpec`, and `IntegrationCheckoutUnsupportedError` from the package root for public use.
  - Tests: coverage for redaction (including URL-embedded creds) and provider/service flows across `@shipfox/api-integration-core-dto`, `@shipfox/api-integration-core`, `@shipfox/api-integration-github`, and `@shipfox/api-integration-debug`, plus a GitHub client test validating token scope and expiry.

<sup>Written for commit 67eb6f74201874e74e9795638690f01cb69b4ef2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

