### PR TITLE
Track per-step execution attempts

### DIFF
--- a/.changeset/lucky-pandas-attend.md
+++ b/.changeset/lucky-pandas-attend.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": minor
+---
+
+Track per-step execution attempts: add a `step_attempts` history table and a `steps.current_attempt` column, open a running attempt at dispatch and finalize it at report, and make step-result reporting attempt-aware (idempotent duplicate reports, rejected future attempts, no-op stale attempts).

--- a/libs/api/workflows-dto/src/schemas/job-execution.ts
+++ b/libs/api/workflows-dto/src/schemas/job-execution.ts
@@ -9,9 +9,9 @@ export const nextStepResponseSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('step'),
     step: stepDtoSchema,
-    // The attempt number this dispatch runs. The runner echoes it back on report
-    // so a late report from a superseded attempt can be ignored. Always 1 until
-    // per-step attempts land (PR B: steps.current_attempt).
+    // The attempt number this dispatch runs (the step's current attempt). The
+    // runner echoes it back on report so a late report from a superseded attempt
+    // is ignored. 1 until a durable restart (PR E) bumps it.
     attempt: z.number().int().positive(),
   }),
   z.object({
@@ -27,12 +27,12 @@ export const reportStepBodySchema = z
     status: z.enum(['succeeded', 'failed']),
     error: stepErrorDtoSchema.optional(),
     // The attempt the runner was dispatched, echoed from next-step. Optional on
-    // the wire for now; idempotency enforcement against it lands in PR B.
+    // the wire (older runners omit it); when present it drives attempt-aware
+    // idempotency in `recordStepResult`.
     attempt: z.number().int().positive().optional(),
-    // Process exit code on success and failure. The runner sends it, but it is
-    // not persisted yet: PR B stores it per attempt and PR D consumes it for
-    // gates (success_if: exit_code == 0). On failure it is also carried under
-    // `error.exit_code`.
+    // Process exit code on success and failure. Persisted on the step attempt;
+    // consumed by gate evaluation (success_if: exit_code == 0) in PR D. On
+    // failure it is also carried under `error.exit_code`.
     exit_code: z.number().int().nullable().optional(),
   })
   .refine((body) => (body.status === 'succeeded' ? body.error == null : body.error != null), {

--- a/libs/api/workflows-dto/src/schemas/job-execution.ts
+++ b/libs/api/workflows-dto/src/schemas/job-execution.ts
@@ -9,14 +9,19 @@ export const nextStepResponseSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('step'),
     step: stepDtoSchema,
-    // The attempt number this dispatch runs (the step's current attempt). The
-    // runner echoes it back on report so a late report from a superseded attempt
-    // is ignored. 1 until a durable restart (PR E) bumps it.
-    attempt: z.number().int().positive(),
+    attempt: z
+      .number()
+      .int()
+      .positive()
+      .describe(
+        'Attempt number for this step dispatch. Echo it back when reporting the step result so stale reports from older attempts can be ignored.',
+      ),
   }),
   z.object({
     kind: z.literal('done'),
-    status: z.enum(['succeeded', 'failed']),
+    status: z
+      .enum(['succeeded', 'failed'])
+      .describe('Terminal status of the job when no step remains to run.'),
   }),
 ]);
 
@@ -24,16 +29,33 @@ export type NextStepResponseDto = z.infer<typeof nextStepResponseSchema>;
 
 export const reportStepBodySchema = z
   .object({
-    status: z.enum(['succeeded', 'failed']),
-    error: stepErrorDtoSchema.optional(),
-    // The attempt the runner was dispatched, echoed from next-step. Optional on
-    // the wire (older runners omit it); when present it drives attempt-aware
-    // idempotency in `recordStepResult`.
-    attempt: z.number().int().positive().optional(),
-    // Process exit code on success and failure. Persisted on the step attempt;
-    // consumed by gate evaluation (success_if: exit_code == 0) in PR D. On
-    // failure it is also carried under `error.exit_code`.
-    exit_code: z.number().int().nullable().optional(),
+    status: z.enum(['succeeded', 'failed']).describe('Final status reported for the step attempt.'),
+    error: stepErrorDtoSchema
+      .optional()
+      .describe('Failure details. Required when status is failed.'),
+    attempt: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Attempt number echoed from next-step. Older runners may omit it; when present, it protects the workflow from stale reports.',
+      ),
+    exit_code: z
+      .number()
+      .int()
+      .nullable()
+      .optional()
+      .describe(
+        'Process exit code for the step attempt. Persisted as the canonical attempt exit code and used by gate evaluation.',
+      ),
+    output: z
+      .record(z.string(), z.unknown())
+      .nullable()
+      .optional()
+      .describe(
+        'Structured output captured for attempt history. Large textual logs are stored separately.',
+      ),
   })
   .refine((body) => (body.status === 'succeeded' ? body.error == null : body.error != null), {
     message: 'succeeded steps must not include an error and failed steps must include one',
@@ -41,10 +63,13 @@ export const reportStepBodySchema = z
 
 export type ReportStepBodyDto = z.infer<typeof reportStepBodySchema>;
 
-/** `cancel` tells the agent to stop working on the job: it finished without full success. */
 export const reportStepResponseSchema = z.object({
-  ok: z.boolean(),
-  cancel: z.boolean(),
+  ok: z.boolean().describe('Whether the step report was accepted.'),
+  cancel: z
+    .boolean()
+    .describe(
+      'Whether the runner should stop working on the job because it finished without full success.',
+    ),
 });
 
 export type ReportStepResponseDto = z.infer<typeof reportStepResponseSchema>;

--- a/libs/api/workflows/drizzle/0001_step_attempts.sql
+++ b/libs/api/workflows/drizzle/0001_step_attempts.sql
@@ -12,7 +12,9 @@ CREATE TABLE "workflows_step_attempts" (
 	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"finished_at" timestamp with time zone,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "workflows_step_attempts_step_id_attempt_uq" UNIQUE("step_id","attempt")
+	CONSTRAINT "workflows_step_attempts_step_id_attempt_uq" UNIQUE("step_id","attempt"),
+	CONSTRAINT "workflows_step_attempts_attempt_positive_ck" CHECK ("workflows_step_attempts"."attempt" > 0),
+	CONSTRAINT "workflows_step_attempts_status_not_pending_ck" CHECK ("workflows_step_attempts"."status" <> 'pending')
 );
 --> statement-breakpoint
 ALTER TABLE "workflows_steps" ADD COLUMN "current_attempt" integer DEFAULT 1 NOT NULL;--> statement-breakpoint

--- a/libs/api/workflows/drizzle/0001_step_attempts.sql
+++ b/libs/api/workflows/drizzle/0001_step_attempts.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "workflows_step_attempts" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"step_id" uuid NOT NULL,
+	"job_id" uuid NOT NULL,
+	"attempt" integer NOT NULL,
+	"status" "workflows_step_status" NOT NULL,
+	"output" jsonb,
+	"error" jsonb,
+	"exit_code" integer,
+	"gate_result" jsonb,
+	"restart_reason" text,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"finished_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "workflows_step_attempts_step_id_attempt_uq" UNIQUE("step_id","attempt")
+);
+--> statement-breakpoint
+ALTER TABLE "workflows_steps" ADD COLUMN "current_attempt" integer DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "workflows_step_attempts" ADD CONSTRAINT "workflows_step_attempts_step_id_workflows_steps_id_fk" FOREIGN KEY ("step_id") REFERENCES "public"."workflows_steps"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "workflows_step_attempts" ADD CONSTRAINT "workflows_step_attempts_job_id_workflows_jobs_id_fk" FOREIGN KEY ("job_id") REFERENCES "public"."workflows_jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "workflows_step_attempts_job_id_idx" ON "workflows_step_attempts" USING btree ("job_id");

--- a/libs/api/workflows/drizzle/meta/0001_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,722 @@
+{
+  "id": "37221128-e713-4c32-a224-2f82932c4bb6",
+  "prevId": "301aaed3-fce2-4b05-886e-3ed924bc1b75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_jobs_run_id_idx": {
+          "name": "workflows_jobs_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_jobs_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_reason": {
+          "name": "restart_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_step_attempts_job_id_idx": {
+          "name": "workflows_step_attempts_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_step_attempts_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_id_idx": {
+          "name": "workflows_steps_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_steps_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "waiting_for_dependencies",
+        "ready",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "awaiting_manual"
+      ]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/0001_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0001_snapshot.json
@@ -310,7 +310,16 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_status_not_pending_ck": {
+          "name": "workflows_step_attempts_status_not_pending_ck",
+          "value": "\"workflows_step_attempts\".\"status\" <> 'pending'"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.workflows_steps": {

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1778685886013,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1781129096855,
+      "tag": "0001_step_attempts",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -1,5 +1,9 @@
 export type StepStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
+// A step_attempts row exists only once an attempt is dispatched, so it is never
+// 'pending'.
+export type StepAttemptStatus = Exclude<StepStatus, 'pending'>;
+
 export interface Step {
   id: string;
   jobId: string;
@@ -11,6 +15,30 @@ export interface Step {
   error: Record<string, unknown> | null;
   position: number;
   version: number;
+  // Execution-attempt identity for the current projection: which attempt the
+  // status/output/error above reflect. Distinct from `version` (the optimistic
+  // row counter). Starts at 1; bumped only when a step is rewound by a durable
+  // restart (PR E).
+  currentAttempt: number;
   createdAt: Date;
   updatedAt: Date;
+}
+
+// Append-only execution history: one row per dispatched attempt of a step. The
+// current projection lives on `Step`; this is the audit trail and the
+// idempotency anchor (unique on (stepId, attempt)).
+export interface StepAttempt {
+  id: string;
+  stepId: string;
+  jobId: string;
+  attempt: number;
+  status: StepAttemptStatus;
+  output: Record<string, unknown> | null;
+  error: Record<string, unknown> | null;
+  exitCode: number | null;
+  gateResult: Record<string, unknown> | null;
+  restartReason: string | null;
+  startedAt: Date;
+  finishedAt: Date | null;
+  createdAt: Date;
 }

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -34,3 +34,20 @@ export class StepNotRunningError extends Error {
     this.name = 'StepNotRunningError';
   }
 }
+
+// A report whose attempt is ahead of the step's current attempt. The host
+// allocates attempt numbers, so a runner can never report one it was not
+// dispatched — this is a protocol error, not an idempotent no-op.
+export class StepAttemptAheadError extends Error {
+  constructor(
+    readonly stepId: string,
+    readonly jobId: string,
+    readonly reportedAttempt: number,
+    readonly currentAttempt: number,
+  ) {
+    super(
+      `Step ${stepId} in job ${jobId} reported attempt ${reportedAttempt} ahead of current attempt ${currentAttempt}`,
+    );
+    this.name = 'StepAttemptAheadError';
+  }
+}

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -2,6 +2,7 @@ import {WORKFLOWS_JOB_COMPLETED} from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {workflowsOutbox} from '#db/schema/outbox.js';
+import {stepAttempts as stepAttemptsTable} from '#db/schema/step-attempts.js';
 import {steps as stepsTable} from '#db/schema/steps.js';
 import {bulkUpdateStepStatuses, getStepAttempts, getStepsByJobId} from '#db/workflow-runs.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
@@ -221,6 +222,7 @@ describe('recordStepResult', () => {
     expect(after[0]?.status).toBe('failed');
     expect(after[1]?.status).toBe('cancelled');
     expect(after[2]?.status).toBe('cancelled');
+    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
   });
 });
 
@@ -303,6 +305,23 @@ describe('recordStepResult job-completion event', () => {
     expect(duplicate).toEqual({jobFinished: true, status: 'succeeded'});
     expect(await jobCompletedEvents(jobId)).toHaveLength(1);
   });
+
+  test('concurrent final reports enqueue exactly one completion event', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await nextStepForJob(jobId);
+
+    const outcomes = await Promise.all([
+      recordStepResult({jobId, stepId, status: 'succeeded', attempt: 1, exitCode: 0}),
+      recordStepResult({jobId, stepId, status: 'succeeded', attempt: 1, exitCode: 0}),
+    ]);
+
+    expect(outcomes).toEqual([
+      {jobFinished: true, status: 'succeeded'},
+      {jobFinished: true, status: 'succeeded'},
+    ]);
+    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
+  });
 });
 
 describe('step attempts', () => {
@@ -340,6 +359,9 @@ describe('step attempts', () => {
     expect(attempts).toHaveLength(1);
     expect(attempts[0]).toMatchObject({attempt: 1, status: 'succeeded', exitCode: 0, error: null});
     expect(attempts[0]?.finishedAt).not.toBeNull();
+    const [step] = await getStepsByJobId(jobId);
+    expect(step?.currentAttempt).toBe(attempts[0]?.attempt);
+    expect(step?.status).toBe(attempts[0]?.status);
   });
 
   test('a failed report finalizes the attempt with its error and exit code', async () => {
@@ -358,6 +380,53 @@ describe('step attempts', () => {
     expect(attempt).toMatchObject({status: 'failed', exitCode: 1, error: {message: 'boom'}});
   });
 
+  test('reporting creates a missing running attempt before finalization', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    // Migration boundary: a step may already be running before PR B's attempt
+    // rows exist. Reporting should backfill the attempt row and finalize it.
+    await db().update(stepsTable).set({status: 'running'}).where(eq(stepsTable.id, stepId));
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'succeeded',
+      output: {summary: 'ok'},
+      exitCode: 0,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({
+      stepId,
+      attempt: 1,
+      status: 'succeeded',
+      output: {summary: 'ok'},
+      exitCode: 0,
+    });
+    const [step] = await getStepsByJobId(jobId);
+    expect(step?.currentAttempt).toBe(attempt?.attempt);
+    expect(step?.status).toBe(attempt?.status);
+    expect(step?.output).toBeNull();
+  });
+
+  test('persists structured output on the attempt row', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await nextStepForJob(jobId);
+
+    await recordStepResult({
+      jobId,
+      stepId,
+      status: 'succeeded',
+      output: {artifact: 'dist/app.tgz'},
+      exitCode: 0,
+    });
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.output).toEqual({artifact: 'dist/app.tgz'});
+  });
+
   test('a duplicate report leaves the finalized attempt unchanged (never-downgrade)', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const stepId = steps[0]?.id as string;
@@ -368,6 +437,36 @@ describe('step attempts', () => {
 
     const [attempt] = await getStepAttempts(jobId);
     expect(attempt).toMatchObject({status: 'succeeded', exitCode: 0});
+  });
+
+  test('rejects non-positive attempt rows at the database boundary', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+
+    await expect(
+      db()
+        .insert(stepAttemptsTable)
+        .values({
+          jobId,
+          stepId: steps[0]?.id as string,
+          attempt: 0,
+          status: 'running',
+        }),
+    ).rejects.toThrow();
+  });
+
+  test('rejects pending attempt rows at the database boundary', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+
+    await expect(
+      db()
+        .insert(stepAttemptsTable)
+        .values({
+          jobId,
+          stepId: steps[0]?.id as string,
+          attempt: 1,
+          status: 'pending',
+        }),
+    ).rejects.toThrow();
   });
 
   test('rejects a report whose attempt is ahead of the current attempt', async () => {

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -2,9 +2,15 @@ import {WORKFLOWS_JOB_COMPLETED} from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {workflowsOutbox} from '#db/schema/outbox.js';
-import {bulkUpdateStepStatuses, getStepsByJobId} from '#db/workflow-runs.js';
+import {steps as stepsTable} from '#db/schema/steps.js';
+import {bulkUpdateStepStatuses, getStepAttempts, getStepsByJobId} from '#db/workflow-runs.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
-import {JobNotFoundError, StepNotFoundError, StepNotRunningError} from './errors.js';
+import {
+  JobNotFoundError,
+  StepAttemptAheadError,
+  StepNotFoundError,
+  StepNotRunningError,
+} from './errors.js';
 import {nextStepForJob, recordStepResult} from './job-execution.js';
 
 async function jobCompletedEvents(jobId: string): Promise<Array<{status: string}>> {
@@ -231,6 +237,8 @@ describe('nextStepForJob concurrency', () => {
     expect(idA).toBe(idB);
     const running = (await getStepsByJobId(jobId)).filter((s) => s.status === 'running');
     expect(running).toHaveLength(1);
+    // The onConflictDoNothing backstop keeps a single attempt row under contention.
+    expect(await getStepAttempts(jobId)).toHaveLength(1);
   });
 });
 
@@ -293,6 +301,125 @@ describe('recordStepResult job-completion event', () => {
     });
 
     expect(duplicate).toEqual({jobFinished: true, status: 'succeeded'});
+    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
+  });
+});
+
+describe('step attempts', () => {
+  test('dispatch opens a running attempt row at attempt 1', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+
+    await nextStepForJob(jobId);
+
+    const attempts = await getStepAttempts(jobId);
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]).toMatchObject({stepId: steps[0]?.id, attempt: 1, status: 'running'});
+  });
+
+  test('re-delivery does not open a second attempt row', async () => {
+    const {jobId} = await arrangeJobWithSteps(2);
+
+    await nextStepForJob(jobId);
+    await nextStepForJob(jobId);
+
+    expect(await getStepAttempts(jobId)).toHaveLength(1);
+  });
+
+  test('reporting finalizes the attempt with status and exit code', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId);
+
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'succeeded',
+      exitCode: 0,
+    });
+
+    const attempts = await getStepAttempts(jobId);
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]).toMatchObject({attempt: 1, status: 'succeeded', exitCode: 0, error: null});
+    expect(attempts[0]?.finishedAt).not.toBeNull();
+  });
+
+  test('a failed report finalizes the attempt with its error and exit code', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId);
+
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'failed',
+      error: {message: 'boom'},
+      exitCode: 1,
+    });
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({status: 'failed', exitCode: 1, error: {message: 'boom'}});
+  });
+
+  test('a duplicate report leaves the finalized attempt unchanged (never-downgrade)', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId, status: 'succeeded', exitCode: 0});
+
+    await recordStepResult({jobId, stepId, status: 'failed', exitCode: 9});
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({status: 'succeeded', exitCode: 0});
+  });
+
+  test('rejects a report whose attempt is ahead of the current attempt', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    await nextStepForJob(jobId);
+
+    await expect(
+      recordStepResult({jobId, stepId: steps[0]?.id as string, status: 'succeeded', attempt: 2}),
+    ).rejects.toBeInstanceOf(StepAttemptAheadError);
+  });
+
+  test('a stale older-attempt report is an idempotent no-op', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await nextStepForJob(jobId);
+    // Simulate a rewind having bumped the current attempt to 2.
+    await db()
+      .update(stepsTable)
+      .set({currentAttempt: 2, status: 'running'})
+      .where(eq(stepsTable.id, stepId));
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'failed',
+      error: {message: 'late'},
+      attempt: 1,
+    });
+
+    expect(outcome).toEqual({jobFinished: false});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('running'); // projection untouched by the stale report
+  });
+
+  test('a stale report on an already-finished job reports finished without a second completion event', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await nextStepForJob(jobId);
+    await recordStepResult({jobId, stepId, status: 'succeeded', exitCode: 0});
+    // Simulate a later rewind bump on the now-terminal step.
+    await db().update(stepsTable).set({currentAttempt: 2}).where(eq(stepsTable.id, stepId));
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'failed',
+      error: {message: 'late'},
+      attempt: 1,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+    // The applied-gated outbox write must not fire on the stale path.
     expect(await jobCompletedEvents(jobId)).toHaveLength(1);
   });
 });

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -4,6 +4,7 @@ import {
   cancelRemainingSteps,
   finishStepAttempt,
   getStepsByJobIdForUpdate,
+  insertRunningStepAttempt,
   markStepRunning,
   writeJobCompletedOutbox,
 } from '#db/workflow-runs.js';
@@ -61,6 +62,10 @@ export interface RecordStepResultParams {
   stepId: string;
   status: 'succeeded' | 'failed';
   error?: Record<string, unknown> | null;
+  // Structured runner output for audit/history on the attempt row. The current
+  // step projection keeps status/error only until logs/output have a stable
+  // product contract.
+  output?: Record<string, unknown> | null;
   // Process exit code reported by the runner (PR B persists it on the attempt).
   exitCode?: number | null;
   // The attempt the runner was dispatched. Omitted = "the step's current
@@ -109,12 +114,20 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
       if (target.status === 'pending') {
         throw new StepNotRunningError(params.stepId, params.jobId);
       }
+      // Migration/back-compat boundary: a running step may predate the
+      // step_attempts table or have been marked running by legacy code. Create
+      // the audit row just before finalization if dispatch did not already do it.
+      await insertRunningStepAttempt(
+        {jobId: params.jobId, stepId: params.stepId, attempt: current},
+        tx,
+      );
       await finishStepAttempt(
         {
           stepId: params.stepId,
           attempt: current,
           status: params.status,
           error: params.error ?? null,
+          output: params.output ?? null,
           exitCode: params.exitCode ?? null,
         },
         tx,

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -2,13 +2,19 @@ import {withTransaction} from '#db/db.js';
 import {
   applyStepResult,
   cancelRemainingSteps,
+  finishStepAttempt,
   getStepsByJobIdForUpdate,
   markStepRunning,
   writeJobCompletedOutbox,
 } from '#db/workflow-runs.js';
 import type {RuntimeCompletionStatus} from './entities/runtime-dag.js';
 import type {Step, StepStatus} from './entities/step.js';
-import {JobNotFoundError, StepNotFoundError, StepNotRunningError} from './errors.js';
+import {
+  JobNotFoundError,
+  StepAttemptAheadError,
+  StepNotFoundError,
+  StepNotRunningError,
+} from './errors.js';
 
 const TERMINAL_STATUSES: ReadonlySet<StepStatus> = new Set(['succeeded', 'failed', 'cancelled']);
 
@@ -55,11 +61,22 @@ export interface RecordStepResultParams {
   stepId: string;
   status: 'succeeded' | 'failed';
   error?: Record<string, unknown> | null;
+  // Process exit code reported by the runner (PR B persists it on the attempt).
+  exitCode?: number | null;
+  // The attempt the runner was dispatched. Omitted = "the step's current
+  // attempt" (back-compat for callers that don't track attempts yet).
+  attempt?: number;
 }
 
 export type RecordStepResultOutcome =
   | {jobFinished: false}
   | {jobFinished: true; status: CompletionStatus};
+
+function outcomeFromSteps(steps: Step[]): RecordStepResultOutcome {
+  return steps.every((step) => isTerminal(step.status))
+    ? {jobFinished: true, status: deriveCompletion(steps)}
+    : {jobFinished: false};
+}
 
 export function recordStepResult(params: RecordStepResultParams): Promise<RecordStepResultOutcome> {
   // The failed result and its sibling cancellations are two writes; one
@@ -71,12 +88,37 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
 
     if (!target) throw new StepNotFoundError(params.stepId, params.jobId);
 
+    // Attempt-aware idempotency, evaluated before the running/terminal checks and
+    // anchored on the step's current attempt (the step_attempts unique constraint
+    // is the race backstop).
+    const current = target.currentAttempt;
+    const reported = params.attempt ?? current;
+    if (reported > current) {
+      // The host allocates attempts; a runner cannot report one ahead of dispatch.
+      throw new StepAttemptAheadError(params.stepId, params.jobId, reported, current);
+    }
+    if (reported < current) {
+      // A stale report from a superseded attempt (e.g. after a rewind bumped the
+      // current attempt). No-op: leave the projection untouched.
+      return outcomeFromSteps(steps);
+    }
+
     let applied = false;
     if (!isTerminal(target.status)) {
       // A result may only land on a step that was actually handed out.
       if (target.status === 'pending') {
         throw new StepNotRunningError(params.stepId, params.jobId);
       }
+      await finishStepAttempt(
+        {
+          stepId: params.stepId,
+          attempt: current,
+          status: params.status,
+          error: params.error ?? null,
+          exitCode: params.exitCode ?? null,
+        },
+        tx,
+      );
       await applyStepResult(
         {
           jobId: params.jobId,

--- a/libs/api/workflows/src/db/db.ts
+++ b/libs/api/workflows/src/db/db.ts
@@ -2,10 +2,11 @@ import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
 import {jobs} from './schema/jobs.js';
 import {workflowsOutbox} from './schema/outbox.js';
+import {stepAttempts} from './schema/step-attempts.js';
 import {steps} from './schema/steps.js';
 import {workflowRuns} from './schema/workflow-runs.js';
 
-export const schema = {workflowRuns, jobs, steps, workflowsOutbox};
+export const schema = {workflowRuns, jobs, steps, stepAttempts, workflowsOutbox};
 
 let _db: NodePgDatabase<typeof schema> | undefined;
 

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -22,6 +22,7 @@ export {
   createWorkflowRun,
   failJobAsTimedOut,
   getJobsByRunId,
+  getStepAttempts,
   getStepsByJobId,
   getStepsByJobIds,
   getWorkflowRunAggregates,

--- a/libs/api/workflows/src/db/schema/step-attempts.ts
+++ b/libs/api/workflows/src/db/schema/step-attempts.ts
@@ -1,5 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, integer, jsonb, text, timestamp, unique, uuid} from 'drizzle-orm/pg-core';
+import {sql} from 'drizzle-orm';
+import {check, index, integer, jsonb, text, timestamp, unique, uuid} from 'drizzle-orm/pg-core';
 import type {StepAttempt, StepAttemptStatus} from '#core/entities/step.js';
 import {pgTable} from './common.js';
 import {jobs} from './jobs.js';
@@ -38,6 +39,8 @@ export const stepAttempts = pgTable(
   (table) => [
     unique('workflows_step_attempts_step_id_attempt_uq').on(table.stepId, table.attempt),
     index('workflows_step_attempts_job_id_idx').on(table.jobId),
+    check('workflows_step_attempts_attempt_positive_ck', sql`${table.attempt} > 0`),
+    check('workflows_step_attempts_status_not_pending_ck', sql`${table.status} <> 'pending'`),
   ],
 );
 

--- a/libs/api/workflows/src/db/schema/step-attempts.ts
+++ b/libs/api/workflows/src/db/schema/step-attempts.ts
@@ -1,0 +1,63 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, integer, jsonb, text, timestamp, unique, uuid} from 'drizzle-orm/pg-core';
+import type {StepAttempt, StepAttemptStatus} from '#core/entities/step.js';
+import {pgTable} from './common.js';
+import {jobs} from './jobs.js';
+import {stepStatusEnum, steps} from './steps.js';
+
+// Append-only execution history. One row per dispatched attempt of a step,
+// inserted `running` at dispatch and finalized terminal at report. `steps` holds
+// the fast current projection; this table is the audit trail and — via the
+// unique (step_id, attempt) constraint — the idempotency anchor.
+export const stepAttempts = pgTable(
+  'step_attempts',
+  {
+    id: uuidv7PrimaryKey(),
+    stepId: uuid('step_id')
+      .notNull()
+      .references(() => steps.id),
+    // Denormalized so attempt history is queryable per job without a join.
+    jobId: uuid('job_id')
+      .notNull()
+      .references(() => jobs.id),
+    attempt: integer('attempt').notNull(),
+    // Reuses the step status enum, but a row is created only once dispatched, so
+    // it is never 'pending'.
+    status: stepStatusEnum('status').notNull(),
+    output: jsonb('output').$type<Record<string, unknown>>(),
+    error: jsonb('error').$type<Record<string, unknown>>(),
+    exitCode: integer('exit_code'),
+    // Gate evaluation payload for this attempt (populated in PR D).
+    gateResult: jsonb('gate_result').$type<Record<string, unknown>>(),
+    // Why this attempt triggered a restart (populated in PR E).
+    restartReason: text('restart_reason'),
+    startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
+    finishedAt: timestamp('finished_at', {withTimezone: true}),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    unique('workflows_step_attempts_step_id_attempt_uq').on(table.stepId, table.attempt),
+    index('workflows_step_attempts_job_id_idx').on(table.jobId),
+  ],
+);
+
+export type StepAttemptDb = typeof stepAttempts.$inferSelect;
+export type StepAttemptCreateDb = typeof stepAttempts.$inferInsert;
+
+export function toStepAttempt(row: StepAttemptDb): StepAttempt {
+  return {
+    id: row.id,
+    stepId: row.stepId,
+    jobId: row.jobId,
+    attempt: row.attempt,
+    status: row.status as StepAttemptStatus,
+    output: (row.output as Record<string, unknown>) ?? null,
+    error: (row.error as Record<string, unknown>) ?? null,
+    exitCode: row.exitCode ?? null,
+    gateResult: (row.gateResult as Record<string, unknown>) ?? null,
+    restartReason: row.restartReason ?? null,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt ?? null,
+    createdAt: row.createdAt,
+  };
+}

--- a/libs/api/workflows/src/db/schema/steps.ts
+++ b/libs/api/workflows/src/db/schema/steps.ts
@@ -27,6 +27,9 @@ export const steps = pgTable(
     error: jsonb('error').$type<Record<string, unknown>>(),
     position: integer('position').notNull(),
     version: integer('version').notNull().default(1),
+    // Execution-attempt identity (which attempt the projection reflects), NOT the
+    // optimistic `version` counter. Starts at 1; bumped only on rewind (PR E).
+    currentAttempt: integer('current_attempt').notNull().default(1),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
   },
@@ -48,6 +51,7 @@ export function toStep(row: StepDb): Step {
     error: (row.error as Record<string, unknown>) ?? null,
     position: row.position,
     version: row.version,
+    currentAttempt: row.currentAttempt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -8,12 +8,13 @@ import {
 import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, asc, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql} from 'drizzle-orm';
 import type {Job, JobStatus} from '#core/entities/job.js';
-import type {Step, StepStatus} from '#core/entities/step.js';
+import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
 import type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from '#core/entities/workflow-run.js';
 import {materializeWorkflowModel} from '#core/workflow-runtime/index.js';
 import {db, type Tx} from './db.js';
 import {jobs, toJob} from './schema/jobs.js';
 import {workflowsOutbox} from './schema/outbox.js';
+import {stepAttempts, toStepAttempt} from './schema/step-attempts.js';
 import {steps, toStep} from './schema/steps.js';
 import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
 
@@ -639,7 +640,77 @@ export async function markStepRunning(params: MarkStepRunningParams, tx: Tx): Pr
     )
     .returning();
   const row = rows[0];
-  return row ? toStep(row) : null;
+  if (!row) return null;
+  const step = toStep(row);
+  // Open the attempt this dispatch runs. onConflictDoNothing makes a racing
+  // re-dispatch a no-op against the unique (step_id, attempt) anchor; normal
+  // re-delivery returns the already-running step without calling this.
+  await insertRunningStepAttempt(
+    {jobId: step.jobId, stepId: step.id, attempt: step.currentAttempt},
+    tx,
+  );
+  return step;
+}
+
+export interface InsertRunningStepAttemptParams {
+  jobId: string;
+  stepId: string;
+  attempt: number;
+}
+
+export async function insertRunningStepAttempt(
+  params: InsertRunningStepAttemptParams,
+  tx: Tx,
+): Promise<void> {
+  await tx
+    .insert(stepAttempts)
+    .values({
+      jobId: params.jobId,
+      stepId: params.stepId,
+      attempt: params.attempt,
+      status: 'running',
+    })
+    .onConflictDoNothing();
+}
+
+export interface FinishStepAttemptParams {
+  stepId: string;
+  attempt: number;
+  status: StepAttemptStatus;
+  error?: Record<string, unknown> | null;
+  exitCode?: number | null;
+  gateResult?: Record<string, unknown> | null;
+}
+
+// Finalize the running attempt to a terminal state. The `status='running'` guard
+// makes this idempotent: a duplicate report finds the attempt already terminal
+// and updates nothing (never-downgrade for the audit row).
+export async function finishStepAttempt(params: FinishStepAttemptParams, tx: Tx): Promise<void> {
+  await tx
+    .update(stepAttempts)
+    .set({
+      status: params.status,
+      error: params.error ?? null,
+      exitCode: params.exitCode ?? null,
+      gateResult: params.gateResult ?? null,
+      finishedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(stepAttempts.stepId, params.stepId),
+        eq(stepAttempts.attempt, params.attempt),
+        eq(stepAttempts.status, 'running'),
+      ),
+    );
+}
+
+export async function getStepAttempts(jobId: string): Promise<StepAttempt[]> {
+  const rows = await db()
+    .select()
+    .from(stepAttempts)
+    .where(eq(stepAttempts.jobId, jobId))
+    .orderBy(asc(stepAttempts.stepId), asc(stepAttempts.attempt));
+  return rows.map(toStepAttempt);
 }
 
 export interface ApplyStepResultParams {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -670,14 +670,15 @@ export async function insertRunningStepAttempt(
       attempt: params.attempt,
       status: 'running',
     })
-    .onConflictDoNothing();
+    .onConflictDoNothing({target: [stepAttempts.stepId, stepAttempts.attempt]});
 }
 
 export interface FinishStepAttemptParams {
   stepId: string;
   attempt: number;
-  status: StepAttemptStatus;
+  status: Exclude<StepAttemptStatus, 'running'>;
   error?: Record<string, unknown> | null;
+  output?: Record<string, unknown> | null;
   exitCode?: number | null;
   gateResult?: Record<string, unknown> | null;
 }
@@ -690,6 +691,7 @@ export async function finishStepAttempt(params: FinishStepAttemptParams, tx: Tx)
     .update(stepAttempts)
     .set({
       status: params.status,
+      output: params.output ?? null,
       error: params.error ?? null,
       exitCode: params.exitCode ?? null,
       gateResult: params.gateResult ?? null,

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -1,6 +1,9 @@
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {eq} from 'drizzle-orm';
 import {recordStepResult} from '#core/job-execution.js';
+import {db} from '#db/db.js';
+import {steps as stepsTable} from '#db/schema/steps.js';
 import {getStepsByJobId} from '#db/workflow-runs.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
@@ -199,5 +202,24 @@ describe('POST /runs/jobs/current/steps/next', () => {
     expect(new Set(ids).size).toBe(1);
     const running = (await getStepsByJobId(jobId)).filter((s) => s.status === 'running');
     expect(running).toHaveLength(1);
+  });
+
+  test("returns the step's current attempt so the runner can echo it", async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    // Simulate a durable restart having bumped the first step's current attempt.
+    await db()
+      .update(stepsTable)
+      .set({currentAttempt: 2})
+      .where(eq(stepsTable.id, steps[0]?.id as string));
+    const token = await mintLeaseToken({jobId});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().attempt).toBe(2);
   });
 });

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -27,9 +27,10 @@ export const nextStepRoute = defineRoute({
     const next = await nextStepForJob(leasedJob.jobId);
 
     if (next.kind === 'step') {
-      // Always attempt 1 until per-step attempts land (PR B wires the real
-      // current_attempt through nextStepForJob).
-      return {kind: 'step' as const, step: toStepDto(next.step), attempt: 1};
+      // The runner echoes this back on report so a stale report from a superseded
+      // attempt is ignored. It is 1 until a durable restart (PR E) bumps the
+      // step's current attempt.
+      return {kind: 'step' as const, step: toStepDto(next.step), attempt: next.step.currentAttempt};
     }
     return {kind: 'done' as const, status: next.status};
   },

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -261,4 +261,20 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
     expect(after[0]?.status).toBe('succeeded');
     expect(after[1]?.status).toBe('pending');
   });
+
+  test('a report whose attempt is ahead of the current attempt → 409 step-attempt-ahead', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const token = await mintLeaseToken({jobId});
+    await nextStepForJob(jobId);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: reportUrl(steps[0]?.id as string),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {status: 'succeeded', attempt: 2},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('step-attempt-ahead');
+  });
 });

--- a/libs/api/workflows/src/presentation/routes/report-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.test.ts
@@ -1,7 +1,7 @@
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {nextStepForJob} from '#core/job-execution.js';
-import {getStepsByJobId} from '#db/workflow-runs.js';
+import {getStepAttempts, getStepsByJobId} from '#db/workflow-runs.js';
 import {arrangeJobWithSteps} from '#test/fixtures/job-with-steps.js';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {leaseTokenRouteGroup} from './index.js';
@@ -105,6 +105,26 @@ describe('POST /runs/jobs/current/steps/:stepId/report', () => {
     expect(res.statusCode).toBe(200);
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.error).toEqual({message: 'boom', exitCode: 1, signal: 'SIGKILL'});
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.exitCode).toBe(1);
+  });
+
+  test('persists structured output on the attempt row', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const token = await mintLeaseToken({jobId});
+    await nextStepForJob(jobId);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: reportUrl(steps[0]?.id as string),
+      headers: {authorization: `Bearer ${token}`},
+      payload: {status: 'succeeded', output: {artifact: 'dist/app.tgz'}, exit_code: 0},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.output).toEqual({artifact: 'dist/app.tgz'});
+    expect(attempt?.exitCode).toBe(0);
   });
 
   test('rejects a failed report without an error', async () => {

--- a/libs/api/workflows/src/presentation/routes/report-step.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.ts
@@ -39,7 +39,8 @@ export const reportStepRoute = defineRoute({
       stepId,
       status: request.body.status,
       error: fromStepErrorDto(request.body.error),
-      exitCode: request.body.exit_code ?? null,
+      output: request.body.output ?? null,
+      exitCode: request.body.exit_code ?? request.body.error?.exit_code ?? null,
       ...(request.body.attempt !== undefined ? {attempt: request.body.attempt} : {}),
     });
 

--- a/libs/api/workflows/src/presentation/routes/report-step.ts
+++ b/libs/api/workflows/src/presentation/routes/report-step.ts
@@ -2,7 +2,7 @@ import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {reportStepBodySchema, reportStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {StepNotFoundError, StepNotRunningError} from '#core/errors.js';
+import {StepAttemptAheadError, StepNotFoundError, StepNotRunningError} from '#core/errors.js';
 import {recordStepResult} from '#core/job-execution.js';
 import {fromStepErrorDto} from '#presentation/dto/step.js';
 
@@ -25,6 +25,9 @@ export const reportStepRoute = defineRoute({
     if (error instanceof StepNotRunningError) {
       throw new ClientError(error.message, 'step-not-running', {status: 409});
     }
+    if (error instanceof StepAttemptAheadError) {
+      throw new ClientError(error.message, 'step-attempt-ahead', {status: 409});
+    }
     throw error;
   },
   handler: async (request) => {
@@ -36,6 +39,8 @@ export const reportStepRoute = defineRoute({
       stepId,
       status: request.body.status,
       error: fromStepErrorDto(request.body.error),
+      exitCode: request.body.exit_code ?? null,
+      ...(request.body.attempt !== undefined ? {attempt: request.body.attempt} : {}),
     });
 
     return {ok: true, cancel: outcome.jobFinished && outcome.status === 'failed'};


### PR DESCRIPTION
Adds durable per-step attempt history.

What changes:
- Adds `workflows_step_attempts` and `steps.current_attempt`.
- `nextStepForJob` opens a running attempt when dispatching a step.
- `recordStepResult` finalizes the current attempt and is attempt-aware: duplicate final reports are idempotent, stale older reports are ignored, and ahead-of-current reports are rejected.
- `workflows_step_attempts.exit_code` is the canonical persisted exit code for attempt history; report output is also persisted on the attempt row.
- DB checks enforce positive attempt numbers and no `pending` attempt rows.
- Migration boundary: steps already running before this table exists may not have a dispatch-time attempt row, so reporting backfills a running attempt row before finalization. Its `started_at` is approximate in that case.

Refs ENG-397

<!-- stk:begin -->
## Stack

Part 1 of 5.

Depends on: none
Next: #153

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #152 | `durable-gate/02-step-attempts` | `main` |
| 2 | #153 | `durable-gate/03-pure-decision` | `durable-gate/02-step-attempts` |
| 3 | #154 | `durable-gate/04-gate-eval-terminal` | `durable-gate/03-pure-decision` |
| 4 | #155 | `durable-gate/05-durable-restart` | `durable-gate/04-gate-eval-terminal` |
| 5 | #156 | `durable-gate/06-dashboard-attempts` | `durable-gate/05-durable-restart` |

<!-- stk:end -->