### PR TITLE
Extract a pure step-transition decision layer

### DIFF
--- a/.changeset/swift-meadows-decide.md
+++ b/.changeset/swift-meadows-decide.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Extract the step-report decision into a pure `decideStepTransition` plus a durable `applyStepTransition`, creating the seam where gate evaluation and durable restart will plug in. No behavior change.

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1,35 +1,28 @@
 import {withTransaction} from '#db/db.js';
 import {
-  applyStepResult,
-  cancelRemainingSteps,
-  finishStepAttempt,
   getStepsByJobIdForUpdate,
   insertRunningStepAttempt,
   markStepRunning,
-  writeJobCompletedOutbox,
 } from '#db/workflow-runs.js';
 import type {RuntimeCompletionStatus} from './entities/runtime-dag.js';
-import type {Step, StepStatus} from './entities/step.js';
+import type {Step} from './entities/step.js';
 import {
   JobNotFoundError,
   StepAttemptAheadError,
   StepNotFoundError,
   StepNotRunningError,
 } from './errors.js';
-
-const TERMINAL_STATUSES: ReadonlySet<StepStatus> = new Set(['succeeded', 'failed', 'cancelled']);
+import {
+  applyStepTransition,
+  type StepProgressionOutcome,
+} from './step-transition/apply-step-transition.js';
+import {
+  decideStepTransition,
+  deriveCompletion,
+  isTerminal,
+} from './step-transition/decide-step-transition.js';
 
 type CompletionStatus = RuntimeCompletionStatus;
-
-function isTerminal(status: StepStatus): boolean {
-  return TERMINAL_STATUSES.has(status);
-}
-
-// Anything other than an all-succeeded job is a failure, so an externally
-// cancelled job never reads as a vacuous success.
-function deriveCompletion(steps: Step[]): CompletionStatus {
-  return steps.every((step) => step.status === 'succeeded') ? 'succeeded' : 'failed';
-}
 
 export type NextStep = {kind: 'step'; step: Step} | {kind: 'done'; status: CompletionStatus};
 
@@ -73,9 +66,7 @@ export interface RecordStepResultParams {
   attempt?: number;
 }
 
-export type RecordStepResultOutcome =
-  | {jobFinished: false}
-  | {jobFinished: true; status: CompletionStatus};
+export type RecordStepResultOutcome = StepProgressionOutcome;
 
 function outcomeFromSteps(steps: Step[]): RecordStepResultOutcome {
   return steps.every((step) => isTerminal(step.status))
@@ -84,9 +75,9 @@ function outcomeFromSteps(steps: Step[]): RecordStepResultOutcome {
 }
 
 export function recordStepResult(params: RecordStepResultParams): Promise<RecordStepResultOutcome> {
-  // The failed result and its sibling cancellations are two writes; one
-  // transaction keeps them atomic, so a crashed-then-retried report can never
-  // leave siblings stranded once the step itself is terminal.
+  // One transaction keeps the attempt finalize, the step result, and any sibling
+  // cancellations atomic, so a crashed-then-retried report can never leave
+  // siblings stranded once the step itself is terminal.
   return withTransaction(async (tx) => {
     const steps = await getStepsByJobIdForUpdate(params.jobId, tx);
     const target = steps.find((step) => step.id === params.stepId);
@@ -95,7 +86,8 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
 
     // Attempt-aware idempotency, evaluated before the running/terminal checks and
     // anchored on the step's current attempt (the step_attempts unique constraint
-    // is the race backstop).
+    // is the race backstop). These DB-state-dependent guards stay in the service;
+    // only the semantic decision below is pure.
     const current = target.currentAttempt;
     const reported = params.attempt ?? current;
     if (reported > current) {
@@ -107,58 +99,28 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
       // current attempt). No-op: leave the projection untouched.
       return outcomeFromSteps(steps);
     }
-
-    let applied = false;
-    if (!isTerminal(target.status)) {
-      // A result may only land on a step that was actually handed out.
-      if (target.status === 'pending') {
-        throw new StepNotRunningError(params.stepId, params.jobId);
-      }
-      // Migration/back-compat boundary: a running step may predate the
-      // step_attempts table or have been marked running by legacy code. Create
-      // the audit row just before finalization if dispatch did not already do it.
-      await insertRunningStepAttempt(
-        {jobId: params.jobId, stepId: params.stepId, attempt: current},
-        tx,
-      );
-      await finishStepAttempt(
-        {
-          stepId: params.stepId,
-          attempt: current,
-          status: params.status,
-          error: params.error ?? null,
-          output: params.output ?? null,
-          exitCode: params.exitCode ?? null,
-        },
-        tx,
-      );
-      await applyStepResult(
-        {
-          jobId: params.jobId,
-          stepId: params.stepId,
-          status: params.status,
-          error: params.error ?? null,
-        },
-        tx,
-      );
-      if (params.status === 'failed') {
-        await cancelRemainingSteps({jobId: params.jobId}, tx);
-      }
-      applied = true;
-    }
     // A terminal target is a duplicate report, left untouched.
-
-    const after = await getStepsByJobIdForUpdate(params.jobId, tx);
-    if (after.every((step) => isTerminal(step.status))) {
-      const status = deriveCompletion(after);
-      // Only this call's transition to terminal emits the completion signal, so
-      // a duplicate report on an already-finished job never enqueues a second
-      // event (no double signal to the job workflow).
-      if (applied) {
-        await writeJobCompletedOutbox(tx, {jobId: params.jobId, status});
-      }
-      return {jobFinished: true, status};
+    if (isTerminal(target.status)) return outcomeFromSteps(steps);
+    // A result may only land on a step that was actually handed out.
+    if (target.status === 'pending') {
+      throw new StepNotRunningError(params.stepId, params.jobId);
     }
-    return {jobFinished: false};
+
+    // Migration/back-compat boundary: a running step may predate the
+    // step_attempts table or have been marked running by legacy code. Create
+    // the audit row just before finalization if dispatch did not already do it.
+    await insertRunningStepAttempt(
+      {jobId: params.jobId, stepId: params.stepId, attempt: current},
+      tx,
+    );
+
+    const result = {
+      status: params.status,
+      error: params.error ?? null,
+      output: params.output ?? null,
+      exitCode: params.exitCode ?? null,
+    };
+    const decision = decideStepTransition({steps, target, reportedAttempt: reported, result});
+    return applyStepTransition(decision, {jobId: params.jobId, result}, tx);
   });
 }

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.test.ts
@@ -1,0 +1,36 @@
+import type {Tx} from '#db/db.js';
+import {applyStepTransition} from './apply-step-transition.js';
+import type {StepTransitionDecision} from './decide-step-transition.js';
+
+// The restart kinds throw before touching the transaction, so a stub tx is safe.
+const tx = {} as Tx;
+const ctx = {jobId: 'job-1', result: {status: 'failed' as const}};
+
+describe('applyStepTransition unsupported decisions', () => {
+  test('restart-job-from-step throws until durable restart lands (PR E)', async () => {
+    const decision: StepTransitionDecision = {
+      kind: 'restart-job-from-step',
+      failedStepId: 's1',
+      restartFromStepId: 's0',
+      attempt: 1,
+      reason: 'gate failed',
+    };
+
+    await expect(applyStepTransition(decision, ctx, tx)).rejects.toThrow(
+      'Unsupported step transition',
+    );
+  });
+
+  test('fail-job-restart-exhausted throws until durable restart lands (PR E)', async () => {
+    const decision: StepTransitionDecision = {
+      kind: 'fail-job-restart-exhausted',
+      failedStepId: 's1',
+      attempt: 3,
+      maxAttempts: 3,
+    };
+
+    await expect(applyStepTransition(decision, ctx, tx)).rejects.toThrow(
+      'Unsupported step transition',
+    );
+  });
+});

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
@@ -1,0 +1,95 @@
+import type {Tx} from '#db/db.js';
+import {
+  applyStepResult,
+  cancelRemainingSteps,
+  finishStepAttempt,
+  getStepsByJobIdForUpdate,
+  writeJobCompletedOutbox,
+} from '#db/workflow-runs.js';
+import {
+  deriveCompletion,
+  isTerminal,
+  type StepResult,
+  type StepTransitionDecision,
+} from './decide-step-transition.js';
+
+export type StepProgressionOutcome =
+  | {jobFinished: false}
+  | {jobFinished: true; status: 'succeeded' | 'failed'};
+
+export interface ApplyStepTransitionContext {
+  jobId: string;
+  result: StepResult;
+}
+
+// Durable side of the decision: writes the attempt + projection for a transition,
+// then derives job completion from the post-apply projection and enqueues the
+// completion event in the same transaction. Only called for a running target, so
+// every path here is an actual state change (idempotent no-ops are handled by the
+// caller before deciding).
+export async function applyStepTransition(
+  decision: StepTransitionDecision,
+  ctx: ApplyStepTransitionContext,
+  tx: Tx,
+): Promise<StepProgressionOutcome> {
+  switch (decision.kind) {
+    case 'complete-step':
+    case 'complete-job': {
+      await finishStepAttempt(
+        {
+          stepId: decision.stepId,
+          attempt: decision.attempt,
+          status: 'succeeded',
+          output: ctx.result.output ?? null,
+          exitCode: ctx.result.exitCode ?? null,
+        },
+        tx,
+      );
+      await applyStepResult(
+        {jobId: ctx.jobId, stepId: decision.stepId, status: 'succeeded', error: null},
+        tx,
+      );
+      break;
+    }
+    case 'fail-job': {
+      await finishStepAttempt(
+        {
+          stepId: decision.failedStepId,
+          attempt: decision.attempt,
+          status: 'failed',
+          error: ctx.result.error ?? null,
+          output: ctx.result.output ?? null,
+          exitCode: ctx.result.exitCode ?? null,
+        },
+        tx,
+      );
+      await applyStepResult(
+        {
+          jobId: ctx.jobId,
+          stepId: decision.failedStepId,
+          status: 'failed',
+          error: ctx.result.error ?? null,
+        },
+        tx,
+      );
+      // The just-failed step is terminal, so this cancels only the steps after it.
+      await cancelRemainingSteps({jobId: ctx.jobId}, tx);
+      break;
+    }
+    case 'restart-job-from-step':
+    case 'fail-job-restart-exhausted':
+      // Durable restart lands in PR E.
+      throw new Error(`Unsupported step transition: ${decision.kind}`);
+  }
+
+  // Re-derive completion from the post-apply projection so the outcome is robust
+  // to the cancel sweep above; emit the completion event exactly once, here on
+  // the applied path.
+  const after = await getStepsByJobIdForUpdate(ctx.jobId, tx);
+  if (after.every((step) => isTerminal(step.status))) {
+    const status = deriveCompletion(after);
+    await writeJobCompletedOutbox(tx, {jobId: ctx.jobId, status});
+    return {jobFinished: true, status};
+  }
+  return {jobFinished: false};
+}

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -1,0 +1,119 @@
+import type {Step} from '../entities/step.js';
+import {decideStepTransition, deriveCompletion, isTerminal} from './decide-step-transition.js';
+
+function step(overrides: Partial<Step> & {id: string; position: number}): Step {
+  return {
+    jobId: 'job-1',
+    name: null,
+    status: 'pending',
+    type: 'run',
+    config: {},
+    output: null,
+    error: null,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('decideStepTransition', () => {
+  test('a succeeded step with pending siblings advances the step', () => {
+    const target = step({id: 's0', position: 0, status: 'running'});
+    const steps = [target, step({id: 's1', position: 1, status: 'pending'})];
+
+    const decision = decideStepTransition({
+      steps,
+      target,
+      reportedAttempt: 1,
+      result: {status: 'succeeded'},
+    });
+
+    expect(decision).toEqual({kind: 'complete-step', stepId: 's0', attempt: 1});
+  });
+
+  test('a succeeded step completes the job when every other step is terminal', () => {
+    const target = step({id: 's1', position: 1, status: 'running'});
+    const steps = [step({id: 's0', position: 0, status: 'succeeded'}), target];
+
+    const decision = decideStepTransition({
+      steps,
+      target,
+      reportedAttempt: 1,
+      result: {status: 'succeeded'},
+    });
+
+    expect(decision).toEqual({kind: 'complete-job', stepId: 's1', attempt: 1});
+  });
+
+  test('a single succeeded step completes the job', () => {
+    const target = step({id: 's0', position: 0, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'succeeded'},
+    });
+
+    expect(decision).toEqual({kind: 'complete-job', stepId: 's0', attempt: 1});
+  });
+
+  test('a failed step fails the job and cancels from its position', () => {
+    const target = step({id: 's1', position: 1, status: 'running'});
+    const steps = [
+      step({id: 's0', position: 0, status: 'succeeded'}),
+      target,
+      step({id: 's2', position: 2, status: 'pending'}),
+    ];
+
+    const decision = decideStepTransition({
+      steps,
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', error: {message: 'boom'}},
+    });
+
+    expect(decision).toEqual({
+      kind: 'fail-job',
+      failedStepId: 's1',
+      attempt: 1,
+      cancelFromPosition: 1,
+    });
+  });
+
+  test('echoes the reported attempt in the decision', () => {
+    const target = step({id: 's0', position: 0, status: 'running', currentAttempt: 2});
+    const steps = [target, step({id: 's1', position: 1, status: 'pending'})];
+
+    const decision = decideStepTransition({
+      steps,
+      target,
+      reportedAttempt: 2,
+      result: {status: 'succeeded'},
+    });
+
+    expect(decision).toMatchObject({kind: 'complete-step', attempt: 2});
+  });
+});
+
+describe('deriveCompletion / isTerminal', () => {
+  test('isTerminal covers the terminal states', () => {
+    expect(isTerminal('succeeded')).toBe(true);
+    expect(isTerminal('failed')).toBe(true);
+    expect(isTerminal('cancelled')).toBe(true);
+    expect(isTerminal('running')).toBe(false);
+    expect(isTerminal('pending')).toBe(false);
+  });
+
+  test('deriveCompletion is succeeded only when every step succeeded', () => {
+    expect(deriveCompletion([step({id: 'a', position: 0, status: 'succeeded'})])).toBe('succeeded');
+    expect(
+      deriveCompletion([
+        step({id: 'a', position: 0, status: 'succeeded'}),
+        step({id: 'b', position: 1, status: 'cancelled'}),
+      ]),
+    ).toBe('failed');
+  });
+});

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -1,0 +1,83 @@
+import type {RuntimeCompletionStatus} from '../entities/runtime-dag.js';
+import type {Step, StepStatus} from '../entities/step.js';
+
+const TERMINAL_STATUSES: ReadonlySet<StepStatus> = new Set(['succeeded', 'failed', 'cancelled']);
+
+export function isTerminal(status: StepStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+// Anything other than an all-succeeded job is a failure, so an externally
+// cancelled job never reads as a vacuous success.
+export function deriveCompletion(steps: Step[]): RuntimeCompletionStatus {
+  return steps.every((step) => step.status === 'succeeded') ? 'succeeded' : 'failed';
+}
+
+// The result the runner reported for the step being decided.
+export interface StepResult {
+  status: 'succeeded' | 'failed';
+  exitCode?: number | null;
+  error?: Record<string, unknown> | null;
+  output?: Record<string, unknown> | null;
+}
+
+export interface DecideStepTransitionInput {
+  // Full job projection, position-ordered (as returned by getStepsByJobIdForUpdate).
+  steps: Step[];
+  // The reporting step, already confirmed running at `reportedAttempt`.
+  target: Step;
+  reportedAttempt: number;
+  result: StepResult;
+  // PR D injects the gate outcome here; PR E adds the restart attempt cap. Absent
+  // ⇒ no gate, so `result.status` is authoritative.
+}
+
+// The semantic outcome of a step report, independent of persistence. The restart
+// variants are typed now but only produced once durable restart lands (PR E).
+export type StepTransitionDecision =
+  | {kind: 'complete-step'; stepId: string; attempt: number}
+  // The step succeeds and is the last to finish; apply re-derives the job's
+  // terminal status from the projection (it may be `failed` if a sibling was
+  // cancelled), so the status is not carried on the decision.
+  | {kind: 'complete-job'; stepId: string; attempt: number}
+  | {kind: 'fail-job'; failedStepId: string; attempt: number; cancelFromPosition: number}
+  | {
+      kind: 'restart-job-from-step';
+      failedStepId: string;
+      restartFromStepId: string;
+      attempt: number;
+      reason: string;
+    }
+  | {
+      kind: 'fail-job-restart-exhausted';
+      failedStepId: string;
+      attempt: number;
+      maxAttempts: number;
+    };
+
+// Pure: maps a step report to a transition decision. No DB, no expression engine.
+// PR C handles the gate-less cases (the current default behavior); PR D/E extend
+// it with gate evaluation and durable restart.
+export function decideStepTransition(input: DecideStepTransitionInput): StepTransitionDecision {
+  const {steps, target, reportedAttempt, result} = input;
+
+  if (result.status === 'failed') {
+    // No gate: a failed step fails the job and cancels the steps after it.
+    return {
+      kind: 'fail-job',
+      failedStepId: target.id,
+      attempt: reportedAttempt,
+      cancelFromPosition: target.position,
+    };
+  }
+
+  // Succeeded: completes the job when every other step is already terminal,
+  // otherwise just advances this step.
+  const everyOtherTerminal = steps
+    .filter((step) => step.id !== target.id)
+    .every((step) => isTerminal(step.status));
+  if (everyOtherTerminal) {
+    return {kind: 'complete-job', stepId: target.id, attempt: reportedAttempt};
+  }
+  return {kind: 'complete-step', stepId: target.id, attempt: reportedAttempt};
+}


### PR DESCRIPTION
Extracts the pure step-transition decision layer from the workflow host.

What changes:
- Adds a pure `decideStepTransition` function for step report semantics.
- Keeps database locking, idempotency checks, and persistence in the workflow host/apply layer.
- Preserves the existing ordinary success/failure behavior while creating a narrow extension point for gate and restart decisions.

Refs ENG-397

<!-- stk:begin -->
## Stack

Part 1 of 4.

Depends on: none
Next: #154

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #153 | `durable-gate/03-pure-decision` | `main` |
| 2 | #154 | `durable-gate/04-gate-eval-terminal` | `durable-gate/03-pure-decision` |
| 3 | #155 | `durable-gate/05-durable-restart` | `durable-gate/04-gate-eval-terminal` |
| 4 | #156 | `durable-gate/06-dashboard-attempts` | `durable-gate/05-durable-restart` |

<!-- stk:end -->