### PR TITLE
Execute step gates (terminal pass/fail), fail closed on restart

### DIFF
--- a/.changeset/gentle-gates-evaluate.md
+++ b/.changeset/gentle-gates-evaluate.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": minor
+---
+
+Execute step gates at runtime: evaluate `gate.success_if` (CEL) against the step's exit code to decide pass/fail — overriding the raw command status — and record the gate result on the attempt. A failing gate fails the job; a missing exit code or an evaluation error fails closed as a plain command failure; a failing gate with `on_failure.restart_from` fails closed with a structured `restart_unsupported` error until durable restart lands.

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -44,6 +44,7 @@
     "@shipfox/api-runners": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
+    "@shipfox/expression": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -522,3 +522,114 @@ describe('step attempts', () => {
     expect(await jobCompletedEvents(jobId)).toHaveLength(1);
   });
 });
+
+describe('gate evaluation', () => {
+  async function attachGate(stepId: string, gate: Record<string, unknown>): Promise<void> {
+    await db()
+      .update(stepsTable)
+      .set({config: {run: 'echo hi', gate}})
+      .where(eq(stepsTable.id, stepId));
+  }
+
+  test('a passing gate succeeds a step despite a non-zero command exit', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await attachGate(stepId, {
+      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 1'},
+    });
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'failed',
+      error: {message: 'exit 1'},
+      exitCode: 1,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+    expect((await getStepsByJobId(jobId))[0]?.status).toBe('succeeded');
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.gateResult).toMatchObject({passed: true});
+  });
+
+  test('a failing gate with restart_from fails closed with a restart_unsupported error', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await attachGate(stepId, {
+      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+      on_failure: {restart_from: 'producer'},
+    });
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'failed',
+      error: {message: 'exit 1'},
+      exitCode: 1,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]?.status).toBe('failed');
+    expect(after[0]?.error).toMatchObject({kind: 'restart_unsupported', restart_from: 'producer'});
+  });
+
+  test('a failing gate without on_failure fails the job with a gate_failed error', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await attachGate(stepId, {
+      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+    });
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'failed',
+      error: {message: 'exit 1'},
+      exitCode: 1,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    expect((await getStepsByJobId(jobId))[0]?.error).toMatchObject({kind: 'gate_failed'});
+  });
+
+  test('a signal-killed step (no exit code) is a plain failure, gate not evaluated', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await attachGate(stepId, {
+      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+      on_failure: {restart_from: 'producer'},
+    });
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'failed',
+      error: {message: 'Killed by signal SIGKILL'},
+      exitCode: null,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    // Uncheckable → plain command failure, NOT restart_unsupported.
+    expect((await getStepsByJobId(jobId))[0]?.error).toMatchObject({
+      message: 'Killed by signal SIGKILL',
+    });
+  });
+});
+
+describe('bulkUpdateStepStatuses attempt finalization', () => {
+  test('finalizes a dispatched step’s running attempt when the job is swept', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    await nextStepForJob(jobId); // opens a running attempt for step 0
+
+    await bulkUpdateStepStatuses({jobId, status: 'cancelled'});
+
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({stepId: steps[0]?.id, status: 'cancelled'});
+    expect(attempt?.finishedAt).not.toBeNull();
+  });
+});

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -21,6 +21,7 @@ import {
   deriveCompletion,
   isTerminal,
 } from './step-transition/decide-step-transition.js';
+import {evaluateGate, gateResultPayload, readStepGate} from './step-transition/evaluate-gate.js';
 
 type CompletionStatus = RuntimeCompletionStatus;
 
@@ -120,7 +121,22 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
       output: params.output ?? null,
       exitCode: params.exitCode ?? null,
     };
-    const decision = decideStepTransition({steps, target, reportedAttempt: reported, result});
-    return applyStepTransition(decision, {jobId: params.jobId, result}, tx);
+    // Evaluate the gate (if any) at the service boundary — the only place the CEL
+    // engine runs — and pass the precomputed outcome into the pure decision.
+    const gate = readStepGate(target.config);
+    const gateOutcome = evaluateGate(gate, result);
+    const decision = decideStepTransition({
+      steps,
+      target,
+      reportedAttempt: reported,
+      result,
+      gateOutcome,
+      ...(gate?.onFailure ? {gateOnFailure: gate.onFailure} : {}),
+    });
+    return applyStepTransition(
+      decision,
+      {jobId: params.jobId, result, gateResult: gateResultPayload(gateOutcome, result.exitCode)},
+      tx,
+    );
   });
 }

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
@@ -20,6 +20,8 @@ export type StepProgressionOutcome =
 export interface ApplyStepTransitionContext {
   jobId: string;
   result: StepResult;
+  // Gate evaluation audit payload to record on the attempt, when a gate ran.
+  gateResult?: Record<string, unknown> | null;
 }
 
 // Durable side of the decision: writes the attempt + projection for a transition,
@@ -35,6 +37,8 @@ export async function applyStepTransition(
   switch (decision.kind) {
     case 'complete-step':
     case 'complete-job': {
+      // A passing gate makes a step succeed even if the raw command status was
+      // 'failed', so the projection error is cleared regardless of the report.
       await finishStepAttempt(
         {
           stepId: decision.stepId,
@@ -42,6 +46,7 @@ export async function applyStepTransition(
           status: 'succeeded',
           output: ctx.result.output ?? null,
           exitCode: ctx.result.exitCode ?? null,
+          gateResult: ctx.gateResult ?? null,
         },
         tx,
       );
@@ -57,9 +62,10 @@ export async function applyStepTransition(
           stepId: decision.failedStepId,
           attempt: decision.attempt,
           status: 'failed',
-          error: ctx.result.error ?? null,
           output: ctx.result.output ?? null,
+          error: decision.failureError,
           exitCode: ctx.result.exitCode ?? null,
+          gateResult: ctx.gateResult ?? null,
         },
         tx,
       );
@@ -68,7 +74,7 @@ export async function applyStepTransition(
           jobId: ctx.jobId,
           stepId: decision.failedStepId,
           status: 'failed',
-          error: ctx.result.error ?? null,
+          error: decision.failureError,
         },
         tx,
       );

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -80,7 +80,74 @@ describe('decideStepTransition', () => {
       failedStepId: 's1',
       attempt: 1,
       cancelFromPosition: 1,
+      failureError: {message: 'boom'},
     });
+  });
+
+  test('a passing gate succeeds the step even when the raw status is failed', () => {
+    const target = step({id: 's0', position: 0, status: 'running'});
+    const steps = [target, step({id: 's1', position: 1, status: 'pending'})];
+
+    const decision = decideStepTransition({
+      steps,
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', exitCode: 1, error: {message: 'exit 1'}},
+      gateOutcome: {kind: 'passed', source: 'exit_code == 1'},
+    });
+
+    expect(decision).toEqual({kind: 'complete-step', stepId: 's0', attempt: 1});
+  });
+
+  test('a failing gate without on_failure fails the job with a gate_failed error', () => {
+    const target = step({id: 's0', position: 0, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', exitCode: 1},
+      gateOutcome: {kind: 'failed', source: 'exit_code == 0'},
+    });
+
+    expect(decision).toMatchObject({
+      kind: 'fail-job',
+      failedStepId: 's0',
+      failureError: {kind: 'gate_failed', source: 'exit_code == 0'},
+    });
+  });
+
+  test('a failing gate with restart_from fails closed (restart_unsupported) until PR E', () => {
+    const target = step({id: 's1', position: 1, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [step({id: 's0', position: 0, status: 'succeeded'}), target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', exitCode: 1},
+      gateOutcome: {kind: 'failed', source: 'exit_code == 0'},
+      gateOnFailure: {restartFrom: 's0'},
+    });
+
+    expect(decision).toMatchObject({
+      kind: 'fail-job',
+      failureError: {kind: 'restart_unsupported', restart_from: 's0'},
+    });
+  });
+
+  test('an uncheckable gate (no exit code) is a plain command failure, not a restart', () => {
+    const target = step({id: 's0', position: 0, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', exitCode: null, error: {message: 'killed'}},
+      gateOutcome: {kind: 'uncheckable', reason: 'no exit code'},
+      gateOnFailure: {restartFrom: 's0'},
+    });
+
+    expect(decision).toMatchObject({kind: 'fail-job', failureError: {message: 'killed'}});
   });
 
   test('echoes the reported attempt in the decision', () => {
@@ -95,6 +162,38 @@ describe('decideStepTransition', () => {
     });
 
     expect(decision).toMatchObject({kind: 'complete-step', attempt: 2});
+  });
+
+  test('a failing gate overrides a raw succeeded status (downward override)', () => {
+    const target = step({id: 's0', position: 0, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'succeeded', exitCode: 0},
+      gateOutcome: {kind: 'failed', source: 'exit_code == 1'},
+    });
+
+    expect(decision).toMatchObject({kind: 'fail-job', failureError: {kind: 'gate_failed'}});
+  });
+
+  test('a raw failure with on_failure but no success_if fails closed (restart_unsupported)', () => {
+    const target = step({id: 's1', position: 1, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [step({id: 's0', position: 0, status: 'succeeded'}), target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', exitCode: 1},
+      // No gateOutcome (no success_if) but a restart policy is configured.
+      gateOnFailure: {restartFrom: 's0'},
+    });
+
+    expect(decision).toMatchObject({
+      kind: 'fail-job',
+      failureError: {kind: 'restart_unsupported', restart_from: 's0'},
+    });
   });
 });
 

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -21,6 +21,16 @@ export interface StepResult {
   output?: Record<string, unknown> | null;
 }
 
+// Precomputed gate evaluation (the CEL engine runs in evaluate-gate.ts, never
+// here). `passed`/`failed` are clean evaluations; `uncheckable` means the gate
+// could not be evaluated (no exit code, or an evaluation error) and is treated
+// as a plain command failure — never a restart.
+export type GateOutcome =
+  | {kind: 'no-gate'}
+  | {kind: 'passed'; source: string}
+  | {kind: 'failed'; source: string}
+  | {kind: 'uncheckable'; reason: string};
+
 export interface DecideStepTransitionInput {
   // Full job projection, position-ordered (as returned by getStepsByJobIdForUpdate).
   steps: Step[];
@@ -28,8 +38,12 @@ export interface DecideStepTransitionInput {
   target: Step;
   reportedAttempt: number;
   result: StepResult;
-  // PR D injects the gate outcome here; PR E adds the restart attempt cap. Absent
-  // ⇒ no gate, so `result.status` is authoritative.
+  // Precomputed gate evaluation. Absent ⇒ no gate, so `result.status` is authoritative.
+  gateOutcome?: GateOutcome;
+  // The gate's on_failure policy, if any. Drives the restart branch (fail-closed
+  // until PR E makes durable restart executable).
+  gateOnFailure?: {restartFrom: string; output?: string};
+  // PR E adds the restart attempt cap here.
 }
 
 // The semantic outcome of a step report, independent of persistence. The restart
@@ -40,7 +54,15 @@ export type StepTransitionDecision =
   // terminal status from the projection (it may be `failed` if a sibling was
   // cancelled), so the status is not carried on the decision.
   | {kind: 'complete-job'; stepId: string; attempt: number}
-  | {kind: 'fail-job'; failedStepId: string; attempt: number; cancelFromPosition: number}
+  | {
+      kind: 'fail-job';
+      failedStepId: string;
+      attempt: number;
+      cancelFromPosition: number;
+      // The error to record on the step/attempt (the reported error, or a
+      // structured gate error).
+      failureError: Record<string, unknown> | null;
+    }
   | {
       kind: 'restart-job-from-step';
       failedStepId: string;
@@ -55,29 +77,83 @@ export type StepTransitionDecision =
       maxAttempts: number;
     };
 
-// Pure: maps a step report to a transition decision. No DB, no expression engine.
-// PR C handles the gate-less cases (the current default behavior); PR D/E extend
-// it with gate evaluation and durable restart.
-export function decideStepTransition(input: DecideStepTransitionInput): StepTransitionDecision {
-  const {steps, target, reportedAttempt, result} = input;
-
-  if (result.status === 'failed') {
-    // No gate: a failed step fails the job and cancels the steps after it.
-    return {
-      kind: 'fail-job',
-      failedStepId: target.id,
-      attempt: reportedAttempt,
-      cancelFromPosition: target.position,
-    };
-  }
-
-  // Succeeded: completes the job when every other step is already terminal,
-  // otherwise just advances this step.
+function succeed(target: Step, attempt: number, steps: Step[]): StepTransitionDecision {
+  // Completes the job when every other step is already terminal, otherwise just
+  // advances this step.
   const everyOtherTerminal = steps
     .filter((step) => step.id !== target.id)
     .every((step) => isTerminal(step.status));
-  if (everyOtherTerminal) {
-    return {kind: 'complete-job', stepId: target.id, attempt: reportedAttempt};
+  return everyOtherTerminal
+    ? {kind: 'complete-job', stepId: target.id, attempt}
+    : {kind: 'complete-step', stepId: target.id, attempt};
+}
+
+function fail(
+  target: Step,
+  attempt: number,
+  failureError: Record<string, unknown> | null,
+): StepTransitionDecision {
+  return {
+    kind: 'fail-job',
+    failedStepId: target.id,
+    attempt,
+    cancelFromPosition: target.position,
+    failureError,
+  };
+}
+
+// A failure that carried restart intent we cannot yet honor. Fail loudly so it is
+// never silently degraded to an ordinary failure (PR E turns this into a rewind).
+function restartUnsupportedError(restartFrom: string): Record<string, unknown> {
+  return {
+    kind: 'restart_unsupported',
+    message: `gate requested restart_from "${restartFrom}" but durable restart is not enabled`,
+    restart_from: restartFrom,
+  };
+}
+
+// Pure: maps a step report (and its precomputed gate outcome) to a transition
+// decision. No DB, no expression engine. PR C handled the gate-less cases; this
+// adds terminal gate pass/fail and fails closed for an unsupported restart. PR E
+// turns the fail-closed restart branch into an actual rewind.
+export function decideStepTransition(input: DecideStepTransitionInput): StepTransitionDecision {
+  const {steps, target, reportedAttempt, result, gateOnFailure} = input;
+  const gate = input.gateOutcome ?? {kind: 'no-gate'};
+
+  if (gate.kind === 'no-gate') {
+    if (result.status === 'succeeded') return succeed(target, reportedAttempt, steps);
+    // `on_failure` may be set without a `success_if` predicate (the document
+    // schema allows it): a raw command failure then still carries restart intent,
+    // so fail closed loudly rather than as a plain failure.
+    if (gateOnFailure?.restartFrom) {
+      return fail(target, reportedAttempt, restartUnsupportedError(gateOnFailure.restartFrom));
+    }
+    return fail(target, reportedAttempt, result.error ?? null);
   }
-  return {kind: 'complete-step', stepId: target.id, attempt: reportedAttempt};
+
+  if (gate.kind === 'passed') {
+    // The gate is authoritative over the raw command status.
+    return succeed(target, reportedAttempt, steps);
+  }
+
+  if (gate.kind === 'uncheckable') {
+    // No exit code (signal-kill) or an evaluation error: a plain command failure.
+    // Fail closed — never a restart.
+    return fail(
+      target,
+      reportedAttempt,
+      result.error ?? {kind: 'gate_uncheckable', message: gate.reason},
+    );
+  }
+
+  // gate.kind === 'failed'
+  if (gateOnFailure?.restartFrom) {
+    // Durable restart is not executable until PR E; fail loudly.
+    return fail(target, reportedAttempt, restartUnsupportedError(gateOnFailure.restartFrom));
+  }
+  return fail(target, reportedAttempt, {
+    kind: 'gate_failed',
+    message: 'gate condition not met',
+    source: gate.source,
+  });
 }

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -1,0 +1,99 @@
+import {evaluateGate, gateResultPayload, readStepGate} from './evaluate-gate.js';
+
+function gateConfig(source: string, restartFrom?: string): Record<string, unknown> {
+  return {
+    run: 'echo hi',
+    gate: {
+      success_if: {language: 'cel', check: 'syntax', source},
+      ...(restartFrom ? {on_failure: {restart_from: restartFrom}} : {}),
+    },
+  };
+}
+
+describe('readStepGate', () => {
+  test('returns undefined when the config has no gate', () => {
+    expect(readStepGate({run: 'echo hi'})).toBeUndefined();
+  });
+
+  test('parses success_if and on_failure', () => {
+    const gate = readStepGate(gateConfig('exit_code == 0', 'producer'));
+    expect(gate?.successIf?.source).toBe('exit_code == 0');
+    expect(gate?.onFailure).toEqual({restartFrom: 'producer'});
+  });
+});
+
+describe('evaluateGate', () => {
+  test('no gate → no-gate', () => {
+    expect(
+      evaluateGate(readStepGate({run: 'echo hi'}), {status: 'succeeded', exitCode: 0}),
+    ).toEqual({
+      kind: 'no-gate',
+    });
+  });
+
+  test('exit_code == 0 passes for exit 0', () => {
+    const gate = readStepGate(gateConfig('exit_code == 0'));
+    expect(evaluateGate(gate, {status: 'succeeded', exitCode: 0})).toEqual({
+      kind: 'passed',
+      source: 'exit_code == 0',
+    });
+  });
+
+  test('exit_code == 0 fails for a non-zero exit', () => {
+    const gate = readStepGate(gateConfig('exit_code == 0'));
+    expect(evaluateGate(gate, {status: 'failed', exitCode: 1})).toEqual({
+      kind: 'failed',
+      source: 'exit_code == 0',
+    });
+  });
+
+  test('a passing gate can succeed a non-zero exit (success_if: exit_code == 1)', () => {
+    const gate = readStepGate(gateConfig('exit_code == 1'));
+    expect(evaluateGate(gate, {status: 'failed', exitCode: 1})).toMatchObject({kind: 'passed'});
+  });
+
+  test('a missing exit code is uncheckable (never evaluated)', () => {
+    const gate = readStepGate(gateConfig('exit_code == 0'));
+    expect(evaluateGate(gate, {status: 'failed', exitCode: null})).toMatchObject({
+      kind: 'uncheckable',
+    });
+  });
+
+  test('an evaluation error is uncheckable, not a gate failure', () => {
+    const gate = readStepGate(gateConfig('missing_var == 0'));
+    expect(evaluateGate(gate, {status: 'succeeded', exitCode: 0})).toMatchObject({
+      kind: 'uncheckable',
+    });
+  });
+});
+
+describe('gateResultPayload', () => {
+  test('no-gate → null', () => {
+    expect(gateResultPayload({kind: 'no-gate'}, 0)).toBeNull();
+  });
+
+  test('passed records the source and evaluated exit code', () => {
+    expect(gateResultPayload({kind: 'passed', source: 'exit_code == 0'}, 0)).toEqual({
+      passed: true,
+      source: 'exit_code == 0',
+      exit_code: 0,
+    });
+  });
+
+  test('failed records the source and evaluated exit code', () => {
+    expect(gateResultPayload({kind: 'failed', source: 'exit_code == 0'}, 1)).toEqual({
+      passed: false,
+      source: 'exit_code == 0',
+      exit_code: 1,
+    });
+  });
+
+  test('uncheckable records the reason and a null exit code', () => {
+    expect(gateResultPayload({kind: 'uncheckable', reason: 'no exit code'}, null)).toEqual({
+      passed: false,
+      uncheckable: true,
+      reason: 'no exit code',
+      exit_code: null,
+    });
+  });
+});

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -1,0 +1,92 @@
+import {
+  evaluateWorkflowPredicate,
+  type WorkflowExpression,
+  WorkflowExpressionEvaluationError,
+} from '@shipfox/expression';
+import type {GateOutcome, StepResult} from './decide-step-transition.js';
+
+// The gate as parsed from a step's materialized `config.gate` (snake_case JSON).
+export interface StepGate {
+  successIf?: WorkflowExpression;
+  onFailure?: {restartFrom: string; output?: string};
+}
+
+// Read the gate persisted on a step's config by the materializer. Returns
+// undefined when the step has no gate of interest.
+export function readStepGate(config: Record<string, unknown>): StepGate | undefined {
+  const gate = config.gate;
+  if (!gate || typeof gate !== 'object') return undefined;
+  const raw = gate as Record<string, unknown>;
+
+  const successIfRaw = raw.success_if as Record<string, unknown> | undefined;
+  const successIf =
+    successIfRaw && typeof successIfRaw.source === 'string'
+      ? // The model validated this expression before materialization; the stored
+        // JSON is structurally a WorkflowExpression.
+        (successIfRaw as unknown as WorkflowExpression)
+      : undefined;
+
+  const onFailureRaw = raw.on_failure as Record<string, unknown> | undefined;
+  const onFailure =
+    onFailureRaw && typeof onFailureRaw.restart_from === 'string'
+      ? {
+          restartFrom: onFailureRaw.restart_from,
+          ...(typeof onFailureRaw.output === 'string' ? {output: onFailureRaw.output} : {}),
+        }
+      : undefined;
+
+  if (!successIf && !onFailure) return undefined;
+  return {
+    ...(successIf ? {successIf} : {}),
+    ...(onFailure ? {onFailure} : {}),
+  };
+}
+
+// Evaluate a step's gate against the run-step result. This is the ONLY place that
+// runs the CEL engine. It fails closed: a missing exit code or an evaluation
+// error is `uncheckable` (a plain command failure), never a gate-failure that
+// could trigger a restart.
+//
+// NOTE: callers run this inside the FOR UPDATE transaction, so the eval holds the
+// job's step-row locks. The context is a single scalar (`exit_code`) today, so
+// this is cheap — but do not widen the context (or add CEL call sites) inside the
+// lock without an eval budget. `language` is assumed CEL (the only language the
+// materializer writes); the evaluator reads only `.source`.
+export function evaluateGate(gate: StepGate | undefined, result: StepResult): GateOutcome {
+  if (!gate?.successIf) return {kind: 'no-gate'};
+  const source = gate.successIf.source;
+
+  if (result.exitCode === null || result.exitCode === undefined) {
+    return {kind: 'uncheckable', reason: 'step produced no exit code'};
+  }
+
+  try {
+    const passed = evaluateWorkflowPredicate(gate.successIf, {exit_code: result.exitCode});
+    return passed ? {kind: 'passed', source} : {kind: 'failed', source};
+  } catch (error) {
+    if (error instanceof WorkflowExpressionEvaluationError) {
+      return {kind: 'uncheckable', reason: 'gate expression evaluation failed'};
+    }
+    throw error;
+  }
+}
+
+// Build the audit payload recorded on the step attempt for a gate evaluation.
+// Includes the evaluated `exit_code` so the gate decision is reconstructable from
+// the attempt row alone (PR E / audit), independent of the column shape.
+export function gateResultPayload(
+  outcome: GateOutcome,
+  exitCode: number | null | undefined,
+): Record<string, unknown> | null {
+  const exit_code = exitCode ?? null;
+  switch (outcome.kind) {
+    case 'no-gate':
+      return null;
+    case 'passed':
+      return {passed: true, source: outcome.source, exit_code};
+    case 'failed':
+      return {passed: false, source: outcome.source, exit_code};
+    case 'uncheckable':
+      return {passed: false, uncheckable: true, reason: outcome.reason, exit_code};
+  }
+}

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -480,6 +480,20 @@ export async function bulkUpdateStepStatuses(
         sql`${steps.status} NOT IN ('succeeded','failed','cancelled')`,
       ),
     );
+
+  // Finalize any open attempt rows for the steps just terminalized, so a
+  // dispatched-then-timed-out/cancelled step never leaves a `running` audit row
+  // stranded (it would otherwise read as phantom in-flight work to gate/restart
+  // logic). The just-failed step on the normal report path is already terminal,
+  // so this only catches the bulk timeout/cancel sweeps.
+  // Only ever called with a terminal sweep status (cancelled on the failed-sibling
+  // path, failed on timeout).
+  if (params.status === 'failed' || params.status === 'cancelled') {
+    await executor
+      .update(stepAttempts)
+      .set({status: params.status, finishedAt: new Date()})
+      .where(and(eq(stepAttempts.jobId, params.jobId), eq(stepAttempts.status, 'running')));
+  }
 }
 
 export interface ReportedStepResult {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1477,6 +1477,9 @@ importers:
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../workflows-dto
+      '@shipfox/expression':
+        specifier: workspace:*
+        version: link:../../shared/expression
       '@shipfox/node-drizzle':
         specifier: workspace:*
         version: link:../../shared/node/drizzle


### PR DESCRIPTION
Executes terminal step gates without durable restart yet.

What changes:
- Evaluates `gate.success_if` at the workflow-host boundary.
- Lets a passing gate mark a step succeeded even when the raw command failed.
- Lets a failed gate fail the job when no restart is executable yet.
- Fails closed for configured restart intent until the durable restart PR adds the rewind path.
- Persists gate evaluation details on the attempt history row.

Refs ENG-397

<!-- stk:begin -->
## Stack

Part 1 of 3.

Depends on: none
Next: #155

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #154 | `durable-gate/04-gate-eval-terminal` | `main` |
| 2 | #155 | `durable-gate/05-durable-restart` | `durable-gate/04-gate-eval-terminal` |
| 3 | #156 | `durable-gate/06-dashboard-attempts` | `durable-gate/05-durable-restart` |

<!-- stk:end -->