### PR TITLE
Expose step attempt history in the run-detail API

### DIFF
--- a/.changeset/calm-otters-observe.md
+++ b/.changeset/calm-otters-observe.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+---
+
+Expose step attempts in the read API: the run-detail endpoint now returns `current_attempt` on each step plus its per-attempt history (`attempts[]`, with status, exit code, gate result and restart reason), so a restarted step's attempts are visible.

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -27,8 +27,10 @@ export {
   runListResponseSchema,
   runResponseSchema,
   runStatusSchema,
+  type StepAttemptDto,
   type StepDto,
   type StepErrorDtoShape,
+  stepAttemptDtoSchema,
   stepDtoSchema,
   stepErrorDtoSchema,
 } from '#schemas/index.js';

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -31,8 +31,10 @@ export {
   runStatusSchema,
 } from './run.js';
 export {
+  type StepAttemptDto,
   type StepDto,
   type StepErrorDtoShape,
+  stepAttemptDtoSchema,
   stepDtoSchema,
   stepErrorDtoSchema,
 } from './step.js';

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -19,8 +19,33 @@ export const stepDtoSchema = z.object({
   config: z.record(z.string(), z.unknown()),
   error: stepErrorDtoSchema,
   position: z.number(),
+  // Execution-attempt identity of the current projection (>1 after a restart).
+  current_attempt: z.number().int(),
   created_at: z.string(),
   updated_at: z.string(),
 });
 
 export type StepDto = z.infer<typeof stepDtoSchema>;
+
+// One execution attempt of a step (the durable history behind the current
+// projection). Surfaced in run details so a restarted step's attempts are visible.
+export const stepAttemptDtoSchema = z.object({
+  id: z.string().uuid(),
+  step_id: z.string().uuid(),
+  job_id: z.string().uuid(),
+  attempt: z.number().int().positive(),
+  status: z.string(),
+  exit_code: z.number().int().nullable(),
+  // `output`, `error`, and `gate_result` are opaque audit blobs: the raw jsonb
+  // persisted for the attempt, NOT snake_case-normalized (their nested keys may
+  // be camelCase, e.g. `error.exitCode`). Consume the top-level snake_case
+  // `exit_code` for the numeric code; treat these as display/debug payloads.
+  output: z.record(z.string(), z.unknown()).nullable(),
+  error: z.record(z.string(), z.unknown()).nullable(),
+  gate_result: z.record(z.string(), z.unknown()).nullable(),
+  restart_reason: z.string().nullable(),
+  started_at: z.string(),
+  finished_at: z.string().nullable(),
+});
+
+export type StepAttemptDto = z.infer<typeof stepAttemptDtoSchema>;

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -23,6 +23,7 @@ export {
   failJobAsTimedOut,
   getJobsByRunId,
   getStepAttempts,
+  getStepAttemptsByJobIds,
   getStepsByJobId,
   getStepsByJobIds,
   getWorkflowRunAggregates,

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -807,6 +807,16 @@ export async function getStepAttempts(jobId: string): Promise<StepAttempt[]> {
   return rows.map(toStepAttempt);
 }
 
+export async function getStepAttemptsByJobIds(jobIds: string[]): Promise<StepAttempt[]> {
+  if (jobIds.length === 0) return [];
+  const rows = await db()
+    .select()
+    .from(stepAttempts)
+    .where(inArray(stepAttempts.jobId, jobIds))
+    .orderBy(asc(stepAttempts.stepId), asc(stepAttempts.attempt));
+  return rows.map(toStepAttempt);
+}
+
 export interface ApplyStepResultParams {
   jobId: string;
   stepId: string;

--- a/libs/api/workflows/src/presentation/dto/index.ts
+++ b/libs/api/workflows/src/presentation/dto/index.ts
@@ -1,3 +1,3 @@
 export {toJobDto} from './job.js';
-export {toStepDto} from './step.js';
+export {toStepAttemptDto, toStepDto} from './step.js';
 export {toRunDto} from './workflow-run.js';

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -1,5 +1,5 @@
-import type {StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
-import type {Step} from '#core/entities/step.js';
+import type {StepAttemptDto, StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
+import type {Step, StepAttempt} from '#core/entities/step.js';
 
 // Domain `error` is loosely typed (jsonb), so narrow it to the fixed runner
 // contract rather than trusting whatever shape the row happens to hold.
@@ -40,7 +40,25 @@ export function toStepDto(step: Step): StepDto {
     config: step.config,
     error: toStepErrorDto(step.error),
     position: step.position,
+    current_attempt: step.currentAttempt,
     created_at: step.createdAt.toISOString(),
     updated_at: step.updatedAt.toISOString(),
+  };
+}
+
+export function toStepAttemptDto(attempt: StepAttempt): StepAttemptDto {
+  return {
+    id: attempt.id,
+    step_id: attempt.stepId,
+    job_id: attempt.jobId,
+    attempt: attempt.attempt,
+    status: attempt.status,
+    exit_code: attempt.exitCode,
+    output: attempt.output,
+    error: attempt.error,
+    gate_result: attempt.gateResult,
+    restart_reason: attempt.restartReason,
+    started_at: attempt.startedAt.toISOString(),
+    finished_at: attempt.finishedAt ? attempt.finishedAt.toISOString() : null,
   };
 }

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -1,9 +1,13 @@
 import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
 import {requireProjectAccess} from '@shipfox/api-projects';
 import {ClientError} from '@shipfox/node-fastify';
+import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
+import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
+import {db} from '#db/db.js';
+import {steps as stepsTable} from '#db/schema/steps.js';
 import {
   applyStepResults,
   createWorkflowRun,
@@ -221,5 +225,117 @@ describe('GET /api/workflows/runs/:id', () => {
     });
 
     expect(res.statusCode).toBe(500);
+  });
+
+  test('exposes step current_attempt and attempt history', async () => {
+    const projectId = crypto.randomUUID();
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId: crypto.randomUUID(),
+      model: workflowModel({
+        name: 'Test',
+        jobs: {build: {steps: [{run: 'a'}, {run: 'b'}]}},
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const jobId = (await getJobsByRunId(run.id))[0]?.id as string;
+    const steps = await getStepsByJobId(jobId);
+    await nextStepForJob(jobId);
+    await recordStepResult({
+      jobId,
+      stepId: steps[0]?.id as string,
+      status: 'succeeded',
+      exitCode: 0,
+    });
+
+    const res = await app.inject({method: 'GET', url: `/api/workflows/runs/${run.id}`});
+
+    expect(res.statusCode).toBe(200);
+    const [step0, step1] = res.json().jobs[0].steps;
+    expect(step0.current_attempt).toBe(1);
+    expect(step0.attempts).toHaveLength(1);
+    expect(step0.attempts[0]).toMatchObject({attempt: 1, status: 'succeeded', exit_code: 0});
+    // A never-dispatched step has no attempt history yet.
+    expect(step1.current_attempt).toBe(1);
+    expect(step1.attempts).toEqual([]);
+  });
+
+  test('exposes multiple ordered attempts for a restarted step', async () => {
+    const projectId = crypto.randomUUID();
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId: crypto.randomUUID(),
+      model: workflowModel({
+        name: 'Test',
+        jobs: {build: {steps: [{run: 'produce'}, {run: 'review'}]}},
+      }),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+    const jobId = (await getJobsByRunId(run.id))[0]?.id as string;
+    const steps = await getStepsByJobId(jobId);
+    const producerId = steps[0]?.id as string;
+    const reviewerId = steps[1]?.id as string;
+    // reviewer gate: succeed only on exit 0; otherwise restart from producer.
+    await db().update(stepsTable).set({name: 'producer'}).where(eq(stepsTable.id, producerId));
+    await db()
+      .update(stepsTable)
+      .set({
+        config: {
+          run: 'review',
+          gate: {
+            success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+            on_failure: {restart_from: 'producer'},
+          },
+        },
+      })
+      .where(eq(stepsTable.id, reviewerId));
+    const runStep = async (stepId: string, exitCode: number) => {
+      await nextStepForJob(jobId);
+      await recordStepResult({
+        jobId,
+        stepId,
+        status: exitCode === 0 ? 'succeeded' : 'failed',
+        ...(exitCode === 0 ? {} : {error: {message: `exit ${exitCode}`}}),
+        exitCode,
+      });
+    };
+    await runStep(producerId, 0); // producer attempt 1 succeeds
+    await runStep(reviewerId, 1); // reviewer attempt 1 gate-fails → restart, both bumped to 2
+    await runStep(producerId, 0); // producer attempt 2 succeeds
+    await runStep(reviewerId, 0); // reviewer attempt 2 gate-passes → job done
+
+    const res = await app.inject({method: 'GET', url: `/api/workflows/runs/${run.id}`});
+
+    expect(res.statusCode).toBe(200);
+    const [producer, reviewer] = res.json().jobs[0].steps;
+    expect(producer.current_attempt).toBe(2);
+    expect(producer.attempts.map((a: {attempt: number}) => a.attempt)).toEqual([1, 2]);
+    expect(reviewer.current_attempt).toBe(2);
+    const reviewerAttempts = reviewer.attempts as Array<{
+      attempt: number;
+      status: string;
+      exit_code: number | null;
+      gate_result: unknown;
+      restart_reason: string | null;
+    }>;
+    expect(reviewerAttempts.map((a) => a.attempt)).toEqual([1, 2]); // ordered by attempt
+    expect(reviewerAttempts[0]?.status).toBe('failed');
+    expect(reviewerAttempts[0]?.exit_code).toBe(1);
+    expect(reviewerAttempts[0]?.gate_result).toMatchObject({passed: false});
+    expect(reviewerAttempts[0]?.restart_reason).toBeTruthy();
+    expect(reviewerAttempts[1]?.status).toBe('succeeded');
+    expect(reviewerAttempts[1]?.exit_code).toBe(0);
   });
 });

--- a/libs/api/workflows/src/presentation/routes/get-run.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.ts
@@ -1,14 +1,27 @@
 import {requireProjectAccess} from '@shipfox/api-projects';
-import {jobDtoSchema, runResponseSchema, stepDtoSchema} from '@shipfox/api-workflows-dto';
+import {
+  jobDtoSchema,
+  runResponseSchema,
+  stepAttemptDtoSchema,
+  stepDtoSchema,
+} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {getJobsByRunId, getStepsByJobIds, getWorkflowRunById} from '#db/index.js';
-import {toJobDto, toRunDto, toStepDto} from '#presentation/dto/index.js';
+import {
+  getJobsByRunId,
+  getStepAttemptsByJobIds,
+  getStepsByJobIds,
+  getWorkflowRunById,
+} from '#db/index.js';
+import {toJobDto, toRunDto, toStepAttemptDto, toStepDto} from '#presentation/dto/index.js';
 
 const runDetailResponseSchema = runResponseSchema.extend({
   jobs: z.array(
     jobDtoSchema.extend({
-      steps: z.array(stepDtoSchema),
+      // Each step carries its attempt history (one entry per dispatched attempt;
+      // a restarted step has more than one). `current_attempt` on the step points
+      // at the latest.
+      steps: z.array(stepDtoSchema.extend({attempts: z.array(stepAttemptDtoSchema)})),
     }),
   ),
 });
@@ -41,11 +54,20 @@ export const getRunRoute = defineRoute({
     });
 
     const runJobs = await getJobsByRunId(run.id);
-    const allSteps = await getStepsByJobIds(runJobs.map((j) => j.id));
+    const jobIds = runJobs.map((j) => j.id);
+    const [allSteps, allAttempts] = await Promise.all([
+      getStepsByJobIds(jobIds),
+      getStepAttemptsByJobIds(jobIds),
+    ]);
 
     const jobDtos = runJobs.map((job) => ({
       ...toJobDto(job),
-      steps: allSteps.filter((s) => s.jobId === job.id).map(toStepDto),
+      steps: allSteps
+        .filter((s) => s.jobId === job.id)
+        .map((step) => ({
+          ...toStepDto(step),
+          attempts: allAttempts.filter((a) => a.stepId === step.id).map(toStepAttemptDto),
+        })),
     }));
 
     return {


### PR DESCRIPTION
Exposes step attempt history in the run-detail API.

What changes:
- `GET /api/workflows/runs/:id` includes each step's ordered `attempts` array.
- Attempt DTOs expose positive `attempt` numbers and top-level `exit_code` so consumers do not need to inspect nested error payloads.
- The current step projection still exposes `current_attempt` separately from attempt history.

Refs ENG-397

<!-- stk:begin -->
## Stack

Part 1 of 1.

Depends on: none
Next: none

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #156 | `durable-gate/06-dashboard-attempts` | `main` |

<!-- stk:end -->