### PR TITLE
[api/auth] Document the lease token security perimeter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,33 @@ planning-doc decisions (`/plan-eng-review A1`) in module or function headers.
 Speculation about future work ("today X, tomorrow Y") and tracked tasks belong in
 `TODOS.md`, the issue tracker, or the design doc, not in code that outlives them.
 
+## Auth & token security
+
+The auth module issues two stateless bearer tokens — a **user session token** and
+a **job lease token** — each signed with its own dedicated secret. The full
+security model (trust boundaries, scope, threat model, and rotation) lives in
+`libs/api/auth/README.md#security-model`; read it before touching anything that
+mints, verifies, or carries either token.
+
+The job lease token is a single-job **capability**, not an identity. When working
+near it, keep its authority narrow:
+
+- **Keep the scope to one job.** Do not add claims that grant access beyond the
+  single job the lease names. It is not a runner identity, not workspace-wide, and
+  not a replacement for the long-lived runner credential.
+- **Keep a single issuer; everyone else verifies only.** Scheduling mints leases;
+  every other side does an in-process signature check with no callback. Treat the
+  runner and the agent workload it hosts as untrusted — they only present a token.
+- **Keep the lifetime bounded** and never trade the short TTL for convenience.
+- **Server state is the final gate.** A valid token must never be sufficient to
+  advance work on its own — terminal job/step state always wins, and cancellation
+  rides on the heartbeat response.
+- **Never log a raw token.** There is no automatic redaction; tokens must not reach
+  logs, traces, or error payloads. Secrets come from configuration, never code.
+
+If the no-revocation window proves too wide, bind the lease to live runner or job
+state — do not broaden what the token itself authorizes.
+
 ## Error handling
 
 Error handling is a cross-layer concern, not an HTTP detail. The guiding

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,8 +256,9 @@ near it, keep its authority narrow:
   runner and the agent workload it hosts as untrusted — they only present a token.
 - **Keep the lifetime bounded** and never trade the short TTL for convenience.
 - **Server state is the final gate.** A valid token must never be sufficient to
-  advance work on its own — terminal job/step state always wins, and cancellation
-  rides on the heartbeat response.
+  advance work on its own — on the lease path, terminal step/progression state
+  always wins (job finalization is enforced outside it), and cancellation rides on
+  the heartbeat response.
 - **Never log a raw token.** There is no automatic redaction; tokens must not reach
   logs, traces, or error payloads. Secrets come from configuration, never code.
 

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -55,62 +55,88 @@ Required environment:
 | `SMTP_USER` | none | Optional SMTP user. |
 | `SMTP_PASSWORD` | none | Optional SMTP password. |
 
-## Auth methods
+## Security model
 
-The module exposes two Fastify auth methods. Both read an HS256 token from the
-`Authorization: Bearer <token>` header and verify it statelessly — signature and
-expiry are checked, but the claims are trusted without a database read. They
-differ in who they authenticate and what they grant access to, which is what
-makes the stateless tradeoff acceptable in each case.
+The module issues two kinds of bearer token, both presented as
+`Authorization: Bearer <token>`. Both are **stateless**: each is signed with
+HMAC-SHA256 and verified by checking its signature and expiry alone, with no
+database read on the request path. They differ in who they authenticate and what
+they grant, and the stateless tradeoff is accepted for a different reason in each
+case. Each is signed with its own dedicated secret, so neither token type can be
+used in place of the other.
 
-### User JWT (`createJwtAuthMethod`)
+### User session token
 
-- **Design:** a stateless session token. Signed with `AUTH_JWT_SECRET`, it carries
-  the user identity and membership list in its claims so protected routes can
-  authorize without a per-request user/membership lookup.
+- **Design:** a stateless session token. It carries the user's identity and
+  current membership list in its claims so protected routes can authorize without
+  a per-request user or membership lookup.
 - **Audience:** signed-in users on first-party clients (web app, CLI).
-- **Grants access to:** the user's own account routes (`/me`, `/change-password`)
-  and, downstream, any route that authorizes against the membership claims. Scope
-  is "this user, with these memberships" — not a single resource.
+- **Grants:** the user's own account routes and, downstream, any route that
+  authorizes against the membership claims. Its scope is "this user, with these
+  memberships" — never a single resource.
 - **Lifecycle:**
   - *Emit* — issued on login, signup verification, and password reset.
-  - *Exchange* — sent as a bearer token on each request; the longer-lived refresh
-    cookie mints a fresh access token via `/refresh`.
+  - *Exchange* — sent on each request; a longer-lived refresh session mints a
+    fresh token when it expires.
   - *Store* — held in client memory only, never persisted to disk or local
-    storage; refresh tokens are stored server-side as hashes.
-  - *Discard* — expires on its own (`AUTH_JWT_EXPIRES_IN`, 15m); the refresh
-    session is revoked by `/logout` and by password change.
+    storage. Refresh sessions are stored server-side as hashes, never in raw form.
+  - *Discard* — expires on its own (minutes, not hours); the refresh session is
+    revoked on logout and on password change.
 - **Tradeoff — stale memberships:** because memberships ride in the claims, a
-  membership change only takes effect on the next refresh (≤15m). Accepted because
-  the access token is short-lived, so the staleness window is bounded and a
-  per-request membership read is avoided.
+  membership change only takes effect on the next refresh. Accepted because the
+  token is short-lived, so the staleness window is bounded and a per-request
+  membership read is avoided.
 
-### Job lease token (`createLeaseTokenAuthMethod`)
+### Job lease token
 
-- **Design:** a single-job capability token, not a session. Signed with a
-  dedicated secret (`AUTH_JOB_LEASE_TOKEN_SECRET`) and a fixed audience, its claims
-  (`jobId`, `runId`, `workspaceId`, `runnerTokenId`) describe exactly what the
-  bearer may act on. The signed token is the sole authority.
-- **Audience:** a runner process acting on behalf of one claimed job — machine to
-  machine, never a logged-in user.
-- **Grants access to:** only the runner-facing endpoints a runner uses to report
-  status and drive orchestration over the lifecycle of the job named in `jobId`.
-  The other ids are carried for consumers but do not widen access. Scope is "this
-  one job," which is why no broader authorization check is needed.
-- **Lifecycle:**
-  - *Emit* — minted by Scheduling when a runner claims a job, not by a login flow.
-  - *Exchange* — sent as a bearer token on every status-reporting and
-    orchestration call for the lease's duration.
-  - *Store* — held in the runner's memory only for the life of the job, never
-    written to disk; not persisted server-side.
-  - *Discard* — expires on its own (`AUTH_JOB_LEASE_TOKEN_EXPIRES_IN`, 90m); there
-    is no explicit invalidation step.
-- **Tradeoff — no revocation:** `runnerTokenId` is *not* checked against the
-  runner-token table, so a lease minted just before its runner token is revoked
-  stays usable until it expires (≤90m). Accepted because access is bounded both in
-  time (short lease) and in scope (a single job), so the blast radius is small, and
-  a per-request DB check would sit on the hot status-reporting path. Bind to runner
-  status only if that window proves too wide.
+A single-job **capability** token, not a session. It is the means by which a
+runner proves it is the legitimate holder of one specific job while it reports
+progress and drives that job to completion.
+
+- **Scope — exactly one job.** The token authorizes action on the single job it
+  names, for the runner holding it. It is **not** a runner identity, it is **not**
+  workspace-wide, and it is **not** a substitute for the long-lived runner
+  credential used to claim work in the first place. The surrounding identifiers it
+  carries (run, workspace, the claiming runner) are context for consumers; they do
+  not widen what the bearer may touch.
+- **Trust boundary.** There is exactly one issuer: the scheduling side mints a
+  lease only when a runner claims a job. Everything downstream only *verifies* — an
+  in-process signature check, with no callback to the issuer. The runner, and the
+  untrusted agent workload it hosts, never mints or modifies a token; it only
+  presents the one it was handed.
+- **Mechanics.** Signed with HMAC-SHA256 using a dedicated secret, separate from
+  the user-session secret. Its claims name the job and its surrounding context and
+  nothing more, and it carries a fixed audience so a token minted for one purpose
+  cannot be replayed against another. It is short-lived (bounded in hours, not
+  days). The signing secret is supplied through configuration, never embedded in
+  code or committed. The raw token must **never** be written to logs, traces, or
+  error payloads — there is no automatic redaction to fall back on.
+- **Defense in depth — server state is the final authority.** A valid token is
+  never sufficient on its own to advance work. Server-side job and step state is
+  the ultimate gate: a report against work that has already reached a terminal
+  state (finished, failed, or cancelled) is ignored, so a still-valid token cannot
+  resurrect or re-drive a job that is already done. Cancellation flows the other
+  way as well — the server can ask the runner to stop at any point, and that
+  request rides on the response to each heartbeat rather than depending on the
+  token.
+- **Threat model.** A leaked or replayed token has a deliberately small blast
+  radius: it grants action on one already-claimed job, and only until it expires.
+  It cannot claim new work, impersonate a runner, or reach other workspaces. If the
+  *signing secret* leaks, the response is to rotate it; rotation invalidates every
+  live lease at once (they fail signature verification) and forces fresh claims.
+  Isolating this secret from the user-session secret is what lets one be rotated
+  without disrupting the other.
+- **Tradeoff — no per-token revocation.** A single outstanding lease cannot be
+  revoked on its own; it simply expires. The claiming runner's credential is not
+  re-checked on each request, so a lease minted just before that credential is
+  revoked stays usable until it expires. Accepted because access is bounded in both
+  time (short lease) and scope (one job), keeping the blast radius small, and
+  because a per-request check would sit on the hot progress-reporting path.
+- **Guidelines for future changes.** Keep the authority narrow: do not add claims
+  that grant access beyond the single job, keep the lifetime bounded, keep a single
+  issuer, and keep every other side verify-only. If the no-revocation window ever
+  proves too wide, the right fix is to bind the lease to live runner or job state —
+  not to broaden what the token itself can authorize.
 
 ## Routes
 

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -112,13 +112,13 @@ progress and drives that job to completion.
   code or committed. The raw token must **never** be written to logs, traces, or
   error payloads — there is no automatic redaction to fall back on.
 - **Defense in depth — server state is the final authority.** A valid token is
-  never sufficient on its own to advance work. Server-side job and step state is
-  the ultimate gate: a report against work that has already reached a terminal
-  state (finished, failed, or cancelled) is ignored, so a still-valid token cannot
-  resurrect or re-drive a job that is already done. Cancellation flows the other
-  way as well — the server can ask the runner to stop at any point, and that
-  request rides on the response to each heartbeat rather than depending on the
-  token.
+  never sufficient on its own to advance work. On the lease's own request path the
+  gate is server-side step and progression state: a report against a step that has
+  already reached a terminal state (finished, failed, or cancelled) is ignored, so
+  a still-valid token cannot re-drive work that is already done. Job-level
+  finalization is enforced outside the lease path. Cancellation flows the other way
+  as well — the server can ask the runner to stop at any point, and that request
+  rides on the response to each heartbeat rather than depending on the token.
 - **Threat model.** A leaked or replayed token has a deliberately small blast
   radius: it grants action on one already-claimed job, and only until it expires.
   It cannot claim new work, impersonate a runner, or reach other workspaces. If the

--- a/libs/api/auth/src/presentation/auth/lease-token-auth.ts
+++ b/libs/api/auth/src/presentation/auth/lease-token-auth.ts
@@ -12,7 +12,7 @@ import {verifyJobLeaseToken} from '#core/job-lease-token.js';
  * revoked stays usable until it expires (`AUTH_JOB_LEASE_TOKEN_EXPIRES_IN`, 90m).
  * Accepted deliberately for a short-lived, job-scoped capability token; tightening
  * this would mean a per-request DB lookup on the hot status-reporting path. See the
- * "Auth methods" section in the package README for the full rationale.
+ * "Security model" section in the package README for the full rationale.
  */
 export function createLeaseTokenAuthMethod(): AuthMethod {
   return {


### PR DESCRIPTION
Reworks the auth package's `## Auth methods` README section into a code-free `## Security model` overview covering both bearer tokens, and adds matching guardrails to `AGENTS.md`.

The user session token kept its design/lifecycle/tradeoff shape, abstracted away from secret names and route paths. The job lease token is rebuilt around the six areas ENG-401 asked for, most of which were previously missing or only implied:

- **Scope** — states the negatives: not a runner identity, not workspace-wide, not a substitute for the runner credential.
- **Trust boundary** — single issuer (scheduling), everyone else verify-only in-process with no callback, runner/agent untrusted and only presents the token.
- **Mechanics** — HS256, dedicated secret, fixed audience to block cross-purpose replay, bounded TTL, secret from config, never log the raw token (no auto-redaction safety net).
- **Defense in depth** — server job/step state is the final gate; terminal-state reports are ignored; cancellation rides the heartbeat response.
- **Threat model** — small blast radius for a leaked/replayed token; secret leak → rotate → all live leases invalid.
- **Guidelines for future changes** — don't widen claims, bound the TTL, single issuer, verify-only elsewhere.

The doc stays deliberately abstract from the implementation (no file or function names) — it's a security overview, not a build guide. The existing code comment that referenced the old section name was repointed.

Two gaps surfaced while writing that are intentionally **not** addressed here (docs-only PR), worth follow-ups:
- There is no explicit job-finalized gate in code today — safety comes from step-state idempotency. The doc describes that reality rather than overclaiming.
- No log redaction is configured anywhere, so "never log the token" has no automatic backstop.

Refs ENG-401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked `libs/api/auth` into a code-free Security model for both bearer tokens and defined the job lease token’s perimeter (scope, trust boundary, mechanics, defense-in-depth, threat model, change guidelines). Clarifies that the lease path gates on step/progression state only (job finalization is enforced outside it), adds matching guardrails in `AGENTS.md`, and updates the lease auth comment to reference the new section; completes ENG-401.

<sup>Written for commit 9872a72f2e1082efb2e02b2360aab402eaa6f691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

