### PR TITLE
Document configuration properties for self-hosters

### DIFF
--- a/.changeset/calm-otters-document.md
+++ b/.changeset/calm-otters-document.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/node-error-monitoring": patch
+"@shipfox/node-fastify": patch
+"@shipfox/node-log": patch
+"@shipfox/node-opentelemetry": patch
+"@shipfox/node-postgres": patch
+"@shipfox/node-temporal": patch
+---
+
+Documents every environment-variable config param with a `desc` field so self-hosters can see what each variable does and how to set it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,9 +174,10 @@ missing value fails startup. Keep the file flat: declare the schema, then derive
 any helpers (such as a mailer) below it.
 
 Document every variable with the validator's `desc` property, never a `//` comment
-beside it. `desc` is part of envalid's output, so it reaches the operators who
-self-host the service; a comment never leaves the source file. When you find an
-existing `//` note on a config param, move it into `desc`.
+beside it. `desc` stays attached to the schema: envalid's default reporter prints it
+when a required variable is missing at startup, and any config tooling can read it.
+A `//` comment never leaves the source file. When you find an existing `//` note on
+a config param, move it into `desc`.
 
 Write the descriptions for self-hosters, not for maintainers:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,42 @@ Each E2E package must also declare an explicit workspace dependency on the packa
 it verifies, such as `@shipfox/client-auth` for `@shipfox/e2e-client-auth`, so
 Turbo includes the referenced package in the task DAG.
 
+### Configuration
+
+Each app and each package that reads the environment owns a `src/config.ts`. It
+calls `createConfig` from `@shipfox/config` (a thin wrapper over envalid) with one
+validator per variable: `str`, `num`, `bool`, `host`, `port`, `url`, or `email`. A
+validator with a `default` is optional; one without a default is required, so a
+missing value fails startup. Keep the file flat: declare the schema, then derive
+any helpers (such as a mailer) below it.
+
+Document every variable with the validator's `desc` property, never a `//` comment
+beside it. `desc` is part of envalid's output, so it reaches the operators who
+self-host the service; a comment never leaves the source file. When you find an
+existing `//` note on a config param, move it into `desc`.
+
+Write the descriptions for self-hosters, not for maintainers:
+
+- Plain language, one idea per sentence, present tense.
+- Say what the variable does and how to set it.
+- List the accepted values when the variable is constrained: enums like
+  `LOG_LEVEL` or `MAILER_TRANSPORT`, a URL, a comma-separated list.
+- Note when a variable is required, or when it depends on another (for example,
+  `SMTP_HOST` is required when `MAILER_TRANSPORT` is `smtp`).
+- No marketing words.
+
+```ts
+export const config = createConfig({
+  AUTH_JWT_SECRET: str({
+    desc: 'Secret used to sign and verify user access tokens (JWTs). Required, with no default, so startup fails when it is missing.',
+  }),
+  MAILER_TRANSPORT: str({
+    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
+    default: 'console',
+  }),
+});
+```
+
 ## Code comments
 
 Default to fewer comments. Well-named functions, types, and variables carry the

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,6 +1,12 @@
 import {bool, createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  E2E_ENABLED: bool({default: false}),
-  E2E_ADMIN_API_KEY: str({default: undefined}),
+  E2E_ENABLED: bool({
+    desc: 'Enables the end-to-end test routes under /__e2e. Keep it false in production.',
+    default: false,
+  }),
+  E2E_ADMIN_API_KEY: str({
+    desc: 'Bearer token that protects the E2E admin routes. Set it when E2E_ENABLED is true.',
+    default: undefined,
+  }),
 });

--- a/apps/runner/src/config.ts
+++ b/apps/runner/src/config.ts
@@ -1,17 +1,31 @@
 import {createConfig, num, str} from '@shipfox/config';
 
 export const config = createConfig({
-  SHIPFOX_API_URL: str(),
-  SHIPFOX_POLL_INTERVAL_MS: num({default: 5000}),
-  SHIPFOX_POLL_MAX_INTERVAL_MS: num({default: 30000}),
-  SHIPFOX_RUNNER_TOKEN: str({default: 'static-poc-token'}),
-  SHIPFOX_RUNNER_WORKSPACE_ROOT: str({
-    default: undefined,
-    desc: 'Parent directory for per-job workspaces. When unset, per-job directories are created under the OS temp directory. The runner only ever creates and cleans a per-job child directory under this root; it never touches the root itself. Rejected at startup if it resolves to an unsafe path (see resolveWorkspaceRoot in workspace.ts).',
+  SHIPFOX_API_URL: str({
+    desc: 'Base URL of the Shipfox API the runner connects to, such as https://api.shipfox.io. Required.',
   }),
-  // Heartbeat tick interval. Must be << stuck-job threshold (180s server-side).
-  SHIPFOX_HEARTBEAT_INTERVAL_MS: num({default: 10_000}),
-  // Max time a single in-flight heartbeat may stay outstanding before the loop
-  // aborts it and schedules the next tick. Bounds overlap under a hung API.
-  SHIPFOX_HEARTBEAT_MAX_STALE_MS: num({default: 10_000}),
+  SHIPFOX_POLL_INTERVAL_MS: num({
+    desc: 'How often the runner asks the API for new jobs, in milliseconds. The runner backs off toward SHIPFOX_POLL_MAX_INTERVAL_MS while idle or after errors.',
+    default: 5000,
+  }),
+  SHIPFOX_POLL_MAX_INTERVAL_MS: num({
+    desc: 'Largest interval the poll backoff can reach, in milliseconds. This caps how long the runner waits between job checks.',
+    default: 30000,
+  }),
+  SHIPFOX_RUNNER_TOKEN: str({
+    desc: 'Bearer token the runner uses to authenticate with the API. Set a real value in production.',
+    default: 'static-poc-token',
+  }),
+  SHIPFOX_RUNNER_WORKSPACE_ROOT: str({
+    desc: 'Parent directory for per-job workspaces. When unset, per-job directories are created under the OS temp directory. The runner only ever creates and cleans a per-job child directory under this root; it never touches the root itself. Rejected at startup if it resolves to an unsafe path (see resolveWorkspaceRoot in workspace.ts).',
+    default: undefined,
+  }),
+  SHIPFOX_HEARTBEAT_INTERVAL_MS: num({
+    desc: "How often the runner sends a heartbeat, in milliseconds. Keep it well below the server's stuck-job threshold of 180 seconds.",
+    default: 10_000,
+  }),
+  SHIPFOX_HEARTBEAT_MAX_STALE_MS: num({
+    desc: 'How long a single heartbeat request may stay open, in milliseconds. After this time the runner cancels it and starts the next one. This limits overlapping requests when the API hangs.',
+    default: 10_000,
+  }),
 });

--- a/e2e/core/src/config.ts
+++ b/e2e/core/src/config.ts
@@ -1,7 +1,16 @@
 import {createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  API_URL: str({default: 'http://localhost:16101'}),
-  CLIENT_URL: str({default: 'http://localhost:5173'}),
-  E2E_ADMIN_API_KEY: str({default: 'e2e-admin-api-key'}),
+  API_URL: str({
+    desc: 'Base URL of the API that the end-to-end tests run against.',
+    default: 'http://localhost:16101',
+  }),
+  CLIENT_URL: str({
+    desc: 'Base URL of the client app that the end-to-end tests run against.',
+    default: 'http://localhost:5173',
+  }),
+  E2E_ADMIN_API_KEY: str({
+    desc: "Bearer token the end-to-end tests use to call the API's E2E admin routes. Must match the API's E2E_ADMIN_API_KEY.",
+    default: 'e2e-admin-api-key',
+  }),
 });

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -2,21 +2,56 @@ import {createConfig, num, str} from '@shipfox/config';
 import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
 
 export const config = createConfig({
-  AUTH_JWT_SECRET: str(),
-  AUTH_JWT_EXPIRES_IN: str({default: '15m'}),
-  // Mirrors AUTH_JWT_SECRET handling: required, no default — fail fast on misconfig.
-  AUTH_JOB_LEASE_TOKEN_SECRET: str(),
-  // TTL must outlast a job (JOB_MAX_DURATION is 60 minutes) plus margin.
-  AUTH_JOB_LEASE_TOKEN_EXPIRES_IN: str({default: '90m'}),
-  AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: num({default: 14}),
-  AUTH_REFRESH_COOKIE_NAME: str({default: 'shipfox_refresh_token'}),
-  CLIENT_BASE_URL: str({default: 'http://localhost:3000'}),
-  MAILER_TRANSPORT: str({default: 'console'}),
-  MAILER_FROM: str({default: 'noreply@shipfox.local'}),
-  SMTP_HOST: str({default: undefined}),
-  SMTP_PORT: num({default: 587}),
-  SMTP_USER: str({default: undefined}),
-  SMTP_PASSWORD: str({default: undefined}),
+  AUTH_JWT_SECRET: str({
+    desc: 'Secret used to sign and verify user access tokens (JWTs). Required, with no default, so startup fails when it is missing.',
+  }),
+  AUTH_JWT_EXPIRES_IN: str({
+    desc: 'How long an access token stays valid. Accepts a duration string such as 15m, 1h, or 7d.',
+    default: '15m',
+  }),
+  AUTH_JOB_LEASE_TOKEN_SECRET: str({
+    desc: 'Secret used to sign and verify job lease tokens. Required, with no default, so startup fails when it is missing.',
+  }),
+  AUTH_JOB_LEASE_TOKEN_EXPIRES_IN: str({
+    desc: 'How long a job lease token stays valid. Set it longer than the longest job (JOB_MAX_DURATION is 60 minutes) plus a safety margin.',
+    default: '90m',
+  }),
+  AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: num({
+    desc: 'How many days a refresh token stays valid before the user must sign in again.',
+    default: 14,
+  }),
+  AUTH_REFRESH_COOKIE_NAME: str({
+    desc: 'Name of the browser cookie that stores the refresh token.',
+    default: 'shipfox_refresh_token',
+  }),
+  CLIENT_BASE_URL: str({
+    desc: 'Base URL of the client app. Used to build links in emails such as password resets.',
+    default: 'http://localhost:3000',
+  }),
+  MAILER_TRANSPORT: str({
+    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
+    default: 'console',
+  }),
+  MAILER_FROM: str({
+    desc: 'Sender address shown on outgoing emails.',
+    default: 'noreply@shipfox.local',
+  }),
+  SMTP_HOST: str({
+    desc: 'Hostname of the SMTP server. Required when MAILER_TRANSPORT is smtp.',
+    default: undefined,
+  }),
+  SMTP_PORT: num({
+    desc: 'Port of the SMTP server.',
+    default: 587,
+  }),
+  SMTP_USER: str({
+    desc: 'Username for SMTP authentication. Leave it unset if the server needs no login.',
+    default: undefined,
+  }),
+  SMTP_PASSWORD: str({
+    desc: 'Password for SMTP authentication. Leave it unset if the server needs no login.',
+    default: undefined,
+  }),
 });
 
 function createMailer(): Mailer {

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -30,6 +30,7 @@ export const config = createConfig({
   }),
   MAILER_TRANSPORT: str({
     desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
+    choices: ['console', 'smtp'],
     default: 'console',
   }),
   MAILER_FROM: str({

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -1,7 +1,16 @@
 import {bool, createConfig} from '@shipfox/config';
 
 export const config = createConfig({
-  INTEGRATIONS_ENABLE_DEBUG_PROVIDER: bool({default: false}),
-  INTEGRATIONS_ENABLE_GITHUB_PROVIDER: bool({default: false}),
-  INTEGRATIONS_ENABLE_SENTRY_PROVIDER: bool({default: false}),
+  INTEGRATIONS_ENABLE_DEBUG_PROVIDER: bool({
+    desc: 'Enables the debug integration provider, which is meant for testing. Keep it false in production.',
+    default: false,
+  }),
+  INTEGRATIONS_ENABLE_GITHUB_PROVIDER: bool({
+    desc: 'Enables the GitHub integration provider so users can connect GitHub.',
+    default: false,
+  }),
+  INTEGRATIONS_ENABLE_SENTRY_PROVIDER: bool({
+    desc: 'Enables the Sentry integration provider so users can connect Sentry.',
+    default: false,
+  }),
 });

--- a/libs/api/integration/github/src/config.ts
+++ b/libs/api/integration/github/src/config.ts
@@ -1,13 +1,27 @@
 import {createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  GITHUB_APP_ID: str(),
-  GITHUB_APP_PRIVATE_KEY: str(),
-  GITHUB_APP_CLIENT_ID: str(),
-  GITHUB_APP_CLIENT_SECRET: str(),
-  GITHUB_APP_WEBHOOK_SECRET: str(),
-  GITHUB_APP_SLUG: str(),
-  GITHUB_INSTALL_STATE_SECRET: str(),
+  GITHUB_APP_ID: str({
+    desc: "Numeric ID of the GitHub App, found on the app's settings page. Required.",
+  }),
+  GITHUB_APP_PRIVATE_KEY: str({
+    desc: 'Private key of the GitHub App in PEM format, used to sign API requests. Newlines may be written as \\n and are restored at runtime. Required.',
+  }),
+  GITHUB_APP_CLIENT_ID: str({
+    desc: 'OAuth client ID of the GitHub App, used for user sign-in. Required.',
+  }),
+  GITHUB_APP_CLIENT_SECRET: str({
+    desc: 'OAuth client secret of the GitHub App. Required.',
+  }),
+  GITHUB_APP_WEBHOOK_SECRET: str({
+    desc: 'Secret used to verify the signature of incoming GitHub webhooks. Must match the value set on the GitHub App. Required.',
+  }),
+  GITHUB_APP_SLUG: str({
+    desc: 'URL slug of the GitHub App, used to build install and callback links. Required.',
+  }),
+  GITHUB_INSTALL_STATE_SECRET: str({
+    desc: 'Secret used to sign the state token that protects the GitHub App install flow. Required.',
+  }),
 });
 
 export function normalizedGithubPrivateKey(): string {

--- a/libs/api/integration/sentry/src/config.ts
+++ b/libs/api/integration/sentry/src/config.ts
@@ -1,13 +1,17 @@
 import {bool, createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  // CLIENT_ID and SLUG are not used by this webhook receiver; they are consumed by
-  // the install/OAuth + app-token-exchange flow in the next PR. Declared now so the
-  // app credential contract is defined once rather than toggled across PRs.
-  SENTRY_APP_CLIENT_ID: str(),
-  // Shared secret used to verify inbound webhook HMAC-SHA256 signatures (Sentry
-  // signs deliveries with it, we verify them); also keys app token exchange later.
-  SENTRY_APP_CLIENT_SECRET: str(),
-  SENTRY_APP_SLUG: str(),
-  SENTRY_APP_VERIFY_INSTALL: bool({default: true}),
+  SENTRY_APP_CLIENT_ID: str({
+    desc: 'OAuth client ID of the Sentry app. Reserved for the install and app-token-exchange flow; the webhook receiver does not read it yet. Required.',
+  }),
+  SENTRY_APP_CLIENT_SECRET: str({
+    desc: 'Shared secret used to verify the HMAC-SHA256 signature on inbound Sentry webhooks. Must match the value set on the Sentry app. Required.',
+  }),
+  SENTRY_APP_SLUG: str({
+    desc: 'URL slug of the Sentry app, used to build install and callback links. Required.',
+  }),
+  SENTRY_APP_VERIFY_INSTALL: bool({
+    desc: 'Verifies the signature on Sentry app installation requests. Keep it true; turn it off only for local testing.',
+    default: true,
+  }),
 });

--- a/libs/api/workspaces/src/config.ts
+++ b/libs/api/workspaces/src/config.ts
@@ -8,6 +8,7 @@ export const config = createConfig({
   }),
   MAILER_TRANSPORT: str({
     desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
+    choices: ['console', 'smtp'],
     default: 'console',
   }),
   MAILER_FROM: str({

--- a/libs/api/workspaces/src/config.ts
+++ b/libs/api/workspaces/src/config.ts
@@ -2,13 +2,34 @@ import {createConfig, num, str} from '@shipfox/config';
 import {createConsoleMailer, createSmtpMailer, type Mailer} from '@shipfox/node-mailer';
 
 export const config = createConfig({
-  CLIENT_BASE_URL: str({default: 'http://localhost:3000'}),
-  MAILER_TRANSPORT: str({default: 'console'}),
-  MAILER_FROM: str({default: 'noreply@shipfox.local'}),
-  SMTP_HOST: str({default: undefined}),
-  SMTP_PORT: num({default: 587}),
-  SMTP_USER: str({default: undefined}),
-  SMTP_PASSWORD: str({default: undefined}),
+  CLIENT_BASE_URL: str({
+    desc: 'Base URL of the client app. Used to build links in workspace invitation emails.',
+    default: 'http://localhost:3000',
+  }),
+  MAILER_TRANSPORT: str({
+    desc: 'How emails are delivered. Use console to print them to the log, or smtp to send them through an SMTP server.',
+    default: 'console',
+  }),
+  MAILER_FROM: str({
+    desc: 'Sender address shown on outgoing emails.',
+    default: 'noreply@shipfox.local',
+  }),
+  SMTP_HOST: str({
+    desc: 'Hostname of the SMTP server. Required when MAILER_TRANSPORT is smtp.',
+    default: undefined,
+  }),
+  SMTP_PORT: num({
+    desc: 'Port of the SMTP server.',
+    default: 587,
+  }),
+  SMTP_USER: str({
+    desc: 'Username for SMTP authentication. Leave it unset if the server needs no login.',
+    default: undefined,
+  }),
+  SMTP_PASSWORD: str({
+    desc: 'Password for SMTP authentication. Leave it unset if the server needs no login.',
+    default: undefined,
+  }),
 });
 
 function createMailer(): Mailer {

--- a/libs/shared/node/error-monitoring/src/config.ts
+++ b/libs/shared/node/error-monitoring/src/config.ts
@@ -1,7 +1,16 @@
 import {createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  SENTRY_DSN: str({default: undefined}),
-  SENTRY_ENVIRONMENT: str({default: undefined}),
-  SENTRY_IMAGE: str({default: undefined}),
+  SENTRY_DSN: str({
+    desc: 'Sentry DSN that error reports are sent to. Leave it unset to turn Sentry off.',
+    default: undefined,
+  }),
+  SENTRY_ENVIRONMENT: str({
+    desc: 'Environment name attached to Sentry events, such as production or staging.',
+    default: undefined,
+  }),
+  SENTRY_IMAGE: str({
+    desc: 'Container image name and tag of the running build. The release version is read from the tag and attached to Sentry events.',
+    default: undefined,
+  }),
 });

--- a/libs/shared/node/fastify/src/config.ts
+++ b/libs/shared/node/fastify/src/config.ts
@@ -1,8 +1,20 @@
 import {createConfig, host, num, str} from '@shipfox/config';
 
 export const config = createConfig({
-  BROWSER_ALLOWED_ORIGIN: str({default: undefined}),
-  CLIENT_BASE_URL: str({default: 'http://localhost:3000'}),
-  HOST: host({default: '0.0.0.0'}),
-  PORT: num({default: 3000}),
+  BROWSER_ALLOWED_ORIGIN: str({
+    desc: 'Origins allowed to call the API from a browser (CORS). Accepts one origin or a comma-separated list. Falls back to CLIENT_BASE_URL when unset.',
+    default: undefined,
+  }),
+  CLIENT_BASE_URL: str({
+    desc: 'Base URL of the client app. Used as the allowed browser origin when BROWSER_ALLOWED_ORIGIN is unset.',
+    default: 'http://localhost:3000',
+  }),
+  HOST: host({
+    desc: 'Network address the server binds to. The default 0.0.0.0 listens on all interfaces.',
+    default: '0.0.0.0',
+  }),
+  PORT: num({
+    desc: 'Port the server listens on.',
+    default: 3000,
+  }),
 });

--- a/libs/shared/node/log/src/config.ts
+++ b/libs/shared/node/log/src/config.ts
@@ -1,8 +1,20 @@
 import {bool, createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  LOG_LEVEL: str({default: 'info'}),
-  LOG_PRETTY: bool({default: false}),
-  LOG_STDOUT: bool({default: true}),
-  LOG_FILE: str({default: undefined}),
+  LOG_LEVEL: str({
+    desc: 'Lowest log level that gets written. Accepts fatal, error, warn, info, debug, trace, or silent.',
+    default: 'info',
+  }),
+  LOG_PRETTY: bool({
+    desc: 'Formats logs for human reading instead of JSON. Use it in local development.',
+    default: false,
+  }),
+  LOG_STDOUT: bool({
+    desc: 'Writes logs to standard output. Turn it off to log only to a file.',
+    default: true,
+  }),
+  LOG_FILE: str({
+    desc: 'Path to a file that also receives logs. Parent folders are created if needed. Leave it unset to disable file logging.',
+    default: undefined,
+  }),
 });

--- a/libs/shared/node/opentelemetry/src/common.ts
+++ b/libs/shared/node/opentelemetry/src/common.ts
@@ -15,8 +15,14 @@ import {ATTR_SERVICE_NAME} from '@opentelemetry/semantic-conventions';
 import {createConfig, str, url} from '@shipfox/config';
 
 export const env = createConfig({
-  OTEL_SERVICE_NAME: str({default: undefined}),
-  TRACES_COLLECTOR_URL: url({default: undefined}),
+  OTEL_SERVICE_NAME: str({
+    desc: 'Service name reported on the telemetry this process emits. Leave it unset to use the auto-detected resource name.',
+    default: undefined,
+  }),
+  TRACES_COLLECTOR_URL: url({
+    desc: 'OTLP endpoint that traces are exported to. Leave it unset to disable trace export.',
+    default: undefined,
+  }),
 });
 
 /**

--- a/libs/shared/node/opentelemetry/src/config.ts
+++ b/libs/shared/node/opentelemetry/src/config.ts
@@ -11,6 +11,7 @@ export const config = createConfig({
   }),
   OTEL_DIAG_LOG_LEVEL: str({
     desc: "Verbosity of OpenTelemetry's own diagnostic logs. Accepts none, error, warn, info, debug, verbose, or all.",
+    choices: ['none', 'error', 'warn', 'info', 'debug', 'verbose', 'all'],
     default: 'none',
   }),
 });

--- a/libs/shared/node/opentelemetry/src/config.ts
+++ b/libs/shared/node/opentelemetry/src/config.ts
@@ -1,7 +1,16 @@
 import {createConfig, port, str} from '@shipfox/config';
 
 export const config = createConfig({
-  OTEL_INSTANCE_METRICS_PORT: port({default: 9464}),
-  OTEL_SERVICE_METRICS_PORT: port({default: 9474}),
-  OTEL_DIAG_LOG_LEVEL: str({default: 'none'}),
+  OTEL_INSTANCE_METRICS_PORT: port({
+    desc: 'Port that exposes per-instance Prometheus metrics.',
+    default: 9464,
+  }),
+  OTEL_SERVICE_METRICS_PORT: port({
+    desc: 'Port that exposes service-wide Prometheus metrics.',
+    default: 9474,
+  }),
+  OTEL_DIAG_LOG_LEVEL: str({
+    desc: "Verbosity of OpenTelemetry's own diagnostic logs. Accepts none, error, warn, info, debug, verbose, or all.",
+    default: 'none',
+  }),
 });

--- a/libs/shared/node/postgres/src/config.ts
+++ b/libs/shared/node/postgres/src/config.ts
@@ -1,10 +1,28 @@
 import {createConfig, host, num, str} from '@shipfox/config';
 
 export const config = createConfig({
-  POSTGRES_HOST: host({default: 'localhost'}),
-  POSTGRES_PORT: num({default: 5432}),
-  POSTGRES_USERNAME: str({default: 'shipfox'}),
-  POSTGRES_PASSWORD: str({default: 'password'}),
-  POSTGRES_DATABASE: str({default: 'api'}),
-  POSTGRES_MAX_CONNECTIONS: num({default: 10}),
+  POSTGRES_HOST: host({
+    desc: 'Hostname of the PostgreSQL server.',
+    default: 'localhost',
+  }),
+  POSTGRES_PORT: num({
+    desc: 'Port of the PostgreSQL server.',
+    default: 5432,
+  }),
+  POSTGRES_USERNAME: str({
+    desc: 'Username used to connect to PostgreSQL.',
+    default: 'shipfox',
+  }),
+  POSTGRES_PASSWORD: str({
+    desc: 'Password used to connect to PostgreSQL. Set a strong value in production.',
+    default: 'password',
+  }),
+  POSTGRES_DATABASE: str({
+    desc: 'Name of the PostgreSQL database to use.',
+    default: 'api',
+  }),
+  POSTGRES_MAX_CONNECTIONS: num({
+    desc: 'Largest number of connections the pool keeps open. Higher values allow more queries at once but use more resources.',
+    default: 10,
+  }),
 });

--- a/libs/shared/node/temporal/src/config.ts
+++ b/libs/shared/node/temporal/src/config.ts
@@ -1,7 +1,16 @@
 import {createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  TEMPORAL_ADDRESS: str({default: 'localhost:7233'}),
-  TEMPORAL_NAMESPACE: str({default: 'default'}),
-  TEMPORAL_TASK_QUEUE: str({default: 'shipfox'}),
+  TEMPORAL_ADDRESS: str({
+    desc: 'Address of the Temporal server in host:port form.',
+    default: 'localhost:7233',
+  }),
+  TEMPORAL_NAMESPACE: str({
+    desc: 'Temporal namespace that workflows and activities run in.',
+    default: 'default',
+  }),
+  TEMPORAL_TASK_QUEUE: str({
+    desc: 'Task queue that workers and clients share. Workers and clients must use the same value.',
+    default: 'shipfox',
+  }),
 });

--- a/libs/shared/node/tokens/src/config.ts
+++ b/libs/shared/node/tokens/src/config.ts
@@ -1,5 +1,8 @@
 import {createConfig, str} from '@shipfox/config';
 
 export const config = createConfig({
-  TOKEN_ENVIRONMENT: str({default: undefined}),
+  TOKEN_ENVIRONMENT: str({
+    desc: 'Optional label added to generated token prefixes to separate environments, such as staging. When set, only tokens that carry the same label pass validation.',
+    default: undefined,
+  }),
 });


### PR DESCRIPTION
Adds a `desc` field to every environment-variable config param across the apps and shared packages, documenting what each variable does and how to set it, and records the convention in AGENTS.md.

Self-hosters configure the service through these env vars, but the params were defined with bare validators and only the occasional inline `//` comment that never surfaces to operators. envalid already supports a `desc` field on each validator, so this moves the existing author notes into `desc` and fills in the gaps, making the descriptions the single place that explains the configuration surface.

Descriptions are written for end-users rather than maintainers: plain language, one idea per sentence, present tense, and the accepted values wherever a param is constrained (enums like `LOG_LEVEL` / `MAILER_TRANSPORT` / `OTEL_DIAG_LOG_LEVEL`, URLs, the `BROWSER_ALLOWED_ORIGIN` comma list, the `TOKEN_ENVIRONMENT` prefix-matching rule). No behavior change.

A new `### Configuration` section in AGENTS.md captures the structure (per-package `src/config.ts` via `createConfig`, required vs defaulted params) and the rule that every variable is documented through the validator's `desc` field, so future config additions follow the same pattern.

Notes for review:
- The non-obvious params (poll backoff, `SENTRY_IMAGE` release extraction, `TOKEN_ENVIRONMENT` validation, the CORS fallback to `CLIENT_BASE_URL`) were checked against their actual usage so the wording matches behavior.
- `CLIENT_BASE_URL`, `MAILER_TRANSPORT`, `MAILER_FROM`, and the `SMTP_*` set are declared in both `api-auth` and `api-workspaces`. Both copies are documented consistently; collapsing that duplication is left as a separate refactor.