### PR TITLE
[runner] Add per-job workspace manager and step CWD

### DIFF
--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -1,0 +1,43 @@
+# @shipfox/runner
+
+Polls the Shipfox API for jobs and executes their steps on the runner host.
+
+## Host prerequisites
+
+- **`git`** must be installed on the runner host and on `PATH`. Each job is
+  executed against a checkout of its project repository, so a runner without
+  `git` cannot run repository-backed jobs.
+
+## Workspace directories
+
+The runner prepares a fresh working directory for every job, runs all of the
+job's steps from it, and removes it afterwards. Steps do **not** inherit the
+runner process's working directory.
+
+### `SHIPFOX_RUNNER_WORKSPACE_ROOT` (optional)
+
+Parent directory under which per-job working directories are created.
+
+- **Unset (default):** per-job directories are created under the OS temp
+  directory.
+- **Set:** per-job directories are created under the configured path.
+
+The runner only ever creates and cleans a per-job child directory under this
+root; it never touches the root itself. The directory is pre-cleaned before use
+(so a directory left by a previous crash is never reused) and removed after the
+job completes, fails, or is cancelled.
+
+The value is validated once at startup. The runner refuses to start when the
+configured root is empty, the filesystem root (`/`), or a home directory.
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SHIPFOX_API_URL` | — | Base URL of the Shipfox API. |
+| `SHIPFOX_RUNNER_TOKEN` | `static-poc-token` | Bearer token used to authenticate with the API. |
+| `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
+| `SHIPFOX_POLL_INTERVAL_MS` | `5000` | Base poll interval when requesting jobs. |
+| `SHIPFOX_POLL_MAX_INTERVAL_MS` | `30000` | Maximum backoff interval when no jobs are available. |
+| `SHIPFOX_HEARTBEAT_INTERVAL_MS` | `10000` | Heartbeat tick interval for an in-flight job. |
+| `SHIPFOX_HEARTBEAT_MAX_STALE_MS` | `10000` | Max time a single heartbeat may stay outstanding before it is aborted. |

--- a/apps/runner/src/config.ts
+++ b/apps/runner/src/config.ts
@@ -5,6 +5,12 @@ export const config = createConfig({
   SHIPFOX_POLL_INTERVAL_MS: num({default: 5000}),
   SHIPFOX_POLL_MAX_INTERVAL_MS: num({default: 30000}),
   SHIPFOX_RUNNER_TOKEN: str({default: 'static-poc-token'}),
+  // Parent directory for per-job workspaces. When unset, per-job directories
+  // are created under the OS temp directory. The runner only ever creates and
+  // cleans a per-job child directory under this root; it never touches the root
+  // itself. Rejected at startup if it resolves to an unsafe path (see
+  // resolveWorkspaceRoot in workspace.ts).
+  SHIPFOX_RUNNER_WORKSPACE_ROOT: str({default: undefined}),
   // Heartbeat tick interval. Must be << stuck-job threshold (180s server-side).
   SHIPFOX_HEARTBEAT_INTERVAL_MS: num({default: 10_000}),
   // Max time a single in-flight heartbeat may stay outstanding before the loop

--- a/apps/runner/src/config.ts
+++ b/apps/runner/src/config.ts
@@ -5,12 +5,10 @@ export const config = createConfig({
   SHIPFOX_POLL_INTERVAL_MS: num({default: 5000}),
   SHIPFOX_POLL_MAX_INTERVAL_MS: num({default: 30000}),
   SHIPFOX_RUNNER_TOKEN: str({default: 'static-poc-token'}),
-  // Parent directory for per-job workspaces. When unset, per-job directories
-  // are created under the OS temp directory. The runner only ever creates and
-  // cleans a per-job child directory under this root; it never touches the root
-  // itself. Rejected at startup if it resolves to an unsafe path (see
-  // resolveWorkspaceRoot in workspace.ts).
-  SHIPFOX_RUNNER_WORKSPACE_ROOT: str({default: undefined}),
+  SHIPFOX_RUNNER_WORKSPACE_ROOT: str({
+    default: undefined,
+    desc: 'Parent directory for per-job workspaces. When unset, per-job directories are created under the OS temp directory. The runner only ever creates and cleans a per-job child directory under this root; it never touches the root itself. Rejected at startup if it resolves to an unsafe path (see resolveWorkspaceRoot in workspace.ts).',
+  }),
   // Heartbeat tick interval. Must be << stuck-job threshold (180s server-side).
   SHIPFOX_HEARTBEAT_INTERVAL_MS: num({default: 10_000}),
   // Max time a single in-flight heartbeat may stay outstanding before the loop

--- a/apps/runner/src/executor.test.ts
+++ b/apps/runner/src/executor.test.ts
@@ -89,6 +89,19 @@ describe('executeJob', () => {
     });
   });
 
+  it('forwards cwd to executeRunStep', async () => {
+    mockExecuteRunStep.mockResolvedValue({success: true, output: '', error: null});
+
+    const job = buildJob([{position: 0}]);
+
+    await executeJob(job, {cwd: '/tmp/shipfox-job-x'});
+
+    expect(mockExecuteRunStep).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({cwd: '/tmp/shipfox-job-x'}),
+    );
+  });
+
   it('handles a single step job', async () => {
     mockExecuteRunStep.mockResolvedValue({success: true, output: 'done\n', error: null});
 

--- a/apps/runner/src/executor.ts
+++ b/apps/runner/src/executor.ts
@@ -9,7 +9,7 @@ export interface ExecuteJobResult {
 
 export async function executeJob(
   job: JobPayloadDto,
-  options: {signal?: AbortSignal} = {},
+  options: {signal?: AbortSignal; cwd?: string} = {},
 ): Promise<ExecuteJobResult> {
   const steps = [...job.steps].sort((a, b) => a.position - b.position);
   const reported: StepResultDto[] = [];

--- a/apps/runner/src/run-step.test.ts
+++ b/apps/runner/src/run-step.test.ts
@@ -1,3 +1,6 @@
+import {mkdtemp, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {basename, join} from 'node:path';
 import {executeRunStep} from '#run-step.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
@@ -66,6 +69,22 @@ describe('executeRunStep', () => {
     expect(result.error?.exit_code).toBeNull();
     expect(result.error?.signal).toBe('SIGKILL');
     expect(result.error?.message).toContain('SIGKILL');
+  });
+
+  it('runs the step in the provided cwd', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'shipfox-cwd-test-'));
+    try {
+      const step = buildStep({config: {run: 'pwd'}});
+
+      const result = await executeRunStep(step, {cwd: dir});
+
+      expect(result.success).toBe(true);
+      // macOS resolves tmpdir() through a /private symlink, so match the unique
+      // mkdtemp suffix rather than the full path.
+      expect(result.output).toContain(basename(dir));
+    } finally {
+      await rm(dir, {recursive: true, force: true});
+    }
   });
 
   it('handles multi-line scripts', async () => {

--- a/apps/runner/src/run-step.ts
+++ b/apps/runner/src/run-step.ts
@@ -70,8 +70,6 @@ function spawnAndCapture(
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
     // parent chain). We don't unref() — output capture still needs `close`.
-    // cwd is the per-job workspace directory; steps no longer inherit the
-    // runner process CWD.
     const child = spawn(shell, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,

--- a/apps/runner/src/run-step.ts
+++ b/apps/runner/src/run-step.ts
@@ -20,7 +20,7 @@ const MAX_OUTPUT_BYTES = 1024 * 1024; // 1MB
 
 export function executeRunStep(
   step: JobPayloadStepDto,
-  options: {signal?: AbortSignal} = {},
+  options: {signal?: AbortSignal; cwd?: string} = {},
 ): Promise<StepResult> {
   if (step.type !== 'run') {
     return Promise.resolve({
@@ -44,7 +44,7 @@ export function executeRunStep(
 
 async function runShellCommand(
   command: string,
-  options: {signal?: AbortSignal},
+  options: {signal?: AbortSignal; cwd?: string},
 ): Promise<StepResult> {
   const scriptPath = join(tmpdir(), `shipfox-runner-${randomUUID()}.sh`);
 
@@ -56,7 +56,10 @@ async function runShellCommand(
   }
 }
 
-function spawnAndCapture(scriptPath: string, options: {signal?: AbortSignal}): Promise<StepResult> {
+function spawnAndCapture(
+  scriptPath: string,
+  options: {signal?: AbortSignal; cwd?: string},
+): Promise<StepResult> {
   return new Promise((resolve) => {
     const shell = findShell();
     const args =
@@ -67,9 +70,12 @@ function spawnAndCapture(scriptPath: string, options: {signal?: AbortSignal}): P
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
     // parent chain). We don't unref() — output capture still needs `close`.
+    // cwd is the per-job workspace directory; steps no longer inherit the
+    // runner process CWD.
     const child = spawn(shell, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
+      cwd: options.cwd,
     });
 
     let output = '';

--- a/apps/runner/src/runner.test.ts
+++ b/apps/runner/src/runner.test.ts
@@ -1,0 +1,135 @@
+vi.mock('#config.js', () => ({
+  config: {
+    SHIPFOX_API_URL: 'http://localhost',
+    SHIPFOX_POLL_INTERVAL_MS: 5000,
+    SHIPFOX_POLL_MAX_INTERVAL_MS: 30000,
+    SHIPFOX_HEARTBEAT_INTERVAL_MS: 10_000,
+    SHIPFOX_HEARTBEAT_MAX_STALE_MS: 10_000,
+  },
+}));
+
+vi.mock('#heartbeat-loop.js', () => ({
+  startHeartbeatLoop: vi.fn(() => ({stop: vi.fn()})),
+}));
+
+vi.mock('#workspace.js', async (importActual) => ({
+  ...(await importActual<typeof import('#workspace.js')>()),
+  prepareWorkspace: vi.fn(),
+  resolveWorkspaceRoot: vi.fn(),
+}));
+
+vi.mock('#executor.js', () => ({
+  executeJob: vi.fn(),
+}));
+
+vi.mock('#api-client.js', () => ({
+  completeJob: vi.fn(),
+  requestJob: vi.fn(),
+  HTTPError: class HTTPError extends Error {},
+}));
+
+import {completeJob, requestJob} from '#api-client.js';
+import {executeJob} from '#executor.js';
+import {runJob, startRunner} from '#runner.js';
+import {prepareWorkspace, resolveWorkspaceRoot, UnsafeWorkspaceRootError} from '#workspace.js';
+
+const mockPrepareWorkspace = vi.mocked(prepareWorkspace);
+const mockResolveWorkspaceRoot = vi.mocked(resolveWorkspaceRoot);
+const mockExecuteJob = vi.mocked(executeJob);
+const mockCompleteJob = vi.mocked(completeJob);
+const mockRequestJob = vi.mocked(requestJob);
+
+const JOB = {
+  job_id: '00000000-0000-0000-0000-000000000001',
+  run_id: '00000000-0000-0000-0000-000000000002',
+  job_name: 'test-job',
+  steps: [],
+} as Parameters<typeof runJob>[0];
+
+const WORKSPACE_ROOT = '/tmp/shipfox-test-root';
+
+function mockWorkspace() {
+  const cleanup = vi.fn().mockResolvedValue(undefined);
+  mockPrepareWorkspace.mockResolvedValue({cwd: '/tmp/shipfox-job-1', cleanup});
+  return cleanup;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runJob', () => {
+  beforeEach(() => {
+    mockCompleteJob.mockResolvedValue({} as never);
+  });
+
+  it('cleans up and reports completion on success', async () => {
+    const cleanup = mockWorkspace();
+    mockExecuteJob.mockResolvedValue({status: 'succeeded', steps: []});
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    expect(mockCompleteJob).toHaveBeenCalledWith(
+      expect.objectContaining({jobId: JOB.job_id, status: 'succeeded'}),
+    );
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports completion before cleaning up (D2)', async () => {
+    const cleanup = mockWorkspace();
+    mockExecuteJob.mockResolvedValue({status: 'succeeded', steps: []});
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    const completeOrder = mockCompleteJob.mock.invocationCallOrder[0] ?? 0;
+    const cleanupOrder = cleanup.mock.invocationCallOrder[0] ?? 0;
+    expect(completeOrder).toBeLessThan(cleanupOrder);
+  });
+
+  it('cleans up when a step fails', async () => {
+    const cleanup = mockWorkspace();
+    mockExecuteJob.mockResolvedValue({
+      status: 'failed',
+      steps: [{step_id: JOB.job_id, status: 'failed', error: {message: 'boom'}}],
+    });
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    expect(mockCompleteJob).toHaveBeenCalledWith(expect.objectContaining({status: 'failed'}));
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up when execution throws (e.g. cancellation)', async () => {
+    const cleanup = mockWorkspace();
+    mockExecuteJob.mockRejectedValue(new Error('aborted'));
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    expect(mockCompleteJob).toHaveBeenCalledWith(
+      expect.objectContaining({status: 'failed', steps: []}),
+    );
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails the job with empty steps and runs no steps when prepare fails', async () => {
+    mockPrepareWorkspace.mockRejectedValue(new Error('mkdir failed'));
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    expect(mockExecuteJob).not.toHaveBeenCalled();
+    expect(mockCompleteJob).toHaveBeenCalledWith(
+      expect.objectContaining({status: 'failed', steps: []}),
+    );
+  });
+});
+
+describe('startRunner', () => {
+  it('exits before polling when the workspace root is unsafe', async () => {
+    mockResolveWorkspaceRoot.mockImplementation(() => {
+      throw new UnsafeWorkspaceRootError('/');
+    });
+
+    await expect(startRunner()).rejects.toThrow(UnsafeWorkspaceRootError);
+    expect(mockRequestJob).not.toHaveBeenCalled();
+  });
+});

--- a/apps/runner/src/runner.ts
+++ b/apps/runner/src/runner.ts
@@ -4,6 +4,7 @@ import {completeJob, HTTPError, requestJob} from '#api-client.js';
 import {config} from '#config.js';
 import {type ExecuteJobResult, executeJob} from '#executor.js';
 import {startHeartbeatLoop} from '#heartbeat-loop.js';
+import {prepareWorkspace, resolveWorkspaceRoot, type Workspace} from '#workspace.js';
 
 let running = true;
 let shuttingDown = false;
@@ -14,8 +15,17 @@ let currentJobAbortController: AbortController | undefined;
 export async function startRunner(): Promise<void> {
   setupSignalHandlers();
 
+  // Validate the workspace root once at startup so a dangerous/misconfigured
+  // root crashes the process at deploy time (index.ts exits non-zero) rather
+  // than silently failing every job.
+  const workspaceRoot = resolveWorkspaceRoot(config);
+
   logger().info(
-    {apiUrl: config.SHIPFOX_API_URL, pollInterval: config.SHIPFOX_POLL_INTERVAL_MS},
+    {
+      apiUrl: config.SHIPFOX_API_URL,
+      pollInterval: config.SHIPFOX_POLL_INTERVAL_MS,
+      workspaceRoot,
+    },
     'Runner started',
   );
 
@@ -38,7 +48,7 @@ export async function startRunner(): Promise<void> {
         'Job received',
       );
 
-      await runJob(job);
+      await runJob(job, workspaceRoot);
     } catch (pollError) {
       logger().error({err: pollError}, 'Poll cycle failed');
       currentInterval = Math.min(currentInterval * 1.5, config.SHIPFOX_POLL_MAX_INTERVAL_MS);
@@ -49,7 +59,10 @@ export async function startRunner(): Promise<void> {
   logger().info('Runner stopped');
 }
 
-async function runJob(job: Awaited<ReturnType<typeof requestJob>> & object): Promise<void> {
+export async function runJob(
+  job: Awaited<ReturnType<typeof requestJob>> & object,
+  workspaceRoot: string,
+): Promise<void> {
   const ac = new AbortController();
   currentJobAbortController = ac;
 
@@ -58,9 +71,13 @@ async function runJob(job: Awaited<ReturnType<typeof requestJob>> & object): Pro
     maxStaleMs: config.SHIPFOX_HEARTBEAT_MAX_STALE_MS,
   });
 
+  let workspace: Workspace | undefined;
   let result: ExecuteJobResult;
   try {
-    result = await executeJob(job, {signal: ac.signal});
+    // A prepare failure (unsafe path, mkdir/rm error) fails the job before any
+    // step runs — the catch below reports failed with empty steps.
+    workspace = await prepareWorkspace(job, workspaceRoot);
+    result = await executeJob(job, {signal: ac.signal, cwd: workspace.cwd});
     logger().info({jobId: job.job_id, status: result.status}, 'Job execution finished');
   } catch (execError) {
     logger().error({err: execError, jobId: job.job_id}, 'Job execution failed');
@@ -72,9 +89,9 @@ async function runJob(job: Awaited<ReturnType<typeof requestJob>> & object): Pro
     if (currentJobAbortController === ac) currentJobAbortController = undefined;
   }
 
-  // 404 here is the expected signal that the backend already finalized this
-  // job; do not retry, do not fall through to the outer catch (would re-attempt).
   try {
+    // 404 here is the expected signal that the backend already finalized this
+    // job; do not retry, do not fall through to the outer catch (would re-attempt).
     await completeJob({jobId: job.job_id, status: result.status, steps: result.steps});
     logger().info({jobId: job.job_id, status: result.status}, 'Job completed');
   } catch (reportError) {
@@ -86,6 +103,11 @@ async function runJob(job: Awaited<ReturnType<typeof requestJob>> & object): Pro
     } else {
       logger().error({err: reportError, jobId: job.job_id}, 'Failed to report job completion');
     }
+  } finally {
+    // Clean up after reporting (so a hung cleanup can't lose the completion)
+    // and in a finally so success, step failure, unsupported steps, and
+    // cancellation all attempt it. cleanup() swallows its own errors.
+    if (workspace) await workspace.cleanup();
   }
 }
 

--- a/apps/runner/src/runner.ts
+++ b/apps/runner/src/runner.ts
@@ -15,9 +15,8 @@ let currentJobAbortController: AbortController | undefined;
 export async function startRunner(): Promise<void> {
   setupSignalHandlers();
 
-  // Validate the workspace root once at startup so a dangerous/misconfigured
-  // root crashes the process at deploy time (index.ts exits non-zero) rather
-  // than silently failing every job.
+  // Fail fast at startup: a dangerous root should crash the process at deploy,
+  // not silently fail every job.
   const workspaceRoot = resolveWorkspaceRoot(config);
 
   logger().info(
@@ -74,8 +73,6 @@ export async function runJob(
   let workspace: Workspace | undefined;
   let result: ExecuteJobResult;
   try {
-    // A prepare failure (unsafe path, mkdir/rm error) fails the job before any
-    // step runs — the catch below reports failed with empty steps.
     workspace = await prepareWorkspace(job, workspaceRoot);
     result = await executeJob(job, {signal: ac.signal, cwd: workspace.cwd});
     logger().info({jobId: job.job_id, status: result.status}, 'Job execution finished');
@@ -104,9 +101,7 @@ export async function runJob(
       logger().error({err: reportError, jobId: job.job_id}, 'Failed to report job completion');
     }
   } finally {
-    // Clean up after reporting (so a hung cleanup can't lose the completion)
-    // and in a finally so success, step failure, unsupported steps, and
-    // cancellation all attempt it. cleanup() swallows its own errors.
+    // Clean up after reporting so a slow cleanup can't lose the completion.
     if (workspace) await workspace.cleanup();
   }
 }

--- a/apps/runner/src/workspace.test.ts
+++ b/apps/runner/src/workspace.test.ts
@@ -72,10 +72,18 @@ describe('prepareWorkspace', () => {
     await expect(readStale()).rejects.toThrow();
   });
 
-  it('derives the directory name only from safe characters', async () => {
-    const workspace = await prepareWorkspace({job_id: '../../etc/passwd'}, root);
+  it('names the directory after the job id', async () => {
+    const jobId = '44444444-4444-4444-8444-444444444444';
 
-    expect(workspace.cwd).toBe(join(root, 'shipfox-job-etcpasswd'));
+    const workspace = await prepareWorkspace({job_id: jobId}, root);
+
+    expect(workspace.cwd).toBe(join(root, `job-${jobId}`));
+  });
+
+  it('rejects a job id that is not a UUID', async () => {
+    const prepare = () => prepareWorkspace({job_id: '../../etc/passwd'}, root);
+
+    await expect(prepare()).rejects.toThrow();
   });
 
   it('cleanup() removes the directory', async () => {

--- a/apps/runner/src/workspace.test.ts
+++ b/apps/runner/src/workspace.test.ts
@@ -1,0 +1,102 @@
+import {mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
+import {homedir, tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {
+  cleanupWorkspace,
+  prepareWorkspace,
+  resolveWorkspaceRoot,
+  UnsafeWorkspaceRootError,
+} from '#workspace.js';
+
+describe('resolveWorkspaceRoot', () => {
+  it('returns the configured root when set', () => {
+    const root = resolveWorkspaceRoot({SHIPFOX_RUNNER_WORKSPACE_ROOT: '/var/shipfox/work'});
+
+    expect(root).toBe('/var/shipfox/work');
+  });
+
+  it('falls back to the OS temp dir when unset', () => {
+    const root = resolveWorkspaceRoot({});
+
+    expect(root).toBe(tmpdir());
+  });
+
+  it.each(['', '   '])('rejects an empty/whitespace root (%j)', (value) => {
+    const resolveRoot = () => resolveWorkspaceRoot({SHIPFOX_RUNNER_WORKSPACE_ROOT: value});
+
+    expect(resolveRoot).toThrow(UnsafeWorkspaceRootError);
+  });
+
+  it('rejects the filesystem root', () => {
+    const resolveRoot = () => resolveWorkspaceRoot({SHIPFOX_RUNNER_WORKSPACE_ROOT: '/'});
+
+    expect(resolveRoot).toThrow(UnsafeWorkspaceRootError);
+  });
+
+  it('rejects the home directory', () => {
+    const resolveRoot = () => resolveWorkspaceRoot({SHIPFOX_RUNNER_WORKSPACE_ROOT: homedir()});
+
+    expect(resolveRoot).toThrow(UnsafeWorkspaceRootError);
+  });
+});
+
+describe('prepareWorkspace', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'shipfox-ws-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, {recursive: true, force: true});
+  });
+
+  it('creates a per-job directory under the root', async () => {
+    const workspace = await prepareWorkspace(
+      {job_id: '11111111-1111-4111-8111-111111111111'},
+      root,
+    );
+
+    expect(workspace.cwd.startsWith(root)).toBe(true);
+    expect((await stat(workspace.cwd)).isDirectory()).toBe(true);
+  });
+
+  it('pre-cleans a dirty directory left from a previous run', async () => {
+    const jobId = '22222222-2222-4222-8222-222222222222';
+    const first = await prepareWorkspace({job_id: jobId}, root);
+    await writeFile(join(first.cwd, 'stale.txt'), 'leftover');
+
+    const second = await prepareWorkspace({job_id: jobId}, root);
+
+    const readStale = () => stat(join(second.cwd, 'stale.txt'));
+    await expect(readStale()).rejects.toThrow();
+  });
+
+  it('derives the directory name only from safe characters', async () => {
+    const workspace = await prepareWorkspace({job_id: '../../etc/passwd'}, root);
+
+    expect(workspace.cwd).toBe(join(root, 'shipfox-job-etcpasswd'));
+  });
+
+  it('cleanup() removes the directory', async () => {
+    const workspace = await prepareWorkspace(
+      {job_id: '33333333-3333-4333-8333-333333333333'},
+      root,
+    );
+
+    await workspace.cleanup();
+
+    const readDir = () => stat(workspace.cwd);
+    await expect(readDir()).rejects.toThrow();
+  });
+});
+
+describe('cleanupWorkspace', () => {
+  it('does not throw when the directory is missing', async () => {
+    const missing = join(tmpdir(), 'shipfox-job-does-not-exist-xyz');
+
+    const result = await cleanupWorkspace(missing);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/apps/runner/src/workspace.test.ts
+++ b/apps/runner/src/workspace.test.ts
@@ -3,6 +3,7 @@ import {homedir, tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
   cleanupWorkspace,
+  InvalidJobIdError,
   prepareWorkspace,
   resolveWorkspaceRoot,
   UnsafeWorkspaceRootError,
@@ -83,7 +84,7 @@ describe('prepareWorkspace', () => {
   it('rejects a job id that is not a UUID', async () => {
     const prepare = () => prepareWorkspace({job_id: '../../etc/passwd'}, root);
 
-    await expect(prepare()).rejects.toThrow();
+    await expect(prepare()).rejects.toThrow(InvalidJobIdError);
   });
 
   it('cleanup() removes the directory', async () => {

--- a/apps/runner/src/workspace.ts
+++ b/apps/runner/src/workspace.ts
@@ -50,14 +50,22 @@ export interface Workspace {
   cleanup(): Promise<void>;
 }
 
+// The job id is the only input to the per-job path; assert it is the UUID the
+// API contract guarantees rather than munging it, so a malformed id fails the
+// job loudly instead of silently reshaping the directory name.
+const JOB_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Pre-cleans the per-job directory before creating it, so a directory left by a
- * previous crash is never reused. The name derives only from the
- * (server-assigned) job id, so no user-controlled fragment reaches the path.
+ * previous crash is never reused. Throws when the job id is not the UUID the
+ * API contract guarantees, since it is the only input to the directory path.
  */
 export async function prepareWorkspace(job: {job_id: string}, root: string): Promise<Workspace> {
-  const segment = job.job_id.replace(/[^A-Za-z0-9-]/g, '');
-  const cwd = join(root, `shipfox-job-${segment}`);
+  if (!JOB_ID_PATTERN.test(job.job_id)) {
+    throw new Error(`Cannot prepare workspace: invalid job id ${job.job_id}`);
+  }
+
+  const cwd = join(root, `job-${job.job_id}`);
 
   // Pre-clean the per-job directory only — never the configured root.
   await rm(cwd, {recursive: true, force: true});

--- a/apps/runner/src/workspace.ts
+++ b/apps/runner/src/workspace.ts
@@ -1,0 +1,75 @@
+import {mkdir, rm} from 'node:fs/promises';
+import {homedir, tmpdir} from 'node:os';
+import {join, parse, resolve} from 'node:path';
+import {logger} from '@shipfox/node-opentelemetry';
+
+// Thrown when SHIPFOX_RUNNER_WORKSPACE_ROOT resolves to a path we refuse to
+// manage per-job directories under: an empty value, the filesystem root, or a
+// home directory. Validated once at startup so the operator sees the misconfig
+// at deploy time rather than as silent per-job failures.
+export class UnsafeWorkspaceRootError extends Error {
+  constructor(public readonly root: string) {
+    super(`Unsafe workspace root: ${root || '(empty)'}`);
+    this.name = 'UnsafeWorkspaceRootError';
+  }
+}
+
+export interface WorkspaceConfig {
+  SHIPFOX_RUNNER_WORKSPACE_ROOT?: string | undefined;
+}
+
+// Resolve the parent directory for per-job workspaces. Returns the configured
+// root (validated) when set, otherwise the OS temp directory. The temp
+// fallback is trusted and not validated against the unsafe-path rules.
+export function resolveWorkspaceRoot(config: WorkspaceConfig): string {
+  const configured = config.SHIPFOX_RUNNER_WORKSPACE_ROOT;
+
+  if (configured === undefined) return tmpdir();
+
+  if (configured.trim() === '') throw new UnsafeWorkspaceRootError(configured);
+
+  const resolved = resolve(configured);
+
+  // A filesystem root ('/' on POSIX, 'C:\\' on Windows) has no parent and would
+  // put job dirs at the top level — never manage cleanup there.
+  if (resolved === parse(resolved).root) throw new UnsafeWorkspaceRootError(configured);
+
+  // The home directory holds the operator's files; a stray recursive cleanup
+  // there would be catastrophic.
+  if (resolved === resolve(homedir())) throw new UnsafeWorkspaceRootError(configured);
+
+  return resolved;
+}
+
+export interface Workspace {
+  cwd: string;
+  cleanup(): Promise<void>;
+}
+
+// Create a fresh per-job directory under `root` and return its path plus a
+// cleanup handle. The directory name is derived only from the job id (a
+// server-assigned UUID), sanitized to a conservative character set so no
+// user-controlled path fragment can ever appear. The per-job directory is
+// pre-cleaned before creation so a leftover directory from a previous crash is
+// never reused.
+export async function prepareWorkspace(job: {job_id: string}, root: string): Promise<Workspace> {
+  const segment = job.job_id.replace(/[^A-Za-z0-9-]/g, '');
+  const cwd = join(root, `shipfox-job-${segment}`);
+
+  // Pre-clean the per-job directory only — never the configured root.
+  await rm(cwd, {recursive: true, force: true});
+  await mkdir(cwd, {recursive: true});
+
+  return {cwd, cleanup: () => cleanupWorkspace(cwd)};
+}
+
+// Remove a per-job directory. Cleanup failures are logged and swallowed: a
+// dirty directory must never mask the job result, and the next job's
+// prepareWorkspace pre-clean will reclaim it.
+export async function cleanupWorkspace(cwd: string): Promise<void> {
+  try {
+    await rm(cwd, {recursive: true, force: true});
+  } catch (err) {
+    logger().warn({err, cwd}, 'Failed to clean up job workspace');
+  }
+}

--- a/apps/runner/src/workspace.ts
+++ b/apps/runner/src/workspace.ts
@@ -3,10 +3,12 @@ import {homedir, tmpdir} from 'node:os';
 import {join, parse, resolve} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
 
-// Thrown when SHIPFOX_RUNNER_WORKSPACE_ROOT resolves to a path we refuse to
-// manage per-job directories under: an empty value, the filesystem root, or a
-// home directory. Validated once at startup so the operator sees the misconfig
-// at deploy time rather than as silent per-job failures.
+/**
+ * Thrown when `SHIPFOX_RUNNER_WORKSPACE_ROOT` resolves to a path we refuse to
+ * manage per-job directories under (empty, the filesystem root, or a home
+ * directory). Surfaced at startup so the operator catches the misconfig at
+ * deploy rather than as silent per-job failures.
+ */
 export class UnsafeWorkspaceRootError extends Error {
   constructor(public readonly root: string) {
     super(`Unsafe workspace root: ${root || '(empty)'}`);
@@ -18,9 +20,11 @@ export interface WorkspaceConfig {
   SHIPFOX_RUNNER_WORKSPACE_ROOT?: string | undefined;
 }
 
-// Resolve the parent directory for per-job workspaces. Returns the configured
-// root (validated) when set, otherwise the OS temp directory. The temp
-// fallback is trusted and not validated against the unsafe-path rules.
+/**
+ * Falls back to the OS temp directory when no root is configured. Only a
+ * configured root is validated (throws {@link UnsafeWorkspaceRootError}); the
+ * temp fallback is trusted.
+ */
 export function resolveWorkspaceRoot(config: WorkspaceConfig): string {
   const configured = config.SHIPFOX_RUNNER_WORKSPACE_ROOT;
 
@@ -46,12 +50,11 @@ export interface Workspace {
   cleanup(): Promise<void>;
 }
 
-// Create a fresh per-job directory under `root` and return its path plus a
-// cleanup handle. The directory name is derived only from the job id (a
-// server-assigned UUID), sanitized to a conservative character set so no
-// user-controlled path fragment can ever appear. The per-job directory is
-// pre-cleaned before creation so a leftover directory from a previous crash is
-// never reused.
+/**
+ * Pre-cleans the per-job directory before creating it, so a directory left by a
+ * previous crash is never reused. The name derives only from the
+ * (server-assigned) job id, so no user-controlled fragment reaches the path.
+ */
 export async function prepareWorkspace(job: {job_id: string}, root: string): Promise<Workspace> {
   const segment = job.job_id.replace(/[^A-Za-z0-9-]/g, '');
   const cwd = join(root, `shipfox-job-${segment}`);
@@ -63,9 +66,10 @@ export async function prepareWorkspace(job: {job_id: string}, root: string): Pro
   return {cwd, cleanup: () => cleanupWorkspace(cwd)};
 }
 
-// Remove a per-job directory. Cleanup failures are logged and swallowed: a
-// dirty directory must never mask the job result, and the next job's
-// prepareWorkspace pre-clean will reclaim it.
+/**
+ * Never throws: failures are logged and swallowed so a dirty directory can't
+ * mask the job result; the next prepareWorkspace pre-clean reclaims it.
+ */
 export async function cleanupWorkspace(cwd: string): Promise<void> {
   try {
     await rm(cwd, {recursive: true, force: true});

--- a/apps/runner/src/workspace.ts
+++ b/apps/runner/src/workspace.ts
@@ -16,6 +16,17 @@ export class UnsafeWorkspaceRootError extends Error {
   }
 }
 
+/**
+ * Thrown when a job's id is not the UUID the API contract guarantees, so it
+ * cannot be used as the per-job directory name.
+ */
+export class InvalidJobIdError extends Error {
+  constructor(public readonly jobId: string) {
+    super(`Invalid job id: ${jobId}`);
+    this.name = 'InvalidJobIdError';
+  }
+}
+
 export interface WorkspaceConfig {
   SHIPFOX_RUNNER_WORKSPACE_ROOT?: string | undefined;
 }
@@ -62,7 +73,7 @@ const JOB_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
  */
 export async function prepareWorkspace(job: {job_id: string}, root: string): Promise<Workspace> {
   if (!JOB_ID_PATTERN.test(job.job_id)) {
-    throw new Error(`Cannot prepare workspace: invalid job id ${job.job_id}`);
+    throw new InvalidJobIdError(job.job_id);
   }
 
   const cwd = join(root, `job-${job.job_id}`);


### PR DESCRIPTION
Make runner job execution workspace-aware: prepare a fresh per-job directory, run every step from it via `cwd`, and clean it up on every exit path.

## Why

Today the runner executes step commands wherever its process happens to sit — there is no per-job working directory and steps inherit the runner's CWD. This is the first step of the "Runner-managed workspaces" project: the runner should prepare, own, and clean the filesystem workspace for each job before repository checkout lands.

## What

- New `apps/runner/src/workspace.ts`: `resolveWorkspaceRoot` (configured root or OS-temp fallback, rejects empty/`/`/home dir), `prepareWorkspace` (per-job dir named from the job id, pre-cleaned then created), `cleanupWorkspace` (logs-and-swallows so it never masks the job result).
- Thread `cwd` through `executeJob` → `executeRunStep` → `spawn`. The `detached` + process-group `killGroup()` cancellation path is unchanged.
- `runner.ts`: validate the workspace root once at startup (a dangerous root exits the process at deploy, not silently per job); report completion before cleanup; clean up in a `finally` so success, step failure, unsupported steps, and cancellation all reclaim the directory. A prepare failure fails the job with empty steps and runs nothing.
- New `apps/runner/README.md`: documents the `git` host prerequisite and `SHIPFOX_RUNNER_WORKSPACE_ROOT`.

## Notes for reviewers

- The workspace manager is intentionally **execution-model-agnostic** so it survives the in-flight per-step-loop work (ENG-399): if that merges first, only the cwd + prepare/cleanup wiring rebases onto the step loop.
- Tests use a fake/local checkout path. The real `git` shallow clone lands in ENG-405; the checkout-token fetch in ENG-406.
- No changeset: this touches only the private `apps/runner` (no npm consumers).

Refs ENG-404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-job workspace manager to `@shipfox/runner`: each job gets a fresh `job-<id>` directory, steps run from it via `cwd`, and the directory is removed on every exit path. Validates the workspace root at startup and enforces UUID job ids for workspace naming (ENG-404).

- **New Features**
  - Validates `SHIPFOX_RUNNER_WORKSPACE_ROOT` at startup; rejects empty, `/`, or home; falls back to OS temp; throws `UnsafeWorkspaceRootError`.
  - `prepareWorkspace` creates `job-<id>` dirs, pre-cleans stale dirs, and throws `InvalidJobIdError` for non-UUID ids; `cleanupWorkspace` logs and swallows errors.
  - Threads `cwd` through `executeJob` → `executeRunStep` → `spawn` so steps run in the job workspace.
  - Reports completion before cleanup; prepare failures fail the job early with no steps.
  - Docs added to `apps/runner/README.md`; moved workspace root description into `envalid` `desc` and converted workspace docs to JSDoc.

<sup>Written for commit 40d92cb43a36de5a679a5ddff37d3846780ab5c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

