### PR TITLE
[api/integrations] Add Sentry install/connect flow

### DIFF
--- a/.changeset/sentry-install-connect.md
+++ b/.changeset/sentry-install-connect.md
@@ -1,0 +1,29 @@
+---
+"@shipfox/api-integration-sentry": minor
+"@shipfox/api-integration-sentry-dto": minor
+"@shipfox/api-integration-core": patch
+---
+
+Add the Sentry install/connect flow so a workspace member can link a Sentry
+installation to a Shipfox workspace, writing the connection + installation rows
+that the webhook receiver looks up.
+
+- `@shipfox/api-integration-sentry`: add a stateless `SentryApiClient`
+  (authorization-code exchange, org-slug derivation, optional verify-install),
+  `handleSentryConnect`, and two authenticated routes —
+  `POST /integrations/sentry/install` (returns the external-install URL) and
+  `POST /integrations/sentry/connect` (links the installation). Sentry has no
+  `state` param, so the workspace is taken from the request body and authorized
+  against the live session; the org slug is derived from Sentry, never trusted
+  from the body. The verify-install side effect runs after the row is persisted,
+  and no Sentry token is stored. Provider HTTP errors map to a typed
+  `SentryIntegrationProviderError` and never carry the token, code, or client
+  secret.
+- `@shipfox/api-integration-sentry-dto`: add the install/connect request and
+  response schemas.
+- `@shipfox/api-integration-core`: wire the `getExistingSentryConnection` and
+  `connectSentryInstallation` closures into the Sentry provider (internal
+  wiring, no public API change).
+
+A concurrent same-install connect race (shared with GitHub) is tracked
+separately in ENG-409.

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -3,6 +3,7 @@ import {fileURLToPath} from 'node:url';
 import type {IntegrationConnection as CoreIntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {createDebugIntegrationProvider} from '@shipfox/api-integration-debug';
 import type {ConnectGithubInstallationInput} from '@shipfox/api-integration-github';
+import type {ConnectSentryInstallationInput} from '@shipfox/api-integration-sentry';
 import type {ModuleDatabase, ShipfoxModule} from '@shipfox/node-module';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 import {
@@ -178,12 +179,56 @@ async function loadGithubModuleParts(): Promise<GithubModuleParts> {
 async function loadSentryModuleParts(): Promise<SentryModuleParts> {
   const {
     createSentryIntegrationProvider,
+    getSentryInstallationByInstallationUuid,
+    upsertSentryInstallation,
     db: sentryDb,
     migrationsPath: sentryMigrationsPath,
   } = await import('@shipfox/api-integration-sentry');
 
+  async function getExistingSentryConnection(input: {
+    installationUuid: string;
+  }): Promise<CoreIntegrationConnection<'sentry'> | undefined> {
+    const installation = await getSentryInstallationByInstallationUuid(input.installationUuid);
+    if (!installation) return undefined;
+    const connection = await getIntegrationConnectionById(installation.connectionId);
+    if (!connection) return undefined;
+    return connection as CoreIntegrationConnection<'sentry'>;
+  }
+
+  async function connectSentryInstallation(
+    input: ConnectSentryInstallationInput,
+  ): Promise<CoreIntegrationConnection<'sentry'>> {
+    return await db().transaction(async (tx) => {
+      const connection = await upsertIntegrationConnection(
+        {
+          workspaceId: input.workspaceId,
+          provider: 'sentry',
+          externalAccountId: input.installationUuid,
+          displayName: input.displayName,
+          lifecycleStatus: 'active',
+        },
+        {tx},
+      );
+
+      await upsertSentryInstallation(
+        {
+          connectionId: connection.id,
+          installationUuid: input.installationUuid,
+          orgSlug: input.orgSlug,
+          status: 'installed',
+          installerUserId: input.installerUserId,
+        },
+        {tx},
+      );
+
+      return connection as CoreIntegrationConnection<'sentry'>;
+    });
+  }
+
   return {
     provider: createSentryIntegrationProvider({
+      getExistingSentryConnection,
+      connectSentryInstallation,
       coreDb: db,
       publishIntegrationEventReceived,
       recordDeliveryOnly,

--- a/libs/api/integration/sentry-dto/src/schemas/index.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/index.ts
@@ -1,1 +1,2 @@
+export * from './sentry.js';
 export * from './webhooks.js';

--- a/libs/api/integration/sentry-dto/src/schemas/sentry.test.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/sentry.test.ts
@@ -1,0 +1,63 @@
+import {sentryConnectBodySchema} from './sentry.js';
+
+describe('sentryConnectBodySchema', () => {
+  test('accepts a valid connect tuple', () => {
+    const body = {
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+      code: 'install-code',
+      installation_id: 'install-uuid-1',
+    };
+
+    const parsed = sentryConnectBodySchema.parse(body);
+
+    expect(parsed.installation_id).toBe('install-uuid-1');
+  });
+
+  test('rejects a missing code', () => {
+    const body = {
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+      installation_id: 'install-uuid-1',
+    };
+
+    const result = sentryConnectBodySchema.safeParse(body);
+
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a non-uuid workspace_id', () => {
+    const body = {
+      workspace_id: 'not-a-uuid',
+      code: 'install-code',
+      installation_id: 'install-uuid-1',
+    };
+
+    const result = sentryConnectBodySchema.safeParse(body);
+
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an empty installation_id', () => {
+    const body = {
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+      code: 'install-code',
+      installation_id: '',
+    };
+
+    const result = sentryConnectBodySchema.safeParse(body);
+
+    expect(result.success).toBe(false);
+  });
+
+  test('does not accept org_slug into the parsed body', () => {
+    const body = {
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+      code: 'install-code',
+      installation_id: 'install-uuid-1',
+      org_slug: 'acme',
+    };
+
+    const parsed = sentryConnectBodySchema.parse(body);
+
+    expect('org_slug' in parsed).toBe(false);
+  });
+});

--- a/libs/api/integration/sentry-dto/src/schemas/sentry.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/sentry.ts
@@ -1,0 +1,24 @@
+import {integrationConnectionDtoSchema} from '@shipfox/api-integration-core-dto';
+import {z} from 'zod';
+
+export const createSentryInstallBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+});
+export type CreateSentryInstallBodyDto = z.infer<typeof createSentryInstallBodySchema>;
+
+export const createSentryInstallResponseSchema = z.object({
+  install_url: z.string().url(),
+});
+export type CreateSentryInstallResponseDto = z.infer<typeof createSentryInstallResponseSchema>;
+
+// org_slug is deliberately absent: it is derived from Sentry after the exchange,
+// so a forged slug in the body cannot influence the stored connection.
+export const sentryConnectBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  code: z.string().min(1),
+  installation_id: z.string().min(1),
+});
+export type SentryConnectBodyDto = z.infer<typeof sentryConnectBodySchema>;
+
+export const sentryConnectResponseSchema = integrationConnectionDtoSchema;
+export type SentryConnectResponseDto = z.infer<typeof sentryConnectResponseSchema>;

--- a/libs/api/integration/sentry/README.md
+++ b/libs/api/integration/sentry/README.md
@@ -2,7 +2,8 @@
 
 Shipfox API Integration Sentry receives Sentry App webhooks and publishes
 normalized integration events for downstream modules such as triggers and
-projects.
+projects. It also exposes the install/connect flow that links a Sentry
+installation to a Shipfox workspace.
 
 ## Setup
 
@@ -54,6 +55,34 @@ Downstream trigger payloads receive the normalized `SentryIssuePayload` in
 
 A raw Sentry `ignored` action is normalized to `issue.archived` with
 `payload.action: 'archived'`.
+
+## Install / Connect Routes
+
+The provider mounts these authenticated routes (`AUTH_USER` bearer token):
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `POST` | `/integrations/sentry/install` | Returns the Sentry external-install URL for a workspace. |
+| `POST` | `/integrations/sentry/connect` | Links a Sentry installation to a workspace after the install redirect. |
+
+Sentry has no `state` parameter in its install redirect, so the workspace is
+taken from the request body (`workspace_id`) and authorized against the live
+session. `POST /connect` accepts `{workspace_id, code, installation_id}` only —
+the organization slug is derived from Sentry after the code exchange, never
+trusted from the client. The exchanged token is used in-memory for the optional
+verify-install call and then discarded; **no Sentry token is persisted**.
+
+## Sentry App registration
+
+Configure the Sentry App (Settings → Developer Settings → your app):
+
+- **Redirect URL:** point it at the client callback route, which reads
+  `code`, `installationId`, and `orgSlug` from the redirect query and calls
+  `POST /integrations/sentry/connect`.
+- **Webhooks:** enable the **Issue** resource so issue webhooks are delivered.
+- **Verify Install:** when enabled, the connect flow issues a
+  `PUT /api/0/sentry-app-installations/{installation_id}/` to mark the
+  installation installed; mirror the toggle with `SENTRY_APP_VERIFY_INSTALL`.
 
 ## Development
 

--- a/libs/api/integration/sentry/package.json
+++ b/libs/api/integration/sentry/package.json
@@ -37,14 +37,17 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-sentry-dto": "workspace:*",
+    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "ky": "^2.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/libs/api/integration/sentry/src/api/client.test.ts
+++ b/libs/api/integration/sentry/src/api/client.test.ts
@@ -1,0 +1,147 @@
+import {HTTPError, TimeoutError} from 'ky';
+import {SentryIntegrationProviderError} from '#core/errors.js';
+import {createSentryApiClient} from './client.js';
+
+const {postMock, getMock, putMock} = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  getMock: vi.fn(),
+  putMock: vi.fn(),
+}));
+
+vi.mock('ky', () => {
+  class HTTPError extends Error {
+    constructor(public response: {status: number; headers: Headers}) {
+      super('http');
+      this.name = 'HTTPError';
+    }
+  }
+  class TimeoutError extends Error {
+    constructor() {
+      super('timeout');
+      this.name = 'TimeoutError';
+    }
+  }
+  return {default: {post: postMock, get: getMock, put: putMock}, HTTPError, TimeoutError};
+});
+
+function resolves(data: unknown) {
+  return {json: () => Promise.resolve(data)};
+}
+
+function rejects(error: unknown) {
+  return {json: () => Promise.reject(error)};
+}
+
+function httpError(status: number, headers: Record<string, string> = {}): HTTPError {
+  return new HTTPError({status, headers: new Headers(headers)});
+}
+
+describe('createSentryApiClient.exchangeAuthorizationCode', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    getMock.mockReset();
+    putMock.mockReset();
+  });
+
+  it('returns the token, refresh token, and expiry', async () => {
+    postMock.mockReturnValue(
+      resolves({token: 'tok', refreshToken: 'refresh', expiresAt: '2026-06-11T12:00:00.000Z'}),
+    );
+    const client = createSentryApiClient();
+
+    const result = await client.exchangeAuthorizationCode({
+      installationUuid: 'uuid-1',
+      code: 'the-code',
+    });
+
+    expect(result).toEqual({
+      token: 'tok',
+      refreshToken: 'refresh',
+      expiresAt: '2026-06-11T12:00:00.000Z',
+    });
+  });
+
+  it('maps a 429 to rate-limited with retry-after seconds', async () => {
+    postMock.mockReturnValue(rejects(httpError(429, {'retry-after': '30'})));
+    const client = createSentryApiClient();
+
+    const result = client.exchangeAuthorizationCode({installationUuid: 'uuid-1', code: 'c'});
+
+    await expect(result).rejects.toMatchObject({reason: 'rate-limited', retryAfterSeconds: 30});
+    await expect(result).rejects.toBeInstanceOf(SentryIntegrationProviderError);
+  });
+
+  it('maps a 5xx to provider-unavailable', async () => {
+    postMock.mockReturnValue(rejects(httpError(503)));
+    const client = createSentryApiClient();
+
+    const result = client.exchangeAuthorizationCode({installationUuid: 'uuid-1', code: 'c'});
+
+    await expect(result).rejects.toMatchObject({reason: 'provider-unavailable'});
+  });
+
+  it('maps a forged-code 4xx to access-denied', async () => {
+    postMock.mockReturnValue(rejects(httpError(403)));
+    const client = createSentryApiClient();
+
+    const result = client.exchangeAuthorizationCode({installationUuid: 'uuid-1', code: 'c'});
+
+    await expect(result).rejects.toMatchObject({reason: 'access-denied'});
+  });
+
+  it('maps a timeout to timeout', async () => {
+    postMock.mockReturnValue(rejects(new TimeoutError()));
+    const client = createSentryApiClient();
+
+    const result = client.exchangeAuthorizationCode({installationUuid: 'uuid-1', code: 'c'});
+
+    await expect(result).rejects.toMatchObject({reason: 'timeout'});
+  });
+
+  it('maps a response without a token to malformed-provider-response', async () => {
+    postMock.mockReturnValue(resolves({refreshToken: 'r', expiresAt: 'x'}));
+    const client = createSentryApiClient();
+
+    const result = client.exchangeAuthorizationCode({installationUuid: 'uuid-1', code: 'c'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+
+  it('never leaks the code or client secret into the thrown error', async () => {
+    postMock.mockReturnValue(rejects(httpError(403)));
+    const client = createSentryApiClient();
+
+    const error = await client
+      .exchangeAuthorizationCode({installationUuid: 'uuid-1', code: 'super-secret-code'})
+      .catch((thrown: unknown) => thrown);
+
+    const serialized = `${(error as Error).message} ${JSON.stringify(error)} ${String((error as {cause?: unknown}).cause)}`;
+    expect(serialized).not.toContain('super-secret-code');
+    expect(serialized).not.toContain('test-client-secret');
+    expect((error as {cause?: unknown}).cause).toBeUndefined();
+  });
+});
+
+describe('createSentryApiClient.getInstallation', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it('derives the organization slug', async () => {
+    getMock.mockReturnValue(resolves({organization: {slug: 'acme'}}));
+    const client = createSentryApiClient();
+
+    const result = await client.getInstallation({installationUuid: 'uuid-1', token: 'tok'});
+
+    expect(result).toEqual({orgSlug: 'acme'});
+  });
+
+  it('maps a response without an organization slug to malformed-provider-response', async () => {
+    getMock.mockReturnValue(resolves({organization: {}}));
+    const client = createSentryApiClient();
+
+    const result = client.getInstallation({installationUuid: 'uuid-1', token: 'tok'});
+
+    await expect(result).rejects.toMatchObject({reason: 'malformed-provider-response'});
+  });
+});

--- a/libs/api/integration/sentry/src/api/client.ts
+++ b/libs/api/integration/sentry/src/api/client.ts
@@ -1,0 +1,127 @@
+import ky, {HTTPError, TimeoutError} from 'ky';
+import {config} from '#config.js';
+import {SentryIntegrationProviderError} from '#core/errors.js';
+
+const SENTRY_API_BASE = 'https://sentry.io/api/0';
+
+export interface SentryAuthorization {
+  token: string;
+  refreshToken: string;
+  expiresAt: string;
+}
+
+export interface SentryInstallationDetails {
+  orgSlug: string;
+}
+
+export interface SentryApiClient {
+  exchangeAuthorizationCode(input: {
+    installationUuid: string;
+    code: string;
+  }): Promise<SentryAuthorization>;
+  // Derived from Sentry so the org slug is never trusted from the client body.
+  getInstallation(input: {
+    installationUuid: string;
+    token: string;
+  }): Promise<SentryInstallationDetails>;
+  verifyInstallation(input: {installationUuid: string; token: string}): Promise<void>;
+}
+
+export function createSentryApiClient(): SentryApiClient {
+  return {
+    async exchangeAuthorizationCode(input) {
+      const body = await mapSentryError(() =>
+        ky
+          .post(
+            `${SENTRY_API_BASE}/sentry-app-installations/${input.installationUuid}/authorizations/`,
+            {
+              json: {
+                grant_type: 'authorization_code',
+                client_id: config.SENTRY_APP_CLIENT_ID,
+                client_secret: config.SENTRY_APP_CLIENT_SECRET,
+                code: input.code,
+              },
+            },
+          )
+          .json<{token?: unknown; refreshToken?: unknown; expiresAt?: unknown}>(),
+      );
+
+      if (
+        typeof body.token !== 'string' ||
+        typeof body.refreshToken !== 'string' ||
+        typeof body.expiresAt !== 'string'
+      ) {
+        throw new SentryIntegrationProviderError(
+          'malformed-provider-response',
+          'Sentry authorization response did not include a token',
+        );
+      }
+      return {token: body.token, refreshToken: body.refreshToken, expiresAt: body.expiresAt};
+    },
+
+    async getInstallation(input) {
+      const body = await mapSentryError(() =>
+        ky
+          .get(`${SENTRY_API_BASE}/sentry-app-installations/${input.installationUuid}/`, {
+            headers: {authorization: `Bearer ${input.token}`},
+          })
+          .json<{organization?: {slug?: unknown}}>(),
+      );
+
+      const slug = body.organization?.slug;
+      if (typeof slug !== 'string' || slug.length === 0) {
+        throw new SentryIntegrationProviderError(
+          'malformed-provider-response',
+          'Sentry installation response did not include an organization slug',
+        );
+      }
+      return {orgSlug: slug};
+    },
+
+    async verifyInstallation(input) {
+      await mapSentryError(() =>
+        ky
+          .put(`${SENTRY_API_BASE}/sentry-app-installations/${input.installationUuid}/`, {
+            headers: {authorization: `Bearer ${input.token}`},
+            json: {status: 'installed'},
+          })
+          .json<unknown>(),
+      );
+    },
+  };
+}
+
+// Build the error from status + a fixed message only — never the request body,
+// token, code, or client secret — so secrets cannot leak through the logged `cause`.
+async function mapSentryError<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof SentryIntegrationProviderError) throw error;
+    if (error instanceof HTTPError) {
+      const {status, headers} = error.response;
+      if (status === 429) {
+        throw new SentryIntegrationProviderError(
+          'rate-limited',
+          'Sentry request was rate limited',
+          retryAfterSeconds(headers),
+        );
+      }
+      if (status >= 500) {
+        throw new SentryIntegrationProviderError('provider-unavailable', 'Sentry request failed');
+      }
+      throw new SentryIntegrationProviderError('access-denied', 'Sentry request was rejected');
+    }
+    if (error instanceof TimeoutError) {
+      throw new SentryIntegrationProviderError('timeout', 'Sentry request timed out');
+    }
+    throw new SentryIntegrationProviderError('provider-unavailable', 'Sentry request failed');
+  }
+}
+
+function retryAfterSeconds(headers: Headers): number | undefined {
+  const retryAfter = headers.get('retry-after');
+  if (!retryAfter) return undefined;
+  const parsed = Number.parseInt(retryAfter, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}

--- a/libs/api/integration/sentry/src/core/errors.ts
+++ b/libs/api/integration/sentry/src/core/errors.ts
@@ -1,3 +1,16 @@
+import {IntegrationProviderError} from '@shipfox/api-integration-core-dto';
+
+export class SentryIntegrationProviderError extends IntegrationProviderError {}
+
+export class SentryInstallationAlreadyLinkedError extends Error {
+  constructor(public readonly installationUuid: string) {
+    super(
+      `Sentry installation is already linked to another Shipfox workspace: ${installationUuid}`,
+    );
+    this.name = 'SentryInstallationAlreadyLinkedError';
+  }
+}
+
 /**
  * Base for issue deliveries we received and authenticated but deliberately do
  * not publish. The webhook layer records them for dedup and acknowledges with a

--- a/libs/api/integration/sentry/src/core/install.test.ts
+++ b/libs/api/integration/sentry/src/core/install.test.ts
@@ -104,6 +104,18 @@ describe('handleSentryConnect', () => {
     expect(sentry.verifyInstallation).not.toHaveBeenCalled();
   });
 
+  it('returns the persisted connection when verify-install fails (non-fatal)', async () => {
+    const sentry = sentryClient({
+      verifyInstallation: vi.fn(() => Promise.reject(new Error('verify failed'))),
+    });
+    const {connectSentryInstallation, result} = run({sentry});
+
+    const connected = await result;
+
+    expect(connectSentryInstallation).toHaveBeenCalled();
+    expect(connected.lifecycleStatus).toBe('active');
+  });
+
   it('throws when the installation is linked to a different workspace', async () => {
     const sentry = sentryClient();
     const {result} = run({

--- a/libs/api/integration/sentry/src/core/install.test.ts
+++ b/libs/api/integration/sentry/src/core/install.test.ts
@@ -1,0 +1,153 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {SentryApiClient} from '#api/client.js';
+import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
+import {type ConnectSentryInstallationInput, handleSentryConnect} from './install.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_WORKSPACE_ID = '22222222-2222-4222-8222-222222222222';
+const INSTALL_UUID = 'install-uuid-1';
+
+function sentryClient(overrides: Partial<SentryApiClient> = {}): SentryApiClient {
+  return {
+    exchangeAuthorizationCode: vi.fn(() =>
+      Promise.resolve({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'}),
+    ),
+    getInstallation: vi.fn(() => Promise.resolve({orgSlug: 'acme'})),
+    verifyInstallation: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function connection(
+  overrides: Partial<IntegrationConnection<'sentry'>> = {},
+): IntegrationConnection<'sentry'> {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: WORKSPACE_ID,
+    provider: 'sentry',
+    externalAccountId: INSTALL_UUID,
+    displayName: 'Sentry acme',
+    lifecycleStatus: 'active',
+    capabilities: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+interface RunOptions {
+  sentry?: SentryApiClient;
+  verifyInstall?: boolean;
+  existing?: IntegrationConnection<'sentry'> | undefined;
+}
+
+function run(options: RunOptions = {}) {
+  const sentry = options.sentry ?? sentryClient();
+  const connectSentryInstallation = vi.fn((input: ConnectSentryInstallationInput) =>
+    Promise.resolve(
+      connection({
+        workspaceId: input.workspaceId,
+        externalAccountId: input.installationUuid,
+        displayName: input.displayName,
+      }),
+    ),
+  );
+  const getExistingSentryConnection = vi.fn(() => Promise.resolve(options.existing));
+
+  const result = handleSentryConnect({
+    sentry,
+    workspaceId: WORKSPACE_ID,
+    code: 'the-code',
+    installationUuid: INSTALL_UUID,
+    installerUserId: 'user-1',
+    verifyInstall: options.verifyInstall ?? true,
+    getExistingSentryConnection,
+    connectSentryInstallation,
+  });
+
+  return {sentry, connectSentryInstallation, getExistingSentryConnection, result};
+}
+
+describe('handleSentryConnect', () => {
+  it('exchanges, derives the org, persists, then verifies last', async () => {
+    const sentry = sentryClient();
+    const {connectSentryInstallation, result} = run({sentry});
+
+    const connected = await result;
+
+    expect(sentry.exchangeAuthorizationCode).toHaveBeenCalledWith({
+      installationUuid: INSTALL_UUID,
+      code: 'the-code',
+    });
+    expect(connectSentryInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: WORKSPACE_ID,
+        installationUuid: INSTALL_UUID,
+        orgSlug: 'acme',
+        displayName: 'Sentry acme',
+        installerUserId: 'user-1',
+      }),
+    );
+    expect(connected.provider).toBe('sentry');
+    // Verify runs AFTER the row is persisted.
+    const connectOrder = connectSentryInstallation.mock.invocationCallOrder[0];
+    const verifyOrder = vi.mocked(sentry.verifyInstallation).mock.invocationCallOrder[0];
+    expect(connectOrder).toBeLessThan(verifyOrder ?? 0);
+  });
+
+  it('skips verifyInstallation when the flag is off', async () => {
+    const sentry = sentryClient();
+    const {result} = run({sentry, verifyInstall: false});
+
+    await result;
+
+    expect(sentry.verifyInstallation).not.toHaveBeenCalled();
+  });
+
+  it('throws when the installation is linked to a different workspace', async () => {
+    const sentry = sentryClient();
+    const {result} = run({
+      sentry,
+      existing: connection({workspaceId: OTHER_WORKSPACE_ID}),
+    });
+
+    await expect(result).rejects.toBeInstanceOf(SentryInstallationAlreadyLinkedError);
+    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent for an already-active same-workspace connection', async () => {
+    const sentry = sentryClient();
+    const existing = connection({workspaceId: WORKSPACE_ID, lifecycleStatus: 'active'});
+    const {connectSentryInstallation, result} = run({sentry, existing});
+
+    const connected = await result;
+
+    expect(connected).toBe(existing);
+    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+    expect(connectSentryInstallation).not.toHaveBeenCalled();
+  });
+
+  it('re-activates a disabled same-workspace connection', async () => {
+    const sentry = sentryClient();
+    const existing = connection({workspaceId: WORKSPACE_ID, lifecycleStatus: 'disabled'});
+    const {connectSentryInstallation, result} = run({sentry, existing});
+
+    const connected = await result;
+
+    expect(sentry.exchangeAuthorizationCode).toHaveBeenCalled();
+    expect(connectSentryInstallation).toHaveBeenCalled();
+    expect(connected.lifecycleStatus).toBe('active');
+  });
+
+  it('persists nothing when the code exchange fails', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() => Promise.reject(new Error('forged code'))),
+    });
+    const {connectSentryInstallation, result} = run({sentry});
+
+    await expect(result).rejects.toThrow('forged code');
+    expect(sentry.getInstallation).not.toHaveBeenCalled();
+    expect(connectSentryInstallation).not.toHaveBeenCalled();
+    expect(sentry.verifyInstallation).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -1,0 +1,75 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {SentryApiClient} from '#api/client.js';
+import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
+
+export interface ConnectSentryInstallationInput {
+  workspaceId: string;
+  installationUuid: string;
+  orgSlug: string;
+  displayName: string;
+  installerUserId: string;
+}
+
+export interface HandleSentryConnectParams {
+  sentry: SentryApiClient;
+  workspaceId: string;
+  code: string;
+  installationUuid: string;
+  installerUserId: string;
+  verifyInstall: boolean;
+  getExistingSentryConnection: (input: {
+    installationUuid: string;
+  }) => Promise<IntegrationConnection<'sentry'> | undefined>;
+  connectSentryInstallation: (
+    input: ConnectSentryInstallationInput,
+  ) => Promise<IntegrationConnection<'sentry'>>;
+}
+
+// The "verify install" side effect runs AFTER the row is durably persisted, so a
+// verify failure leaves a working connection rather than a Sentry-side "installed"
+// state pointing at a row that was never written.
+export async function handleSentryConnect(
+  params: HandleSentryConnectParams,
+): Promise<IntegrationConnection<'sentry'>> {
+  const existing = await params.getExistingSentryConnection({
+    installationUuid: params.installationUuid,
+  });
+  if (existing && existing.workspaceId !== params.workspaceId) {
+    throw new SentryInstallationAlreadyLinkedError(params.installationUuid);
+  }
+  // Short-circuit so a replayed callback does not re-exchange the single-use code.
+  if (existing && existing.lifecycleStatus === 'active') {
+    return existing;
+  }
+
+  // Exchanging the code is also the authenticity check — a forged installation
+  // id fails here and nothing is persisted.
+  const authorization = await params.sentry.exchangeAuthorizationCode({
+    installationUuid: params.installationUuid,
+    code: params.code,
+  });
+
+  const {orgSlug} = await params.sentry.getInstallation({
+    installationUuid: params.installationUuid,
+    token: authorization.token,
+  });
+
+  // For a previously uninstalled (disabled) connection, this re-activates both the
+  // connection lifecycle and the installation status.
+  const connection = await params.connectSentryInstallation({
+    workspaceId: params.workspaceId,
+    installationUuid: params.installationUuid,
+    orgSlug,
+    displayName: `Sentry ${orgSlug}`,
+    installerUserId: params.installerUserId,
+  });
+
+  if (params.verifyInstall) {
+    await params.sentry.verifyInstallation({
+      installationUuid: params.installationUuid,
+      token: authorization.token,
+    });
+  }
+
+  return connection;
+}

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -1,4 +1,5 @@
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {SentryApiClient} from '#api/client.js';
 import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
 
@@ -65,10 +66,21 @@ export async function handleSentryConnect(
   });
 
   if (params.verifyInstall) {
-    await params.sentry.verifyInstallation({
-      installationUuid: params.installationUuid,
-      token: authorization.token,
-    });
+    // Best-effort: the connection is already persisted and receiving webhooks, so
+    // a verify failure only leaves the install pending on Sentry's side. Failing
+    // the connect would strand a working row behind the idempotent short-circuit
+    // on retry (re-verifying needs a fresh token we cannot mint yet), so we log it.
+    try {
+      await params.sentry.verifyInstallation({
+        installationUuid: params.installationUuid,
+        token: authorization.token,
+      });
+    } catch (error) {
+      logger().warn(
+        {installationUuid: params.installationUuid, connectionId: connection.id, err: error},
+        'sentry connect: verify-install failed after persistence, connection is active',
+      );
+    }
   }
 
   return connection;

--- a/libs/api/integration/sentry/src/index.ts
+++ b/libs/api/integration/sentry/src/index.ts
@@ -5,10 +5,22 @@ import type {
   UpdateIntegrationConnectionLifecycleStatusFn,
 } from '@shipfox/api-integration-core-dto';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {createSentryApiClient, type SentryApiClient} from '#api/client.js';
 import {closeDb, db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
+import {
+  type CreateSentryIntegrationRoutesOptions,
+  createSentryIntegrationRoutes,
+} from '#presentation/routes/install.js';
 import {createSentryWebhookRoutes} from '#presentation/routes/webhooks.js';
 
+export type {SentryApiClient} from '#api/client.js';
+export {
+  SentryInstallationAlreadyLinkedError,
+  SentryIntegrationProviderError,
+} from '#core/errors.js';
+export type {ConnectSentryInstallationInput} from '#core/install.js';
+export {handleSentryConnect} from '#core/install.js';
 export {handleSentryInstallationLifecycle, handleSentryIssueEvent} from '#core/webhook.js';
 export type {
   SentryInstallation,
@@ -22,7 +34,9 @@ export {
 } from '#db/installations.js';
 export {closeDb, db, migrationsPath};
 
-export interface CreateSentryIntegrationProviderOptions {
+export interface CreateSentryIntegrationProviderOptions
+  extends Omit<CreateSentryIntegrationRoutesOptions, 'sentry'> {
+  sentry?: SentryApiClient | undefined;
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
@@ -31,10 +45,17 @@ export interface CreateSentryIntegrationProviderOptions {
 }
 
 export function createSentryIntegrationProvider(options: CreateSentryIntegrationProviderOptions) {
+  const sentry = options.sentry ?? createSentryApiClient();
+
   return {
     provider: 'sentry' as const,
     displayName: 'Sentry',
     routes: [
+      createSentryIntegrationRoutes({
+        sentry,
+        getExistingSentryConnection: options.getExistingSentryConnection,
+        connectSentryInstallation: options.connectSentryInstallation,
+      }),
       createSentryWebhookRoutes({
         coreDb: options.coreDb,
         publishIntegrationEventReceived: options.publishIntegrationEventReceived,

--- a/libs/api/integration/sentry/src/presentation/dto/integrations.ts
+++ b/libs/api/integration/sentry/src/presentation/dto/integrations.ts
@@ -1,0 +1,16 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+
+// Sentry exposes no adapters, so its connections carry no capabilities.
+export function toIntegrationConnectionDto(connection: IntegrationConnection<'sentry'>) {
+  return {
+    id: connection.id,
+    workspace_id: connection.workspaceId,
+    provider: connection.provider,
+    external_account_id: connection.externalAccountId,
+    display_name: connection.displayName,
+    lifecycle_status: connection.lifecycleStatus,
+    capabilities: [],
+    created_at: connection.createdAt.toISOString(),
+    updated_at: connection.updatedAt.toISOString(),
+  };
+}

--- a/libs/api/integration/sentry/src/presentation/routes/errors.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/errors.ts
@@ -1,0 +1,25 @@
+import type {IntegrationProviderErrorReason} from '@shipfox/api-integration-core-dto';
+import {ClientError} from '@shipfox/node-fastify';
+import {
+  SentryInstallationAlreadyLinkedError,
+  SentryIntegrationProviderError,
+} from '#core/errors.js';
+
+function providerStatus(reason: IntegrationProviderErrorReason): number {
+  if (reason === 'rate-limited') return 429;
+  if (reason === 'timeout' || reason === 'provider-unavailable') return 503;
+  return 422;
+}
+
+export function sentryRouteErrorHandler(error: unknown): never {
+  if (error instanceof SentryInstallationAlreadyLinkedError) {
+    throw new ClientError(error.message, 'sentry-installation-already-linked', {status: 409});
+  }
+  if (error instanceof SentryIntegrationProviderError) {
+    throw new ClientError(error.message, error.reason, {
+      details: {retry_after_seconds: error.retryAfterSeconds},
+      status: providerStatus(error.reason),
+    });
+  }
+  throw error;
+}

--- a/libs/api/integration/sentry/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.test.ts
@@ -1,0 +1,227 @@
+import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import type {SentryApiClient} from '#api/client.js';
+import {SentryIntegrationProviderError} from '#core/errors.js';
+import {createSentryIntegrationProvider} from '#index.js';
+
+vi.mock('@shipfox/api-workspaces', () => ({
+  requireMembership: vi.fn(({workspaceId}) =>
+    Promise.resolve({
+      workspaceId,
+      workspace: {
+        id: workspaceId,
+        name: 'Workspace',
+        status: 'active',
+        settings: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      userId: 'user-1',
+      role: 'admin',
+    }),
+  ),
+}));
+
+const {requireMembership} = await import('@shipfox/api-workspaces');
+const requireMembershipMock = vi.mocked(requireMembership);
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: (request: FastifyRequest) => {
+    if (request.headers.authorization !== 'Bearer user') {
+      throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
+    }
+    setUserContext(
+      request,
+      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+    );
+    return Promise.resolve();
+  },
+};
+
+function sentryClient(overrides: Partial<SentryApiClient> = {}): SentryApiClient {
+  return {
+    exchangeAuthorizationCode: vi.fn(() =>
+      Promise.resolve({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'}),
+    ),
+    getInstallation: vi.fn(() => Promise.resolve({orgSlug: 'acme'})),
+    verifyInstallation: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+interface CreateTestAppOptions {
+  sentry?: SentryApiClient;
+  existingConnection?: IntegrationConnection<'sentry'> | undefined;
+}
+
+async function createTestApp(options: CreateTestAppOptions = {}): Promise<FastifyInstance> {
+  const provider = createSentryIntegrationProvider({
+    sentry: options.sentry ?? sentryClient(),
+    getExistingSentryConnection: vi.fn(() => Promise.resolve(options.existingConnection)),
+    connectSentryInstallation: vi.fn((input) =>
+      Promise.resolve({
+        id: crypto.randomUUID(),
+        workspaceId: input.workspaceId,
+        provider: 'sentry' as const,
+        externalAccountId: input.installationUuid,
+        displayName: input.displayName,
+        lifecycleStatus: 'active' as const,
+        capabilities: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+    ),
+    // Webhook receiver dependencies — install/connect tests don't exercise them.
+    coreDb: vi.fn() as never,
+    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+    recordDeliveryOnly: vi.fn(() => Promise.resolve()),
+    getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
+    updateConnectionLifecycleStatus: vi.fn(() => Promise.resolve(undefined)),
+  });
+  const app = await createApp({auth: [fakeUserAuth], routes: provider.routes, swagger: false});
+  await app.ready();
+  return app;
+}
+
+function connectPayload() {
+  return {
+    workspace_id: crypto.randomUUID(),
+    code: 'the-code',
+    installation_id: 'install-uuid-1',
+  };
+}
+
+describe('Sentry integration routes', () => {
+  beforeEach(async () => {
+    requireMembershipMock.mockClear();
+    await closeApp();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('requires auth for the install URL', async () => {
+    const app = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/install',
+      payload: {workspace_id: crypto.randomUUID()},
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns the external-install URL for a member', async () => {
+    const app = await createTestApp();
+    const workspaceId = crypto.randomUUID();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/install',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: workspaceId},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().install_url).toBe(
+      'https://sentry.io/sentry-apps/shipfox-test/external-install/',
+    );
+    expect(requireMembershipMock).toHaveBeenCalledWith(expect.objectContaining({workspaceId}));
+  });
+
+  it('requires auth for connect', async () => {
+    const app = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('connects an installation and returns a connection DTO with no capabilities', async () => {
+    const app = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().provider).toBe('sentry');
+    expect(res.json().external_account_id).toBe('install-uuid-1');
+    expect(res.json().display_name).toBe('Sentry acme');
+    expect(res.json().capabilities).toEqual([]);
+  });
+
+  it('returns 403 when the caller is not a workspace member', async () => {
+    requireMembershipMock.mockRejectedValueOnce(
+      new ClientError('Not a member of this workspace', 'forbidden', {status: 403}),
+    );
+    const app = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('returns 409 when the installation is already linked to another workspace', async () => {
+    const app = await createTestApp({
+      existingConnection: {
+        id: crypto.randomUUID(),
+        workspaceId: crypto.randomUUID(),
+        provider: 'sentry',
+        externalAccountId: 'install-uuid-1',
+        displayName: 'Sentry acme',
+        lifecycleStatus: 'active',
+        capabilities: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('sentry-installation-already-linked');
+  });
+
+  it('maps a provider error to its status', async () => {
+    const app = await createTestApp({
+      sentry: sentryClient({
+        exchangeAuthorizationCode: vi.fn(() =>
+          Promise.reject(new SentryIntegrationProviderError('access-denied', 'rejected')),
+        ),
+      }),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('access-denied');
+  });
+});

--- a/libs/api/integration/sentry/src/presentation/routes/install.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.ts
@@ -1,0 +1,91 @@
+import {AUTH_USER, requireUserContext} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {
+  createSentryInstallBodySchema,
+  createSentryInstallResponseSchema,
+  sentryConnectBodySchema,
+  sentryConnectResponseSchema,
+} from '@shipfox/api-integration-sentry-dto';
+import {requireMembership} from '@shipfox/api-workspaces';
+import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {SentryApiClient} from '#api/client.js';
+import {config} from '#config.js';
+import {type ConnectSentryInstallationInput, handleSentryConnect} from '#core/install.js';
+import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
+import {sentryRouteErrorHandler} from './errors.js';
+
+export interface CreateSentryIntegrationRoutesOptions {
+  sentry: SentryApiClient;
+  getExistingSentryConnection: (input: {
+    installationUuid: string;
+  }) => Promise<IntegrationConnection<'sentry'> | undefined>;
+  connectSentryInstallation: (
+    input: ConnectSentryInstallationInput,
+  ) => Promise<IntegrationConnection<'sentry'>>;
+}
+
+export function createSentryIntegrationRoutes({
+  sentry,
+  getExistingSentryConnection,
+  connectSentryInstallation,
+}: CreateSentryIntegrationRoutesOptions): RouteGroup {
+  const createInstallRoute = defineRoute({
+    method: 'POST',
+    path: '/install',
+    auth: AUTH_USER,
+    description: 'Create a Sentry app external-install URL for a workspace.',
+    schema: {
+      body: createSentryInstallBodySchema,
+      response: {
+        200: createSentryInstallResponseSchema,
+      },
+    },
+    handler: async (request) => {
+      const {workspace_id: workspaceId} = request.body;
+
+      await requireMembership({request, workspaceId});
+
+      // Sentry has no state param to embed; the server owns the slug.
+      const installUrl = `https://sentry.io/sentry-apps/${config.SENTRY_APP_SLUG}/external-install/`;
+      return {install_url: installUrl};
+    },
+  });
+
+  const connectRoute = defineRoute({
+    method: 'POST',
+    path: '/connect',
+    auth: AUTH_USER,
+    description: 'Link a Sentry installation to a workspace after the install redirect.',
+    schema: {
+      body: sentryConnectBodySchema,
+      response: {
+        200: sentryConnectResponseSchema,
+      },
+    },
+    errorHandler: sentryRouteErrorHandler,
+    handler: async (request) => {
+      const {workspace_id: workspaceId, code, installation_id: installationUuid} = request.body;
+      const actor = requireUserContext(request);
+
+      await requireMembership({request, workspaceId});
+
+      const connection = await handleSentryConnect({
+        sentry,
+        workspaceId,
+        code,
+        installationUuid,
+        installerUserId: actor.userId,
+        verifyInstall: config.SENTRY_APP_VERIFY_INSTALL,
+        getExistingSentryConnection,
+        connectSentryInstallation,
+      });
+
+      return toIntegrationConnectionDto(connection);
+    },
+  });
+
+  return {
+    prefix: '/integrations/sentry',
+    routes: [createInstallRoute, connectRoute],
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1028,12 +1028,18 @@ importers:
 
   libs/api/integration/sentry:
     dependencies:
+      '@shipfox/api-auth-context':
+        specifier: workspace:*
+        version: link:../../auth-context
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../core-dto
       '@shipfox/api-integration-sentry-dto':
         specifier: workspace:*
         version: link:../sentry-dto
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../../shared/common/config
@@ -1052,6 +1058,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      ky:
+        specifier: ^2.0.0
+        version: 2.0.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Adds the Sentry **install/connect flow** so a workspace member can link a Sentry installation to a Shipfox workspace. This is **PR2 of 2** — PR1 (#147) shipped the webhook receiver; without a way to create the installation + connection rows, every inbound webhook resolved to "unknown installation" and was dropped, so PR1 is inert in production until this lands.

## Why

PR1 normalizes Sentry issue webhooks and publishes `integrations.event.received`, but the receiver looks up an `integrations_sentry_installations` row that nothing created yet. PR2 adds the two routes that write that row + the core `integrations_connections` row, so resolving/unresolving a Sentry issue fans out to matching workflow trigger subscriptions.

## What

- **`@shipfox/api-integration-sentry`:** a stateless `SentryApiClient` (authorization-code exchange, org-slug derivation, optional verify-install), `handleSentryConnect`, and two authenticated routes — `POST /integrations/sentry/install` (returns the external-install URL) and `POST /integrations/sentry/connect` (links the installation). Provider HTTP failures map to a typed `SentryIntegrationProviderError`.
- **`@shipfox/api-integration-sentry-dto`:** install/connect request/response schemas.
- **`@shipfox/api-integration-core`:** wires the `getExistingSentryConnection` + `connectSentryInstallation` closures into the provider (internal wiring, no public API change).

## Decisions worth a careful review

- **No state param → POST /connect, session-authorized.** Sentry's install redirect carries no `state`, so the workspace comes from the request body and is authorized with `requireMembership`. `AUTH_USER` is **bearer-token** auth (not cookie), so authenticated POSTs are inherently CSRF-safe — no API-level CSRF guard. The residual lure risk (a member submitting an attacker's org tuple) is mitigated by the client confirmation screen in the follow-up UI ticket.
- **`org_slug` is derived from Sentry, not trusted from the body.** The connect body is `{workspace_id, code, installation_id}` only; the org slug comes from a `getInstallation` call after the exchange.
- **Persist before verify.** `verifyInstallation` (the `PUT status=installed` side effect) runs **after** the DB transaction, so a verify failure leaves a working connection rather than a Sentry-side "installed" state pointing at a row that was never written.
- **No secrets stored or logged.** No Sentry token is persisted; the error mapper never carries the token, OAuth code, or client secret into the thrown error's `cause`/`data` (asserted by a test).
- **Idempotent reconnect + disabled re-activation.** An already-active same-workspace connection short-circuits before the (single-use) code exchange; a previously-uninstalled (disabled) connection re-activates both the connection lifecycle and the installation status.

## Known limitation (deferred)

A concurrent same-install connect to two workspaces can repoint the installation row and orphan the loser's active connection. GitHub's provider has the identical pattern; the shared core-layer fix is tracked in ENG-409. Low probability (one install per org, unguessable id, both sides need a real installer).

## Out of scope (follow-up ticket)

Client UI (connect button, Sentry callback page, workspace-confirmation screen) and `/__e2e/integration-sentry` helper routes.

Refs ENG-409

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Sentry install/connect flow with `POST /integrations/sentry/install` and `POST /integrations/sentry/connect` to link a Sentry installation to a workspace and activate webhook handling.

- **New Features**
  - Introduced stateless `SentryApiClient` (code exchange, org-slug derivation, optional verify-install) with typed `SentryIntegrationProviderError`; tokens are never stored and secrets never leak in errors.
  - Added authenticated routes: `POST /integrations/sentry/install` (returns external install URL) and `POST /integrations/sentry/connect` (creates connection) with schemas in `@shipfox/api-integration-sentry-dto`; enforce `AUTH_USER` and workspace membership via `@shipfox/api-workspaces`.
  - Derive `org_slug` from Sentry; request accepts `{workspace_id, code, installation_id}` only. Persist connection + installation in one transaction before verify; verify-install is best-effort and non-fatal after persistence.
  - Idempotent reconnect and disabled re-activation; 409 when installation is linked to another workspace; provider errors map to 422/429/503.
  - Wired `getExistingSentryConnection` and `connectSentryInstallation` into `@shipfox/api-integration-core`. Concurrent connect race is tracked in ENG-409.

- **Dependencies**
  - Added `ky`, `@shipfox/api-auth-context`, and `@shipfox/api-workspaces`.

<sup>Written for commit 12a26124f190cfc2b3b4cf4838bb092f03927303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

