### PR TITLE
Clarify JSDoc guidance for internal functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,8 +264,10 @@ restate the type or the name:
  */
 ```
 
-Skip JSDoc entirely on internal, app-local, or self-evident functions; a
-docstring that only echoes `getRunner(id): Runner` is noise.
+Self-evident functions need no docstring at all; one that echoes
+`getRunner(id): Runner` is noise. But when an internal function does earn a
+comment, prefer `/** ... */` over a loose `//`: it attaches to the symbol and
+surfaces on hover at every call site.
 
 ### Keep planning and process out of the source
 


### PR DESCRIPTION
Refine the "Use JSDoc for documentation, not narration" section of the agent guidelines.

The previous wording ("Skip JSDoc entirely on internal, app-local, or self-evident functions") read as a blanket ban on JSDoc for any internal function. That collides with the section's own bar for comments: when an internal function genuinely carries a why that earns a comment, the real choice is not JSDoc versus nothing, it is JSDoc versus a loose `//`. JSDoc wins there because it attaches to the symbol, surfaces on hover at every call site, and travels with the signature.

The rule for *whether* to comment is unchanged; only the guidance on *form* is sharpened. Self-evident functions still get no docstring.

Docs-only change to the root AGENTS.md (CLAUDE.md is a symlink to it), so no package is affected and no changeset is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified JSDoc guidance: self-evident functions get no docstring; when an internal function needs a why comment, prefer a `/** ... */` block over a loose `//` so it attaches to the symbol and shows on hover at call sites.
Docs-only change to AGENTS.md; no code or package changes.

<sup>Written for commit ca90e25f5a6e9f62b76adf099893b836b06a2932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

