### PR TITLE
Build packages before running their tests

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -32,7 +32,7 @@
     },
     "test": {
       "cache": true,
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build", "build"]
     },
     "test:e2e": {
       "cache": false,


### PR DESCRIPTION
Add the package's own `build` to the `test` task's `dependsOn` in `turbo.jsonc`, alongside the existing upstream `^build`.

Tests that launch a Temporal worker load the workflow code from the package's compiled `dist` output rather than from source. Without a self-build dependency, Turbo could run a package's `test` task before its `build`, so the worker would start against stale or missing compiled output. Declaring the dependency makes Turbo always build a package before running its tests, and it applies to every package whose tests spin up a Temporal worker (e.g. `@shipfox/api-workflows`), not just one.

Scoped this to the global `test` task rather than a single package override, since the constraint holds for any test suite that boots Temporal from `dist`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure each package builds before its tests run by adding `build` alongside `^build` to `test.dependsOn` in `turbo.jsonc`. This prevents Temporal worker tests from running against stale or missing `dist` output across all packages (e.g., `@shipfox/api-workflows`).

<sup>Written for commit 89ecfd510bf673568ab47edf713ff94a23b5c144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

