### PR TITLE
[api/workflows] Add a synthetic "Set up job" step with setup-error reporting

### DIFF
--- a/.changeset/eng-412-setup-job-step.md
+++ b/.changeset/eng-412-setup-job-step.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+---
+
+Give every runner-dispatched job a synthetic "Set up job" step at position 0 (à la GitHub Actions), so failures that happen around the user steps — workspace preparation today, the repository checkout next — are reported through the existing per-step protocol instead of hanging the job until the lease/timeout fires. The runner prepares the per-job workspace inside this step and reports the outcome; a failed setup flows through the existing fail-job cascade, finalizing the job `failed` in seconds with no user step run.
+
+Extends `stepErrorDtoSchema` with an optional machine-readable `reason` (`workspace_prep_failed`, `git_unavailable`, `checkout_*`, `setup_aborted`) and a `category` (`setup` | `user`). The runner reports `reason`; the server derives `category` from the step type on read (the runner is an untrusted boundary). The restart resolver now skips the synthetic step so a user step named "Set up job" can never rewind setup mid-job.

--- a/apps/runner/src/runner.test.ts
+++ b/apps/runner/src/runner.test.ts
@@ -14,7 +14,8 @@ vi.mock('#heartbeat-loop.js', () => ({
 
 vi.mock('#workspace.js', async (importActual) => ({
   ...(await importActual<typeof import('#workspace.js')>()),
-  prepareWorkspace: vi.fn(),
+  jobWorkspacePath: vi.fn(),
+  cleanupWorkspace: vi.fn(),
   resolveWorkspaceRoot: vi.fn(),
 }));
 
@@ -31,9 +32,16 @@ vi.mock('#api-client.js', () => ({
 import {createLeaseClient, requestJob} from '#api-client.js';
 import {runJob, startRunner} from '#runner.js';
 import {runJobSteps} from '#step-loop.js';
-import {prepareWorkspace, resolveWorkspaceRoot, UnsafeWorkspaceRootError} from '#workspace.js';
+import {
+  cleanupWorkspace,
+  InvalidJobIdError,
+  jobWorkspacePath,
+  resolveWorkspaceRoot,
+  UnsafeWorkspaceRootError,
+} from '#workspace.js';
 
-const mockPrepareWorkspace = vi.mocked(prepareWorkspace);
+const mockJobWorkspacePath = vi.mocked(jobWorkspacePath);
+const mockCleanupWorkspace = vi.mocked(cleanupWorkspace);
 const mockResolveWorkspaceRoot = vi.mocked(resolveWorkspaceRoot);
 const mockRunJobSteps = vi.mocked(runJobSteps);
 const mockCreateLeaseClient = vi.mocked(createLeaseClient);
@@ -48,46 +56,44 @@ const JOB = {
 } as Parameters<typeof runJob>[0];
 
 const WORKSPACE_ROOT = '/tmp/shipfox-test-root';
-
-function mockWorkspace() {
-  const cleanup = vi.fn().mockResolvedValue(undefined);
-  mockPrepareWorkspace.mockResolvedValue({cwd: '/tmp/job-1', cleanup});
-  return cleanup;
-}
+const JOB_CWD = '/tmp/shipfox-test-root/job-1';
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe('runJob', () => {
-  it('runs the step loop with the workspace cwd and lease client, then cleans up', async () => {
-    const cleanup = mockWorkspace();
+  it('runs the step loop with the per-job cwd and lease client, then cleans up', async () => {
+    mockJobWorkspacePath.mockReturnValue(JOB_CWD);
     mockRunJobSteps.mockResolvedValue();
 
     await runJob(JOB, WORKSPACE_ROOT);
 
     expect(mockCreateLeaseClient).toHaveBeenCalledWith(JOB.lease_token);
     expect(mockRunJobSteps).toHaveBeenCalledWith(
-      expect.objectContaining({jobId: JOB.job_id, cwd: '/tmp/job-1'}),
+      expect.objectContaining({jobId: JOB.job_id, cwd: JOB_CWD}),
     );
-    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(mockCleanupWorkspace).toHaveBeenCalledWith(JOB_CWD);
   });
 
-  it('cleans up when the step loop throws', async () => {
-    const cleanup = mockWorkspace();
+  it('cleans up the per-job cwd when the step loop throws', async () => {
+    mockJobWorkspacePath.mockReturnValue(JOB_CWD);
     mockRunJobSteps.mockRejectedValue(new Error('aborted'));
 
     await runJob(JOB, WORKSPACE_ROOT);
 
-    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(mockCleanupWorkspace).toHaveBeenCalledWith(JOB_CWD);
   });
 
-  it('runs no steps when preparing the workspace fails', async () => {
-    mockPrepareWorkspace.mockRejectedValue(new Error('mkdir failed'));
+  it('skips the job without running the loop or cleaning up when the job id is invalid', async () => {
+    mockJobWorkspacePath.mockImplementation(() => {
+      throw new InvalidJobIdError(JOB.job_id);
+    });
 
     await runJob(JOB, WORKSPACE_ROOT);
 
     expect(mockRunJobSteps).not.toHaveBeenCalled();
+    expect(mockCleanupWorkspace).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/runner/src/runner.ts
+++ b/apps/runner/src/runner.ts
@@ -4,7 +4,7 @@ import {createLeaseClient, requestJob} from '#api-client.js';
 import {config} from '#config.js';
 import {startHeartbeatLoop} from '#heartbeat-loop.js';
 import {runJobSteps} from '#step-loop.js';
-import {prepareWorkspace, resolveWorkspaceRoot, type Workspace} from '#workspace.js';
+import {cleanupWorkspace, jobWorkspacePath, resolveWorkspaceRoot} from '#workspace.js';
 
 let running = true;
 let shuttingDown = false;
@@ -59,6 +59,17 @@ export async function runJob(
   job: Awaited<ReturnType<typeof requestJob>> & object,
   workspaceRoot: string,
 ): Promise<void> {
+  // The path is deterministic, so compute it up front for cleanup on every exit
+  // path; the setup step (position 0) creates the directory. An invalid job id is
+  // an internal/claim error: bail before starting any per-job resources.
+  let cwd: string;
+  try {
+    cwd = jobWorkspacePath(job.job_id, workspaceRoot);
+  } catch (error) {
+    logger().error({err: error, jobId: job.job_id}, 'Invalid job id; skipping job');
+    return;
+  }
+
   const ac = new AbortController();
   currentJobAbortController = ac;
 
@@ -67,22 +78,21 @@ export async function runJob(
     maxStaleMs: config.SHIPFOX_HEARTBEAT_MAX_STALE_MS,
   });
 
-  let workspace: Workspace | undefined;
   try {
-    workspace = await prepareWorkspace(job, workspaceRoot);
     const leaseClient = createLeaseClient(job.lease_token);
-    await runJobSteps({jobId: job.job_id, leaseClient, signal: ac.signal, cwd: workspace.cwd});
+    await runJobSteps({jobId: job.job_id, leaseClient, signal: ac.signal, cwd});
     logger().info({jobId: job.job_id}, 'Job step loop finished');
   } catch (stepLoopError) {
-    // Workspace prep failed, retries are exhausted, or a non-retryable error surfaced.
-    // Bail this job; the lease expires server-side and the outer poll moves on. Do not
-    // re-pull (would re-execute).
+    // A non-retryable error surfaced (e.g. an invalid job id, or an unexpected
+    // throw from the loop). Bail this job; the lease expires server-side and the
+    // outer poll moves on. Do not re-pull (would re-execute). Setup failures do
+    // NOT reach here — they report through the step protocol and finalize the job.
     logger().error({err: stepLoopError, jobId: job.job_id}, 'Job step loop failed');
   } finally {
     heartbeatLoop.stop();
     if (currentJobAbortController === ac) currentJobAbortController = undefined;
     // Clean up the per-job workspace on every exit path.
-    if (workspace) await workspace.cleanup();
+    await cleanupWorkspace(cwd);
   }
 }
 

--- a/apps/runner/src/runner.ts
+++ b/apps/runner/src/runner.ts
@@ -83,10 +83,10 @@ export async function runJob(
     await runJobSteps({jobId: job.job_id, leaseClient, signal: ac.signal, cwd});
     logger().info({jobId: job.job_id}, 'Job step loop finished');
   } catch (stepLoopError) {
-    // A non-retryable error surfaced (e.g. an invalid job id, or an unexpected
-    // throw from the loop). Bail this job; the lease expires server-side and the
-    // outer poll moves on. Do not re-pull (would re-execute). Setup failures do
-    // NOT reach here — they report through the step protocol and finalize the job.
+    // A non-retryable error surfaced (e.g. an unexpected throw from the loop).
+    // Bail this job; the lease expires server-side and the outer poll moves on.
+    // Do not re-pull (would re-execute). Setup failures do NOT reach here — they
+    // report through the step protocol and finalize the job.
     logger().error({err: stepLoopError, jobId: job.job_id}, 'Job step loop failed');
   } finally {
     heartbeatLoop.stop();

--- a/apps/runner/src/setup-step.test.ts
+++ b/apps/runner/src/setup-step.test.ts
@@ -1,0 +1,35 @@
+vi.mock('#workspace.js', () => ({
+  createJobDir: vi.fn(),
+}));
+
+import {executeSetupStep} from '#setup-step.js';
+import {createJobDir} from '#workspace.js';
+
+const mockCreateJobDir = vi.mocked(createJobDir);
+
+const CWD = '/tmp/shipfox-test-root/job-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('executeSetupStep', () => {
+  it('prepares the workspace and succeeds', async () => {
+    mockCreateJobDir.mockResolvedValue();
+
+    const result = await executeSetupStep({cwd: CWD});
+
+    expect(mockCreateJobDir).toHaveBeenCalledWith(CWD);
+    expect(result).toEqual({success: true, output: '', error: null, exit_code: 0});
+  });
+
+  it('reports workspace_prep_failed when creating the directory fails', async () => {
+    mockCreateJobDir.mockRejectedValue(new Error('mkdir denied'));
+
+    const result = await executeSetupStep({cwd: CWD});
+
+    expect(result.success).toBe(false);
+    expect(result.exit_code).toBeNull();
+    expect(result.error).toEqual({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+  });
+});

--- a/apps/runner/src/setup-step.ts
+++ b/apps/runner/src/setup-step.ts
@@ -1,12 +1,9 @@
 import type {StepResult} from '#run-step.js';
 import {createJobDir} from '#workspace.js';
 
-// The synthetic "Set up job" step body. Today it owns workspace preparation; the
-// repository checkout (and the `git` precondition it needs) plug in here with
-// ENG-405, reporting `checkout_*` / `git_unavailable` reasons through the same
-// StepResult shape. Failures are reported through the normal step protocol, so a
-// setup failure fails the job in seconds instead of hanging until the lease
-// expires.
+// The synthetic "Set up job" step body. It owns per-job workspace preparation and
+// reports failures through the normal step protocol, so a setup failure fails the
+// job in seconds instead of hanging until the lease expires.
 //
 // Abort handling lives in the step loop, not here: an aborted job stops the loop
 // before it reports (see step-loop.ts), exactly like an abort during any step.

--- a/apps/runner/src/setup-step.ts
+++ b/apps/runner/src/setup-step.ts
@@ -1,0 +1,29 @@
+import type {StepResult} from '#run-step.js';
+import {createJobDir} from '#workspace.js';
+
+// The synthetic "Set up job" step body. Today it owns workspace preparation; the
+// repository checkout (and the `git` precondition it needs) plug in here with
+// ENG-405, reporting `checkout_*` / `git_unavailable` reasons through the same
+// StepResult shape. Failures are reported through the normal step protocol, so a
+// setup failure fails the job in seconds instead of hanging until the lease
+// expires.
+//
+// Abort handling lives in the step loop, not here: an aborted job stops the loop
+// before it reports (see step-loop.ts), exactly like an abort during any step.
+export async function executeSetupStep(params: {cwd: string}): Promise<StepResult> {
+  try {
+    await createJobDir(params.cwd);
+  } catch (error) {
+    return {
+      success: false,
+      output: '',
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        reason: 'workspace_prep_failed',
+      },
+      exit_code: null,
+    };
+  }
+
+  return {success: true, output: '', error: null, exit_code: 0};
+}

--- a/apps/runner/src/step-loop.test.ts
+++ b/apps/runner/src/step-loop.test.ts
@@ -4,6 +4,7 @@ import {HTTPError} from 'ky';
 const requestNextStepMock = vi.fn();
 const reportStepMock = vi.fn();
 const executeRunStepMock = vi.fn();
+const executeSetupStepMock = vi.fn();
 
 vi.mock('#api-client.js', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
@@ -13,6 +14,10 @@ vi.mock('#api-client.js', () => ({
 
 vi.mock('#run-step.js', () => ({
   executeRunStep: (...args: unknown[]) => executeRunStepMock(...args),
+}));
+
+vi.mock('#setup-step.js', () => ({
+  executeSetupStep: (...args: unknown[]) => executeSetupStepMock(...args),
 }));
 
 const {runJobSteps} = await import('#step-loop.js');
@@ -25,13 +30,18 @@ describe('runJobSteps', () => {
     requestNextStepMock.mockReset();
     reportStepMock.mockReset();
     executeRunStepMock.mockReset();
+    executeSetupStepMock.mockReset();
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
+    // Setup succeeds by default; tests that exercise setup failure override it.
+    executeSetupStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
   });
 
-  it('pulls, executes, reports (echoing attempt + exit_code), then stops on done', async () => {
-    const step = buildStep();
+  it('runs the setup step then a run step against the prepared cwd, reporting both', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
     requestNextStepMock
-      .mockResolvedValueOnce(stepResponse(step, 1))
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
       .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
     executeRunStepMock.mockResolvedValue({
       success: true,
@@ -43,16 +53,64 @@ describe('runJobSteps', () => {
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
 
-    expect(executeRunStepMock).toHaveBeenCalledTimes(1);
+    expect(executeSetupStepMock).toHaveBeenCalledWith({cwd: '/work'});
+    expect(executeRunStepMock).toHaveBeenCalledWith(run, {signal: ac.signal, cwd: '/work'});
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
-      stepId: step.id,
+      stepId: run.id,
       attempt: 1,
       status: 'succeeded',
       error: null,
       exitCode: 0,
       signal: ac.signal,
     });
-    expect(requestNextStepMock).toHaveBeenCalledTimes(2);
+    expect(requestNextStepMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports the setup step failed with its reason, then stops on cancel:true (no user step runs)', async () => {
+    const setup = buildSetupStep();
+    const error = {message: 'mkdir denied', reason: 'workspace_prep_failed' as const};
+    requestNextStepMock.mockResolvedValueOnce(stepResponse(setup, 1));
+    executeSetupStepMock.mockResolvedValueOnce({
+      success: false,
+      output: '',
+      error,
+      exit_code: null,
+    });
+    reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
+      stepId: setup.id,
+      attempt: 1,
+      status: 'failed',
+      error,
+      exitCode: null,
+      signal: ac.signal,
+    });
+    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(requestNextStepMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails a run step dispatched before setup without spawning it', async () => {
+    const run = buildRunStep();
+    requestNextStepMock.mockResolvedValueOnce(stepResponse(run, 1));
+    reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    expect(executeSetupStepMock).not.toHaveBeenCalled();
+    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
+      stepId: run.id,
+      attempt: 1,
+      status: 'failed',
+      error: {message: 'Run step dispatched before setup prepared the workspace'},
+      exitCode: null,
+      signal: ac.signal,
+    });
   });
 
   it('stops immediately when there are no steps', async () => {
@@ -61,7 +119,7 @@ describe('runJobSteps', () => {
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
 
-    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(reportStepMock).not.toHaveBeenCalled();
   });
 
@@ -73,7 +131,7 @@ describe('runJobSteps', () => {
       runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'}),
     ).resolves.toBeUndefined();
 
-    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(reportStepMock).not.toHaveBeenCalled();
   });
 
@@ -88,37 +146,47 @@ describe('runJobSteps', () => {
     expect(requestNextStepMock).toHaveBeenCalledTimes(1);
   });
 
-  it('reports a failed step with its exit_code, then stops on cancel:true', async () => {
-    const step = buildStep();
+  it('reports a failed run step with its exit_code after setup, then stops on cancel:true', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
     const error = {message: 'Command exited with code 1', exit_code: 1};
-    requestNextStepMock.mockResolvedValueOnce(stepResponse(step, 1));
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
     executeRunStepMock.mockResolvedValueOnce({
       success: false,
       output: 'boom\n',
       error,
       exit_code: 1,
     });
-    reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
-      stepId: step.id,
+      stepId: run.id,
       attempt: 1,
       status: 'failed',
       error,
       exitCode: 1,
       signal: ac.signal,
     });
-    expect(requestNextStepMock).toHaveBeenCalledTimes(1);
+    expect(requestNextStepMock).toHaveBeenCalledTimes(2);
   });
 
   it('reports the step failed when executeRunStep throws (no leaked error, no hung step)', async () => {
-    const step = buildStep();
-    requestNextStepMock.mockResolvedValueOnce(stepResponse(step, 2));
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 2));
     executeRunStepMock.mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
-    reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
     await expect(
@@ -126,7 +194,7 @@ describe('runJobSteps', () => {
     ).resolves.toBeUndefined();
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
-      stepId: step.id,
+      stepId: run.id,
       attempt: 2,
       status: 'failed',
       error: {message: 'ENOSPC: no space left on device'},
@@ -135,18 +203,18 @@ describe('runJobSteps', () => {
     });
   });
 
-  it('does not report when the signal aborts mid-step', async () => {
-    const step = buildStep();
+  it('does not report when the signal aborts during setup', async () => {
+    const setup = buildSetupStep();
     const ac = new AbortController();
-    requestNextStepMock.mockResolvedValueOnce(stepResponse(step, 1));
-    executeRunStepMock.mockImplementationOnce(() => {
+    requestNextStepMock.mockResolvedValueOnce(stepResponse(setup, 1));
+    executeSetupStepMock.mockImplementationOnce(() => {
       ac.abort();
       return Promise.resolve({success: true, output: '', error: null, exit_code: 0});
     });
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
 
-    expect(executeRunStepMock).toHaveBeenCalledTimes(1);
+    expect(executeSetupStepMock).toHaveBeenCalledTimes(1);
     expect(reportStepMock).not.toHaveBeenCalled();
   });
 
@@ -159,6 +227,21 @@ describe('runJobSteps', () => {
     expect(requestNextStepMock).not.toHaveBeenCalled();
   });
 });
+
+function buildSetupStep(overrides: Partial<StepDto> = {}): StepDto {
+  return buildStep({
+    id: '00000000-0000-0000-0000-0000000000b0',
+    name: 'Set up job',
+    type: 'setup',
+    config: {},
+    position: 0,
+    ...overrides,
+  });
+}
+
+function buildRunStep(overrides: Partial<StepDto> = {}): StepDto {
+  return buildStep({position: 1, ...overrides});
+}
 
 function buildStep(overrides: Partial<StepDto> = {}): StepDto {
   return {

--- a/apps/runner/src/step-loop.ts
+++ b/apps/runner/src/step-loop.ts
@@ -3,6 +3,7 @@ import {logger} from '@shipfox/node-opentelemetry';
 import type {KyInstance} from 'ky';
 import {HTTPError, reportStep, requestNextStep} from '#api-client.js';
 import {executeRunStep, type StepResult} from '#run-step.js';
+import {executeSetupStep} from '#setup-step.js';
 
 // Reporting a step before pulling the next one is the safety invariant: a lost report is
 // retried in place (next/report are idempotent), so a step is never re-pulled or
@@ -14,6 +15,13 @@ export async function runJobSteps(params: {
   cwd: string;
 }): Promise<void> {
   const {jobId, leaseClient, signal, cwd} = params;
+
+  // The setup step (position 0) prepares the workspace; every run step assumes it
+  // ran. This guard makes the invariant explicit: a run step pulled before a
+  // successful setup is reported as a clean failure rather than spawning against an
+  // unprepared cwd. It assumes one runner executes a job's full lifecycle, which
+  // holds today (a job is never re-dispatched mid-flight).
+  let workspacePrepared = false;
 
   while (!signal.aborted) {
     let next: NextStepResponseDto;
@@ -43,7 +51,23 @@ export async function runJobSteps(params: {
 
     let result: StepResult;
     try {
-      result = await executeRunStep(step, {signal, cwd});
+      if (step.type === 'setup') {
+        result = await executeSetupStep({cwd});
+        if (result.success) workspacePrepared = true;
+      } else if (!workspacePrepared) {
+        // Invariant violation (a run step before setup prepared the cwd), not a
+        // setup-phase failure, so no `reason`. step.type is 'run' so the server
+        // derives category 'user'. Only reachable for a setup-less in-flight job
+        // hitting a new runner during the rollout window.
+        result = {
+          success: false,
+          output: '',
+          error: {message: 'Run step dispatched before setup prepared the workspace'},
+          exit_code: null,
+        };
+      } else {
+        result = await executeRunStep(step, {signal, cwd});
+      }
     } catch (error) {
       // A local executor failure (e.g. writing the temp script) throws before a
       // StepResult exists. Report the step failed so it does not hang `running`.
@@ -64,7 +88,10 @@ export async function runJobSteps(params: {
     if (result.success) {
       logger().info({jobId, stepId: step.id, stepName: step.name}, `Step ${stepLabel} succeeded`);
     } else {
-      logger().error({jobId, stepId: step.id, stepName: step.name}, `Step ${stepLabel} failed`);
+      logger().error(
+        {jobId, stepId: step.id, stepName: step.name, reason: result.error?.reason},
+        `Step ${stepLabel} failed`,
+      );
     }
 
     const report = await reportStep(leaseClient, {

--- a/apps/runner/src/workspace.test.ts
+++ b/apps/runner/src/workspace.test.ts
@@ -3,8 +3,9 @@ import {homedir, tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
   cleanupWorkspace,
+  createJobDir,
   InvalidJobIdError,
-  prepareWorkspace,
+  jobWorkspacePath,
   resolveWorkspaceRoot,
   UnsafeWorkspaceRootError,
 } from '#workspace.js';
@@ -41,7 +42,25 @@ describe('resolveWorkspaceRoot', () => {
   });
 });
 
-describe('prepareWorkspace', () => {
+describe('jobWorkspacePath', () => {
+  const root = '/var/shipfox/work';
+
+  it('names the directory after the job id under the root', () => {
+    const jobId = '44444444-4444-4444-8444-444444444444';
+
+    const cwd = jobWorkspacePath(jobId, root);
+
+    expect(cwd).toBe(join(root, `job-${jobId}`));
+  });
+
+  it('rejects a job id that is not a UUID', () => {
+    const resolve = () => jobWorkspacePath('../../etc/passwd', root);
+
+    expect(resolve).toThrow(InvalidJobIdError);
+  });
+});
+
+describe('createJobDir', () => {
   let root: string;
 
   beforeEach(async () => {
@@ -52,51 +71,23 @@ describe('prepareWorkspace', () => {
     await rm(root, {recursive: true, force: true});
   });
 
-  it('creates a per-job directory under the root', async () => {
-    const workspace = await prepareWorkspace(
-      {job_id: '11111111-1111-4111-8111-111111111111'},
-      root,
-    );
+  it('creates the per-job directory', async () => {
+    const cwd = join(root, 'job-11111111-1111-4111-8111-111111111111');
 
-    expect(workspace.cwd.startsWith(root)).toBe(true);
-    expect((await stat(workspace.cwd)).isDirectory()).toBe(true);
+    await createJobDir(cwd);
+
+    expect((await stat(cwd)).isDirectory()).toBe(true);
   });
 
   it('pre-cleans a dirty directory left from a previous run', async () => {
-    const jobId = '22222222-2222-4222-8222-222222222222';
-    const first = await prepareWorkspace({job_id: jobId}, root);
-    await writeFile(join(first.cwd, 'stale.txt'), 'leftover');
+    const cwd = join(root, 'job-22222222-2222-4222-8222-222222222222');
+    await createJobDir(cwd);
+    await writeFile(join(cwd, 'stale.txt'), 'leftover');
 
-    const second = await prepareWorkspace({job_id: jobId}, root);
+    await createJobDir(cwd);
 
-    const readStale = () => stat(join(second.cwd, 'stale.txt'));
+    const readStale = () => stat(join(cwd, 'stale.txt'));
     await expect(readStale()).rejects.toThrow();
-  });
-
-  it('names the directory after the job id', async () => {
-    const jobId = '44444444-4444-4444-8444-444444444444';
-
-    const workspace = await prepareWorkspace({job_id: jobId}, root);
-
-    expect(workspace.cwd).toBe(join(root, `job-${jobId}`));
-  });
-
-  it('rejects a job id that is not a UUID', async () => {
-    const prepare = () => prepareWorkspace({job_id: '../../etc/passwd'}, root);
-
-    await expect(prepare()).rejects.toThrow(InvalidJobIdError);
-  });
-
-  it('cleanup() removes the directory', async () => {
-    const workspace = await prepareWorkspace(
-      {job_id: '33333333-3333-4333-8333-333333333333'},
-      root,
-    );
-
-    await workspace.cleanup();
-
-    const readDir = () => stat(workspace.cwd);
-    await expect(readDir()).rejects.toThrow();
   });
 });
 

--- a/apps/runner/src/workspace.ts
+++ b/apps/runner/src/workspace.ts
@@ -56,38 +56,39 @@ export function resolveWorkspaceRoot(config: WorkspaceConfig): string {
   return resolved;
 }
 
-export interface Workspace {
-  cwd: string;
-  cleanup(): Promise<void>;
-}
-
 // The job id is the only input to the per-job path; assert it is the UUID the
 // API contract guarantees rather than munging it, so a malformed id fails the
 // job loudly instead of silently reshaping the directory name.
 const JOB_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
- * Pre-cleans the per-job directory before creating it, so a directory left by a
- * previous crash is never reused. Throws when the job id is not the UUID the
- * API contract guarantees, since it is the only input to the directory path.
+ * The deterministic per-job directory path. Pure: validates the id and builds the
+ * path without touching the filesystem, so `runJob` can compute it up front (for
+ * cleanup on every exit path) while the setup step owns the actual directory
+ * creation. Throws {@link InvalidJobIdError} when the id is not the UUID the API
+ * contract guarantees, since it is the only input to the path.
  */
-export async function prepareWorkspace(job: {job_id: string}, root: string): Promise<Workspace> {
-  if (!JOB_ID_PATTERN.test(job.job_id)) {
-    throw new InvalidJobIdError(job.job_id);
+export function jobWorkspacePath(jobId: string, root: string): string {
+  if (!JOB_ID_PATTERN.test(jobId)) {
+    throw new InvalidJobIdError(jobId);
   }
+  return join(root, `job-${jobId}`);
+}
 
-  const cwd = join(root, `job-${job.job_id}`);
-
+/**
+ * Pre-cleans the per-job directory before creating it, so a directory left by a
+ * previous crash is never reused. Run inside the setup step so a prep failure is
+ * reported through the step protocol rather than bailing the job.
+ */
+export async function createJobDir(cwd: string): Promise<void> {
   // Pre-clean the per-job directory only — never the configured root.
   await rm(cwd, {recursive: true, force: true});
   await mkdir(cwd, {recursive: true});
-
-  return {cwd, cleanup: () => cleanupWorkspace(cwd)};
 }
 
 /**
  * Never throws: failures are logged and swallowed so a dirty directory can't
- * mask the job result; the next prepareWorkspace pre-clean reclaims it.
+ * mask the job result; the next createJobDir pre-clean reclaims it.
  */
 export async function cleanupWorkspace(cwd: string): Promise<void> {
   try {

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -29,10 +29,14 @@ export {
   runStatusSchema,
   type StepAttemptDto,
   type StepDto,
+  type StepErrorCategory,
   type StepErrorDtoShape,
+  type StepErrorReason,
   stepAttemptDtoSchema,
   stepDtoSchema,
+  stepErrorCategorySchema,
   stepErrorDtoSchema,
+  stepErrorReasonSchema,
 } from '#schemas/index.js';
 export {
   WORKFLOW_RUN_CREATED,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -33,8 +33,12 @@ export {
 export {
   type StepAttemptDto,
   type StepDto,
+  type StepErrorCategory,
   type StepErrorDtoShape,
+  type StepErrorReason,
   stepAttemptDtoSchema,
   stepDtoSchema,
+  stepErrorCategorySchema,
   stepErrorDtoSchema,
+  stepErrorReasonSchema,
 } from './step.js';

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -1,9 +1,9 @@
 import {z} from 'zod';
 
 // Machine-readable cause of a setup-phase failure, for DB troubleshooting. The
-// runner reports it; `checkout_*` and `git_unavailable` arrive with the checkout
-// work (ENG-405), `setup_aborted` is reserved for a future best-effort abort-report
-// path (today an abort stops the runner without reporting).
+// runner reports it and the server stores it as-is. The runner currently emits
+// `workspace_prep_failed`; the `checkout_*`, `git_unavailable`, and `setup_aborted`
+// values complete the taxonomy the read path accepts.
 export const stepErrorReasonSchema = z.enum([
   'checkout_failed',
   'checkout_auth_failed',

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -1,10 +1,33 @@
 import {z} from 'zod';
 
+// Machine-readable cause of a setup-phase failure, for DB troubleshooting. The
+// runner reports it; `checkout_*` and `git_unavailable` arrive with the checkout
+// work (ENG-405), `setup_aborted` is reserved for a future best-effort abort-report
+// path (today an abort stops the runner without reporting).
+export const stepErrorReasonSchema = z.enum([
+  'checkout_failed',
+  'checkout_auth_failed',
+  'checkout_unavailable',
+  'git_unavailable',
+  'workspace_prep_failed',
+  'setup_aborted',
+]);
+
+export type StepErrorReason = z.infer<typeof stepErrorReasonSchema>;
+
+// Whether a failure is infrastructure (`setup`) or user-code (`user`). Server-derived
+// from the step's type on the read path; the runner never sends it.
+export const stepErrorCategorySchema = z.enum(['setup', 'user']);
+
+export type StepErrorCategory = z.infer<typeof stepErrorCategorySchema>;
+
 export const stepErrorDtoSchema = z
   .object({
     message: z.string(),
     exit_code: z.number().int().nullable().optional(),
     signal: z.string().optional(),
+    reason: stepErrorReasonSchema.optional(),
+    category: stepErrorCategorySchema.optional(),
   })
   .nullable();
 

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.test.ts
@@ -138,6 +138,35 @@ describe('decideStepTransition', () => {
     });
   });
 
+  test('restart_from never resolves to the synthetic setup step (no workspace re-delete)', () => {
+    // A user step legitimately named "Set up job" shares its name with the synthetic
+    // setup step at position 0. Restart must resolve to the user step, not position 0.
+    const setup = step({
+      id: 'setup',
+      name: 'Set up job',
+      type: 'setup',
+      position: 0,
+      status: 'succeeded',
+    });
+    const userSetup = step({id: 's1', name: 'Set up job', position: 1, status: 'succeeded'});
+    const target = step({id: 's2', position: 2, status: 'running'});
+
+    const decision = decideStepTransition({
+      steps: [setup, userSetup, target],
+      target,
+      reportedAttempt: 1,
+      result: {status: 'failed', exitCode: 1},
+      gateOutcome: {kind: 'failed', source: 'exit_code == 0'},
+      gateOnFailure: {restartFrom: 'Set up job'},
+    });
+
+    expect(decision).toMatchObject({
+      kind: 'restart-job-from-step',
+      restartFromStepId: 's1',
+      restartFromPosition: 1,
+    });
+  });
+
   test('restart is refused (exhausted) once the gating step hits the attempt cap', () => {
     const restartTarget = step({id: 's0', name: 'producer', position: 0, status: 'succeeded'});
     const target = step({id: 's1', position: 1, status: 'running'});

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -143,8 +143,15 @@ export function decideStepTransition(input: DecideStepTransitionInput): StepTran
 
   // 3. Restart when a policy is configured and the failure is checkable.
   if (gateOnFailure?.restartFrom && !uncheckable) {
+    // Exclude the synthetic setup step: a user step legitimately named "Set up job"
+    // would otherwise resolve to position 0 and rewind setup (deleting the workspace
+    // mid-job). Duplicate user-step names are already impossible (normalize rejects
+    // them with duplicate-step-id), so this is the only collision to guard.
     const restartStep = steps.find(
-      (step) => step.position < target.position && step.name === gateOnFailure.restartFrom,
+      (step) =>
+        step.type !== 'setup' &&
+        step.position < target.position &&
+        step.name === gateOnFailure.restartFrom,
     );
     if (!restartStep) {
       // The model validates restart_from to an earlier named step, but fail closed

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -37,6 +37,14 @@ describe('materializeWorkflowModel', () => {
 
     const rows = materializeWorkflowModel(model);
 
+    const setupStep = {
+      sourceName: 'Set up job',
+      status: 'pending',
+      type: 'setup',
+      config: {},
+      position: 0,
+    };
+
     expect(rows).toEqual([
       {
         sourceName: 'build',
@@ -44,12 +52,13 @@ describe('materializeWorkflowModel', () => {
         runner: ['ubuntu-latest'],
         position: 0,
         steps: [
+          setupStep,
           {
             sourceName: 'install',
             status: 'pending',
             type: 'run',
             config: {run: 'npm install'},
-            position: 0,
+            position: 1,
           },
           {
             sourceName: null,
@@ -62,7 +71,7 @@ describe('materializeWorkflowModel', () => {
                 on_failure: {restart_from: 'install', output: 'Build failed'},
               },
             },
-            position: 1,
+            position: 2,
           },
         ],
       },
@@ -72,15 +81,26 @@ describe('materializeWorkflowModel', () => {
         runner: ['ubuntu-latest', 'node-22'],
         position: 1,
         steps: [
+          setupStep,
           {
             sourceName: null,
             status: 'pending',
             type: 'run',
             config: {run: 'npm test'},
-            position: 0,
+            position: 1,
           },
         ],
       },
+    ]);
+  });
+
+  it('gives a job with no user steps just the synthetic setup step', () => {
+    const model = workflowModel({jobs: {noop: {steps: []}}});
+
+    const rows = materializeWorkflowModel(model);
+
+    expect(rows[0]?.steps).toEqual([
+      {sourceName: 'Set up job', status: 'pending', type: 'setup', config: {}, position: 0},
     ]);
   });
 

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -20,10 +20,9 @@ export interface MaterializedWorkflowStep {
 }
 
 // Synthetic "Set up job" step prepended to every job at position 0, mirroring
-// GitHub Actions' implicit setup step. The runner prepares the workspace (and,
-// with ENG-405, checks out the repo) here; failures report through the normal
-// step protocol instead of hanging the job until the lease/timeout fires. Its
-// config is credential-free.
+// GitHub Actions' implicit setup step. The runner prepares the workspace here;
+// failures report through the normal step protocol instead of hanging the job
+// until the lease/timeout fires. Its config is credential-free.
 const SETUP_STEP: MaterializedWorkflowStep = {
   sourceName: 'Set up job',
   status: 'pending',

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -14,10 +14,23 @@ export interface MaterializedWorkflowJob {
 export interface MaterializedWorkflowStep {
   readonly sourceName: string | null;
   readonly status: 'pending';
-  readonly type: WorkflowModelStep['kind'];
+  readonly type: WorkflowModelStep['kind'] | 'setup';
   readonly config: Readonly<Record<string, unknown>>;
   readonly position: number;
 }
+
+// Synthetic "Set up job" step prepended to every job at position 0, mirroring
+// GitHub Actions' implicit setup step. The runner prepares the workspace (and,
+// with ENG-405, checks out the repo) here; failures report through the normal
+// step protocol instead of hanging the job until the lease/timeout fires. Its
+// config is credential-free.
+const SETUP_STEP: MaterializedWorkflowStep = {
+  sourceName: 'Set up job',
+  status: 'pending',
+  type: 'setup',
+  config: {},
+  position: 0,
+};
 
 export function materializeWorkflowModel(model: WorkflowModel): readonly MaterializedWorkflowJob[] {
   const jobsById = new Map(model.jobs.map((job) => [job.id, job]));
@@ -27,13 +40,18 @@ export function materializeWorkflowModel(model: WorkflowModel): readonly Materia
     dependencies: dependencySourceNames(job, jobsById),
     runner: job.runner,
     position,
-    steps: job.steps.map((step, stepPosition) => ({
-      sourceName: step.sourceName ?? null,
-      status: 'pending',
-      type: step.kind,
-      config: stepConfig(step),
-      position: stepPosition,
-    })),
+    // Every job runs on a runner (scheduling never filters on the runner field),
+    // so every job gets a setup step. User steps shift to position 1..n.
+    steps: [
+      SETUP_STEP,
+      ...job.steps.map((step, stepPosition) => ({
+        sourceName: step.sourceName ?? null,
+        status: 'pending' as const,
+        type: step.kind,
+        config: stepConfig(step),
+        position: stepPosition + 1,
+      })),
+    ],
   }));
 }
 

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1,7 +1,8 @@
 import {WORKFLOW_RUN_CREATED, WORKFLOWS_JOB_TIMED_OUT} from '@shipfox/api-workflows-dto';
-import {and, eq, sql} from 'drizzle-orm';
+import {eq, sql} from 'drizzle-orm';
 import {JobNotFoundError} from '#core/errors.js';
 import {recordStepResult} from '#core/job-execution.js';
+import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 import {db} from './db.js';
 import {jobs} from './schema/jobs.js';
@@ -860,18 +861,9 @@ describe('workflow run queries', () => {
         },
       });
       const jobId = (await getJobsByRunId(run.id))[0]?.id as string;
-      // createWorkflowRun prepends a synthetic "Set up job" step to every job. These
-      // tests exercise step-execution mechanics in isolation, so strip it and renumber
-      // the user steps back to 0-based to match the steps they declared.
-      await db().transaction(async (tx) => {
-        await tx
-          .delete(stepsTable)
-          .where(and(eq(stepsTable.jobId, jobId), eq(stepsTable.type, 'setup')));
-        await tx
-          .update(stepsTable)
-          .set({position: sql`${stepsTable.position} - 1`})
-          .where(eq(stepsTable.jobId, jobId));
-      });
+      // These tests exercise step-execution mechanics in isolation, so strip the
+      // synthetic setup step and renumber the user steps back to 0-based.
+      await stripSetupStep(jobId);
       const running = await updateJobStatus({jobId, status: 'running', expectedVersion: 1});
       const jobSteps = await getStepsByJobId(jobId);
       return {jobId, runningVersion: running.version, jobSteps};

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1,5 +1,5 @@
 import {WORKFLOW_RUN_CREATED, WORKFLOWS_JOB_TIMED_OUT} from '@shipfox/api-workflows-dto';
-import {eq, sql} from 'drizzle-orm';
+import {and, eq, sql} from 'drizzle-orm';
 import {JobNotFoundError} from '#core/errors.js';
 import {recordStepResult} from '#core/job-execution.js';
 import {workflowModel} from '#test/index.js';
@@ -66,9 +66,16 @@ describe('workflow run queries', () => {
       expect(runJobs).toHaveLength(1);
       expect(runJobs[0]?.name).toBe('build');
 
+      // Every job gets a synthetic "Set up job" step at position 0; user steps follow.
       const jobSteps = await getStepsByJobId(runJobs[0]?.id as string);
-      expect(jobSteps).toHaveLength(1);
-      expect(jobSteps[0]?.config).toEqual({run: 'echo hello'});
+      expect(jobSteps).toHaveLength(2);
+      expect(jobSteps[0]).toMatchObject({
+        type: 'setup',
+        name: 'Set up job',
+        position: 0,
+        config: {},
+      });
+      expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
     });
 
     test('writes workflows.run.created outbox event in same transaction', async () => {
@@ -241,9 +248,11 @@ describe('workflow run queries', () => {
       const runJobs = await getJobsByRunId(run.id);
       expect(runJobs).toHaveLength(1);
 
+      // A job with no user steps still gets the synthetic setup step.
       const jobSteps = await getStepsByJobId(runJobs[0]?.id as string);
 
-      expect(jobSteps).toHaveLength(0);
+      expect(jobSteps).toHaveLength(1);
+      expect(jobSteps[0]).toMatchObject({type: 'setup', name: 'Set up job', position: 0});
     });
 
     test('stores step with optional name', async () => {
@@ -269,8 +278,10 @@ describe('workflow run queries', () => {
       const runJobs = await getJobsByRunId(run.id);
       const jobSteps = await getStepsByJobId(runJobs[0]?.id as string);
 
-      expect(jobSteps[0]?.name).toBe('Install deps');
-      expect(jobSteps[1]?.name).toBeNull();
+      // Index 0 is the synthetic setup step; user steps start at index 1.
+      expect(jobSteps[0]?.name).toBe('Set up job');
+      expect(jobSteps[1]?.name).toBe('Install deps');
+      expect(jobSteps[2]?.name).toBeNull();
     });
 
     test('stores frozen step config', async () => {
@@ -294,8 +305,9 @@ describe('workflow run queries', () => {
       const runJobs = await getJobsByRunId(run.id);
       const jobSteps = await getStepsByJobId(runJobs[0]?.id as string);
 
-      expect(jobSteps[0]?.type).toBe('run');
-      expect(jobSteps[0]?.config).toEqual({run: 'make build'});
+      // Index 0 is the synthetic setup step; the user run step is at index 1.
+      expect(jobSteps[1]?.type).toBe('run');
+      expect(jobSteps[1]?.config).toEqual({run: 'make build'});
     });
 
     test('stores inputs when provided', async () => {
@@ -515,10 +527,12 @@ describe('workflow run queries', () => {
       const runJobs = await getJobsByRunId(run.id);
       const jobSteps = await getStepsByJobId(runJobs[0]?.id as string);
 
-      expect(jobSteps).toHaveLength(3);
-      expect(jobSteps[0]?.position).toBe(0);
+      // The synthetic setup step occupies position 0; user steps follow at 1..3.
+      expect(jobSteps).toHaveLength(4);
+      expect(jobSteps[0]).toMatchObject({type: 'setup', position: 0});
       expect(jobSteps[1]?.position).toBe(1);
       expect(jobSteps[2]?.position).toBe(2);
+      expect(jobSteps[3]?.position).toBe(3);
     });
   });
 
@@ -789,8 +803,9 @@ describe('workflow run queries', () => {
       const jobId = runJobs[0]?.id ?? '';
       await bulkUpdateStepStatuses({jobId, status: 'succeeded'});
 
+      // 3 user steps + the synthetic setup step.
       const jobSteps = await getStepsByJobId(jobId);
-      expect(jobSteps).toHaveLength(3);
+      expect(jobSteps).toHaveLength(4);
       for (const step of jobSteps) {
         expect(step.status).toBe('succeeded');
       }
@@ -845,6 +860,18 @@ describe('workflow run queries', () => {
         },
       });
       const jobId = (await getJobsByRunId(run.id))[0]?.id as string;
+      // createWorkflowRun prepends a synthetic "Set up job" step to every job. These
+      // tests exercise step-execution mechanics in isolation, so strip it and renumber
+      // the user steps back to 0-based to match the steps they declared.
+      await db().transaction(async (tx) => {
+        await tx
+          .delete(stepsTable)
+          .where(and(eq(stepsTable.jobId, jobId), eq(stepsTable.type, 'setup')));
+        await tx
+          .update(stepsTable)
+          .set({position: sql`${stepsTable.position} - 1`})
+          .where(eq(stepsTable.jobId, jobId));
+      });
       const running = await updateJobStatus({jobId, status: 'running', expectedVersion: 1});
       const jobSteps = await getStepsByJobId(jobId);
       return {jobId, runningVersion: running.version, jobSteps};

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -1,0 +1,75 @@
+import type {Step} from '#core/entities/step.js';
+import {fromStepErrorDto, toStepDto} from './step.js';
+
+function step(overrides: Partial<Step> & {type: string}): Step {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    jobId: '00000000-0000-0000-0000-0000000000aa',
+    name: null,
+    status: 'failed',
+    config: {},
+    output: null,
+    error: null,
+    position: 0,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('fromStepErrorDto', () => {
+  it('persists the machine-readable reason in camelCase', () => {
+    const persisted = fromStepErrorDto({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+
+    expect(persisted).toEqual({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+  });
+
+  it('ignores a runner-supplied category (the server derives it on read)', () => {
+    const persisted = fromStepErrorDto({
+      message: 'mkdir denied',
+      reason: 'workspace_prep_failed',
+      category: 'setup',
+    });
+
+    expect(persisted).not.toHaveProperty('category');
+  });
+
+  it('returns null for a missing error', () => {
+    expect(fromStepErrorDto(undefined)).toBeNull();
+    expect(fromStepErrorDto(null)).toBeNull();
+  });
+});
+
+describe('toStepDto error category', () => {
+  it("derives category 'setup' for a setup step error and surfaces the reason", () => {
+    const dto = toStepDto(
+      step({type: 'setup', error: {message: 'mkdir denied', reason: 'workspace_prep_failed'}}),
+    );
+
+    expect(dto.error).toEqual({
+      message: 'mkdir denied',
+      reason: 'workspace_prep_failed',
+      category: 'setup',
+    });
+  });
+
+  it("derives category 'user' for a run step error", () => {
+    const dto = toStepDto(
+      step({type: 'run', error: {message: 'Command exited with code 1', exitCode: 1}}),
+    );
+
+    expect(dto.error).toEqual({
+      message: 'Command exited with code 1',
+      exit_code: 1,
+      category: 'user',
+    });
+  });
+
+  it('renders no error (and no category) for a successful step', () => {
+    const dto = toStepDto(step({type: 'run', status: 'succeeded', error: null}));
+
+    expect(dto.error).toBeNull();
+  });
+});

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -1,22 +1,38 @@
-import type {StepAttemptDto, StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
+import {
+  type StepAttemptDto,
+  type StepDto,
+  type StepErrorCategory,
+  type StepErrorDtoShape,
+  stepErrorReasonSchema,
+} from '@shipfox/api-workflows-dto';
 import type {Step, StepAttempt} from '#core/entities/step.js';
 
 // Domain `error` is loosely typed (jsonb), so narrow it to the fixed runner
-// contract rather than trusting whatever shape the row happens to hold.
-function toStepErrorDto(error: Record<string, unknown> | null): StepErrorDtoShape {
+// contract rather than trusting whatever shape the row happens to hold. `category`
+// is not stored on the row; the caller derives it from the step type and passes it
+// in (server-authoritative, never trusted from the runner).
+function toStepErrorDto(
+  error: Record<string, unknown> | null,
+  category: StepErrorCategory,
+): StepErrorDtoShape {
   if (error === null) return null;
   const message = typeof error.message === 'string' ? error.message : '';
   const exitCode = error.exitCode;
   const signal = typeof error.signal === 'string' ? error.signal : undefined;
+  const reason = stepErrorReasonSchema.safeParse(error.reason);
   return {
     message,
     ...(exitCode === null || typeof exitCode === 'number' ? {exit_code: exitCode} : {}),
     ...(signal === undefined ? {} : {signal}),
+    ...(reason.success ? {reason: reason.data} : {}),
+    category,
   };
 }
 
 // Inverse of toStepErrorDto: reported wire errors land on the domain row in
-// camelCase so the read path renders them back without a special case.
+// camelCase so the read path renders them back without a special case. `category`
+// is intentionally NOT persisted — the server derives it from the step type on
+// read, so a runner-supplied category is ignored here.
 export function fromStepErrorDto(
   error: StepErrorDtoShape | undefined,
 ): Record<string, unknown> | null {
@@ -27,6 +43,7 @@ export function fromStepErrorDto(
       ? {exitCode: error.exit_code}
       : {}),
     ...(typeof error.signal === 'string' ? {signal: error.signal} : {}),
+    ...(error.reason === undefined ? {} : {reason: error.reason}),
   };
 }
 
@@ -38,7 +55,7 @@ export function toStepDto(step: Step): StepDto {
     status: step.status,
     type: step.type,
     config: step.config,
-    error: toStepErrorDto(step.error),
+    error: toStepErrorDto(step.error, step.type === 'setup' ? 'setup' : 'user'),
     position: step.position,
     current_attempt: step.currentAttempt,
     created_at: step.createdAt.toISOString(),

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -99,9 +99,11 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(body.id).toBe(run.id);
     expect(body.jobs).toHaveLength(1);
     expect(body.jobs[0].name).toBe('build');
-    expect(body.jobs[0].steps).toHaveLength(2);
-    expect(body.jobs[0].steps[0].name).toBe('Install');
-    expect(body.jobs[0].steps[1].name).toBeNull();
+    // Synthetic setup step at position 0, then the two user steps.
+    expect(body.jobs[0].steps).toHaveLength(3);
+    expect(body.jobs[0].steps[0].name).toBe('Set up job');
+    expect(body.jobs[0].steps[1].name).toBe('Install');
+    expect(body.jobs[0].steps[2].name).toBeNull();
   });
 
   test('exposes per-step error and cancelled status after a failed per-step report', async () => {
@@ -152,9 +154,11 @@ describe('GET /api/workflows/runs/:id', () => {
 
     expect(res.statusCode).toBe(200);
     const body = res.json();
+    // steps[0] is the setup step (reported succeeded above); the failed user step
+    // follows. A failed step's error carries the server-derived category 'user'.
     const responseSteps = body.jobs[0].steps as Array<{
       status: string;
-      error: {message: string; exit_code?: number | null} | null;
+      error: {message: string; exit_code?: number | null; category?: string} | null;
     }>;
     expect(responseSteps[0]?.status).toBe('succeeded');
     expect(responseSteps[0]?.error).toBeNull();
@@ -162,6 +166,7 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(responseSteps[1]?.error).toEqual({
       message: 'Command exited with code 1',
       exit_code: 1,
+      category: 'user',
     });
     expect(responseSteps[2]?.status).toBe('cancelled');
     expect(responseSteps[2]?.error).toBeNull();
@@ -284,8 +289,10 @@ describe('GET /api/workflows/runs/:id', () => {
     });
     const jobId = (await getJobsByRunId(run.id))[0]?.id as string;
     const steps = await getStepsByJobId(jobId);
-    const producerId = steps[0]?.id as string;
-    const reviewerId = steps[1]?.id as string;
+    // steps[0] is the synthetic setup step; the user steps follow at 1..2.
+    const setupId = steps[0]?.id as string;
+    const producerId = steps[1]?.id as string;
+    const reviewerId = steps[2]?.id as string;
     // reviewer gate: succeed only on exit 0; otherwise restart from producer.
     await db().update(stepsTable).set({name: 'producer'}).where(eq(stepsTable.id, producerId));
     await db()
@@ -310,6 +317,7 @@ describe('GET /api/workflows/runs/:id', () => {
         exitCode,
       });
     };
+    await runStep(setupId, 0); // setup (position 0) succeeds first
     await runStep(producerId, 0); // producer attempt 1 succeeds
     await runStep(reviewerId, 1); // reviewer attempt 1 gate-fails → restart, both bumped to 2
     await runStep(producerId, 0); // producer attempt 2 succeeds
@@ -318,7 +326,7 @@ describe('GET /api/workflows/runs/:id', () => {
     const res = await app.inject({method: 'GET', url: `/api/workflows/runs/${run.id}`});
 
     expect(res.statusCode).toBe(200);
-    const [producer, reviewer] = res.json().jobs[0].steps;
+    const [, producer, reviewer] = res.json().jobs[0].steps;
     expect(producer.current_attempt).toBe(2);
     expect(producer.attempts.map((a: {attempt: number}) => a.attempt)).toEqual([1, 2]);
     expect(reviewer.current_attempt).toBe(2);

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
@@ -1,5 +1,6 @@
 import {ApplicationFailure} from '@temporalio/common';
 import {createWorkflowRun, getJobsByRunId, updateJobStatus} from '#db/index.js';
+import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 import {resolveLeaseExpiredJobActivity} from './orchestration-activities.js';
 
@@ -36,6 +37,9 @@ describe('resolveLeaseExpiredJobActivity', () => {
 
   test('a malformed job (no steps) fails non-retryably so it never loops to the backstop', async () => {
     const {jobId, runningVersion} = await seedRunningJob(0);
+    // createWorkflowRun always prepends the synthetic setup step, so strip it to
+    // reproduce a genuinely stepless (malformed) job.
+    await stripSetupStep(jobId);
 
     const error = await resolveLeaseExpiredJobActivity({
       jobId,

--- a/libs/api/workflows/test/fixtures/job-with-steps.ts
+++ b/libs/api/workflows/test/fixtures/job-with-steps.ts
@@ -1,16 +1,14 @@
-import {and, eq, sql} from 'drizzle-orm';
 import type {Step} from '#core/entities/step.js';
-import {db} from '#db/db.js';
-import {steps as stepsTable} from '#db/schema/steps.js';
 import {createWorkflowRun, getJobsByRunId, getStepsByJobId} from '#db/workflow-runs.js';
+import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 
 // Jobs and steps have no standalone factory — they only exist as children
-// materialized from a WorkflowModel by createWorkflowRun. createWorkflowRun
-// prepends a synthetic "Set up job" step to every job; this fixture exercises
-// step-execution mechanics in isolation, so it strips that step (renumbering the
-// user steps back to 0-based) to keep the arrangement focused. The setup step's
-// own behavior is covered by materialize / createWorkflowRun / runner tests.
+// materialized from a WorkflowModel by createWorkflowRun, which also prepends a
+// synthetic "Set up job" step to every job. This fixture exercises step-execution
+// mechanics in isolation, so it strips that step (see stripSetupStep) to keep the
+// arrangement focused. The setup step's own behavior is covered by materialize /
+// createWorkflowRun / runner tests.
 export async function arrangeJobWithSteps(
   stepCount: number,
 ): Promise<{jobId: string; steps: Step[]}> {
@@ -37,17 +35,7 @@ export async function arrangeJobWithSteps(
   const jobs = await getJobsByRunId(run.id);
   const jobId = jobs[0]?.id as string;
 
-  // Drop the synthetic setup step and shift the user steps back to 0-based so the
-  // returned arrangement matches what the step-execution tests expect.
-  await db().transaction(async (tx) => {
-    await tx
-      .delete(stepsTable)
-      .where(and(eq(stepsTable.jobId, jobId), eq(stepsTable.type, 'setup')));
-    await tx
-      .update(stepsTable)
-      .set({position: sql`${stepsTable.position} - 1`})
-      .where(eq(stepsTable.jobId, jobId));
-  });
+  await stripSetupStep(jobId);
 
   const steps = await getStepsByJobId(jobId);
   return {jobId, steps};

--- a/libs/api/workflows/test/fixtures/job-with-steps.ts
+++ b/libs/api/workflows/test/fixtures/job-with-steps.ts
@@ -1,9 +1,16 @@
+import {and, eq, sql} from 'drizzle-orm';
 import type {Step} from '#core/entities/step.js';
+import {db} from '#db/db.js';
+import {steps as stepsTable} from '#db/schema/steps.js';
 import {createWorkflowRun, getJobsByRunId, getStepsByJobId} from '#db/workflow-runs.js';
 import {workflowModel} from '#test/index.js';
 
 // Jobs and steps have no standalone factory — they only exist as children
-// materialized from a WorkflowModel by createWorkflowRun.
+// materialized from a WorkflowModel by createWorkflowRun. createWorkflowRun
+// prepends a synthetic "Set up job" step to every job; this fixture exercises
+// step-execution mechanics in isolation, so it strips that step (renumbering the
+// user steps back to 0-based) to keep the arrangement focused. The setup step's
+// own behavior is covered by materialize / createWorkflowRun / runner tests.
 export async function arrangeJobWithSteps(
   stepCount: number,
 ): Promise<{jobId: string; steps: Step[]}> {
@@ -29,6 +36,19 @@ export async function arrangeJobWithSteps(
 
   const jobs = await getJobsByRunId(run.id);
   const jobId = jobs[0]?.id as string;
+
+  // Drop the synthetic setup step and shift the user steps back to 0-based so the
+  // returned arrangement matches what the step-execution tests expect.
+  await db().transaction(async (tx) => {
+    await tx
+      .delete(stepsTable)
+      .where(and(eq(stepsTable.jobId, jobId), eq(stepsTable.type, 'setup')));
+    await tx
+      .update(stepsTable)
+      .set({position: sql`${stepsTable.position} - 1`})
+      .where(eq(stepsTable.jobId, jobId));
+  });
+
   const steps = await getStepsByJobId(jobId);
   return {jobId, steps};
 }

--- a/libs/api/workflows/test/fixtures/strip-setup-step.ts
+++ b/libs/api/workflows/test/fixtures/strip-setup-step.ts
@@ -1,0 +1,18 @@
+import {and, eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {steps as stepsTable} from '#db/schema/steps.js';
+
+// createWorkflowRun prepends a synthetic "Set up job" step to every job. Tests that
+// exercise step-execution mechanics in isolation strip it and renumber the user
+// steps back to 0-based, so their arrangement matches the steps they declared.
+export async function stripSetupStep(jobId: string): Promise<void> {
+  await db().transaction(async (tx) => {
+    await tx
+      .delete(stepsTable)
+      .where(and(eq(stepsTable.jobId, jobId), eq(stepsTable.type, 'setup')));
+    await tx
+      .update(stepsTable)
+      .set({position: sql`${stepsTable.position} - 1`})
+      .where(eq(stepsTable.jobId, jobId));
+  });
+}


### PR DESCRIPTION
Give every runner-dispatched job a first-class "Set up job" step at position 0 (à la GitHub Actions), so failures that happen *around* the user steps are reported through the existing per-step protocol instead of hanging the job.

## Why

After the per-step protocol (#163), job finalization is entirely step-report-driven: the runner can only report against a `stepId` it pulled from `next`. Anything that fails around the steps — workspace prep today, the repository checkout next — has no reporting channel. Today the runner logs and bails; the 180s stuck-job detector emits `runners.job.lease_expired` (which has no subscriber, so it only frees the runner slot), and the job sits `running` until the 60-minute `JOB_MAX_DURATION` finalizes it with only `timedOutAt` and no machine-readable cause. The user watches a hang for an hour, then sees a generic timeout. This also blocks ENG-405, whose "fail before steps with a stable reason" deliverable isn't expressible without a setup-failure path.

## What

- **Server**: `materializeWorkflowModel` prepends a synthetic `{type:'setup', name:'Set up job', config:{}, position:0}` step to every job (every job runs on a runner — scheduling never filters on the runner field); user steps shift to 1..n. A failed setup step flows through the existing fail-job cascade, finalizing the job `failed` in seconds with no user step run.
- **DTO**: `stepErrorDtoSchema` gains optional `reason` (`workspace_prep_failed`, `git_unavailable`, `checkout_*`, `setup_aborted`) and `category` (`setup` | `user`).
- **Trust boundary**: the runner reports only `reason`; the server derives `category` from the authoritative `step.type` on read (`toStepDto`), since the runner/agent is untrusted. The read mapper also now carries `reason` through (it previously narrowed the error and would have dropped it).
- **Restart safety**: the gate `restart_from` resolver skips `type:'setup'`, so a user step named "Set up job" can never rewind setup (and delete the workspace) mid-job. Duplicate user-step names are already rejected by `normalizeWorkflowDocument`, so this fully closes the collision.
- **Runner**: `workspace.ts` is split into pure `jobWorkspacePath` + `createJobDir`; `runJob` computes the cwd up front and cleans it on every exit path; a new `setup-step.ts` owns workspace prep (the ENG-405 checkout plugs in here); `step-loop.ts` dispatches `setup` vs `run` behind a strict `workspacePrepared` guard.

## Notes for reviewers

- **Out of scope, by decision**: a hard runner *crash* mid-setup (and a graceful abort) still hangs until the 60-min timeout, because the abort path stops the loop before it can report and `lease_expired` has no subscriber. Wiring that event is a separate liveness concern.
- The `git` precondition and actual checkout are deferred to ENG-405; this setup step is prep-only today (so git-less jobs don't fail). `git_unavailable`/`checkout_*`/`setup_aborted` are defined in the enum now to keep it stable.
- The legacy `POST /runners/jobs/:jobId/complete` route's canonical-set check is incompatible with the synthetic step, but the current runner never calls it and a separate task is already removing it.
- Test-fixture note: the shared `arrangeJobWithSteps` fixture and the legacy `applyStepResults` `seedJob` strip the synthetic step (renumbering to 0-based) to keep step-mechanics tests focused; the setup step is asserted directly in the materialize, `createWorkflowRun`, get-run, restart-resolver, DTO-mapper, and runner tests.

Refs ENG-412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synthetic “Set up job” step at position 0 so setup failures are reported per-step and jobs fail fast instead of hanging. Supports ENG-412 with stable, machine-readable setup failure reasons.

- **New Features**
  - Server prepends a `type: 'setup'` step at position 0; user steps shift to 1..n. Jobs with no user steps still include this step. Restart-from logic skips the synthetic step.
  - `@shipfox/api-workflows-dto`: step error adds optional `reason` (e.g. `workspace_prep_failed`) and `category` (`setup` | `user`). Runner reports `reason`; server derives `category` on read.
  - Runner: per-job cwd via `jobWorkspacePath`; setup step creates the workspace with `createJobDir`; step loop dispatches `setup` vs `run` with a guard to fail cleanly if a run step is pulled before setup; early-return on invalid job id; always cleans the workspace via `cleanupWorkspace`.

- **Refactors**
  - Extracted `stripSetupStep` test fixture to keep step-mechanics tests focused; removed future-work references and fixed a stale comment.

<sup>Written for commit c8bae675bee65a5648a3b2702fa5144f27054ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

