### PR TITLE
[api/integrations] Guard connect against a concurrent same-install race (time-of-check to time-of-use)

### DIFF
--- a/.changeset/eng-409-toctou-connect-guard.md
+++ b/.changeset/eng-409-toctou-connect-guard.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-sentry": patch
+---
+
+Harden integration connect against a concurrent same-install race. The installation upsert now only (re)points an installation at the connection that already owns it: the `onConflictDoUpdate` carries a `setWhere(connection_id = this connection)` predicate and throws `*InstallationAlreadyLinkedError` when the conflicting row belongs to a different connection. Two concurrent connects of the same provider install to different workspaces no longer leave one workspace with an active orphan connection while the install's webhooks silently route to the other; the losing transaction rolls back and surfaces a 409.

--- a/libs/api/integration/github/src/core/errors.ts
+++ b/libs/api/integration/github/src/core/errors.ts
@@ -17,7 +17,7 @@ export class GithubInstallationNotAuthorizedError extends Error {
 }
 
 export class GithubInstallationAlreadyLinkedError extends Error {
-  constructor(installationId: number) {
+  constructor(installationId: number | string) {
     super(`GitHub installation is already linked to another Shipfox workspace: ${installationId}`);
   }
 }

--- a/libs/api/integration/github/src/db/installations.test.ts
+++ b/libs/api/integration/github/src/db/installations.test.ts
@@ -1,0 +1,67 @@
+import {randomUUID} from 'node:crypto';
+import {GithubInstallationAlreadyLinkedError} from '#core/errors.js';
+import {db} from './db.js';
+import {
+  getGithubInstallationByInstallationId,
+  type UpsertGithubInstallationParams,
+  upsertGithubInstallation,
+} from './installations.js';
+import {githubInstallations} from './schema/installations.js';
+
+function installationParams(
+  overrides: Partial<UpsertGithubInstallationParams> = {},
+): UpsertGithubInstallationParams {
+  return {
+    connectionId: randomUUID(),
+    installationId: `${Math.floor(Math.random() * 1_000_000)}`,
+    accountLogin: 'shipfox',
+    accountType: 'Organization',
+    repositorySelection: 'all',
+    latestEvent: {id: 1},
+    ...overrides,
+  };
+}
+
+describe('github installations persistence', () => {
+  beforeEach(async () => {
+    await db().delete(githubInstallations);
+  });
+
+  test('upsert updates in place when the same connection reconnects, without duplicating', async () => {
+    const installationId = `${Date.now()}`;
+    const connectionId = randomUUID();
+    await upsertGithubInstallation(installationParams({connectionId, installationId}));
+
+    const updated = await upsertGithubInstallation(
+      installationParams({connectionId, installationId, accountLogin: 'shipfox-renamed'}),
+    );
+
+    expect(updated.connectionId).toBe(connectionId);
+    expect(updated.accountLogin).toBe('shipfox-renamed');
+    const fetched = await getGithubInstallationByInstallationId(installationId);
+    expect(fetched?.accountLogin).toBe('shipfox-renamed');
+  });
+
+  test('upsert rejects repointing an installation to a different connection (TOCTOU guard)', async () => {
+    const installationId = `${Date.now()}`;
+    const firstConnectionId = randomUUID();
+    const secondConnectionId = randomUUID();
+    await upsertGithubInstallation(
+      installationParams({connectionId: firstConnectionId, installationId}),
+    );
+
+    const repoint = upsertGithubInstallation(
+      installationParams({connectionId: secondConnectionId, installationId}),
+    );
+
+    await expect(repoint).rejects.toBeInstanceOf(GithubInstallationAlreadyLinkedError);
+    const fetched = await getGithubInstallationByInstallationId(installationId);
+    expect(fetched?.connectionId).toBe(firstConnectionId);
+  });
+
+  test('getGithubInstallationByInstallationId returns undefined for a miss', async () => {
+    const result = await getGithubInstallationByInstallationId('missing');
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/libs/api/integration/github/src/db/installations.ts
+++ b/libs/api/integration/github/src/db/installations.ts
@@ -1,4 +1,5 @@
 import {eq} from 'drizzle-orm';
+import {GithubInstallationAlreadyLinkedError} from '#core/errors.js';
 import {db} from './db.js';
 import {githubInstallations, toGithubInstallation} from './schema/installations.js';
 
@@ -53,6 +54,13 @@ export async function upsertGithubInstallation(
     })
     .onConflictDoUpdate({
       target: githubInstallations.installationId,
+      // TOCTOU guard: only (re)point this installation at the connection that
+      // already owns it. A concurrent connect of the same installation to a
+      // different workspace inserts its own connection row, so its connectionId
+      // differs here; the predicate is false, Postgres updates nothing, and the
+      // empty RETURNING below rolls the losing transaction back instead of
+      // silently repointing the installation (cross-tenant event misroute).
+      setWhere: eq(githubInstallations.connectionId, params.connectionId),
       set: {
         connectionId: params.connectionId,
         accountLogin: params.accountLogin,
@@ -67,7 +75,7 @@ export async function upsertGithubInstallation(
     })
     .returning();
 
-  if (!row) throw new Error('GitHub installation upsert returned no rows');
+  if (!row) throw new GithubInstallationAlreadyLinkedError(params.installationId);
   return toGithubInstallation(row);
 }
 

--- a/libs/api/integration/sentry/src/db/installations.test.ts
+++ b/libs/api/integration/sentry/src/db/installations.test.ts
@@ -1,4 +1,5 @@
 import {randomUUID} from 'node:crypto';
+import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
 import {db} from './db.js';
 import {
   getSentryInstallationByInstallationUuid,
@@ -15,28 +16,71 @@ describe('sentry installations persistence', () => {
     await db().delete(sentryInstallations);
   });
 
-  test('upsert inserts then updates on conflicting installation_uuid without duplicating', async () => {
+  test('upsert updates in place when the same connection reconnects, without duplicating', async () => {
+    const installationUuid = randomUUID();
+    const connectionId = randomUUID();
+
+    await upsertSentryInstallation({
+      connectionId,
+      installationUuid,
+      orgSlug: 'acme',
+      status: 'installed',
+    });
+    const updated = await upsertSentryInstallation({
+      connectionId,
+      installationUuid,
+      orgSlug: 'acme-renamed',
+      status: 'installed',
+    });
+
+    expect(updated.connectionId).toBe(connectionId);
+    expect(updated.orgSlug).toBe('acme-renamed');
+    const fetched = await getSentryInstallationByInstallationUuid(installationUuid);
+    expect(fetched?.orgSlug).toBe('acme-renamed');
+  });
+
+  test('upsert rejects repointing an installation to a different connection (TOCTOU guard)', async () => {
     const installationUuid = randomUUID();
     const firstConnectionId = randomUUID();
     const secondConnectionId = randomUUID();
-
     await upsertSentryInstallation({
       connectionId: firstConnectionId,
       installationUuid,
       orgSlug: 'acme',
       status: 'installed',
     });
-    const updated = await upsertSentryInstallation({
+
+    const repoint = upsertSentryInstallation({
       connectionId: secondConnectionId,
       installationUuid,
-      orgSlug: 'acme-renamed',
+      orgSlug: 'acme',
       status: 'installed',
     });
 
-    expect(updated.connectionId).toBe(secondConnectionId);
-    expect(updated.orgSlug).toBe('acme-renamed');
+    await expect(repoint).rejects.toBeInstanceOf(SentryInstallationAlreadyLinkedError);
     const fetched = await getSentryInstallationByInstallationUuid(installationUuid);
-    expect(fetched?.orgSlug).toBe('acme-renamed');
+    expect(fetched?.connectionId).toBe(firstConnectionId);
+  });
+
+  test('upsert claims a verified-unclaimed row by setting connection_id (first claim)', async () => {
+    const installationUuid = randomUUID();
+    const connectionId = randomUUID();
+    await persistVerifiedUnclaimedInstallation({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'webhook-hash',
+    });
+
+    const claimed = await upsertSentryInstallation({
+      connectionId,
+      installationUuid,
+      orgSlug: 'acme',
+      status: 'installed',
+    });
+
+    expect(claimed.connectionId).toBe(connectionId);
+    const fetched = await getSentryInstallationByInstallationUuid(installationUuid);
+    expect(fetched?.connectionId).toBe(connectionId);
   });
 
   test('markSentryInstallationDeleted sets status and returns the updated row', async () => {

--- a/libs/api/integration/sentry/src/db/installations.ts
+++ b/libs/api/integration/sentry/src/db/installations.ts
@@ -1,4 +1,5 @@
-import {and, eq, isNull, lt} from 'drizzle-orm';
+import {and, eq, isNull, lt, sql} from 'drizzle-orm';
+import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
 import {db} from './db.js';
 import {sentryInstallations, toSentryInstallation} from './schema/installations.js';
 
@@ -52,6 +53,15 @@ export async function upsertSentryInstallation(
     })
     .onConflictDoUpdate({
       target: sentryInstallations.installationUuid,
+      // TOCTOU guard: allow the update only when this installation is unclaimed
+      // (connection_id IS NULL, the first claim of a verified-unclaimed row) or
+      // already owned by this same connection (idempotent reconnect). A concurrent
+      // claim of the same installation to a different workspace commits its own
+      // connection_id first; this losing transaction then sees a different non-null
+      // connection_id, the predicate is false, Postgres updates nothing, and the
+      // empty RETURNING below rolls it back instead of silently repointing the
+      // installation (cross-tenant event misroute).
+      setWhere: sql`${sentryInstallations.connectionId} is null or ${sentryInstallations.connectionId} = ${params.connectionId}`,
       set: {
         connectionId: params.connectionId,
         orgSlug: params.orgSlug,
@@ -63,7 +73,7 @@ export async function upsertSentryInstallation(
     })
     .returning();
 
-  if (!row) throw new Error('Sentry installation upsert returned no rows');
+  if (!row) throw new SentryInstallationAlreadyLinkedError(params.installationUuid);
   return toSentryInstallation(row);
 }
 


### PR DESCRIPTION
Make the integration connect flow safe against a concurrent same-install race across two workspaces. This is a time-of-check to time-of-use (TOCTOU) bug: the flow checks for an existing connection, then writes based on that now-stale check.

## The bug

The connect flow was read-then-write. `getExisting{Github,Sentry}Connection` reads, then `upsert{Github,Sentry}Installation` ran `onConflictDoUpdate` on the installation's unique id and **unconditionally** set `connectionId`. Two concurrent connects of the same provider install to **different** workspaces both passed the read-check, each inserted its own `integrations_connections` row (different workspace, so no unique conflict), then the second installation upsert repointed the installation row's `connectionId` from connection A to connection B.

Webhook routing resolves the tenant purely by `installation.connectionId`, so workspace A was left with an **active orphan** connection that owned nothing while that install's webhooks silently routed to workspace B. A cross-tenant event misroute, not just a dangling row. The `AlreadyLinkedError` read-check only held sequentially (it is the time-of-check; the upsert is the time-of-use, and the window between them is the race).

## The fix

Make the conflict branch conditional. `onConflictDoUpdate` now carries `setWhere(connection_id = this connection)`, so it only (re)points an installation at the connection that already owns it. When the conflicting row belongs to a different connection the predicate is false, `RETURNING` is empty, and the upsert throws the provider's existing `*InstallationAlreadyLinkedError`.

Postgres serializes the two inserts on the unique installation key under READ COMMITTED: the losing transaction waits for the winner to commit, re-evaluates the conflict, updates nothing, and rolls back in full (including its just-inserted orphan connection). The loser gets a clean 409 via the existing error -> route mapping. Same-workspace reconnect/reactivation is unaffected because the connection row is keyed by `(workspaceId, provider, externalAccountId)` and is never recreated, so `connection_id` matches and the update proceeds.

Applied to both `libs/api/integration/github` and `libs/api/integration/sentry`.

## Approach notes

- Per-provider guard rather than a shared core helper: the two installation tables live in separate packages with different conflict-target columns, and the guard is ~2 lines each. Revisit hoisting when a third provider lands.
- Deliberately did **not** add the optional "reclaim a disabled/deleted install for a different workspace" branch: it needs a cross-table read that `ON CONFLICT ... WHERE` cannot express, and providers issue a new install id on reinstall so it is practically unreachable. Failing safe (409) is non-corrupting.
- End-to-end concurrency / orphan-absence coverage is deferred to the already-planned integrations E2E work; the unit tests here are deterministic conflict tests.

## Follow-ups filed

- ENG-445: harden webhook **routing** against a stale/mispointed installation pointer (defense-in-depth, surfaced by an independent Codex review).
- ENG-438 updated: handle GitHub `installation.deleted` lifecycle (today GitHub drops all non-`push` events, so an uninstall never marks the install deleted or disables the connection; Sentry already does this).

Refs ENG-409