### PR TITLE
[api/integrations] Make the signed Sentry installation webhook authoritative

### DIFF
--- a/.changeset/eng-436-sentry-webhook-authoritative.md
+++ b/.changeset/eng-436-sentry-webhook-authoritative.md
@@ -1,0 +1,29 @@
+---
+"@shipfox/api-integration-sentry-dto": minor
+"@shipfox/api-integration-sentry": minor
+"@shipfox/api-integration-core": minor
+"@shipfox/client-integrations": patch
+---
+
+[api/integrations] Make the signed Sentry installation webhook authoritative.
+
+- `@shipfox/api-integration-sentry-dto`: reshape `sentryInstallationWebhookSchema`
+  to read `data.installation.{uuid, organization.slug, status, code}` plus an
+  optional top-level `actor`. Only consumed fields are validated and the raw
+  `code` is never logged.
+- `@shipfox/api-integration-sentry`: the signed `installation.created` webhook now
+  exchanges the single-use code and persists a verified-but-unclaimed installation
+  (`connection_id IS NULL`, `code_hash = sha256(code)`). The browser flow narrows
+  to a claim that binds a verified install to a workspace under unified claim auth
+  (exchange-success, same-code hash match, or a retryable
+  `verification-in-progress` while a concurrent webhook is mid-exchange), with a
+  proof-mismatch 403 closing the bare-uuid IDOR. The exchange/verify run outside
+  the DB transaction; a short transaction wraps persist + delivery record. Adds
+  `connection_id` nullable + `code_hash` to the installations table and a daily TTL
+  cron that tombstones never-claimed installs.
+- `@shipfox/api-integration-core`: inject the Sentry client into the webhook
+  context, resolve a null `connection_id` to "no connection" for pre-claim issue
+  deliveries, and register the unclaimed-installation cleanup cron when Sentry is
+  enabled.
+- `@shipfox/client-integrations`: treat the retryable `verification-in-progress`
+  response as a backoff-eligible failure on the connect callback.

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -210,8 +210,7 @@ async function loadSentryModuleParts(): Promise<SentryModuleParts> {
         {tx},
       );
 
-      // Promotes the verified-unclaimed row to claimed by setting connection_id,
-      // and refreshes code_hash so a re-entry with a fresh code stays claimable.
+      // Promotes the verified-unclaimed row to claimed by setting connection_id.
       await upsertSentryInstallation(
         {
           connectionId: connection.id,

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -181,17 +181,16 @@ async function loadSentryModuleParts(): Promise<SentryModuleParts> {
   const {
     createSentryIntegrationProvider,
     getSentryInstallationByInstallationUuid,
+    persistVerifiedUnclaimedInstallation,
     upsertSentryInstallation,
     db: sentryDb,
     migrationsPath: sentryMigrationsPath,
   } = await import('@shipfox/api-integration-sentry');
 
-  async function getExistingSentryConnection(input: {
-    installationUuid: string;
-  }): Promise<CoreIntegrationConnection<'sentry'> | undefined> {
-    const installation = await getSentryInstallationByInstallationUuid(input.installationUuid);
-    if (!installation) return undefined;
-    const connection = await getIntegrationConnectionById(installation.connectionId);
+  async function getConnectionById(
+    id: string,
+  ): Promise<CoreIntegrationConnection<'sentry'> | undefined> {
+    const connection = await getIntegrationConnectionById(id);
     if (!connection) return undefined;
     return connection as CoreIntegrationConnection<'sentry'>;
   }
@@ -211,12 +210,15 @@ async function loadSentryModuleParts(): Promise<SentryModuleParts> {
         {tx},
       );
 
+      // Promotes the verified-unclaimed row to claimed by setting connection_id,
+      // and refreshes code_hash so a re-entry with a fresh code stays claimable.
       await upsertSentryInstallation(
         {
           connectionId: connection.id,
           installationUuid: input.installationUuid,
           orgSlug: input.orgSlug,
           status: 'installed',
+          codeHash: input.codeHash,
           installerUserId: input.installerUserId,
         },
         {tx},
@@ -228,8 +230,11 @@ async function loadSentryModuleParts(): Promise<SentryModuleParts> {
 
   return {
     provider: createSentryIntegrationProvider({
-      getExistingSentryConnection,
+      getSentryInstallation: ({installationUuid}) =>
+        getSentryInstallationByInstallationUuid(installationUuid),
+      getConnectionById,
       connectSentryInstallation,
+      persistVerifiedUnclaimedInstallation,
       coreDb: db,
       publishIntegrationEventReceived,
       recordDeliveryOnly,
@@ -306,6 +311,17 @@ export async function createIntegrationsContext(
             id: 'integrations-prune-webhook-deliveries',
             cronSchedule: '0 3 * * *',
           },
+          // Only when Sentry is enabled: its tables exist only then, and the
+          // activity reads them.
+          ...(sentry
+            ? [
+                {
+                  name: 'pruneUnclaimedSentryInstallationsCron',
+                  id: 'integrations-prune-unclaimed-sentry-installations',
+                  cronSchedule: '0 4 * * *',
+                },
+              ]
+            : []),
         ],
       },
     ],

--- a/libs/api/integration/core/src/temporal/activities/index.ts
+++ b/libs/api/integration/core/src/temporal/activities/index.ts
@@ -1,7 +1,9 @@
+import {pruneUnclaimedSentryInstallationsActivity} from './prune-unclaimed-sentry-installations.js';
 import {pruneWebhookDeliveriesActivity} from './prune-webhook-deliveries.js';
 
 export function createIntegrationsMaintenanceActivities() {
   return {
     pruneWebhookDeliveriesActivity,
+    pruneUnclaimedSentryInstallationsActivity,
   };
 }

--- a/libs/api/integration/core/src/temporal/activities/prune-unclaimed-sentry-installations.ts
+++ b/libs/api/integration/core/src/temporal/activities/prune-unclaimed-sentry-installations.ts
@@ -1,0 +1,14 @@
+import {SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS} from '#temporal/constants.js';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export async function pruneUnclaimedSentryInstallationsActivity(): Promise<{tombstoned: number}> {
+  // Imported dynamically so loading the activity registry never pulls in the
+  // Sentry package's config: this cron is only scheduled when Sentry is enabled,
+  // and the import resolves its env then (mirrors core's provider loading).
+  const {pruneUnclaimedSentryInstallations} = await import('@shipfox/api-integration-sentry');
+  const olderThan = new Date(
+    Date.now() - SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS * MS_PER_DAY,
+  );
+  return await pruneUnclaimedSentryInstallations({olderThan});
+}

--- a/libs/api/integration/core/src/temporal/constants.ts
+++ b/libs/api/integration/core/src/temporal/constants.ts
@@ -1,3 +1,8 @@
 export const INTEGRATIONS_MAINTENANCE_TASK_QUEUE = 'integrations-maintenance';
 
 export const WEBHOOK_DELIVERY_RETENTION_DAYS = 30;
+
+// How long a verified Sentry install may sit unclaimed before the TTL cron
+// tombstones it. Bounds a never-finished install instead of leaving it pending
+// forever; a reinstall always mints a fresh uuid, so a tombstone is never revived.
+export const SENTRY_UNCLAIMED_INSTALLATION_RETENTION_DAYS = 7;

--- a/libs/api/integration/core/src/temporal/workflows/index.ts
+++ b/libs/api/integration/core/src/temporal/workflows/index.ts
@@ -1,1 +1,2 @@
+export {pruneUnclaimedSentryInstallationsCron} from './prune-unclaimed-sentry-installations-cron.js';
 export {pruneWebhookDeliveriesCron} from './prune-webhook-deliveries-cron.js';

--- a/libs/api/integration/core/src/temporal/workflows/prune-unclaimed-sentry-installations-cron.ts
+++ b/libs/api/integration/core/src/temporal/workflows/prune-unclaimed-sentry-installations-cron.ts
@@ -1,0 +1,15 @@
+import {log, proxyActivities} from '@temporalio/workflow';
+import type {createIntegrationsMaintenanceActivities} from '../activities/index.js';
+
+const {pruneUnclaimedSentryInstallationsActivity} = proxyActivities<
+  ReturnType<typeof createIntegrationsMaintenanceActivities>
+>({
+  startToCloseTimeout: '5 minutes',
+});
+
+export async function pruneUnclaimedSentryInstallationsCron(): Promise<void> {
+  const {tombstoned} = await pruneUnclaimedSentryInstallationsActivity();
+  if (tombstoned > 0) {
+    log.info('Tombstoned stale unclaimed Sentry installations', {tombstoned});
+  }
+}

--- a/libs/api/integration/sentry-dto/src/schemas/webhooks.test.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/webhooks.test.ts
@@ -97,17 +97,49 @@ describe('sentryIssueWebhookSchema', () => {
 });
 
 describe('sentryInstallationWebhookSchema', () => {
-  test('parses a created installation envelope', () => {
-    const body = {action: 'created', installation: {uuid: 'install-uuid-1'}};
+  test('parses a created installation envelope with uuid, org slug, status, and code', () => {
+    const body = {
+      action: 'created',
+      actor: {type: 'user', id: 42, name: 'Ada'},
+      data: {
+        installation: {
+          uuid: 'install-uuid-1',
+          status: 'installed',
+          code: 'grant-code-1',
+          organization: {slug: 'acme'},
+          extra: 'ignored',
+        },
+      },
+    };
 
     const parsed = sentryInstallationWebhookSchema.parse(body);
 
     expect(parsed.action).toBe('created');
-    expect(parsed.installation.uuid).toBe('install-uuid-1');
+    expect(parsed.data.installation.uuid).toBe('install-uuid-1');
+    expect(parsed.data.installation.organization?.slug).toBe('acme');
+    expect(parsed.data.installation.code).toBe('grant-code-1');
+  });
+
+  test('tolerates a missing status, actor, code, and organization', () => {
+    const body = {action: 'deleted', data: {installation: {uuid: 'install-uuid-1'}}};
+
+    const parsed = sentryInstallationWebhookSchema.parse(body);
+
+    expect(parsed.action).toBe('deleted');
+    expect(parsed.data.installation.uuid).toBe('install-uuid-1');
+    expect(parsed.data.installation.code).toBeUndefined();
   });
 
   test('rejects an unknown installation action', () => {
-    const body = {action: 'suspended', installation: {uuid: 'install-uuid-1'}};
+    const body = {action: 'suspended', data: {installation: {uuid: 'install-uuid-1'}}};
+
+    const result = sentryInstallationWebhookSchema.safeParse(body);
+
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a payload missing data.installation.uuid', () => {
+    const body = {action: 'created', data: {installation: {}}};
 
     const result = sentryInstallationWebhookSchema.safeParse(body);
 

--- a/libs/api/integration/sentry-dto/src/schemas/webhooks.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/webhooks.ts
@@ -31,8 +31,29 @@ export const sentryIssueWebhookSchema = z.object({
 });
 export type SentryIssueWebhookDto = z.infer<typeof sentryIssueWebhookSchema>;
 
+// Sentry delivers the installation lifecycle under `data.installation` (issue
+// webhooks instead carry a top-level `installation`). The signed payload carries
+// the same material the browser redirect delivers unauthenticated — the install
+// uuid, the org slug, and the single-use authorization `code`. Only consumed
+// fields are validated; `status`/`actor` are tolerated-but-optional. The raw
+// `code` is security-sensitive and must never be logged.
 export const sentryInstallationWebhookSchema = z.object({
   action: z.enum(['created', 'deleted']),
-  installation: z.object({uuid: z.string().min(1)}),
+  // Identifies who performed the install in Sentry. Logged only; never trusted.
+  actor: z
+    .object({
+      type: z.string().optional(),
+      id: z.union([z.string(), z.number()]).optional(),
+      name: z.string().optional(),
+    })
+    .optional(),
+  data: z.object({
+    installation: z.object({
+      uuid: z.string().min(1),
+      status: z.string().optional(),
+      code: z.string().min(1).optional(),
+      organization: z.object({slug: z.string().min(1)}).optional(),
+    }),
+  }),
 });
 export type SentryInstallationWebhookDto = z.infer<typeof sentryInstallationWebhookSchema>;

--- a/libs/api/integration/sentry-dto/src/schemas/webhooks.ts
+++ b/libs/api/integration/sentry-dto/src/schemas/webhooks.ts
@@ -39,7 +39,8 @@ export type SentryIssueWebhookDto = z.infer<typeof sentryIssueWebhookSchema>;
 // `code` is security-sensitive and must never be logged.
 export const sentryInstallationWebhookSchema = z.object({
   action: z.enum(['created', 'deleted']),
-  // Identifies who performed the install in Sentry. Logged only; never trusted.
+  // Identifies who performed the install in Sentry. Tolerated for forward-compat
+  // but not consumed; never trusted.
   actor: z
     .object({
       type: z.string().optional(),

--- a/libs/api/integration/sentry/drizzle/0000_initial.sql
+++ b/libs/api/integration/sentry/drizzle/0000_initial.sql
@@ -1,9 +1,10 @@
 CREATE TABLE "integrations_sentry_installations" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
-	"connection_id" uuid NOT NULL,
+	"connection_id" uuid,
 	"installation_uuid" text NOT NULL,
 	"org_slug" text NOT NULL,
 	"status" text NOT NULL,
+	"code_hash" text,
 	"installer_user_id" uuid,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL

--- a/libs/api/integration/sentry/src/api/client.ts
+++ b/libs/api/integration/sentry/src/api/client.ts
@@ -31,10 +31,13 @@ export interface SentryApiClient {
 export function createSentryApiClient(): SentryApiClient {
   return {
     async exchangeAuthorizationCode(input) {
+      // Encode the uuid: it originates from the request body / webhook payload, so
+      // a path separator in it must not be able to alter the request path (the host
+      // is already pinned to SENTRY_API_BASE).
       const body = await mapSentryError('exchange-authorization-code', () =>
         ky
           .post(
-            `${SENTRY_API_BASE}/sentry-app-installations/${input.installationUuid}/authorizations/`,
+            `${SENTRY_API_BASE}/sentry-app-installations/${encodeURIComponent(input.installationUuid)}/authorizations/`,
             {
               json: {
                 grant_type: 'authorization_code',
@@ -63,9 +66,12 @@ export function createSentryApiClient(): SentryApiClient {
     async getInstallation(input) {
       const body = await mapSentryError('get-installation', () =>
         ky
-          .get(`${SENTRY_API_BASE}/sentry-app-installations/${input.installationUuid}/`, {
-            headers: {authorization: `Bearer ${input.token}`},
-          })
+          .get(
+            `${SENTRY_API_BASE}/sentry-app-installations/${encodeURIComponent(input.installationUuid)}/`,
+            {
+              headers: {authorization: `Bearer ${input.token}`},
+            },
+          )
           .json<{organization?: {slug?: unknown}}>(),
       );
 
@@ -82,10 +88,13 @@ export function createSentryApiClient(): SentryApiClient {
     async verifyInstallation(input) {
       await mapSentryError('verify-installation', () =>
         ky
-          .put(`${SENTRY_API_BASE}/sentry-app-installations/${input.installationUuid}/`, {
-            headers: {authorization: `Bearer ${input.token}`},
-            json: {status: 'installed'},
-          })
+          .put(
+            `${SENTRY_API_BASE}/sentry-app-installations/${encodeURIComponent(input.installationUuid)}/`,
+            {
+              headers: {authorization: `Bearer ${input.token}`},
+              json: {status: 'installed'},
+            },
+          )
           .json<unknown>(),
       );
     },

--- a/libs/api/integration/sentry/src/connection-external-url.test.ts
+++ b/libs/api/integration/sentry/src/connection-external-url.test.ts
@@ -19,6 +19,7 @@ function installation(overrides: Partial<SentryInstallation> = {}): SentryInstal
     installationUuid: 'install-1',
     orgSlug: 'acme',
     status: 'installed',
+    codeHash: null,
     installerUserId: null,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -29,8 +30,10 @@ function installation(overrides: Partial<SentryInstallation> = {}): SentryInstal
 function createProvider(lookup: (connectionId: string) => Promise<SentryInstallation | undefined>) {
   return createSentryIntegrationProvider({
     sentry: sentryClient(),
-    getExistingSentryConnection: vi.fn(() => Promise.resolve(undefined)),
+    getSentryInstallation: vi.fn(() => Promise.resolve(undefined)),
+    getConnectionById: vi.fn(() => Promise.resolve(undefined)),
     connectSentryInstallation: vi.fn() as never,
+    persistVerifiedUnclaimedInstallation: vi.fn() as never,
     coreDb: vi.fn() as never,
     publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),

--- a/libs/api/integration/sentry/src/core/errors.ts
+++ b/libs/api/integration/sentry/src/core/errors.ts
@@ -66,3 +66,16 @@ export class SentryConnectionNotFoundError extends SentryIssueDroppedError {
     this.name = 'SentryConnectionNotFoundError';
   }
 }
+
+/**
+ * A verified install that no workspace has claimed yet (`connection_id IS NULL`),
+ * so an issue delivery has no workspace to publish against. Dropped (204) like the
+ * other pre-publish cases; kept distinct from SentryConnectionNotFoundError so the
+ * carried identifier is unambiguously an installation uuid, not a connection id.
+ */
+export class SentryInstallationUnclaimedError extends SentryIssueDroppedError {
+  constructor(public readonly installationUuid: string) {
+    super(`Sentry installation is verified but not yet claimed: ${installationUuid}`);
+    this.name = 'SentryInstallationUnclaimedError';
+  }
+}

--- a/libs/api/integration/sentry/src/core/errors.ts
+++ b/libs/api/integration/sentry/src/core/errors.ts
@@ -12,6 +12,33 @@ export class SentryInstallationAlreadyLinkedError extends Error {
 }
 
 /**
+ * The claim could not prove control of the named install: the presented code
+ * neither exchanged successfully nor matched the stored `code_hash`. Surfaced as
+ * a 403 so a forged or leaked bare uuid cannot bind someone else's install.
+ */
+export class SentryClaimProofMismatchError extends Error {
+  constructor(public readonly installationUuid: string) {
+    super(`Sentry claim could not be verified for installation: ${installationUuid}`);
+    this.name = 'SentryClaimProofMismatchError';
+  }
+}
+
+/**
+ * A concurrent path (the signed webhook) is mid-exchange for this install, so the
+ * verified row is not visible to the claim yet. Retryable: the existing client
+ * backoff re-calls and finds the now-persisted row.
+ */
+export class SentryVerificationInProgressError extends Error {
+  constructor(
+    public readonly installationUuid: string,
+    public readonly retryAfterSeconds = 2,
+  ) {
+    super(`Sentry installation verification is still in progress: ${installationUuid}`);
+    this.name = 'SentryVerificationInProgressError';
+  }
+}
+
+/**
  * Base for issue deliveries we received and authenticated but deliberately do
  * not publish. The webhook layer records them for dedup and acknowledges with a
  * 204 rather than treating them as failures — a sustained non-2xx can make Sentry

--- a/libs/api/integration/sentry/src/core/install.test.ts
+++ b/libs/api/integration/sentry/src/core/install.test.ts
@@ -324,4 +324,19 @@ describe('handleSentryConnect — simultaneous race', () => {
     expect(connected).toBe(existing);
     expect(connectSentryInstallation).not.toHaveBeenCalled();
   });
+
+  it('surfaces a terminal deleted error when the row is tombstoned between lookups', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+      ),
+    });
+    const {result} = run({
+      sentry,
+      // First lookup sees no row; the re-read finds it tombstoned.
+      installSequence: [undefined, installation({status: 'deleted'})],
+    });
+
+    await expect(result).rejects.toBeInstanceOf(SentryInstallationDeletedError);
+  });
 });

--- a/libs/api/integration/sentry/src/core/install.test.ts
+++ b/libs/api/integration/sentry/src/core/install.test.ts
@@ -1,11 +1,25 @@
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import type {SentryApiClient} from '#api/client.js';
-import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
-import {type ConnectSentryInstallationInput, handleSentryConnect} from './install.js';
+import {
+  SentryClaimProofMismatchError,
+  SentryInstallationAlreadyLinkedError,
+  SentryInstallationDeletedError,
+  SentryIntegrationProviderError,
+  SentryVerificationInProgressError,
+} from '#core/errors.js';
+import type {SentryInstallation} from '#db/installations.js';
+import {
+  type ConnectSentryInstallationInput,
+  handleSentryConnect,
+  hashAuthorizationCode,
+} from './install.js';
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const OTHER_WORKSPACE_ID = '22222222-2222-4222-8222-222222222222';
 const INSTALL_UUID = 'install-uuid-1';
+const CODE = 'the-code';
+const CODE_HASH = hashAuthorizationCode(CODE);
+const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
 
 function sentryClient(overrides: Partial<SentryApiClient> = {}): SentryApiClient {
   return {
@@ -22,7 +36,7 @@ function connection(
   overrides: Partial<IntegrationConnection<'sentry'>> = {},
 ): IntegrationConnection<'sentry'> {
   return {
-    id: crypto.randomUUID(),
+    id: CONNECTION_ID,
     workspaceId: WORKSPACE_ID,
     provider: 'sentry',
     externalAccountId: INSTALL_UUID,
@@ -35,14 +49,40 @@ function connection(
   };
 }
 
+function installation(overrides: Partial<SentryInstallation> = {}): SentryInstallation {
+  return {
+    id: 'row-1',
+    connectionId: null,
+    installationUuid: INSTALL_UUID,
+    orgSlug: 'acme',
+    status: 'installed',
+    codeHash: CODE_HASH,
+    installerUserId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
 interface RunOptions {
   sentry?: SentryApiClient;
   verifyInstall?: boolean;
-  existing?: IntegrationConnection<'sentry'> | undefined;
+  code?: string;
+  install?: SentryInstallation | undefined;
+  installSequence?: (SentryInstallation | undefined)[];
+  connection?: IntegrationConnection<'sentry'> | undefined;
 }
 
 function run(options: RunOptions = {}) {
   const sentry = options.sentry ?? sentryClient();
+  const sequence = options.installSequence ?? [options.install];
+  let call = 0;
+  const getSentryInstallation = vi.fn(() => {
+    const value = sequence[Math.min(call, sequence.length - 1)];
+    call += 1;
+    return Promise.resolve(value);
+  });
+  const getConnectionById = vi.fn(() => Promise.resolve(options.connection));
   const connectSentryInstallation = vi.fn((input: ConnectSentryInstallationInput) =>
     Promise.resolve(
       connection({
@@ -52,59 +92,67 @@ function run(options: RunOptions = {}) {
       }),
     ),
   );
-  const getExistingSentryConnection = vi.fn(() => Promise.resolve(options.existing));
+  const persistVerifiedUnclaimedInstallation = vi.fn(
+    (input: {installationUuid: string; orgSlug: string; codeHash: string}) =>
+      Promise.resolve(installation({connectionId: null, ...input})),
+  );
 
   const result = handleSentryConnect({
     sentry,
     workspaceId: WORKSPACE_ID,
-    code: 'the-code',
+    code: options.code ?? CODE,
     installationUuid: INSTALL_UUID,
     installerUserId: 'user-1',
     verifyInstall: options.verifyInstall ?? true,
-    getExistingSentryConnection,
+    getSentryInstallation,
+    getConnectionById,
     connectSentryInstallation,
+    persistVerifiedUnclaimedInstallation,
   });
 
-  return {sentry, connectSentryInstallation, getExistingSentryConnection, result};
+  return {
+    sentry,
+    getSentryInstallation,
+    getConnectionById,
+    connectSentryInstallation,
+    persistVerifiedUnclaimedInstallation,
+    result,
+  };
 }
 
-describe('handleSentryConnect', () => {
-  it('exchanges, derives the org, persists, then verifies last', async () => {
+describe('handleSentryConnect — browser-first (no row)', () => {
+  it('exchanges, persists the unclaimed row, then binds and verifies last', async () => {
     const sentry = sentryClient();
-    const {connectSentryInstallation, result} = run({sentry});
+    const {connectSentryInstallation, persistVerifiedUnclaimedInstallation, result} = run({sentry});
 
     const connected = await result;
 
     expect(sentry.exchangeAuthorizationCode).toHaveBeenCalledWith({
       installationUuid: INSTALL_UUID,
-      code: 'the-code',
+      code: CODE,
+    });
+    expect(persistVerifiedUnclaimedInstallation).toHaveBeenCalledWith({
+      installationUuid: INSTALL_UUID,
+      orgSlug: 'acme',
+      codeHash: CODE_HASH,
     });
     expect(connectSentryInstallation).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: WORKSPACE_ID,
         installationUuid: INSTALL_UUID,
         orgSlug: 'acme',
-        displayName: 'Sentry acme',
+        codeHash: CODE_HASH,
         installerUserId: 'user-1',
       }),
     );
     expect(connected.provider).toBe('sentry');
-    // Verify runs AFTER the row is persisted.
-    const connectOrder = connectSentryInstallation.mock.invocationCallOrder[0];
+
+    const persistOrder = persistVerifiedUnclaimedInstallation.mock.invocationCallOrder[0];
     const verifyOrder = vi.mocked(sentry.verifyInstallation).mock.invocationCallOrder[0];
-    expect(connectOrder).toBeLessThan(verifyOrder ?? 0);
+    expect(persistOrder).toBeLessThan(verifyOrder ?? 0);
   });
 
-  it('skips verifyInstallation when the flag is off', async () => {
-    const sentry = sentryClient();
-    const {result} = run({sentry, verifyInstall: false});
-
-    await result;
-
-    expect(sentry.verifyInstallation).not.toHaveBeenCalled();
-  });
-
-  it('returns the persisted connection when verify-install fails (non-fatal)', async () => {
+  it('binds even when the best-effort verify fails (non-fatal)', async () => {
     const sentry = sentryClient({
       verifyInstallation: vi.fn(() => Promise.reject(new Error('verify failed'))),
     });
@@ -116,21 +164,85 @@ describe('handleSentryConnect', () => {
     expect(connected.lifecycleStatus).toBe('active');
   });
 
-  it('throws when the installation is linked to a different workspace', async () => {
-    const sentry = sentryClient();
-    const {result} = run({
+  it('persists nothing when the code exchange fails outright', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SentryIntegrationProviderError('timeout', 'slow')),
+      ),
+    });
+    const {connectSentryInstallation, persistVerifiedUnclaimedInstallation, result} = run({sentry});
+
+    await expect(result).rejects.toBeInstanceOf(SentryIntegrationProviderError);
+    expect(persistVerifiedUnclaimedInstallation).not.toHaveBeenCalled();
+    expect(connectSentryInstallation).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleSentryConnect — verified, unclaimed row exists (webhook-first)', () => {
+  it('binds via same-code race when the exchange is already used and the hash matches', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+      ),
+    });
+    const {connectSentryInstallation, persistVerifiedUnclaimedInstallation, result} = run({
       sentry,
-      existing: connection({workspaceId: OTHER_WORKSPACE_ID}),
+      install: installation({connectionId: null, codeHash: CODE_HASH}),
     });
 
-    await expect(result).rejects.toBeInstanceOf(SentryInstallationAlreadyLinkedError);
-    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+    const connected = await result;
+
+    expect(persistVerifiedUnclaimedInstallation).not.toHaveBeenCalled();
+    expect(connectSentryInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({installationUuid: INSTALL_UUID, codeHash: CODE_HASH}),
+    );
+    expect(connected.provider).toBe('sentry');
   });
 
-  it('is idempotent for an already-active same-workspace connection', async () => {
+  it('binds via a fresh successful exchange (re-entry with a new code), updating the hash', async () => {
+    const freshCode = 'fresh-code';
     const sentry = sentryClient();
-    const existing = connection({workspaceId: WORKSPACE_ID, lifecycleStatus: 'active'});
-    const {connectSentryInstallation, result} = run({sentry, existing});
+    const {connectSentryInstallation, result} = run({
+      sentry,
+      code: freshCode,
+      install: installation({connectionId: null, codeHash: hashAuthorizationCode('old-code')}),
+    });
+
+    await result;
+
+    expect(sentry.exchangeAuthorizationCode).toHaveBeenCalledWith({
+      installationUuid: INSTALL_UUID,
+      code: freshCode,
+    });
+    expect(connectSentryInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({codeHash: hashAuthorizationCode(freshCode)}),
+    );
+  });
+
+  it('rejects with proof mismatch (IDOR) when the code is already used and the hash differs', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+      ),
+    });
+    const {connectSentryInstallation, result} = run({
+      sentry,
+      code: 'forged-code',
+      install: installation({connectionId: null, codeHash: CODE_HASH}),
+    });
+
+    await expect(result).rejects.toBeInstanceOf(SentryClaimProofMismatchError);
+    expect(connectSentryInstallation).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleSentryConnect — already claimed / tombstoned', () => {
+  it('is idempotent for an install already claimed to the same workspace', async () => {
+    const existing = connection({workspaceId: WORKSPACE_ID});
+    const {sentry, connectSentryInstallation, result} = run({
+      install: installation({connectionId: CONNECTION_ID}),
+      connection: existing,
+    });
 
     const connected = await result;
 
@@ -139,27 +251,57 @@ describe('handleSentryConnect', () => {
     expect(connectSentryInstallation).not.toHaveBeenCalled();
   });
 
-  it('re-activates a disabled same-workspace connection', async () => {
-    const sentry = sentryClient();
-    const existing = connection({workspaceId: WORKSPACE_ID, lifecycleStatus: 'disabled'});
-    const {connectSentryInstallation, result} = run({sentry, existing});
+  it('throws when the install is claimed to a different workspace', async () => {
+    const {sentry, result} = run({
+      install: installation({connectionId: CONNECTION_ID}),
+      connection: connection({workspaceId: OTHER_WORKSPACE_ID}),
+    });
+
+    await expect(result).rejects.toBeInstanceOf(SentryInstallationAlreadyLinkedError);
+    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('throws when the install is tombstoned', async () => {
+    const {sentry, result} = run({
+      install: installation({status: 'deleted'}),
+    });
+
+    await expect(result).rejects.toBeInstanceOf(SentryInstallationDeletedError);
+    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleSentryConnect — simultaneous race', () => {
+  it('returns a retryable error when the code is already used and no row is visible yet', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+      ),
+    });
+    const {result} = run({sentry, installSequence: [undefined, undefined]});
+
+    await expect(result).rejects.toBeInstanceOf(SentryVerificationInProgressError);
+  });
+
+  it('reconciles when the concurrent webhook persisted the row between lookups', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi
+        .fn()
+        // First (browser) exchange loses the race; on re-read we find the row and
+        // the second exchange is "already used" with a matching hash → bind.
+        .mockRejectedValueOnce(new SentryIntegrationProviderError('access-denied', 'already used'))
+        .mockRejectedValueOnce(new SentryIntegrationProviderError('access-denied', 'already used')),
+    });
+    const {connectSentryInstallation, result} = run({
+      sentry,
+      installSequence: [undefined, installation({connectionId: null, codeHash: CODE_HASH})],
+    });
 
     const connected = await result;
 
-    expect(sentry.exchangeAuthorizationCode).toHaveBeenCalled();
-    expect(connectSentryInstallation).toHaveBeenCalled();
-    expect(connected.lifecycleStatus).toBe('active');
-  });
-
-  it('persists nothing when the code exchange fails', async () => {
-    const sentry = sentryClient({
-      exchangeAuthorizationCode: vi.fn(() => Promise.reject(new Error('forged code'))),
-    });
-    const {connectSentryInstallation, result} = run({sentry});
-
-    await expect(result).rejects.toThrow('forged code');
-    expect(sentry.getInstallation).not.toHaveBeenCalled();
-    expect(connectSentryInstallation).not.toHaveBeenCalled();
-    expect(sentry.verifyInstallation).not.toHaveBeenCalled();
+    expect(connected.provider).toBe('sentry');
+    expect(connectSentryInstallation).toHaveBeenCalledWith(
+      expect.objectContaining({codeHash: CODE_HASH}),
+    );
   });
 });

--- a/libs/api/integration/sentry/src/core/install.test.ts
+++ b/libs/api/integration/sentry/src/core/install.test.ts
@@ -304,4 +304,24 @@ describe('handleSentryConnect — simultaneous race', () => {
       expect.objectContaining({codeHash: CODE_HASH}),
     );
   });
+
+  it('resolves idempotently when the concurrent webhook claimed the row between lookups', async () => {
+    const sentry = sentryClient({
+      exchangeAuthorizationCode: vi.fn(() =>
+        Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+      ),
+    });
+    const existing = connection({workspaceId: WORKSPACE_ID});
+    const {connectSentryInstallation, result} = run({
+      sentry,
+      // First lookup sees no row; the re-read finds it already claimed.
+      installSequence: [undefined, installation({connectionId: CONNECTION_ID})],
+      connection: existing,
+    });
+
+    const connected = await result;
+
+    expect(connected).toBe(existing);
+    expect(connectSentryInstallation).not.toHaveBeenCalled();
+  });
 });

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -1,4 +1,4 @@
-import {createHash} from 'node:crypto';
+import {createHash, timingSafeEqual} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {SentryApiClient, SentryAuthorization} from '#api/client.js';
@@ -30,6 +30,14 @@ export function hashAuthorizationCode(code: string): string {
   return createHash('sha256').update(code).digest('hex');
 }
 
+// Constant-time compare of two sha256 hex digests, matching the HMAC check in
+// signature.ts. The length guard runs first because timingSafeEqual throws on a
+// length mismatch, and a digest's length is not secret.
+function codeHashesEqual(presented: string, stored: string): boolean {
+  if (presented.length !== stored.length) return false;
+  return timingSafeEqual(Buffer.from(presented), Buffer.from(stored));
+}
+
 export interface VerifyAndPersistUnclaimedInstallationParams {
   sentry: SentryApiClient;
   installationUuid: string;
@@ -50,12 +58,12 @@ export interface VerifyAndPersistUnclaimedInstallationResult {
 
 /**
  * Security-critical exchange → persist → best-effort verify, shared by the signed
- * webhook and the browser-first claim (D4). The exchange is the authenticity
- * check and spends the single-use code, so it runs OUTSIDE any DB transaction
- * (D2); the caller's `persistVerifiedUnclaimedInstallation` owns the short
- * transaction. The verify runs AFTER the row is durably persisted (D5), so a
- * verify failure leaves a claimable row rather than a Sentry-side "installed"
- * state pointing at a row that was never written. Never logs the raw code.
+ * webhook and the browser-first claim. The exchange is the authenticity check and
+ * spends the single-use code, so it runs OUTSIDE any DB transaction; the caller's
+ * `persistVerifiedUnclaimedInstallation` owns the short transaction. The verify
+ * runs AFTER the row is durably persisted, so a verify failure leaves a claimable
+ * row rather than a Sentry-side "installed" state pointing at a row that was never
+ * written. Never logs the raw code.
  */
 export async function verifyAndPersistUnclaimedInstallation(
   params: VerifyAndPersistUnclaimedInstallationParams,
@@ -115,7 +123,7 @@ export interface HandleSentryConnectParams {
  * webhook-authoritative flow). The webhook persists the verified-unclaimed row;
  * this proves the claimant controls the install and sets `connection_id`.
  *
- * Proof rules (unified claim auth, D1/D3):
+ * Proof rules (unified claim auth):
  * - exchange succeeds → browser-first winner or a re-entry with a fresh code.
  * - exchange "already used" + the presented code hashes to the stored hash →
  *   the same code the webhook spent, so the claimant holds it (same-code race).
@@ -164,7 +172,10 @@ async function claimVerifiedInstall(
     });
   } catch (error) {
     if (isCodeAlreadyUsed(error)) {
-      if (install.codeHash && hashAuthorizationCode(params.code) === install.codeHash) {
+      if (
+        install.codeHash &&
+        codeHashesEqual(hashAuthorizationCode(params.code), install.codeHash)
+      ) {
         return bindClaim(params, {orgSlug: install.orgSlug, codeHash: install.codeHash});
       }
       throw new SentryClaimProofMismatchError(params.installationUuid);

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -1,7 +1,18 @@
+import {createHash} from 'node:crypto';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {SentryApiClient} from '#api/client.js';
-import {SentryInstallationAlreadyLinkedError} from '#core/errors.js';
+import type {SentryApiClient, SentryAuthorization} from '#api/client.js';
+import {
+  SentryClaimProofMismatchError,
+  SentryInstallationAlreadyLinkedError,
+  SentryInstallationDeletedError,
+  SentryIntegrationProviderError,
+  SentryVerificationInProgressError,
+} from '#core/errors.js';
+import type {
+  PersistVerifiedUnclaimedInstallationParams,
+  SentryInstallation,
+} from '#db/installations.js';
 
 export interface ConnectSentryInstallationInput {
   workspaceId: string;
@@ -9,6 +20,75 @@ export interface ConnectSentryInstallationInput {
   orgSlug: string;
   displayName: string;
   installerUserId: string;
+  codeHash: string;
+}
+
+// sha256 of the single-use authorization code. Stored on the install row so the
+// claim can prove the claimant holds the same code Sentry issued, without ever
+// persisting a live credential (the code is dead once exchanged).
+export function hashAuthorizationCode(code: string): string {
+  return createHash('sha256').update(code).digest('hex');
+}
+
+export interface VerifyAndPersistUnclaimedInstallationParams {
+  sentry: SentryApiClient;
+  installationUuid: string;
+  code: string;
+  // Known from the signed webhook payload; omit to derive it from Sentry after
+  // the exchange (the browser-first claim carries no payload).
+  orgSlug?: string | undefined;
+  verifyInstall: boolean;
+  persistVerifiedUnclaimedInstallation: (
+    input: PersistVerifiedUnclaimedInstallationParams,
+  ) => Promise<SentryInstallation>;
+}
+
+export interface VerifyAndPersistUnclaimedInstallationResult {
+  installation: SentryInstallation;
+  authorization: SentryAuthorization;
+}
+
+/**
+ * Security-critical exchange → persist → best-effort verify, shared by the signed
+ * webhook and the browser-first claim (D4). The exchange is the authenticity
+ * check and spends the single-use code, so it runs OUTSIDE any DB transaction
+ * (D2); the caller's `persistVerifiedUnclaimedInstallation` owns the short
+ * transaction. The verify runs AFTER the row is durably persisted (D5), so a
+ * verify failure leaves a claimable row rather than a Sentry-side "installed"
+ * state pointing at a row that was never written. Never logs the raw code.
+ */
+export async function verifyAndPersistUnclaimedInstallation(
+  params: VerifyAndPersistUnclaimedInstallationParams,
+): Promise<VerifyAndPersistUnclaimedInstallationResult> {
+  const authorization = await params.sentry.exchangeAuthorizationCode({
+    installationUuid: params.installationUuid,
+    code: params.code,
+  });
+
+  const orgSlug =
+    params.orgSlug ??
+    (
+      await params.sentry.getInstallation({
+        installationUuid: params.installationUuid,
+        token: authorization.token,
+      })
+    ).orgSlug;
+
+  const installation = await params.persistVerifiedUnclaimedInstallation({
+    installationUuid: params.installationUuid,
+    orgSlug,
+    codeHash: hashAuthorizationCode(params.code),
+  });
+
+  if (params.verifyInstall) {
+    await bestEffortVerifyInstallation({
+      sentry: params.sentry,
+      installationUuid: params.installationUuid,
+      token: authorization.token,
+    });
+  }
+
+  return {installation, authorization};
 }
 
 export interface HandleSentryConnectParams {
@@ -18,70 +98,193 @@ export interface HandleSentryConnectParams {
   installationUuid: string;
   installerUserId: string;
   verifyInstall: boolean;
-  getExistingSentryConnection: (input: {
+  getSentryInstallation: (input: {
     installationUuid: string;
-  }) => Promise<IntegrationConnection<'sentry'> | undefined>;
+  }) => Promise<SentryInstallation | undefined>;
+  getConnectionById: (id: string) => Promise<IntegrationConnection<'sentry'> | undefined>;
   connectSentryInstallation: (
     input: ConnectSentryInstallationInput,
   ) => Promise<IntegrationConnection<'sentry'>>;
+  persistVerifiedUnclaimedInstallation: (
+    input: PersistVerifiedUnclaimedInstallationParams,
+  ) => Promise<SentryInstallation>;
 }
 
-// The "verify install" side effect runs AFTER the row is durably persisted, so a
-// verify failure leaves a working connection rather than a Sentry-side "installed"
-// state pointing at a row that was never written.
+/**
+ * Binds a verified Sentry installation to a workspace (the claim half of the
+ * webhook-authoritative flow). The webhook persists the verified-unclaimed row;
+ * this proves the claimant controls the install and sets `connection_id`.
+ *
+ * Proof rules (unified claim auth, D1/D3):
+ * - exchange succeeds → browser-first winner or a re-entry with a fresh code.
+ * - exchange "already used" + the presented code hashes to the stored hash →
+ *   the same code the webhook spent, so the claimant holds it (same-code race).
+ * - exchange "already used" + the verified row is not visible yet → a concurrent
+ *   webhook is mid-exchange; retryable so the client backoff reconciles.
+ * - anything else on an existing unclaimed row → proof mismatch (403, IDOR gate).
+ */
 export async function handleSentryConnect(
   params: HandleSentryConnectParams,
 ): Promise<IntegrationConnection<'sentry'>> {
-  const existing = await params.getExistingSentryConnection({
-    installationUuid: params.installationUuid,
-  });
-  if (existing && existing.workspaceId !== params.workspaceId) {
-    throw new SentryInstallationAlreadyLinkedError(params.installationUuid);
+  const install = await params.getSentryInstallation({installationUuid: params.installationUuid});
+
+  if (install) {
+    if (install.status === 'deleted') {
+      throw new SentryInstallationDeletedError(params.installationUuid);
+    }
+    if (install.connectionId) {
+      return resolveClaimedInstall(params, install.connectionId);
+    }
+    return claimVerifiedInstall(params, install);
   }
-  // Short-circuit so a replayed callback does not re-exchange the single-use code.
-  if (existing && existing.lifecycleStatus === 'active') {
-    return existing;
+
+  return claimBrowserFirst(params);
+}
+
+async function resolveClaimedInstall(
+  params: HandleSentryConnectParams,
+  connectionId: string,
+): Promise<IntegrationConnection<'sentry'>> {
+  const connection = await params.getConnectionById(connectionId);
+  if (connection && connection.workspaceId === params.workspaceId) {
+    return connection;
+  }
+  throw new SentryInstallationAlreadyLinkedError(params.installationUuid);
+}
+
+async function claimVerifiedInstall(
+  params: HandleSentryConnectParams,
+  install: SentryInstallation,
+): Promise<IntegrationConnection<'sentry'>> {
+  let authorization: SentryAuthorization;
+  try {
+    authorization = await params.sentry.exchangeAuthorizationCode({
+      installationUuid: params.installationUuid,
+      code: params.code,
+    });
+  } catch (error) {
+    if (isCodeAlreadyUsed(error)) {
+      if (install.codeHash && hashAuthorizationCode(params.code) === install.codeHash) {
+        return bindClaim(params, {orgSlug: install.orgSlug, codeHash: install.codeHash});
+      }
+      throw new SentryClaimProofMismatchError(params.installationUuid);
+    }
+    throw error;
   }
 
-  // Exchanging the code is also the authenticity check — a forged installation
-  // id fails here and nothing is persisted.
-  const authorization = await params.sentry.exchangeAuthorizationCode({
-    installationUuid: params.installationUuid,
-    code: params.code,
+  const connection = await bindClaim(params, {
+    orgSlug: install.orgSlug,
+    codeHash: hashAuthorizationCode(params.code),
   });
-
-  const {orgSlug} = await params.sentry.getInstallation({
-    installationUuid: params.installationUuid,
-    token: authorization.token,
-  });
-
-  // For a previously uninstalled (disabled) connection, this re-activates both the
-  // connection lifecycle and the installation status.
-  const connection = await params.connectSentryInstallation({
-    workspaceId: params.workspaceId,
-    installationUuid: params.installationUuid,
-    orgSlug,
-    displayName: `Sentry ${orgSlug}`,
-    installerUserId: params.installerUserId,
-  });
-
   if (params.verifyInstall) {
-    // Best-effort: the connection is already persisted and receiving webhooks, so
-    // a verify failure only leaves the install pending on Sentry's side. Failing
-    // the connect would strand a working row behind the idempotent short-circuit
-    // on retry (re-verifying needs a fresh token we cannot mint yet), so we log it.
-    try {
-      await params.sentry.verifyInstallation({
-        installationUuid: params.installationUuid,
-        token: authorization.token,
-      });
-    } catch (error) {
-      logger().warn(
-        {installationUuid: params.installationUuid, connectionId: connection.id, err: error},
-        'sentry connect: verify-install failed after persistence, connection is active',
-      );
+    await bestEffortVerifyInstallation({
+      sentry: params.sentry,
+      installationUuid: params.installationUuid,
+      token: authorization.token,
+      connectionId: connection.id,
+    });
+  }
+  return connection;
+}
+
+async function claimBrowserFirst(
+  params: HandleSentryConnectParams,
+): Promise<IntegrationConnection<'sentry'>> {
+  let result: VerifyAndPersistUnclaimedInstallationResult;
+  try {
+    result = await verifyAndPersistUnclaimedInstallation({
+      sentry: params.sentry,
+      installationUuid: params.installationUuid,
+      code: params.code,
+      verifyInstall: false,
+      persistVerifiedUnclaimedInstallation: params.persistVerifiedUnclaimedInstallation,
+    });
+  } catch (error) {
+    if (isCodeAlreadyUsed(error)) {
+      return reconcileConcurrentClaim(params);
+    }
+    throw error;
+  }
+
+  const connection = await bindClaim(params, {
+    orgSlug: result.installation.orgSlug,
+    codeHash: hashAuthorizationCode(params.code),
+  });
+  if (params.verifyInstall) {
+    await bestEffortVerifyInstallation({
+      sentry: params.sentry,
+      installationUuid: params.installationUuid,
+      token: result.authorization.token,
+      connectionId: connection.id,
+    });
+  }
+  return connection;
+}
+
+// The browser-first exchange got "already used" with no row visible at lookup: a
+// concurrent webhook won the exchange. Re-read once — if its verified row is now
+// visible we reconcile through the same proof rules; if it got claimed we resolve
+// it; otherwise it is still mid-flight, so the claim is retryable.
+async function reconcileConcurrentClaim(
+  params: HandleSentryConnectParams,
+): Promise<IntegrationConnection<'sentry'>> {
+  const reread = await params.getSentryInstallation({installationUuid: params.installationUuid});
+  if (reread && reread.status !== 'deleted') {
+    if (reread.connectionId) {
+      return resolveClaimedInstall(params, reread.connectionId);
+    }
+    if (isVerifiedUnclaimed(reread)) {
+      return claimVerifiedInstall(params, reread);
     }
   }
+  throw new SentryVerificationInProgressError(params.installationUuid);
+}
 
-  return connection;
+function isVerifiedUnclaimed(install: SentryInstallation): boolean {
+  return install.connectionId === null && install.status === 'installed';
+}
+
+function bindClaim(
+  params: HandleSentryConnectParams,
+  binding: {orgSlug: string; codeHash: string},
+): Promise<IntegrationConnection<'sentry'>> {
+  return params.connectSentryInstallation({
+    workspaceId: params.workspaceId,
+    installationUuid: params.installationUuid,
+    orgSlug: binding.orgSlug,
+    displayName: `Sentry ${binding.orgSlug}`,
+    installerUserId: params.installerUserId,
+    codeHash: binding.codeHash,
+  });
+}
+
+async function bestEffortVerifyInstallation(input: {
+  sentry: SentryApiClient;
+  installationUuid: string;
+  token: string;
+  connectionId?: string;
+}): Promise<void> {
+  // The row is already persisted and receiving webhooks, so a verify failure only
+  // leaves the install pending on Sentry's side (re-verifying needs a fresh token
+  // we cannot mint here). Log it rather than failing a working claim.
+  try {
+    await input.sentry.verifyInstallation({
+      installationUuid: input.installationUuid,
+      token: input.token,
+    });
+  } catch (error) {
+    logger().warn(
+      {installationUuid: input.installationUuid, connectionId: input.connectionId, err: error},
+      'sentry connect: verify-install failed after persistence',
+    );
+  }
+}
+
+// The Sentry client collapses a reused, expired, or forged code to a single
+// `access-denied` provider error; we cannot tell them apart from the response.
+// On an install we already know was verified, the most likely cause is the code
+// having been spent already, so the hash check disambiguates rather than the
+// error itself.
+function isCodeAlreadyUsed(error: unknown): boolean {
+  return error instanceof SentryIntegrationProviderError && error.reason === 'access-denied';
 }

--- a/libs/api/integration/sentry/src/core/install.ts
+++ b/libs/api/integration/sentry/src/core/install.ts
@@ -235,12 +235,16 @@ async function claimBrowserFirst(
 // The browser-first exchange got "already used" with no row visible at lookup: a
 // concurrent webhook won the exchange. Re-read once — if its verified row is now
 // visible we reconcile through the same proof rules; if it got claimed we resolve
-// it; otherwise it is still mid-flight, so the claim is retryable.
+// it; if it was tombstoned we surface that terminally (matching the top-level
+// check); otherwise it is still mid-flight, so the claim is retryable.
 async function reconcileConcurrentClaim(
   params: HandleSentryConnectParams,
 ): Promise<IntegrationConnection<'sentry'>> {
   const reread = await params.getSentryInstallation({installationUuid: params.installationUuid});
-  if (reread && reread.status !== 'deleted') {
+  if (reread?.status === 'deleted') {
+    throw new SentryInstallationDeletedError(params.installationUuid);
+  }
+  if (reread) {
     if (reread.connectionId) {
       return resolveClaimedInstall(params, reread.connectionId);
     }

--- a/libs/api/integration/sentry/src/core/webhook.test.ts
+++ b/libs/api/integration/sentry/src/core/webhook.test.ts
@@ -58,6 +58,25 @@ describe('handleSentryIssueEvent', () => {
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
   });
 
+  test('throws SentryConnectionNotFoundError for a verified-but-unclaimed installation', async () => {
+    const installationUuid = randomUUID();
+    await sentryInstallationFactory.create({installationUuid, connectionId: null});
+    const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+    const getIntegrationConnectionById = vi.fn();
+
+    const run = handleSentryIssueEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      payload: issuePayload(installationUuid),
+      publishIntegrationEventReceived,
+      getIntegrationConnectionById,
+    });
+
+    await expect(run).rejects.toBeInstanceOf(SentryConnectionNotFoundError);
+    expect(getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
   test('throws SentryConnectionNotFoundError when the installation has no connection', async () => {
     const installationUuid = randomUUID();
     await sentryInstallationFactory.create({installationUuid});

--- a/libs/api/integration/sentry/src/core/webhook.test.ts
+++ b/libs/api/integration/sentry/src/core/webhook.test.ts
@@ -7,6 +7,7 @@ import {
   SentryConnectionNotFoundError,
   SentryInstallationDeletedError,
   SentryInstallationNotFoundError,
+  SentryInstallationUnclaimedError,
 } from './errors.js';
 import {handleSentryIssueEvent, normalizeSentryIssueAction} from './webhook.js';
 
@@ -58,7 +59,7 @@ describe('handleSentryIssueEvent', () => {
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
   });
 
-  test('throws SentryConnectionNotFoundError for a verified-but-unclaimed installation', async () => {
+  test('throws SentryInstallationUnclaimedError for a verified-but-unclaimed installation', async () => {
     const installationUuid = randomUUID();
     await sentryInstallationFactory.create({installationUuid, connectionId: null});
     const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
@@ -72,7 +73,7 @@ describe('handleSentryIssueEvent', () => {
       getIntegrationConnectionById,
     });
 
-    await expect(run).rejects.toBeInstanceOf(SentryConnectionNotFoundError);
+    await expect(run).rejects.toBeInstanceOf(SentryInstallationUnclaimedError);
     expect(getIntegrationConnectionById).not.toHaveBeenCalled();
     expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
   });

--- a/libs/api/integration/sentry/src/core/webhook.ts
+++ b/libs/api/integration/sentry/src/core/webhook.ts
@@ -13,6 +13,7 @@ import {
   SentryConnectionNotFoundError,
   SentryInstallationDeletedError,
   SentryInstallationNotFoundError,
+  SentryInstallationUnclaimedError,
   SentryIntegrationProviderError,
 } from '#core/errors.js';
 import {verifyAndPersistUnclaimedInstallation} from '#core/install.js';
@@ -54,7 +55,7 @@ export async function handleSentryIssueEvent(params: HandleSentryIssueEventParam
   // A verified-but-unclaimed install has no workspace yet, so there is nothing to
   // publish an event against. This is the pre-claim drop window (counted/logged).
   if (!installation.connectionId) {
-    throw new SentryConnectionNotFoundError(installationUuid);
+    throw new SentryInstallationUnclaimedError(installationUuid);
   }
 
   const connection = await params.getIntegrationConnectionById(installation.connectionId, {
@@ -87,9 +88,11 @@ export interface HandleSentryInstallationCreatedParams {
   code: string | undefined;
   sentry: SentryApiClient;
   verifyInstall: boolean;
-  getSentryInstallation: (installationUuid: string) => Promise<SentryInstallation | undefined>;
+  getSentryInstallation: (input: {
+    installationUuid: string;
+  }) => Promise<SentryInstallation | undefined>;
   // Persists the verified-unclaimed row and records the delivery in one short
-  // transaction (D2), returning the persisted row.
+  // transaction, returning the persisted row.
   persistUnclaimedAndRecordDelivery: (input: {
     installationUuid: string;
     orgSlug: string;
@@ -104,16 +107,15 @@ export interface HandleSentryInstallationCreatedParams {
 /**
  * The authoritative `installation.created` path. Whichever of webhook or browser
  * arrives first exchanges the single-use code and persists a verified-unclaimed
- * row (D1); the other reconciles. Idempotent on the installation uuid. The
- * exchange runs outside any DB transaction (D2); a short transaction wraps only
- * persist + delivery record. On any exchange failure the delivery is
- * record-and-dropped (204) — the browser may still win, or the code expired.
- * Never logs the raw code.
+ * row; the other reconciles. Idempotent on the installation uuid. The exchange
+ * runs outside any DB transaction; a short transaction wraps only persist +
+ * delivery record. On an exchange failure the delivery is record-and-dropped
+ * (204) — the browser may still win, or the code expired. Never logs the raw code.
  */
 export async function handleSentryInstallationCreated(
   params: HandleSentryInstallationCreatedParams,
 ): Promise<void> {
-  const existing = await params.getSentryInstallation(params.installationUuid);
+  const existing = await params.getSentryInstallation({installationUuid: params.installationUuid});
   if (existing) {
     logger().debug(
       {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
@@ -148,20 +150,32 @@ export async function handleSentryInstallationCreated(
         }),
     });
   } catch (error) {
-    // `reason` distinguishes a transient/expected drop (access-denied: the code
-    // was already spent, e.g. the browser won) from a likely misconfiguration
-    // (a bad client id/secret/slug fails every install) so log-based alerting can
-    // fire on the sustained case. Never logs the raw code.
-    const reason = error instanceof SentryIntegrationProviderError ? error.reason : undefined;
-    logger().warn(
-      {
-        deliveryId: params.deliveryId,
-        installationUuid: params.installationUuid,
-        reason,
-        err: error,
-      },
-      'sentry webhook: installation.created exchange failed, dropping',
-    );
+    if (error instanceof SentryIntegrationProviderError) {
+      // The Sentry exchange (or org-slug lookup) failed, so we never durably
+      // spent the code on a row we own. `reason` distinguishes a transient/expected
+      // drop (access-denied: the code was already spent, e.g. the browser won) from
+      // a likely misconfiguration (a bad client id/secret/slug fails every install)
+      // so log-based alerting can fire on the sustained case. Never logs the raw code.
+      logger().warn(
+        {
+          deliveryId: params.deliveryId,
+          installationUuid: params.installationUuid,
+          reason: error.reason,
+          err: error,
+        },
+        'sentry webhook: installation.created exchange failed, dropping',
+      );
+    } else {
+      // The exchange succeeded (the single-use code is now spent) but the persist
+      // transaction failed, so no row exists and Sentry will not usefully
+      // re-deliver — the install is stranded until a reinstall mints a fresh uuid.
+      // Log at error so alerting catches it; still record-and-drop because retrying
+      // a spent code cannot recover the row. Never logs the raw code.
+      logger().error(
+        {deliveryId: params.deliveryId, installationUuid: params.installationUuid, err: error},
+        'sentry webhook: installation.created persisted nothing after a successful exchange, install stranded until reinstall',
+      );
+    }
     await params.recordDelivery(params.deliveryId);
   }
 }

--- a/libs/api/integration/sentry/src/core/webhook.ts
+++ b/libs/api/integration/sentry/src/core/webhook.ts
@@ -7,14 +7,19 @@ import type {
   UpdateIntegrationConnectionLifecycleStatusFn,
 } from '@shipfox/api-integration-core-dto';
 import type {SentryIssueWebhookDto} from '@shipfox/api-integration-sentry-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {SentryApiClient} from '#api/client.js';
 import {
   SentryConnectionNotFoundError,
   SentryInstallationDeletedError,
   SentryInstallationNotFoundError,
+  SentryIntegrationProviderError,
 } from '#core/errors.js';
+import {verifyAndPersistUnclaimedInstallation} from '#core/install.js';
 import {
   getSentryInstallationByInstallationUuid,
   markSentryInstallationDeleted,
+  type SentryInstallation,
 } from '#db/installations.js';
 
 const SENTRY_SOURCE = 'sentry';
@@ -31,9 +36,9 @@ export interface HandleSentryIssueEventParams {
 
 // Publishes the mapped event for a verified issue delivery. Throws a typed
 // SentryIssueDroppedError subclass when the delivery references state we cannot
-// publish against (unknown/deleted installation, missing connection); the webhook
-// layer records-and-drops those. Dedup of an already-seen delivery is handled
-// inside publishIntegrationEventReceived.
+// publish against (unknown/deleted installation, or an install not yet claimed
+// into a workspace); the webhook layer records-and-drops those. Dedup of an
+// already-seen delivery is handled inside publishIntegrationEventReceived.
 export async function handleSentryIssueEvent(params: HandleSentryIssueEventParams): Promise<void> {
   const installationUuid = params.payload.installation.uuid;
 
@@ -45,6 +50,11 @@ export async function handleSentryIssueEvent(params: HandleSentryIssueEventParam
   }
   if (installation.status === DELETED_STATUS) {
     throw new SentryInstallationDeletedError(installationUuid);
+  }
+  // A verified-but-unclaimed install has no workspace yet, so there is nothing to
+  // publish an event against. This is the pre-claim drop window (counted/logged).
+  if (!installation.connectionId) {
+    throw new SentryConnectionNotFoundError(installationUuid);
   }
 
   const connection = await params.getIntegrationConnectionById(installation.connectionId, {
@@ -68,34 +78,120 @@ export async function handleSentryIssueEvent(params: HandleSentryIssueEventParam
   });
 }
 
-export interface HandleSentryInstallationLifecycleParams {
+export interface HandleSentryInstallationCreatedParams {
+  deliveryId: string;
+  installationUuid: string;
+  // From the signed payload; the webhook is authoritative so the slug is trusted
+  // without a getInstallation round-trip. The code is the single-use grant.
+  orgSlug: string | undefined;
+  code: string | undefined;
+  sentry: SentryApiClient;
+  verifyInstall: boolean;
+  getSentryInstallation: (installationUuid: string) => Promise<SentryInstallation | undefined>;
+  // Persists the verified-unclaimed row and records the delivery in one short
+  // transaction (D2), returning the persisted row.
+  persistUnclaimedAndRecordDelivery: (input: {
+    installationUuid: string;
+    orgSlug: string;
+    codeHash: string;
+    deliveryId: string;
+  }) => Promise<SentryInstallation>;
+  // Records the delivery for dedup without persisting an install (reconcile/no-op,
+  // missing code, or exchange failure → record-and-drop).
+  recordDelivery: (deliveryId: string) => Promise<void>;
+}
+
+/**
+ * The authoritative `installation.created` path. Whichever of webhook or browser
+ * arrives first exchanges the single-use code and persists a verified-unclaimed
+ * row (D1); the other reconciles. Idempotent on the installation uuid. The
+ * exchange runs outside any DB transaction (D2); a short transaction wraps only
+ * persist + delivery record. On any exchange failure the delivery is
+ * record-and-dropped (204) — the browser may still win, or the code expired.
+ * Never logs the raw code.
+ */
+export async function handleSentryInstallationCreated(
+  params: HandleSentryInstallationCreatedParams,
+): Promise<void> {
+  const existing = await params.getSentryInstallation(params.installationUuid);
+  if (existing) {
+    logger().debug(
+      {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
+      'sentry webhook: installation.created for an existing row, reconciling',
+    );
+    await params.recordDelivery(params.deliveryId);
+    return;
+  }
+
+  if (!params.code) {
+    logger().warn(
+      {deliveryId: params.deliveryId, installationUuid: params.installationUuid},
+      'sentry webhook: installation.created without an authorization code, dropping',
+    );
+    await params.recordDelivery(params.deliveryId);
+    return;
+  }
+
+  try {
+    await verifyAndPersistUnclaimedInstallation({
+      sentry: params.sentry,
+      installationUuid: params.installationUuid,
+      code: params.code,
+      orgSlug: params.orgSlug,
+      verifyInstall: params.verifyInstall,
+      persistVerifiedUnclaimedInstallation: ({installationUuid, orgSlug, codeHash}) =>
+        params.persistUnclaimedAndRecordDelivery({
+          installationUuid,
+          orgSlug,
+          codeHash,
+          deliveryId: params.deliveryId,
+        }),
+    });
+  } catch (error) {
+    // `reason` distinguishes a transient/expected drop (access-denied: the code
+    // was already spent, e.g. the browser won) from a likely misconfiguration
+    // (a bad client id/secret/slug fails every install) so log-based alerting can
+    // fire on the sustained case. Never logs the raw code.
+    const reason = error instanceof SentryIntegrationProviderError ? error.reason : undefined;
+    logger().warn(
+      {
+        deliveryId: params.deliveryId,
+        installationUuid: params.installationUuid,
+        reason,
+        err: error,
+      },
+      'sentry webhook: installation.created exchange failed, dropping',
+    );
+    await params.recordDelivery(params.deliveryId);
+  }
+}
+
+export interface HandleSentryInstallationDeletedParams {
   tx: IntegrationTx;
   deliveryId: string;
-  action: 'created' | 'deleted';
   installationUuid: string;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   updateConnectionLifecycleStatus: UpdateIntegrationConnectionLifecycleStatusFn;
 }
 
-export async function handleSentryInstallationLifecycle(
-  params: HandleSentryInstallationLifecycleParams,
+// Tombstones the install and disables its connection if one exists. An unknown
+// uuid (never installed, or reinstall mints a fresh uuid) only records the
+// delivery: there is no tombstone row to write. Runs entirely in the caller's
+// transaction — no exchange is needed.
+export async function handleSentryInstallationDeleted(
+  params: HandleSentryInstallationDeletedParams,
 ): Promise<void> {
-  if (params.action === 'deleted') {
-    const installation = await markSentryInstallationDeleted(
-      {installationUuid: params.installationUuid},
+  const installation = await markSentryInstallationDeleted(
+    {installationUuid: params.installationUuid},
+    {tx: params.tx},
+  );
+  if (installation?.connectionId) {
+    await params.updateConnectionLifecycleStatus(
+      {id: installation.connectionId, lifecycleStatus: 'disabled'},
       {tx: params.tx},
     );
-    if (installation) {
-      await params.updateConnectionLifecycleStatus(
-        {id: installation.connectionId, lifecycleStatus: 'disabled'},
-        {tx: params.tx},
-      );
-    }
   }
 
-  // Every delivery is recorded for dedup. The connect flow owns row creation, so
-  // an early lifecycle webhook with no matching row is recorded without creating a
-  // partial installation from an unauthenticated provider callback.
   await params.recordDeliveryOnly({
     tx: params.tx,
     provider: SENTRY_SOURCE,

--- a/libs/api/integration/sentry/src/db/installations.test.ts
+++ b/libs/api/integration/sentry/src/db/installations.test.ts
@@ -2,7 +2,10 @@ import {randomUUID} from 'node:crypto';
 import {db} from './db.js';
 import {
   getSentryInstallationByInstallationUuid,
+  listUnclaimedSentryInstallations,
   markSentryInstallationDeleted,
+  persistVerifiedUnclaimedInstallation,
+  pruneUnclaimedSentryInstallations,
   upsertSentryInstallation,
 } from './installations.js';
 import {sentryInstallations} from './schema/installations.js';
@@ -62,5 +65,116 @@ describe('sentry installations persistence', () => {
     const result = await getSentryInstallationByInstallationUuid('missing');
 
     expect(result).toBeUndefined();
+  });
+
+  test('persistVerifiedUnclaimedInstallation inserts an unclaimed row with a code hash', async () => {
+    const installationUuid = randomUUID();
+
+    const persisted = await persistVerifiedUnclaimedInstallation({
+      installationUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash-1',
+    });
+
+    expect(persisted.connectionId).toBeNull();
+    expect(persisted.status).toBe('installed');
+    expect(persisted.codeHash).toBe('hash-1');
+  });
+
+  test('persistVerifiedUnclaimedInstallation never clobbers a claimed connection or downgrades status', async () => {
+    const installationUuid = randomUUID();
+    const connectionId = randomUUID();
+    await upsertSentryInstallation({
+      connectionId,
+      installationUuid,
+      orgSlug: 'acme',
+      status: 'installed',
+      codeHash: 'claimed-hash',
+    });
+
+    const reconciled = await persistVerifiedUnclaimedInstallation({
+      installationUuid,
+      orgSlug: 'acme-renamed',
+      codeHash: 'webhook-hash',
+    });
+
+    // A late webhook refreshes the slug/hash but leaves the claim intact.
+    expect(reconciled.connectionId).toBe(connectionId);
+    expect(reconciled.status).toBe('installed');
+    expect(reconciled.orgSlug).toBe('acme-renamed');
+    expect(reconciled.codeHash).toBe('webhook-hash');
+  });
+
+  test('listUnclaimedSentryInstallations returns only rows with no connection', async () => {
+    const claimedUuid = randomUUID();
+    const unclaimedUuid = randomUUID();
+    await upsertSentryInstallation({
+      connectionId: randomUUID(),
+      installationUuid: claimedUuid,
+      orgSlug: 'acme',
+      status: 'installed',
+    });
+    await persistVerifiedUnclaimedInstallation({
+      installationUuid: unclaimedUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash',
+    });
+
+    const unclaimed = await listUnclaimedSentryInstallations();
+
+    expect(unclaimed.map((row) => row.installationUuid)).toEqual([unclaimedUuid]);
+  });
+
+  test('listUnclaimedSentryInstallations filters by age when olderThan is given', async () => {
+    const unclaimedUuid = randomUUID();
+    await persistVerifiedUnclaimedInstallation({
+      installationUuid: unclaimedUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash',
+    });
+
+    const future = new Date(Date.now() + 60_000);
+    const past = new Date(Date.now() - 60_000);
+
+    expect(await listUnclaimedSentryInstallations({olderThan: future})).toHaveLength(1);
+    expect(await listUnclaimedSentryInstallations({olderThan: past})).toHaveLength(0);
+  });
+
+  test('pruneUnclaimedSentryInstallations tombstones stale unclaimed rows and leaves fresh ones', async () => {
+    const staleUuid = randomUUID();
+    await persistVerifiedUnclaimedInstallation({
+      installationUuid: staleUuid,
+      orgSlug: 'acme',
+      codeHash: 'hash',
+    });
+
+    const youngResult = await pruneUnclaimedSentryInstallations({
+      olderThan: new Date(Date.now() - 60_000),
+    });
+    expect(youngResult.tombstoned).toBe(0);
+
+    const staleResult = await pruneUnclaimedSentryInstallations({
+      olderThan: new Date(Date.now() + 60_000),
+    });
+    expect(staleResult.tombstoned).toBe(1);
+    expect((await getSentryInstallationByInstallationUuid(staleUuid))?.status).toBe('deleted');
+    expect(await listUnclaimedSentryInstallations()).toHaveLength(0);
+  });
+
+  test('pruneUnclaimedSentryInstallations never tombstones a claimed install', async () => {
+    const claimedUuid = randomUUID();
+    await upsertSentryInstallation({
+      connectionId: randomUUID(),
+      installationUuid: claimedUuid,
+      orgSlug: 'acme',
+      status: 'installed',
+    });
+
+    const result = await pruneUnclaimedSentryInstallations({
+      olderThan: new Date(Date.now() + 60_000),
+    });
+
+    expect(result.tombstoned).toBe(0);
+    expect((await getSentryInstallationByInstallationUuid(claimedUuid))?.status).toBe('installed');
   });
 });

--- a/libs/api/integration/sentry/src/db/installations.ts
+++ b/libs/api/integration/sentry/src/db/installations.ts
@@ -1,4 +1,4 @@
-import {eq} from 'drizzle-orm';
+import {and, eq, isNull, lt} from 'drizzle-orm';
 import {db} from './db.js';
 import {sentryInstallations, toSentryInstallation} from './schema/installations.js';
 
@@ -6,10 +6,11 @@ export type SentryInstallationStatus = 'installed' | 'deleted';
 
 export interface SentryInstallation {
   id: string;
-  connectionId: string;
+  connectionId: string | null;
   installationUuid: string;
   orgSlug: string;
   status: string;
+  codeHash: string | null;
   installerUserId: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -20,7 +21,14 @@ export interface UpsertSentryInstallationParams {
   installationUuid: string;
   orgSlug: string;
   status: SentryInstallationStatus;
+  codeHash?: string | null | undefined;
   installerUserId?: string | null | undefined;
+}
+
+export interface PersistVerifiedUnclaimedInstallationParams {
+  installationUuid: string;
+  orgSlug: string;
+  codeHash: string;
 }
 
 type SentryDb = ReturnType<typeof db>;
@@ -39,6 +47,7 @@ export async function upsertSentryInstallation(
       installationUuid: params.installationUuid,
       orgSlug: params.orgSlug,
       status: params.status,
+      codeHash: params.codeHash ?? null,
       installerUserId: params.installerUserId ?? null,
     })
     .onConflictDoUpdate({
@@ -47,6 +56,7 @@ export async function upsertSentryInstallation(
         connectionId: params.connectionId,
         orgSlug: params.orgSlug,
         status: params.status,
+        codeHash: params.codeHash ?? null,
         installerUserId: params.installerUserId ?? null,
         updatedAt: now,
       },
@@ -55,6 +65,67 @@ export async function upsertSentryInstallation(
 
   if (!row) throw new Error('Sentry installation upsert returned no rows');
   return toSentryInstallation(row);
+}
+
+/**
+ * Inserts the verified-but-unclaimed install half (`connection_id = NULL`,
+ * `status = 'installed'`) after a successful code exchange. Idempotent on the
+ * installation uuid: a conflicting row refreshes only `code_hash`/`org_slug`/
+ * `updated_at`, so a webhook that lands after a claim never clobbers the
+ * `connection_id` it set nor downgrades a `deleted` tombstone back to installed.
+ */
+export async function persistVerifiedUnclaimedInstallation(
+  params: PersistVerifiedUnclaimedInstallationParams,
+  options: {tx?: unknown} = {},
+): Promise<SentryInstallation> {
+  const executor = (options.tx ?? db()) as SentryDb | SentryTx;
+  const now = new Date();
+  const [row] = await executor
+    .insert(sentryInstallations)
+    .values({
+      connectionId: null,
+      installationUuid: params.installationUuid,
+      orgSlug: params.orgSlug,
+      status: 'installed',
+      codeHash: params.codeHash,
+    })
+    .onConflictDoUpdate({
+      target: sentryInstallations.installationUuid,
+      set: {
+        orgSlug: params.orgSlug,
+        codeHash: params.codeHash,
+        updatedAt: now,
+      },
+    })
+    .returning();
+
+  if (!row) throw new Error('Sentry installation persist returned no rows');
+  return toSentryInstallation(row);
+}
+
+/**
+ * Verified installs no user has claimed yet (`connection_id IS NULL`,
+ * `status='installed'`). Tombstoned rows are excluded so the TTL cron stays
+ * idempotent and the unclaimed metric stays accurate. Pass `olderThan` to scope
+ * to stale rows for the cron.
+ */
+export async function listUnclaimedSentryInstallations(
+  params: {olderThan?: Date} = {},
+  options: {tx?: unknown} = {},
+): Promise<SentryInstallation[]> {
+  const executor = (options.tx ?? db()) as SentryDb | SentryTx;
+  const conditions = [
+    isNull(sentryInstallations.connectionId),
+    eq(sentryInstallations.status, 'installed'),
+  ];
+  if (params.olderThan) {
+    conditions.push(lt(sentryInstallations.createdAt, params.olderThan));
+  }
+  const rows = await executor
+    .select()
+    .from(sentryInstallations)
+    .where(and(...conditions));
+  return rows.map(toSentryInstallation);
 }
 
 export async function getSentryInstallationByInstallationUuid(
@@ -85,6 +156,30 @@ export async function getSentryInstallationByConnectionId(
   const row = rows[0];
   if (!row) return undefined;
   return toSentryInstallation(row);
+}
+
+/**
+ * Tombstones verified-unclaimed installs older than `olderThan` (the TTL cleanup
+ * cron). Bounds a never-claimed install rather than leaving it pending forever.
+ * Returns how many rows were tombstoned. We hold no Sentry token for these rows
+ * (tokens are never persisted), so the Sentry-side uninstall is out of scope here.
+ */
+export async function pruneUnclaimedSentryInstallations(
+  params: {olderThan: Date},
+  options: {tx?: unknown} = {},
+): Promise<{tombstoned: number}> {
+  const executor = (options.tx ?? db()) as SentryDb | SentryTx;
+  const result = await executor
+    .update(sentryInstallations)
+    .set({status: 'deleted', updatedAt: new Date()})
+    .where(
+      and(
+        isNull(sentryInstallations.connectionId),
+        eq(sentryInstallations.status, 'installed'),
+        lt(sentryInstallations.createdAt, params.olderThan),
+      ),
+    );
+  return {tombstoned: result.rowCount ?? 0};
 }
 
 export async function markSentryInstallationDeleted(

--- a/libs/api/integration/sentry/src/db/schema/installations.ts
+++ b/libs/api/integration/sentry/src/db/schema/installations.ts
@@ -7,10 +7,17 @@ export const sentryInstallations = pgTable(
   'installations',
   {
     id: uuidv7PrimaryKey(),
-    connectionId: uuid('connection_id').notNull(),
+    // Null until a logged-in user claims the verified install into a workspace.
+    // An unclaimed install (`connection_id IS NULL`, `status='installed'`) is
+    // persisted by the authoritative webhook before any browser claim arrives.
+    connectionId: uuid('connection_id'),
     installationUuid: text('installation_uuid').notNull(),
     orgSlug: text('org_slug').notNull(),
     status: text('status').notNull(),
+    // sha256(authorization code) of the exchange that verified this install.
+    // The claim presents the code and we match the hash, so a bare uuid alone
+    // cannot bind the install (IDOR guard) without storing a live credential.
+    codeHash: text('code_hash'),
     installerUserId: uuid('installer_user_id'),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
@@ -31,6 +38,7 @@ export function toSentryInstallation(row: SentryInstallationDb): SentryInstallat
     installationUuid: row.installationUuid,
     orgSlug: row.orgSlug,
     status: row.status,
+    codeHash: row.codeHash,
     installerUserId: row.installerUserId,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/libs/api/integration/sentry/src/index.ts
+++ b/libs/api/integration/sentry/src/index.ts
@@ -7,7 +7,10 @@ import type {
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {createSentryApiClient, type SentryApiClient} from '#api/client.js';
 import {closeDb, db} from '#db/db.js';
-import {getSentryInstallationByConnectionId} from '#db/installations.js';
+import {
+  getSentryInstallationByConnectionId,
+  persistVerifiedUnclaimedInstallation,
+} from '#db/installations.js';
 import {migrationsPath} from '#db/migrations.js';
 import {
   type CreateSentryIntegrationRoutesOptions,
@@ -17,13 +20,28 @@ import {createSentryWebhookRoutes} from '#presentation/routes/webhooks.js';
 
 export type {SentryApiClient} from '#api/client.js';
 export {
+  SentryClaimProofMismatchError,
   SentryInstallationAlreadyLinkedError,
+  SentryInstallationDeletedError,
   SentryIntegrationProviderError,
+  SentryVerificationInProgressError,
 } from '#core/errors.js';
-export type {ConnectSentryInstallationInput} from '#core/install.js';
-export {handleSentryConnect} from '#core/install.js';
-export {handleSentryInstallationLifecycle, handleSentryIssueEvent} from '#core/webhook.js';
 export type {
+  ConnectSentryInstallationInput,
+  VerifyAndPersistUnclaimedInstallationParams,
+} from '#core/install.js';
+export {
+  handleSentryConnect,
+  hashAuthorizationCode,
+  verifyAndPersistUnclaimedInstallation,
+} from '#core/install.js';
+export {
+  handleSentryInstallationCreated,
+  handleSentryInstallationDeleted,
+  handleSentryIssueEvent,
+} from '#core/webhook.js';
+export type {
+  PersistVerifiedUnclaimedInstallationParams,
   SentryInstallation,
   SentryInstallationStatus,
   UpsertSentryInstallationParams,
@@ -31,13 +49,19 @@ export type {
 export {
   getSentryInstallationByConnectionId,
   getSentryInstallationByInstallationUuid,
+  listUnclaimedSentryInstallations,
   markSentryInstallationDeleted,
+  persistVerifiedUnclaimedInstallation,
+  pruneUnclaimedSentryInstallations,
   upsertSentryInstallation,
 } from '#db/installations.js';
 export {closeDb, db, migrationsPath};
 
 export interface CreateSentryIntegrationProviderOptions
-  extends Omit<CreateSentryIntegrationRoutesOptions, 'sentry'> {
+  extends Omit<
+    CreateSentryIntegrationRoutesOptions,
+    'sentry' | 'persistVerifiedUnclaimedInstallation'
+  > {
   sentry?: SentryApiClient | undefined;
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
@@ -45,12 +69,15 @@ export interface CreateSentryIntegrationProviderOptions
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
   updateConnectionLifecycleStatus: UpdateIntegrationConnectionLifecycleStatusFn;
   getSentryInstallationByConnectionId?: typeof getSentryInstallationByConnectionId | undefined;
+  persistVerifiedUnclaimedInstallation?: typeof persistVerifiedUnclaimedInstallation | undefined;
 }
 
 export function createSentryIntegrationProvider(options: CreateSentryIntegrationProviderOptions) {
   const sentry = options.sentry ?? createSentryApiClient();
   const getInstallationByConnectionId =
     options.getSentryInstallationByConnectionId ?? getSentryInstallationByConnectionId;
+  const persistUnclaimed =
+    options.persistVerifiedUnclaimedInstallation ?? persistVerifiedUnclaimedInstallation;
 
   return {
     provider: 'sentry' as const,
@@ -63,10 +90,13 @@ export function createSentryIntegrationProvider(options: CreateSentryIntegration
     routes: [
       createSentryIntegrationRoutes({
         sentry,
-        getExistingSentryConnection: options.getExistingSentryConnection,
+        getSentryInstallation: options.getSentryInstallation,
+        getConnectionById: options.getConnectionById,
         connectSentryInstallation: options.connectSentryInstallation,
+        persistVerifiedUnclaimedInstallation: persistUnclaimed,
       }),
       createSentryWebhookRoutes({
+        sentry,
         coreDb: options.coreDb,
         publishIntegrationEventReceived: options.publishIntegrationEventReceived,
         recordDeliveryOnly: options.recordDeliveryOnly,

--- a/libs/api/integration/sentry/src/presentation/routes/errors.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/errors.ts
@@ -1,8 +1,11 @@
 import type {IntegrationProviderErrorReason} from '@shipfox/api-integration-core-dto';
 import {ClientError} from '@shipfox/node-fastify';
 import {
+  SentryClaimProofMismatchError,
   SentryInstallationAlreadyLinkedError,
+  SentryInstallationDeletedError,
   SentryIntegrationProviderError,
+  SentryVerificationInProgressError,
 } from '#core/errors.js';
 
 function providerStatus(reason: IntegrationProviderErrorReason): number {
@@ -14,6 +17,20 @@ function providerStatus(reason: IntegrationProviderErrorReason): number {
 export function sentryRouteErrorHandler(error: unknown): never {
   if (error instanceof SentryInstallationAlreadyLinkedError) {
     throw new ClientError(error.message, 'sentry-installation-already-linked', {status: 409});
+  }
+  if (error instanceof SentryInstallationDeletedError) {
+    throw new ClientError(error.message, 'sentry-installation-deleted', {status: 409});
+  }
+  if (error instanceof SentryClaimProofMismatchError) {
+    throw new ClientError(error.message, 'sentry-claim-proof-mismatch', {status: 403});
+  }
+  if (error instanceof SentryVerificationInProgressError) {
+    // Retryable: a concurrent webhook is mid-exchange. 503 + retry_after lands in
+    // the client backoff that already treats >= 500 as retryable.
+    throw new ClientError(error.message, 'sentry-verification-in-progress', {
+      status: 503,
+      details: {retry_after_seconds: error.retryAfterSeconds},
+    });
   }
   if (error instanceof SentryIntegrationProviderError) {
     throw new ClientError(error.message, error.reason, {

--- a/libs/api/integration/sentry/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.test.ts
@@ -4,6 +4,7 @@ import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-f
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import type {SentryApiClient} from '#api/client.js';
 import {SentryIntegrationProviderError} from '#core/errors.js';
+import type {SentryInstallation} from '#db/installations.js';
 import {createSentryIntegrationProvider} from '#index.js';
 
 vi.mock('@shipfox/api-workspaces', () => ({
@@ -52,15 +53,35 @@ function sentryClient(overrides: Partial<SentryApiClient> = {}): SentryApiClient
   };
 }
 
+function unclaimedInstallation(overrides: Partial<SentryInstallation> = {}): SentryInstallation {
+  return {
+    id: 'row-1',
+    connectionId: null,
+    installationUuid: 'install-uuid-1',
+    orgSlug: 'acme',
+    status: 'installed',
+    codeHash: null,
+    installerUserId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
 interface CreateTestAppOptions {
   sentry?: SentryApiClient;
+  installation?: SentryInstallation | undefined;
   existingConnection?: IntegrationConnection<'sentry'> | undefined;
 }
 
 async function createTestApp(options: CreateTestAppOptions = {}): Promise<FastifyInstance> {
   const provider = createSentryIntegrationProvider({
     sentry: options.sentry ?? sentryClient(),
-    getExistingSentryConnection: vi.fn(() => Promise.resolve(options.existingConnection)),
+    getSentryInstallation: vi.fn(() => Promise.resolve(options.installation)),
+    getConnectionById: vi.fn(() => Promise.resolve(options.existingConnection)),
+    persistVerifiedUnclaimedInstallation: vi.fn((input) =>
+      Promise.resolve(unclaimedInstallation({...input})),
+    ),
     connectSentryInstallation: vi.fn((input) =>
       Promise.resolve({
         id: crypto.randomUUID(),
@@ -180,9 +201,11 @@ describe('Sentry integration routes', () => {
   });
 
   it('returns 409 when the installation is already linked to another workspace', async () => {
+    const connectionId = crypto.randomUUID();
     const app = await createTestApp({
+      installation: unclaimedInstallation({connectionId}),
       existingConnection: {
-        id: crypto.randomUUID(),
+        id: connectionId,
         workspaceId: crypto.randomUUID(),
         provider: 'sentry',
         externalAccountId: 'install-uuid-1',
@@ -205,11 +228,11 @@ describe('Sentry integration routes', () => {
     expect(res.json().code).toBe('sentry-installation-already-linked');
   });
 
-  it('maps a provider error to its status', async () => {
+  it('maps a non-access-denied provider error to its status', async () => {
     const app = await createTestApp({
       sentry: sentryClient({
         exchangeAuthorizationCode: vi.fn(() =>
-          Promise.reject(new SentryIntegrationProviderError('access-denied', 'rejected')),
+          Promise.reject(new SentryIntegrationProviderError('rate-limited', 'slow down')),
         ),
       }),
     });
@@ -221,7 +244,27 @@ describe('Sentry integration routes', () => {
       payload: connectPayload(),
     });
 
-    expect(res.statusCode).toBe(422);
-    expect(res.json().code).toBe('access-denied');
+    expect(res.statusCode).toBe(429);
+    expect(res.json().code).toBe('rate-limited');
+  });
+
+  it('returns a retryable 503 when a concurrent webhook is still verifying the install', async () => {
+    const app = await createTestApp({
+      sentry: sentryClient({
+        exchangeAuthorizationCode: vi.fn(() =>
+          Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+        ),
+      }),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.json().code).toBe('sentry-verification-in-progress');
   });
 });

--- a/libs/api/integration/sentry/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.test.ts
@@ -267,4 +267,41 @@ describe('Sentry integration routes', () => {
     expect(res.statusCode).toBe(503);
     expect(res.json().code).toBe('sentry-verification-in-progress');
   });
+
+  it('returns 403 when the presented code cannot prove control of a verified install', async () => {
+    const app = await createTestApp({
+      installation: unclaimedInstallation({codeHash: 'a-different-hash'}),
+      sentry: sentryClient({
+        exchangeAuthorizationCode: vi.fn(() =>
+          Promise.reject(new SentryIntegrationProviderError('access-denied', 'already used')),
+        ),
+      }),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('sentry-claim-proof-mismatch');
+  });
+
+  it('returns 409 when the installation is tombstoned', async () => {
+    const app = await createTestApp({
+      installation: unclaimedInstallation({status: 'deleted'}),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/sentry/connect',
+      headers: {authorization: 'Bearer user'},
+      payload: connectPayload(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('sentry-installation-deleted');
+  });
 });

--- a/libs/api/integration/sentry/src/presentation/routes/install.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.ts
@@ -11,23 +11,33 @@ import {defineRoute, type RouteGroup} from '@shipfox/node-fastify';
 import type {SentryApiClient} from '#api/client.js';
 import {config} from '#config.js';
 import {type ConnectSentryInstallationInput, handleSentryConnect} from '#core/install.js';
+import type {
+  PersistVerifiedUnclaimedInstallationParams,
+  SentryInstallation,
+} from '#db/installations.js';
 import {toIntegrationConnectionDto} from '#presentation/dto/integrations.js';
 import {sentryRouteErrorHandler} from './errors.js';
 
 export interface CreateSentryIntegrationRoutesOptions {
   sentry: SentryApiClient;
-  getExistingSentryConnection: (input: {
+  getSentryInstallation: (input: {
     installationUuid: string;
-  }) => Promise<IntegrationConnection<'sentry'> | undefined>;
+  }) => Promise<SentryInstallation | undefined>;
+  getConnectionById: (id: string) => Promise<IntegrationConnection<'sentry'> | undefined>;
   connectSentryInstallation: (
     input: ConnectSentryInstallationInput,
   ) => Promise<IntegrationConnection<'sentry'>>;
+  persistVerifiedUnclaimedInstallation: (
+    input: PersistVerifiedUnclaimedInstallationParams,
+  ) => Promise<SentryInstallation>;
 }
 
 export function createSentryIntegrationRoutes({
   sentry,
-  getExistingSentryConnection,
+  getSentryInstallation,
+  getConnectionById,
   connectSentryInstallation,
+  persistVerifiedUnclaimedInstallation,
 }: CreateSentryIntegrationRoutesOptions): RouteGroup {
   const createInstallRoute = defineRoute({
     method: 'POST',
@@ -76,8 +86,10 @@ export function createSentryIntegrationRoutes({
         installationUuid,
         installerUserId: actor.userId,
         verifyInstall: config.SENTRY_APP_VERIFY_INSTALL,
-        getExistingSentryConnection,
+        getSentryInstallation,
+        getConnectionById,
         connectSentryInstallation,
+        persistVerifiedUnclaimedInstallation,
       });
 
       return toIntegrationConnectionDto(connection);

--- a/libs/api/integration/sentry/src/presentation/routes/installation-handler.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/installation-handler.ts
@@ -7,9 +7,7 @@ import {
   persistVerifiedUnclaimedInstallation,
 } from '#db/installations.js';
 import type {SentryWebhookContext} from './webhook-context.js';
-import {parseAndValidateOrDrop} from './webhook-delivery.js';
-
-const SENTRY_PROVIDER = 'sentry';
+import {parseAndValidateOrDrop, SENTRY_PROVIDER} from './webhook-delivery.js';
 
 // Validates an installation lifecycle delivery, then applies it. `created` is the
 // authoritative install signal: it exchanges the single-use code and persists a
@@ -56,7 +54,7 @@ export async function handleInstallationResource(args: {
     code: installation.code,
     sentry: context.sentry,
     verifyInstall: config.SENTRY_APP_VERIFY_INSTALL,
-    getSentryInstallation: (installationUuid) =>
+    getSentryInstallation: ({installationUuid}) =>
       getSentryInstallationByInstallationUuid(installationUuid),
     persistUnclaimedAndRecordDelivery: ({installationUuid, orgSlug, codeHash, deliveryId: id}) =>
       context.coreDb().transaction(async (tx) => {

--- a/libs/api/integration/sentry/src/presentation/routes/installation-handler.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/installation-handler.ts
@@ -1,12 +1,21 @@
 import {sentryInstallationWebhookSchema} from '@shipfox/api-integration-sentry-dto';
 import type {FastifyReply} from 'fastify';
-import {handleSentryInstallationLifecycle} from '#core/webhook.js';
+import {config} from '#config.js';
+import {handleSentryInstallationCreated, handleSentryInstallationDeleted} from '#core/webhook.js';
+import {
+  getSentryInstallationByInstallationUuid,
+  persistVerifiedUnclaimedInstallation,
+} from '#db/installations.js';
 import type {SentryWebhookContext} from './webhook-context.js';
 import {parseAndValidateOrDrop} from './webhook-delivery.js';
 
-// Validates an installation lifecycle delivery, then applies it in a transaction.
-// A `deleted` action disables the connection and marks the installation deleted;
-// other actions are recorded only (the connect flow owns row creation).
+const SENTRY_PROVIDER = 'sentry';
+
+// Validates an installation lifecycle delivery, then applies it. `created` is the
+// authoritative install signal: it exchanges the single-use code and persists a
+// verified-unclaimed row (exchange outside any transaction; persist + delivery
+// record in one short transaction). `deleted` tombstones the install and disables
+// the connection in a single transaction.
 export async function handleInstallationResource(args: {
   context: SentryWebhookContext;
   reply: FastifyReply;
@@ -24,15 +33,44 @@ export async function handleInstallationResource(args: {
   });
   if (!payload) return null;
 
-  await context.coreDb().transaction(async (tx) => {
-    await handleSentryInstallationLifecycle({
-      tx,
-      deliveryId,
-      action: payload.action,
-      installationUuid: payload.installation.uuid,
-      recordDeliveryOnly: context.recordDeliveryOnly,
-      updateConnectionLifecycleStatus: context.updateConnectionLifecycleStatus,
+  const installation = payload.data.installation;
+
+  if (payload.action === 'deleted') {
+    await context.coreDb().transaction(async (tx) => {
+      await handleSentryInstallationDeleted({
+        tx,
+        deliveryId,
+        installationUuid: installation.uuid,
+        recordDeliveryOnly: context.recordDeliveryOnly,
+        updateConnectionLifecycleStatus: context.updateConnectionLifecycleStatus,
+      });
     });
+    reply.code(204);
+    return null;
+  }
+
+  await handleSentryInstallationCreated({
+    deliveryId,
+    installationUuid: installation.uuid,
+    orgSlug: installation.organization?.slug,
+    code: installation.code,
+    sentry: context.sentry,
+    verifyInstall: config.SENTRY_APP_VERIFY_INSTALL,
+    getSentryInstallation: (installationUuid) =>
+      getSentryInstallationByInstallationUuid(installationUuid),
+    persistUnclaimedAndRecordDelivery: ({installationUuid, orgSlug, codeHash, deliveryId: id}) =>
+      context.coreDb().transaction(async (tx) => {
+        const persisted = await persistVerifiedUnclaimedInstallation(
+          {installationUuid, orgSlug, codeHash},
+          {tx},
+        );
+        await context.recordDeliveryOnly({tx, provider: SENTRY_PROVIDER, deliveryId: id});
+        return persisted;
+      }),
+    recordDelivery: (id) =>
+      context.coreDb().transaction(async (tx) => {
+        await context.recordDeliveryOnly({tx, provider: SENTRY_PROVIDER, deliveryId: id});
+      }),
   });
 
   reply.code(204);

--- a/libs/api/integration/sentry/src/presentation/routes/webhook-context.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/webhook-context.ts
@@ -5,14 +5,18 @@ import type {
   UpdateIntegrationConnectionLifecycleStatusFn,
 } from '@shipfox/api-integration-core-dto';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import type {SentryApiClient} from '#api/client.js';
 
 /**
  * The capabilities a Sentry webhook handler needs from the rest of the system.
- * `@shipfox/api-integration-core` owns and wires these in production; tests fake
- * them with spies. Passing them in keeps the route decoupled from core's
- * persistence and avoids a package dependency cycle.
+ * `@shipfox/api-integration-core` owns and wires the core persistence in
+ * production; tests fake them with spies. Passing them in keeps the route
+ * decoupled from core's persistence and avoids a package dependency cycle. The
+ * Sentry client is injected too so the authoritative `installation.created` path
+ * can exchange the code, and tests can fake the exchange.
  */
 export interface SentryWebhookContext {
+  sentry: SentryApiClient;
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
   publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;

--- a/libs/api/integration/sentry/src/presentation/routes/webhook-delivery.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/webhook-delivery.ts
@@ -3,7 +3,7 @@ import type {FastifyReply} from 'fastify';
 import type {z} from 'zod';
 import type {SentryWebhookContext} from './webhook-context.js';
 
-const SENTRY_PROVIDER = 'sentry';
+export const SENTRY_PROVIDER = 'sentry';
 
 /**
  * Parses and validates a delivery body, recording-and-dropping it (HTTP 204) when

--- a/libs/api/integration/sentry/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/webhooks.test.ts
@@ -4,6 +4,9 @@ import {sentryIssueActionSchema} from '@shipfox/api-integration-sentry-dto';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
+import type {SentryApiClient} from '#api/client.js';
+import {SentryIntegrationProviderError} from '#core/errors.js';
+import {hashAuthorizationCode} from '#core/install.js';
 import {db} from '#db/db.js';
 import {sentryInstallations} from '#db/schema/installations.js';
 import {
@@ -15,6 +18,17 @@ import {createSentryWebhookRoutes} from './webhooks.js';
 
 const CLIENT_SECRET = 'test-client-secret';
 const URL = '/webhooks/integrations/sentry';
+
+function sentryClient(overrides: Partial<SentryApiClient> = {}): SentryApiClient {
+  return {
+    exchangeAuthorizationCode: vi.fn(() =>
+      Promise.resolve({token: 'tok', refreshToken: 'refresh', expiresAt: 'x'}),
+    ),
+    getInstallation: vi.fn(() => Promise.resolve({orgSlug: 'acme'})),
+    verifyInstallation: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
 
 // The route persists through injected core functions (publishIntegrationEventReceived,
 // recordDeliveryOnly, getIntegrationConnectionById, updateConnectionLifecycleStatus)
@@ -40,20 +54,25 @@ function fakeConnection(overrides: Partial<IntegrationConnection> = {}): Integra
 
 interface TestApp {
   app: FastifyInstance;
+  sentry: SentryApiClient;
   publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
   recordDeliveryOnly: ReturnType<typeof vi.fn>;
   getIntegrationConnectionById: ReturnType<typeof vi.fn>;
   updateConnectionLifecycleStatus: ReturnType<typeof vi.fn>;
 }
 
-async function createTestApp(options: {connection?: IntegrationConnection} = {}): Promise<TestApp> {
+async function createTestApp(
+  options: {connection?: IntegrationConnection; sentry?: SentryApiClient} = {},
+): Promise<TestApp> {
   const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
   const recordDeliveryOnly = vi.fn(() => Promise.resolve());
   const getIntegrationConnectionById = vi.fn(() =>
     Promise.resolve(options.connection ?? fakeConnection()),
   );
   const updateConnectionLifecycleStatus = vi.fn(() => Promise.resolve(undefined));
+  const sentry = options.sentry ?? sentryClient();
   const routes = createSentryWebhookRoutes({
+    sentry,
     coreDb: db,
     publishIntegrationEventReceived,
     recordDeliveryOnly,
@@ -64,6 +83,7 @@ async function createTestApp(options: {connection?: IntegrationConnection} = {})
   await app.ready();
   return {
     app,
+    sentry,
     publishIntegrationEventReceived,
     recordDeliveryOnly,
     getIntegrationConnectionById,
@@ -73,12 +93,13 @@ async function createTestApp(options: {connection?: IntegrationConnection} = {})
 
 async function seedInstallation(
   installationUuid: string,
-  options: {connectionId?: string; status?: 'installed' | 'deleted'} = {},
+  options: {connectionId?: string | null; status?: 'installed' | 'deleted'; codeHash?: string} = {},
 ): Promise<void> {
   await sentryInstallationFactory.create({
     installationUuid,
     ...(options.connectionId !== undefined && {connectionId: options.connectionId}),
     ...(options.status !== undefined && {status: options.status}),
+    ...(options.codeHash !== undefined && {codeHash: options.codeHash}),
   });
 }
 
@@ -466,6 +487,29 @@ describe('Sentry webhook route', () => {
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
 
+  test('records the delivery only for an issue from a verified-but-unclaimed installation', async () => {
+    const installationUuid = 'install-unclaimed';
+    await seedInstallation(installationUuid, {connectionId: null});
+    const {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById} =
+      await createTestApp();
+    const deliveryId = randomUUID();
+    const body = JSON.stringify(
+      sentryIssueWebhookFactory.build({action: 'created', installation: {uuid: installationUuid}}),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: signedHeaders(body, 'issue', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
   test('records the delivery only for a non-issue, non-installation resource', async () => {
     const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();
@@ -551,7 +595,7 @@ describe('Sentry webhook route', () => {
     const body = JSON.stringify(
       sentryInstallationWebhookFactory.build({
         action: 'deleted',
-        installation: {uuid: installationUuid},
+        data: {installation: {uuid: installationUuid}},
       }),
     );
 
@@ -578,7 +622,7 @@ describe('Sentry webhook route', () => {
     const body = JSON.stringify(
       sentryInstallationWebhookFactory.build({
         action: 'deleted',
-        installation: {uuid: 'never-installed'},
+        data: {installation: {uuid: 'never-installed'}},
       }),
     );
 
@@ -594,13 +638,15 @@ describe('Sentry webhook route', () => {
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
 
-  test('installation/created records the delivery and creates no installation row', async () => {
-    const {app, recordDeliveryOnly, updateConnectionLifecycleStatus} = await createTestApp();
+  test('installation/created exchanges the code and persists a verified-unclaimed row', async () => {
+    const installationUuid = 'install-created-webhook';
+    const code = 'grant-code-webhook';
+    const {app, sentry, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify(
       sentryInstallationWebhookFactory.build({
         action: 'created',
-        installation: {uuid: 'install-pending'},
+        data: {installation: {uuid: installationUuid, code, organization: {slug: 'acme'}}},
       }),
     );
 
@@ -612,8 +658,95 @@ describe('Sentry webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(await readInstallation('install-pending')).toBeUndefined();
-    expect(updateConnectionLifecycleStatus).not.toHaveBeenCalled();
+    expect(sentry.exchangeAuthorizationCode).toHaveBeenCalledWith({installationUuid, code});
+    const row = await readInstallation(installationUuid);
+    expect(row?.connectionId).toBeNull();
+    expect(row?.status).toBe('installed');
+    expect(row?.orgSlug).toBe('acme');
+    expect(row?.codeHash).toBe(hashAuthorizationCode(code));
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  test('installation/created reconciles to a no-op when a row already exists', async () => {
+    const installationUuid = 'install-created-existing';
+    await seedInstallation(installationUuid, {connectionId: null, codeHash: 'pre-existing'});
+    const {app, sentry, recordDeliveryOnly} = await createTestApp();
+    const deliveryId = randomUUID();
+    const body = JSON.stringify(
+      sentryInstallationWebhookFactory.build({
+        action: 'created',
+        data: {
+          installation: {uuid: installationUuid, code: 'new-code', organization: {slug: 'acme'}},
+        },
+      }),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: signedHeaders(body, 'installation', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    // No re-exchange and the stored hash is untouched (no clobber).
+    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+    expect((await readInstallation(installationUuid))?.codeHash).toBe('pre-existing');
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  test('installation/created without a code records-and-drops without persisting', async () => {
+    const installationUuid = 'install-created-nocode';
+    const {app, sentry, recordDeliveryOnly} = await createTestApp();
+    const deliveryId = randomUUID();
+    // Built literally rather than via the factory: the factory always supplies a
+    // code and Fishery deep-merges, so an override cannot remove it.
+    const body = JSON.stringify({
+      action: 'created',
+      data: {installation: {uuid: installationUuid, organization: {slug: 'acme'}}},
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: signedHeaders(body, 'installation', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
+    expect(await readInstallation(installationUuid)).toBeUndefined();
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  test('installation/created records-and-drops when the code exchange fails', async () => {
+    const installationUuid = 'install-created-exchangefail';
+    const {app, recordDeliveryOnly} = await createTestApp({
+      sentry: sentryClient({
+        exchangeAuthorizationCode: vi.fn(() =>
+          Promise.reject(new SentryIntegrationProviderError('access-denied', 'spent')),
+        ),
+      }),
+    });
+    const deliveryId = randomUUID();
+    const body = JSON.stringify(
+      sentryInstallationWebhookFactory.build({
+        action: 'created',
+        data: {
+          installation: {uuid: installationUuid, code: 'spent-code', organization: {slug: 'acme'}},
+        },
+      }),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: signedHeaders(body, 'installation', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(await readInstallation(installationUuid)).toBeUndefined();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
   });
 
@@ -621,7 +754,10 @@ describe('Sentry webhook route', () => {
     const {app, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify(
-      sentryInstallationWebhookFactory.build({action: 'suspended', installation: {uuid: 'x'}}),
+      sentryInstallationWebhookFactory.build({
+        action: 'suspended',
+        data: {installation: {uuid: 'x'}},
+      }),
     );
 
     const res = await app.inject({

--- a/libs/api/integration/sentry/test/factories/sentry-installation-webhook.ts
+++ b/libs/api/integration/sentry/test/factories/sentry-installation-webhook.ts
@@ -1,17 +1,35 @@
 import {Factory} from 'fishery';
 
 // Raw Sentry installation webhook payload, shaped exactly as Sentry delivers it
-// over the wire. Tests serialize the built object to form a signed request body;
-// the route parses and validates it with the production Zod schema. Build-only —
-// the payload is never persisted, so there is no onCreate handler.
+// over the wire: the lifecycle data nests under `data.installation` and carries
+// the single-use authorization `code`. Tests serialize the built object to form a
+// signed request body; the route parses and validates it with the production Zod
+// schema. Build-only — the payload is never persisted, so there is no onCreate
+// handler.
 export interface SentryInstallationWebhookPayload {
   action: string;
-  installation: {uuid: string};
+  actor?: {type?: string; id?: string | number; name?: string};
+  data: {
+    installation: {
+      uuid: string;
+      status?: string;
+      code?: string;
+      organization?: {slug: string};
+    };
+  };
 }
 
 export const sentryInstallationWebhookFactory = Factory.define<SentryInstallationWebhookPayload>(
   ({sequence}) => ({
     action: 'created',
-    installation: {uuid: `install-${sequence}`},
+    actor: {type: 'user', id: sequence, name: 'Installer'},
+    data: {
+      installation: {
+        uuid: `install-${sequence}`,
+        status: 'installed',
+        code: `grant-code-${sequence}`,
+        organization: {slug: 'acme'},
+      },
+    },
   }),
 );

--- a/libs/api/integration/sentry/test/factories/sentry-installation.ts
+++ b/libs/api/integration/sentry/test/factories/sentry-installation.ts
@@ -1,21 +1,33 @@
 import {Factory} from 'fishery';
 import {
+  persistVerifiedUnclaimedInstallation,
   type SentryInstallation,
   type SentryInstallationStatus,
   upsertSentryInstallation,
 } from '#db/installations.js';
 
+// Persists either a claimed install (default: `connectionId` set) or, when
+// `connectionId` is null, a verified-unclaimed install via the dedicated insert
+// so tests can exercise the webhook-authoritative pre-claim state.
 export const sentryInstallationFactory = Factory.define<SentryInstallation>(
   ({sequence, onCreate}) => {
-    onCreate((installation) =>
-      upsertSentryInstallation({
+    onCreate((installation) => {
+      if (installation.connectionId === null) {
+        return persistVerifiedUnclaimedInstallation({
+          installationUuid: installation.installationUuid,
+          orgSlug: installation.orgSlug,
+          codeHash: installation.codeHash ?? 'unclaimed-code-hash',
+        });
+      }
+      return upsertSentryInstallation({
         connectionId: installation.connectionId,
         installationUuid: installation.installationUuid,
         orgSlug: installation.orgSlug,
         status: installation.status as SentryInstallationStatus,
+        codeHash: installation.codeHash,
         installerUserId: installation.installerUserId,
-      }),
-    );
+      });
+    });
 
     return {
       id: crypto.randomUUID(),
@@ -23,6 +35,7 @@ export const sentryInstallationFactory = Factory.define<SentryInstallation>(
       installationUuid: `install-${sequence + 1}`,
       orgSlug: 'acme',
       status: 'installed',
+      codeHash: null,
       installerUserId: null,
       createdAt: new Date(),
       updatedAt: new Date(),

--- a/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
@@ -137,7 +137,8 @@ describe('SentryCallbackPage', () => {
           message: 'slow down',
           code: 'rate-limited',
           status: 429,
-          details: {retry_after_seconds: 60},
+          // Real wire shape: client-api stores the whole {code, details} body as ApiError.details.
+          details: {code: 'rate-limited', details: {retry_after_seconds: 60}},
         }),
       )
       .mockRejectedValueOnce(new ApiError({message: 'down', code: 'timeout', status: 503}));

--- a/libs/client/integrations/src/sentry-callback.test.ts
+++ b/libs/client/integrations/src/sentry-callback.test.ts
@@ -144,6 +144,22 @@ describe('classifySentryConnectError', () => {
     });
   });
 
+  test('503 verification-in-progress is retryable and carries retry_after_seconds', () => {
+    const result = classifySentryConnectError(
+      apiError({
+        code: 'sentry-verification-in-progress',
+        status: 503,
+        details: {retry_after_seconds: 2},
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: 'retryable',
+      message: 'Finishing Sentry verification. This only takes a moment.',
+      retryAfterSeconds: 2,
+    });
+  });
+
   test.each(['timeout', 'provider-unavailable'])('503 %s is retryable', (code) => {
     const result = classifySentryConnectError(apiError({code, status: 503}));
 

--- a/libs/client/integrations/src/sentry-callback.test.ts
+++ b/libs/client/integrations/src/sentry-callback.test.ts
@@ -134,7 +134,12 @@ describe('classifySentryConnectError', () => {
 
   test('429 rate-limited is retryable and carries retry_after_seconds', () => {
     const result = classifySentryConnectError(
-      apiError({code: 'rate-limited', status: 429, details: {retry_after_seconds: 30}}),
+      // Real wire shape: client-api stores the whole {code, details} body as ApiError.details.
+      apiError({
+        code: 'rate-limited',
+        status: 429,
+        details: {code: 'rate-limited', details: {retry_after_seconds: 30}},
+      }),
     );
 
     expect(result).toEqual({
@@ -149,7 +154,7 @@ describe('classifySentryConnectError', () => {
       apiError({
         code: 'sentry-verification-in-progress',
         status: 503,
-        details: {retry_after_seconds: 2},
+        details: {code: 'sentry-verification-in-progress', details: {retry_after_seconds: 2}},
       }),
     );
 

--- a/libs/client/integrations/src/sentry-callback.ts
+++ b/libs/client/integrations/src/sentry-callback.ts
@@ -88,6 +88,15 @@ export function classifySentryConnectError(error: unknown): SentryConnectFailure
         startOver: false,
       };
     }
+    if (error.code === 'sentry-verification-in-progress') {
+      // A concurrent signed webhook is still verifying the install. The grant code
+      // is untouched, so the existing backoff re-calls and finds the verified row.
+      return {
+        kind: 'retryable',
+        message: 'Finishing Sentry verification. This only takes a moment.',
+        retryAfterSeconds: retryAfterSeconds(error.details),
+      };
+    }
     if (error.code === 'rate-limited') {
       return {
         kind: 'retryable',

--- a/libs/client/integrations/src/sentry-callback.ts
+++ b/libs/client/integrations/src/sentry-callback.ts
@@ -127,8 +127,13 @@ export function classifySentryConnectError(error: unknown): SentryConnectFailure
 }
 
 function retryAfterSeconds(details: unknown): number | undefined {
+  // client-api's toApiError stores the whole response body as ApiError.details,
+  // so the structured payload lives one level deeper at details.details (mirrors
+  // project-error.ts apiDetails()).
   if (typeof details !== 'object' || details === null) return undefined;
-  const value = (details as Record<string, unknown>).retry_after_seconds;
+  const inner = (details as Record<string, unknown>).details;
+  if (typeof inner !== 'object' || inner === null) return undefined;
+  const value = (inner as Record<string, unknown>).retry_after_seconds;
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 


### PR DESCRIPTION
Makes Sentry's HMAC-signed `installation.created` webhook the authoritative install signal. Whichever path arrives first — the server-to-server webhook or the browser redirect — exchanges the single-use authorization code and persists a **verified, unclaimed** installation (`connection_id IS NULL`, `code_hash = sha256(code)`). The browser flow narrows to a **claim**: a logged-in user binds that verified install to a workspace.

Previously the signed webhook was record-and-dropped, so installs that never finished the browser redirect were invisible and authenticity rested entirely on the unauthenticated redirect. Discarding an authenticated delivery of the same material was the gap this closes.

## How it works
- **Webhook `created`** reconciles to a no-op when a row already exists, otherwise exchanges the code and persists the unclaimed row. The exchange runs outside any DB transaction; a short transaction wraps only persist + delivery record. Any exchange failure is record-and-dropped (204) so Sentry does not disable the app.
- **Claim** (`POST /integrations/sentry/connect`, body contract unchanged) uses unified proof: a fresh exchange (browser-first or re-entry with a new code), a same-code hash match (the webhook already spent it), or a retryable `verification-in-progress` while a concurrent webhook is mid-exchange. A non-matching code on a verified install returns 403 — the bare-uuid IDOR gate.
- **Pre-claim issue deliveries** (install verified but not yet claimed → no workspace) are record-and-dropped.
- **TTL cron** tombstones never-claimed installs older than 7 days; a reinstall always mints a fresh uuid, so a tombstone is never revived.

## Design note for reviewers
The Sentry client collapses "code already used" and "code invalid" into one `access-denied` reason, so a browser-first claim with no verified row and an `access-denied` exchange is ambiguous. Per the plan's locked decision (D3), this resolves to a retryable `verification-in-progress` (503) rather than a terminal 422 — a genuinely bad code reads as retryable, bounded by the TTL cron and user abandonment. One pre-existing test that assumed 422 was updated accordingly.

## Notes
- `0000_initial.sql` is edited in place (`connection_id` nullable + `code_hash`) per the plan's local-only acceptance; fresh CI DBs apply it cleanly, a persistent DB that already ran the original migration needs its `drizzle.__drizzle_migrations_integrations_sentry` tracking reset.
- Observability is logs-only (no metrics/traces), per request.

Refs ENG-436

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Sentry’s HMAC‑signed installation.created webhook the authoritative install path. We persist a verified‑but‑unclaimed install first and the browser callback only claims it, with added hardening and correct client backoff (ENG-436).

- **New Features**
  - Webhook‑first install: exchange the single‑use code and persist an unclaimed row (`connection_id = NULL`, `code_hash = sha256(code)`); the browser flow claims and binds to a workspace.
  - Claim proof rules: fresh exchange, same‑code hash match, or retryable `sentry-verification-in-progress` (503 with `retry_after_seconds`); non‑matching code returns 403; tombstoned/deleted installs return 409, including during reconcile.
  - Pre‑claim issue deliveries are recorded and dropped as `SentryInstallationUnclaimedError` (no workspace yet).
  - Added TTL cron to tombstone unclaimed installs after 7 days; scheduled only when Sentry is enabled.
  - `sentryInstallationWebhookSchema` now reads `data.installation.{uuid, organization.slug, status, code}` with optional `actor`; only consumed fields validated and the raw code is never logged.
  - DB schema: `connection_id` is now nullable and `code_hash` added.
  - Webhook context injects the Sentry client; core wires helpers to fetch installs, get connections by id, and persist verified‑unclaimed installs.
  - Sentry API calls URL‑encode `installationUuid`; claim hash comparison is constant‑time.
  - Client: `@shipfox/client-integrations` treats `sentry-verification-in-progress` (503) as retryable and reads nested `retry_after_seconds`; 429 rate limits also provide backoff.

- **Migration**
  - Apply DB migrations (adds `code_hash`, makes `connection_id` nullable). If a persistent DB already applied the original initial migration, reset `drizzle.__drizzle_migrations_integrations_sentry` before reapplying the edited `0000_initial.sql`.
  - Ensure Temporal workers deploy the new maintenance cron for pruning unclaimed installs.
  - No body changes for `POST /integrations/sentry/connect`; clients already handle 503 `sentry-verification-in-progress` and parse nested backoff hints.

<sup>Written for commit fffef71ebda3a67dc1f8661256311be21ebe04b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

