### PR TITLE
Bulk-expire stuck job leases in a single transaction

### DIFF
--- a/.changeset/eng-432-bulk-expire-stuck-jobs.md
+++ b/.changeset/eng-432-bulk-expire-stuck-jobs.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-outbox": minor
+"@shipfox/api-runners": patch
+---
+
+Stuck-job expiry now reaps a bounded batch in one transaction instead of N+1: a single `DELETE … RETURNING` (oldest-first, `FOR UPDATE SKIP LOCKED`, capped at 100 per tick) feeds a multi-row outbox insert via the new `writeOutboxEvents` helper. Behavior is unchanged (same rows reaped, one `runners.job.lease_expired` event per reaped job, same orphan-pending sweep).

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -1,5 +1,5 @@
 import {issueJobLeaseToken} from '@shipfox/api-auth';
-import {claimPendingJob, expireStuckJob, findStuckJobs} from '#db/jobs.js';
+import {claimPendingJob, expireStuckJobs} from '#db/jobs.js';
 
 export interface ClaimJobResult {
   jobId: string;
@@ -24,22 +24,9 @@ export async function claimJob(params: {
   return {jobId: claimed.jobId, runId: claimed.runId, leaseToken};
 }
 
-// N+1 by design (~1 SELECT + N DELETEs per tick): each candidate gets its own
-// guarded DELETE so a heartbeat landing mid-tick spares the live row, and its
-// outbox event commits in isolation. Chosen for simplicity over a bulk
-// DELETE…RETURNING + multi-row outbox insert at the current low tick volume.
 export async function detectAndExpireStuckJobs(params: {
   thresholdSeconds: number;
 }): Promise<{expired: number}> {
-  const candidates = await findStuckJobs({thresholdSeconds: params.thresholdSeconds});
-
-  let expired = 0;
-  for (const candidate of candidates) {
-    const result = await expireStuckJob({
-      jobId: candidate.jobId,
-      staleBeforeMs: params.thresholdSeconds * 1000,
-    });
-    if (result) expired += 1;
-  }
-  return {expired};
+  const reaped = await expireStuckJobs({thresholdSeconds: params.thresholdSeconds});
+  return {expired: reaped.length};
 }

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -5,8 +5,7 @@ export {closeDb, db, schema} from './db.js';
 export type {ClaimedJob, ScheduleJobParams} from './jobs.js';
 export {
   claimPendingJob,
-  expireStuckJob,
-  findStuckJobs,
+  expireStuckJobs,
   recordHeartbeat,
   releaseJob,
   scheduleJob,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -6,7 +6,7 @@ import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {db} from './db.js';
 import {
   claimPendingJob,
-  expireStuckJob,
+  expireStuckJobs,
   recordHeartbeat,
   releaseJob,
   requestJobCancellation,
@@ -467,11 +467,12 @@ describe('detectAndExpireStuckJobs', () => {
   it('double-expiring the same stuck job emits exactly one event', async () => {
     const {jobId} = await makeStaleJob(600);
 
-    const first = await expireStuckJob({jobId, staleBeforeMs: 180_000});
-    const second = await expireStuckJob({jobId, staleBeforeMs: 180_000});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
-    expect(first).toBeDefined();
-    expect(second).toBeUndefined();
+    expect(await db().select().from(runningJobs).where(eq(runningJobs.jobId, jobId))).toHaveLength(
+      0,
+    );
     expect(await outboxForJobs([jobId])).toHaveLength(1);
   });
 
@@ -481,7 +482,7 @@ describe('detectAndExpireStuckJobs', () => {
     // without this sweep it would stay re-claimable for an already-finished job.
     await db().insert(pendingJobs).values({workspaceId, jobId, runId});
 
-    await expireStuckJob({jobId, staleBeforeMs: 180_000});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
     expect(await runningJobsForTest()).toHaveLength(0);
     expect(await db().select().from(pendingJobs).where(eq(pendingJobs.jobId, jobId))).toHaveLength(
@@ -493,13 +494,69 @@ describe('detectAndExpireStuckJobs', () => {
     const {jobId, runId} = await makeStaleJob(60);
     await db().insert(pendingJobs).values({workspaceId, jobId, runId});
 
-    const result = await expireStuckJob({jobId, staleBeforeMs: 180_000});
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
     // The sweep is gated on actually reaping a running row, so a live job's
     // pending row is untouched.
-    expect(result).toBeUndefined();
     expect(await db().select().from(pendingJobs).where(eq(pendingJobs.jobId, jobId))).toHaveLength(
       1,
     );
+  });
+
+  it('returns the reaped {jobId, runId} per row without leaking the internal id', async () => {
+    const {jobId, runId} = await makeStaleJob(600);
+
+    const reaped = await expireStuckJobs({thresholdSeconds: 180});
+
+    const mine = reaped.find((row) => row.jobId === jobId);
+    expect(mine).toEqual({jobId, runId});
+    expect(mine).not.toHaveProperty('id');
+  });
+
+  it('writes one lease_expired event per reaped job in a single bulk insert', async () => {
+    const stuck1 = await makeStaleJob(600);
+    const stuck2 = await makeStaleJob(600);
+
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
+
+    const outbox = await outboxForJobs([stuck1.jobId, stuck2.jobId]);
+    expect(outbox).toHaveLength(2);
+    expect(outbox.every((row) => row.eventType === RUNNER_JOB_LEASE_EXPIRED)).toBe(true);
+  });
+
+  it('two concurrent ticks reap each stuck job exactly once (no double-emit)', async () => {
+    const stuck1 = await makeStaleJob(600);
+    const stuck2 = await makeStaleJob(600);
+
+    await Promise.all([
+      detectAndExpireStuckJobs({thresholdSeconds: 180}),
+      detectAndExpireStuckJobs({thresholdSeconds: 180}),
+    ]);
+
+    expect(await runningJobsForTest()).toHaveLength(0);
+    expect(await outboxForJobs([stuck1.jobId, stuck2.jobId])).toHaveLength(2);
+  });
+
+  it('a reaper tick and a concurrent claim of the same orphan-pending job leave consistent state', async () => {
+    const {jobId, runId} = await makeStaleJob(600);
+    // Orphan pending row from a post-claim enqueue retry for an already-running job.
+    await db().insert(pendingJobs).values({workspaceId, jobId, runId});
+
+    // The reaper locks running-then-pending while the claim locks pending-then-running;
+    // a deadlock loser rolls back, so either side may settle as rejected.
+    await Promise.allSettled([
+      detectAndExpireStuckJobs({thresholdSeconds: 180}),
+      claimPendingJob({workspaceId, runnerTokenId}),
+    ]);
+
+    // A follow-up tick finishes any reap that lost a deadlock race.
+    await detectAndExpireStuckJobs({thresholdSeconds: 180});
+
+    // The expired job is gone and not re-claimable; its orphan pending row is swept.
+    expect(await runningJobsForTest()).toHaveLength(0);
+    expect(await db().select().from(pendingJobs).where(eq(pendingJobs.jobId, jobId))).toHaveLength(
+      0,
+    );
+    expect(await claimPendingJob({workspaceId, runnerTokenId})).toBeNull();
   });
 });

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -1,6 +1,6 @@
 import {RUNNER_JOB_LEASE_EXPIRED, type RunnersEventMap} from '@shipfox/api-runners-dto';
-import {writeOutboxEvent} from '@shipfox/node-outbox';
-import {and, asc, eq, lt, sql} from 'drizzle-orm';
+import {writeOutboxEvents} from '@shipfox/node-outbox';
+import {and, asc, eq, inArray, lt, sql} from 'drizzle-orm';
 import {RunningJobNotFoundError} from '#core/errors.js';
 import {db} from './db.js';
 import {runnersOutbox} from './schema/outbox.js';
@@ -101,51 +101,57 @@ export async function releaseJob(params: {jobId: string}): Promise<void> {
 }
 
 /**
- * Deletes a stuck running-job lease and emits `runners.job.lease_expired`.
+ * Reaps stale leases (bounded by `limit`), emitting one
+ * `runners.job.lease_expired` event per reaped job.
  *
- * Race-safe by construction: the stale-heartbeat guard lives inside the DELETE's
- * WHERE and the outbox event is written in the same transaction only when a row
- * was deleted, so a heartbeat landing between an outer `findStuckJobs` read and
- * this call leaves the live job untouched, and overlapping detector runs cannot
- * double-emit. `runId` comes from `RETURNING`. Once a running row is reaped it
- * also sweeps any orphan pending row for the job (same as `releaseJob`): if the
- * workflow's best-effort `releaseJob` failed, reaping only the running row would
- * leave that orphan re-claimable for an already-finished job. Distinct from
- * `releaseJob` (the workflow-driven cleanup), which is unconditional and emits no
- * event: the two guard on different predicates, so the resemblance is shallow.
+ * The cutoff is re-checked in the DELETE, not just the locking subquery, so a
+ * heartbeat landing mid-call spares the live row. Each reaped job also sweeps its
+ * pending row: a failed best-effort `releaseJob` would otherwise leave an orphan
+ * that a later claim re-runs as an already-finished job.
+ *
+ * Locks running-then-pending, the inverse of `claimPendingJob` / `releaseJob`.
+ * That pre-existing asymmetry opens a narrow deadlock window against a concurrent
+ * claim of the same orphan-pending job; Postgres breaks it and the cron retries.
  */
-export async function expireStuckJob(params: {
-  jobId: string;
-  staleBeforeMs: number;
-}): Promise<{runId: string} | undefined> {
+export async function expireStuckJobs(params: {
+  thresholdSeconds: number;
+  limit?: number;
+}): Promise<Array<{jobId: string; runId: string}>> {
   return await db().transaction(async (tx) => {
-    const deleted = await tx
+    const cutoff = sql`now() - (${params.thresholdSeconds} || ' seconds')::interval`;
+
+    const staleIds = tx
+      .select({id: runningJobs.id})
+      .from(runningJobs)
+      .where(lt(runningJobs.lastHeartbeatAt, cutoff))
+      .orderBy(asc(runningJobs.lastHeartbeatAt))
+      .limit(params.limit ?? 100)
+      .for('update', {skipLocked: true});
+
+    const reaped = await tx
       .delete(runningJobs)
-      .where(
-        and(
-          eq(runningJobs.jobId, params.jobId),
-          lt(
-            runningJobs.lastHeartbeatAt,
-            sql`now() - (${params.staleBeforeMs} || ' milliseconds')::interval`,
-          ),
-        ),
-      )
-      .returning({runId: runningJobs.runId});
+      .where(and(inArray(runningJobs.id, staleIds), lt(runningJobs.lastHeartbeatAt, cutoff)))
+      .returning({jobId: runningJobs.jobId, runId: runningJobs.runId});
 
-    const row = deleted[0];
-    if (!row) return undefined;
+    if (reaped.length === 0) return [];
 
-    await tx.delete(pendingJobs).where(eq(pendingJobs.jobId, params.jobId));
+    await tx.delete(pendingJobs).where(
+      inArray(
+        pendingJobs.jobId,
+        reaped.map((row) => row.jobId),
+      ),
+    );
 
-    await writeOutboxEvent<RunnersEventMap>(tx, runnersOutbox, {
-      type: RUNNER_JOB_LEASE_EXPIRED,
-      payload: {
-        jobId: params.jobId,
-        runId: row.runId,
-      },
-    });
+    await writeOutboxEvents<RunnersEventMap>(
+      tx,
+      runnersOutbox,
+      reaped.map((row) => ({
+        type: RUNNER_JOB_LEASE_EXPIRED,
+        payload: {jobId: row.jobId, runId: row.runId},
+      })),
+    );
 
-    return {runId: row.runId};
+    return reaped;
   });
 }
 
@@ -175,22 +181,4 @@ export async function requestJobCancellation(params: {jobId: string}): Promise<v
       cancellationRequestedAt: sql`COALESCE(${runningJobs.cancellationRequestedAt}, now())`,
     })
     .where(eq(runningJobs.jobId, params.jobId));
-}
-
-// Candidate set only — callers must re-check the cutoff inside any subsequent
-// DELETE so a heartbeat that lands between this read and the write is honored.
-export async function findStuckJobs(params: {
-  thresholdSeconds: number;
-  limit?: number;
-}): Promise<Array<{jobId: string}>> {
-  return await db()
-    .select({jobId: runningJobs.jobId})
-    .from(runningJobs)
-    .where(
-      lt(
-        runningJobs.lastHeartbeatAt,
-        sql`now() - (${params.thresholdSeconds} || ' seconds')::interval`,
-      ),
-    )
-    .limit(params.limit ?? 100);
 }

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -31,6 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -42,6 +44,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/libs/shared/node/outbox/src/index.ts
+++ b/libs/shared/node/outbox/src/index.ts
@@ -1,4 +1,4 @@
 export type {OutboxTable} from './schema.js';
 export {createOutboxTable} from './schema.js';
 export type {DomainEvent, EventMapLike, EventPayload, EventType} from './types.js';
-export {writeOutboxEvent} from './write.js';
+export {writeOutboxEvent, writeOutboxEvents} from './write.js';

--- a/libs/shared/node/outbox/src/write.test.ts
+++ b/libs/shared/node/outbox/src/write.test.ts
@@ -1,0 +1,58 @@
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+import {createOutboxTable} from './schema.js';
+import {writeOutboxEvent, writeOutboxEvents} from './write.js';
+
+const outboxTable = createOutboxTable(pgTableCreator((name) => name));
+
+interface TestEventMap {
+  'thing.created': {id: string};
+  'thing.deleted': {id: string; reason: string};
+}
+
+function fakeTx() {
+  const values = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn(() => ({values}));
+  return {tx: {insert}, insert, values};
+}
+
+describe('writeOutboxEvents', () => {
+  it('is a no-op for an empty batch (Drizzle rejects values([]))', async () => {
+    const {tx, insert, values} = fakeTx();
+
+    await writeOutboxEvents<TestEventMap>(tx, outboxTable, []);
+
+    expect(insert).not.toHaveBeenCalled();
+    expect(values).not.toHaveBeenCalled();
+  });
+
+  it('maps every event to one multi-row insert', async () => {
+    const {tx, insert, values} = fakeTx();
+
+    await writeOutboxEvents<TestEventMap>(tx, outboxTable, [
+      {type: 'thing.created', payload: {id: 'a'}},
+      {type: 'thing.deleted', payload: {id: 'b', reason: 'gone'}},
+    ]);
+
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(insert).toHaveBeenCalledWith(outboxTable);
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledWith([
+      {eventType: 'thing.created', payload: {id: 'a'}},
+      {eventType: 'thing.deleted', payload: {id: 'b', reason: 'gone'}},
+    ]);
+  });
+});
+
+describe('writeOutboxEvent', () => {
+  it('delegates to writeOutboxEvents with a single-element batch', async () => {
+    const {tx, values} = fakeTx();
+
+    await writeOutboxEvent<TestEventMap>(tx, outboxTable, {
+      type: 'thing.created',
+      payload: {id: 'a'},
+    });
+
+    expect(values).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledWith([{eventType: 'thing.created', payload: {id: 'a'}}]);
+  });
+});

--- a/libs/shared/node/outbox/src/write.ts
+++ b/libs/shared/node/outbox/src/write.ts
@@ -1,19 +1,41 @@
 import type {OutboxTable} from './schema.js';
 import type {EventMapLike, EventType} from './types.js';
 
+type OutboxRow = {eventType: string; payload: unknown};
+
 interface DrizzleInsertable {
   insert: (table: OutboxTable) => {
-    values: (values: {eventType: string; payload: unknown}) => Promise<unknown>;
+    values: {
+      (value: OutboxRow): Promise<unknown>;
+      (values: OutboxRow[]): Promise<unknown>;
+    };
   };
 }
+
+type OutboxEvent<TMap extends EventMapLike> = {
+  [K in EventType<TMap>]: {type: K; payload: TMap[K]};
+}[EventType<TMap>];
 
 export async function writeOutboxEvent<TMap extends EventMapLike>(
   tx: DrizzleInsertable,
   outboxTable: OutboxTable,
-  event: {[K in EventType<TMap>]: {type: K; payload: TMap[K]}}[EventType<TMap>],
+  event: OutboxEvent<TMap>,
 ): Promise<void> {
-  await tx.insert(outboxTable).values({
-    eventType: event.type,
-    payload: event.payload,
-  });
+  await writeOutboxEvents<TMap>(tx, outboxTable, [event]);
+}
+
+export async function writeOutboxEvents<TMap extends EventMapLike>(
+  tx: DrizzleInsertable,
+  outboxTable: OutboxTable,
+  events: Array<OutboxEvent<TMap>>,
+): Promise<void> {
+  // Drizzle's `.values([])` emits invalid SQL, so an empty batch is a no-op.
+  if (events.length === 0) return;
+
+  await tx.insert(outboxTable).values(
+    events.map((event) => ({
+      eventType: event.type,
+      payload: event.payload,
+    })),
+  );
 }

--- a/libs/shared/node/outbox/vitest.config.ts
+++ b/libs/shared/node/outbox/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2647,6 +2647,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
 
   libs/shared/node/postgres:
     dependencies:


### PR DESCRIPTION
Replaces the N+1 stuck-job expiry in the `stuckJobDetector` cron with a single bounded transaction.

Previously each tick ran one SELECT of stale rows, then a per-row `DELETE ... RETURNING` + single-row outbox insert, each in its own transaction (~1 SELECT + N DELETEs + N inserts). This collapses it into one `expireStuckJobs`: a `DELETE ... RETURNING` over the oldest stale rows (`FOR UPDATE SKIP LOCKED`, capped at 100 per tick, with the stale cutoff re-checked inside the DELETE) feeding a multi-row outbox insert through a new `writeOutboxEvents` helper in `@shipfox/node-outbox`. `writeOutboxEvent` now delegates to the plural helper so there is one insert path.

Observable behavior is unchanged: the same rows are reaped, one `runners.job.lease_expired` event is emitted per reaped job, and orphan pending rows for reaped jobs are still swept in the same transaction.

### Review notes
- **Bounded over literal.** The ticket's literal SQL is an unbounded `DELETE ... WHERE last_heartbeat_at < cutoff`. I kept the existing 100-row cap (via a `FOR UPDATE SKIP LOCKED` subquery) to bound per-tick work and the outbox burst under a mass-outage backlog. The cron drains 100/min.
- **Lock ordering.** The reaper keeps its existing running-then-pending order, the inverse of `claimPendingJob`/`releaseJob` (pending-then-running). That asymmetry predates this change (today's per-row `expireStuckJob` already orders running-then-pending); batching only widens the window. It is now documented in the function comment and covered by a reaper-vs-claim concurrency test that asserts a consistent end state (a deadlock loser rolls back and the next tick finishes the reap).
- **Tests.** Added returns-shape (no `id` leak), multi-row outbox, reaper-vs-reaper and reaper-vs-claim concurrency tests; node-outbox gets its first unit test + Vitest config.

Fixes ENG-432

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-expire stuck running-job leases in one transaction to replace the prior N+1 deletes/inserts. Behavior is unchanged; work is bounded to 100 rows per tick with `FOR UPDATE SKIP LOCKED`.

- **Refactors**
  - Implements ENG-432: bulk `DELETE … RETURNING` feeding a multi-row outbox insert.
  - Adds `expireStuckJobs(thresholdSeconds, limit=100)` returning `{jobId, runId}`; rechecks the cutoff in the `DELETE` and reaps oldest-first with locked-row skipping.
  - Removes `findStuckJobs`/`expireStuckJob`; `detectAndExpireStuckJobs` now uses the bulk path and returns the expired count.
  - Introduces `writeOutboxEvents` in `@shipfox/node-outbox` (no-op on empty batch); `writeOutboxEvent` delegates to it; exports, test scripts, and Vitest setup added, plus concurrency and outbox tests.

<sup>Written for commit 60e5408601592090ce3b29e998dce8f1ff2c61be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

