### PR TITLE
[skills/pr] Default to closing keywords for resolved tickets

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -136,7 +136,7 @@ via the admin panel, preventing starvation for other tenants.
 Considered a global queue with fair-scheduling, but per-org limits are
 simpler to reason about and easier to tune per customer.
 
-Refs LINEAR-123
+Closes LINEAR-123
 ```
 
 ### Bug Fix PR
@@ -164,15 +164,27 @@ Prepares for adding rate-limiting per token in LINEAR-789.
 
 ## Issue References
 
-Reference Linear tickets in the PR body:
+Reference Linear tickets in the PR body. Linear's
+[magic words](https://linear.app/docs/github#link-through-pull-requests) decide
+whether merging closes the ticket.
 
-| Syntax             | Effect                                   |
-| ------------------ | ---------------------------------------- |
-| `Fixes LINEAR-123` | Links and signals the ticket is resolved |
-| `Refs LINEAR-123`  | Links without closing                    |
+**Default to a closing keyword.** If merging the PR completes the ticket's work,
+use `Closes` / `Fixes` / `Resolves` so it moves to Done. Only use a non-closing
+keyword (`Refs`, `Part of`, `Related to`) when the PR is partial work that
+leaves the ticket open.
 
-If a ticket is referenced in the user request, command arguments, or branch
-name, include the appropriate reference in the PR body.
+| Keywords                        | Effect on merge                 |
+| ------------------------------- | ------------------------------- |
+| `Closes`, `Fixes`, `Resolves`   | Links **and** closes the ticket |
+| `Refs`, `Part of`, `Related to` | Links without closing           |
+
+```markdown
+Closes LINEAR-123
+```
+
+Include a reference whenever a ticket is named in the request, arguments, or
+branch name. When unsure whether the PR fully resolves it, ask rather than
+defaulting to `Refs`.
 
 ## Guidelines
 


### PR DESCRIPTION
The `pr` skill documented both closing (`Fixes`) and non-closing (`Refs`) Linear keywords but never said when to use which. As a result, PRs created with the skill kept defaulting to `Refs`, which links a ticket without closing it, leaving resolved tickets open after merge.

This rewrites the Issue References section to make a closing keyword (`Closes` / `Fixes` / `Resolves`) the default when the PR resolves the ticket, and reserves non-closing keywords (`Refs` / `Part of` / `Related to`) for genuinely partial work. The feature-PR example is updated to use `Closes` so the examples match the new guidance.

Docs-only change to a shared skill (loaded by both Claude and Codex), so no changeset and no package code is affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `pr` skill docs to default to closing keywords (`Closes`/`Fixes`/`Resolves`) when a PR resolves a Linear ticket, so tickets move to Done on merge. Clarifies when to use non-closing keywords (`Refs`/`Part of`/`Related to`) and updates the feature PR example to use `Closes`.

<sup>Written for commit e39c8afe66dd4644dfd72b10f294c3d47745cd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

