### PR TITLE
[e2e/integrations] Add E2E + visual coverage for the integrations catalogue and Sentry flow

### DIFF
--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -18,6 +18,8 @@
     "type": "shipfox-tsc-check"
   },
   "devDependencies": {
+    "@shipfox/api-integration-core-dto": "workspace:*",
+    "@shipfox/api-integration-sentry-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/client-integrations": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",

--- a/e2e/client/integrations/tests/install-redirect-helpers.ts
+++ b/e2e/client/integrations/tests/install-redirect-helpers.ts
@@ -1,0 +1,58 @@
+import type {Page} from '@shipfox/playwright';
+import {expect} from './test.js';
+
+export interface InstallRedirectExpectation {
+  /** App route that mounts the RedirectInstallPage (e.g. /workspaces/$wid/integrations/sentry). */
+  installPath: string;
+  /** Glob matching the install POST endpoint, e.g. a trailing /integrations/sentry/install. */
+  installEndpoint: string;
+  /** External provider origin the page redirects to (e.g. https://sentry.io). */
+  externalHost: string;
+  /** install_url the stubbed endpoint returns and that the page must redirect to. */
+  expectedUrl: string;
+  /**
+   * Runs inside the install-POST handler, after the body is captured but before
+   * the response is fulfilled — i.e. while the app document is still intact and
+   * the redirect has not fired. Sentry uses it to read its sessionStorage
+   * handoff, which is unreadable once the aborted navigation denies the document.
+   */
+  beforeReleaseInstall?: () => void | Promise<void>;
+}
+
+// RedirectInstallPage fires the install POST on mount and then
+// `window.location.assign(install_url)`. We register both routes BEFORE
+// navigating (a route added after page.goto loses to the real backend),
+// capture the attempted external URL inside the handler before aborting it
+// (an aborted top-level navigation leaves no asserting-against final URL), and
+// assert the install POST carried the workspace id so the test exercises more
+// than mocked plumbing.
+export async function assertInstallRedirect(
+  page: Page,
+  expectation: InstallRedirectExpectation,
+): Promise<void> {
+  let installBody: {workspace_id?: unknown} | undefined;
+  let resolveNavigation!: (url: string) => void;
+  const navigated = new Promise<string>((resolve) => {
+    resolveNavigation = resolve;
+  });
+
+  await page.route(`${expectation.externalHost}/**`, async (route) => {
+    resolveNavigation(route.request().url());
+    await route.abort();
+  });
+  await page.route(expectation.installEndpoint, async (route) => {
+    installBody = route.request().postDataJSON();
+    await expectation.beforeReleaseInstall?.();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({install_url: expectation.expectedUrl}),
+    });
+  });
+
+  await page.goto(expectation.installPath);
+  const navigatedUrl = await navigated;
+
+  expect(navigatedUrl).toBe(expectation.expectedUrl);
+  expect(installBody?.workspace_id).toBeTruthy();
+}

--- a/e2e/client/integrations/tests/install-redirect.e2e.ts
+++ b/e2e/client/integrations/tests/install-redirect.e2e.ts
@@ -1,0 +1,52 @@
+import {assertInstallRedirect} from './install-redirect-helpers.js';
+import {expect, test} from './test.js';
+
+const SENTRY_INSTALL_URL = 'https://sentry.io/sentry-apps/test-app/external-install/';
+const GITHUB_INSTALL_URL = 'https://github.com/apps/test-app/installations/new';
+const SENTRY_INSTALL_WORKSPACE_KEY = 'shipfox.sentry-install.workspace-id';
+
+test('Sentry install redirects to Sentry and stores the workspace handoff', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({
+    userId: user.user.id,
+    name: 'Sentry Install Workspace',
+  });
+  await auth.loginAs(page, user);
+
+  await assertInstallRedirect(page, {
+    installPath: `/workspaces/${workspace.id}/integrations/sentry`,
+    installEndpoint: '**/integrations/sentry/install',
+    externalHost: 'https://sentry.io',
+    expectedUrl: SENTRY_INSTALL_URL,
+    // Sentry's redirect carries no state param, so the install page stashes the
+    // workspace id for the callback to pre-select. Read it before the redirect
+    // fires — once the navigation is aborted the document denies storage access.
+    beforeReleaseInstall: async () => {
+      const storedWorkspaceId = await page.evaluate(
+        (key) => window.sessionStorage.getItem(key),
+        SENTRY_INSTALL_WORKSPACE_KEY,
+      );
+      expect(storedWorkspaceId).toBe(workspace.id);
+    },
+  });
+});
+
+test('GitHub install redirects to GitHub', async ({page, auth, workspaces}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({
+    userId: user.user.id,
+    name: 'GitHub Install Workspace',
+  });
+  await auth.loginAs(page, user);
+
+  await assertInstallRedirect(page, {
+    installPath: `/workspaces/${workspace.id}/integrations/github`,
+    installEndpoint: '**/integrations/github/install',
+    externalHost: 'https://github.com',
+    expectedUrl: GITHUB_INSTALL_URL,
+  });
+});

--- a/e2e/client/integrations/tests/sentry-callback.e2e.ts
+++ b/e2e/client/integrations/tests/sentry-callback.e2e.ts
@@ -1,0 +1,146 @@
+import type {SentryConnectResponseDto} from '@shipfox/api-integration-sentry-dto';
+import {argosScreenshot, type Page} from '@shipfox/playwright';
+import {expect, test} from './test.js';
+
+const CALLBACK_URL =
+  '/integrations/sentry/callback?code=test-code&installation_id=test-install&org_slug=acme';
+
+// Typed against the real connect response DTO so a contract change fails
+// `turbo type` instead of letting the stub pass on a stale shape (e2e packages
+// import *-dto packages for types only — see settings-catalogue.e2e.ts).
+function sentryConnectionFixture(workspaceId: string): SentryConnectResponseDto {
+  return {
+    id: '00000000-0000-4000-8000-0000000000ab',
+    workspace_id: workspaceId,
+    provider: 'sentry',
+    external_account_id: 'acme',
+    display_name: 'Sentry acme',
+    lifecycle_status: 'active',
+    capabilities: [],
+    external_url: 'https://acme.sentry.io/',
+    created_at: '2026-01-15T12:00:00.000Z',
+    updated_at: '2026-01-15T12:00:00.000Z',
+  };
+}
+
+async function stubConnect(page: Page, response: {status: number; body: unknown}): Promise<void> {
+  await page.route('**/integrations/sentry/connect', async (route) => {
+    await route.fulfill({
+      status: response.status,
+      contentType: 'application/json',
+      body: JSON.stringify(response.body),
+    });
+  });
+}
+
+test('Sentry callback shows an error when required params are missing', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  await workspaces.create({userId: user.user.id});
+  await auth.loginAs(page, user);
+
+  await page.goto('/integrations/sentry/callback');
+
+  await expect(
+    page.getByText(
+      'This Sentry link is missing required parameters. Start the install again from your workspace settings.',
+    ),
+  ).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Back to Shipfox'})).toBeVisible();
+
+  await argosScreenshot(page, 'integrations/sentry-callback-missing-params');
+});
+
+test('Sentry callback shows the workspace picker', async ({page, auth, workspaces}) => {
+  const user = await auth.createUser();
+  await workspaces.create({userId: user.user.id, name: 'Sentry Picker Workspace'});
+  await auth.loginAs(page, user);
+
+  await page.goto(CALLBACK_URL);
+
+  await expect(page.getByRole('heading', {name: 'Connect Sentry'})).toBeVisible();
+  await expect(page.getByText('Connect the Sentry org "acme" to a workspace.')).toBeVisible();
+  await expect(page.getByRole('button', {name: 'Connect'})).toBeVisible();
+
+  await argosScreenshot(page, 'integrations/sentry-callback-pick-workspace');
+});
+
+test('Sentry callback connects to a workspace on success', async ({page, auth, workspaces}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({
+    userId: user.user.id,
+    name: 'Sentry Connect Workspace',
+  });
+  await auth.loginAs(page, user);
+
+  await stubConnect(page, {status: 200, body: sentryConnectionFixture(workspace.id)});
+
+  await page.goto(CALLBACK_URL);
+  await expect(page.getByRole('heading', {name: 'Connect Sentry'})).toBeVisible();
+  await page.getByRole('button', {name: 'Connect'}).click();
+
+  // The stub never persisted a connection, so we assert only the success toast
+  // and the redirect target — not that Sentry appears in the gallery.
+  await expect(page.getByText('Sentry connected.')).toBeVisible();
+  await expect(page).toHaveURL(
+    new RegExp(`/workspaces/${workspace.id}/settings/integrations/?$`, 'u'),
+  );
+});
+
+test('Sentry callback offers Start over on a terminal failure', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  await workspaces.create({userId: user.user.id, name: 'Sentry Terminal Workspace'});
+  await auth.loginAs(page, user);
+
+  // A spent grant code returns a 4xx with no recovery except a fresh install,
+  // so classifySentryConnectError yields a terminal failure with startOver.
+  await stubConnect(page, {
+    status: 400,
+    body: {
+      message: 'This Sentry link could not be completed. Start the install again.',
+      code: 'access-denied',
+    },
+  });
+
+  await page.goto(
+    '/integrations/sentry/callback?code=spent-code&installation_id=test-install&org_slug=acme',
+  );
+  await page.getByRole('button', {name: 'Connect'}).click();
+
+  await expect(
+    page.getByText('This Sentry link could not be completed. Start the install again.'),
+  ).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Start over'})).toBeVisible();
+
+  await argosScreenshot(page, 'integrations/sentry-callback-terminal');
+});
+
+test('Sentry callback offers Retry on a retryable failure', async ({page, auth, workspaces}) => {
+  const user = await auth.createUser();
+  await workspaces.create({userId: user.user.id, name: 'Sentry Retry Workspace'});
+  await auth.loginAs(page, user);
+
+  // A rate-limit (no retry-after window) classifies as retryable, so the Retry
+  // button stays enabled.
+  await stubConnect(page, {
+    status: 429,
+    body: {message: 'Sentry is rate limiting requests.', code: 'rate-limited'},
+  });
+
+  await page.goto(CALLBACK_URL);
+  await page.getByRole('button', {name: 'Connect'}).click();
+
+  await expect(
+    page.getByText('Sentry is rate limiting requests. Try again in a moment.'),
+  ).toBeVisible();
+  await expect(page.getByRole('button', {name: 'Retry'})).toBeVisible();
+
+  await argosScreenshot(page, 'integrations/sentry-callback-retryable');
+});

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -1,0 +1,92 @@
+import type {ListIntegrationProvidersResponseDto} from '@shipfox/api-integration-core-dto';
+import {argosScreenshot, type Page} from '@shipfox/playwright';
+import {expect, test} from './test.js';
+
+const ADDED_DATE_RE = /^Added /u;
+
+// The settings catalogue's Available grid is the surface PR #179 shipped, but
+// the e2e API may only enable Debug. Stub the providers list so the multi-tile
+// grid renders deterministically and the screenshot guards the GitHub/Sentry
+// tiles regardless of provider config. Typed against the real response DTO so a
+// contract change fails `turbo type` — e2e packages depend on *-dto packages
+// for types only (the runtime schema would load the package's dist, which
+// self-references src and is not loadable under the test runner).
+const CATALOGUE_PROVIDERS: ListIntegrationProvidersResponseDto = {
+  providers: [
+    {provider: 'github', display_name: 'GitHub', capabilities: ['source_control']},
+    {provider: 'sentry', display_name: 'Sentry', capabilities: []},
+    {provider: 'debug', display_name: 'Debug', capabilities: ['source_control']},
+  ],
+};
+
+async function stubProviders(page: Page): Promise<void> {
+  await page.route('**/integration-providers', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(CATALOGUE_PROVIDERS),
+    });
+  });
+}
+
+test('settings catalogue lists available providers with an empty installed state', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({
+    userId: user.user.id,
+    name: 'Integrations Settings Workspace',
+  });
+  await auth.loginAs(page, user);
+
+  // Register the providers stub before navigating: the gallery fires its
+  // queries on mount.
+  await stubProviders(page);
+
+  await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
+
+  await expect(page.getByRole('heading', {name: 'Available integrations'})).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Connect GitHub'})).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Connect Sentry'})).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Connect Debug'})).toBeVisible();
+  await expect(page.getByText('No integrations connected yet')).toBeVisible();
+
+  await argosScreenshot(page, 'integrations/settings-empty');
+});
+
+test('settings catalogue shows a connected provider after Debug connect', async ({
+  page,
+  auth,
+  workspaces,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({
+    userId: user.user.id,
+    name: 'Integrations Installed Workspace',
+  });
+  await auth.loginAs(page, user);
+
+  // Real Debug connect (no external dependency): the install page creates the
+  // connection on mount, fires the success toast, then forwards to
+  // /workspaces/$wid, so we explicitly return to settings to inspect the row.
+  await page.goto(`/workspaces/${workspace.id}/integrations/debug`);
+  await expect(page.getByText('Debug source control connected.')).toBeVisible();
+
+  await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
+
+  const installed = page.locator('section[aria-label="Installed integrations"]');
+  await expect(installed.getByText('Debug', {exact: true})).toBeVisible();
+  await expect(installed.getByText('Connected')).toBeVisible();
+
+  // `Added <date>` is server-generated, so it would drift the Argos baseline
+  // every day. Pin it to a fixed string before the snapshot (repo convention:
+  // see e2e/client/runners/tests/runner-token-flows.e2e.ts), keeping the row
+  // anchored to the real Debug connection otherwise.
+  await installed.getByText(ADDED_DATE_RE).evaluate((element) => {
+    element.textContent = 'Added Jan 15, 2026';
+  });
+
+  await argosScreenshot(page, 'integrations/settings-installed');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,12 @@ importers:
 
   e2e/client/integrations:
     devDependencies:
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/core-dto
+      '@shipfox/api-integration-sentry-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/sentry-dto
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome


### PR DESCRIPTION
Adds a first batch of Playwright E2E + Argos visual coverage for the reworked integrations surfaces, which shipped with no end-to-end or screenshot coverage: the settings integration catalogue (#179) and the Sentry connect flow (#174). Work extends the existing `@shipfox/e2e-client-integrations` package — no new packages, no production-code changes.

## What's covered

- **Settings catalogue** — empty state (providers stubbed for a deterministic multi-tile Available grid) and installed state via the real Debug connect flow, with the volatile `Added <date>` pinned so the Argos baseline doesn't drift daily.
- **Sentry callback** — missing-params, workspace picker, connect success, and terminal + retryable failure states. The connect endpoint is network-stubbed so no live `sentry.io` call is needed in CI (the connect core is already unit-tested).
- **Install redirects** — Sentry and GitHub assert the external install URL via a shared `assertInstallRedirect` helper (registers routes before navigation, captures the URL before aborting, asserts the POST carries `workspace_id`), plus the Sentry `sessionStorage` handoff read in the pre-navigation window.

## Why these shapes

`POST /integrations/sentry/connect` exchanges the OAuth code against the live Sentry API, so a real connect can't run deterministically in CI — hence client-surface coverage with the external-dependent endpoints stubbed at the Playwright layer.

DTO imports are **type-only**, matching every other e2e package. A contract change still fails `turbo type`, while importing the runtime zod schema would load the `*-dto` package's `dist`, which self-references `src` and is not loadable under the test runner.

## Reviewer notes

- **Six new Argos snapshots** need baseline-accepting: `integrations/settings-empty`, `settings-installed`, `sentry-callback-missing-params`, `-pick-workspace`, `-terminal`, `-retryable`.
- All 10 specs pass locally (`turbo test:e2e`), and `turbo build/test/check` are green.
- Pre-existing packaging issue worth a separate look: the `*-dto` packages' built `dist/index.js` keeps `#contracts/index.js` subpath imports that the `"#*": "./src/*"` map resolves to a non-existent `src/contracts/index.js`, so they're only loadable via the source/`development` condition. Harmless for the type-only consumers here, but it would bite any built-Node runtime consumer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright E2E and Argos visual tests for the integrations settings catalogue and the Sentry connect flow, plus install redirect checks for Sentry and GitHub. Improves coverage for these reworked surfaces with no production changes.

- **New Features**
  - Settings catalogue: tests empty and installed states; provider list stubbed for a stable multi-tile grid; pins “Added <date>” to keep snapshots stable.
  - Sentry callback: covers missing params, workspace picker, success, and terminal/retryable failures; stubs the connect endpoint to avoid external calls.
  - Install redirects: shared helper asserts external URL and `workspace_id` on POST; verifies Sentry `sessionStorage` handoff before navigation.

- **Dependencies**
  - Added `@shipfox/api-integration-core-dto` and `@shipfox/api-integration-sentry-dto` as dev deps for type-only checks (contract changes fail `turbo type`).

<sup>Written for commit 4a6c6a0547d135497b1986bd3622294b7ba154d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

