### PR TITLE
[runner] Shallow-clone the repository in the setup step

### DIFF
--- a/.changeset/eng-405-shallow-clone-checkout.md
+++ b/.changeset/eng-405-shallow-clone-checkout.md
@@ -1,0 +1,14 @@
+---
+"@shipfox/runner-workspace": patch
+"@shipfox/runner-execution": patch
+"@shipfox/runner-protocol": patch
+---
+
+Implement the repository checkout inside the runner's "Set up job" step. The setup
+step now ensures `git` is available, exchanges the job lease for short-lived
+read-only checkout credentials via the checkout-token endpoint, and shallow-clones
+the project repository's default branch into the per-job directory. Every failure
+mode (missing `git`, denied credential, unreachable provider, generic clone failure)
+fails the job before any user step runs with a machine-readable `reason`. Credentials
+are injected with a one-shot `http.extraHeader`, never persisted to `.git/config`,
+and redacted from error messages.

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -14,6 +14,14 @@ The runner prepares a fresh working directory for every job, runs all of the
 job's steps from it, and removes it afterwards. Steps do **not** inherit the
 runner process's working directory.
 
+During the synthetic "Set up job" step, the runner exchanges the job's lease for
+short-lived, read-only checkout credentials and shallow-clones the project
+repository into the per-job directory. The credentials are fetched only after the
+job is claimed, are never persisted to disk or `.git/config`, and never appear in
+logs or step errors. A setup failure (missing `git`, a denied credential, or an
+unreachable provider) fails the job before any step runs, with a machine-readable
+reason recorded on the step.
+
 ### `SHIPFOX_RUNNER_WORKSPACE_ROOT` (optional)
 
 Parent directory under which per-job working directories are created.

--- a/libs/runner/execution/package.json
+++ b/libs/runner/execution/package.json
@@ -39,7 +39,9 @@
   "dependencies": {
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
-    "@shipfox/runner-workspace": "workspace:*"
+    "@shipfox/runner-protocol": "workspace:*",
+    "@shipfox/runner-workspace": "workspace:*",
+    "ky": "^2.0.0"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -1,35 +1,162 @@
-vi.mock('@shipfox/runner-workspace', () => ({
-  createJobDir: vi.fn(),
+import {HTTPError} from 'ky';
+
+const requestCheckoutTokenMock = vi.fn();
+const assertGitAvailableMock = vi.fn();
+const createJobDirMock = vi.fn();
+const checkoutRepositoryMock = vi.fn();
+
+vi.mock('@shipfox/runner-protocol', () => ({
+  requestCheckoutToken: (...args: unknown[]) => requestCheckoutTokenMock(...args),
+  HTTPError,
 }));
 
-import {createJobDir} from '@shipfox/runner-workspace';
-import {executeSetupStep} from '#core/setup-step.js';
+// CheckoutError is a real class (setup-step branches on instanceof), so keep the actual
+// implementation and only stub the side-effecting functions.
+vi.mock('@shipfox/runner-workspace', async () => {
+  const actual = await vi.importActual<typeof import('@shipfox/runner-workspace')>(
+    '@shipfox/runner-workspace',
+  );
+  return {
+    ...actual,
+    assertGitAvailable: (...args: unknown[]) => assertGitAvailableMock(...args),
+    createJobDir: (...args: unknown[]) => createJobDirMock(...args),
+    checkoutRepository: (...args: unknown[]) => checkoutRepositoryMock(...args),
+  };
+});
 
-const mockCreateJobDir = vi.mocked(createJobDir);
+const {executeSetupStep} = await import('#core/setup-step.js');
+const {CheckoutError} = await import('@shipfox/runner-workspace');
 
 const CWD = '/tmp/shipfox-test-root/job-1';
+const leaseClient = {} as never;
+const signal = new AbortController().signal;
+
+function checkoutResponse(auth?: unknown) {
+  return {
+    repository_url: 'https://github.com/acme/repo.git',
+    ref: 'main',
+    auth,
+  };
+}
+
+function run() {
+  return executeSetupStep({cwd: CWD, leaseClient, signal});
+}
+
+function httpError(status: number, body?: unknown): HTTPError {
+  const response = {
+    status,
+    clone: () => ({json: async () => body ?? {}}),
+  } as unknown as Response;
+  return new HTTPError(response, {} as Request, {} as ConstructorParameters<typeof HTTPError>[2]);
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
+  assertGitAvailableMock.mockResolvedValue(undefined);
+  createJobDirMock.mockResolvedValue(undefined);
+  requestCheckoutTokenMock.mockResolvedValue(checkoutResponse());
+  checkoutRepositoryMock.mockResolvedValue(undefined);
 });
 
 describe('executeSetupStep', () => {
-  it('prepares the workspace and succeeds', async () => {
-    mockCreateJobDir.mockResolvedValue();
+  it('prepares the workspace, checks out the repo, and succeeds', async () => {
+    requestCheckoutTokenMock.mockResolvedValue(
+      checkoutResponse({kind: 'bearer', token: 't', expires_at: '2026-01-01T00:00:00Z'}),
+    );
 
-    const result = await executeSetupStep({cwd: CWD});
+    const result = await run();
 
-    expect(mockCreateJobDir).toHaveBeenCalledWith(CWD);
+    expect(assertGitAvailableMock).toHaveBeenCalledOnce();
+    expect(createJobDirMock).toHaveBeenCalledWith(CWD);
+    expect(requestCheckoutTokenMock).toHaveBeenCalledWith(leaseClient, {signal});
+    expect(checkoutRepositoryMock).toHaveBeenCalledWith({
+      repositoryUrl: 'https://github.com/acme/repo.git',
+      ref: 'main',
+      auth: {kind: 'bearer', token: 't', expires_at: '2026-01-01T00:00:00Z'},
+      cwd: CWD,
+      signal,
+    });
     expect(result).toEqual({success: true, output: '', error: null, exit_code: 0});
   });
 
-  it('reports workspace_prep_failed when creating the directory fails', async () => {
-    mockCreateJobDir.mockRejectedValue(new Error('mkdir denied'));
+  it('checks git before minting a credential', async () => {
+    assertGitAvailableMock.mockRejectedValue(new Error('git is not available on the runner host'));
 
-    const result = await executeSetupStep({cwd: CWD});
+    const result = await run();
+
+    expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
+    expect(createJobDirMock).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error?.reason).toBe('git_unavailable');
+  });
+
+  it('reports workspace_prep_failed when creating the directory fails', async () => {
+    createJobDirMock.mockRejectedValue(new Error('mkdir denied'));
+
+    const result = await run();
+
+    expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
+    expect(result.error).toEqual({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+  });
+
+  it.each([
+    {status: 401, reason: 'checkout_auth_failed'},
+    {status: 403, reason: 'checkout_auth_failed'},
+    {status: 429, reason: 'checkout_unavailable'},
+    {status: 503, reason: 'checkout_unavailable'},
+    {status: 404, reason: 'checkout_failed'},
+    {status: 409, reason: 'checkout_failed'},
+    {status: 422, reason: 'checkout_failed'},
+  ])('maps a $status checkout-token error to $reason', async ({status, reason}) => {
+    requestCheckoutTokenMock.mockRejectedValue(httpError(status));
+
+    const result = await run();
+
+    expect(checkoutRepositoryMock).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error?.reason).toBe(reason);
+  });
+
+  it.each([
+    {code: 'access-denied', reason: 'checkout_auth_failed'},
+    {code: 'rate-limited', reason: 'checkout_unavailable'},
+    {code: 'provider-unavailable', reason: 'checkout_unavailable'},
+  ])('maps a 422 with code $code to $reason', async ({code, reason}) => {
+    requestCheckoutTokenMock.mockRejectedValue(httpError(422, {code}));
+
+    const result = await run();
+
+    expect(result.error?.reason).toBe(reason);
+  });
+
+  it('maps a non-HTTP checkout-token error to checkout_failed', async () => {
+    requestCheckoutTokenMock.mockRejectedValue(new Error('socket hang up'));
+
+    const result = await run();
+
+    expect(result.error).toEqual({message: 'socket hang up', reason: 'checkout_failed'});
+  });
+
+  it.each([
+    {kind: 'auth' as const, reason: 'checkout_auth_failed'},
+    {kind: 'unavailable' as const, reason: 'checkout_unavailable'},
+    {kind: 'failed' as const, reason: 'checkout_failed'},
+    {kind: 'aborted' as const, reason: 'setup_aborted'},
+  ])('maps a $kind clone failure to $reason', async ({kind, reason}) => {
+    checkoutRepositoryMock.mockRejectedValue(new CheckoutError(kind, 'boom'));
+
+    const result = await run();
 
     expect(result.success).toBe(false);
-    expect(result.exit_code).toBeNull();
-    expect(result.error).toEqual({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+    expect(result.error?.reason).toBe(reason);
+  });
+
+  it('maps an unexpected clone error to checkout_failed', async () => {
+    checkoutRepositoryMock.mockRejectedValue(new Error('weird'));
+
+    const result = await run();
+
+    expect(result.error).toEqual({message: 'weird', reason: 'checkout_failed'});
   });
 });

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -43,12 +43,18 @@ function run() {
   return executeSetupStep({cwd: CWD, leaseClient, signal});
 }
 
+// ky populates `error.data` with the pre-parsed body and consumes `error.response`, so
+// the production classifier reads `error.data` — mirror that here rather than faking a
+// re-readable `response.clone().json()`, which production can never do.
 function httpError(status: number, body?: unknown): HTTPError {
-  const response = {
-    status,
-    clone: () => ({json: async () => body ?? {}}),
-  } as unknown as Response;
-  return new HTTPError(response, {} as Request, {} as ConstructorParameters<typeof HTTPError>[2]);
+  const response = {status} as unknown as Response;
+  const error = new HTTPError(
+    response,
+    {} as Request,
+    {} as ConstructorParameters<typeof HTTPError>[2],
+  );
+  error.data = body;
+  return error;
 }
 
 beforeEach(() => {

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -41,7 +41,7 @@ export async function executeSetupStep(params: {
   try {
     checkout = await requestCheckoutToken(leaseClient, {signal});
   } catch (error) {
-    return fail(error, await classifyCheckoutTokenError(error));
+    return fail(error, classifyCheckoutTokenError(error));
   }
 
   try {
@@ -73,11 +73,11 @@ const CHECKOUT_KIND_REASON: Record<CheckoutFailureKind, StepErrorReason> = {
 // missing checkout intent (404) and everything else fold into the generic failure.
 // CheckoutError messages are already redacted in the workspace layer; the token-fetch
 // error never carries credential material.
-async function classifyCheckoutTokenError(error: unknown): Promise<StepErrorReason> {
+function classifyCheckoutTokenError(error: unknown): StepErrorReason {
   if (!(error instanceof HTTPError)) return 'checkout_failed';
 
   const {status} = error.response;
-  const code = await readErrorCode(error);
+  const code = readErrorCode(error);
 
   if (status === 401 || status === 403 || code === 'access-denied' || code === 'forbidden') {
     return 'checkout_auth_failed';
@@ -94,14 +94,13 @@ async function classifyCheckoutTokenError(error: unknown): Promise<StepErrorReas
   return 'checkout_failed';
 }
 
-async function readErrorCode(error: HTTPError): Promise<string | undefined> {
-  try {
-    const body: unknown = await error.response.clone().json();
-    if (body && typeof body === 'object' && 'code' in body && typeof body.code === 'string') {
-      return body.code;
-    }
-  } catch {
-    // Body is not JSON or already consumed; fall back to status-only mapping.
+// ky consumes the response body to populate `error.data` before throwing, so the body
+// is already read here: `error.response.json()` would throw "Body has already been
+// consumed". Read ky's pre-parsed `data` instead.
+function readErrorCode(error: HTTPError): string | undefined {
+  const body = error.data;
+  if (body && typeof body === 'object' && 'code' in body && typeof body.code === 'string') {
+    return body.code;
   }
   return undefined;
 }

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -1,26 +1,116 @@
-import {createJobDir} from '@shipfox/runner-workspace';
+import type {CheckoutTokenResponseDto, StepErrorReason} from '@shipfox/api-workflows-dto';
+import {HTTPError, requestCheckoutToken} from '@shipfox/runner-protocol';
+import {
+  assertGitAvailable,
+  CheckoutError,
+  type CheckoutFailureKind,
+  checkoutRepository,
+  createJobDir,
+} from '@shipfox/runner-workspace';
+import type {KyInstance} from 'ky';
 import type {StepResult} from '#core/step-result.js';
 
-// The synthetic "Set up job" step body. It owns per-job workspace preparation and
-// reports failures through the normal step protocol, so a setup failure fails the
-// job in seconds instead of hanging until the lease expires.
+// The synthetic "Set up job" step body. It owns per-job workspace preparation and the
+// repository checkout, reporting failures through the normal step protocol so a setup
+// failure fails the job in seconds instead of hanging until the lease expires.
 //
-// Abort handling lives in the step loop, not here: an aborted job stops the loop
-// before it reports (see step-loop.ts), exactly like an abort during any step.
-export async function executeSetupStep(params: {cwd: string}): Promise<StepResult> {
+// Abort handling lives in the step loop, not here: an aborted job stops the loop before
+// it reports (see step-loop.ts), exactly like an abort during any step. The git child is
+// still killed via `signal`, and the per-job workspace is cleaned up in runJob's finally.
+export async function executeSetupStep(params: {
+  cwd: string;
+  leaseClient: KyInstance;
+  signal: AbortSignal;
+}): Promise<StepResult> {
+  const {cwd, leaseClient, signal} = params;
+
+  // Check git before minting a credential: a host without git never hits the provider.
   try {
-    await createJobDir(params.cwd);
+    await assertGitAvailable();
   } catch (error) {
-    return {
-      success: false,
-      output: '',
-      error: {
-        message: error instanceof Error ? error.message : String(error),
-        reason: 'workspace_prep_failed',
-      },
-      exit_code: null,
-    };
+    return fail(error, 'git_unavailable');
+  }
+
+  try {
+    await createJobDir(cwd);
+  } catch (error) {
+    return fail(error, 'workspace_prep_failed');
+  }
+
+  let checkout: CheckoutTokenResponseDto;
+  try {
+    checkout = await requestCheckoutToken(leaseClient, {signal});
+  } catch (error) {
+    return fail(error, await classifyCheckoutTokenError(error));
+  }
+
+  try {
+    await checkoutRepository({
+      repositoryUrl: checkout.repository_url,
+      ref: checkout.ref,
+      auth: checkout.auth,
+      cwd,
+      signal,
+    });
+  } catch (error) {
+    const reason =
+      error instanceof CheckoutError ? CHECKOUT_KIND_REASON[error.kind] : 'checkout_failed';
+    return fail(error, reason);
   }
 
   return {success: true, output: '', error: null, exit_code: 0};
+}
+
+const CHECKOUT_KIND_REASON: Record<CheckoutFailureKind, StepErrorReason> = {
+  auth: 'checkout_auth_failed',
+  unavailable: 'checkout_unavailable',
+  failed: 'checkout_failed',
+  aborted: 'setup_aborted',
+};
+
+// Maps a checkout-token endpoint failure to a reason. Auth denial and the backend's
+// retryable provider signals (429/503, or their typed `code`) get distinct reasons; a
+// missing checkout intent (404) and everything else fold into the generic failure.
+// CheckoutError messages are already redacted in the workspace layer; the token-fetch
+// error never carries credential material.
+async function classifyCheckoutTokenError(error: unknown): Promise<StepErrorReason> {
+  if (!(error instanceof HTTPError)) return 'checkout_failed';
+
+  const {status} = error.response;
+  const code = await readErrorCode(error);
+
+  if (status === 401 || status === 403 || code === 'access-denied' || code === 'forbidden') {
+    return 'checkout_auth_failed';
+  }
+  if (
+    status === 429 ||
+    status === 503 ||
+    code === 'rate-limited' ||
+    code === 'timeout' ||
+    code === 'provider-unavailable'
+  ) {
+    return 'checkout_unavailable';
+  }
+  return 'checkout_failed';
+}
+
+async function readErrorCode(error: HTTPError): Promise<string | undefined> {
+  try {
+    const body: unknown = await error.response.clone().json();
+    if (body && typeof body === 'object' && 'code' in body && typeof body.code === 'string') {
+      return body.code;
+    }
+  } catch {
+    // Body is not JSON or already consumed; fall back to status-only mapping.
+  }
+  return undefined;
+}
+
+function fail(error: unknown, reason: StepErrorReason): StepResult {
+  return {
+    success: false,
+    output: '',
+    error: {message: error instanceof Error ? error.message : String(error), reason},
+    exit_code: null,
+  };
 }

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -50,7 +50,11 @@ describe('runJobSteps', () => {
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
 
-    expect(executeSetupStepMock).toHaveBeenCalledWith({cwd: '/work'});
+    expect(executeSetupStepMock).toHaveBeenCalledWith({
+      cwd: '/work',
+      leaseClient,
+      signal: ac.signal,
+    });
     expect(executeRunStepMock).toHaveBeenCalledWith(run, {signal: ac.signal, cwd: '/work'});
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: run.id,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -51,7 +51,7 @@ export async function runJobSteps(params: {
     let result: StepResult;
     try {
       if (step.type === 'setup') {
-        result = await executeSetupStep({cwd});
+        result = await executeSetupStep({cwd, leaseClient, signal});
         if (result.success) workspacePrepared = true;
       } else if (!workspacePrepared) {
         // Invariant violation (a run step before setup prepared the cwd), not a

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -6,6 +6,7 @@ import {
   createLeaseClient,
   heartbeat,
   reportStep,
+  requestCheckoutToken,
   requestJob,
   requestNextStep,
 } from '#api-client.js';
@@ -72,6 +73,24 @@ describe('api-client auth contexts', () => {
     expect(next).toEqual({kind: 'done', status: 'succeeded'});
     expect(calls[0]?.url).toContain('runs/jobs/current/steps/next');
     expect(calls[0]?.authorization).toBe('Bearer lease-abc');
+  });
+
+  it('requestCheckoutToken sends the lease token and parses the checkout response', async () => {
+    stubFetch(() =>
+      jsonResponse({
+        repository_url: 'https://github.com/acme/repo.git',
+        ref: 'main',
+        auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00.000Z'},
+      }),
+    );
+    const leaseClient = createLeaseClient('lease-ghi');
+
+    const checkout = await requestCheckoutToken(leaseClient);
+
+    expect(checkout.repository_url).toBe('https://github.com/acme/repo.git');
+    expect(checkout.ref).toBe('main');
+    expect(calls[0]?.url).toContain('runs/jobs/current/checkout-token');
+    expect(calls[0]?.authorization).toBe('Bearer lease-ghi');
   });
 
   it('reportStep sends the lease token to the per-step report endpoint', async () => {

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -5,6 +5,8 @@ import {
   heartbeatResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {
+  type CheckoutTokenResponseDto,
+  checkoutTokenResponseSchema,
   type NextStepResponseDto,
   nextStepResponseSchema,
   type ReportStepResponseDto,
@@ -92,6 +94,20 @@ export async function reportStep(
     ...(params.signal ? {signal: params.signal} : {}),
   });
   return reportStepResponseSchema.parse(await response.json());
+}
+
+// Exchanges the job lease for short-lived, read-only checkout credentials. The job is
+// identified by the lease claims, so no id is sent. Retries ride the leaseClient policy
+// (which honors Retry-After); each retry re-mints a fresh short-lived credential.
+export async function requestCheckoutToken(
+  leaseClient: KyInstance,
+  options: {signal?: AbortSignal} = {},
+): Promise<CheckoutTokenResponseDto> {
+  const response = await leaseClient.post(
+    'runs/jobs/current/checkout-token',
+    options.signal ? {signal: options.signal} : undefined,
+  );
+  return checkoutTokenResponseSchema.parse(await response.json());
 }
 
 export async function heartbeat(

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -3,6 +3,7 @@ export {
   HTTPError,
   heartbeat,
   reportStep,
+  requestCheckoutToken,
   requestJob,
   requestNextStep,
 } from '#api-client.js';

--- a/libs/runner/workspace/package.json
+++ b/libs/runner/workspace/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*"
   },

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -1,0 +1,82 @@
+import {execFile} from 'node:child_process';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {promisify} from 'node:util';
+import {assertGitAvailable, CheckoutError, checkoutRepository} from '#checkout.js';
+
+// Exercises checkoutRepository against a real local git remote (file://), so an argv or
+// flag mistake a mock would accept fails here. git is a runner host prerequisite, so it is
+// present in CI. Only the network/auth/abort paths (which a local remote cannot produce)
+// stay mocked in checkout.test.ts.
+const execFileAsync = promisify(execFile);
+
+let workdir: string;
+let sourceRepo: string;
+let cwd: string;
+
+async function git(args: string[], dir: string): Promise<void> {
+  await execFileAsync('git', args, {cwd: dir});
+}
+
+beforeEach(async () => {
+  workdir = await mkdtemp(join(tmpdir(), 'shipfox-checkout-'));
+
+  sourceRepo = join(workdir, 'source');
+  await mkdir(sourceRepo, {recursive: true});
+  await git(['init', '-b', 'main'], sourceRepo);
+  await git(['config', 'user.email', 'test@shipfox.io'], sourceRepo);
+  await git(['config', 'user.name', 'Test'], sourceRepo);
+  // Override a host/global commit.gpgsign=true: the throwaway repo has no signing key.
+  await git(['config', 'commit.gpgsign', 'false'], sourceRepo);
+  await writeFile(join(sourceRepo, 'README.md'), '# hello\n');
+  await git(['add', '.'], sourceRepo);
+  await git(['commit', '-m', 'initial'], sourceRepo);
+
+  // The per-job directory the workspace manager prepares: present and empty.
+  cwd = join(workdir, 'job-1');
+  await mkdir(cwd, {recursive: true});
+});
+
+afterEach(async () => {
+  await rm(workdir, {recursive: true, force: true});
+});
+
+describe('checkoutRepository (real git)', () => {
+  it('clones the requested ref into the per-job directory', async () => {
+    await checkoutRepository({repositoryUrl: `file://${sourceRepo}`, ref: 'main', cwd});
+
+    const readme = await readFile(join(cwd, 'README.md'), 'utf8');
+    expect(readme).toBe('# hello\n');
+  });
+
+  it('never persists the credential to .git/config', async () => {
+    await checkoutRepository({
+      repositoryUrl: `file://${sourceRepo}`,
+      ref: 'main',
+      cwd,
+      auth: {kind: 'bearer', token: 'super-secret-token', expires_at: '2026-01-01T00:00:00Z'},
+    });
+
+    const gitConfig = await readFile(join(cwd, '.git', 'config'), 'utf8');
+    expect(gitConfig).not.toContain('super-secret-token');
+    expect(gitConfig.toLowerCase()).not.toContain('extraheader');
+  });
+
+  it('fails with a generic CheckoutError for a missing ref', async () => {
+    const error = await checkoutRepository({
+      repositoryUrl: `file://${sourceRepo}`,
+      ref: 'does-not-exist',
+      cwd,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(CheckoutError);
+    expect((error as CheckoutError).kind).toBe('failed');
+  });
+});
+
+describe('assertGitAvailable (real git)', () => {
+  it('resolves when git is on PATH', async () => {
+    await expect(assertGitAvailable()).resolves.toBeUndefined();
+  });
+});

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -63,6 +63,25 @@ describe('checkoutRepository (real git)', () => {
     expect(gitConfig.toLowerCase()).not.toContain('extraheader');
   });
 
+  it('never persists a basic credential to .git/config', async () => {
+    await checkoutRepository({
+      repositoryUrl: `file://${sourceRepo}`,
+      ref: 'main',
+      cwd,
+      auth: {
+        kind: 'basic',
+        username: 'x-token',
+        token: 'super-secret-token',
+        expires_at: '2026-01-01T00:00:00Z',
+      },
+    });
+
+    const gitConfig = await readFile(join(cwd, '.git', 'config'), 'utf8');
+    expect(gitConfig).not.toContain('super-secret-token');
+    expect(gitConfig).not.toContain(Buffer.from('x-token:super-secret-token').toString('base64'));
+    expect(gitConfig.toLowerCase()).not.toContain('extraheader');
+  });
+
   it('fails with a generic CheckoutError for a missing ref', async () => {
     const error = await checkoutRepository({
       repositoryUrl: `file://${sourceRepo}`,

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -1,0 +1,157 @@
+// Mocked-execFile tests: assert the exact git argv, failure classification, and redaction
+// without spawning git. The real-git happy path lives in checkout.realgit.test.ts.
+const execFileMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+const {checkoutRepository, CheckoutError, redactSecrets} = await import('#checkout.js');
+
+type ExecCallback = (error: unknown, result?: {stdout: string; stderr: string}) => void;
+
+function callbackOf(args: unknown[]): ExecCallback {
+  return args[args.length - 1] as ExecCallback;
+}
+
+function resolveExec() {
+  execFileMock.mockImplementation((...args: unknown[]) =>
+    callbackOf(args)(null, {stdout: '', stderr: ''}),
+  );
+}
+
+function rejectExec(error: unknown) {
+  execFileMock.mockImplementation((...args: unknown[]) => callbackOf(args)(error));
+}
+
+function gitError(stderr: string): Error & {stderr: string} {
+  return Object.assign(new Error('Command failed'), {stderr});
+}
+
+const BASE = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main', cwd: '/work/job-1'};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('checkoutRepository argv', () => {
+  it('shallow-clones the single branch with no -c when there is no auth', async () => {
+    resolveExec();
+
+    await checkoutRepository(BASE);
+
+    expect(execFileMock).toHaveBeenCalledOnce();
+    const [file, args] = execFileMock.mock.calls[0] as [string, string[]];
+    expect(file).toBe('git');
+    expect(args).toEqual([
+      'clone',
+      '--depth=1',
+      '--single-branch',
+      '--branch',
+      'main',
+      'https://github.com/acme/repo.git',
+      '/work/job-1',
+    ]);
+  });
+
+  it('injects a bearer credential via a one-shot http.extraHeader', async () => {
+    resolveExec();
+
+    await checkoutRepository({
+      ...BASE,
+      auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00Z'},
+    });
+
+    const [, args] = execFileMock.mock.calls[0] as [string, string[]];
+    expect(args.slice(0, 3)).toEqual([
+      '-c',
+      'http.extraHeader=Authorization: Bearer tok-123',
+      'clone',
+    ]);
+  });
+
+  it('injects a basic credential as a base64 Authorization header', async () => {
+    resolveExec();
+
+    await checkoutRepository({
+      ...BASE,
+      auth: {
+        kind: 'basic',
+        username: 'x-token',
+        token: 'tok-123',
+        expires_at: '2026-01-01T00:00:00Z',
+      },
+    });
+
+    const [, args] = execFileMock.mock.calls[0] as [string, string[]];
+    const expected = Buffer.from('x-token:tok-123').toString('base64');
+    expect(args[1]).toBe(`http.extraHeader=Authorization: Basic ${expected}`);
+  });
+
+  it('disables interactive credential prompts', async () => {
+    resolveExec();
+
+    await checkoutRepository(BASE);
+
+    const options = execFileMock.mock.calls[0]?.[2] as {env: Record<string, string>};
+    expect(options.env.GIT_TERMINAL_PROMPT).toBe('0');
+  });
+});
+
+describe('checkoutRepository failure classification', () => {
+  it('classifies a rejected credential as an auth failure', async () => {
+    rejectExec(gitError("fatal: Authentication failed for 'https://github.com/acme/repo.git/'"));
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({
+      name: 'CheckoutError',
+      kind: 'auth',
+    });
+  });
+
+  it('classifies an unreachable provider as unavailable', async () => {
+    rejectExec(gitError('fatal: unable to access: Could not resolve host: github.com'));
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
+  });
+
+  it('classifies an unknown clone failure as a generic failure', async () => {
+    rejectExec(gitError('fatal: Remote branch main not found in upstream origin'));
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'failed'});
+  });
+
+  it('classifies an aborted clone as aborted', async () => {
+    rejectExec(Object.assign(new Error('The operation was aborted'), {name: 'AbortError'}));
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'aborted'});
+  });
+
+  it('redacts the token from a failure message', async () => {
+    rejectExec(gitError('fatal: bad request sending tok-123 to remote'));
+
+    const error = await checkoutRepository({
+      ...BASE,
+      auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00Z'},
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(CheckoutError);
+    expect((error as Error).message).not.toContain('tok-123');
+    expect((error as Error).message).toContain('***');
+  });
+});
+
+describe('redactSecrets', () => {
+  it('removes every occurrence of each secret', () => {
+    expect(redactSecrets('token=abc and again abc', ['abc'])).toBe('token=*** and again ***');
+  });
+
+  it('strips URL-embedded credentials', () => {
+    expect(redactSecrets('clone https://user:pass@github.com/x.git failed', [])).toBe(
+      'clone https://***@github.com/x.git failed',
+    );
+  });
+
+  it('ignores empty secrets', () => {
+    expect(redactSecrets('unchanged', [''])).toBe('unchanged');
+  });
+});

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -114,6 +114,26 @@ describe('checkoutRepository failure classification', () => {
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
   });
 
+  it('classifies a git-side 403 as an auth failure', async () => {
+    rejectExec(
+      gitError(
+        "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 403",
+      ),
+    );
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'auth'});
+  });
+
+  it('classifies a git-side 5xx as unavailable', async () => {
+    rejectExec(
+      gitError(
+        "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 503",
+      ),
+    );
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
+  });
+
   it('classifies an unknown clone failure as a generic failure', async () => {
     rejectExec(gitError('fatal: Remote branch main not found in upstream origin'));
 
@@ -137,6 +157,69 @@ describe('checkoutRepository failure classification', () => {
     expect(error).toBeInstanceOf(CheckoutError);
     expect((error as Error).message).not.toContain('tok-123');
     expect((error as Error).message).toContain('***');
+  });
+
+  it('redacts the base64 form of a basic credential from a failure message', async () => {
+    const base64 = Buffer.from('x-token:tok-123').toString('base64');
+    rejectExec(gitError(`fatal: bad request sending ${base64} to remote`));
+
+    const error = await checkoutRepository({
+      ...BASE,
+      auth: {
+        kind: 'basic',
+        username: 'x-token',
+        token: 'tok-123',
+        expires_at: '2026-01-01T00:00:00Z',
+      },
+    }).catch((e: unknown) => e);
+
+    expect((error as Error).message).not.toContain(base64);
+    expect((error as Error).message).toContain('***');
+  });
+
+  it('redacts a basic credential when stderr is empty and the argv leaks into error.message', async () => {
+    const base64 = Buffer.from('x-token:tok-123').toString('base64');
+    // No stderr: classifyCloneError falls back to the execFile error.message, which on
+    // Node carries the full argv including the Authorization header value.
+    rejectExec(
+      Object.assign(
+        new Error(
+          `Command failed: git -c http.extraHeader=Authorization: Basic ${base64} clone --depth=1`,
+        ),
+        {stderr: ''},
+      ),
+    );
+
+    const error = await checkoutRepository({
+      ...BASE,
+      auth: {
+        kind: 'basic',
+        username: 'x-token',
+        token: 'tok-123',
+        expires_at: '2026-01-01T00:00:00Z',
+      },
+    }).catch((e: unknown) => e);
+
+    expect((error as Error).message).not.toContain(base64);
+    expect((error as Error).message).not.toContain('tok-123');
+    expect((error as Error).message).toContain('***');
+  });
+
+  it('scrubs the token from the error cause so it cannot ride the cause chain into a log', async () => {
+    const raw = Object.assign(
+      new Error('Command failed: git -c http.extraHeader=Authorization: Bearer tok-123 clone ...'),
+      {stderr: 'fatal: Authentication failed'},
+    );
+    rejectExec(raw);
+
+    const error = await checkoutRepository({
+      ...BASE,
+      auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00Z'},
+    }).catch((e: unknown) => e);
+
+    const cause = (error as Error).cause as Error;
+    expect(cause.message).not.toContain('tok-123');
+    expect(cause.message).toContain('***');
   });
 });
 

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -134,6 +134,16 @@ describe('checkoutRepository failure classification', () => {
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
   });
 
+  it('classifies a git-side 429 (rate limit) as unavailable', async () => {
+    rejectExec(
+      gitError(
+        "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 429",
+      ),
+    );
+
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
+  });
+
   it('classifies an unknown clone failure as a generic failure', async () => {
     rejectExec(gitError('fatal: Remote branch main not found in upstream origin'));
 

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -1,0 +1,131 @@
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+import type {CheckoutTokenAuthDto} from '@shipfox/api-workflows-dto';
+
+const execFileAsync = promisify(execFile);
+
+/** Thrown when `git` is not on the runner host's PATH; surfaced as `git_unavailable`. */
+export class GitUnavailableError extends Error {
+  constructor(options?: ErrorOptions) {
+    super('git is not available on the runner host', options);
+    this.name = 'GitUnavailableError';
+  }
+}
+
+/**
+ * Why a clone failed, kept abstract here so the workspace layer does not depend on the
+ * step-error DTO. The setup step maps each kind to a machine-readable `reason`.
+ */
+export type CheckoutFailureKind = 'auth' | 'unavailable' | 'failed' | 'aborted';
+
+export class CheckoutError extends Error {
+  constructor(
+    public readonly kind: CheckoutFailureKind,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'CheckoutError';
+  }
+}
+
+/** Throws {@link GitUnavailableError} when `git` cannot be invoked on the host. */
+export async function assertGitAvailable(): Promise<void> {
+  try {
+    await execFileAsync('git', ['--version']);
+  } catch (error) {
+    throw new GitUnavailableError({cause: error});
+  }
+}
+
+/**
+ * Removes every occurrence of each secret plus any URL-embedded `user:pass@` credential
+ * from `text`, so a clone error never carries token material into a log or step result.
+ */
+export function redactSecrets(text: string, secrets: string[]): string {
+  let redacted = text;
+  for (const secret of secrets) {
+    if (secret) redacted = redacted.split(secret).join('***');
+  }
+  return redacted.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
+}
+
+// git surfaces credential rejection and provider-availability failures only through
+// stderr text, so classification is pattern-based. Auth wins over unavailable when both
+// could match, since a rejected credential is the more actionable cause.
+const AUTH_FAILURE =
+  /authentication failed|could not read username|invalid username or password|terminal prompts disabled|403 forbidden|permission denied \(publickey\)|access denied/i;
+const PROVIDER_UNAVAILABLE =
+  /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution/i;
+
+/**
+ * Shallow-clones `ref` of `repositoryUrl` into `cwd` (which must already exist and be empty).
+ *
+ * The credential is injected with a one-shot `-c http.extraHeader`, never embedded in the
+ * clone URL, so it is not persisted to `.git/config` where later user steps could read it.
+ * `GIT_TERMINAL_PROMPT=0` turns a missing or denied credential into an immediate error
+ * instead of a hang on an interactive prompt. Failures are classified into a
+ * {@link CheckoutError} and have any token material redacted from their message.
+ */
+export async function checkoutRepository(params: {
+  repositoryUrl: string;
+  ref: string;
+  auth?: CheckoutTokenAuthDto | undefined;
+  cwd: string;
+  signal?: AbortSignal | undefined;
+}): Promise<void> {
+  const {repositoryUrl, ref, auth, cwd, signal} = params;
+
+  const args: string[] = [];
+  if (auth) {
+    args.push('-c', `http.extraHeader=Authorization: ${authorizationValue(auth)}`);
+  }
+  args.push('clone', '--depth=1', '--single-branch', '--branch', ref, repositoryUrl, cwd);
+
+  try {
+    await execFileAsync('git', args, {
+      env: {...process.env, GIT_TERMINAL_PROMPT: '0'},
+      ...(signal ? {signal} : {}),
+    });
+  } catch (error) {
+    throw classifyCloneError(error, auth?.token);
+  }
+}
+
+function authorizationValue(auth: CheckoutTokenAuthDto): string {
+  if (auth.kind === 'bearer') return `Bearer ${auth.token}`;
+  const basic = Buffer.from(`${auth.username}:${auth.token}`).toString('base64');
+  return `Basic ${basic}`;
+}
+
+function classifyCloneError(error: unknown, token: string | undefined): CheckoutError {
+  if (isAbortError(error)) {
+    return new CheckoutError('aborted', 'Checkout aborted', {cause: error});
+  }
+
+  const stderr = stderrOf(error);
+  const message = redactSecrets(stderr.trim() || errorMessage(error), token ? [token] : []);
+
+  if (AUTH_FAILURE.test(stderr)) return new CheckoutError('auth', message, {cause: error});
+  if (PROVIDER_UNAVAILABLE.test(stderr)) {
+    return new CheckoutError('unavailable', message, {cause: error});
+  }
+  return new CheckoutError('failed', message, {cause: error});
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function stderrOf(error: unknown): string {
+  if (error && typeof error === 'object' && 'stderr' in error) {
+    const {stderr} = error as {stderr?: unknown};
+    if (typeof stderr === 'string') return stderr;
+    if (Buffer.isBuffer(stderr)) return stderr.toString();
+  }
+  return '';
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -54,9 +54,9 @@ export function redactSecrets(text: string, secrets: string[]): string {
 // stderr text, so classification is pattern-based. Auth wins over unavailable when both
 // could match, since a rejected credential is the more actionable cause.
 const AUTH_FAILURE =
-  /authentication failed|could not read username|invalid username or password|terminal prompts disabled|403 forbidden|permission denied \(publickey\)|access denied/i;
+  /authentication failed|could not read username|invalid username or password|terminal prompts disabled|403 forbidden|the requested url returned error: 40[13]|permission denied \(publickey\)|access denied/i;
 const PROVIDER_UNAVAILABLE =
-  /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution/i;
+  /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution|the requested url returned error: 5\d\d/i;
 
 /**
  * Shallow-clones `ref` of `repositoryUrl` into `cwd` (which must already exist and be empty).
@@ -88,29 +88,53 @@ export async function checkoutRepository(params: {
       ...(signal ? {signal} : {}),
     });
   } catch (error) {
-    throw classifyCloneError(error, auth?.token);
+    throw classifyCloneError(error, auth);
   }
+}
+
+function basicCredential(auth: {username: string; token: string}): string {
+  return Buffer.from(`${auth.username}:${auth.token}`).toString('base64');
 }
 
 function authorizationValue(auth: CheckoutTokenAuthDto): string {
   if (auth.kind === 'bearer') return `Bearer ${auth.token}`;
-  const basic = Buffer.from(`${auth.username}:${auth.token}`).toString('base64');
-  return `Basic ${basic}`;
+  return `Basic ${basicCredential(auth)}`;
 }
 
-function classifyCloneError(error: unknown, token: string | undefined): CheckoutError {
+// Every form the credential takes on the wire is secret. For basic auth the raw token is
+// not a substring of the base64 the header carries, so redacting only the token would
+// leak the base64; include it explicitly.
+function secretsOf(auth: CheckoutTokenAuthDto | undefined): string[] {
+  if (!auth) return [];
+  if (auth.kind === 'bearer') return [auth.token];
+  return [auth.token, basicCredential(auth)];
+}
+
+function classifyCloneError(error: unknown, auth: CheckoutTokenAuthDto | undefined): CheckoutError {
   if (isAbortError(error)) {
     return new CheckoutError('aborted', 'Checkout aborted', {cause: error});
   }
 
+  const secrets = secretsOf(auth);
   const stderr = stderrOf(error);
-  const message = redactSecrets(stderr.trim() || errorMessage(error), token ? [token] : []);
+  const message = redactSecrets(stderr.trim() || errorMessage(error), secrets);
+  // The raw execFile error carries the full argv (including the Authorization header) in
+  // its `message`/`cmd`, so it can never ride the cause chain into a logger un-redacted.
+  const cause = secrets.length > 0 ? redactedCause(error, secrets) : error;
 
-  if (AUTH_FAILURE.test(stderr)) return new CheckoutError('auth', message, {cause: error});
+  if (AUTH_FAILURE.test(stderr)) return new CheckoutError('auth', message, {cause});
   if (PROVIDER_UNAVAILABLE.test(stderr)) {
-    return new CheckoutError('unavailable', message, {cause: error});
+    return new CheckoutError('unavailable', message, {cause});
   }
-  return new CheckoutError('failed', message, {cause: error});
+  return new CheckoutError('failed', message, {cause});
+}
+
+// Rebuilds the failure cause with every secret stripped from its message, preserving the
+// original error name for diagnostics while guaranteeing no credential survives on it.
+function redactedCause(error: unknown, secrets: string[]): Error {
+  const scrubbed = new Error(redactSecrets(errorMessage(error), secrets));
+  if (error instanceof Error) scrubbed.name = error.name;
+  return scrubbed;
 }
 
 function isAbortError(error: unknown): boolean {

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -56,7 +56,7 @@ export function redactSecrets(text: string, secrets: string[]): string {
 const AUTH_FAILURE =
   /authentication failed|could not read username|invalid username or password|terminal prompts disabled|403 forbidden|the requested url returned error: 40[13]|permission denied \(publickey\)|access denied/i;
 const PROVIDER_UNAVAILABLE =
-  /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution|the requested url returned error: 5\d\d/i;
+  /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution|the requested url returned error: (?:429|5\d\d)/i;
 
 /**
  * Shallow-clones `ref` of `repositoryUrl` into `cwd` (which must already exist and be empty).

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -1,4 +1,12 @@
 export {
+  assertGitAvailable,
+  CheckoutError,
+  type CheckoutFailureKind,
+  checkoutRepository,
+  GitUnavailableError,
+  redactSecrets,
+} from '#checkout.js';
+export {
   cleanupWorkspace,
   createJobDir,
   InvalidJobIdError,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2352,9 +2352,15 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/runner-protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@shipfox/runner-workspace':
         specifier: workspace:*
         version: link:../workspace
+      ky:
+        specifier: ^2.0.0
+        version: 2.0.2
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*
@@ -2448,6 +2454,9 @@ importers:
 
   libs/runner/workspace:
     dependencies:
+      '@shipfox/api-workflows-dto':
+        specifier: workspace:*
+        version: link:../../api/workflows-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
@@ -9429,6 +9438,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
Performs the real repository checkout inside the runner's synthetic "Set up job" step. Until now the setup step only prepared the per-job workspace directory; this fills in the checkout body: ensure `git` is available, exchange the job lease for short-lived read-only checkout credentials via the checkout-token endpoint (ENG-406), and shallow-clone the project's default branch into the per-job directory.

This is the last piece that makes runner-dispatched jobs repository-aware. The "fail before steps" reporting channel already exists (the synthetic setup step from ENG-412), so a checkout failure now flows through the normal step protocol and fails the job in seconds instead of hanging until lease expiry.

## Failure handling

Every checkout failure mode fails the job before any user step runs, with a machine-readable `reason` persisted on the step:

- `git_unavailable` - git is not on the runner host's PATH (checked **before** minting a credential, so a host without git never hits the provider).
- `checkout_auth_failed` - credential exchange denied (401/403, or a provider `access-denied`/`forbidden`), or git rejected the credential.
- `checkout_unavailable` - provider unavailable: the backend's 429/503 retryable signal, or a git-side network failure (unreachable host / timeout). Mapped here for troubleshooting honesty; the retry policy stays a separate concern.
- `checkout_failed` - generic clone failure, missing checkout intent, and other token-endpoint errors.

## Credential handling

The credential is injected with a one-shot `git -c http.extraHeader`, never embedded in the clone URL, so it is **not** persisted to `.git/config` where later user steps running in the same cwd could read it (asserted by a real-git test). `GIT_TERMINAL_PROMPT=0` turns a denied credential into an immediate error instead of a hang. Token material is redacted from any error message. The shared redaction helper and credential-lifetime guarantees remain owned by ENG-408 (which this unblocks); this PR ships a local redactor.

## Shape

Per an engineering-review pass, the whole setup phase stays cohesive in `executeSetupStep` (token fetch + git + clone + reason mapping). `execution` gains a dependency on `protocol`, which does not violate the ENG-410 rule (nobody imports orchestration; only protocol touches the wire) and naturally orders the git check ahead of credential minting.

## Review notes

- `workspace/checkout.ts` is the new module (git invocation, stderr classification, redaction).
- Tests use a real local `file://` git remote for the happy path, credential non-persistence, and bad-ref failure; `execFile` is mocked only for the network/auth/abort paths a local remote cannot produce.
- One known edge, deliberately deferred: an unscoped `extraHeader` would ride a cross-origin redirect. GitHub/debug providers do not redirect cross-host, so it is low risk for MVP; per-host scoping is a natural ENG-408 follow-up.

Closes ENG-405

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shallow-clone the repository during the runner’s “Set up job” step using short‑lived checkout tokens, with fast, machine‑readable failure reasons. Implements ENG‑405 to make jobs repository‑aware and prevent hangs before steps run.

- **New Features**
  - Check for `git` before minting credentials; fail with `git_unavailable`.
  - Exchange the lease for checkout credentials via `requestCheckoutToken`, then shallow‑clone the default branch into the per‑job dir.
  - Map failures to stable reasons: `checkout_auth_failed`, `checkout_unavailable`, `checkout_failed`, and `setup_aborted`; workspace prep errors use `workspace_prep_failed`.
  - Inject credentials with a one‑shot `git -c http.extraHeader`; never persist to `.git/config`; redact tokens in errors.
  - Abort‑aware: kill the git child via the job signal and report `setup_aborted` when applicable.

- **Bug Fixes**
  - Correctly classify checkout‑token errors using `ky`’s `HTTPError.data`: 422 `access‑denied`/`forbidden` → `checkout_auth_failed`; 429/503 and provider codes (`rate‑limited`, `timeout`, `provider‑unavailable`) → `checkout_unavailable`.
  - Harden redaction: remove all wire forms of credentials (including base64 for basic auth) and scrub the original exec error from the cause chain.
  - Widen git stderr matching to cover real 401/403, 5xx, and 429 rate‑limit messages.

<sup>Written for commit 2205c4574b09e4380bfb77a84df95ca1c02df75a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

