### PR TITLE
Preserve workflow definition source YAML

### DIFF
--- a/libs/api/definitions-dto/src/schemas/dto.ts
+++ b/libs/api/definitions-dto/src/schemas/dto.ts
@@ -29,6 +29,7 @@ export const definitionDtoSchema = z.object({
   sha: z.string().nullable(),
   ref: z.string().nullable(),
   name: z.string(),
+  workflow_source_yaml: z.string().nullable(),
   workflow_document: z.unknown(),
   workflow_model: z.unknown(),
   manual_trigger: z

--- a/libs/api/definitions/src/core/entities/workflow-definition.ts
+++ b/libs/api/definitions/src/core/entities/workflow-definition.ts
@@ -4,6 +4,7 @@ import type {WorkflowModel} from './workflow-model.js';
 export type WorkflowSpec = WorkflowDocument;
 
 export interface WorkflowDefinitionPayload {
+  sourceYaml?: string | null;
   document: WorkflowDocument;
   model: WorkflowModel;
 }
@@ -21,6 +22,7 @@ export interface WorkflowDefinition {
    * before they migrate to `document`/`model`.
    */
   definition: WorkflowSpec;
+  sourceYaml: string | null;
   document: WorkflowDocument;
   model: WorkflowModel;
   contentHash: string | null;

--- a/libs/api/definitions/src/core/parse-definition.test.ts
+++ b/libs/api/definitions/src/core/parse-definition.test.ts
@@ -16,6 +16,7 @@ describe('parseDefinition', () => {
 
     const definition = parseDefinition(yaml);
 
+    expect(definition.sourceYaml).toBe(yaml);
     expect(definition.document.name).toBe('Simple build');
     expect(definition.document.triggers?.on_push?.source).toBe('github');
     expect(definition.document.triggers?.on_push?.event).toBe('push');

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -150,6 +150,7 @@ describe('fetchAndParseWorkflows', () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('CI');
     expect(result[0]?.path).toBe('.shipfox/workflows/ci.yml');
+    expect(result[0]?.definition.sourceYaml).toContain('name: CI');
     expect(result[0]?.contentHash).toMatch(SHA256_HEX_RE);
   });
 

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -109,7 +109,12 @@ export async function fetchAndParseWorkflows(
     try {
       const definition = parseDefinition(snapshot.content);
       const contentHash = sha256Hex(snapshot.content);
-      return {path: snapshot.path, name: definition.document.name, definition, contentHash};
+      return {
+        path: snapshot.path,
+        name: definition.document.name,
+        definition,
+        contentHash,
+      };
     } catch (error) {
       if (error instanceof DefinitionParseError) {
         throw new DefinitionSyncPermanentError(

--- a/libs/api/definitions/src/core/validate-definition.test.ts
+++ b/libs/api/definitions/src/core/validate-definition.test.ts
@@ -14,6 +14,7 @@ jobs:
 
     expect(result.valid).toBe(true);
     if (result.valid) {
+      expect(result.definition.sourceYaml).toBe(yaml);
       expect(result.definition.document.name).toBe('Test');
       expect(result.definition.document.jobs.build?.steps).toHaveLength(1);
       expect(result.definition.model.jobs[0]?.id).toBe('build');

--- a/libs/api/definitions/src/core/validate-definition.ts
+++ b/libs/api/definitions/src/core/validate-definition.ts
@@ -13,7 +13,7 @@ export function validateDefinition(yamlContent: string): ValidationResult {
   try {
     const document = parseWorkflowYaml(yamlContent);
     const model = normalizeWorkflowDocument(document);
-    return {valid: true, definition: {document, model}};
+    return {valid: true, definition: {sourceYaml: yamlContent, document, model}};
   } catch (error) {
     return {valid: false, errors: validationErrorsFor(error)};
   }

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -26,7 +26,7 @@ function definitionFields(name = 'Test Workflow'): WorkflowDefinitionPayload {
     name,
     jobs: {build: {steps: [{run: 'echo hello'}]}},
   };
-  return {document, model: normalizeWorkflowDocument(document)};
+  return {sourceYaml: `name: ${name}\n`, document, model: normalizeWorkflowDocument(document)};
 }
 
 async function listOutboxRowsForProject(projectId: string) {
@@ -66,12 +66,34 @@ describe('definition queries', () => {
       expect(definition.projectId).toBe(projectId);
       expect(definition.configPath).toBe('.shipfox/workflows/test.yml');
       expect(definition.name).toBe('Test');
-      expect({document: definition.document, model: definition.model}).toEqual(definitionFields());
+      expect({
+        sourceYaml: definition.sourceYaml,
+        document: definition.document,
+        model: definition.model,
+      }).toEqual(definitionFields());
       expect(definition.sha).toBeNull();
       expect(definition.ref).toBeNull();
       expect(definition.fetchedAt).toBeInstanceOf(Date);
       expect(definition.createdAt).toBeInstanceOf(Date);
       expect(definition.updatedAt).toBeInstanceOf(Date);
+    });
+
+    test('maps legacy rows without source YAML to null', async () => {
+      const {document, model} = definitionFields('Legacy');
+      const rows = await db()
+        .insert(workflowDefinitions)
+        .values({
+          projectId,
+          configPath: '.shipfox/workflows/legacy.yml',
+          name: 'Legacy',
+          definition: {document, model},
+        })
+        .returning({id: workflowDefinitions.id});
+
+      const definition = await getDefinitionById(rows[0]?.id ?? '');
+
+      expect(definition?.sourceYaml).toBeNull();
+      expect(definition?.document.name).toBe('Legacy');
     });
 
     test('updates existing definition on conflict (same project_id + config_path)', async () => {

--- a/libs/api/definitions/src/db/definitions.ts
+++ b/libs/api/definitions/src/db/definitions.ts
@@ -24,6 +24,7 @@ export interface UpsertDefinitionParams {
   configPath?: string | null | undefined;
   source?: 'manual' | 'vcs' | undefined;
   name: string;
+  sourceYaml?: string | null | undefined;
   document: WorkflowDocument;
   model: WorkflowModel;
   contentHash?: string | null | undefined;
@@ -38,6 +39,7 @@ function buildUpsertQuery(tx: Tx, params: UpsertDefinitionParams) {
   }
 
   const definition: WorkflowDefinitionPayload = {
+    sourceYaml: params.sourceYaml ?? null,
     document: params.document,
     model: params.model,
   };
@@ -255,6 +257,7 @@ export interface ApplyVcsDefinitionsBatchParams {
     name: string;
     document: WorkflowDocument;
     model: WorkflowModel;
+    sourceYaml?: string | null | undefined;
     contentHash: string;
   }>;
 }
@@ -298,6 +301,7 @@ export async function applyVcsDefinitionsBatch(
         source: 'vcs',
         ref: params.ref,
         name: item.name,
+        sourceYaml: item.sourceYaml,
         document: item.document,
         model: item.model,
         contentHash: item.contentHash,

--- a/libs/api/definitions/src/db/schema/definitions.ts
+++ b/libs/api/definitions/src/db/schema/definitions.ts
@@ -56,6 +56,7 @@ export function toDefinition(row: DefinitionDb): WorkflowDefinition {
     ref: row.ref,
     name: row.name,
     definition: row.definition.document,
+    sourceYaml: row.definition.sourceYaml ?? null,
     document: row.definition.document,
     model: row.definition.model,
     contentHash: row.contentHash,

--- a/libs/api/definitions/src/presentation/dto/definition.test.ts
+++ b/libs/api/definitions/src/presentation/dto/definition.test.ts
@@ -27,6 +27,7 @@ describe('toDefinitionDto', () => {
       ref: null,
       name: document.name,
       definition: document,
+      sourceYaml: 'name: Manual workflow\n',
       document,
       model: normalizeWorkflowDocument(document),
       contentHash: null,
@@ -46,6 +47,7 @@ describe('toDefinitionDto', () => {
       sha: null,
       ref: null,
       name: document.name,
+      workflow_source_yaml: definition.sourceYaml,
       workflow_document: document,
       workflow_model: definition.model,
       manual_trigger: {name: 'run_now'},
@@ -53,5 +55,38 @@ describe('toDefinitionDto', () => {
       created_at: '2026-06-09T10:00:01.000Z',
       updated_at: '2026-06-09T10:00:02.000Z',
     });
+  });
+
+  it('maps missing source YAML to null', () => {
+    const document = {
+      name: 'Legacy workflow',
+      jobs: {
+        build: {
+          steps: [{run: 'pnpm build'}],
+        },
+      },
+    };
+    const definition: WorkflowDefinition = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      projectId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      configPath: '.shipfox/workflows/legacy.yml',
+      source: 'vcs',
+      sha: null,
+      ref: 'main',
+      name: document.name,
+      definition: document,
+      sourceYaml: null,
+      document,
+      model: normalizeWorkflowDocument(document),
+      contentHash: null,
+      fetchedAt: new Date('2026-06-09T10:00:00.000Z'),
+      createdAt: new Date('2026-06-09T10:00:01.000Z'),
+      updatedAt: new Date('2026-06-09T10:00:02.000Z'),
+      deletedAt: null,
+    };
+
+    const result = toDefinitionDto(definition);
+
+    expect(result.workflow_source_yaml).toBeNull();
   });
 });

--- a/libs/api/definitions/src/presentation/dto/definition.ts
+++ b/libs/api/definitions/src/presentation/dto/definition.ts
@@ -15,6 +15,7 @@ export function toDefinitionDto(definition: WorkflowDefinition): DefinitionDto {
     sha: definition.sha,
     ref: definition.ref,
     name: definition.name,
+    workflow_source_yaml: definition.sourceYaml,
     workflow_document: definition.document,
     workflow_model: definition.model,
     manual_trigger: manualEntry ? {name: manualEntry[0]} : null,

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -68,6 +68,7 @@ jobs:
     expect(body.config_path).toBe('.shipfox/workflows/test.yml');
     expect(body.source).toBe('manual');
     expect(body.name).toBe('Test Workflow');
+    expect(body.workflow_source_yaml).toBe(validYaml);
     expect(body.workflow_document.name).toBe('Test Workflow');
     expect(body.workflow_model.kind).toBe('workflow');
     expect(body.sha).toBeNull();

--- a/libs/api/definitions/src/presentation/routes/create-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.ts
@@ -40,6 +40,7 @@ export const createDefinitionRoute = defineRoute({
       configPath: config_path,
       source,
       name: parsed.document.name,
+      sourceYaml: parsed.sourceYaml,
       document: parsed.document,
       model: parsed.model,
       sha,

--- a/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
@@ -32,6 +32,7 @@ jobs:
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.valid).toBe(true);
+    expect(body.workflow_source_yaml).toContain('name: Test');
     expect(body.workflow_document.name).toBe('Test');
     expect(body.workflow_model.kind).toBe('workflow');
   });

--- a/libs/api/definitions/src/presentation/routes/validate-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.ts
@@ -15,6 +15,7 @@ const validationErrorSchema = z.object({
 const validationResultSchema = z.union([
   z.object({
     valid: z.literal(true),
+    workflow_source_yaml: definitionDtoSchema.shape.workflow_source_yaml,
     workflow_document: definitionDtoSchema.shape.workflow_document,
     workflow_model: definitionDtoSchema.shape.workflow_model,
   }),
@@ -41,6 +42,7 @@ export const validateDefinitionRoute = defineRoute({
     if (result.valid) {
       return {
         valid: true as const,
+        workflow_source_yaml: result.definition.sourceYaml ?? null,
         workflow_document: result.definition.document,
         workflow_model: result.definition.model,
       };

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -235,6 +235,7 @@ describe('definition sync activities', () => {
         expect.objectContaining({ref: 'abc123', path: '.shipfox/workflows/ci.yml'}),
       );
       expect(rows[0]?.ref).toBe('main');
+      expect(rows[0]?.definition.sourceYaml).toBe(validYaml);
     });
   });
 

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -115,6 +115,7 @@ function createFetchAndApplyActivity(sourceControl: IntegrationSourceControlServ
         upserts: definitions.map((entry) => ({
           configPath: entry.path,
           name: entry.name,
+          sourceYaml: entry.definition.sourceYaml,
           document: entry.definition.document,
           model: entry.definition.model,
           contentHash: entry.contentHash,

--- a/libs/api/definitions/test/factories/definition.ts
+++ b/libs/api/definitions/test/factories/definition.ts
@@ -15,7 +15,11 @@ function defaultDefinition(): WorkflowDefinitionPayload {
       },
     },
   };
-  return {document, model: normalizeWorkflowDocument(document)};
+  return {
+    sourceYaml: 'name: Test Workflow\n',
+    document,
+    model: normalizeWorkflowDocument(document),
+  };
 }
 
 interface DefinitionTransients {
@@ -33,6 +37,7 @@ export const definitionFactory = Factory.define<WorkflowDefinition, DefinitionTr
         configPath: definition.configPath,
         source: definition.source,
         name: definition.name,
+        sourceYaml: definition.sourceYaml,
         document: definition.document,
         model: definition.model,
         contentHash: definition.contentHash ?? undefined,
@@ -52,7 +57,9 @@ export const definitionFactory = Factory.define<WorkflowDefinition, DefinitionTr
       ref: null,
       name: `Test Workflow ${sequence}`,
       definition: definition.document,
-      ...definition,
+      sourceYaml: definition.sourceYaml ?? null,
+      document: definition.document,
+      model: definition.model,
       contentHash: null,
       fetchedAt: new Date(),
       createdAt: new Date(),

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -29,6 +29,7 @@ function buildDefinition(overrides?: Partial<WorkflowDefinition>): WorkflowDefin
     ref: null,
     name: 'Test Workflow',
     definition: document,
+    sourceYaml: 'name: Test Workflow\n',
     document,
     model,
     contentHash: null,

--- a/libs/client/projects/src/pages/project-runs-page.test.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.test.tsx
@@ -154,6 +154,7 @@ function definitionsDto() {
         sha: 'abc123',
         ref: 'main',
         name: 'Deploy production',
+        workflow_source_yaml: 'name: Deploy production\n',
         workflow_document: {
           name: 'Deploy production',
           jobs: {deploy: {steps: [{run: './deploy.sh'}]}},

--- a/libs/client/projects/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.test.tsx
@@ -230,6 +230,7 @@ function baseDefinitionsDto() {
         sha: 'abc123',
         ref: 'main',
         name: 'Deploy production',
+        workflow_source_yaml: 'name: Deploy production\n',
         workflow_document: {
           name: 'Deploy production',
           triggers: {on_demand: {source: 'manual', event: 'fire'}},


### PR DESCRIPTION
<!-- stk:begin -->
## Stack

Part 1 of 2.

Depends on: none
Next: #191

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #190 | `workflow-execution-dashboard/02-definition-source` | `workflow-execution-dashboard/01-run-detail-contract` |
| 2 | #191 | `workflow-execution-dashboard/03-run-source-snapshot` | `workflow-execution-dashboard/02-definition-source` |

<!-- stk:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves and returns the original workflow YAML for each definition. Adds a nullable `workflow_source_yaml` to API responses and passes `sourceYaml` through parsing, validation, VCS sync, DB, and routes.

- New Features
  - Persist `sourceYaml` in the definition JSON stored in DB.
  - Expose as `workflow_source_yaml` in definition DTOs and validate-definition responses.
  - Capture YAML during parse/validation and VCS sync; propagate on create and batch apply.
  - Map legacy rows without stored YAML to null.

<sup>Written for commit 8573d488f69a9de3bf66df9c4b71d0fb0f39ae55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

