### PR TITLE
Snapshot workflow source for runs

### DIFF
--- a/libs/api/workflows-dto/src/schemas/run.ts
+++ b/libs/api/workflows-dto/src/schemas/run.ts
@@ -76,6 +76,9 @@ export const runResponseSchema = runDtoSchema;
 export type RunResponseDto = z.infer<typeof runResponseSchema>;
 
 export const runDetailDtoSchema = runResponseSchema.extend({
+  workflow_source_yaml: z.string().nullable(),
+  workflow_document: z.unknown().nullable(),
+  workflow_model: z.unknown().nullable(),
   jobs: z.array(
     jobDtoSchema.extend({
       // Each step carries its attempt history (one entry per dispatched attempt;

--- a/libs/api/workflows/drizzle/0002_definition_snapshot.sql
+++ b/libs/api/workflows/drizzle/0002_definition_snapshot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflows_workflow_runs" ADD COLUMN "definition_snapshot" jsonb;

--- a/libs/api/workflows/drizzle/meta/0002_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,737 @@
+{
+  "id": "cfb008f6-c9df-41f4-a755-db5fbb276f45",
+  "prevId": "37221128-e713-4c32-a224-2f82932c4bb6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_jobs_run_id_idx": {
+          "name": "workflows_jobs_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_jobs_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_reason": {
+          "name": "restart_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_step_attempts_job_id_idx": {
+          "name": "workflows_step_attempts_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_step_attempts_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_status_not_pending_ck": {
+          "name": "workflows_step_attempts_status_not_pending_ck",
+          "value": "\"workflows_step_attempts\".\"status\" <> 'pending'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_id_idx": {
+          "name": "workflows_steps_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_steps_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_snapshot": {
+          "name": "definition_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "waiting_for_dependencies",
+        "ready",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "awaiting_manual"
+      ]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781129096855,
       "tag": "0001_step_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781549278735,
+      "tag": "0002_definition_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -1,3 +1,5 @@
+import type {WorkflowModel, WorkflowSpec} from '@shipfox/api-definitions';
+
 export type WorkflowRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
 export type TriggerPayload =
@@ -22,6 +24,12 @@ export type TriggerPayload =
       data: unknown;
     };
 
+export interface WorkflowRunDefinitionSnapshot {
+  sourceYaml: string | null;
+  document: WorkflowSpec;
+  model: WorkflowModel;
+}
+
 export interface WorkflowRun {
   id: string;
   workspaceId: string;
@@ -32,6 +40,7 @@ export interface WorkflowRun {
   triggerSource: string;
   triggerEvent: string;
   triggerPayload: TriggerPayload;
+  definitionSnapshot: WorkflowRunDefinitionSnapshot | null;
   inputs: Record<string, unknown> | null;
   triggerIdempotencyKey: string | null;
   version: number;

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -79,6 +79,11 @@ describe('runWorkflow', () => {
     expect(run.triggerSource).toBe('manual');
     expect(run.triggerEvent).toBe('fire');
     expect(run.triggerPayload).toEqual(triggerPayload);
+    expect(run.definitionSnapshot).toEqual({
+      sourceYaml: definition.sourceYaml,
+      document: definition.document,
+      model: definition.model,
+    });
   });
 
   test('persists an integration trigger payload intact', async () => {

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -26,6 +26,10 @@ export async function runWorkflow(params: RunWorkflowParams): Promise<WorkflowRu
     definitionId: definition.id,
     name: definition.name,
     model: definition.model,
+    definitionSnapshot: {
+      sourceYaml: definition.sourceYaml,
+      document: definition.document,
+    },
     triggerPayload: params.triggerPayload,
     inputs: params.inputs,
     triggerIdempotencyKey: params.triggerIdempotencyKey,

--- a/libs/api/workflows/src/db/schema/workflow-runs.ts
+++ b/libs/api/workflows/src/db/schema/workflow-runs.ts
@@ -9,7 +9,11 @@ import {
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
-import type {TriggerPayload, WorkflowRun} from '#core/entities/workflow-run.js';
+import type {
+  TriggerPayload,
+  WorkflowRun,
+  WorkflowRunDefinitionSnapshot,
+} from '#core/entities/workflow-run.js';
 import {pgTable} from './common.js';
 
 export const workflowRunStatusEnum = pgEnum('workflows_run_status', [
@@ -32,6 +36,7 @@ export const workflowRuns = pgTable(
     triggerSource: text('trigger_source').notNull(),
     triggerEvent: text('trigger_event').notNull(),
     triggerPayload: jsonb('trigger_payload').notNull().$type<TriggerPayload>(),
+    definitionSnapshot: jsonb('definition_snapshot').$type<WorkflowRunDefinitionSnapshot>(),
     inputs: jsonb('inputs').$type<Record<string, unknown>>(),
     // Idempotency token for at-least-once outbox replays. Unique when set; NULL is unconstrained (Postgres default).
     triggerIdempotencyKey: text('trigger_idempotency_key'),
@@ -77,6 +82,7 @@ export function toWorkflowRun(row: WorkflowRunDb): WorkflowRun {
     triggerSource: row.triggerSource,
     triggerEvent: row.triggerEvent,
     triggerPayload: row.triggerPayload as TriggerPayload,
+    definitionSnapshot: row.definitionSnapshot ?? null,
     inputs: row.inputs ?? null,
     triggerIdempotencyKey: row.triggerIdempotencyKey,
     version: row.version,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -58,6 +58,7 @@ describe('workflow run queries', () => {
       expect(run.definitionId).toBe(definitionId);
       expect(run.status).toBe('pending');
       expect(run.triggerPayload).toMatchObject({source: 'manual', event: 'fire'});
+      expect(run.definitionSnapshot).toBeNull();
       expect(run.inputs).toBeNull();
       expect(run.version).toBe(1);
       expect(run.createdAt).toBeInstanceOf(Date);
@@ -77,6 +78,35 @@ describe('workflow run queries', () => {
         config: {},
       });
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
+    });
+
+    test('persists the definition snapshot with the run', async () => {
+      const model = buildModel();
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        definitionSnapshot: {
+          sourceYaml: 'name: Test\n',
+          document: {name: 'Test', jobs: {build: {steps: [{run: 'echo hello'}]}}},
+        },
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const stored = await getWorkflowRunById(run.id);
+
+      expect(stored?.definitionSnapshot).toEqual({
+        sourceYaml: 'name: Test\n',
+        document: {name: 'Test', jobs: {build: {steps: [{run: 'echo hello'}]}}},
+        model,
+      });
     });
 
     test('writes workflows.run.created outbox event in same transaction', async () => {
@@ -333,12 +363,18 @@ describe('workflow run queries', () => {
       const subscriptionId = crypto.randomUUID();
       const eventId = crypto.randomUUID();
       const idempotencyKey = `${subscriptionId}:${eventId}`;
+      const firstModel = buildModel({name: 'First snapshot'});
+      const secondModel = buildModel({name: 'Second snapshot'});
 
       const first = await createWorkflowRun({
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel(),
+        model: firstModel,
+        definitionSnapshot: {
+          sourceYaml: 'name: First snapshot\n',
+          document: {name: 'First snapshot', jobs: {build: {steps: [{run: 'echo first'}]}}},
+        },
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -351,7 +387,11 @@ describe('workflow run queries', () => {
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel(),
+        model: secondModel,
+        definitionSnapshot: {
+          sourceYaml: 'name: Second snapshot\n',
+          document: {name: 'Second snapshot', jobs: {build: {steps: [{run: 'echo second'}]}}},
+        },
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -363,6 +403,7 @@ describe('workflow run queries', () => {
 
       expect(second.id).toBe(first.id);
       expect(second.triggerIdempotencyKey).toBe(idempotencyKey);
+      expect(second.definitionSnapshot).toEqual(first.definitionSnapshot);
 
       const allJobs = await getJobsByRunId(first.id);
       expect(allJobs).toHaveLength(1);

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -11,7 +11,12 @@ import {and, asc, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql} fro
 import type {Job, JobStatus} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
-import type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from '#core/entities/workflow-run.js';
+import type {
+  TriggerPayload,
+  WorkflowRun,
+  WorkflowRunDefinitionSnapshot,
+  WorkflowRunStatus,
+} from '#core/entities/workflow-run.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import {materializeWorkflowModel} from '#core/workflow-runtime/index.js';
@@ -22,12 +27,15 @@ import {stepAttempts, toStepAttempt} from './schema/step-attempts.js';
 import {steps, toStep} from './schema/steps.js';
 import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
 
+type CreateWorkflowRunDefinitionSnapshot = Omit<WorkflowRunDefinitionSnapshot, 'model'>;
+
 export interface CreateWorkflowRunParams {
   workspaceId: string;
   projectId: string;
   definitionId: string;
   name?: string | undefined;
   model: WorkflowModel;
+  definitionSnapshot?: CreateWorkflowRunDefinitionSnapshot | null | undefined;
   triggerPayload: TriggerPayload;
   inputs?: Record<string, unknown> | undefined;
   triggerIdempotencyKey?: string | undefined;
@@ -48,6 +56,9 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
         triggerSource: params.triggerPayload.source,
         triggerEvent: params.triggerPayload.event,
         triggerPayload: params.triggerPayload,
+        definitionSnapshot: params.definitionSnapshot
+          ? {...params.definitionSnapshot, model: params.model}
+          : null,
         inputs: params.inputs ?? null,
         triggerIdempotencyKey: params.triggerIdempotencyKey ?? null,
       })

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -98,6 +98,9 @@ describe('GET /api/workflows/runs/:id', () => {
     const body = res.json();
     expect(body.id).toBe(run.id);
     expect(body.duration_ms).toBe(0);
+    expect(body.workflow_source_yaml).toBeNull();
+    expect(body.workflow_document).toBeNull();
+    expect(body.workflow_model).toBeNull();
     expect(body.jobs).toHaveLength(1);
     expect(body.jobs[0].name).toBe('build');
     expect(body.jobs[0].duration_ms).toBe(0);
@@ -107,6 +110,76 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(body.jobs[0].steps[0].duration_ms).toBe(0);
     expect(body.jobs[0].steps[1].name).toBe('Install');
     expect(body.jobs[0].steps[2].name).toBeNull();
+  });
+
+  test('returns the immutable definition snapshot when present', async () => {
+    const projectId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+    const model = workflowModel({name: 'Snapshot source'});
+    const document = {name: 'Snapshot source', jobs: {build: {steps: [{run: 'echo hello'}]}}};
+
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model,
+      definitionSnapshot: {
+        sourceYaml: 'name: Snapshot source\n',
+        document,
+      },
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${run.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workflow_source_yaml).toBe('name: Snapshot source\n');
+    expect(body.workflow_document).toEqual(document);
+    expect(body.workflow_model).toEqual(model);
+  });
+
+  test('returns null source YAML without dropping document and model snapshot fields', async () => {
+    const projectId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+    const model = workflowModel({name: 'Generated definition'});
+    const document = {name: 'Generated definition', jobs: {build: {steps: [{run: 'echo hello'}]}}};
+
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model,
+      definitionSnapshot: {
+        sourceYaml: null,
+        document,
+      },
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${run.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workflow_source_yaml).toBeNull();
+    expect(body.workflow_document).toEqual(document);
+    expect(body.workflow_model).toEqual(model);
   });
 
   test('exposes per-step error and cancelled status after a failed per-step report', async () => {

--- a/libs/api/workflows/src/presentation/routes/get-run.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.ts
@@ -56,6 +56,9 @@ export const getRunRoute = defineRoute({
 
     return {
       ...toRunDto(run),
+      workflow_source_yaml: run.definitionSnapshot?.sourceYaml ?? null,
+      workflow_document: run.definitionSnapshot?.document ?? null,
+      workflow_model: run.definitionSnapshot?.model ?? null,
       jobs: jobDtos,
     };
   },

--- a/libs/api/workflows/test/factories/workflow-run.ts
+++ b/libs/api/workflows/test/factories/workflow-run.ts
@@ -15,6 +15,7 @@ export const workflowRunFactory = Factory.define<WorkflowRun>(({onCreate}) => {
       definitionId: run.definitionId,
       name: run.name,
       model: workflowModel({name: run.name}),
+      definitionSnapshot: run.definitionSnapshot,
       triggerPayload: run.triggerPayload,
       inputs: run.inputs ?? undefined,
     });
@@ -36,6 +37,7 @@ export const workflowRunFactory = Factory.define<WorkflowRun>(({onCreate}) => {
       userId: crypto.randomUUID(),
     },
     inputs: null,
+    definitionSnapshot: null,
     triggerIdempotencyKey: null,
     version: 1,
     createdAt: new Date(),

--- a/libs/client/projects/src/hooks/api/workflow-runs.test.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.test.ts
@@ -71,6 +71,9 @@ describe('getWorkflowRun', () => {
           trigger_payload: {source: 'manual', event: 'fire'},
           inputs: null,
           duration_ms: 0,
+          workflow_source_yaml: 'name: Deploy\n',
+          workflow_document: {name: 'Deploy', jobs: {}},
+          workflow_model: {kind: 'workflow', name: 'Deploy'},
           created_at: '2026-05-13T00:00:00.000Z',
           updated_at: '2026-05-13T00:00:00.000Z',
           jobs: [],
@@ -89,5 +92,6 @@ describe('getWorkflowRun', () => {
     );
     expect(request.method).toBe('GET');
     expect(result.duration_ms).toBe(0);
+    expect(result.workflow_source_yaml).toBe('name: Deploy\n');
   });
 });


### PR DESCRIPTION
<!-- stk:begin -->
## Stack

Part 1 of 2.

Depends on: none
Next: #192

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #191 | `workflow-execution-dashboard/03-run-source-snapshot` | `workflow-execution-dashboard/02-definition-source` |
| 2 | #192 | `workflow-execution-dashboard/04-run-detail-frame` | `workflow-execution-dashboard/03-run-source-snapshot` |

<!-- stk:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store an immutable snapshot of the workflow definition on each run and return it from the run detail API. This keeps run details stable even if the workflow changes later.

- **New Features**
  - Persist `definition_snapshot` (JSONB) on `workflows_workflow_runs` with `sourceYaml`, `document`, and `model` from `@shipfox/api-definitions`.
  - Expose snapshot in run detail as `workflow_source_yaml`, `workflow_document`, and `workflow_model` (nullable).
  - Preserve the original snapshot on idempotent replays; tests cover storage and API responses.

- **Migration**
  - Add `definition_snapshot` jsonb column via migration `0002_definition_snapshot`. Backwards compatible (nullable).

<sup>Written for commit 50a6a4f54a13a8b7a9e8e1ba80a983a289f8a66b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

