### PR TITLE
Add workflow run detail frame

### DIFF
--- a/libs/client/projects/src/components/run-row.test.tsx
+++ b/libs/client/projects/src/components/run-row.test.tsx
@@ -1,6 +1,16 @@
 import type {RunDto} from '@shipfox/api-workflows-dto';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
 import {render, screen} from '@testing-library/react';
+import type {ReactElement} from 'react';
 import {RelativeTimeProvider} from '#lib/relative-time.js';
+import {PROJECT_TEST_WID} from '#test/pages.js';
 import {RunRow} from './run-row.js';
 
 function makeRun(overrides: Partial<RunDto> = {}): RunDto {
@@ -22,46 +32,65 @@ function makeRun(overrides: Partial<RunDto> = {}): RunDto {
 }
 
 function renderRow(run: RunDto) {
-  return render(
+  return renderWithRouter(
+    `/workspaces/${PROJECT_TEST_WID}/projects/${run.project_id}/runs`,
     <RelativeTimeProvider>
-      <RunRow run={run} />
+      <RunRow run={run} workspaceId={PROJECT_TEST_WID} />
     </RelativeTimeProvider>,
   );
 }
 
 describe('RunRow', () => {
-  test('renders short id, trigger, workflow name, and terminal duration', () => {
+  test('renders short id, trigger, workflow name, and terminal duration', async () => {
     renderRow(makeRun({status: 'succeeded', duration_ms: 13_000}));
 
-    expect(screen.getByText('abcd1234')).toBeInTheDocument();
+    expect(await screen.findByText('abcd1234')).toBeInTheDocument();
     expect(screen.getByText('manual')).toBeInTheDocument();
     expect(screen.getByText('Deploy production')).toBeInTheDocument();
     expect(screen.getByText('13s')).toBeInTheDocument();
   });
 
-  test('shows "running Xs" with current-time computation for running runs', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(Date.parse('2026-05-13T00:00:30.000Z'));
+  test('shows running duration with current-time computation for running runs', async () => {
+    const createdAt = new Date(Date.now() - 30_500).toISOString();
 
     renderRow(
       makeRun({
         status: 'running',
         duration_ms: 0,
-        created_at: '2026-05-13T00:00:00.000Z',
+        created_at: createdAt,
         updated_at: '2026-05-13T00:00:10.000Z',
       }),
     );
 
-    expect(screen.getByText('running 30s')).toBeInTheDocument();
-
-    vi.useRealTimers();
+    expect(await screen.findByText('running 30s')).toBeInTheDocument();
   });
 
-  test('is not interactive — no role=button, no tabindex on the row', () => {
-    const {container} = renderRow(makeRun());
+  test('links to the run detail route', async () => {
+    renderRow(makeRun());
 
-    const row = container.firstChild as HTMLElement;
-    expect(row.getAttribute('role')).not.toBe('button');
-    expect(row.getAttribute('tabindex')).toBe(null);
+    expect(await screen.findByRole('link')).toHaveAttribute(
+      'href',
+      `/workspaces/${PROJECT_TEST_WID}/projects/p/runs/abcd1234-0000-0000-0000-000000000000`,
+    );
   });
 });
+
+function renderWithRouter(path: string, element: ReactElement) {
+  const rootRoute = createRootRoute({component: Outlet});
+  const runsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/projects/$pid/runs',
+    component: () => element,
+  });
+  const runDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/projects/$pid/runs/$rid',
+    component: () => null,
+  });
+  const router = createRouter({
+    history: createMemoryHistory({initialEntries: [path]}),
+    routeTree: rootRoute.addChildren([runsRoute, runDetailRoute]),
+  });
+
+  return render(<RouterProvider router={router} />);
+}

--- a/libs/client/projects/src/components/run-row.tsx
+++ b/libs/client/projects/src/components/run-row.tsx
@@ -1,15 +1,16 @@
-import type {RunDto, RunStatusDto} from '@shipfox/api-workflows-dto';
+import type {RunDto} from '@shipfox/api-workflows-dto';
 import {Code, Text} from '@shipfox/react-ui';
-import {humanDuration} from '#lib/human-duration.js';
+import {Link} from '@tanstack/react-router';
+import {humanDuration, humanDurationMs} from '#lib/human-duration.js';
 import {RelativeTime} from '#lib/relative-time.js';
-import {StatusDot, type StatusDotVariant} from './status-dot.js';
+import {isTerminalRunStatus, RunStatusPill, runStatusVariant} from './run-status.js';
+import {StatusDot} from './status-dot.js';
 
 /**
  * Single Vercel-style row for a workflow run.
  *
  * Four zones at md+ (id+trigger / status+duration / workflow name / time)
- * collapse to a 2-line stack on sm. Rows are presentational only — no
- * click target until the run-detail surface ships (TODOS.md defers this).
+ * collapse to a 2-line stack on sm.
  *
  *  md+:
  *  ┌─────────────┬──────────────────┬────────────────────────────┬───────────┐
@@ -20,27 +21,16 @@ import {StatusDot, type StatusDotVariant} from './status-dot.js';
  *  sm: status dot + name on row 1; id8 · trigger · time · duration on row 2.
  */
 
-const TERMINAL_STATUSES = new Set<RunStatusDto>(['succeeded', 'failed', 'cancelled']);
-
-const variantByStatus: Record<RunStatusDto, StatusDotVariant> = {
-  pending: 'neutral',
-  running: 'info',
-  succeeded: 'success',
-  failed: 'error',
-  cancelled: 'neutral',
-};
-
-export function RunRow({run}: {run: RunDto}) {
-  const isActive = !TERMINAL_STATUSES.has(run.status);
-  const duration = humanDuration(run.created_at, isActive ? undefined : run.updated_at);
-  const durationLabel = isActive && run.status === 'running' ? `running ${duration}` : duration;
+export function RunRow({run, workspaceId}: {run: RunDto; workspaceId: string}) {
+  const isTerminal = isTerminalRunStatus(run.status);
+  const duration = isTerminal ? humanDurationMs(run.duration_ms) : humanDuration(run.created_at);
+  const durationLabel = run.status === 'running' ? `running ${duration}` : duration;
   const shortId = run.id.slice(0, 8);
 
   return (
-    <div
-      // Presentational row. Not interactive in this PR (see TODOS.md
-      // "Workflow run detail page"). No tabindex, no role=button — when
-      // run-detail ships, swap to a Link and add the chevron.
+    <Link
+      to="/workspaces/$wid/projects/$pid/runs/$rid"
+      params={{wid: workspaceId, pid: run.project_id, rid: run.id}}
       className="flex flex-col gap-6 px-12 py-10 transition-colors hover:bg-background-components-hover md:h-44 md:flex-row md:items-center md:gap-12 md:py-0"
     >
       <div className="flex shrink-0 flex-col gap-2 md:w-140">
@@ -53,16 +43,19 @@ export function RunRow({run}: {run: RunDto}) {
       </div>
 
       <div className="flex shrink-0 items-center gap-6 md:w-140">
-        <StatusDot variant={variantByStatus[run.status]} pulse={run.status === 'running'} />
+        <StatusDot variant={runStatusVariant[run.status]} pulse={run.status === 'running'} />
         <Text size="xs" className="text-foreground-neutral-muted tabular-nums">
           {durationLabel}
         </Text>
       </div>
 
       <div className="min-w-0 flex-1">
-        <Text size="sm" bold className="truncate">
-          {run.name}
-        </Text>
+        <div className="flex min-w-0 items-center gap-8">
+          <Text size="sm" bold className="truncate">
+            {run.name}
+          </Text>
+          <RunStatusPill status={run.status} size="sm" />
+        </div>
       </div>
 
       <div className="shrink-0 md:w-100 md:text-right">
@@ -70,6 +63,6 @@ export function RunRow({run}: {run: RunDto}) {
           <RelativeTime value={run.created_at} />
         </Text>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/libs/client/projects/src/components/run-status.tsx
+++ b/libs/client/projects/src/components/run-status.tsx
@@ -1,0 +1,52 @@
+import type {RunStatusDto} from '@shipfox/api-workflows-dto';
+import {Text} from '@shipfox/react-ui';
+import {StatusDot, type StatusDotVariant} from './status-dot.js';
+
+export const TERMINAL_RUN_STATUSES = new Set<RunStatusDto>(['succeeded', 'failed', 'cancelled']);
+
+export const runStatusVariant: Record<RunStatusDto, StatusDotVariant> = {
+  pending: 'neutral',
+  running: 'info',
+  succeeded: 'success',
+  failed: 'error',
+  cancelled: 'neutral',
+};
+
+const labelByStatus: Record<RunStatusDto, string> = {
+  pending: 'Pending',
+  running: 'Running',
+  succeeded: 'Succeeded',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+};
+
+const pillClassByStatus: Record<RunStatusDto, string> = {
+  pending: 'bg-tag-neutral-bg text-tag-neutral-text border-tag-neutral-border',
+  running: 'bg-tag-blue-bg text-tag-blue-text border-tag-blue-border',
+  succeeded: 'bg-tag-success-bg text-tag-success-text border-tag-success-border',
+  failed: 'bg-tag-error-bg text-tag-error-text border-tag-error-border',
+  cancelled: 'bg-tag-neutral-bg text-tag-neutral-text border-tag-neutral-border',
+};
+
+export function runStatusLabel(status: RunStatusDto) {
+  return labelByStatus[status];
+}
+
+export function isTerminalRunStatus(status: RunStatusDto) {
+  return TERMINAL_RUN_STATUSES.has(status);
+}
+
+export function RunStatusPill({status, size = 'md'}: {status: RunStatusDto; size?: 'sm' | 'md'}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-5 rounded-4 border ${pillClassByStatus[status]} ${
+        size === 'sm' ? 'px-6 py-1' : 'px-7 py-2'
+      }`}
+    >
+      <StatusDot variant={runStatusVariant[status]} pulse={status === 'running'} />
+      <Text size="xs" bold>
+        {runStatusLabel(status)}
+      </Text>
+    </span>
+  );
+}

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -5,6 +5,7 @@ export * from './hooks/api/projects.js';
 export * from './hooks/api/workflow-runs.js';
 export * from './pages/create-project-page.js';
 export * from './pages/home-router.js';
+export * from './pages/project-run-detail-page.js';
 export * from './pages/project-runs-page.js';
 export * from './pages/project-workflows-page.js';
 export * from './pages/projects-hub-page.js';

--- a/libs/client/projects/src/pages/project-run-detail-page.test.tsx
+++ b/libs/client/projects/src/pages/project-run-detail-page.test.tsx
@@ -1,0 +1,166 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {fireEvent, screen} from '@testing-library/react';
+import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
+import {ProjectRunDetailPage} from './project-run-detail-page.js';
+
+const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
+const RUN_ID = '66666666-6666-4666-8666-666666666666';
+const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+const SOURCE_TAB_RE = /Source/i;
+const SOURCE_NAME_RE = /name: Deploy production/;
+
+describe('ProjectRunDetailPage', () => {
+  test('renders the run detail frame from API data', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+      <ProjectRunDetailPage projectId={PROJECT_ID} runId={RUN_ID} />,
+    );
+
+    expect(await screen.findByRole('heading', {name: 'Run 66666666'})).toBeInTheDocument();
+    expect(screen.getAllByText('Runs')).not.toHaveLength(0);
+    expect(screen.getByText('Jobs graph')).toBeInTheDocument();
+    expect(screen.getAllByText('deploy')).not.toHaveLength(0);
+    expect(screen.getByText('Install')).toBeInTheDocument();
+
+    const sourceButtons = screen.getAllByRole('button', {name: SOURCE_TAB_RE});
+    const sourceButton = sourceButtons.at(-1);
+    if (!sourceButton) throw new Error('Source button not rendered');
+    fireEvent.click(sourceButton);
+
+    expect(screen.getByText('workflow.yaml')).toBeInTheDocument();
+    expect(screen.getByText(SOURCE_NAME_RE)).toBeInTheDocument();
+  });
+
+  test('filters the run rail by status and search text', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+      <ProjectRunDetailPage projectId={PROJECT_ID} runId={RUN_ID} />,
+    );
+
+    expect(await screen.findByText('manual · Deploy production')).toBeInTheDocument();
+    expect(screen.getByText('schedule · Nightly regression')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: 'running'}));
+
+    expect(screen.queryByText('manual · Deploy production')).not.toBeInTheDocument();
+    expect(screen.getByText('schedule · Nightly regression')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Filter runs'), {target: {value: 'cleanup'}});
+
+    expect(screen.getByText('No runs match.')).toBeInTheDocument();
+  });
+});
+
+function createRunDetailFetch() {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+
+    if (url.pathname === `/workflows/runs/${RUN_ID}`) {
+      return Promise.resolve(jsonResponse(runDetailDto()));
+    }
+    if (url.pathname === '/workflows/runs') {
+      return Promise.resolve(jsonResponse(runsDto()));
+    }
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function requestInputUrl(input: RequestInfo | URL) {
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+function runsDto() {
+  return {
+    runs: [
+      runSummary(),
+      runSummary({
+        id: '77777777-7777-4777-8777-777777777777',
+        name: 'Nightly regression',
+        status: 'running',
+        trigger_source: 'schedule',
+        duration_ms: 0,
+      }),
+    ],
+    next_cursor: null,
+    filtered_total_count: 2,
+  };
+}
+
+function runSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RUN_ID,
+    project_id: PROJECT_ID,
+    definition_id: DEFINITION_ID,
+    name: 'Deploy production',
+    status: 'failed',
+    trigger_source: 'manual',
+    trigger_event: 'fire',
+    trigger_payload: {source: 'manual', event: 'fire'},
+    inputs: null,
+    duration_ms: 134_000,
+    created_at: '2026-05-13T00:00:00.000Z',
+    updated_at: '2026-05-13T00:02:14.000Z',
+    ...overrides,
+  };
+}
+
+function runDetailDto() {
+  return {
+    ...runsDto().runs[0],
+    workflow_source_yaml:
+      'name: Deploy production\njobs:\n  deploy:\n    steps:\n      - name: Install\n',
+    workflow_document: {name: 'Deploy production', jobs: {deploy: {steps: [{name: 'Install'}]}}},
+    workflow_model: {kind: 'workflow', name: 'Deploy production'},
+    jobs: [
+      {
+        id: '77777777-7777-4777-8777-777777777777',
+        run_id: RUN_ID,
+        name: 'deploy',
+        status: 'failed',
+        dependencies: [],
+        position: 0,
+        duration_ms: 134_000,
+        created_at: '2026-05-13T00:00:00.000Z',
+        updated_at: '2026-05-13T00:02:14.000Z',
+        steps: [
+          {
+            id: '88888888-8888-4888-8888-888888888888',
+            job_id: '77777777-7777-4777-8777-777777777777',
+            name: 'Install',
+            status: 'failed',
+            type: 'run',
+            config: {run: 'pnpm install'},
+            error: {message: 'Install failed', reason: 'command_failed'},
+            position: 1,
+            current_attempt: 1,
+            duration_ms: 42_000,
+            created_at: '2026-05-13T00:00:00.000Z',
+            updated_at: '2026-05-13T00:00:42.000Z',
+            attempts: [
+              {
+                id: '99999999-9999-4999-8999-999999999999',
+                step_id: '88888888-8888-4888-8888-888888888888',
+                job_id: '77777777-7777-4777-8777-777777777777',
+                attempt: 1,
+                status: 'failed',
+                exit_code: 1,
+                output: null,
+                error: {message: 'Install failed'},
+                gate_result: null,
+                restart_reason: null,
+                duration_ms: 42_000,
+                started_at: '2026-05-13T00:00:00.000Z',
+                finished_at: '2026-05-13T00:00:42.000Z',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/libs/client/projects/src/pages/project-run-detail-page.tsx
+++ b/libs/client/projects/src/pages/project-run-detail-page.tsx
@@ -1,0 +1,575 @@
+import type {RunDetailDto, RunDto} from '@shipfox/api-workflows-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {Button, Code, EmptyState, Header, Icon, Skeleton, Text} from '@shipfox/react-ui';
+import {Link, useParams} from '@tanstack/react-router';
+import {useMemo, useState} from 'react';
+import {isTerminalRunStatus, RunStatusPill, runStatusVariant} from '#components/run-status.js';
+import {StatusDot, type StatusDotVariant} from '#components/status-dot.js';
+import {useWorkflowRunQuery, useWorkflowRunsInfiniteQuery} from '#hooks/api/workflow-runs.js';
+import {humanDuration, humanDurationMs} from '#lib/human-duration.js';
+import {RelativeTime, RelativeTimeProvider} from '#lib/relative-time.js';
+
+type DetailMode = 'overview' | 'logs' | 'source';
+type RailFilter = 'all' | 'failed' | 'running';
+type DetailJob = RunDetailDto['jobs'][number];
+type DetailStep = DetailJob['steps'][number];
+
+export function ProjectRunDetailPage({projectId, runId}: {projectId: string; runId: string}) {
+  return (
+    <RelativeTimeProvider>
+      <ProjectRunDetailPageInner projectId={projectId} runId={runId} />
+    </RelativeTimeProvider>
+  );
+}
+
+function ProjectRunDetailPageInner({projectId, runId}: {projectId: string; runId: string}) {
+  const runQuery = useWorkflowRunQuery(runId);
+  const runsQuery = useWorkflowRunsInfiniteQuery(projectId, {});
+  const params = useParams({strict: false}) as {wid?: string};
+  const workspaceId = params.wid ?? '';
+  const railRuns = useMemo(() => {
+    const runs = runsQuery.data?.pages.flatMap((page) => page.runs) ?? [];
+    if (!runQuery.data || runs.some((run) => run.id === runQuery.data.id)) return runs;
+    return [toRunDto(runQuery.data), ...runs];
+  }, [runsQuery.data, runQuery.data]);
+
+  if (runQuery.isPending) return <RunDetailSkeleton />;
+
+  if (runQuery.isError && runQuery.data === undefined) {
+    return <QueryLoadError query={runQuery} subject="run" />;
+  }
+
+  const run = runQuery.data;
+  if (!run) {
+    return (
+      <EmptyState
+        icon="errorWarningLine"
+        title="Run unavailable"
+        description="This workflow run could not be loaded."
+      />
+    );
+  }
+
+  return (
+    <div className="relative left-1/2 flex h-[calc(100vh-180px)] min-h-[620px] w-screen -translate-x-1/2 overflow-hidden border-y border-border-neutral-base bg-background-neutral-base">
+      <RunHistoryRail
+        runs={railRuns}
+        selectedRunId={run.id}
+        workspaceId={workspaceId}
+        isPending={runsQuery.isPending}
+      />
+      <RunWorkspace run={run} workspaceId={workspaceId} />
+    </div>
+  );
+}
+
+function RunDetailSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-16">
+      <Skeleton className="h-36 w-1/3" />
+      <Skeleton className="h-20 w-1/2" />
+      <div className="flex gap-12">
+        <Skeleton className="h-360 w-280" />
+        <Skeleton className="h-360 flex-1" />
+      </div>
+    </div>
+  );
+}
+
+function RunHistoryRail({
+  runs,
+  selectedRunId,
+  workspaceId,
+  isPending,
+}: {
+  runs: RunDto[];
+  selectedRunId: string;
+  workspaceId: string;
+  isPending: boolean;
+}) {
+  const [filter, setFilter] = useState<RailFilter>('all');
+  const [query, setQuery] = useState('');
+  const filteredRuns = runs.filter((run) => {
+    if (filter === 'failed' && run.status !== 'failed') return false;
+    if (filter === 'running' && run.status !== 'running') return false;
+    const needle = query.trim().toLowerCase();
+    if (!needle) return true;
+    return `${run.id} ${run.name} ${run.trigger_source}`.toLowerCase().includes(needle);
+  });
+
+  return (
+    <aside className="flex w-280 shrink-0 flex-col border-r border-border-neutral-base bg-background-neutral-base max-[900px]:hidden">
+      <div className="sticky top-0 z-10 flex flex-col gap-8 border-b border-border-neutral-base bg-background-neutral-base px-12 py-14">
+        <div className="flex items-center justify-between gap-8">
+          <Text
+            size="xs"
+            bold
+            className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
+          >
+            Runs
+          </Text>
+          <Text size="xs" className="text-foreground-neutral-muted tabular-nums">
+            {runs.length}
+          </Text>
+        </div>
+        <label className="flex h-28 items-center gap-6 rounded-6 border border-border-neutral-base bg-background-field-base px-8 text-foreground-neutral-muted">
+          <Icon name="searchLine" className="size-13" />
+          <input
+            aria-label="Filter runs"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Run id or trigger..."
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground-neutral-base outline-none placeholder:text-foreground-neutral-muted"
+          />
+        </label>
+        <div className="flex gap-4">
+          {(['all', 'failed', 'running'] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setFilter(value)}
+              className={`h-24 rounded-4 border px-7 text-xs font-medium capitalize transition-colors ${
+                filter === value
+                  ? 'border-tag-warning-border bg-background-highlight-base text-foreground-highlight-interactive'
+                  : 'border-transparent text-foreground-neutral-muted hover:bg-background-button-transparent-hover hover:text-foreground-neutral-base'
+              }`}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-6">
+        {isPending ? <RailSkeleton /> : null}
+        {!isPending && filteredRuns.length === 0 ? (
+          <Text size="sm" className="px-8 py-20 text-center text-foreground-neutral-muted">
+            No runs match.
+          </Text>
+        ) : null}
+        {filteredRuns.map((run) => (
+          <RailRunLink
+            key={run.id}
+            run={run}
+            selected={run.id === selectedRunId}
+            workspaceId={workspaceId}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+function RailSkeleton() {
+  return (
+    <>
+      {Array.from({length: 5}).map((_, index) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: skeleton row, stable position
+          key={index}
+          className="rounded-8 px-10 py-9"
+        >
+          <Skeleton className="h-14 w-3/4" />
+          <Skeleton className="mt-8 h-12 w-full" />
+        </div>
+      ))}
+    </>
+  );
+}
+
+function RailRunLink({
+  run,
+  selected,
+  workspaceId,
+}: {
+  run: RunDto;
+  selected: boolean;
+  workspaceId: string;
+}) {
+  const isTerminal = isTerminalRunStatus(run.status);
+  const duration = isTerminal ? humanDurationMs(run.duration_ms) : humanDuration(run.created_at);
+  const durationLabel = run.status === 'running' ? `${duration}...` : duration;
+
+  return (
+    <Link
+      to="/workspaces/$wid/projects/$pid/runs/$rid"
+      params={{wid: workspaceId, pid: run.project_id, rid: run.id}}
+      className={`relative flex flex-col gap-6 rounded-8 border px-10 py-9 text-left transition-colors ${
+        selected
+          ? 'border-tag-warning-border bg-background-highlight-base'
+          : 'border-transparent hover:bg-background-components-hover'
+      }`}
+    >
+      {selected ? (
+        <span className="absolute left-0 top-8 bottom-8 w-3 rounded-r-3 bg-background-highlight-interactive" />
+      ) : null}
+      <div className="flex items-center gap-7">
+        <StatusDot variant={runStatusVariant[run.status]} pulse={run.status === 'running'} />
+        <Code variant="label" className="font-semibold">
+          {run.id.slice(0, 8)}
+        </Code>
+        <span className="min-w-0 flex-1" />
+        <Code variant="label" className="text-foreground-neutral-muted">
+          {durationLabel}
+        </Code>
+      </div>
+      <div className="flex min-w-0 items-center gap-6">
+        <Icon name="pulseLine" className="size-12 shrink-0 text-foreground-neutral-muted" />
+        <Text size="xs" className="truncate text-foreground-neutral-muted">
+          {run.trigger_source} · {run.name}
+        </Text>
+      </div>
+    </Link>
+  );
+}
+
+function RunWorkspace({run, workspaceId}: {run: RunDetailDto; workspaceId: string}) {
+  const [mode, setMode] = useState<DetailMode>('overview');
+  const selectedJob = chooseSelectedJob(run);
+
+  return (
+    <section className="flex min-w-0 flex-1 flex-col bg-background-neutral-subtle">
+      <RunHeader run={run} workspaceId={workspaceId} onSource={() => setMode('source')} />
+      <main className="min-h-0 flex-1 overflow-y-auto">
+        <div className="px-20 pt-18 pb-6">
+          <div className="flex items-center justify-between gap-12 pb-10">
+            <Text
+              size="xs"
+              bold
+              className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
+            >
+              Jobs graph
+            </Text>
+          </div>
+          <JobsGraph run={run} selectedJob={selectedJob} />
+        </div>
+        <div className="px-20 pt-12 pb-22">
+          <div className="sticky top-0 z-10 -mx-20 flex flex-wrap items-center justify-between gap-10 border-y border-border-neutral-base bg-background-neutral-subtle px-20 py-10">
+            <div className="min-w-0">
+              <Text
+                size="xs"
+                bold
+                className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
+              >
+                {selectedJob?.name ?? 'Run'} <span className="font-normal">· steps</span>
+              </Text>
+            </div>
+            <ModeTabs value={mode} onChange={setMode} />
+          </div>
+          <ModePanel mode={mode} run={run} job={selectedJob} />
+        </div>
+      </main>
+    </section>
+  );
+}
+
+function RunHeader({
+  run,
+  workspaceId,
+  onSource,
+}: {
+  run: RunDetailDto;
+  workspaceId: string;
+  onSource: () => void;
+}) {
+  const goLabel =
+    run.status === 'failed'
+      ? 'Go to root cause'
+      : run.status === 'running'
+        ? 'Go to active step'
+        : null;
+  const durationLabel =
+    run.status === 'running'
+      ? `${humanDuration(run.created_at)}...`
+      : humanDurationMs(run.duration_ms);
+
+  return (
+    <header className="sticky top-0 z-20 border-b border-border-neutral-base bg-background-neutral-base px-22 py-13">
+      <div className="flex flex-wrap items-center gap-12">
+        <StatusDot variant={runStatusVariant[run.status]} pulse={run.status === 'running'} />
+        <Header variant="h2" className="font-mono text-lg">
+          Run {run.id.slice(0, 8)}
+        </Header>
+        <RunStatusPill status={run.status} />
+        <span className="h-18 w-px bg-border-neutral-base" aria-hidden="true" />
+        <span className="inline-flex min-w-0 items-center gap-6 text-sm text-foreground-neutral-muted">
+          <Icon name="pulseLine" className="size-13 shrink-0" />
+          <Code variant="label" className="truncate text-foreground-neutral-base">
+            {run.trigger_source} · {run.trigger_event}
+          </Code>
+        </span>
+        <span className="inline-flex items-center gap-6 text-sm text-foreground-neutral-muted">
+          <Icon name="timeLine" className="size-13" />
+          <Code variant="label" className="text-foreground-neutral-base">
+            {durationLabel}
+          </Code>
+        </span>
+        <Text size="xs" className="text-foreground-neutral-muted">
+          updated <RelativeTime value={run.updated_at} />
+        </Text>
+        <span className="min-w-12 flex-1" />
+        <div className="flex flex-wrap items-center gap-8">
+          {goLabel ? (
+            <Button size="sm" iconRight="arrowRightLine">
+              {goLabel}
+            </Button>
+          ) : null}
+          <Button size="sm" variant="secondary" iconLeft="fileCodeLine" onClick={onSource}>
+            Workflow source
+          </Button>
+          <Button size="sm" variant="secondary" iconLeft="refreshLine">
+            Re-run
+          </Button>
+          <Button asChild size="sm" variant="transparentMuted" iconLeft="arrowLeftLine">
+            <Link
+              to="/workspaces/$wid/projects/$pid/runs"
+              params={{wid: workspaceId, pid: run.project_id}}
+            >
+              Runs
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function JobsGraph({run, selectedJob}: {run: RunDetailDto; selectedJob: DetailJob | null}) {
+  return (
+    <div className="flex gap-0 overflow-x-auto pb-8">
+      <div className="flex shrink-0 items-center gap-9 rounded-8 border border-border-neutral-base bg-background-components-base px-11 py-9">
+        <div className="flex size-26 items-center justify-center rounded-6 border border-border-neutral-base bg-background-neutral-base text-foreground-neutral-muted">
+          <Icon name="pulseLine" className="size-16" />
+        </div>
+        <div>
+          <Text size="xs" className="font-mono text-foreground-neutral-muted">
+            {run.trigger_source} · trigger
+          </Text>
+          <Text size="xs" bold className="font-mono">
+            {run.trigger_event}
+          </Text>
+        </div>
+      </div>
+      <Connector />
+      {run.jobs.map((job, index) => (
+        <div key={job.id} className="flex shrink-0 items-center">
+          {index > 0 ? <Connector /> : null}
+          <JobNode job={job} selected={job.id === selectedJob?.id} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Connector() {
+  return (
+    <div className="flex w-36 shrink-0 items-center justify-center text-border-neutral-strong">
+      <span className="h-px flex-1 bg-border-neutral-strong" />
+      <Icon name="arrowRightSLine" className="-ml-4 size-14" />
+    </div>
+  );
+}
+
+function JobNode({job, selected}: {job: DetailJob; selected: boolean}) {
+  return (
+    <div
+      className={`flex w-204 shrink-0 flex-col gap-9 overflow-hidden rounded-8 border bg-background-neutral-base px-12 py-11 shadow-border-base ${
+        selected ? 'border-foreground-neutral-muted' : 'border-border-neutral-base'
+      }`}
+    >
+      <div className="flex min-w-0 items-center gap-8">
+        <StatusDot variant={statusVariant(job.status)} pulse={job.status === 'running'} />
+        <Text size="xs" bold className="truncate font-mono">
+          {job.name}
+        </Text>
+      </div>
+      <GenericStatusPill status={job.status} />
+      <div className="flex items-center justify-between gap-8">
+        <Code variant="label" className="text-foreground-neutral-muted">
+          {humanDurationMs(job.duration_ms)}
+        </Code>
+        <Text size="xs" className="truncate text-right text-foreground-neutral-muted">
+          {job.dependencies.length ? `needs ${job.dependencies.join(', ')}` : 'root job'}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+function GenericStatusPill({status}: {status: string}) {
+  const toneClass =
+    status === 'failed'
+      ? 'border-tag-error-border bg-tag-error-bg text-tag-error-text'
+      : status === 'succeeded'
+        ? 'border-tag-success-border bg-tag-success-bg text-tag-success-text'
+        : status === 'running'
+          ? 'border-tag-blue-border bg-tag-blue-bg text-tag-blue-text'
+          : 'border-tag-neutral-border bg-tag-neutral-bg text-tag-neutral-text';
+
+  return (
+    <span
+      className={`inline-flex w-fit rounded-4 border px-6 py-1 text-xs font-semibold ${toneClass}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function ModeTabs({value, onChange}: {value: DetailMode; onChange: (value: DetailMode) => void}) {
+  const options: Array<{
+    value: DetailMode;
+    label: string;
+    icon: 'stackLine' | 'terminalBoxLine' | 'fileCodeLine';
+  }> = [
+    {value: 'overview', label: 'Overview', icon: 'stackLine'},
+    {value: 'logs', label: 'Logs', icon: 'terminalBoxLine'},
+    {value: 'source', label: 'Source', icon: 'fileCodeLine'},
+  ];
+
+  return (
+    <div className="flex rounded-6 border border-border-neutral-base bg-background-neutral-base p-2">
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          className={`flex h-28 items-center gap-5 rounded-4 px-9 text-sm transition-colors ${
+            value === option.value
+              ? 'bg-background-button-neutral-default text-foreground-neutral-base shadow-button-neutral'
+              : 'text-foreground-neutral-muted hover:bg-background-button-transparent-hover hover:text-foreground-neutral-base'
+          }`}
+        >
+          <Icon name={option.icon} className="size-14" />
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ModePanel({mode, run, job}: {mode: DetailMode; run: RunDetailDto; job: DetailJob | null}) {
+  if (mode === 'source') return <SourceShell run={run} />;
+  if (mode === 'logs') return <LogsShell job={job} />;
+  return <OverviewShell job={job} />;
+}
+
+function OverviewShell({job}: {job: DetailJob | null}) {
+  if (!job) {
+    return (
+      <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
+        <Text size="sm" className="text-foreground-neutral-muted">
+          No jobs were recorded for this run.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 pt-10">
+      {job.steps.map((step, index) => (
+        <StepShellRow key={step.id} step={step} index={index} />
+      ))}
+    </div>
+  );
+}
+
+function StepShellRow({step, index}: {step: DetailStep; index: number}) {
+  return (
+    <div className="flex items-center gap-10 rounded-8 border border-border-neutral-base bg-background-neutral-base px-12 py-9 shadow-sm">
+      <Code variant="label" className="w-18 text-foreground-neutral-disabled">
+        {index + 1}
+      </Code>
+      <StatusDot variant={statusVariant(step.status)} pulse={step.status === 'running'} />
+      <Text size="sm" bold className="min-w-0 flex-1 truncate font-mono">
+        {step.name ?? step.type}
+      </Text>
+      <Text size="xs" className="text-foreground-neutral-muted">
+        {step.attempts.length} attempts
+      </Text>
+      <Code variant="label" className="w-56 text-right text-foreground-neutral-muted">
+        {humanDurationMs(step.duration_ms)}
+      </Code>
+    </div>
+  );
+}
+
+function LogsShell({job}: {job: DetailJob | null}) {
+  return (
+    <div className="mt-10 overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
+      <div className="flex items-center justify-between border-b border-white/10 bg-background-contrast-subtle px-12 py-8">
+        <Code variant="label" className="text-foreground-neutral-on-color">
+          {job ? `${job.name} logs` : 'run logs'}
+        </Code>
+        <Text size="xs" className="text-foreground-neutral-muted">
+          preview data
+        </Text>
+      </div>
+      <div className="px-12 py-28 text-center">
+        <Text size="sm" className="text-foreground-neutral-muted">
+          Log rows will appear here when available.
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+function SourceShell({run}: {run: RunDetailDto}) {
+  const source = run.workflow_source_yaml;
+  return (
+    <div className="mt-10 overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
+      <div className="flex items-center justify-between border-b border-white/10 bg-background-contrast-subtle px-12 py-8">
+        <Code variant="label" className="text-foreground-neutral-on-color">
+          workflow.yaml
+        </Code>
+        <Text size="xs" className="text-foreground-neutral-muted">
+          run snapshot
+        </Text>
+      </div>
+      {source ? (
+        <pre className="max-h-[460px] overflow-auto p-12 text-xs leading-18 text-foreground-neutral-on-color">
+          {source}
+        </pre>
+      ) : (
+        <div className="px-12 py-28 text-center">
+          <Text size="sm" className="text-foreground-neutral-muted">
+            This run was created before workflow source snapshots were available.
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function chooseSelectedJob(run: RunDetailDto) {
+  return (
+    run.jobs.find((job) => job.status === 'failed') ??
+    run.jobs.find((job) => job.status === 'running') ??
+    run.jobs[0] ??
+    null
+  );
+}
+
+function toRunDto(run: RunDetailDto): RunDto {
+  return {
+    id: run.id,
+    project_id: run.project_id,
+    definition_id: run.definition_id,
+    name: run.name,
+    status: run.status,
+    trigger_source: run.trigger_source,
+    trigger_event: run.trigger_event,
+    trigger_payload: run.trigger_payload,
+    inputs: run.inputs,
+    duration_ms: run.duration_ms,
+    created_at: run.created_at,
+    updated_at: run.updated_at,
+  };
+}
+
+function statusVariant(status: string): StatusDotVariant {
+  if (status === 'running') return 'info';
+  if (status === 'succeeded') return 'success';
+  if (status === 'failed') return 'error';
+  if (status === 'cancelled') return 'neutral';
+  return 'neutral';
+}

--- a/libs/client/projects/src/pages/project-runs-page.test.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.test.tsx
@@ -5,6 +5,7 @@ import {ProjectRunsPage} from './project-runs-page.js';
 
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+const DEPLOY_PRODUCTION_RE = /Deploy production/;
 const REFRESH_BUTTON_RE = /refresh/i;
 
 describe('ProjectRunsPage', () => {
@@ -18,6 +19,10 @@ describe('ProjectRunsPage', () => {
 
     expect(await screen.findByRole('heading', {name: 'Runs'})).toBeInTheDocument();
     expect((await screen.findAllByText('Deploy production'))[0]).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: DEPLOY_PRODUCTION_RE})).toHaveAttribute(
+      'href',
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/66666666-6666-4666-8666-666666666666`,
+    );
     expect(screen.getByText('Loaded 1 of 2')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
@@ -124,6 +129,7 @@ function runDto(overrides: Partial<{id: string; name: string; status: string}> =
     trigger_event: 'fire',
     trigger_payload: {source: 'manual', event: 'fire'},
     inputs: null,
+    duration_ms: 60_000,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
   };

--- a/libs/client/projects/src/pages/project-runs-page.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.tsx
@@ -113,7 +113,7 @@ function ProjectRunsPageInner({projectId}: {projectId: string}) {
 
       {runs.length > 0 ? (
         <>
-          <RunsList runs={runs} />
+          <RunsList runs={runs} workspaceId={params.wid ?? ''} />
           {runsQuery.isFetchNextPageError ? (
             <Alert variant="error" animated={false}>
               <div className="flex items-center justify-between gap-12">
@@ -332,11 +332,11 @@ function RunsEmptyState({
   );
 }
 
-function RunsList({runs}: {runs: RunDto[]}) {
+function RunsList({runs, workspaceId}: {runs: RunDto[]; workspaceId: string}) {
   return (
     <div className="flex flex-col divide-y divide-border-neutral-base rounded-8 border border-border-neutral-base bg-background-neutral-base">
       {runs.map((run) => (
-        <RunRow key={run.id} run={run} />
+        <RunRow key={run.id} run={run} workspaceId={workspaceId} />
       ))}
     </div>
   );

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -15,6 +15,7 @@ import {type RenderResult, render} from '@testing-library/react';
 import {Provider as JotaiProvider, useSetAtom} from 'jotai';
 import {type ReactElement, useEffect} from 'react';
 import {CreateProjectPage} from '#pages/create-project-page.js';
+import {ProjectRunDetailPage} from '#pages/project-run-detail-page.js';
 import {ProjectRunsPage} from '#pages/project-runs-page.js';
 import {ProjectWorkflowsPage} from '#pages/project-workflows-page.js';
 import {ProjectsHubPage} from '#pages/projects-hub-page.js';
@@ -100,6 +101,20 @@ function createTestRouter(path: string, element: ReactElement) {
       return <ProjectRunsPage projectId={params.pid ?? 'p-1'} />;
     },
   });
+  const projectRunDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/projects/$pid/runs/$rid',
+    component: () => {
+      const params = useParams({strict: false}) as {pid?: string; rid?: string};
+      if (
+        initialPath === `/workspaces/${PROJECT_TEST_WID}/projects/${params.pid}/runs/${params.rid}`
+      ) {
+        return element;
+      }
+
+      return <ProjectRunDetailPage projectId={params.pid ?? 'p-1'} runId={params.rid ?? 'r-1'} />;
+    },
+  });
   const projectWorkflowsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/projects/$pid/workflows',
@@ -122,6 +137,7 @@ function createTestRouter(path: string, element: ReactElement) {
       integrationsRoute,
       projectDetailRoute,
       projectRunsRoute,
+      projectRunDetailRoute,
       projectWorkflowsRoute,
     ]),
   });

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as WorkspacesWidLayoutProjectsPidLayoutRouteImport } from './rout
 import { Route as WorkspacesWidLayoutProjectsPidLayoutIndexRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/index'
 import { Route as WorkspacesWidLayoutProjectsPidLayoutWorkflowsRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/workflows'
 import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs'
+import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsRidRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs_.$rid'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -183,6 +184,12 @@ const WorkspacesWidLayoutProjectsPidLayoutRunsRoute =
     path: '/runs',
     getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRoute,
   } as any)
+const WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute =
+  WorkspacesWidLayoutProjectsPidLayoutRunsRidRouteImport.update({
+    id: '/runs_/$rid',
+    path: '/runs/$rid',
+    getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -211,6 +218,7 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/projects/$pid/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/projects/$pid/': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/projects/$pid/runs/$rid': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -237,6 +245,7 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/projects/$pid/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/projects/$pid': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/projects/$pid/runs/$rid': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -266,6 +275,7 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/projects/$pid/_layout/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout/': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$rid': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -296,6 +306,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/projects/$pid/runs'
     | '/workspaces/$wid/projects/$pid/workflows'
     | '/workspaces/$wid/projects/$pid/'
+    | '/workspaces/$wid/projects/$pid/runs/$rid'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -322,6 +333,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/projects/$pid/runs'
     | '/workspaces/$wid/projects/$pid/workflows'
     | '/workspaces/$wid/projects/$pid'
+    | '/workspaces/$wid/projects/$pid/runs/$rid'
   id:
     | '__root__'
     | '/'
@@ -350,6 +362,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/projects/$pid/_layout/runs'
     | '/workspaces/$wid/_layout/projects/$pid/_layout/workflows'
     | '/workspaces/$wid/_layout/projects/$pid/_layout/'
+    | '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$rid'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -550,6 +563,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRouteImport
       parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRoute
     }
+    '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$rid': {
+      id: '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$rid'
+      path: '/runs/$rid'
+      fullPath: '/workspaces/$wid/projects/$pid/runs/$rid'
+      preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRouteImport
+      parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRoute
+    }
   }
 }
 
@@ -569,6 +589,7 @@ interface WorkspacesWidLayoutProjectsPidLayoutRouteChildren {
   WorkspacesWidLayoutProjectsPidLayoutRunsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   WorkspacesWidLayoutProjectsPidLayoutIndexRoute: typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
 }
 
 const WorkspacesWidLayoutProjectsPidLayoutRouteChildren: WorkspacesWidLayoutProjectsPidLayoutRouteChildren =
@@ -579,6 +600,8 @@ const WorkspacesWidLayoutProjectsPidLayoutRouteChildren: WorkspacesWidLayoutProj
       WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute,
     WorkspacesWidLayoutProjectsPidLayoutIndexRoute:
       WorkspacesWidLayoutProjectsPidLayoutIndexRoute,
+    WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute:
+      WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute,
   }
 
 const WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren =

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs_.$rid.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs_.$rid.tsx
@@ -1,0 +1,11 @@
+import {ProjectRunDetailPage} from '@shipfox/client-projects';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$rid')({
+  component: ProjectRunDetailRoute,
+});
+
+function ProjectRunDetailRoute() {
+  const {pid, rid} = Route.useParams();
+  return <ProjectRunDetailPage projectId={pid} runId={rid} />;
+}


### PR DESCRIPTION
<!-- stk:begin -->
## Stack

Part 1 of 2.

Depends on: none
Next: #193

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #192 | `workflow-execution-dashboard/04-run-detail-frame` | `workflow-execution-dashboard/03-run-source-snapshot` |
| 2 | #193 | `workflow-execution-dashboard/05-graph-inspector` | `workflow-execution-dashboard/04-run-detail-frame` |

<!-- stk:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a workflow run detail page with a jobs graph, steps overview, logs placeholder, and workflow source snapshot. Run rows now link to a new run detail route, with a left rail to browse and filter recent runs.

- **New Features**
  - New `ProjectRunDetailPage` (Overview, Logs, Source) with header, duration, status pill, and updated time.
  - Jobs graph and steps list for the selected job; defaults to failed, then running, else first job.
  - Run history rail with status filters (all/failed/running) and text search; highlights the selected run.
  - Added route `/workspaces/$wid/projects/$pid/runs/$rid` via `@tanstack/react-router` and exported the page from `@shipfox/client-projects`.
  - `RunRow` is now a `Link` to the detail route; runs list passes `workspaceId`.
  - New `run-status.tsx`: `RunStatusPill`, `isTerminalRunStatus`, and `runStatusVariant`; durations use `humanDurationMs` for terminal runs and “running …” for active runs.

<sup>Written for commit 733287883b481562b08b596f9661c0404a1bd0c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

