### PR TITLE
Add workflow run graph inspector

### DIFF
--- a/libs/client/projects/src/pages/project-run-detail-page.test.tsx
+++ b/libs/client/projects/src/pages/project-run-detail-page.test.tsx
@@ -8,6 +8,12 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
 const SOURCE_TAB_RE = /Source/i;
 const SOURCE_NAME_RE = /name: Deploy production/;
+const BUILD_JOB_RE = /^build\s+succeeded/;
+const ARTIFACT_OUTPUT_RE = /"artifact": "dist\/app\.tar\.gz"/;
+const LOCKFILE_OUTPUT_RE = /"lockfile": "stale"/;
+const ATTEMPT_1_RE = /Attempt 1 failed/;
+const CLEANUP_STEP_RE = /Cleanup/;
+const MONITOR_JOB_RE = /^monitor\s+running/;
 
 describe('ProjectRunDetailPage', () => {
   test('renders the run detail frame from API data', async () => {
@@ -22,7 +28,7 @@ describe('ProjectRunDetailPage', () => {
     expect(screen.getAllByText('Runs')).not.toHaveLength(0);
     expect(screen.getByText('Jobs graph')).toBeInTheDocument();
     expect(screen.getAllByText('deploy')).not.toHaveLength(0);
-    expect(screen.getByText('Install')).toBeInTheDocument();
+    expect(screen.getAllByText('Install')).not.toHaveLength(0);
 
     const sourceButtons = screen.getAllByRole('button', {name: SOURCE_TAB_RE});
     const sourceButton = sourceButtons.at(-1);
@@ -52,6 +58,85 @@ describe('ProjectRunDetailPage', () => {
     fireEvent.change(screen.getByLabelText('Filter runs'), {target: {value: 'cleanup'}});
 
     expect(screen.getByText('No runs match.')).toBeInTheDocument();
+  });
+
+  test('updates the inspector when a different job is selected in the graph', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+      <ProjectRunDetailPage projectId={PROJECT_ID} runId={RUN_ID} />,
+    );
+
+    expect(await screen.findByText('Root cause')).toBeInTheDocument();
+    expect(screen.getByText('Package lock mismatch')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: BUILD_JOB_RE}));
+
+    expect(screen.getAllByText('Compile assets')).not.toHaveLength(0);
+    expect(screen.queryByText('Package lock mismatch')).not.toBeInTheDocument();
+    expect(screen.getByText(ARTIFACT_OUTPUT_RE)).toBeInTheDocument();
+  });
+
+  test('shows attempt, gate, output, and empty-attempt details for selected steps', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+      <ProjectRunDetailPage projectId={PROJECT_ID} runId={RUN_ID} />,
+    );
+
+    expect(await screen.findByText('Gate')).toBeInTheDocument();
+    expect(screen.getByText('gate rejected deploy artifacts')).toBeInTheDocument();
+    expect(screen.getByText(LOCKFILE_OUTPUT_RE)).toBeInTheDocument();
+
+    const firstAttemptButton = screen.getAllByRole('button', {name: ATTEMPT_1_RE}).at(0);
+    if (!firstAttemptButton) throw new Error('Attempt 1 button not rendered');
+    fireEvent.click(firstAttemptButton);
+
+    expect(screen.getByText('Registry timeout')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: CLEANUP_STEP_RE}));
+
+    expect(screen.getByText('No attempts have been recorded for this step.')).toBeInTheDocument();
+  });
+
+  test('keeps the inspector tab while selecting another attempt', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+      <ProjectRunDetailPage projectId={PROJECT_ID} runId={RUN_ID} />,
+    );
+
+    expect(await screen.findByText('Root cause')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', {name: 'Logs'}));
+    expect(screen.getByText('attempt #2')).toBeInTheDocument();
+
+    const firstAttemptButton = screen.getAllByRole('button', {name: ATTEMPT_1_RE}).at(0);
+    if (!firstAttemptButton) throw new Error('Attempt 1 button not rendered');
+    fireEvent.click(firstAttemptButton);
+
+    expect(screen.getByText('attempt #1')).toBeInTheDocument();
+    expect(screen.getByText('Log rows will appear here when available.')).toBeInTheDocument();
+  });
+
+  test('shows the active step callout for a running job', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}`,
+      <ProjectRunDetailPage projectId={PROJECT_ID} runId={RUN_ID} />,
+    );
+
+    await screen.findByText('Root cause');
+
+    fireEvent.click(screen.getByRole('button', {name: MONITOR_JOB_RE}));
+
+    expect(screen.getByText('Active step')).toBeInTheDocument();
+    expect(screen.getByText('Currently running.')).toBeInTheDocument();
+    expect(screen.getAllByText('Wait for health check')).not.toHaveLength(0);
   });
 });
 
@@ -118,12 +203,56 @@ function runDetailDto() {
     workflow_model: {kind: 'workflow', name: 'Deploy production'},
     jobs: [
       {
+        id: '11111111-1111-4111-8111-111111111111',
+        run_id: RUN_ID,
+        name: 'build',
+        status: 'succeeded',
+        dependencies: [],
+        position: 0,
+        duration_ms: 52_000,
+        created_at: '2026-05-13T00:00:00.000Z',
+        updated_at: '2026-05-13T00:00:52.000Z',
+        steps: [
+          {
+            id: '22222222-2222-4222-8222-222222222222',
+            job_id: '11111111-1111-4111-8111-111111111111',
+            name: 'Compile assets',
+            status: 'succeeded',
+            type: 'run',
+            config: {run: 'pnpm build'},
+            error: null,
+            position: 1,
+            current_attempt: 1,
+            duration_ms: 52_000,
+            created_at: '2026-05-13T00:00:00.000Z',
+            updated_at: '2026-05-13T00:00:52.000Z',
+            attempts: [
+              {
+                id: '33333333-3333-4333-8333-333333333333',
+                step_id: '22222222-2222-4222-8222-222222222222',
+                job_id: '11111111-1111-4111-8111-111111111111',
+                attempt: 1,
+                status: 'succeeded',
+                exit_code: 0,
+                output: {artifact: 'dist/app.tar.gz'},
+                error: null,
+                gate_result: null,
+                restart_reason: null,
+                duration_ms: 52_000,
+                started_at: '2026-05-13T00:00:00.000Z',
+                finished_at: '2026-05-13T00:00:52.000Z',
+              },
+            ],
+          },
+        ],
+      },
+      {
         id: '77777777-7777-4777-8777-777777777777',
         run_id: RUN_ID,
         name: 'deploy',
         status: 'failed',
-        dependencies: [],
-        position: 0,
+        dependencies: ['build'],
+        position: 1,
         duration_ms: 134_000,
         created_at: '2026-05-13T00:00:00.000Z',
         updated_at: '2026-05-13T00:02:14.000Z',
@@ -135,9 +264,9 @@ function runDetailDto() {
             status: 'failed',
             type: 'run',
             config: {run: 'pnpm install'},
-            error: {message: 'Install failed', reason: 'command_failed'},
+            error: {message: 'Package lock mismatch', reason: 'setup_aborted'},
             position: 1,
-            current_attempt: 1,
+            current_attempt: 2,
             duration_ms: 42_000,
             created_at: '2026-05-13T00:00:00.000Z',
             updated_at: '2026-05-13T00:00:42.000Z',
@@ -150,12 +279,86 @@ function runDetailDto() {
                 status: 'failed',
                 exit_code: 1,
                 output: null,
-                error: {message: 'Install failed'},
+                error: {message: 'Registry timeout'},
+                gate_result: null,
+                restart_reason: 'retry install after registry timeout',
+                duration_ms: 20_000,
+                started_at: '2026-05-13T00:00:00.000Z',
+                finished_at: '2026-05-13T00:00:20.000Z',
+              },
+              {
+                id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                step_id: '88888888-8888-4888-8888-888888888888',
+                job_id: '77777777-7777-4777-8777-777777777777',
+                attempt: 2,
+                status: 'failed',
+                exit_code: 1,
+                output: {lockfile: 'stale', attempt: 'retry'},
+                error: {message: 'Package lock mismatch'},
+                gate_result: {passed: false, expression: 'exit_code == 0', exit_code: 1},
+                restart_reason: 'gate rejected deploy artifacts',
+                duration_ms: 22_000,
+                started_at: '2026-05-13T00:00:20.000Z',
+                finished_at: '2026-05-13T00:00:42.000Z',
+              },
+            ],
+          },
+          {
+            id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            job_id: '77777777-7777-4777-8777-777777777777',
+            name: 'Cleanup',
+            status: 'pending',
+            type: 'run',
+            config: {run: 'pnpm cleanup'},
+            error: null,
+            position: 2,
+            current_attempt: 1,
+            duration_ms: 0,
+            created_at: '2026-05-13T00:00:42.000Z',
+            updated_at: '2026-05-13T00:00:42.000Z',
+            attempts: [],
+          },
+        ],
+      },
+      {
+        id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+        run_id: RUN_ID,
+        name: 'monitor',
+        status: 'running',
+        dependencies: ['deploy'],
+        position: 2,
+        duration_ms: 0,
+        created_at: '2026-05-13T00:02:00.000Z',
+        updated_at: '2026-05-13T00:02:14.000Z',
+        steps: [
+          {
+            id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+            job_id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            name: 'Wait for health check',
+            status: 'running',
+            type: 'run',
+            config: {run: 'curl --fail https://shipfox.example/health'},
+            error: null,
+            position: 1,
+            current_attempt: 1,
+            duration_ms: 0,
+            created_at: '2026-05-13T00:02:00.000Z',
+            updated_at: '2026-05-13T00:02:14.000Z',
+            attempts: [
+              {
+                id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+                step_id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+                job_id: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+                attempt: 1,
+                status: 'running',
+                exit_code: null,
+                output: null,
+                error: null,
                 gate_result: null,
                 restart_reason: null,
-                duration_ms: 42_000,
-                started_at: '2026-05-13T00:00:00.000Z',
-                finished_at: '2026-05-13T00:00:42.000Z',
+                duration_ms: 0,
+                started_at: '2026-05-13T00:02:00.000Z',
+                finished_at: null,
               },
             ],
           },

--- a/libs/client/projects/src/pages/project-run-detail-page.tsx
+++ b/libs/client/projects/src/pages/project-run-detail-page.tsx
@@ -2,7 +2,8 @@ import type {RunDetailDto, RunDto} from '@shipfox/api-workflows-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Button, Code, EmptyState, Header, Icon, Skeleton, Text} from '@shipfox/react-ui';
 import {Link, useParams} from '@tanstack/react-router';
-import {useMemo, useState} from 'react';
+import type {MouseEvent, ReactNode} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import {isTerminalRunStatus, RunStatusPill, runStatusVariant} from '#components/run-status.js';
 import {StatusDot, type StatusDotVariant} from '#components/status-dot.js';
 import {useWorkflowRunQuery, useWorkflowRunsInfiniteQuery} from '#hooks/api/workflow-runs.js';
@@ -13,6 +14,7 @@ type DetailMode = 'overview' | 'logs' | 'source';
 type RailFilter = 'all' | 'failed' | 'running';
 type DetailJob = RunDetailDto['jobs'][number];
 type DetailStep = DetailJob['steps'][number];
+type DetailAttempt = DetailStep['attempts'][number];
 
 export function ProjectRunDetailPage({projectId, runId}: {projectId: string; runId: string}) {
   return (
@@ -225,39 +227,114 @@ function RailRunLink({
 
 function RunWorkspace({run, workspaceId}: {run: RunDetailDto; workspaceId: string}) {
   const [mode, setMode] = useState<DetailMode>('overview');
-  const selectedJob = chooseSelectedJob(run);
+  const defaultJob = chooseSelectedJob(run);
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(defaultJob?.id ?? null);
+  const selectedJob = run.jobs.find((job) => job.id === selectedJobId) ?? defaultJob;
+  const defaultStep = chooseSelectedStep(selectedJob);
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(defaultStep?.id ?? null);
+  const selectedStep = selectedJob?.steps.find((step) => step.id === selectedStepId) ?? defaultStep;
+  const defaultAttempt = chooseSelectedAttempt(selectedStep);
+  const [selectedAttemptNumber, setSelectedAttemptNumber] = useState<number | null>(
+    defaultAttempt?.attempt ?? null,
+  );
+  const selectedAttempt =
+    selectedStep?.attempts.find((attempt) => attempt.attempt === selectedAttemptNumber) ??
+    defaultAttempt;
+
+  useEffect(() => {
+    setSelectedJobId((current) =>
+      current && run.jobs.some((job) => job.id === current) ? current : (defaultJob?.id ?? null),
+    );
+  }, [run.jobs, defaultJob?.id]);
+
+  useEffect(() => {
+    setSelectedStepId((current) =>
+      current && selectedJob?.steps.some((step) => step.id === current)
+        ? current
+        : (defaultStep?.id ?? null),
+    );
+  }, [selectedJob?.steps, defaultStep?.id]);
+
+  useEffect(() => {
+    setSelectedAttemptNumber((current) =>
+      current && selectedStep?.attempts.some((attempt) => attempt.attempt === current)
+        ? current
+        : (defaultAttempt?.attempt ?? null),
+    );
+  }, [selectedStep?.attempts, defaultAttempt?.attempt]);
+
+  function selectJob(jobId: string) {
+    const nextJob = run.jobs.find((job) => job.id === jobId) ?? null;
+    const nextStep = chooseSelectedStep(nextJob);
+    const nextAttempt = chooseSelectedAttempt(nextStep);
+    setSelectedJobId(nextJob?.id ?? null);
+    setSelectedStepId(nextStep?.id ?? null);
+    setSelectedAttemptNumber(nextAttempt?.attempt ?? null);
+    setMode('overview');
+  }
+
+  function selectStep(stepId: string, attemptNumber?: number) {
+    const nextStep = selectedJob?.steps.find((step) => step.id === stepId) ?? null;
+    const nextAttempt =
+      attemptNumber == null
+        ? chooseSelectedAttempt(nextStep)
+        : (nextStep?.attempts.find((attempt) => attempt.attempt === attemptNumber) ?? null);
+    setSelectedStepId(nextStep?.id ?? null);
+    setSelectedAttemptNumber(nextAttempt?.attempt ?? null);
+  }
 
   return (
     <section className="flex min-w-0 flex-1 flex-col bg-background-neutral-subtle">
       <RunHeader run={run} workspaceId={workspaceId} onSource={() => setMode('source')} />
-      <main className="min-h-0 flex-1 overflow-y-auto">
-        <div className="px-20 pt-18 pb-6">
-          <div className="flex items-center justify-between gap-12 pb-10">
-            <Text
-              size="xs"
-              bold
-              className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
-            >
-              Jobs graph
-            </Text>
-          </div>
-          <JobsGraph run={run} selectedJob={selectedJob} />
-        </div>
-        <div className="px-20 pt-12 pb-22">
-          <div className="sticky top-0 z-10 -mx-20 flex flex-wrap items-center justify-between gap-10 border-y border-border-neutral-base bg-background-neutral-subtle px-20 py-10">
-            <div className="min-w-0">
+      <main className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="min-w-0 flex-1 overflow-y-auto">
+          <div className="px-20 pt-18 pb-6">
+            <div className="flex items-center justify-between gap-12 pb-10">
               <Text
                 size="xs"
                 bold
                 className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
               >
-                {selectedJob?.name ?? 'Run'} <span className="font-normal">· steps</span>
+                Jobs graph
               </Text>
             </div>
-            <ModeTabs value={mode} onChange={setMode} />
+            <JobsGraph run={run} selectedJob={selectedJob} onSelectJob={selectJob} />
           </div>
-          <ModePanel mode={mode} run={run} job={selectedJob} />
+          <div className="px-20 pt-12 pb-22">
+            <div className="sticky top-0 z-10 -mx-20 flex flex-wrap items-center justify-between gap-10 border-y border-border-neutral-base bg-background-neutral-subtle px-20 py-10">
+              <div className="min-w-0">
+                <Text
+                  size="xs"
+                  bold
+                  className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
+                >
+                  {selectedJob?.name ?? 'Run'} <span className="font-normal">· step lane</span>
+                </Text>
+              </div>
+              <Text size="xs" className="text-foreground-neutral-muted tabular-nums">
+                {selectedJob?.steps.length ?? 0} steps
+              </Text>
+            </div>
+            <StepLane
+              job={selectedJob}
+              selectedStep={selectedStep}
+              selectedAttempt={selectedAttempt}
+              onSelectStep={selectStep}
+            />
+          </div>
         </div>
+        <SelectionInspector
+          mode={mode}
+          run={run}
+          job={selectedJob}
+          step={selectedStep}
+          attempt={selectedAttempt}
+          onMode={setMode}
+          onSelectAttempt={(attemptNumber) => {
+            if (!selectedStep) return;
+            selectStep(selectedStep.id, attemptNumber);
+          }}
+        />
       </main>
     </section>
   );
@@ -334,9 +411,21 @@ function RunHeader({
   );
 }
 
-function JobsGraph({run, selectedJob}: {run: RunDetailDto; selectedJob: DetailJob | null}) {
+function JobsGraph({
+  run,
+  selectedJob,
+  onSelectJob,
+}: {
+  run: RunDetailDto;
+  selectedJob: DetailJob | null;
+  onSelectJob: (jobId: string) => void;
+}) {
+  const scrollSelectedJobIntoView = useCallback((node: HTMLDivElement | null) => {
+    node?.scrollIntoView({block: 'nearest', inline: 'center'});
+  }, []);
+
   return (
-    <div className="flex gap-0 overflow-x-auto pb-8">
+    <section className="flex gap-0 overflow-x-auto pb-8" aria-label="Workflow jobs graph">
       <div className="flex shrink-0 items-center gap-9 rounded-8 border border-border-neutral-base bg-background-components-base px-11 py-9">
         <div className="flex size-26 items-center justify-center rounded-6 border border-border-neutral-base bg-background-neutral-base text-foreground-neutral-muted">
           <Icon name="pulseLine" className="size-16" />
@@ -352,12 +441,16 @@ function JobsGraph({run, selectedJob}: {run: RunDetailDto; selectedJob: DetailJo
       </div>
       <Connector />
       {run.jobs.map((job, index) => (
-        <div key={job.id} className="flex shrink-0 items-center">
+        <div
+          key={job.id}
+          ref={job.id === selectedJob?.id ? scrollSelectedJobIntoView : undefined}
+          className="flex shrink-0 items-center"
+        >
           {index > 0 ? <Connector /> : null}
-          <JobNode job={job} selected={job.id === selectedJob?.id} />
+          <JobNode job={job} selected={job.id === selectedJob?.id} onSelect={onSelectJob} />
         </div>
       ))}
-    </div>
+    </section>
   );
 }
 
@@ -370,11 +463,24 @@ function Connector() {
   );
 }
 
-function JobNode({job, selected}: {job: DetailJob; selected: boolean}) {
+function JobNode({
+  job,
+  selected,
+  onSelect,
+}: {
+  job: DetailJob;
+  selected: boolean;
+  onSelect: (jobId: string) => void;
+}) {
   return (
-    <div
-      className={`flex w-204 shrink-0 flex-col gap-9 overflow-hidden rounded-8 border bg-background-neutral-base px-12 py-11 shadow-border-base ${
-        selected ? 'border-foreground-neutral-muted' : 'border-border-neutral-base'
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={() => onSelect(job.id)}
+      className={`flex w-204 shrink-0 flex-col gap-9 overflow-hidden rounded-8 border bg-background-neutral-base px-12 py-11 text-left shadow-border-base transition-colors hover:bg-background-components-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive ${
+        selected
+          ? 'border-border-highlights-interactive bg-background-highlight-base'
+          : 'border-border-neutral-base'
       }`}
     >
       <div className="flex min-w-0 items-center gap-8">
@@ -392,7 +498,7 @@ function JobNode({job, selected}: {job: DetailJob; selected: boolean}) {
           {job.dependencies.length ? `needs ${job.dependencies.join(', ')}` : 'root job'}
         </Text>
       </div>
-    </div>
+    </button>
   );
 }
 
@@ -447,16 +553,20 @@ function ModeTabs({value, onChange}: {value: DetailMode; onChange: (value: Detai
   );
 }
 
-function ModePanel({mode, run, job}: {mode: DetailMode; run: RunDetailDto; job: DetailJob | null}) {
-  if (mode === 'source') return <SourceShell run={run} />;
-  if (mode === 'logs') return <LogsShell job={job} />;
-  return <OverviewShell job={job} />;
-}
-
-function OverviewShell({job}: {job: DetailJob | null}) {
+function StepLane({
+  job,
+  selectedStep,
+  selectedAttempt,
+  onSelectStep,
+}: {
+  job: DetailJob | null;
+  selectedStep: DetailStep | null;
+  selectedAttempt: DetailAttempt | null;
+  onSelectStep: (stepId: string, attemptNumber?: number) => void;
+}) {
   if (!job) {
     return (
-      <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
+      <div className="mt-10 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
         <Text size="sm" className="text-foreground-neutral-muted">
           No jobs were recorded for this run.
         </Text>
@@ -465,43 +575,470 @@ function OverviewShell({job}: {job: DetailJob | null}) {
   }
 
   return (
-    <div className="flex flex-col gap-4 pt-10">
-      {job.steps.map((step, index) => (
-        <StepShellRow key={step.id} step={step} index={index} />
-      ))}
+    <div className="mt-10 overflow-x-auto rounded-8 border border-border-neutral-base bg-background-neutral-base p-12">
+      {job.steps.length === 0 ? (
+        <Text size="sm" className="text-foreground-neutral-muted">
+          This job has no recorded steps.
+        </Text>
+      ) : (
+        <div className="flex min-w-max items-stretch">
+          {job.steps.map((step, index) => (
+            <div key={step.id} className="flex items-center">
+              {index > 0 ? <Connector /> : null}
+              <StepNode
+                step={step}
+                index={index}
+                selected={step.id === selectedStep?.id}
+                selectedAttempt={selectedAttempt}
+                onSelect={onSelectStep}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
-function StepShellRow({step, index}: {step: DetailStep; index: number}) {
+function StepNode({
+  step,
+  index,
+  selected,
+  selectedAttempt,
+  onSelect,
+}: {
+  step: DetailStep;
+  index: number;
+  selected: boolean;
+  selectedAttempt: DetailAttempt | null;
+  onSelect: (stepId: string, attemptNumber?: number) => void;
+}) {
+  const label = stepLabel(step);
+
   return (
-    <div className="flex items-center gap-10 rounded-8 border border-border-neutral-base bg-background-neutral-base px-12 py-9 shadow-sm">
-      <Code variant="label" className="w-18 text-foreground-neutral-disabled">
-        {index + 1}
-      </Code>
-      <StatusDot variant={statusVariant(step.status)} pulse={step.status === 'running'} />
-      <Text size="sm" bold className="min-w-0 flex-1 truncate font-mono">
-        {step.name ?? step.type}
+    <div
+      className={`flex w-220 shrink-0 flex-col gap-9 rounded-8 border px-12 py-10 text-left transition-colors hover:bg-background-components-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive ${
+        selected
+          ? 'border-border-highlights-interactive bg-background-highlight-base'
+          : 'border-border-neutral-base bg-background-neutral-base'
+      }`}
+    >
+      <button
+        type="button"
+        aria-pressed={selected}
+        onClick={() => onSelect(step.id)}
+        className="flex flex-col gap-9 rounded-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive"
+      >
+        <div className="flex min-w-0 items-center gap-8">
+          <Code variant="label" className="w-18 text-foreground-neutral-disabled">
+            {String(index + 1).padStart(2, '0')}
+          </Code>
+          <StatusDot variant={statusVariant(step.status)} pulse={step.status === 'running'} />
+          <Text size="sm" bold className="min-w-0 flex-1 truncate font-mono">
+            {label}
+          </Text>
+        </div>
+        <div className="flex items-center justify-between gap-8">
+          <GenericStatusPill status={step.status} />
+          <Code variant="label" className="text-foreground-neutral-muted">
+            {humanDurationMs(step.duration_ms)}
+          </Code>
+        </div>
+      </button>
+      {step.attempts.length > 0 ? (
+        <div className="flex flex-wrap gap-5">
+          {step.attempts.map((attempt) => (
+            <AttemptChip
+              key={attempt.id}
+              attempt={attempt}
+              selected={selected && attempt.attempt === selectedAttempt?.attempt}
+              onSelect={(event) => {
+                event.stopPropagation();
+                onSelect(step.id, attempt.attempt);
+              }}
+            />
+          ))}
+        </div>
+      ) : (
+        <Code variant="label" className="text-foreground-neutral-muted">
+          {step.status === 'pending' ? 'not started' : 'not run'}
+        </Code>
+      )}
+    </div>
+  );
+}
+
+function AttemptChip({
+  attempt,
+  selected,
+  onSelect,
+}: {
+  attempt: DetailAttempt;
+  selected: boolean;
+  onSelect: (event: MouseEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`Attempt ${attempt.attempt} ${attempt.status}`}
+      aria-pressed={selected}
+      onClick={onSelect}
+      className={`inline-flex h-22 items-center gap-4 rounded-4 border px-6 text-xs font-mono transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive ${
+        selected
+          ? 'border-border-highlights-interactive bg-background-highlight-interactive text-foreground-neutral-on-color'
+          : `${statusSurfaceClass(attempt.status)} hover:bg-background-components-hover`
+      }`}
+    >
+      #{attempt.attempt}
+      <StatusDot variant={statusVariant(attempt.status)} pulse={attempt.status === 'running'} />
+    </button>
+  );
+}
+
+function SelectionInspector({
+  mode,
+  run,
+  job,
+  step,
+  attempt,
+  onMode,
+  onSelectAttempt,
+}: {
+  mode: DetailMode;
+  run: RunDetailDto;
+  job: DetailJob | null;
+  step: DetailStep | null;
+  attempt: DetailAttempt | null;
+  onMode: (mode: DetailMode) => void;
+  onSelectAttempt: (attemptNumber: number) => void;
+}) {
+  return (
+    <aside className="flex w-380 shrink-0 flex-col border-l border-border-neutral-base bg-background-neutral-base max-[1120px]:hidden">
+      <div className="border-b border-border-neutral-base px-14 py-12">
+        <div className="flex min-w-0 items-center gap-5 pb-10 text-xs text-foreground-neutral-muted">
+          <Code variant="label">#{run.id.slice(0, 8)}</Code>
+          {job ? (
+            <>
+              <Icon name="arrowRightSLine" className="size-13" />
+              <Code variant="label" className="truncate">
+                {job.name}
+              </Code>
+            </>
+          ) : null}
+          {step ? (
+            <>
+              <Icon name="arrowRightSLine" className="size-13" />
+              <Code variant="label" className="truncate">
+                {stepLabel(step)}
+              </Code>
+            </>
+          ) : null}
+          {attempt ? (
+            <>
+              <Icon name="arrowRightSLine" className="size-13" />
+              <Code variant="label">#{attempt.attempt}</Code>
+            </>
+          ) : null}
+        </div>
+        <div className="flex min-w-0 items-center gap-8 pb-12">
+          <StatusDot variant={statusVariant(step?.status ?? job?.status ?? run.status)} />
+          <Text size="sm" bold className="min-w-0 flex-1 truncate font-mono">
+            {step ? stepLabel(step) : (job?.name ?? run.name)}
+          </Text>
+          <GenericStatusPill status={step?.status ?? job?.status ?? run.status} />
+        </div>
+        <ModeTabs value={mode} onChange={onMode} />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {!step ? (
+          <div className="px-16 py-24">
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Select a step in the lane to inspect status, attempts, output, gates and source.
+            </Text>
+          </div>
+        ) : mode === 'source' ? (
+          <SourceShell run={run} />
+        ) : mode === 'logs' ? (
+          <LogsShell job={job} step={step} attempt={attempt} />
+        ) : (
+          <InspectorOverview
+            run={run}
+            job={job}
+            step={step}
+            attempt={attempt}
+            onSelectAttempt={onSelectAttempt}
+          />
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function InspectorOverview({
+  run,
+  job,
+  step,
+  attempt,
+  onSelectAttempt,
+}: {
+  run: RunDetailDto;
+  job: DetailJob | null;
+  step: DetailStep;
+  attempt: DetailAttempt | null;
+  onSelectAttempt: (attemptNumber: number) => void;
+}) {
+  const command = stepCommand(step);
+  const showRootCause =
+    step.status === 'failed' ||
+    step.status === 'running' ||
+    attempt?.status === 'failed' ||
+    attempt?.status === 'running';
+
+  return (
+    <div className="flex flex-col gap-12 px-14 py-12">
+      {showRootCause ? <RootCauseCard run={run} step={step} attempt={attempt} /> : null}
+
+      <div className="rounded-8 border border-border-neutral-base bg-background-subtle-base p-10">
+        <div className="mb-7 flex items-center justify-between gap-8">
+          <Text
+            size="xs"
+            bold
+            className="uppercase tracking-[0.07em] text-foreground-neutral-muted"
+          >
+            Command
+          </Text>
+          <Code variant="label" className="text-foreground-neutral-muted">
+            {step.type}
+          </Code>
+        </div>
+        <pre className="max-h-112 overflow-auto whitespace-pre-wrap rounded-6 border border-border-neutral-base bg-background-neutral-base p-8 text-xs leading-18 text-foreground-neutral-base">
+          {command}
+        </pre>
+      </div>
+
+      <InspectorSection title="Details">
+        <InspectorKeyValue label="job" value={job?.name ?? 'run'} />
+        <InspectorKeyValue label="step" value={stepLabel(step)} />
+        <InspectorKeyValue label="duration" value={humanDurationMs(step.duration_ms)} />
+        <InspectorKeyValue label="attempts" value={String(step.attempts.length)} />
+        {attempt?.exit_code != null ? (
+          <InspectorKeyValue label="exit code" value={String(attempt.exit_code)} />
+        ) : null}
+      </InspectorSection>
+
+      {attempt?.gate_result ? <GateCard gateResult={attempt.gate_result} /> : null}
+      {attempt?.restart_reason ? <RestartCard restartReason={attempt.restart_reason} /> : null}
+      {attempt?.output ? <JsonSection title="Output" value={attempt.output} /> : null}
+      {step.error || attempt?.error ? (
+        <JsonSection title="Error" value={attempt?.error ?? step.error ?? {}} tone="error" />
+      ) : null}
+
+      <AttemptHistory attempts={step.attempts} selected={attempt} onSelect={onSelectAttempt} />
+    </div>
+  );
+}
+
+function RootCauseCard({
+  run,
+  step,
+  attempt,
+}: {
+  run: RunDetailDto;
+  step: DetailStep;
+  attempt: DetailAttempt | null;
+}) {
+  const running = step.status === 'running' || attempt?.status === 'running';
+  const isDefaultFailure = chooseSelectedStep(chooseSelectedJob(run))?.id === step.id;
+  const title = running ? 'Active step' : isDefaultFailure ? 'Root cause' : 'Step failure';
+  const message =
+    extractErrorMessage(attempt?.error) ??
+    step.error?.message ??
+    (attempt?.gate_result ? gateResultSummary(attempt.gate_result, attempt.exit_code) : null) ??
+    (attempt?.exit_code != null ? `Failed with exit code ${attempt.exit_code}.` : null) ??
+    (running ? 'Currently running.' : `${run.status} at ${stepLabel(step)}.`);
+
+  return (
+    <div
+      className={`rounded-8 border p-11 ${
+        running
+          ? 'border-tag-blue-border bg-tag-blue-bg text-tag-blue-text'
+          : 'border-tag-error-border bg-tag-error-bg text-tag-error-text'
+      }`}
+    >
+      <div className="mb-6 flex items-center gap-7">
+        <Icon name={running ? 'loader4Line' : 'errorWarningLine'} className="size-14" />
+        <Text size="sm" bold>
+          {title}
+        </Text>
+      </div>
+      <Text size="sm">{message}</Text>
+    </div>
+  );
+}
+
+function GateCard({gateResult}: {gateResult: Record<string, unknown>}) {
+  const passed = gatePassed(gateResult);
+  return (
+    <InspectorSection title="Gate">
+      <div
+        className={`rounded-6 border p-9 ${
+          passed === false
+            ? 'border-tag-error-border bg-tag-error-bg text-tag-error-text'
+            : passed === true
+              ? 'border-tag-success-border bg-tag-success-bg text-tag-success-text'
+              : 'border-border-neutral-base bg-background-subtle-base'
+        }`}
+      >
+        <div className="mb-6 flex items-center gap-7">
+          <Icon
+            name={passed === false ? 'shieldFlashLine' : 'shieldCheckLine'}
+            className="size-14"
+          />
+          <Text size="sm" bold>
+            {passed === false ? 'Gate failed' : passed === true ? 'Gate passed' : 'Gate result'}
+          </Text>
+        </div>
+        <pre className="overflow-auto whitespace-pre-wrap text-xs leading-18">
+          {compactJson(gateResult)}
+        </pre>
+      </div>
+    </InspectorSection>
+  );
+}
+
+function RestartCard({restartReason}: {restartReason: string}) {
+  return (
+    <InspectorSection title="Restart">
+      <div className="flex items-start gap-7 rounded-6 border border-border-neutral-base bg-background-subtle-base p-9">
+        <Icon name="restartLine" className="mt-2 size-14 text-foreground-neutral-muted" />
+        <Text size="sm" className="text-foreground-neutral-base">
+          {restartReason}
+        </Text>
+      </div>
+    </InspectorSection>
+  );
+}
+
+function JsonSection({
+  title,
+  value,
+  tone,
+}: {
+  title: string;
+  value: Record<string, unknown>;
+  tone?: 'error';
+}) {
+  return (
+    <InspectorSection title={title}>
+      <pre
+        className={`max-h-176 overflow-auto whitespace-pre-wrap rounded-6 border p-9 text-xs leading-18 ${
+          tone === 'error'
+            ? 'border-tag-error-border bg-tag-error-bg text-tag-error-text'
+            : 'border-border-neutral-base bg-background-subtle-base text-foreground-neutral-base'
+        }`}
+      >
+        {compactJson(value)}
+      </pre>
+    </InspectorSection>
+  );
+}
+
+function InspectorSection({title, children}: {title: string; children: ReactNode}) {
+  return (
+    <section className="flex flex-col gap-7">
+      <Text size="xs" bold className="uppercase tracking-[0.07em] text-foreground-neutral-muted">
+        {title}
       </Text>
+      {children}
+    </section>
+  );
+}
+
+function InspectorKeyValue({label, value}: {label: string; value: string}) {
+  return (
+    <div className="grid grid-cols-[90px_minmax(0,1fr)] gap-8 border-b border-border-neutral-base py-5 last:border-b-0">
       <Text size="xs" className="text-foreground-neutral-muted">
-        {step.attempts.length} attempts
+        {label}
       </Text>
-      <Code variant="label" className="w-56 text-right text-foreground-neutral-muted">
-        {humanDurationMs(step.duration_ms)}
+      <Code variant="label" className="min-w-0 truncate text-right">
+        {value}
       </Code>
     </div>
   );
 }
 
-function LogsShell({job}: {job: DetailJob | null}) {
+function AttemptHistory({
+  attempts,
+  selected,
+  onSelect,
+}: {
+  attempts: DetailAttempt[];
+  selected: DetailAttempt | null;
+  onSelect: (attemptNumber: number) => void;
+}) {
   return (
-    <div className="mt-10 overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
+    <InspectorSection title="Attempts">
+      {attempts.length === 0 ? (
+        <Text
+          size="sm"
+          className="rounded-6 border border-border-neutral-base bg-background-subtle-base p-10 text-foreground-neutral-muted"
+        >
+          No attempts have been recorded for this step.
+        </Text>
+      ) : (
+        <div className="flex flex-col gap-5">
+          {attempts.map((attempt) => (
+            <button
+              key={attempt.id}
+              type="button"
+              aria-pressed={attempt.attempt === selected?.attempt}
+              onClick={() => onSelect(attempt.attempt)}
+              className={`flex items-center gap-8 rounded-6 border px-9 py-7 text-left transition-colors hover:bg-background-components-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive ${
+                attempt.attempt === selected?.attempt
+                  ? 'border-border-highlights-interactive bg-background-highlight-base'
+                  : 'border-border-neutral-base bg-background-neutral-base'
+              }`}
+            >
+              <StatusDot
+                variant={statusVariant(attempt.status)}
+                pulse={attempt.status === 'running'}
+              />
+              <Code variant="label" className="w-42">
+                #{attempt.attempt}
+              </Code>
+              <Text size="xs" className="flex-1 text-foreground-neutral-muted">
+                {attempt.status}
+                {attempt.exit_code != null ? ` · exit ${attempt.exit_code}` : ''}
+              </Text>
+              <Code variant="label" className="text-foreground-neutral-muted">
+                {humanDurationMs(attempt.duration_ms)}
+              </Code>
+            </button>
+          ))}
+        </div>
+      )}
+    </InspectorSection>
+  );
+}
+
+function LogsShell({
+  job,
+  step,
+  attempt,
+}: {
+  job: DetailJob | null;
+  step: DetailStep | null;
+  attempt: DetailAttempt | null;
+}) {
+  return (
+    <div className="m-14 overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
       <div className="flex items-center justify-between border-b border-white/10 bg-background-contrast-subtle px-12 py-8">
         <Code variant="label" className="text-foreground-neutral-on-color">
-          {job ? `${job.name} logs` : 'run logs'}
+          {step ? `${stepLabel(step)} logs` : job ? `${job.name} logs` : 'run logs'}
         </Code>
         <Text size="xs" className="text-foreground-neutral-muted">
-          preview data
+          {attempt ? `attempt #${attempt.attempt}` : 'preview data'}
         </Text>
       </div>
       <div className="px-12 py-28 text-center">
@@ -516,7 +1053,7 @@ function LogsShell({job}: {job: DetailJob | null}) {
 function SourceShell({run}: {run: RunDetailDto}) {
   const source = run.workflow_source_yaml;
   return (
-    <div className="mt-10 overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
+    <div className="m-14 overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
       <div className="flex items-center justify-between border-b border-white/10 bg-background-contrast-subtle px-12 py-8">
         <Code variant="label" className="text-foreground-neutral-on-color">
           workflow.yaml
@@ -549,6 +1086,27 @@ function chooseSelectedJob(run: RunDetailDto) {
   );
 }
 
+function chooseSelectedStep(job: DetailJob | null | undefined) {
+  if (!job) return null;
+  return (
+    job.steps.find((step) => step.status === 'failed') ??
+    job.steps.find((step) => step.status === 'running') ??
+    job.steps[0] ??
+    null
+  );
+}
+
+function chooseSelectedAttempt(step: DetailStep | null | undefined) {
+  if (!step || step.attempts.length === 0) return null;
+  return (
+    step.attempts.find((attempt) => attempt.attempt === step.current_attempt) ??
+    step.attempts.find((attempt) => attempt.status === 'failed') ??
+    step.attempts.find((attempt) => attempt.status === 'running') ??
+    step.attempts.at(-1) ??
+    null
+  );
+}
+
 function toRunDto(run: RunDetailDto): RunDto {
   return {
     id: run.id,
@@ -572,4 +1130,48 @@ function statusVariant(status: string): StatusDotVariant {
   if (status === 'failed') return 'error';
   if (status === 'cancelled') return 'neutral';
   return 'neutral';
+}
+
+function statusSurfaceClass(status: string) {
+  if (status === 'failed') return 'border-tag-error-border bg-tag-error-bg text-tag-error-text';
+  if (status === 'succeeded') {
+    return 'border-tag-success-border bg-tag-success-bg text-tag-success-text';
+  }
+  if (status === 'running') return 'border-tag-blue-border bg-tag-blue-bg text-tag-blue-text';
+  return 'border-tag-neutral-border bg-tag-neutral-bg text-tag-neutral-text';
+}
+
+function stepLabel(step: DetailStep) {
+  return step.name ?? step.type;
+}
+
+function stepCommand(step: DetailStep) {
+  const run = step.config.run;
+  const command = step.config.command;
+  if (typeof run === 'string') return run;
+  if (typeof command === 'string') return command;
+  return compactJson(step.config);
+}
+
+function compactJson(value: unknown) {
+  return JSON.stringify(value, null, 2) ?? '';
+}
+
+function extractErrorMessage(value: Record<string, unknown> | null | undefined) {
+  const message = value?.message;
+  return typeof message === 'string' ? message : null;
+}
+
+function gatePassed(value: Record<string, unknown>) {
+  const passed = value.passed;
+  return typeof passed === 'boolean' ? passed : null;
+}
+
+function gateResultSummary(value: Record<string, unknown>, exitCode: number | null | undefined) {
+  const passed = gatePassed(value);
+  if (passed === false && exitCode != null)
+    return `Gate rejected the result with exit code ${exitCode}.`;
+  if (passed === false) return 'Gate rejected the result.';
+  if (passed === true) return 'Gate passed.';
+  return 'Gate result was recorded.';
 }


### PR DESCRIPTION
Adds the Phase 5 run detail graph and inspector behavior on top of the Phase 4 dashboard frame.

The frame previously selected the failed job implicitly and rendered placeholder step content. This makes job, step, and attempt selection interactive so a failed workflow run can be triaged from the overview before opening logs.

The implementation intentionally keeps Logs as a placeholder and uses the existing run-detail DTO blobs for gate, output, restart, and error display. Cycle ribbons, restart edges, richer log/source panes, copy controls, and key-value gate rendering are left for the logs/source/fidelity phase.

Design comparison was performed against the extracted Claude Design React source and preview screenshot. Claude consult findings around keyboard focus and preserving the active inspector tab across selection changes were applied before commit.

<!-- stk:begin -->
## Stack

Part 1 of 2.

Depends on: none
Next: #194

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #193 | `workflow-execution-dashboard/05-graph-inspector` | `workflow-execution-dashboard/04-run-detail-frame` |
| 2 | #194 | `workflow-execution-dashboard/06-logs-source-fidelity` | `workflow-execution-dashboard/05-graph-inspector` |

<!-- stk:end -->