### PR TITLE
Add the runner log capture pipeline

### DIFF
--- a/.changeset/eng-440-runner-log-capture.md
+++ b/.changeset/eng-440-runner-log-capture.md
@@ -3,9 +3,8 @@
 "@shipfox/runner-execution": minor
 "@shipfox/runner-protocol": minor
 "@shipfox/runner-orchestration": patch
-"@shipfox/api-workflows-dto": patch
 ---
 
-Add the runner-side log capture pipeline: per step attempt, the runner captures merged stdout/stderr, frames it as versioned NDJSON (runner-assigned timestamps, 16KB payload cap with UTF-8-safe splitting, ANSI preserved), write-through spools it to an append-only file under the job workspace, and uploads it with an offset-CAS protocol that resumes via a zero-length probe and dedupes. The step report now declares the stream's final raw length so the log module can mark it complete without the report blocking on drain. Output capture moves off the legacy in-memory 1MB buffer onto an `onOutput` sink.
+Add the runner-side log capture pipeline: per step attempt, the runner captures merged stdout/stderr, frames it as versioned NDJSON (runner-assigned timestamps, 16KB payload cap with UTF-8-safe splitting, ANSI preserved), write-through spools it to an append-only file under the job workspace, and uploads it with an offset-CAS protocol that resumes via a zero-length probe and dedupes. Output capture moves off the legacy in-memory 1MB buffer onto an `onOutput` sink.
 
 This consumes the `@shipfox/api-logs-dto` contract and the server `/logs` ingest route shipped by the log ingest foundation (ENG-439). Masking lands in a follow-up issue, so this pipeline must be enabled only once that exists.

--- a/.changeset/eng-440-runner-log-capture.md
+++ b/.changeset/eng-440-runner-log-capture.md
@@ -1,0 +1,11 @@
+---
+"@shipfox/runner-logs": minor
+"@shipfox/runner-execution": minor
+"@shipfox/runner-protocol": minor
+"@shipfox/runner-orchestration": patch
+"@shipfox/api-workflows-dto": patch
+---
+
+Add the runner-side log capture pipeline: per step attempt, the runner captures merged stdout/stderr, frames it as versioned NDJSON (runner-assigned timestamps, 16KB payload cap with UTF-8-safe splitting, ANSI preserved), write-through spools it to an append-only file under the job workspace, and uploads it with an offset-CAS protocol that resumes via a zero-length probe and dedupes. The step report now declares the stream's final raw length so the log module can mark it complete without the report blocking on drain. Output capture moves off the legacy in-memory 1MB buffer onto an `onOutput` sink.
+
+This consumes the `@shipfox/api-logs-dto` contract and the server `/logs` ingest route shipped by the log ingest foundation (ENG-439). Masking lands in a follow-up issue, so this pipeline must be enabled only once that exists.

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -50,3 +50,7 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_HEARTBEAT_INTERVAL_MS` | `10000` | Heartbeat tick interval for an in-flight job. |
 | `SHIPFOX_HEARTBEAT_MAX_STALE_MS` | `10000` | Max time a single heartbeat may stay outstanding before it is aborted. |
 | `ANTHROPIC_API_KEY` | none | Anthropic API key the embedded pi harness uses to run agent steps against Anthropic models. Read from the process environment. Unset or empty disables agent steps, which then fail at invocation; other step types are unaffected. |
+| `SHIPFOX_LOG_FLUSH_INTERVAL_MS` | `2000` | How often buffered step logs are uploaded. Bounds how much recent output is lost if the runner dies mid-step. |
+| `SHIPFOX_LOG_FLUSH_BYTES` | `262144` | Backlog size that triggers an early log upload before the interval elapses, so bursts do not wait for the timer. |
+| `SHIPFOX_LOG_SPOOL_MAX_BYTES` | `67108864` | Max not-yet-acknowledged log bytes kept on disk per step attempt. Beyond this, output is dropped and a gap marker is recorded. |
+| `SHIPFOX_LOG_DRAIN_TIMEOUT_MS` | `5000` | How long the runner waits at job end for in-flight log uploads before deleting the workspace. |

--- a/libs/api/workflows-dto/src/schemas/job-execution.ts
+++ b/libs/api/workflows-dto/src/schemas/job-execution.ts
@@ -56,6 +56,14 @@ export const reportStepBodySchema = z
       .describe(
         'Structured output captured for attempt history. Large textual logs are stored separately.',
       ),
+    log_stream_length: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe(
+        'Final length in raw NDJSON bytes of the attempt log stream. The log module marks the stream complete once its committed length reaches this value, so the report never blocks on log drain.',
+      ),
   })
   .refine((body) => (body.status === 'succeeded' ? body.error == null : body.error != null), {
     message: 'succeeded steps must not include an error and failed steps must include one',

--- a/libs/api/workflows-dto/src/schemas/job-execution.ts
+++ b/libs/api/workflows-dto/src/schemas/job-execution.ts
@@ -56,14 +56,6 @@ export const reportStepBodySchema = z
       .describe(
         'Structured output captured for attempt history. Large textual logs are stored separately.',
       ),
-    log_stream_length: z
-      .number()
-      .int()
-      .nonnegative()
-      .optional()
-      .describe(
-        'Final length in raw NDJSON bytes of the attempt log stream. The log module marks the stream complete once its committed length reaches this value, so the report never blocks on log drain.',
-      ),
   })
   .refine((body) => (body.status === 'succeeded' ? body.error == null : body.error != null), {
     message: 'succeeded steps must not include an error and failed steps must include one',

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -2,19 +2,35 @@ import {mkdtemp, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
-import {executeRunStep} from '#core/run-step.js';
+import {executeRunStep, type OutputSink} from '#core/run-step.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const ESRCH_REGEX = /ESRCH/;
 
+// Collects what the durable pipeline would receive, the way the runner now
+// captures step output (StepResult no longer carries it).
+function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
+  const chunks: Buffer[] = [];
+  const sources: string[] = [];
+  return {
+    sink: (chunk, source) => {
+      chunks.push(chunk);
+      sources.push(source);
+    },
+    text: () => Buffer.concat(chunks).toString(),
+    sources: () => sources,
+  };
+}
+
 describe('executeRunStep', () => {
   it('succeeds with exit code 0', async () => {
     const step = buildStep({config: {run: 'echo hello'}});
+    const output = collectOutput();
 
-    const result = await executeRunStep(step);
+    const result = await executeRunStep(step, {onOutput: output.sink});
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain('hello');
+    expect(output.text()).toContain('hello');
     expect(result.exit_code).toBe(0);
   });
 
@@ -28,25 +44,29 @@ describe('executeRunStep', () => {
     expect(result.exit_code).toBe(1);
   });
 
-  it('captures both stdout and stderr', async () => {
+  it('captures both stdout and stderr with their origin', async () => {
     const step = buildStep({config: {run: 'echo out && echo err >&2'}});
+    const output = collectOutput();
 
-    const result = await executeRunStep(step);
+    const result = await executeRunStep(step, {onOutput: output.sink});
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain('out');
-    expect(result.output).toContain('err');
+    expect(output.text()).toContain('out');
+    expect(output.text()).toContain('err');
+    expect(output.sources()).toContain('stdout');
+    expect(output.sources()).toContain('stderr');
   });
 
   it('returns failure for unsupported step type with the reason on error.message', async () => {
     const step = buildStep({type: 'docker', config: {image: 'node:20'}});
+    const output = collectOutput();
 
-    const result = await executeRunStep(step);
+    const result = await executeRunStep(step, {onOutput: output.sink});
 
     expect(result.success).toBe(false);
     expect(result.error?.message).toContain('Unsupported step type: docker');
     expect(result.error?.exit_code).toBeUndefined();
-    expect(result.output).toBe('');
+    expect(output.text()).toBe('');
   });
 
   it('returns failure when config.run is missing with the reason on error.message', async () => {
@@ -78,13 +98,14 @@ describe('executeRunStep', () => {
     const dir = await mkdtemp(join(tmpdir(), 'shipfox-cwd-test-'));
     try {
       const step = buildStep({config: {run: 'pwd'}});
+      const output = collectOutput();
 
-      const result = await executeRunStep(step, {cwd: dir});
+      const result = await executeRunStep(step, {cwd: dir, onOutput: output.sink});
 
       expect(result.success).toBe(true);
       // macOS resolves tmpdir() through a /private symlink, so match the unique
       // mkdtemp suffix rather than the full path.
-      expect(result.output).toContain(basename(dir));
+      expect(output.text()).toContain(basename(dir));
     } finally {
       await rm(dir, {recursive: true, force: true});
     }
@@ -94,12 +115,13 @@ describe('executeRunStep', () => {
     const step = buildStep({
       config: {run: 'echo first\necho second'},
     });
+    const output = collectOutput();
 
-    const result = await executeRunStep(step);
+    const result = await executeRunStep(step, {onOutput: output.sink});
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain('first');
-    expect(result.output).toContain('second');
+    expect(output.text()).toContain('first');
+    expect(output.text()).toContain('second');
   });
 
   it('fails on first error with pipefail', async () => {
@@ -130,8 +152,9 @@ describe('executeRunStep', () => {
     const step = buildStep({
       config: {run: 'sleep 30 & echo "GRANDCHILD_PID=$!"; wait'},
     });
+    const output = collectOutput();
     const ac = new AbortController();
-    const promise = executeRunStep(step, {signal: ac.signal});
+    const promise = executeRunStep(step, {signal: ac.signal, onOutput: output.sink});
 
     await new Promise((r) => setTimeout(r, 200));
     ac.abort();
@@ -139,7 +162,7 @@ describe('executeRunStep', () => {
     const result = await promise;
     expect(result.success).toBe(false);
 
-    const match = result.output.match(GRANDCHILD_PID_REGEX);
+    const match = output.text().match(GRANDCHILD_PID_REGEX);
     expect(match).not.toBeNull();
     const grandchildPid = Number(match?.[1]);
 

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -7,16 +7,25 @@ import type {StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {StepResult} from '#core/step-result.js';
 
-const MAX_OUTPUT_BYTES = 1024 * 1024; // 1MB
+/**
+ * Receives each captured output chunk with its origin pipe. The runner tees step
+ * output to its own stdout/stderr for container observability and, separately,
+ * feeds it here for the durable log pipeline. Durability and output caps (per-record,
+ * the unacked-backlog cap, and the server budget) are the sink's concern, not the
+ * executor's.
+ */
+export type OutputSink = (chunk: Buffer, source: 'stdout' | 'stderr') => void;
 
-export function executeRunStep(
-  step: StepDto,
-  options: {signal?: AbortSignal; cwd?: string} = {},
-): Promise<StepResult> {
+interface RunStepOptions {
+  signal?: AbortSignal;
+  cwd?: string;
+  onOutput?: OutputSink;
+}
+
+export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Promise<StepResult> {
   if (step.type !== 'run') {
     return Promise.resolve({
       success: false,
-      output: '',
       error: {message: `Unsupported step type: ${step.type}`},
       exit_code: null,
     });
@@ -26,7 +35,6 @@ export function executeRunStep(
   if (!command) {
     return Promise.resolve({
       success: false,
-      output: '',
       error: {message: 'Step config.run is missing or empty'},
       exit_code: null,
     });
@@ -35,10 +43,7 @@ export function executeRunStep(
   return runShellCommand(command, options);
 }
 
-async function runShellCommand(
-  command: string,
-  options: {signal?: AbortSignal; cwd?: string},
-): Promise<StepResult> {
+async function runShellCommand(command: string, options: RunStepOptions): Promise<StepResult> {
   const scriptPath = join(tmpdir(), `shipfox-runner-${randomUUID()}.sh`);
 
   try {
@@ -49,10 +54,7 @@ async function runShellCommand(
   }
 }
 
-function spawnAndCapture(
-  scriptPath: string,
-  options: {signal?: AbortSignal; cwd?: string},
-): Promise<StepResult> {
+function spawnAndCapture(scriptPath: string, options: RunStepOptions): Promise<StepResult> {
   return new Promise((resolve) => {
     const shell = findShell();
     const args =
@@ -69,27 +71,16 @@ function spawnAndCapture(
       cwd: options.cwd,
     });
 
-    let output = '';
-    let truncated = false;
-
-    const appendOutput = (chunk: Buffer) => {
-      const text = chunk.toString();
-      output += text;
-
-      if (Buffer.byteLength(output) > MAX_OUTPUT_BYTES) {
-        output = output.slice(-MAX_OUTPUT_BYTES);
-        truncated = true;
-      }
-    };
-
+    // stdout and stderr are two separate pipes, so the sink sees them merged by
+    // arrival order, not kernel/wall-clock order; origin is preserved per chunk.
     child.stdout.on('data', (chunk: Buffer) => {
       process.stdout.write(chunk);
-      appendOutput(chunk);
+      options.onOutput?.(chunk, 'stdout');
     });
 
     child.stderr.on('data', (chunk: Buffer) => {
       process.stderr.write(chunk);
-      appendOutput(chunk);
+      options.onOutput?.(chunk, 'stderr');
     });
 
     const killGroup = () => {
@@ -122,9 +113,8 @@ function spawnAndCapture(
 
     child.on('close', (code, signal) => {
       cleanupAbortListener();
-      const finalOutput = truncated ? `[output truncated]\n${output}` : output;
       if (code === 0) {
-        resolve({success: true, output: finalOutput, error: null, exit_code: 0});
+        resolve({success: true, error: null, exit_code: 0});
         return;
       }
       // code === null when the child was terminated by a signal (e.g. SIGKILL
@@ -137,7 +127,7 @@ function spawnAndCapture(
               ...(signal ? {signal} : {}),
             }
           : {message: `Command exited with code ${code}`, exit_code: code};
-      resolve({success: false, output: finalOutput, error, exit_code: code});
+      resolve({success: false, error, exit_code: code});
     });
 
     child.on('error', (err) => {
@@ -145,7 +135,6 @@ function spawnAndCapture(
       logger().error({err}, 'Failed to spawn shell process');
       resolve({
         success: false,
-        output: '',
         error: {message: `Failed to spawn process: ${err.message}`},
         exit_code: null,
       });

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -83,7 +83,7 @@ describe('executeSetupStep', () => {
       cwd: CWD,
       signal,
     });
-    expect(result).toEqual({success: true, output: '', error: null, exit_code: 0});
+    expect(result).toEqual({success: true, error: null, exit_code: 0});
   });
 
   it('checks git before minting a credential', async () => {

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -58,7 +58,7 @@ export async function executeSetupStep(params: {
     return fail(error, reason);
   }
 
-  return {success: true, output: '', error: null, exit_code: 0};
+  return {success: true, error: null, exit_code: 0};
 }
 
 const CHECKOUT_KIND_REASON: Record<CheckoutFailureKind, StepErrorReason> = {
@@ -108,7 +108,6 @@ function readErrorCode(error: HTTPError): string | undefined {
 function fail(error: unknown, reason: StepErrorReason): StepResult {
   return {
     success: false,
-    output: '',
     error: {message: error instanceof Error ? error.message : String(error), reason},
     exit_code: null,
   };

--- a/libs/runner/execution/src/core/step-result.ts
+++ b/libs/runner/execution/src/core/step-result.ts
@@ -2,10 +2,10 @@ import type {StepErrorDtoShape} from '@shipfox/api-workflows-dto';
 
 export interface StepResult {
   success: boolean;
-  // Captured stdout/stderr for runner-side observability and tests (the
-  // grandchild-PID extraction in run-step.test.ts depends on this). Never sent
-  // to the API: per-step logs are a separate concern (future S3-backed logs).
-  output: string;
+  // Buffered output a step produces in memory (e.g. an agent step's summary). Run
+  // steps leave it unset: their stdout/stderr streams through the log pipeline
+  // (onOutput sink) rather than being buffered here. Never sent to the API.
+  output?: string;
   // Populated when success is false. Null on success.
   error: StepErrorDtoShape;
   // 0 on success, the exit code on failure, null when signal-killed or never spawned.

--- a/libs/runner/execution/src/index.ts
+++ b/libs/runner/execution/src/index.ts
@@ -1,3 +1,3 @@
-export {executeRunStep} from '#core/run-step.js';
+export {executeRunStep, type OutputSink} from '#core/run-step.js';
 export {executeSetupStep} from '#core/setup-step.js';
 export type {StepResult} from '#core/step-result.js';

--- a/libs/runner/logs/package.json
+++ b/libs/runner/logs/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@shipfox/runner-protocol",
+  "name": "@shipfox/runner-logs",
   "license": "MIT",
   "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/platform.git",
-    "directory": "libs/runner/protocol"
+    "directory": "libs/runner/logs"
   },
   "private": true,
   "type": "module",
@@ -38,11 +38,9 @@
   },
   "dependencies": {
     "@shipfox/api-logs-dto": "workspace:*",
-    "@shipfox/api-runners-dto": "workspace:*",
-    "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
-    "ky": "^2.0.0"
+    "@shipfox/runner-protocol": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/runner/logs/src/api/spool.test.ts
+++ b/libs/runner/logs/src/api/spool.test.ts
@@ -59,7 +59,9 @@ describe('AttemptSpool', () => {
 
     const open = () => AttemptSpool.open(join(dir, 'logs'), STEP_ID, 9);
 
-    expect(open).toThrow();
+    // Assert the original error propagates (not just that something threw), so a future
+    // change that swallows it or rethrows a different error is caught.
+    expect(open).toThrow(expect.objectContaining({code: 'EACCES'}));
   });
 
   it('rejects a non-UUID step id before touching the filesystem', () => {

--- a/libs/runner/logs/src/api/spool.test.ts
+++ b/libs/runner/logs/src/api/spool.test.ts
@@ -4,12 +4,37 @@ import {join} from 'node:path';
 import {AttemptSpool} from '#api/spool.js';
 import {InvalidStepIdError} from '#core/errors.js';
 
+// Lets a test force a short or zero-length writeSync without a real disk-full. Both flags
+// default off and reset themselves after one call, so every other test hits the real fs.
+const {fsControl} = vi.hoisted(() => ({fsControl: {splitNextWrite: false, zeroNextWrite: false}}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  const realWriteSync = actual.writeSync as (...args: unknown[]) => number;
+  return {
+    ...actual,
+    writeSync: ((fd: number, data: unknown, ...rest: unknown[]) => {
+      if (fsControl.zeroNextWrite) {
+        fsControl.zeroNextWrite = false;
+        return 0;
+      }
+      if (fsControl.splitNextWrite && Buffer.isBuffer(data) && data.length > 1) {
+        fsControl.splitNextWrite = false;
+        return realWriteSync(fd, data, 0, 1); // only the first byte lands this call
+      }
+      return realWriteSync(fd, data, ...rest);
+    }) as typeof actual.writeSync,
+  };
+});
+
 const STEP_ID = '00000000-0000-0000-0000-000000000001';
 
 describe('AttemptSpool', () => {
   let dir: string;
 
   beforeEach(async () => {
+    fsControl.splitNextWrite = false;
+    fsControl.zeroNextWrite = false;
     dir = await mkdtemp(join(tmpdir(), 'shipfox-spool-test-'));
   });
 
@@ -54,6 +79,29 @@ describe('AttemptSpool', () => {
     expect(spool.length).toBe(0);
     // The empty append must not have opened an fd or created the spool file.
     await expect(readFile(join(logsDir, `${STEP_ID}-3.ndjson`))).rejects.toThrow();
+  });
+
+  it('finishes the buffer and tracks exact length when a write returns short', async () => {
+    const logsDir = join(dir, 'logs');
+    const spool = AttemptSpool.open(logsDir, STEP_ID, 4);
+
+    fsControl.splitNextWrite = true; // first writeSync lands only 1 of the 6 bytes
+    spool.append(Buffer.from('hello\n'));
+    spool.close();
+
+    expect(spool.length).toBe(6);
+    const onDisk = await readFile(join(logsDir, `${STEP_ID}-4.ndjson`), 'utf8');
+    expect(onDisk).toBe('hello\n');
+  });
+
+  it('throws when a write makes no progress, so the caller can abandon capture', () => {
+    const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 5);
+
+    fsControl.zeroNextWrite = true;
+    const append = () => spool.append(Buffer.from('x\n'));
+
+    expect(append).toThrow();
+    spool.close();
   });
 
   it('reads a slice from an arbitrary offset, bounded by written length', () => {

--- a/libs/runner/logs/src/api/spool.test.ts
+++ b/libs/runner/logs/src/api/spool.test.ts
@@ -4,15 +4,24 @@ import {join} from 'node:path';
 import {AttemptSpool} from '#api/spool.js';
 import {InvalidStepIdError} from '#core/errors.js';
 
-// Lets a test force a short or zero-length writeSync without a real disk-full. Both flags
-// default off and reset themselves after one call, so every other test hits the real fs.
-const {fsControl} = vi.hoisted(() => ({fsControl: {splitNextWrite: false, zeroNextWrite: false}}));
+// Lets a test force a short/zero-length writeSync or a stat error without real fs conditions.
+// All controls default off (statErrorCode null) so every other test hits the real fs.
+const {fsControl} = vi.hoisted(() => ({
+  fsControl: {splitNextWrite: false, zeroNextWrite: false, statErrorCode: null as string | null},
+}));
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   const realWriteSync = actual.writeSync as (...args: unknown[]) => number;
+  const realStatSync = actual.statSync as (...args: unknown[]) => unknown;
   return {
     ...actual,
+    statSync: ((path: unknown, ...rest: unknown[]) => {
+      if (fsControl.statErrorCode) {
+        throw Object.assign(new Error('forced stat error'), {code: fsControl.statErrorCode});
+      }
+      return realStatSync(path, ...rest);
+    }) as typeof actual.statSync,
     writeSync: ((fd: number, data: unknown, ...rest: unknown[]) => {
       if (fsControl.zeroNextWrite) {
         fsControl.zeroNextWrite = false;
@@ -35,11 +44,22 @@ describe('AttemptSpool', () => {
   beforeEach(async () => {
     fsControl.splitNextWrite = false;
     fsControl.zeroNextWrite = false;
+    fsControl.statErrorCode = null;
     dir = await mkdtemp(join(tmpdir(), 'shipfox-spool-test-'));
   });
 
   afterEach(async () => {
     await rm(dir, {recursive: true, force: true});
+  });
+
+  it('rethrows a non-ENOENT stat error rather than seeding an empty length', () => {
+    // A broken path (e.g. EACCES) must not be silently treated as a fresh, empty spool, which
+    // would diverge the offset state on a resume; ENOENT (a fresh attempt) is still fine.
+    fsControl.statErrorCode = 'EACCES';
+
+    const open = () => AttemptSpool.open(join(dir, 'logs'), STEP_ID, 9);
+
+    expect(open).toThrow();
   });
 
   it('rejects a non-UUID step id before touching the filesystem', () => {

--- a/libs/runner/logs/src/api/spool.test.ts
+++ b/libs/runner/logs/src/api/spool.test.ts
@@ -44,6 +44,18 @@ describe('AttemptSpool', () => {
     expect(onDisk).toBe('hi\n');
   });
 
+  it('treats an empty append as a no-op that opens no file', async () => {
+    const logsDir = join(dir, 'logs');
+    const spool = AttemptSpool.open(logsDir, STEP_ID, 3);
+
+    spool.append(Buffer.alloc(0));
+    spool.close();
+
+    expect(spool.length).toBe(0);
+    // The empty append must not have opened an fd or created the spool file.
+    await expect(readFile(join(logsDir, `${STEP_ID}-3.ndjson`))).rejects.toThrow();
+  });
+
   it('reads a slice from an arbitrary offset, bounded by written length', () => {
     const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 1);
     spool.append(Buffer.from('abcdef'));

--- a/libs/runner/logs/src/api/spool.test.ts
+++ b/libs/runner/logs/src/api/spool.test.ts
@@ -1,0 +1,105 @@
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {AttemptSpool} from '#api/spool.js';
+import {InvalidStepIdError} from '#core/errors.js';
+
+const STEP_ID = '00000000-0000-0000-0000-000000000001';
+
+describe('AttemptSpool', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'shipfox-spool-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  it('rejects a non-UUID step id before touching the filesystem', () => {
+    const open = () => AttemptSpool.open(dir, '../escape', 1);
+
+    expect(open).toThrow(InvalidStepIdError);
+  });
+
+  it('appends bytes and tracks the written length', () => {
+    const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 1);
+
+    spool.append(Buffer.from('one\n'));
+    spool.append(Buffer.from('two\n'));
+
+    expect(spool.length).toBe(8);
+    spool.close();
+  });
+
+  it('lazily creates the logs directory on first append', async () => {
+    const logsDir = join(dir, 'logs');
+    const spool = AttemptSpool.open(logsDir, STEP_ID, 2);
+
+    spool.append(Buffer.from('hi\n'));
+    spool.close();
+
+    const onDisk = await readFile(join(logsDir, `${STEP_ID}-2.ndjson`), 'utf8');
+    expect(onDisk).toBe('hi\n');
+  });
+
+  it('reads a slice from an arbitrary offset, bounded by written length', () => {
+    const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 1);
+    spool.append(Buffer.from('abcdef'));
+
+    const slice = spool.read(2, 3);
+    const past = spool.read(6, 10);
+
+    expect(slice.toString()).toBe('cde');
+    expect(past.length).toBe(0);
+    spool.close();
+  });
+
+  it('stops a windowed read at the last complete record, not mid-line', () => {
+    const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 1);
+    spool.append(Buffer.from('aaaa\nbbbb\ncccc\n'));
+
+    // 7 bytes lands inside the second record ('aaaa\nbb'); only the first is whole.
+    const chunk = spool.read(0, 7);
+
+    expect(chunk.toString()).toBe('aaaa\n');
+    spool.close();
+  });
+
+  it('returns the full window when the spool ends mid-stream on a record boundary', () => {
+    const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 1);
+    spool.append(Buffer.from('aaaa\nbbbb\n'));
+
+    // maxBytes exceeds what is written, so the whole (boundary-terminated) tail comes back.
+    const chunk = spool.read(0, 1024);
+
+    expect(chunk.toString()).toBe('aaaa\nbbbb\n');
+    spool.close();
+  });
+
+  it('yields a split record only when one line exceeds maxBytes, so the uploader never stalls', () => {
+    const spool = AttemptSpool.open(join(dir, 'logs'), STEP_ID, 1);
+    spool.append(Buffer.from('abcdefghij\n'));
+
+    const chunk = spool.read(0, 4);
+
+    expect(chunk.toString()).toBe('abcd');
+    spool.close();
+  });
+
+  it('seeds length from the existing file when an attempt spool is reopened', () => {
+    const logsDir = join(dir, 'logs');
+    const first = AttemptSpool.open(logsDir, STEP_ID, 7);
+    first.append(Buffer.from('hello\n'));
+    first.close();
+
+    const reopened = AttemptSpool.open(logsDir, STEP_ID, 7);
+    reopened.append(Buffer.from('world\n'));
+
+    expect(reopened.length).toBe(12);
+    expect(reopened.read(0, 100).toString()).toBe('hello\nworld\n');
+    expect(reopened.read(6, 100).toString()).toBe('world\n');
+    reopened.close();
+  });
+});

--- a/libs/runner/logs/src/api/spool.test.ts
+++ b/libs/runner/logs/src/api/spool.test.ts
@@ -155,6 +155,12 @@ describe('AttemptSpool', () => {
     first.close();
 
     const reopened = AttemptSpool.open(logsDir, STEP_ID, 7);
+    // Length and reads reflect the on-disk bytes immediately, before any append opens the fd.
+    // The uploader's server-ahead check runs at probe time (pre-append), so this must hold or
+    // a legitimate resume gets mistaken for the server being ahead and is dropped.
+    expect(reopened.length).toBe(6);
+    expect(reopened.read(0, 100).toString()).toBe('hello\n');
+
     reopened.append(Buffer.from('world\n'));
 
     expect(reopened.length).toBe(12);

--- a/libs/runner/logs/src/api/spool.ts
+++ b/libs/runner/logs/src/api/spool.ts
@@ -29,8 +29,12 @@ export class AttemptSpool {
     // first append opens the fd. A fresh attempt's file is absent, so length stays 0.
     try {
       this._length = statSync(filePath).size;
-    } catch {
-      // ENOENT for a fresh attempt; any other stat error surfaces on the first append.
+    } catch (error) {
+      // ENOENT is the common fresh-attempt case (no file yet) and is fine. Any other stat
+      // error means a broken path that would otherwise look like an empty resume and silently
+      // diverge the offset state, so rethrow it; the caller treats a spool-open failure as
+      // abandoned capture and runs the step without logs.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
   }
 

--- a/libs/runner/logs/src/api/spool.ts
+++ b/libs/runner/logs/src/api/spool.ts
@@ -36,8 +36,22 @@ export class AttemptSpool {
 
   append(bytes: Buffer): void {
     if (bytes.length === 0) return;
-    writeSync(this.ensureAppendFd(), bytes);
-    this._length += bytes.length;
+    const fd = this.ensureAppendFd();
+    // writeSync can return a short count: a non-error partial write (an EINTR after some
+    // bytes, or a filesystem filling mid-write). Loop until the whole buffer lands so
+    // _length never drifts ahead of the file (which would tear the offset-addressed stream).
+    // A real out-of-space surfaces as the next call throwing ENOSPC, which the caller turns
+    // into failStream. A zero-byte return with no error is impossible for a regular file, so
+    // treat it as fatal rather than spin forever.
+    let written = 0;
+    while (written < bytes.length) {
+      const n = writeSync(fd, bytes, written, bytes.length - written);
+      if (n === 0) {
+        throw new Error(`Spool write made no progress at offset ${this._length + written}`);
+      }
+      written += n;
+    }
+    this._length += written;
   }
 
   /**

--- a/libs/runner/logs/src/api/spool.ts
+++ b/libs/runner/logs/src/api/spool.ts
@@ -1,0 +1,93 @@
+import {closeSync, fstatSync, mkdirSync, openSync, readSync, writeSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {InvalidStepIdError} from '#core/errors.js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const EMPTY = Buffer.alloc(0);
+
+// Record delimiter. A raw 0x0a only ever ends a record: the framer escapes any
+// newline inside a payload (JSON.stringify emits `\n`, two chars), so the last one
+// in a window is the boundary of the last complete record.
+const NEWLINE = 0x0a;
+
+/**
+ * Per-attempt append-only NDJSON spool. Writes are synchronous (`writeSync`):
+ * the runner runs one job at a time, so a small blocking append is cheaper than
+ * an in-memory write queue and it puts bytes in the OS page cache before the
+ * uploader reads them. Durability against machine death comes from the server
+ * ack, not local fsync; the page cache survives a runner-process restart.
+ */
+export class AttemptSpool {
+  private appendFd: number | undefined;
+  private readFd: number | undefined;
+  private _length = 0;
+
+  private constructor(private readonly filePath: string) {}
+
+  static open(logsDir: string, stepId: string, attempt: number): AttemptSpool {
+    if (!UUID_PATTERN.test(stepId)) throw new InvalidStepIdError(stepId);
+    return new AttemptSpool(join(logsDir, `${stepId}-${attempt}.ndjson`));
+  }
+
+  get length(): number {
+    return this._length;
+  }
+
+  append(bytes: Buffer): void {
+    if (bytes.length === 0) return;
+    writeSync(this.ensureAppendFd(), bytes);
+    this._length += bytes.length;
+  }
+
+  /**
+   * Reads whole NDJSON records starting at `offset`, up to `maxBytes` worth, never
+   * past what has been written. The returned buffer ends on a record boundary (a
+   * trailing `\n`), so the uploader never ships — and the server never commits — a
+   * torn last line, and every committed offset stays parseable.
+   *
+   * Returns empty once caught up. The lone exception to the whole-record guarantee
+   * is a single record larger than `maxBytes`: it is returned split rather than
+   * stalling the uploader, and the offset-addressed byte stream heals the split
+   * server-side once the remainder is appended.
+   */
+  read(offset: number, maxBytes: number): Buffer {
+    const window = Math.min(maxBytes, this._length - offset);
+    if (window <= 0) return EMPTY;
+    const buffer = Buffer.allocUnsafe(window);
+    const bytesRead = readSync(this.ensureReadFd(), buffer, 0, window, offset);
+    const chunk = bytesRead === window ? buffer : buffer.subarray(0, bytesRead);
+
+    const lastNewline = chunk.lastIndexOf(NEWLINE);
+    return lastNewline === -1 ? chunk : chunk.subarray(0, lastNewline + 1);
+  }
+
+  close(): void {
+    if (this.appendFd !== undefined) {
+      closeSync(this.appendFd);
+      this.appendFd = undefined;
+    }
+    if (this.readFd !== undefined) {
+      closeSync(this.readFd);
+      this.readFd = undefined;
+    }
+  }
+
+  private ensureAppendFd(): number {
+    if (this.appendFd === undefined) {
+      mkdirSync(dirname(this.filePath), {recursive: true});
+      this.appendFd = openSync(this.filePath, 'a');
+      // Reopening an existing spool (same step+attempt after a runner-process restart):
+      // seed _length from the on-disk size so reads and append offsets line up with the
+      // bytes already written, instead of treating a non-empty file as empty. A fresh
+      // attempt's file is size 0, so the common path is unaffected.
+      this._length = fstatSync(this.appendFd).size;
+    }
+    return this.appendFd;
+  }
+
+  private ensureReadFd(): number {
+    if (this.readFd === undefined) this.readFd = openSync(this.filePath, 'r');
+    return this.readFd;
+  }
+}

--- a/libs/runner/logs/src/api/spool.ts
+++ b/libs/runner/logs/src/api/spool.ts
@@ -1,4 +1,4 @@
-import {closeSync, fstatSync, mkdirSync, openSync, readSync, writeSync} from 'node:fs';
+import {closeSync, mkdirSync, openSync, readSync, statSync, writeSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {InvalidStepIdError} from '#core/errors.js';
 
@@ -23,7 +23,16 @@ export class AttemptSpool {
   private readFd: number | undefined;
   private _length = 0;
 
-  private constructor(private readonly filePath: string) {}
+  private constructor(private readonly filePath: string) {
+    // Seed length from bytes already on disk (a reopened attempt after a process restart) so
+    // reads, append offsets, and the uploader's server-ahead check are all correct before the
+    // first append opens the fd. A fresh attempt's file is absent, so length stays 0.
+    try {
+      this._length = statSync(filePath).size;
+    } catch {
+      // ENOENT for a fresh attempt; any other stat error surfaces on the first append.
+    }
+  }
 
   static open(logsDir: string, stepId: string, attempt: number): AttemptSpool {
     if (!UUID_PATTERN.test(stepId)) throw new InvalidStepIdError(stepId);
@@ -90,12 +99,9 @@ export class AttemptSpool {
   private ensureAppendFd(): number {
     if (this.appendFd === undefined) {
       mkdirSync(dirname(this.filePath), {recursive: true});
+      // Append mode does not truncate, so the on-disk bytes _length was seeded from at
+      // construction are preserved; opening 'a' here only attaches the write fd.
       this.appendFd = openSync(this.filePath, 'a');
-      // Reopening an existing spool (same step+attempt after a runner-process restart):
-      // seed _length from the on-disk size so reads and append offsets line up with the
-      // bytes already written, instead of treating a non-empty file as empty. A fresh
-      // attempt's file is size 0, so the common path is unaffected.
-      this._length = fstatSync(this.appendFd).size;
     }
     return this.appendFd;
   }

--- a/libs/runner/logs/src/api/uploader.test.ts
+++ b/libs/runner/logs/src/api/uploader.test.ts
@@ -1,0 +1,265 @@
+import type {LogAppendFn, LogAppendOutcome} from '@shipfox/runner-protocol';
+import {LogUploader, type SpoolReader} from '#api/uploader.js';
+
+class FakeSpool implements SpoolReader {
+  private buf: Buffer = Buffer.alloc(0);
+
+  constructor(initial: Buffer = Buffer.alloc(0)) {
+    this.buf = initial;
+  }
+
+  get length(): number {
+    return this.buf.length;
+  }
+
+  append(bytes: Buffer): void {
+    this.buf = Buffer.concat([this.buf, bytes]);
+  }
+
+  read(offset: number, maxBytes: number): Buffer {
+    return this.buf.subarray(offset, offset + maxBytes);
+  }
+}
+
+// An offset-CAS server: extends at offset == committed, acks already-applied
+// when offset < committed, rejects a gap when offset > committed.
+function casServer(opts: {startCommitted?: number; capAt?: number} = {}) {
+  let committed = opts.startCommitted ?? 0;
+  const calls: Array<{offset: number; length: number}> = [];
+  const append: LogAppendFn = ({offset, body}) => {
+    calls.push({offset, length: body.length});
+    if (offset > committed)
+      return Promise.resolve({status: 'conflict', committedLength: committed});
+    if (offset === committed) committed += body.length;
+    const capped = opts.capAt !== undefined && committed >= opts.capAt;
+    return Promise.resolve({status: 'committed', committedLength: committed, capped});
+  };
+  return {append, calls, committed: () => committed};
+}
+
+function scriptedServer(outcomes: LogAppendOutcome[]) {
+  const calls: Array<{offset: number; length: number}> = [];
+  const queue = [...outcomes];
+  const append: LogAppendFn = ({offset, body}) => {
+    calls.push({offset, length: body.length});
+    const next: LogAppendOutcome = queue.shift() ?? {status: 'stopped'};
+    return Promise.resolve(next);
+  };
+  return {append, calls};
+}
+
+// Never resolves on its own; rejects only when its append signal aborts (simulates an
+// API hang). Lets tests assert drain/stop cut the in-flight append rather than waiting.
+function hangingServer() {
+  let calls = 0;
+  let aborts = 0;
+  const append: LogAppendFn = ({signal}) => {
+    calls += 1;
+    return new Promise((_resolve, reject) => {
+      signal?.addEventListener(
+        'abort',
+        () => {
+          aborts += 1;
+          reject(new Error('aborted'));
+        },
+        {once: true},
+      );
+    });
+  };
+  return {append, callCount: () => calls, abortedCount: () => aborts};
+}
+
+const OPTS = {intervalMs: 1000, flushBytes: 1024};
+
+describe('LogUploader.flush', () => {
+  it('probes then ships spooled bytes, advancing acked to committed', async () => {
+    const spool = new FakeSpool(Buffer.from('abcdef'));
+    const server = casServer();
+    const uploader = new LogUploader(spool, server.append, OPTS);
+
+    await uploader.flush();
+
+    expect(uploader.ackedOffset).toBe(6);
+    expect(server.committed()).toBe(6);
+    // First call is the zero-length probe at offset 0.
+    expect(server.calls[0]).toEqual({offset: 0, length: 0});
+  });
+
+  it('resumes over an existing spool without re-sending committed bytes (dedup)', async () => {
+    // Server already holds the first 5 bytes; the spool on disk has all 8.
+    const spool = new FakeSpool(Buffer.from('12345678'));
+    const server = casServer({startCommitted: 5});
+    const uploader = new LogUploader(spool, server.append, OPTS);
+
+    await uploader.flush();
+
+    expect(uploader.ackedOffset).toBe(8);
+    expect(server.committed()).toBe(8);
+    // Only the suffix [5..8) is sent as data; nothing re-sends [0..5).
+    const dataCalls = server.calls.filter((c) => c.length > 0);
+    expect(dataCalls).toEqual([{offset: 5, length: 3}]);
+  });
+
+  it('rewinds to the server offset on a conflict, then resends from there', async () => {
+    const spool = new FakeSpool(Buffer.from('abcde'));
+    const server = scriptedServer([
+      {status: 'committed', committedLength: 0, capped: false}, // probe
+      {status: 'conflict', committedLength: 2}, // first data send → rewind to 2
+      {status: 'committed', committedLength: 5, capped: false}, // resend from 2
+    ]);
+    const uploader = new LogUploader(spool, server.append, OPTS);
+
+    await uploader.flush();
+
+    expect(uploader.ackedOffset).toBe(5);
+    expect(server.calls.map((c) => c.offset)).toEqual([0, 0, 2]);
+  });
+
+  it('stops uploading once the server reports capped', async () => {
+    const spool = new FakeSpool(Buffer.from('0123456789'));
+    const server = casServer({capAt: 4});
+    const uploader = new LogUploader(spool, server.append, {intervalMs: 1000, flushBytes: 4});
+
+    await uploader.flush();
+    const ackedAfterCap = uploader.ackedOffset;
+    await uploader.flush();
+
+    expect(uploader.isCapped()).toBe(true);
+    expect(uploader.ackedOffset).toBe(ackedAfterCap);
+    // No further appends after the cap (probe + one data batch only).
+    expect(server.calls.length).toBe(2);
+  });
+
+  it('stops on a terminal endpoint outcome and sends nothing more', async () => {
+    const spool = new FakeSpool(Buffer.from('abc'));
+    const server = scriptedServer([{status: 'stopped'}]);
+    const uploader = new LogUploader(spool, server.append, OPTS);
+
+    await uploader.flush();
+    await uploader.flush();
+
+    expect(uploader.isStopped()).toBe(true);
+    expect(server.calls.length).toBe(1);
+  });
+
+  it('is single-flight: concurrent flush() calls share one run and probe once', async () => {
+    const spool = new FakeSpool(Buffer.from('abcdef'));
+    const server = casServer();
+    const uploader = new LogUploader(spool, server.append, OPTS);
+
+    const first = uploader.flush();
+    const second = uploader.flush();
+    expect(first).toBe(second);
+
+    await first;
+
+    const probes = server.calls.filter((c) => c.length === 0);
+    expect(probes).toHaveLength(1);
+    expect(uploader.ackedOffset).toBe(6);
+  });
+});
+
+describe('LogUploader.notify', () => {
+  it('flushes only once the unacked backlog reaches flushBytes', async () => {
+    const spool = new FakeSpool();
+    const server = casServer();
+    const uploader = new LogUploader(spool, server.append, {intervalMs: 1000, flushBytes: 10});
+
+    spool.append(Buffer.from('123')); // backlog 3 < 10
+    uploader.notify();
+    expect(server.calls).toHaveLength(0);
+
+    spool.append(Buffer.from('4567890')); // backlog 10 >= 10
+    uploader.notify();
+    await uploader.flush(); // join the notify-triggered flush
+
+    expect(uploader.ackedOffset).toBe(10);
+    uploader.stop();
+  });
+});
+
+describe('LogUploader.stop', () => {
+  it('aborts the in-flight append and makes later flush/notify no-ops', async () => {
+    const spool = new FakeSpool(Buffer.from('a'.repeat(100)));
+    const server = hangingServer();
+    const uploader = new LogUploader(spool, server.append, {intervalMs: 1000, flushBytes: 1024});
+
+    const flushing = uploader.flush(); // probe hangs, inflight controller is set
+    await Promise.resolve();
+    uploader.stop();
+    await flushing;
+
+    expect(uploader.isStopped()).toBe(true);
+    expect(server.abortedCount()).toBe(1);
+
+    const callsBefore = server.callCount();
+    uploader.notify();
+    await uploader.flush();
+    expect(server.callCount()).toBe(callsBefore);
+  });
+});
+
+describe('LogUploader.drain', () => {
+  it('ships everything spooled within the timeout', async () => {
+    const spool = new FakeSpool(Buffer.from('a'.repeat(5000)));
+    const server = casServer();
+    const uploader = new LogUploader(spool, server.append, {intervalMs: 1, flushBytes: 1024});
+
+    await uploader.drain({timeoutMs: 1000});
+
+    expect(uploader.ackedOffset).toBe(5000);
+    expect(server.committed()).toBe(5000);
+  });
+
+  it('returns within the deadline and aborts the in-flight append when the API hangs', async () => {
+    const spool = new FakeSpool(Buffer.from('a'.repeat(100)));
+    const server = hangingServer();
+    const uploader = new LogUploader(spool, server.append, {intervalMs: 1000, flushBytes: 1024});
+
+    const start = Date.now();
+    await uploader.drain({timeoutMs: 20});
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(900); // did not wait for a transport timeout
+    expect(uploader.ackedOffset).toBe(0);
+    expect(server.abortedCount()).toBe(1); // the stuck append was cut
+    uploader.stop();
+  });
+
+  it('returns immediately when the abort signal is already aborted', async () => {
+    const spool = new FakeSpool(Buffer.from('a'.repeat(100)));
+    const server = hangingServer();
+    const uploader = new LogUploader(spool, server.append, {intervalMs: 1000, flushBytes: 1024});
+    const ac = new AbortController();
+    ac.abort();
+
+    await uploader.drain({signal: ac.signal, timeoutMs: 1000});
+
+    expect(uploader.ackedOffset).toBe(0);
+    expect(server.callCount()).toBe(0); // never even started a flush
+    uploader.stop();
+  });
+
+  it('backs off and retries after a flush that does not catch up', async () => {
+    const spool = new FakeSpool(Buffer.from('abcdef'));
+    let committed = 0;
+    let failedOnce = false;
+    const append: LogAppendFn = ({offset, body}) => {
+      if (offset > committed)
+        return Promise.resolve({status: 'conflict', committedLength: committed});
+      if (body.length > 0 && !failedOnce) {
+        failedOnce = true;
+        return Promise.reject(new Error('transient'));
+      }
+      if (offset === committed) committed += body.length;
+      return Promise.resolve({status: 'committed', committedLength: committed, capped: false});
+    };
+    const uploader = new LogUploader(spool, append, {intervalMs: 1, flushBytes: 1024});
+
+    await uploader.drain({timeoutMs: 1000});
+    uploader.stop();
+
+    expect(uploader.ackedOffset).toBe(6);
+    expect(committed).toBe(6);
+  });
+});

--- a/libs/runner/logs/src/api/uploader.test.ts
+++ b/libs/runner/logs/src/api/uploader.test.ts
@@ -142,6 +142,36 @@ describe('LogUploader.flush', () => {
     expect(server.calls.length).toBe(1);
   });
 
+  it('stops instead of looping when a non-empty body makes no progress', async () => {
+    const spool = new FakeSpool(Buffer.from('abcdef'));
+    // A stuck server that accepts but never advances its committed length.
+    let calls = 0;
+    const append: LogAppendFn = () => {
+      calls += 1;
+      return Promise.resolve({status: 'committed', committedLength: 0, capped: false});
+    };
+    const uploader = new LogUploader(spool, append, OPTS);
+
+    await uploader.flush();
+
+    expect(uploader.isStopped()).toBe(true);
+    // Probe, then one data send that made no progress, then stop — not an endless re-send.
+    expect(calls).toBe(2);
+  });
+
+  it('stops when the server committed offset is ahead of the local spool', async () => {
+    const spool = new FakeSpool(Buffer.from('abc')); // 3 bytes on disk
+    // The probe reports the server already holds more than this runner has spooled.
+    const server = scriptedServer([{status: 'committed', committedLength: 10, capped: false}]);
+    const uploader = new LogUploader(spool, server.append, OPTS);
+
+    await uploader.flush();
+
+    expect(uploader.isStopped()).toBe(true);
+    expect(uploader.ackedOffset).toBe(0); // never adopted the foreign offset
+    expect(server.calls).toHaveLength(1); // only the probe; no data shipped onto the prefix
+  });
+
   it('is single-flight: concurrent flush() calls share one run and probe once', async () => {
     const spool = new FakeSpool(Buffer.from('abcdef'));
     const server = casServer();

--- a/libs/runner/logs/src/api/uploader.ts
+++ b/libs/runner/logs/src/api/uploader.ts
@@ -1,0 +1,207 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import type {LogAppendFn, LogAppendOutcome} from '@shipfox/runner-protocol';
+
+const EMPTY_BODY = new Uint8Array(0);
+
+/** The slice of the spool the uploader reads from. */
+export interface SpoolReader {
+  readonly length: number;
+  /**
+   * Reads up to `maxBytes` from `offset`, ending on a record boundary so a body is
+   * never a torn line. Empty once caught up. The uploader stays format-agnostic and
+   * just ships whatever bytes it returns.
+   */
+  read(offset: number, maxBytes: number): Buffer;
+}
+
+export interface UploaderOptions {
+  intervalMs: number;
+  flushBytes: number;
+}
+
+/**
+ * Single-flight, setTimeout-chained uploader. At most one append is in flight:
+ * a flush drains everything currently on the spool, then the next tick is
+ * scheduled. Real appends are only ever made at offset == committed; on
+ * (re)start a zero-length probe learns the server's committed offset first, so a
+ * body never straddles the commit point. `capped` (budget exhausted) and
+ * `stopped` (endpoint gone / lease rejected) are terminal — server-side stream
+ * lifecycle takes over from there.
+ */
+export class LogUploader {
+  private acked = 0;
+  private probed = false;
+  private capped = false;
+  private stopped = false;
+  private flushing: Promise<void> | null = null;
+  private timer: NodeJS.Timeout | undefined;
+  private inflight: AbortController | undefined;
+
+  constructor(
+    private readonly spool: SpoolReader,
+    private readonly append: LogAppendFn,
+    private readonly options: UploaderOptions,
+  ) {}
+
+  get ackedOffset(): number {
+    return this.acked;
+  }
+
+  isCapped(): boolean {
+    return this.capped;
+  }
+
+  isStopped(): boolean {
+    return this.stopped;
+  }
+
+  start(): void {
+    this.scheduleNext();
+  }
+
+  /** Triggers an early flush once the unsent backlog reaches the size threshold. */
+  notify(): void {
+    if (this.terminal()) return;
+    if (this.spool.length - this.acked >= this.options.flushBytes) void this.flush();
+  }
+
+  flush(): Promise<void> {
+    if (this.flushing) return this.flushing;
+    this.flushing = this.runFlush().finally(() => {
+      this.flushing = null;
+    });
+    return this.flushing;
+  }
+
+  /** Drives flushes until caught up, terminal, the signal aborts, or the deadline. */
+  async drain(opts: {signal?: AbortSignal; timeoutMs: number}): Promise<void> {
+    const deadline = Date.now() + opts.timeoutMs;
+    while (!this.terminal() && this.acked < this.spool.length) {
+      if (opts.signal?.aborted || Date.now() >= deadline) break;
+      // Bound the in-flight flush by the remaining drain budget and the abort signal.
+      // Checking only between flushes let a single hung append overrun timeoutMs by a
+      // full transport timeout; racing keeps end-of-job shutdown within the deadline.
+      const timedOut = await raceDeadline(this.flush(), deadline - Date.now(), opts.signal);
+      if (timedOut) break;
+      if (this.terminal() || this.acked >= this.spool.length) return;
+      // The flush did not catch up (transient error): back off, bounded by the deadline.
+      const wait = Math.min(this.options.intervalMs, deadline - Date.now());
+      if (wait > 0) await delay(wait, opts.signal);
+    }
+    // Deadline hit or aborted with a flush still in flight: cut the in-flight append so
+    // the caller (dispose) is not left waiting on a stuck transport. No-op once caught up.
+    this.inflight?.abort();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.inflight?.abort();
+  }
+
+  private terminal(): boolean {
+    return this.stopped || this.capped;
+  }
+
+  private scheduleNext(): void {
+    if (this.terminal()) return;
+    this.timer = setTimeout(() => {
+      void this.flush();
+    }, this.options.intervalMs);
+  }
+
+  private async runFlush(): Promise<void> {
+    if (this.terminal()) return;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    const inflight = new AbortController();
+    this.inflight = inflight;
+    try {
+      if (!this.probed) {
+        this.apply(
+          await this.append({offset: this.acked, body: EMPTY_BODY, signal: inflight.signal}),
+        );
+        this.probed = true;
+      }
+      while (!this.terminal()) {
+        const body = this.spool.read(this.acked, this.options.flushBytes);
+        if (body.length === 0) break;
+        this.apply(await this.append({offset: this.acked, body, signal: inflight.signal}));
+      }
+    } catch (err) {
+      // Network/timeout errors are retried inside the transport; a surfaced error
+      // (a 5xx/unknown status or an abort) just leaves the rest for the next tick.
+      // Single-flight + the flush interval pace retries, so there is no storm.
+      logger().warn({err: String(err)}, 'Log upload flush failed; retrying on the next tick');
+    } finally {
+      if (this.inflight === inflight) this.inflight = undefined;
+      this.scheduleNext();
+    }
+  }
+
+  private apply(outcome: LogAppendOutcome): void {
+    switch (outcome.status) {
+      case 'committed':
+        this.acked = outcome.committedLength;
+        if (outcome.capped) this.capped = true;
+        break;
+      case 'conflict':
+        this.acked = outcome.committedLength;
+        break;
+      case 'stopped':
+        this.stopped = true;
+        break;
+    }
+  }
+}
+
+/**
+ * Resolves `false` if `promise` settles first, or `true` if `timeoutMs` elapses or
+ * `signal` aborts first. The losing promise is left to settle on its own; the caller
+ * decides what to do on a `true` (timed-out) result.
+ */
+function raceDeadline(
+  promise: Promise<void>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  if (timeoutMs <= 0) return Promise.resolve(true);
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const onAbort = () => finish(true);
+    const finish = (timedOut: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      resolve(timedOut);
+    };
+    const timer = setTimeout(() => finish(true), timeoutMs);
+    signal?.addEventListener('abort', onAbort, {once: true});
+    promise.then(
+      () => finish(false),
+      () => finish(false),
+    );
+  });
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener('abort', finish, {once: true});
+  });
+}

--- a/libs/runner/logs/src/api/uploader.ts
+++ b/libs/runner/logs/src/api/uploader.ts
@@ -111,6 +111,9 @@ export class LogUploader {
     this.timer = setTimeout(() => {
       void this.flush();
     }, this.options.intervalMs);
+    // A pending upload tick must not keep the runner process alive on its own; the
+    // step loop drives flushes explicitly and dispose()/stop() clears the timer.
+    this.timer.unref();
   }
 
   private async runFlush(): Promise<void> {
@@ -129,9 +132,25 @@ export class LogUploader {
         this.probed = true;
       }
       while (!this.terminal()) {
+        // drain() can abort the in-flight controller and return; if a misbehaving append
+        // resolves instead of rejecting on abort, this stops the loop from re-sending past
+        // the deadline rather than relying on the transport to honor the signal.
+        if (inflight.signal.aborted) break;
         const body = this.spool.read(this.acked, this.options.flushBytes);
         if (body.length === 0) break;
+        const before = this.acked;
         this.apply(await this.append({offset: this.acked, body, signal: inflight.signal}));
+        // No-progress guard: a non-empty body that did not move the committed offset means a
+        // stuck/garbage server (e.g. constant conflict at the same length). Re-sending the
+        // identical bytes would spin forever, so stop and let the next tick / lifecycle act.
+        if (!this.terminal() && this.acked === before) {
+          logger().warn(
+            {offset: before},
+            'Log append made no progress on a non-empty body; stopping to avoid a re-send loop',
+          );
+          this.stopped = true;
+          break;
+        }
       }
     } catch (err) {
       // Network/timeout errors are retried inside the transport; a surfaced error
@@ -147,16 +166,35 @@ export class LogUploader {
   private apply(outcome: LogAppendOutcome): void {
     switch (outcome.status) {
       case 'committed':
+        if (this.serverAhead(outcome.committedLength)) return;
         this.acked = outcome.committedLength;
         if (outcome.capped) this.capped = true;
         break;
       case 'conflict':
+        if (this.serverAhead(outcome.committedLength)) return;
         this.acked = outcome.committedLength;
         break;
       case 'stopped':
         this.stopped = true;
         break;
     }
+  }
+
+  // The server's committed offset must never exceed what this runner has spooled locally.
+  // If it does (e.g. an attempt re-delivered to a fresh workspace where the server already
+  // holds a prior runner's bytes), adopting that offset would skip this runner's own early
+  // output and splice the rest onto a foreign prefix. Stop instead and let the server's
+  // stream lifecycle close the stream. (spool.length reflects bytes this process has
+  // appended, seeded from the on-disk size on first append; a future durable-restart resume
+  // must seed it before the probe, or bump the attempt so the stream is fresh.)
+  private serverAhead(committedLength: number): boolean {
+    if (committedLength <= this.spool.length) return false;
+    logger().warn(
+      {committedLength, spoolLength: this.spool.length},
+      'Server committed offset is ahead of the local spool; stopping log upload',
+    );
+    this.stopped = true;
+    return true;
   }
 }
 

--- a/libs/runner/logs/src/api/uploader.ts
+++ b/libs/runner/logs/src/api/uploader.ts
@@ -184,9 +184,9 @@ export class LogUploader {
   // If it does (e.g. an attempt re-delivered to a fresh workspace where the server already
   // holds a prior runner's bytes), adopting that offset would skip this runner's own early
   // output and splice the rest onto a foreign prefix. Stop instead and let the server's
-  // stream lifecycle close the stream. (spool.length reflects bytes this process has
-  // appended, seeded from the on-disk size on first append; a future durable-restart resume
-  // must seed it before the probe, or bump the attempt so the stream is fresh.)
+  // stream lifecycle close the stream. (spool.length is seeded from the on-disk size at
+  // construction, before the probe, so a legitimate same-workspace resume reads its existing
+  // bytes here and is not mistaken for the server being ahead.)
   private serverAhead(committedLength: number): boolean {
     if (committedLength <= this.spool.length) return false;
     logger().warn(

--- a/libs/runner/logs/src/config.ts
+++ b/libs/runner/logs/src/config.ts
@@ -1,4 +1,14 @@
+import {MAX_RECORD_DATA_BYTES} from '@shipfox/api-logs-dto';
 import {createConfig, num} from '@shipfox/config';
+
+// The uploader's flush window must hold at least one whole encoded NDJSON record, or
+// spool.read returns a torn (non-newline-terminated) line the server rejects with 400 on
+// every flush. A record's `data` is capped at MAX_RECORD_DATA_BYTES decoded bytes, but
+// JSON-escaping can inflate it ~6x (every byte a `\uXXXX` control char), so the floor clears
+// that worst case plus envelope headroom.
+const MIN_FLUSH_BYTES = MAX_RECORD_DATA_BYTES * 6 + 1024;
+// The server /logs route rejects request bodies over 1 MiB, so a larger window only yields 413s.
+const MAX_FLUSH_BYTES = 1024 * 1024;
 
 export const config = createConfig({
   SHIPFOX_LOG_FLUSH_INTERVAL_MS: num({
@@ -6,7 +16,7 @@ export const config = createConfig({
     default: 2000,
   }),
   SHIPFOX_LOG_FLUSH_BYTES: num({
-    desc: 'Size threshold in bytes that triggers an early log upload before the interval elapses, so bursts of output do not wait for the timer.',
+    desc: `Size threshold in bytes that triggers an early log upload before the interval elapses, so bursts of output do not wait for the timer. Must be between ${MIN_FLUSH_BYTES} and ${MAX_FLUSH_BYTES}: a smaller window cannot hold one whole log record, and a larger one exceeds the server's 1 MiB request limit.`,
     default: 262144,
   }),
   SHIPFOX_LOG_SPOOL_MAX_BYTES: num({
@@ -18,3 +28,15 @@ export const config = createConfig({
     default: 5000,
   }),
 });
+
+// envalid's num has no range support, so enforce the flush-window bounds here: an out-of-range
+// value would otherwise either tear every record (too small) or 413 on every flush (too large),
+// silently stalling log delivery. Fail fast at startup instead, like the rest of config.
+if (
+  config.SHIPFOX_LOG_FLUSH_BYTES < MIN_FLUSH_BYTES ||
+  config.SHIPFOX_LOG_FLUSH_BYTES > MAX_FLUSH_BYTES
+) {
+  throw new Error(
+    `SHIPFOX_LOG_FLUSH_BYTES must be between ${MIN_FLUSH_BYTES} and ${MAX_FLUSH_BYTES} bytes; got ${config.SHIPFOX_LOG_FLUSH_BYTES}.`,
+  );
+}

--- a/libs/runner/logs/src/config.ts
+++ b/libs/runner/logs/src/config.ts
@@ -1,0 +1,20 @@
+import {createConfig, num} from '@shipfox/config';
+
+export const config = createConfig({
+  SHIPFOX_LOG_FLUSH_INTERVAL_MS: num({
+    desc: 'How often the runner uploads buffered step logs, in milliseconds. This bounds how much recent output is lost if the runner machine dies mid-step.',
+    default: 2000,
+  }),
+  SHIPFOX_LOG_FLUSH_BYTES: num({
+    desc: 'Size threshold in bytes that triggers an early log upload before the interval elapses, so bursts of output do not wait for the timer.',
+    default: 262144,
+  }),
+  SHIPFOX_LOG_SPOOL_MAX_BYTES: num({
+    desc: 'Maximum number of not-yet-acknowledged log bytes the runner keeps on disk per step attempt. When the API is unreachable and this backlog is exceeded, further output is dropped and a gap marker is recorded instead of filling the disk.',
+    default: 67108864,
+  }),
+  SHIPFOX_LOG_DRAIN_TIMEOUT_MS: num({
+    desc: 'How long, in milliseconds, the runner waits at the end of a job for in-flight log uploads to finish before deleting the workspace. Bounds shutdown when the API is slow or unreachable.',
+    default: 5000,
+  }),
+});

--- a/libs/runner/logs/src/core/errors.ts
+++ b/libs/runner/logs/src/core/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Thrown when a step id is not the UUID the API contract guarantees, so it cannot
+ * be used in the spool filename (path-traversal guard, mirroring the workspace's
+ * job-id guard).
+ */
+export class InvalidStepIdError extends Error {
+  constructor(public readonly stepId: string) {
+    super(`Invalid step id: ${stepId}`);
+    this.name = 'InvalidStepIdError';
+  }
+}

--- a/libs/runner/logs/src/core/framing.test.ts
+++ b/libs/runner/logs/src/core/framing.test.ts
@@ -1,0 +1,146 @@
+import {type LogRecord, logRecordSchema, MAX_RECORD_DATA_BYTES} from '@shipfox/api-logs-dto';
+import {StreamFramer, splitByUtf8Bytes} from '#core/framing.js';
+
+const REPLACEMENT = '�';
+
+function parseRecords(bytes: Buffer): LogRecord[] {
+  const text = bytes.toString('utf8');
+  if (text.length === 0) return [];
+  return text
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => logRecordSchema.parse(JSON.parse(line)));
+}
+
+function outputData(records: LogRecord[]): string {
+  return records
+    .filter((r) => r.type === 'output')
+    .map((r) => (r.type === 'output' ? r.data : ''))
+    .join('');
+}
+
+describe('StreamFramer.frameOutput', () => {
+  it('frames a chunk into a single output record with origin and stamped ts', () => {
+    const framer = new StreamFramer(() => 1000);
+
+    const framed = framer.frameOutput(Buffer.from('hello world\n'), 'stdout');
+    const [record] = parseRecords(framed.bytes);
+
+    expect(record).toEqual({v: 1, ts: 1000, type: 'output', src: 'stdout', data: 'hello world\n'});
+    expect(framed.payloadBytes).toBe(Buffer.byteLength('hello world\n'));
+  });
+
+  it('preserves ANSI escape bytes verbatim', () => {
+    const framer = new StreamFramer(() => 1);
+    const ansi = '[31mred[0m';
+
+    const framed = framer.frameOutput(Buffer.from(ansi), 'stdout');
+
+    expect(outputData(parseRecords(framed.bytes))).toBe(ansi);
+  });
+
+  it('splits a line longer than the payload cap into multiple records that rejoin', () => {
+    const framer = new StreamFramer(() => 1);
+    const long = 'a'.repeat(MAX_RECORD_DATA_BYTES + 5000);
+
+    const framed = framer.frameOutput(Buffer.from(long), 'stdout');
+    const records = parseRecords(framed.bytes);
+
+    expect(records.length).toBe(2);
+    for (const record of records) {
+      const data = record.type === 'output' ? record.data : '';
+      expect(Buffer.byteLength(data)).toBeLessThanOrEqual(MAX_RECORD_DATA_BYTES);
+    }
+    expect(outputData(records)).toBe(long);
+    expect(framed.payloadBytes).toBe(long.length);
+  });
+
+  it('replaces invalid UTF-8 with the replacement character', () => {
+    const framer = new StreamFramer(() => 1);
+
+    const framed = framer.frameOutput(Buffer.from([0xff, 0xfe]), 'stdout');
+
+    expect(outputData(parseRecords(framed.bytes))).toBe(`${REPLACEMENT}${REPLACEMENT}`);
+  });
+
+  it('reassembles a multi-byte char split across two chunks on the same pipe', () => {
+    const framer = new StreamFramer(() => 1);
+    const euro = Buffer.from('€', 'utf8'); // 0xE2 0x82 0xAC
+
+    const first = framer.frameOutput(euro.subarray(0, 2), 'stdout');
+    const second = framer.frameOutput(euro.subarray(2), 'stdout');
+
+    // The decoder holds the partial sequence, so the first chunk yields nothing.
+    expect(first.bytes.length).toBe(0);
+    expect(outputData(parseRecords(second.bytes))).toBe('€');
+  });
+
+  it('does not complete a stdout partial sequence with stderr bytes', () => {
+    const framer = new StreamFramer(() => 1);
+    const euro = Buffer.from('€', 'utf8');
+
+    framer.frameOutput(euro.subarray(0, 2), 'stdout');
+    const stderrFramed = framer.frameOutput(euro.subarray(2), 'stderr');
+
+    // The trailing byte arrives on stderr, whose decoder never saw the lead bytes,
+    // so it is invalid there and must not reconstruct '€'.
+    expect(outputData(parseRecords(stderrFramed.bytes))).toBe(REPLACEMENT);
+  });
+});
+
+describe('StreamFramer.flushDecoders', () => {
+  it('flushes a held incomplete sequence as the replacement character', () => {
+    const framer = new StreamFramer(() => 1);
+    const euro = Buffer.from('€', 'utf8');
+
+    framer.frameOutput(euro.subarray(0, 2), 'stdout');
+    const flushed = framer.flushDecoders();
+
+    expect(outputData(parseRecords(flushed.bytes))).toBe(REPLACEMENT);
+  });
+});
+
+describe('StreamFramer control records', () => {
+  it('frames the end record with the payload total', () => {
+    const framer = new StreamFramer(() => 7);
+
+    const [record] = parseRecords(framer.frameEnd(2048));
+
+    expect(record).toEqual({
+      v: 1,
+      ts: 7,
+      type: 'control',
+      src: 'system',
+      kind: 'end',
+      total_bytes: 2048,
+    });
+  });
+
+  it('frames a gap record with dropped payload bytes', () => {
+    const framer = new StreamFramer(() => 7);
+
+    const [record] = parseRecords(framer.frameGap(4096));
+
+    expect(record).toEqual({
+      v: 1,
+      ts: 7,
+      type: 'control',
+      src: 'system',
+      kind: 'gap',
+      dropped_bytes: 4096,
+    });
+  });
+});
+
+describe('splitByUtf8Bytes', () => {
+  it('never splits a multi-byte character across parts', () => {
+    const text = '€'.repeat(10000); // 3 bytes each = 30000 bytes
+
+    const parts = splitByUtf8Bytes(text, MAX_RECORD_DATA_BYTES);
+
+    expect(parts.join('')).toBe(text);
+    for (const part of parts) {
+      expect(Buffer.byteLength(part)).toBeLessThanOrEqual(MAX_RECORD_DATA_BYTES);
+    }
+  });
+});

--- a/libs/runner/logs/src/core/framing.test.ts
+++ b/libs/runner/logs/src/core/framing.test.ts
@@ -75,6 +75,18 @@ describe('StreamFramer.frameOutput', () => {
     expect(outputData(parseRecords(second.bytes))).toBe('€');
   });
 
+  it('reassembles a 4-byte code point split across two chunks on the same pipe', () => {
+    const framer = new StreamFramer(() => 1);
+    const grin = Buffer.from('😀', 'utf8'); // 4 bytes: F0 9F 98 80 (a surrogate pair)
+
+    const first = framer.frameOutput(grin.subarray(0, 2), 'stdout');
+    const second = framer.frameOutput(grin.subarray(2), 'stdout');
+
+    // The decoder holds the partial 4-byte sequence, so the first chunk yields nothing.
+    expect(first.bytes.length).toBe(0);
+    expect(outputData(parseRecords(second.bytes))).toBe('😀');
+  });
+
   it('does not complete a stdout partial sequence with stderr bytes', () => {
     const framer = new StreamFramer(() => 1);
     const euro = Buffer.from('€', 'utf8');
@@ -141,6 +153,22 @@ describe('splitByUtf8Bytes', () => {
     expect(parts.join('')).toBe(text);
     for (const part of parts) {
       expect(Buffer.byteLength(part)).toBeLessThanOrEqual(MAX_RECORD_DATA_BYTES);
+    }
+  });
+
+  it('never tears a 4-byte surrogate-pair code point at the byte cap', () => {
+    // '😀' is a surrogate pair (2 UTF-16 units) encoded as 4 UTF-8 bytes. A cap that is not a
+    // multiple of 4 forces splits to land between code points, never inside one.
+    const text = '😀'.repeat(5000); // 4 bytes each = 20000 bytes
+    const maxBytes = 10;
+
+    const parts = splitByUtf8Bytes(text, maxBytes);
+
+    expect(parts.join('')).toBe(text);
+    for (const part of parts) {
+      expect(Buffer.byteLength(part)).toBeLessThanOrEqual(maxBytes);
+      // A torn surrogate pair would not survive a UTF-8 round-trip (becomes U+FFFD).
+      expect(Buffer.from(part, 'utf8').toString('utf8')).toBe(part);
     }
   });
 });

--- a/libs/runner/logs/src/core/framing.ts
+++ b/libs/runner/logs/src/core/framing.ts
@@ -1,0 +1,141 @@
+import {TextDecoder} from 'node:util';
+import {
+  type ControlRecord,
+  type LogRecord,
+  MAX_RECORD_DATA_BYTES,
+  type OutputRecord,
+} from '@shipfox/api-logs-dto';
+
+/** A pipe origin for captured output. */
+export type OutputSource = 'stdout' | 'stderr';
+
+const PIPES: readonly OutputSource[] = ['stdout', 'stderr'];
+
+// v1 record builders. The DTO owns the schema and validation; the runner is the only
+// component that frames records, so the constructors live here at the framing layer.
+function outputRecord(args: {ts: number; src: OutputSource; data: string}): OutputRecord {
+  return {v: 1, ts: args.ts, type: 'output', src: args.src, data: args.data};
+}
+
+function gapRecord(args: {ts: number; droppedBytes: number}): ControlRecord {
+  return {
+    v: 1,
+    ts: args.ts,
+    type: 'control',
+    src: 'system',
+    kind: 'gap',
+    dropped_bytes: args.droppedBytes,
+  };
+}
+
+function endRecord(args: {ts: number; totalBytes: number}): ControlRecord {
+  return {
+    v: 1,
+    ts: args.ts,
+    type: 'control',
+    src: 'system',
+    kind: 'end',
+    total_bytes: args.totalBytes,
+  };
+}
+
+export interface FramedOutput {
+  /** NDJSON line bytes (zero or more records), ready to append to the spool. */
+  bytes: Buffer;
+  /** `data` payload bytes across the produced records (budget/total accounting). */
+  payloadBytes: number;
+}
+
+const EMPTY_FRAME: FramedOutput = {bytes: Buffer.alloc(0), payloadBytes: 0};
+
+function encodeRecord(record: LogRecord): Buffer {
+  return Buffer.from(`${JSON.stringify(record)}\n`, 'utf8');
+}
+
+function utf8Length(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+/**
+ * Split a (well-formed) string into pieces each at most `maxBytes` UTF-8 bytes,
+ * cutting only on code-point boundaries so a multi-byte character is never torn.
+ * A single code point is at most 4 bytes, so it always fits.
+ */
+export function splitByUtf8Bytes(text: string, maxBytes: number): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let bytes = 0;
+  for (let i = 0; i < text.length; ) {
+    const codePoint = text.codePointAt(i) ?? 0;
+    const units = codePoint > 0xffff ? 2 : 1;
+    const cpBytes = utf8Length(codePoint);
+    if (bytes + cpBytes > maxBytes && bytes > 0) {
+      parts.push(text.slice(start, i));
+      start = i;
+      bytes = 0;
+    }
+    bytes += cpBytes;
+    i += units;
+  }
+  parts.push(text.slice(start));
+  return parts;
+}
+
+/**
+ * Turns captured output chunks into NDJSON records. Holds one streaming UTF-8
+ * decoder per pipe so invalid bytes become U+FFFD and a multi-byte character
+ * split across capture chunks is reassembled from that pipe's own bytes (never
+ * completed by the other pipe). Records are not line-aligned; consumers
+ * reconstruct text by concatenating `data`. `ts` is stamped at frame time.
+ */
+export class StreamFramer {
+  private readonly decoders: Record<OutputSource, TextDecoder> = {
+    stdout: new TextDecoder('utf-8', {ignoreBOM: true, fatal: false}),
+    stderr: new TextDecoder('utf-8', {ignoreBOM: true, fatal: false}),
+  };
+
+  constructor(private readonly now: () => number = Date.now) {}
+
+  frameOutput(chunk: Buffer, source: OutputSource): FramedOutput {
+    const text = this.decoders[source].decode(chunk, {stream: true});
+    if (text.length === 0) return EMPTY_FRAME;
+    return this.frameText(text, source);
+  }
+
+  /** Flushes any trailing partial multi-byte sequence held by each decoder. */
+  flushDecoders(): FramedOutput {
+    const buffers: Buffer[] = [];
+    let payloadBytes = 0;
+    for (const source of PIPES) {
+      const tail = this.decoders[source].decode();
+      if (tail.length === 0) continue;
+      const framed = this.frameText(tail, source);
+      buffers.push(framed.bytes);
+      payloadBytes += framed.payloadBytes;
+    }
+    return {bytes: Buffer.concat(buffers), payloadBytes};
+  }
+
+  frameGap(droppedBytes: number): Buffer {
+    return encodeRecord(gapRecord({ts: this.now(), droppedBytes}));
+  }
+
+  frameEnd(totalBytes: number): Buffer {
+    return encodeRecord(endRecord({ts: this.now(), totalBytes}));
+  }
+
+  private frameText(text: string, source: OutputSource): FramedOutput {
+    const parts = splitByUtf8Bytes(text, MAX_RECORD_DATA_BYTES);
+    const buffers: Buffer[] = [];
+    let payloadBytes = 0;
+    const ts = this.now();
+    for (const part of parts) {
+      buffers.push(encodeRecord(outputRecord({ts, src: source, data: part})));
+      payloadBytes += Buffer.byteLength(part, 'utf8');
+    }
+    return {bytes: Buffer.concat(buffers), payloadBytes};
+  }
+}

--- a/libs/runner/logs/src/core/framing.ts
+++ b/libs/runner/logs/src/core/framing.ts
@@ -65,6 +65,10 @@ function utf8Length(codePoint: number): number {
  * A single code point is at most 4 bytes, so it always fits.
  */
 export function splitByUtf8Bytes(text: string, maxBytes: number): string[] {
+  // Fast path for the dominant case (a chunk well under the cap): one native byte
+  // count instead of an O(n) per-code-point scan, with an identical single-part result.
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return [text];
+
   const parts: string[] = [];
   let start = 0;
   let bytes = 0;

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -4,6 +4,7 @@ import {join} from 'node:path';
 import type {LogRecord} from '@shipfox/api-logs-dto';
 import {logRecordSchema} from '@shipfox/api-logs-dto';
 import type {LogAppendFn} from '@shipfox/runner-protocol';
+import {AttemptSpool} from '#api/spool.js';
 import {createStepLogStream} from '#core/step-log-stream.js';
 
 const STEP_ID = '00000000-0000-0000-0000-000000000abc';
@@ -319,5 +320,35 @@ describe('createStepLogStream', () => {
     stream.dispose();
 
     expect(streamLength).toBe(0);
+  });
+
+  it('abandons capture without crashing when a write fails mid-stream', async () => {
+    // First append succeeds; a later one throws like a real fs failure (ENOSPC/EMFILE) after
+    // the spool has already opened and committed bytes. This is the path the open-time test
+    // above does not reach.
+    let appends = 0;
+    const appendSpy = vi.spyOn(AttemptSpool.prototype, 'append').mockImplementation(() => {
+      appends += 1;
+      if (appends >= 2) throw Object.assign(new Error('ENOSPC'), {code: 'ENOSPC'});
+    });
+
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 10,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    // The mid-stream throw originates inside the sink (the child's 'data' handler); it must be
+    // swallowed, not propagated, or it would crash the whole runner. Capture is then abandoned.
+    expect(() => stream.write(Buffer.from('first\n'), 'stdout')).not.toThrow();
+    expect(() => stream.write(Buffer.from('second\n'), 'stdout')).not.toThrow();
+    expect(() => stream.write(Buffer.from('third\n'), 'stdout')).not.toThrow();
+    await expect(stream.close()).resolves.toBeDefined();
+    stream.dispose();
+
+    appendSpy.mockRestore();
   });
 });

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -298,28 +298,24 @@ describe('createStepLogStream', () => {
     }
   });
 
-  it('abandons capture without crashing when the spool cannot be written', async () => {
-    // Pre-create a FILE where the logs directory should be so the spool's mkdir/open throws.
+  it('throws when the spool cannot be opened so the caller can abandon capture', async () => {
+    // Pre-create a FILE where the logs directory should be so the spool's stat/open fails.
     const logsDir = join(dir, 'logs');
     await writeFile(logsDir, 'not a directory');
 
-    const stream = createStepLogStream({
-      logsDir,
-      stepId: STEP_ID,
-      attempt: 8,
-      append: hangingAppend,
-      flushIntervalMs: 100000,
-      now: () => 1,
-    });
+    // The open failure (a non-ENOENT stat error) surfaces here; the orchestrator catches it
+    // and runs the step without capture rather than letting it crash the runner.
+    const open = () =>
+      createStepLogStream({
+        logsDir,
+        stepId: STEP_ID,
+        attempt: 8,
+        append: hangingAppend,
+        flushIntervalMs: 100000,
+        now: () => 1,
+      });
 
-    // The fs failure happens inside the sink; it must be swallowed, not thrown (a throw
-    // here would escape the child's 'data' handler and crash the whole runner).
-    expect(() => stream.write(Buffer.from('boom\n'), 'stdout')).not.toThrow();
-    expect(() => stream.write(Buffer.from('more\n'), 'stdout')).not.toThrow();
-    const {streamLength} = await stream.close();
-    stream.dispose();
-
-    expect(streamLength).toBe(0);
+    expect(open).toThrow();
   });
 
   it('abandons capture without crashing when a write fails mid-stream', async () => {

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -1,0 +1,323 @@
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import {logRecordSchema} from '@shipfox/api-logs-dto';
+import type {LogAppendFn} from '@shipfox/runner-protocol';
+import {createStepLogStream} from '#core/step-log-stream.js';
+
+const STEP_ID = '00000000-0000-0000-0000-000000000abc';
+
+function casServer() {
+  let committed = 0;
+  const append: LogAppendFn = ({offset, body}) => {
+    if (offset > committed)
+      return Promise.resolve({status: 'conflict', committedLength: committed});
+    if (offset === committed) committed += body.length;
+    return Promise.resolve({status: 'committed', committedLength: committed, capped: false});
+  };
+  return {append, committed: () => committed};
+}
+
+// Never resolves, so the server-acked offset stays at 0 (simulates an outage).
+const hangingAppend: LogAppendFn = ({signal}) =>
+  new Promise((_resolve, reject) => {
+    signal?.addEventListener('abort', () => reject(new Error('aborted')), {once: true});
+  });
+
+// Commits like casServer and keeps every non-empty body it accepts, so a test can
+// inspect what actually crossed the wire (the zero-length probe is ignored).
+function recordingServer() {
+  let committed = 0;
+  const bodies: Buffer[] = [];
+  const append: LogAppendFn = ({offset, body}) => {
+    if (offset > committed)
+      return Promise.resolve({status: 'conflict', committedLength: committed});
+    if (offset === committed && body.length > 0) {
+      bodies.push(Buffer.from(body));
+      committed += body.length;
+    }
+    return Promise.resolve({status: 'committed', committedLength: committed, capped: false});
+  };
+  return {append, bodies};
+}
+
+// Commits like casServer but flips `capped` true once committed reaches `capAt`.
+function cappingServer(capAt: number) {
+  let committed = 0;
+  const append: LogAppendFn = ({offset, body}) => {
+    if (offset > committed)
+      return Promise.resolve({status: 'conflict', committedLength: committed});
+    if (offset === committed) committed += body.length;
+    return Promise.resolve({
+      status: 'committed',
+      committedLength: committed,
+      capped: committed >= capAt,
+    });
+  };
+  return {append, committed: () => committed};
+}
+
+describe('createStepLogStream', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'shipfox-stream-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  async function readRecords(attempt: number): Promise<LogRecord[]> {
+    const text = await readFile(join(dir, 'logs', `${STEP_ID}-${attempt}.ndjson`), 'utf8');
+    return text
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => logRecordSchema.parse(JSON.parse(line)));
+  }
+
+  it('spools merged output and an end record, and drains to the server', async () => {
+    const server = casServer();
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 1,
+      append: server.append,
+      flushIntervalMs: 5,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('hello\n'), 'stdout');
+    stream.write(Buffer.from('oops\n'), 'stderr');
+    const {streamLength} = await stream.close();
+    await stream.drain({timeoutMs: 1000});
+    stream.dispose();
+
+    const records = await readRecords(1);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'output', src: 'stdout', data: 'hello\n'},
+      {v: 1, ts: 1, type: 'output', src: 'stderr', data: 'oops\n'},
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'end', total_bytes: 11},
+    ]);
+    expect(server.committed()).toBe(streamLength);
+  });
+
+  it('close() resolves with the raw stream length without waiting on upload', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 2,
+      append: hangingAppend,
+      flushIntervalMs: 5,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('data\n'), 'stdout');
+    const {streamLength} = await stream.close();
+    stream.dispose();
+
+    const onDisk = await readFile(join(dir, 'logs', `${STEP_ID}-2.ndjson`));
+    expect(streamLength).toBe(onDisk.length);
+  });
+
+  it('drops output past the unacked-backlog cap and records a single gap', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 3,
+      append: hangingAppend, // never acks, so the backlog only grows
+      flushIntervalMs: 5,
+      spoolMaxBytes: 150, // fits roughly one record, not two
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('a'.repeat(40)), 'stdout'); // spooled
+    stream.write(Buffer.from('b'.repeat(40)), 'stdout'); // dropped
+    stream.write(Buffer.from('c'.repeat(40)), 'stdout'); // dropped
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(3);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'output', src: 'stdout', data: 'a'.repeat(40)},
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'gap', dropped_bytes: 80},
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'end', total_bytes: 40},
+    ]);
+  });
+
+  it('does not drop or gap a healthy stream under the default cap', async () => {
+    const server = casServer();
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 4,
+      append: server.append,
+      flushIntervalMs: 5,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('a'.repeat(40)), 'stdout');
+    stream.write(Buffer.from('b'.repeat(40)), 'stdout');
+    stream.write(Buffer.from('c'.repeat(40)), 'stdout');
+    await stream.close();
+    await stream.drain({timeoutMs: 1000});
+    stream.dispose();
+
+    const records = await readRecords(4);
+    const gaps = records.filter((r) => r.type === 'control' && r.kind === 'gap');
+    const end = records.find((r) => r.type === 'control' && r.kind === 'end');
+    expect(gaps).toHaveLength(0);
+    expect(end).toEqual({
+      v: 1,
+      ts: 1,
+      type: 'control',
+      src: 'system',
+      kind: 'end',
+      total_bytes: 120,
+    });
+  });
+
+  it('stops emitting and writes no end record once the server caps the budget', async () => {
+    const server = cappingServer(20);
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 5,
+      append: server.append,
+      flushIntervalMs: 100000, // drive flushes via drain(), not the timer
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('a'.repeat(30)), 'stdout'); // crosses the cap once uploaded
+    await stream.drain({timeoutMs: 1000}); // uploader learns capped
+
+    stream.write(Buffer.from('b'.repeat(30)), 'stdout'); // no-op: capped
+    await stream.close();
+    await stream.drain({timeoutMs: 1000});
+    stream.dispose();
+
+    const records = await readRecords(5);
+    // No runner end marker after a server cap (the cap tombstone is server-side).
+    expect(records.some((r) => r.type === 'control' && r.kind === 'end')).toBe(false);
+    const outputs = records.filter((r) => r.type === 'output');
+    expect(outputs).toHaveLength(1);
+    expect(outputs.every((r) => r.type === 'output' && r.data.startsWith('a'))).toBe(true);
+  });
+
+  it('records a gap then resumes output once acks free the backlog', async () => {
+    let acking = false;
+    let committed = 0;
+    const append: LogAppendFn = ({offset, body, signal}) => {
+      if (!acking)
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('aborted')), {once: true});
+        });
+      if (offset > committed)
+        return Promise.resolve({status: 'conflict', committedLength: committed});
+      if (offset === committed) committed += body.length;
+      return Promise.resolve({status: 'committed', committedLength: committed, capped: false});
+    };
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 6,
+      append,
+      flushIntervalMs: 100000, // no background flush; control timing via drain()
+      spoolMaxBytes: 150, // fits one ~96-byte record, not two
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('a'.repeat(40)), 'stdout'); // spooled
+    stream.write(Buffer.from('b'.repeat(40)), 'stdout'); // dropped: backlog over cap
+
+    acking = true;
+    await stream.drain({timeoutMs: 1000}); // acks the first record, freeing the backlog
+
+    stream.write(Buffer.from('c'.repeat(40)), 'stdout'); // now fits: gap then resumed output
+    await stream.close();
+    await stream.drain({timeoutMs: 1000});
+    stream.dispose();
+
+    const records = await readRecords(6);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'output', src: 'stdout', data: 'a'.repeat(40)},
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'gap', dropped_bytes: 40},
+      {v: 1, ts: 1, type: 'output', src: 'stdout', data: 'c'.repeat(40)},
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'end', total_bytes: 80},
+    ]);
+  });
+
+  it('drain returns within the deadline when the API is unreachable', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 7,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('data\n'), 'stdout');
+    await stream.close();
+
+    const start = Date.now();
+    await stream.drain({timeoutMs: 20});
+    const elapsed = Date.now() - start;
+    stream.dispose();
+
+    expect(elapsed).toBeLessThan(900); // bounded; never blocks the report on an unreachable API
+  });
+
+  it('uploads only whole NDJSON records when output spans many flush windows', async () => {
+    const server = recordingServer();
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 9,
+      append: server.append,
+      flushIntervalMs: 5,
+      flushBytes: 150, // larger than one ~96-byte record, smaller than two
+      now: () => 1,
+    });
+
+    for (let i = 0; i < 6; i++) stream.write(Buffer.from(`${'x'.repeat(40)}\n`), 'stdout');
+    await stream.close();
+    await stream.drain({timeoutMs: 1000});
+    stream.dispose();
+
+    // The windowing actually split the stream into several bodies...
+    expect(server.bodies.length).toBeGreaterThan(1);
+    // ...and not one of them is a torn line: each ends on a boundary and parses whole.
+    for (const body of server.bodies) {
+      expect(body.at(-1)).toBe(0x0a);
+      for (const line of body.toString('utf8').split('\n').filter(Boolean)) {
+        expect(() => logRecordSchema.parse(JSON.parse(line))).not.toThrow();
+      }
+    }
+  });
+
+  it('abandons capture without crashing when the spool cannot be written', async () => {
+    // Pre-create a FILE where the logs directory should be so the spool's mkdir/open throws.
+    const logsDir = join(dir, 'logs');
+    await writeFile(logsDir, 'not a directory');
+
+    const stream = createStepLogStream({
+      logsDir,
+      stepId: STEP_ID,
+      attempt: 8,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    // The fs failure happens inside the sink; it must be swallowed, not thrown (a throw
+    // here would escape the child's 'data' handler and crash the whole runner).
+    expect(() => stream.write(Buffer.from('boom\n'), 'stdout')).not.toThrow();
+    expect(() => stream.write(Buffer.from('more\n'), 'stdout')).not.toThrow();
+    const {streamLength} = await stream.close();
+    stream.dispose();
+
+    expect(streamLength).toBe(0);
+  });
+});

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -1,0 +1,163 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import type {LogAppendFn} from '@shipfox/runner-protocol';
+import {AttemptSpool} from '#api/spool.js';
+import {LogUploader} from '#api/uploader.js';
+import {config} from '#config.js';
+import {type OutputSource, StreamFramer} from '#core/framing.js';
+
+export interface StepLogStreamOptions {
+  /** The `<jobWorkspace>/logs` directory the spool file lives in. */
+  logsDir: string;
+  stepId: string;
+  attempt: number;
+  /** Append port bound to the lease client, step, and attempt by the caller. */
+  append: LogAppendFn;
+  flushIntervalMs?: number;
+  flushBytes?: number;
+  spoolMaxBytes?: number;
+  /** Injectable clock for record timestamps (tests). */
+  now?: () => number;
+}
+
+export interface StepLogStream {
+  /** Frames and spools a captured output chunk. Safe to call from a pipe handler. */
+  write(chunk: Buffer, source: OutputSource): void;
+  /**
+   * Flushes decoders, records a trailing gap and the end marker, and resolves
+   * with the final raw stream length. Does NOT wait for upload — the report is
+   * never blocked on log drain.
+   */
+  close(): Promise<{streamLength: number}>;
+  /**
+   * Waits (bounded) for the uploader to ship everything spooled so far.
+   * `timeoutMs` defaults to `SHIPFOX_LOG_DRAIN_TIMEOUT_MS`.
+   */
+  drain(opts?: {signal?: AbortSignal; timeoutMs?: number}): Promise<void>;
+  /** Stops the uploader and closes spool file descriptors. */
+  dispose(): void;
+}
+
+/**
+ * Per step-attempt log pipeline:
+ *
+ *   write(chunk) ─▶ framer ─▶ [backlog cap?] ─▶ spool ─▶ uploader ─▶ /logs
+ *                                  │ over cap
+ *                                  └▶ drop + remember dropped bytes ─▶ gap marker
+ *
+ * The backlog cap bounds UNACKED bytes (spool length minus the server-acked
+ * offset), not total output, so a healthy long stream never drops. Control
+ * records (gap/end) bypass the cap so truncation is always visible.
+ */
+export function createStepLogStream(options: StepLogStreamOptions): StepLogStream {
+  const now = options.now ?? Date.now;
+  const flushBytes = options.flushBytes ?? config.SHIPFOX_LOG_FLUSH_BYTES;
+  const spoolMaxBytes = options.spoolMaxBytes ?? config.SHIPFOX_LOG_SPOOL_MAX_BYTES;
+  const intervalMs = options.flushIntervalMs ?? config.SHIPFOX_LOG_FLUSH_INTERVAL_MS;
+
+  const framer = new StreamFramer(now);
+  const spool = AttemptSpool.open(options.logsDir, options.stepId, options.attempt);
+  const uploader = new LogUploader(spool, options.append, {intervalMs, flushBytes});
+
+  let streamLength = 0;
+  let payloadTotal = 0;
+  let droppedPayload = 0;
+  let dropping = false;
+  let closed = false;
+  let failed = false;
+
+  function spoolBytes(bytes: Buffer): void {
+    spool.append(bytes);
+    streamLength += bytes.length;
+  }
+
+  // A synchronous spool write (writeSync/openSync/mkdirSync) can throw on a real fs
+  // failure (ENOSPC, EMFILE, EACCES, logs dir removed mid-step). That throw originates
+  // inside the child process's stdout/stderr 'data' handler, where it would escape as
+  // an uncaughtException and kill the whole runner. Abandon log capture for this step
+  // instead: the report still goes out, and the server closes the stream via timeout.
+  function failStream(err: unknown): void {
+    if (failed) return;
+    failed = true;
+    logger().error(
+      {err: String(err), stepId: options.stepId, attempt: options.attempt},
+      'Log spool write failed; abandoning log capture for this step',
+    );
+    uploader.stop();
+  }
+
+  function flushPendingGap(): void {
+    if (!dropping) return;
+    spoolBytes(framer.frameGap(droppedPayload));
+    droppedPayload = 0;
+    dropping = false;
+  }
+
+  uploader.start();
+
+  return {
+    write(chunk, source) {
+      // Once the server caps the budget the runner stops emitting; the cap
+      // tombstone is server-side, so no gap is recorded here.
+      if (closed || failed || uploader.isCapped() || uploader.isStopped()) return;
+
+      const framed = framer.frameOutput(chunk, source);
+      if (framed.bytes.length === 0) return;
+
+      const projectedBacklog = streamLength + framed.bytes.length - uploader.ackedOffset;
+      if (projectedBacklog > spoolMaxBytes) {
+        droppedPayload += framed.payloadBytes;
+        dropping = true;
+        return;
+      }
+
+      try {
+        flushPendingGap();
+        spoolBytes(framed.bytes);
+      } catch (err) {
+        failStream(err);
+        return;
+      }
+      payloadTotal += framed.payloadBytes;
+      uploader.notify();
+    },
+
+    close() {
+      if (closed) return Promise.resolve({streamLength});
+      closed = true;
+      if (failed) return Promise.resolve({streamLength});
+
+      try {
+        const tail = framer.flushDecoders();
+        if (tail.bytes.length > 0) {
+          spoolBytes(tail.bytes);
+          payloadTotal += tail.payloadBytes;
+        }
+        flushPendingGap();
+
+        // On a server cap the stream is already closed by the cap tombstone, so the
+        // runner does not append its own end marker.
+        if (!uploader.isCapped()) {
+          spoolBytes(framer.frameEnd(payloadTotal));
+        }
+      } catch (err) {
+        failStream(err);
+        return Promise.resolve({streamLength});
+      }
+
+      uploader.notify();
+      return Promise.resolve({streamLength});
+    },
+
+    async drain(opts = {}) {
+      await uploader.drain({
+        timeoutMs: opts.timeoutMs ?? config.SHIPFOX_LOG_DRAIN_TIMEOUT_MS,
+        ...(opts.signal ? {signal: opts.signal} : {}),
+      });
+    },
+
+    dispose() {
+      uploader.stop();
+      spool.close();
+    },
+  };
+}

--- a/libs/runner/logs/src/index.ts
+++ b/libs/runner/logs/src/index.ts
@@ -1,0 +1,6 @@
+export type {OutputSource} from '#core/framing.js';
+export {
+  createStepLogStream,
+  type StepLogStream,
+  type StepLogStreamOptions,
+} from '#core/step-log-stream.js';

--- a/libs/runner/logs/tsconfig.build.json
+++ b/libs/runner/logs/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/runner/logs/tsconfig.json
+++ b/libs/runner/logs/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/runner/logs/tsconfig.test.json
+++ b/libs/runner/logs/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/runner/logs/vitest.config.ts
+++ b/libs/runner/logs/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/runner/orchestration/package.json
+++ b/libs/runner/orchestration/package.json
@@ -42,6 +42,7 @@
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/runner-agent": "workspace:*",
     "@shipfox/runner-execution": "workspace:*",
+    "@shipfox/runner-logs": "workspace:*",
     "@shipfox/runner-protocol": "workspace:*",
     "@shipfox/runner-workspace": "workspace:*",
     "ky": "^2.0.0"

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -165,6 +165,30 @@ describe('runJobSteps', () => {
     expect(captured?.write).toHaveBeenCalledWith(Buffer.from('hello'), 'stdout');
   });
 
+  it('runs and reports the step when opening the log stream fails (capture abandoned)', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    // Opening the spool throws (e.g. a broken logs dir): capture must be abandoned, not fatal.
+    createStepLogStreamMock.mockImplementationOnce(() => {
+      throw new Error('logs dir is a file');
+    });
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    // The step still runs and is reported succeeded; the stream failure does not fail the step.
+    expect(executeRunStepMock).toHaveBeenCalled();
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({stepId: run.id, status: 'succeeded'}),
+    );
+  });
+
   it('drains and disposes the prior attempt stream before opening the next', async () => {
     const setup = buildSetupStep();
     const run1 = buildRunStep({id: '00000000-0000-0000-0000-0000000000c1', position: 1});

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -184,6 +184,32 @@ describe('runJobSteps', () => {
     expect(events).toContain(`dispose:${run2.id}`);
   });
 
+  it('drains the prior stream before requesting the next step, not after', async () => {
+    const setup = buildSetupStep();
+    const run1 = buildRunStep({id: '00000000-0000-0000-0000-0000000000d1', position: 1});
+    const run2 = buildRunStep({id: '00000000-0000-0000-0000-0000000000d2', position: 2});
+    // Record each pull in the ordered event log so we can assert it relative to the drain.
+    const responses = [
+      stepResponse(setup, 1),
+      stepResponse(run1, 1),
+      stepResponse(run2, 1),
+      {kind: 'done', status: 'succeeded'},
+    ];
+    let pull = 0;
+    requestNextStepMock.mockImplementation(() => {
+      events.push(`pull:${pull}`);
+      return Promise.resolve(responses[pull++]);
+    });
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    // pull index 2 is the request that claims run2. run1's stream must be disposed before it,
+    // so a slow drain delays only the (unclaimed) pull, never a freshly claimed step.
+    expect(events.indexOf(`dispose:${run1.id}`)).toBeLessThan(events.indexOf('pull:2'));
+  });
+
   it('drains and disposes the stream on abort, without reporting', async () => {
     const setup = buildSetupStep();
     const run = buildRunStep();

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -110,7 +110,6 @@ describe('runJobSteps', () => {
       status: 'succeeded',
       error: null,
       exitCode: 0,
-      logStreamLength: STREAM_LENGTH,
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(3);
@@ -304,7 +303,6 @@ describe('runJobSteps', () => {
       status: 'failed',
       error,
       exitCode: 1,
-      logStreamLength: STREAM_LENGTH,
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(2);
@@ -332,7 +330,6 @@ describe('runJobSteps', () => {
       status: 'failed',
       error: {message: 'ENOSPC: no space left on device'},
       exitCode: null,
-      logStreamLength: STREAM_LENGTH,
       signal: ac.signal,
     });
   });

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -3,19 +3,26 @@ import {HTTPError} from 'ky';
 
 const requestNextStepMock = vi.fn();
 const reportStepMock = vi.fn();
+const appendStepLogsMock = vi.fn();
 const executeRunStepMock = vi.fn();
 const executeSetupStepMock = vi.fn();
+const createStepLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
 
 vi.mock('@shipfox/runner-protocol', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
   reportStep: (...args: unknown[]) => reportStepMock(...args),
+  appendStepLogs: (...args: unknown[]) => appendStepLogsMock(...args),
   HTTPError,
 }));
 
 vi.mock('@shipfox/runner-execution', () => ({
   executeRunStep: (...args: unknown[]) => executeRunStepMock(...args),
   executeSetupStep: (...args: unknown[]) => executeSetupStepMock(...args),
+}));
+
+vi.mock('@shipfox/runner-logs', () => ({
+  createStepLogStream: (...args: unknown[]) => createStepLogStreamMock(...args),
 }));
 
 vi.mock('@shipfox/runner-agent', () => ({
@@ -26,17 +33,53 @@ const {runJobSteps} = await import('#core/step-loop.js');
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
 const leaseClient = {} as never;
+const STREAM_LENGTH = 128;
+
+// Ordered log of stream lifecycle events across all created streams, so tests can
+// assert "prior attempt drained before the next opens".
+let events: string[];
+
+interface FakeStream {
+  write: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  drain: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeStream(label: string): FakeStream {
+  return {
+    write: vi.fn(),
+    close: vi.fn(() => {
+      events.push(`close:${label}`);
+      return Promise.resolve({streamLength: STREAM_LENGTH});
+    }),
+    drain: vi.fn(() => {
+      events.push(`drain:${label}`);
+      return Promise.resolve();
+    }),
+    dispose: vi.fn(() => {
+      events.push(`dispose:${label}`);
+    }),
+  };
+}
 
 describe('runJobSteps', () => {
   beforeEach(() => {
     requestNextStepMock.mockReset();
     reportStepMock.mockReset();
+    appendStepLogsMock.mockReset();
     executeRunStepMock.mockReset();
     executeSetupStepMock.mockReset();
+    createStepLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
+    events = [];
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
     // Setup succeeds by default; tests that exercise setup failure override it.
-    executeSetupStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
+    executeSetupStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    createStepLogStreamMock.mockImplementation((opts: {stepId: string}) => {
+      events.push(`create:${opts.stepId}`);
+      return makeFakeStream(opts.stepId);
+    });
   });
 
   it('runs the setup step then a run step against the prepared cwd, reporting both', async () => {
@@ -46,12 +89,7 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce(stepResponse(setup, 1))
       .mockResolvedValueOnce(stepResponse(run, 1))
       .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
-    executeRunStepMock.mockResolvedValue({
-      success: true,
-      output: 'ok\n',
-      error: null,
-      exit_code: 0,
-    });
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
@@ -61,28 +99,118 @@ describe('runJobSteps', () => {
       leaseClient,
       signal: ac.signal,
     });
-    expect(executeRunStepMock).toHaveBeenCalledWith(run, {signal: ac.signal, cwd: '/work'});
+    expect(executeRunStepMock).toHaveBeenCalledWith(run, {
+      signal: ac.signal,
+      cwd: '/work',
+      onOutput: expect.any(Function),
+    });
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: run.id,
       attempt: 1,
       status: 'succeeded',
       error: null,
       exitCode: 0,
+      logStreamLength: STREAM_LENGTH,
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('opens a per-attempt log stream for the run step and disposes it at the end', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 3))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    expect(createStepLogStreamMock).toHaveBeenCalledWith({
+      logsDir: '/work/logs',
+      stepId: run.id,
+      attempt: 3,
+      append: expect.any(Function),
+    });
+    // No stream for the synthetic setup step.
+    expect(createStepLogStreamMock).toHaveBeenCalledTimes(1);
+    // Drained and disposed once the loop finishes.
+    expect(events).toContain(`drain:${run.id}`);
+    expect(events).toContain(`dispose:${run.id}`);
+  });
+
+  it('routes captured output through the stream write sink', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    let captured: FakeStream | undefined;
+    createStepLogStreamMock.mockImplementation((opts: {stepId: string}) => {
+      captured = makeFakeStream(opts.stepId);
+      return captured;
+    });
+    executeRunStepMock.mockImplementation(
+      (_step, opts: {onOutput: (chunk: Buffer, src: string) => void}) => {
+        opts.onOutput(Buffer.from('hello'), 'stdout');
+        return Promise.resolve({success: true, error: null, exit_code: 0});
+      },
+    );
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    expect(captured?.write).toHaveBeenCalledWith(Buffer.from('hello'), 'stdout');
+  });
+
+  it('drains and disposes the prior attempt stream before opening the next', async () => {
+    const setup = buildSetupStep();
+    const run1 = buildRunStep({id: '00000000-0000-0000-0000-0000000000c1', position: 1});
+    const run2 = buildRunStep({id: '00000000-0000-0000-0000-0000000000c2', position: 2});
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run1, 1))
+      .mockResolvedValueOnce(stepResponse(run2, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    // The first stream is drained and disposed before the second is created.
+    expect(events.indexOf(`dispose:${run1.id}`)).toBeLessThan(events.indexOf(`create:${run2.id}`));
+    expect(events).toContain(`dispose:${run2.id}`);
+  });
+
+  it('drains and disposes the stream on abort, without reporting', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    const ac = new AbortController();
+    executeRunStepMock.mockImplementationOnce(() => {
+      ac.abort();
+      return Promise.resolve({success: true, error: null, exit_code: 0});
+    });
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+
+    // Setup completed and was reported; the aborted run step is not.
+    const reportedSteps = reportStepMock.mock.calls.map((call) => call[1].stepId);
+    expect(reportedSteps).not.toContain(run.id);
+    expect(events).toContain(`drain:${run.id}`);
+    expect(events).toContain(`dispose:${run.id}`);
   });
 
   it('reports the setup step failed with its reason, then stops on cancel:true (no user step runs)', async () => {
     const setup = buildSetupStep();
     const error = {message: 'mkdir denied', reason: 'workspace_prep_failed' as const};
     requestNextStepMock.mockResolvedValueOnce(stepResponse(setup, 1));
-    executeSetupStepMock.mockResolvedValueOnce({
-      success: false,
-      output: '',
-      error,
-      exit_code: null,
-    });
+    executeSetupStepMock.mockResolvedValueOnce({success: false, error, exit_code: null});
     reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
@@ -97,6 +225,7 @@ describe('runJobSteps', () => {
       signal: ac.signal,
     });
     expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(createStepLogStreamMock).not.toHaveBeenCalled();
     expect(requestNextStepMock).toHaveBeenCalledTimes(1);
   });
 
@@ -110,6 +239,7 @@ describe('runJobSteps', () => {
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(createStepLogStreamMock).not.toHaveBeenCalled();
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: run.id,
       attempt: 1,
@@ -160,12 +290,7 @@ describe('runJobSteps', () => {
     requestNextStepMock
       .mockResolvedValueOnce(stepResponse(setup, 1))
       .mockResolvedValueOnce(stepResponse(run, 1));
-    executeRunStepMock.mockResolvedValueOnce({
-      success: false,
-      output: 'boom\n',
-      error,
-      exit_code: 1,
-    });
+    executeRunStepMock.mockResolvedValueOnce({success: false, error, exit_code: 1});
     reportStepMock
       .mockResolvedValueOnce({ok: true, cancel: false})
       .mockResolvedValueOnce({ok: true, cancel: true});
@@ -179,6 +304,7 @@ describe('runJobSteps', () => {
       status: 'failed',
       error,
       exitCode: 1,
+      logStreamLength: STREAM_LENGTH,
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(2);
@@ -206,6 +332,7 @@ describe('runJobSteps', () => {
       status: 'failed',
       error: {message: 'ENOSPC: no space left on device'},
       exitCode: null,
+      logStreamLength: STREAM_LENGTH,
       signal: ac.signal,
     });
   });
@@ -216,7 +343,7 @@ describe('runJobSteps', () => {
     requestNextStepMock.mockResolvedValueOnce(stepResponse(setup, 1));
     executeSetupStepMock.mockImplementationOnce(() => {
       ac.abort();
-      return Promise.resolve({success: true, output: '', error: null, exit_code: 0});
+      return Promise.resolve({success: true, error: null, exit_code: 0});
     });
 
     await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
@@ -248,6 +375,7 @@ describe('runJobSteps', () => {
 
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {signal: ac.signal, cwd: '/work'});
     expect(executeRunStepMock).not.toHaveBeenCalled();
+    // No log stream is opened for agent steps, so the report carries no stream length.
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: agent.id,
       attempt: 1,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -33,6 +33,12 @@ export async function runJobSteps(params: {
 
   try {
     while (!signal.aborted) {
+      // Settle the previous run step's stream before pulling the next step, not after: a slow
+      // drain must not delay a freshly claimed step (the server marks it running on pull), and
+      // open fds/uploaders must not accumulate across fast retries.
+      await settleStream({stream: activeStream, signal});
+      activeStream = undefined;
+
       const pulled = await pullNextStep({leaseClient, jobId, signal});
       if (!pulled) return;
       if (signal.aborted) return;
@@ -43,11 +49,6 @@ export async function runJobSteps(params: {
         {jobId, stepId: step.id, stepName: step.name, position: step.position, attempt},
         `Running ${stepLabel}`,
       );
-
-      // Settle the previous run step's stream before this step opens its own, so open
-      // fds and uploaders cannot accumulate across fast retries.
-      await settleStream({stream: activeStream, signal});
-      activeStream = undefined;
 
       const execution = await executeStep({
         step,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -236,9 +236,9 @@ export async function reportStepResult(params: {
     );
   }
 
-  // Close the stream to seal its end record and learn the declared length; the report
-  // carries it without blocking on the upload draining.
-  const logStreamLength = stream ? (await stream.close()).streamLength : undefined;
+  // Seal the stream's end record before reporting so the background uploader can ship it; the
+  // upload drains separately (settleStream), so the report never blocks on it.
+  if (stream) await stream.close();
 
   const report = await reportStep(leaseClient, {
     stepId: step.id,
@@ -247,7 +247,6 @@ export async function reportStepResult(params: {
     // null on success, the error shape on failure — matches reportStepBodySchema's refine.
     error: result.error,
     exitCode: result.exit_code,
-    ...(logStreamLength !== undefined ? {logStreamLength} : {}),
     signal,
   });
 

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -177,19 +177,28 @@ export async function executeStep(params: {
       return {result, preparedWorkspace: false};
     }
 
-    stream = createStepLogStream({
-      logsDir: join(cwd, 'logs'),
-      stepId: step.id,
-      attempt,
-      append: ({offset, body, signal: appendSignal}) =>
-        appendStepLogs(leaseClient, {
-          stepId: step.id,
-          attempt,
-          offset,
-          body,
-          ...(appendSignal ? {signal: appendSignal} : {}),
-        }),
-    });
+    // Log capture is best-effort: if the spool cannot be opened (e.g. a broken logs dir),
+    // abandon capture and run the step without a stream rather than failing the step itself.
+    try {
+      stream = createStepLogStream({
+        logsDir: join(cwd, 'logs'),
+        stepId: step.id,
+        attempt,
+        append: ({offset, body, signal: appendSignal}) =>
+          appendStepLogs(leaseClient, {
+            stepId: step.id,
+            attempt,
+            offset,
+            body,
+            ...(appendSignal ? {signal: appendSignal} : {}),
+          }),
+      });
+    } catch (error) {
+      logger().error(
+        {err: error, jobId, stepId: step.id, attempt},
+        'Failed to open log capture; running the step without it',
+      );
+    }
 
     const result = await executeRunStep(step, {
       signal,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1,13 +1,19 @@
-import type {NextStepResponseDto} from '@shipfox/api-workflows-dto';
+import {join} from 'node:path';
+import type {NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {executeAgentStep} from '@shipfox/runner-agent';
 import {executeRunStep, executeSetupStep, type StepResult} from '@shipfox/runner-execution';
-import {HTTPError, reportStep, requestNextStep} from '@shipfox/runner-protocol';
+import {createStepLogStream, type StepLogStream} from '@shipfox/runner-logs';
+import {appendStepLogs, HTTPError, reportStep, requestNextStep} from '@shipfox/runner-protocol';
 import type {KyInstance} from 'ky';
 
 // Reporting a step before pulling the next one is the safety invariant: a lost report is
 // retried in place (next/report are idempotent), so a step is never re-pulled or
 // re-executed. An abort mid-step stops without reporting, leaving the job for lease expiry.
+//
+// Each run step gets a per-attempt log stream: capture → spool → upload. The prior
+// attempt's stream is drained and disposed before the next opens, and the `finally`
+// drains the last one (bounded) before runJob deletes the workspace the spool lives in.
 export async function runJobSteps(params: {
   jobId: string;
   leaseClient: KyInstance;
@@ -16,102 +22,247 @@ export async function runJobSteps(params: {
 }): Promise<void> {
   const {jobId, leaseClient, signal, cwd} = params;
 
-  // The setup step (position 0) prepares the workspace; every run step assumes it
-  // ran. This guard makes the invariant explicit: a run step pulled before a
-  // successful setup is reported as a clean failure rather than spawning against an
-  // unprepared cwd. It assumes one runner executes a job's full lifecycle, which
-  // holds today (a job is never re-dispatched mid-flight).
+  // The setup step (position 0) prepares the workspace; every run step assumes it ran.
+  // A run step pulled before a successful setup is failed cleanly rather than spawned
+  // against an unprepared cwd. The guard and its rollout rationale live in `executeStep`.
   let workspacePrepared = false;
 
-  while (!signal.aborted) {
-    let next: NextStepResponseDto;
-    try {
-      next = await requestNextStep(leaseClient, {signal});
-    } catch (error) {
-      if (error instanceof HTTPError && error.response.status === 404) {
-        logger().info({jobId}, 'No job for this lease (404); stopping step loop');
+  // The most recent run step's stream, kept until the next iteration settles it (or the
+  // finally does at job end). The step loop is sequential, so at most one tail drains.
+  let activeStream: StepLogStream | undefined;
+
+  try {
+    while (!signal.aborted) {
+      const pulled = await pullNextStep({leaseClient, jobId, signal});
+      if (!pulled) return;
+      if (signal.aborted) return;
+
+      const {step, attempt} = pulled;
+      const stepLabel = step.name ?? `step #${step.position}`;
+      logger().info(
+        {jobId, stepId: step.id, stepName: step.name, position: step.position, attempt},
+        `Running ${stepLabel}`,
+      );
+
+      // Settle the previous run step's stream before this step opens its own, so open
+      // fds and uploaders cannot accumulate across fast retries.
+      await settleStream({stream: activeStream, signal});
+      activeStream = undefined;
+
+      const execution = await executeStep({
+        step,
+        attempt,
+        cwd,
+        leaseClient,
+        signal,
+        workspacePrepared,
+        jobId,
+        stepLabel,
+      });
+      activeStream = execution.stream;
+      if (execution.preparedWorkspace) workspacePrepared = true;
+
+      if (signal.aborted) return;
+
+      const {cancel} = await reportStepResult({
+        leaseClient,
+        step,
+        attempt,
+        result: execution.result,
+        stream: execution.stream,
+        jobId,
+        stepLabel,
+        signal,
+      });
+      if (cancel) {
+        logger().info(
+          {jobId, stepId: step.id},
+          'Job finished without full success; stopping step loop',
+        );
         return;
       }
-      throw error;
+    }
+  } finally {
+    // Drain the last stream (bounded) before runJob deletes the workspace; an abort
+    // cuts the wait short. Whatever did not drain is timeout-closed server-side.
+    await settleStream({stream: activeStream, signal});
+  }
+}
+
+export interface PulledStep {
+  step: StepDto;
+  attempt: number;
+}
+
+// Pulls the next step, translating the loop's two quiet stop conditions into `undefined`:
+// a 404 (the lease no longer maps to a job) and a `done` response. Any other error
+// propagates so the loop bails without re-pulling.
+export async function pullNextStep(params: {
+  leaseClient: KyInstance;
+  jobId: string;
+  signal: AbortSignal;
+}): Promise<PulledStep | undefined> {
+  const {leaseClient, jobId, signal} = params;
+
+  let next: NextStepResponseDto;
+  try {
+    next = await requestNextStep(leaseClient, {signal});
+  } catch (error) {
+    if (error instanceof HTTPError && error.response.status === 404) {
+      logger().info({jobId}, 'No job for this lease (404); stopping step loop');
+      return undefined;
+    }
+    throw error;
+  }
+
+  if (next.kind === 'done') {
+    logger().info({jobId, status: next.status}, 'No more steps; stopping step loop');
+    return undefined;
+  }
+
+  return {step: next.step, attempt: next.attempt};
+}
+
+export interface StepExecution {
+  result: StepResult;
+  /** The run step's log stream, when one was opened; settle it after reporting. */
+  stream?: StepLogStream | undefined;
+  /** True when a setup step succeeded, unlocking the run steps that follow it. */
+  preparedWorkspace: boolean;
+}
+
+// Runs one step and always yields a StepResult, never throws: a crash before a result
+// exists (e.g. writing the temp script) becomes a reported failure so the step does not
+// hang `running`. The log stream is opened for run steps only and returned even on a
+// throw, so the caller can still settle it.
+export async function executeStep(params: {
+  step: StepDto;
+  attempt: number;
+  cwd: string;
+  leaseClient: KyInstance;
+  signal: AbortSignal;
+  workspacePrepared: boolean;
+  jobId: string;
+  stepLabel: string;
+}): Promise<StepExecution> {
+  const {step, attempt, cwd, leaseClient, signal, workspacePrepared, jobId, stepLabel} = params;
+
+  let stream: StepLogStream | undefined;
+  try {
+    if (step.type === 'setup') {
+      const result = await executeSetupStep({cwd, leaseClient, signal});
+      return {result, preparedWorkspace: result.success};
     }
 
-    if (next.kind === 'done') {
-      logger().info({jobId, status: next.status}, 'No more steps; stopping step loop');
-      return;
-    }
-
-    if (signal.aborted) return;
-
-    const {step, attempt} = next;
-    const stepLabel = step.name ?? `step #${step.position}`;
-    logger().info(
-      {jobId, stepId: step.id, stepName: step.name, position: step.position, attempt},
-      `Running ${stepLabel}`,
-    );
-
-    let result: StepResult;
-    try {
-      if (step.type === 'setup') {
-        result = await executeSetupStep({cwd, leaseClient, signal});
-        if (result.success) workspacePrepared = true;
-      } else if (!workspacePrepared) {
-        // Invariant violation (a run or agent step before setup prepared the cwd),
-        // not a setup-phase failure, so no `reason`. step.type is not 'setup' so the
-        // server derives category 'user'. Only reachable for a setup-less in-flight
-        // job hitting a new runner during the rollout window.
-        result = {
+    if (!workspacePrepared) {
+      // Invariant violation (a run or agent step before setup prepared the cwd), not a
+      // setup-phase failure, so no `reason`. step.type is not 'setup' so the server
+      // derives category 'user'. Only reachable for a setup-less in-flight job hitting a
+      // new runner during the rollout window.
+      return {
+        result: {
           success: false,
-          output: '',
           error: {message: 'Run step dispatched before setup prepared the workspace'},
           exit_code: null,
-        };
-      } else if (step.type === 'agent') {
-        result = await executeAgentStep(step, {signal, cwd});
-      } else {
-        result = await executeRunStep(step, {signal, cwd});
-      }
-    } catch (error) {
-      // A local executor failure (e.g. writing the temp script) throws before a
-      // StepResult exists. Report the step failed so it does not hang `running`.
-      logger().error(
-        {err: error, jobId, stepId: step.id},
-        `Step ${stepLabel} crashed before producing a result`,
-      );
-      result = {
-        success: false,
-        output: '',
-        error: {message: error instanceof Error ? error.message : String(error)},
-        exit_code: null,
+        },
+        preparedWorkspace: false,
       };
     }
 
-    if (signal.aborted) return;
-
-    if (result.success) {
-      logger().info({jobId, stepId: step.id, stepName: step.name}, `Step ${stepLabel} succeeded`);
-    } else {
-      logger().error(
-        {jobId, stepId: step.id, stepName: step.name, reason: result.error?.reason},
-        `Step ${stepLabel} failed`,
-      );
+    // Agent steps run the embedded pi harness; they capture their own summary and do not
+    // stream output through the log pipeline (run steps below do).
+    if (step.type === 'agent') {
+      const result = await executeAgentStep(step, {signal, cwd});
+      return {result, preparedWorkspace: false};
     }
 
-    const report = await reportStep(leaseClient, {
+    stream = createStepLogStream({
+      logsDir: join(cwd, 'logs'),
       stepId: step.id,
       attempt,
-      status: result.success ? 'succeeded' : 'failed',
-      // null on success, the error shape on failure — matches reportStepBodySchema's refine.
-      error: result.error,
-      exitCode: result.exit_code,
-      signal,
+      append: ({offset, body, signal: appendSignal}) =>
+        appendStepLogs(leaseClient, {
+          stepId: step.id,
+          attempt,
+          offset,
+          body,
+          ...(appendSignal ? {signal: appendSignal} : {}),
+        }),
     });
 
-    if (report.cancel) {
-      logger().info(
-        {jobId, stepId: step.id},
-        'Job finished without full success; stopping step loop',
-      );
-      return;
-    }
+    const result = await executeRunStep(step, {
+      signal,
+      cwd,
+      onOutput: (chunk, source) => stream?.write(chunk, source),
+    });
+    return {result, stream, preparedWorkspace: false};
+  } catch (error) {
+    logger().error(
+      {err: error, jobId, stepId: step.id},
+      `Step ${stepLabel} crashed before producing a result`,
+    );
+    return {
+      result: {
+        success: false,
+        error: {message: error instanceof Error ? error.message : String(error)},
+        exit_code: null,
+      },
+      stream,
+      preparedWorkspace: false,
+    };
   }
+}
+
+// Logs the outcome, seals the stream to learn its declared length, and reports the step.
+// Returns whether the server asked the loop to stop (job finished without full success).
+export async function reportStepResult(params: {
+  leaseClient: KyInstance;
+  step: StepDto;
+  attempt: number;
+  result: StepResult;
+  stream: StepLogStream | undefined;
+  jobId: string;
+  stepLabel: string;
+  signal: AbortSignal;
+}): Promise<{cancel: boolean}> {
+  const {leaseClient, step, attempt, result, stream, jobId, stepLabel, signal} = params;
+
+  if (result.success) {
+    logger().info({jobId, stepId: step.id, stepName: step.name}, `Step ${stepLabel} succeeded`);
+  } else {
+    logger().error(
+      {jobId, stepId: step.id, stepName: step.name, reason: result.error?.reason},
+      `Step ${stepLabel} failed`,
+    );
+  }
+
+  // Close the stream to seal its end record and learn the declared length; the report
+  // carries it without blocking on the upload draining.
+  const logStreamLength = stream ? (await stream.close()).streamLength : undefined;
+
+  const report = await reportStep(leaseClient, {
+    stepId: step.id,
+    attempt,
+    status: result.success ? 'succeeded' : 'failed',
+    // null on success, the error shape on failure — matches reportStepBodySchema's refine.
+    error: result.error,
+    exitCode: result.exit_code,
+    ...(logStreamLength !== undefined ? {logStreamLength} : {}),
+    signal,
+  });
+
+  return {cancel: report.cancel};
+}
+
+// Closes (idempotent), drains (bounded; an abort cuts it short), and disposes a stream.
+// A no-op when there is no stream, so callers can settle unconditionally.
+export async function settleStream(params: {
+  stream: StepLogStream | undefined;
+  signal: AbortSignal;
+}): Promise<void> {
+  const {stream, signal} = params;
+  if (!stream) return;
+  await stream.close();
+  await stream.drain({signal});
+  stream.dispose();
 }

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -3,6 +3,7 @@
 // test/env.ts (setupFiles), loaded before config is imported.
 
 import {
+  appendStepLogs,
   createLeaseClient,
   heartbeat,
   reportStep,
@@ -107,6 +108,124 @@ describe('api-client auth contexts', () => {
     expect(result).toEqual({ok: true, cancel: false});
     expect(calls[0]?.url).toContain(`runs/jobs/current/steps/${STEP_ID}/report`);
     expect(calls[0]?.authorization).toBe('Bearer lease-def');
+  });
+});
+
+describe('appendStepLogs', () => {
+  it('posts NDJSON to the lease-authed logs endpoint and parses committed', async () => {
+    stubFetch(() => jsonResponse({committed_length: 42, capped: false}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+      offset: 10,
+      body: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(outcome).toEqual({status: 'committed', committedLength: 42, capped: false});
+    expect(calls[0]?.url).toContain(`runs/jobs/current/steps/${STEP_ID}/logs`);
+    expect(calls[0]?.url).toContain('attempt=2');
+    expect(calls[0]?.url).toContain('offset=10');
+    expect(calls[0]?.authorization).toBe('Bearer lease-log');
+  });
+
+  it('surfaces the capped flag from the server', async () => {
+    stubFetch(() => jsonResponse({committed_length: 100, capped: true}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array([1]),
+    });
+
+    expect(outcome).toEqual({status: 'committed', committedLength: 100, capped: true});
+  });
+
+  it('returns conflict with the committed offset on 409', async () => {
+    stubFetch(() => jsonResponse({code: 'offset-gap', details: {committed_length: 7}}, 409));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 99,
+      body: new Uint8Array([1]),
+    });
+
+    expect(outcome).toEqual({status: 'conflict', committedLength: 7});
+  });
+
+  it('returns stopped when the endpoint is absent (404)', async () => {
+    stubFetch(() => new Response(null, {status: 404}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array(0),
+    });
+
+    expect(outcome).toEqual({status: 'stopped'});
+  });
+
+  it('returns stopped when the lease is rejected (401)', async () => {
+    stubFetch(() => new Response(null, {status: 401}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array(0),
+    });
+
+    expect(outcome).toEqual({status: 'stopped'});
+  });
+
+  it('returns stopped when the lease is forbidden (403)', async () => {
+    stubFetch(() => new Response(null, {status: 403}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array(0),
+    });
+
+    expect(outcome).toEqual({status: 'stopped'});
+  });
+
+  it('throws on an unexpected status so the uploader retries on its next tick', async () => {
+    stubFetch(() => new Response(null, {status: 500}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const append = appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array([1]),
+    });
+
+    await expect(append).rejects.toThrow('Log append failed with status 500');
+  });
+
+  it('rejects a non-UUID step id before making any request', async () => {
+    const leaseClient = createLeaseClient('lease-log');
+
+    const append = appendStepLogs(leaseClient, {
+      stepId: '../escape',
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array(0),
+    });
+
+    await expect(append).rejects.toThrow();
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -200,6 +200,48 @@ describe('appendStepLogs', () => {
     expect(outcome).toEqual({status: 'stopped'});
   });
 
+  it('returns stopped on a permanently rejected body (400) so it is not retried forever', async () => {
+    stubFetch(() => jsonResponse({code: 'malformed-log-chunk'}, 400));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array([1]),
+    });
+
+    expect(outcome).toEqual({status: 'stopped'});
+  });
+
+  it('returns stopped on an over-large body (413)', async () => {
+    stubFetch(() => new Response(null, {status: 413}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const outcome = await appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array([1]),
+    });
+
+    expect(outcome).toEqual({status: 'stopped'});
+  });
+
+  it('throws on 429 so a transient rate-limit is retried, not abandoned', async () => {
+    stubFetch(() => new Response(null, {status: 429}));
+    const leaseClient = createLeaseClient('lease-log');
+
+    const append = appendStepLogs(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      offset: 0,
+      body: new Uint8Array([1]),
+    });
+
+    await expect(append).rejects.toThrow('Log append failed with status 429');
+  });
+
   it('throws on an unexpected status so the uploader retries on its next tick', async () => {
     stubFetch(() => new Response(null, {status: 500}));
     const leaseClient = createLeaseClient('lease-log');

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -107,7 +107,6 @@ export async function reportStep(
     status: 'succeeded' | 'failed';
     error?: StepErrorDtoShape;
     exitCode: number | null;
-    logStreamLength?: number;
     signal?: AbortSignal;
   },
 ): Promise<ReportStepResponseDto> {
@@ -116,7 +115,6 @@ export async function reportStep(
     error: params.error ?? undefined,
     attempt: params.attempt,
     exit_code: params.exitCode,
-    ...(params.logStreamLength !== undefined ? {log_stream_length: params.logStreamLength} : {}),
   });
 
   const response = await leaseClient.post(`runs/jobs/current/steps/${params.stepId}/report`, {
@@ -177,13 +175,21 @@ export async function appendStepLogs(
     const {details} = offsetGapResponseSchema.parse(await response.json());
     return {status: 'conflict', committedLength: details.committed_length};
   }
-  // Endpoint absent (deploy skew) or the lease is no longer accepted: stop
-  // uploading and let the server's stream lifecycle close the stream.
-  if (response.status === 404 || response.status === 401 || response.status === 403) {
+  // Any other 4xx is permanent for this request: the endpoint is gone (deploy skew), the
+  // lease is rejected (401/403), or the body will never be accepted (400 malformed, 413 too
+  // large, 415/422, ...). Re-sending the identical body cannot succeed, so stop and let the
+  // server's stream lifecycle close the stream. 408/429 are transient and fall through to
+  // the retry path so server-driven backpressure still paces (not storms) the next attempt.
+  if (
+    response.status >= 400 &&
+    response.status < 500 &&
+    response.status !== 408 &&
+    response.status !== 429
+  ) {
     return {status: 'stopped'};
   }
-  // 5xx (not retried here, since throwHttpErrors disables status-code retry) or any
-  // other unexpected status: throw so the uploader logs it and retries on the next tick.
+  // 5xx, 408, 429, or any other unexpected status: throw so the uploader logs it and retries
+  // on the next tick (throwHttpErrors disables ky's in-transport status-code retry).
   throw new Error(`Log append failed with status ${response.status}`);
 }
 

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -1,3 +1,4 @@
+import {appendLogsResponseSchema, offsetGapResponseSchema} from '@shipfox/api-logs-dto';
 import {
   type ClaimedJobResponseDto,
   claimedJobResponseSchema,
@@ -17,6 +18,33 @@ import {
 import {logger} from '@shipfox/node-opentelemetry';
 import ky, {HTTPError, type KyInstance} from 'ky';
 import {config} from '#config.js';
+
+const STEP_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Media type the append endpoint expects for the raw NDJSON request body. */
+const LOG_NDJSON_CONTENT_TYPE = 'application/x-ndjson';
+
+/**
+ * The runner-facing result of one append, after the transport has interpreted the
+ * HTTP status. `committed` carries the new server offset (and whether the budget is
+ * now exhausted); `conflict` carries the offset to rewind/fast-forward to; `stopped`
+ * means the endpoint is gone or the lease is no longer accepted, so the uploader gives
+ * up (the server's stream lifecycle takes over).
+ */
+export type LogAppendOutcome =
+  | {status: 'committed'; committedLength: number; capped: boolean}
+  | {status: 'conflict'; committedLength: number}
+  | {status: 'stopped'};
+
+/**
+ * The append port the runner's uploader depends on. The caller binds the lease
+ * client, step, and attempt; the uploader only supplies the offset and body.
+ */
+export type LogAppendFn = (args: {
+  offset: number;
+  body: Uint8Array;
+  signal?: AbortSignal;
+}) => Promise<LogAppendOutcome>;
 
 const baseUrl = config.SHIPFOX_API_URL.endsWith('/')
   ? config.SHIPFOX_API_URL
@@ -79,6 +107,7 @@ export async function reportStep(
     status: 'succeeded' | 'failed';
     error?: StepErrorDtoShape;
     exitCode: number | null;
+    logStreamLength?: number;
     signal?: AbortSignal;
   },
 ): Promise<ReportStepResponseDto> {
@@ -87,6 +116,7 @@ export async function reportStep(
     error: params.error ?? undefined,
     attempt: params.attempt,
     exit_code: params.exitCode,
+    ...(params.logStreamLength !== undefined ? {log_stream_length: params.logStreamLength} : {}),
   });
 
   const response = await leaseClient.post(`runs/jobs/current/steps/${params.stepId}/report`, {
@@ -108,6 +138,53 @@ export async function requestCheckoutToken(
     options.signal ? {signal: options.signal} : undefined,
   );
   return checkoutTokenResponseSchema.parse(await response.json());
+}
+
+// throwHttpErrors:false (below) turns off ky's status-code retry for this call, so no
+// HTTP status is retried in-transport here (only network/timeout errors are). Every
+// status is mapped explicitly: 409 and the terminal 4xx to outcomes, 5xx/unknown to a
+// thrown error the uploader retries on its next tick.
+export async function appendStepLogs(
+  leaseClient: KyInstance,
+  params: {
+    stepId: string;
+    attempt: number;
+    offset: number;
+    body: Uint8Array;
+    signal?: AbortSignal;
+  },
+): Promise<LogAppendOutcome> {
+  if (!STEP_ID_PATTERN.test(params.stepId)) {
+    throw new Error(`Invalid step id for log append: ${params.stepId}`);
+  }
+
+  // throwHttpErrors:false so we can read the 409 body ourselves (ky discards it when
+  // it builds an HTTPError). It also disables ky's status-code retry, so 5xx is not
+  // retried in-transport and falls through to the throw below.
+  const response = await leaseClient.post(`runs/jobs/current/steps/${params.stepId}/logs`, {
+    body: params.body,
+    headers: {'content-type': LOG_NDJSON_CONTENT_TYPE},
+    searchParams: {attempt: params.attempt, offset: params.offset},
+    throwHttpErrors: false,
+    ...(params.signal ? {signal: params.signal} : {}),
+  });
+
+  if (response.ok) {
+    const {committed_length, capped} = appendLogsResponseSchema.parse(await response.json());
+    return {status: 'committed', committedLength: committed_length, capped};
+  }
+  if (response.status === 409) {
+    const {details} = offsetGapResponseSchema.parse(await response.json());
+    return {status: 'conflict', committedLength: details.committed_length};
+  }
+  // Endpoint absent (deploy skew) or the lease is no longer accepted: stop
+  // uploading and let the server's stream lifecycle close the stream.
+  if (response.status === 404 || response.status === 401 || response.status === 403) {
+    return {status: 'stopped'};
+  }
+  // 5xx (not retried here, since throwHttpErrors disables status-code retry) or any
+  // other unexpected status: throw so the uploader logs it and retries on the next tick.
+  throw new Error(`Log append failed with status ${response.status}`);
 }
 
 export async function heartbeat(

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -1,7 +1,10 @@
 export {
+  appendStepLogs,
   createLeaseClient,
   HTTPError,
   heartbeat,
+  type LogAppendFn,
+  type LogAppendOutcome,
   reportStep,
   requestCheckoutToken,
   requestJob,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2519,6 +2519,37 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/vitest
 
+  libs/runner/logs:
+    dependencies:
+      '@shipfox/api-logs-dto':
+        specifier: workspace:*
+        version: link:../../api/logs-dto
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../shared/common/config
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
+      '@shipfox/runner-protocol':
+        specifier: workspace:*
+        version: link:../protocol
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
   libs/runner/orchestration:
     dependencies:
       '@shipfox/api-workflows-dto':
@@ -2536,6 +2567,9 @@ importers:
       '@shipfox/runner-execution':
         specifier: workspace:*
         version: link:../execution
+      '@shipfox/runner-logs':
+        specifier: workspace:*
+        version: link:../logs
       '@shipfox/runner-protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -2564,6 +2598,9 @@ importers:
 
   libs/runner/protocol:
     dependencies:
+      '@shipfox/api-logs-dto':
+        specifier: workspace:*
+        version: link:../../api/logs-dto
       '@shipfox/api-runners-dto':
         specifier: workspace:*
         version: link:../../api/runners-dto


### PR DESCRIPTION
Adds the runner side of the log-streaming project. Per step attempt, the runner captures merged stdout/stderr, frames it as versioned NDJSON (runner-assigned timestamps, 16KB UTF-8-safe records, ANSI preserved), write-through spools it to an append-only file under the job workspace, and uploads it to the ingest endpoint with an offset-CAS protocol that resumes via a zero-length probe and dedupes. The step report declares the stream's final raw byte length so the log module marks it complete without the report blocking on log drain. Output capture moves off the legacy in-memory 1MB buffer onto an `onOutput` sink.

Customers currently can't see what their CI steps print: the runner buffers ~1MB in memory and discards it. This is workstream 2 of the "Runner log capture & streaming" project, built against the NDJSON/append contract so it can land in parallel with the ingest foundation.

New surface: `@shipfox/api-logs-dto` (the shared NDJSON record + append contract, also consumed by the forthcoming ingest module) and `@shipfox/runner-logs` (framing/spool/uploader/stream). The transform stage (secret masking + GitHub `::group::` markers, ENG-441) slots in between capture and framing through a pass-through seam left here.

Review notes:
- **Deploy sequencing (no feature flag).** Per the spec's mask-before-spool rule, this must not be enabled on a deployed runner until ENG-441 (masking) and ENG-439 (server `/logs` route) are live, otherwise raw step output (which can contain the runner or job-lease token) reaches the plaintext spool. The uploader treats a 404 as endpoint-absent for deploy-skew safety, but only ordering protects the on-disk spool.
- **`.gitignore` change.** The package dir `libs/runner/logs` collided with the generic `logs` ignore rule, so the whole package was being ignored. Added a scoped `!/libs/runner/logs/` negation. Flagging in case you'd rather rename the package.
- **Offset-CAS / resume.** The uploader only ever appends at `offset == committed` and learns the committed offset via a zero-length probe, so a body never straddles the commit point. `uploader.ts` is worth a careful read.

Closes ENG-440

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the runner-side log capture pipeline with per-attempt stdout/stderr framing, spooling, and resumable upload, and fixes resume seeding and drain timing so uploads aren’t dropped and new steps aren’t delayed. Implements ENG-440.

- **New Features**
  - Capture merged stdout/stderr with runner timestamps; 16KB UTF-8-safe records; ANSI preserved.
  - Append-only per-attempt spool under the job workspace with a backlog cap and a single gap marker; seeded from on-disk length (ignores only ENOENT; rethrows other stat errors unchanged); rejects non-UUID step ids; completes short writes to prevent offset drift.
  - Resumable uploader probes with a zero-length append and only appends at the committed offset; treats 400/413/422 as terminal, retries 408/429; guards no-progress and ahead-of-spool cases; aborts a stuck append at the drain deadline; stops when the server budget is capped; flush window holds a whole record and stays under 1 MiB.
  - Orchestration opens a per-attempt stream, routes `onOutput`, and drains the previous step’s stream before requesting the next step; on spool error (open/write), capture is abandoned and the step proceeds; run steps no longer populate `StepResult.output` (kept for agent-step summaries).
  - API and packages: protocol exposes `appendStepLogs` and types (`LogAppendFn`, `LogAppendOutcome`); removed `log_stream_length` from `reportStep`; new `@shipfox/runner-logs`; runner config adds `SHIPFOX_LOG_FLUSH_INTERVAL_MS`, `SHIPFOX_LOG_FLUSH_BYTES`, `SHIPFOX_LOG_SPOOL_MAX_BYTES`, `SHIPFOX_LOG_DRAIN_TIMEOUT_MS`. Uses `@shipfox/api-logs-dto` and the `/logs` ingest route from ENG-439.

- **Migration**
  - Enable only after ENG-441 (masking) and ENG-439 (`/logs`) ship; otherwise raw output may hit disk. The uploader treats 404 as “endpoint absent.”

<sup>Written for commit cd9de0f5df40ac80c433bd7109965b198cd50821. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

