### PR TITLE
Snapshot workflow source for runs

### DIFF
--- a/libs/api/definitions-dto/src/schemas/dto.ts
+++ b/libs/api/definitions-dto/src/schemas/dto.ts
@@ -29,6 +29,7 @@ export const definitionDtoSchema = z.object({
   sha: z.string().nullable(),
   ref: z.string().nullable(),
   name: z.string(),
+  workflow_source_yaml: z.string().nullable(),
   workflow_document: z.unknown(),
   workflow_model: z.unknown(),
   manual_trigger: z

--- a/libs/api/definitions/src/core/entities/workflow-definition.ts
+++ b/libs/api/definitions/src/core/entities/workflow-definition.ts
@@ -4,6 +4,7 @@ import type {WorkflowModel} from './workflow-model.js';
 export type WorkflowSpec = WorkflowDocument;
 
 export interface WorkflowDefinitionPayload {
+  sourceYaml?: string | null;
   document: WorkflowDocument;
   model: WorkflowModel;
 }
@@ -21,6 +22,7 @@ export interface WorkflowDefinition {
    * before they migrate to `document`/`model`.
    */
   definition: WorkflowSpec;
+  sourceYaml: string | null;
   document: WorkflowDocument;
   model: WorkflowModel;
   contentHash: string | null;

--- a/libs/api/definitions/src/core/parse-definition.test.ts
+++ b/libs/api/definitions/src/core/parse-definition.test.ts
@@ -16,6 +16,7 @@ describe('parseDefinition', () => {
 
     const definition = parseDefinition(yaml);
 
+    expect(definition.sourceYaml).toBe(yaml);
     expect(definition.document.name).toBe('Simple build');
     expect(definition.document.triggers?.on_push?.source).toBe('github');
     expect(definition.document.triggers?.on_push?.event).toBe('push');

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -150,6 +150,7 @@ describe('fetchAndParseWorkflows', () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('CI');
     expect(result[0]?.path).toBe('.shipfox/workflows/ci.yml');
+    expect(result[0]?.definition.sourceYaml).toContain('name: CI');
     expect(result[0]?.contentHash).toMatch(SHA256_HEX_RE);
   });
 

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -109,7 +109,12 @@ export async function fetchAndParseWorkflows(
     try {
       const definition = parseDefinition(snapshot.content);
       const contentHash = sha256Hex(snapshot.content);
-      return {path: snapshot.path, name: definition.document.name, definition, contentHash};
+      return {
+        path: snapshot.path,
+        name: definition.document.name,
+        definition,
+        contentHash,
+      };
     } catch (error) {
       if (error instanceof DefinitionParseError) {
         throw new DefinitionSyncPermanentError(

--- a/libs/api/definitions/src/core/validate-definition.test.ts
+++ b/libs/api/definitions/src/core/validate-definition.test.ts
@@ -14,6 +14,7 @@ jobs:
 
     expect(result.valid).toBe(true);
     if (result.valid) {
+      expect(result.definition.sourceYaml).toBe(yaml);
       expect(result.definition.document.name).toBe('Test');
       expect(result.definition.document.jobs.build?.steps).toHaveLength(1);
       expect(result.definition.model.jobs[0]?.id).toBe('build');

--- a/libs/api/definitions/src/core/validate-definition.ts
+++ b/libs/api/definitions/src/core/validate-definition.ts
@@ -13,7 +13,7 @@ export function validateDefinition(yamlContent: string): ValidationResult {
   try {
     const document = parseWorkflowYaml(yamlContent);
     const model = normalizeWorkflowDocument(document);
-    return {valid: true, definition: {document, model}};
+    return {valid: true, definition: {sourceYaml: yamlContent, document, model}};
   } catch (error) {
     return {valid: false, errors: validationErrorsFor(error)};
   }

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -26,7 +26,7 @@ function definitionFields(name = 'Test Workflow'): WorkflowDefinitionPayload {
     name,
     jobs: {build: {steps: [{run: 'echo hello'}]}},
   };
-  return {document, model: normalizeWorkflowDocument(document)};
+  return {sourceYaml: `name: ${name}\n`, document, model: normalizeWorkflowDocument(document)};
 }
 
 async function listOutboxRowsForProject(projectId: string) {
@@ -66,12 +66,34 @@ describe('definition queries', () => {
       expect(definition.projectId).toBe(projectId);
       expect(definition.configPath).toBe('.shipfox/workflows/test.yml');
       expect(definition.name).toBe('Test');
-      expect({document: definition.document, model: definition.model}).toEqual(definitionFields());
+      expect({
+        sourceYaml: definition.sourceYaml,
+        document: definition.document,
+        model: definition.model,
+      }).toEqual(definitionFields());
       expect(definition.sha).toBeNull();
       expect(definition.ref).toBeNull();
       expect(definition.fetchedAt).toBeInstanceOf(Date);
       expect(definition.createdAt).toBeInstanceOf(Date);
       expect(definition.updatedAt).toBeInstanceOf(Date);
+    });
+
+    test('maps legacy rows without source YAML to null', async () => {
+      const {document, model} = definitionFields('Legacy');
+      const rows = await db()
+        .insert(workflowDefinitions)
+        .values({
+          projectId,
+          configPath: '.shipfox/workflows/legacy.yml',
+          name: 'Legacy',
+          definition: {document, model},
+        })
+        .returning({id: workflowDefinitions.id});
+
+      const definition = await getDefinitionById(rows[0]?.id ?? '');
+
+      expect(definition?.sourceYaml).toBeNull();
+      expect(definition?.document.name).toBe('Legacy');
     });
 
     test('updates existing definition on conflict (same project_id + config_path)', async () => {

--- a/libs/api/definitions/src/db/definitions.ts
+++ b/libs/api/definitions/src/db/definitions.ts
@@ -24,6 +24,7 @@ export interface UpsertDefinitionParams {
   configPath?: string | null | undefined;
   source?: 'manual' | 'vcs' | undefined;
   name: string;
+  sourceYaml?: string | null | undefined;
   document: WorkflowDocument;
   model: WorkflowModel;
   contentHash?: string | null | undefined;
@@ -38,6 +39,7 @@ function buildUpsertQuery(tx: Tx, params: UpsertDefinitionParams) {
   }
 
   const definition: WorkflowDefinitionPayload = {
+    sourceYaml: params.sourceYaml ?? null,
     document: params.document,
     model: params.model,
   };
@@ -255,6 +257,7 @@ export interface ApplyVcsDefinitionsBatchParams {
     name: string;
     document: WorkflowDocument;
     model: WorkflowModel;
+    sourceYaml?: string | null | undefined;
     contentHash: string;
   }>;
 }
@@ -298,6 +301,7 @@ export async function applyVcsDefinitionsBatch(
         source: 'vcs',
         ref: params.ref,
         name: item.name,
+        sourceYaml: item.sourceYaml,
         document: item.document,
         model: item.model,
         contentHash: item.contentHash,

--- a/libs/api/definitions/src/db/schema/definitions.ts
+++ b/libs/api/definitions/src/db/schema/definitions.ts
@@ -56,6 +56,7 @@ export function toDefinition(row: DefinitionDb): WorkflowDefinition {
     ref: row.ref,
     name: row.name,
     definition: row.definition.document,
+    sourceYaml: row.definition.sourceYaml ?? null,
     document: row.definition.document,
     model: row.definition.model,
     contentHash: row.contentHash,

--- a/libs/api/definitions/src/presentation/dto/definition.test.ts
+++ b/libs/api/definitions/src/presentation/dto/definition.test.ts
@@ -27,6 +27,7 @@ describe('toDefinitionDto', () => {
       ref: null,
       name: document.name,
       definition: document,
+      sourceYaml: 'name: Manual workflow\n',
       document,
       model: normalizeWorkflowDocument(document),
       contentHash: null,
@@ -46,6 +47,7 @@ describe('toDefinitionDto', () => {
       sha: null,
       ref: null,
       name: document.name,
+      workflow_source_yaml: definition.sourceYaml,
       workflow_document: document,
       workflow_model: definition.model,
       manual_trigger: {name: 'run_now'},
@@ -53,5 +55,38 @@ describe('toDefinitionDto', () => {
       created_at: '2026-06-09T10:00:01.000Z',
       updated_at: '2026-06-09T10:00:02.000Z',
     });
+  });
+
+  it('maps missing source YAML to null', () => {
+    const document = {
+      name: 'Legacy workflow',
+      jobs: {
+        build: {
+          steps: [{run: 'pnpm build'}],
+        },
+      },
+    };
+    const definition: WorkflowDefinition = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      projectId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      configPath: '.shipfox/workflows/legacy.yml',
+      source: 'vcs',
+      sha: null,
+      ref: 'main',
+      name: document.name,
+      definition: document,
+      sourceYaml: null,
+      document,
+      model: normalizeWorkflowDocument(document),
+      contentHash: null,
+      fetchedAt: new Date('2026-06-09T10:00:00.000Z'),
+      createdAt: new Date('2026-06-09T10:00:01.000Z'),
+      updatedAt: new Date('2026-06-09T10:00:02.000Z'),
+      deletedAt: null,
+    };
+
+    const result = toDefinitionDto(definition);
+
+    expect(result.workflow_source_yaml).toBeNull();
   });
 });

--- a/libs/api/definitions/src/presentation/dto/definition.ts
+++ b/libs/api/definitions/src/presentation/dto/definition.ts
@@ -15,6 +15,7 @@ export function toDefinitionDto(definition: WorkflowDefinition): DefinitionDto {
     sha: definition.sha,
     ref: definition.ref,
     name: definition.name,
+    workflow_source_yaml: definition.sourceYaml,
     workflow_document: definition.document,
     workflow_model: definition.model,
     manual_trigger: manualEntry ? {name: manualEntry[0]} : null,

--- a/libs/api/definitions/src/presentation/routes/create-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.test.ts
@@ -68,6 +68,7 @@ jobs:
     expect(body.config_path).toBe('.shipfox/workflows/test.yml');
     expect(body.source).toBe('manual');
     expect(body.name).toBe('Test Workflow');
+    expect(body.workflow_source_yaml).toBe(validYaml);
     expect(body.workflow_document.name).toBe('Test Workflow');
     expect(body.workflow_model.kind).toBe('workflow');
     expect(body.sha).toBeNull();

--- a/libs/api/definitions/src/presentation/routes/create-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/create-definition.ts
@@ -40,6 +40,7 @@ export const createDefinitionRoute = defineRoute({
       configPath: config_path,
       source,
       name: parsed.document.name,
+      sourceYaml: parsed.sourceYaml,
       document: parsed.document,
       model: parsed.model,
       sha,

--- a/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.test.ts
@@ -32,6 +32,7 @@ jobs:
     expect(res.statusCode).toBe(200);
     const body = res.json();
     expect(body.valid).toBe(true);
+    expect(body.workflow_source_yaml).toContain('name: Test');
     expect(body.workflow_document.name).toBe('Test');
     expect(body.workflow_model.kind).toBe('workflow');
   });

--- a/libs/api/definitions/src/presentation/routes/validate-definition.ts
+++ b/libs/api/definitions/src/presentation/routes/validate-definition.ts
@@ -15,6 +15,7 @@ const validationErrorSchema = z.object({
 const validationResultSchema = z.union([
   z.object({
     valid: z.literal(true),
+    workflow_source_yaml: definitionDtoSchema.shape.workflow_source_yaml,
     workflow_document: definitionDtoSchema.shape.workflow_document,
     workflow_model: definitionDtoSchema.shape.workflow_model,
   }),
@@ -41,6 +42,7 @@ export const validateDefinitionRoute = defineRoute({
     if (result.valid) {
       return {
         valid: true as const,
+        workflow_source_yaml: result.definition.sourceYaml ?? null,
         workflow_document: result.definition.document,
         workflow_model: result.definition.model,
       };

--- a/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.test.ts
@@ -235,6 +235,7 @@ describe('definition sync activities', () => {
         expect.objectContaining({ref: 'abc123', path: '.shipfox/workflows/ci.yml'}),
       );
       expect(rows[0]?.ref).toBe('main');
+      expect(rows[0]?.definition.sourceYaml).toBe(validYaml);
     });
   });
 

--- a/libs/api/definitions/src/temporal/activities/sync-activities.ts
+++ b/libs/api/definitions/src/temporal/activities/sync-activities.ts
@@ -115,6 +115,7 @@ function createFetchAndApplyActivity(sourceControl: IntegrationSourceControlServ
         upserts: definitions.map((entry) => ({
           configPath: entry.path,
           name: entry.name,
+          sourceYaml: entry.definition.sourceYaml,
           document: entry.definition.document,
           model: entry.definition.model,
           contentHash: entry.contentHash,

--- a/libs/api/definitions/test/factories/definition.ts
+++ b/libs/api/definitions/test/factories/definition.ts
@@ -15,7 +15,11 @@ function defaultDefinition(): WorkflowDefinitionPayload {
       },
     },
   };
-  return {document, model: normalizeWorkflowDocument(document)};
+  return {
+    sourceYaml: 'name: Test Workflow\n',
+    document,
+    model: normalizeWorkflowDocument(document),
+  };
 }
 
 interface DefinitionTransients {
@@ -33,6 +37,7 @@ export const definitionFactory = Factory.define<WorkflowDefinition, DefinitionTr
         configPath: definition.configPath,
         source: definition.source,
         name: definition.name,
+        sourceYaml: definition.sourceYaml,
         document: definition.document,
         model: definition.model,
         contentHash: definition.contentHash ?? undefined,
@@ -52,7 +57,9 @@ export const definitionFactory = Factory.define<WorkflowDefinition, DefinitionTr
       ref: null,
       name: `Test Workflow ${sequence}`,
       definition: definition.document,
-      ...definition,
+      sourceYaml: definition.sourceYaml ?? null,
+      document: definition.document,
+      model: definition.model,
       contentHash: null,
       fetchedAt: new Date(),
       createdAt: new Date(),

--- a/libs/api/workflows-dto/src/schemas/run.ts
+++ b/libs/api/workflows-dto/src/schemas/run.ts
@@ -76,6 +76,9 @@ export const runResponseSchema = runDtoSchema;
 export type RunResponseDto = z.infer<typeof runResponseSchema>;
 
 export const runDetailResponseSchema = runResponseSchema.extend({
+  workflow_source_yaml: z.string().nullable(),
+  workflow_document: z.unknown().nullable(),
+  workflow_model: z.unknown().nullable(),
   jobs: z.array(
     jobDtoSchema.extend({
       steps: z.array(stepDtoSchema.extend({attempts: z.array(stepAttemptDtoSchema)})),

--- a/libs/api/workflows/drizzle/0002_definition_snapshot.sql
+++ b/libs/api/workflows/drizzle/0002_definition_snapshot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "workflows_workflow_runs" ADD COLUMN "definition_snapshot" jsonb;

--- a/libs/api/workflows/drizzle/meta/0002_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,737 @@
+{
+  "id": "cfb008f6-c9df-41f4-a755-db5fbb276f45",
+  "prevId": "37221128-e713-4c32-a224-2f82932c4bb6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workflows_jobs": {
+      "name": "workflows_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dependencies": {
+          "name": "dependencies",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner": {
+          "name": "runner",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "timed_out_at": {
+          "name": "timed_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_jobs_run_id_idx": {
+          "name": "workflows_jobs_run_id_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_jobs_run_id_workflows_workflow_runs_id_fk": {
+          "name": "workflows_jobs_run_id_workflows_workflow_runs_id_fk",
+          "tableFrom": "workflows_jobs",
+          "tableTo": "workflows_workflow_runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_outbox": {
+      "name": "workflows_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflows_outbox_pending_idx": {
+          "name": "workflows_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_step_attempts": {
+      "name": "workflows_step_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gate_result": {
+          "name": "gate_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "restart_reason": {
+          "name": "restart_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_step_attempts_job_id_idx": {
+          "name": "workflows_step_attempts_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_step_attempts_step_id_workflows_steps_id_fk": {
+          "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_steps",
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workflows_step_attempts_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_step_attempts_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_step_attempts",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workflows_step_attempts_step_id_attempt_uq": {
+          "name": "workflows_step_attempts_step_id_attempt_uq",
+          "nullsNotDistinct": false,
+          "columns": ["step_id", "attempt"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "workflows_step_attempts_attempt_positive_ck": {
+          "name": "workflows_step_attempts_attempt_positive_ck",
+          "value": "\"workflows_step_attempts\".\"attempt\" > 0"
+        },
+        "workflows_step_attempts_status_not_pending_ck": {
+          "name": "workflows_step_attempts_status_not_pending_ck",
+          "value": "\"workflows_step_attempts\".\"status\" <> 'pending'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflows_steps": {
+      "name": "workflows_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_step_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "current_attempt": {
+          "name": "current_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_steps_job_id_idx": {
+          "name": "workflows_steps_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_steps_job_id_workflows_jobs_id_fk": {
+          "name": "workflows_steps_job_id_workflows_jobs_id_fk",
+          "tableFrom": "workflows_steps",
+          "tableTo": "workflows_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workflows_workflow_runs": {
+      "name": "workflows_workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workflows_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_event": {
+          "name": "trigger_event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_snapshot": {
+          "name": "definition_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_idempotency_key": {
+          "name": "trigger_idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflows_wr_trigger_idempotency_key_unique": {
+          "name": "workflows_wr_trigger_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "trigger_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_created_id_idx": {
+          "name": "workflows_wr_project_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_status_created_id_idx": {
+          "name": "workflows_wr_project_status_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_definition_created_id_idx": {
+          "name": "workflows_wr_project_definition_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_project_trigger_created_id_idx": {
+          "name": "workflows_wr_project_trigger_created_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trigger_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workflows_job_status": {
+      "name": "workflows_job_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "waiting_for_dependencies",
+        "ready",
+        "running",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "awaiting_manual"
+      ]
+    },
+    "public.workflows_step_status": {
+      "name": "workflows_step_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    },
+    "public.workflows_run_status": {
+      "name": "workflows_run_status",
+      "schema": "public",
+      "values": ["pending", "running", "succeeded", "failed", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781129096855,
       "tag": "0001_step_attempts",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1781549278735,
+      "tag": "0002_definition_snapshot",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -1,3 +1,5 @@
+import type {WorkflowModel, WorkflowSpec} from '@shipfox/api-definitions';
+
 export type WorkflowRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
 export type TriggerPayload =
@@ -22,6 +24,12 @@ export type TriggerPayload =
       data: unknown;
     };
 
+export interface WorkflowRunDefinitionSnapshot {
+  sourceYaml: string | null;
+  document: WorkflowSpec;
+  model: WorkflowModel;
+}
+
 export interface WorkflowRun {
   id: string;
   workspaceId: string;
@@ -32,6 +40,7 @@ export interface WorkflowRun {
   triggerSource: string;
   triggerEvent: string;
   triggerPayload: TriggerPayload;
+  definitionSnapshot: WorkflowRunDefinitionSnapshot | null;
   inputs: Record<string, unknown> | null;
   triggerIdempotencyKey: string | null;
   version: number;

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -29,6 +29,7 @@ function buildDefinition(overrides?: Partial<WorkflowDefinition>): WorkflowDefin
     ref: null,
     name: 'Test Workflow',
     definition: document,
+    sourceYaml: 'name: Test Workflow\n',
     document,
     model,
     contentHash: null,
@@ -78,6 +79,11 @@ describe('runWorkflow', () => {
     expect(run.triggerSource).toBe('manual');
     expect(run.triggerEvent).toBe('fire');
     expect(run.triggerPayload).toEqual(triggerPayload);
+    expect(run.definitionSnapshot).toEqual({
+      sourceYaml: definition.sourceYaml,
+      document: definition.document,
+      model: definition.model,
+    });
   });
 
   test('persists an integration trigger payload intact', async () => {

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -26,6 +26,11 @@ export async function runWorkflow(params: RunWorkflowParams): Promise<WorkflowRu
     definitionId: definition.id,
     name: definition.name,
     model: definition.model,
+    definitionSnapshot: {
+      sourceYaml: definition.sourceYaml,
+      document: definition.document,
+      model: definition.model,
+    },
     triggerPayload: params.triggerPayload,
     inputs: params.inputs,
     triggerIdempotencyKey: params.triggerIdempotencyKey,

--- a/libs/api/workflows/src/db/schema/workflow-runs.ts
+++ b/libs/api/workflows/src/db/schema/workflow-runs.ts
@@ -9,7 +9,11 @@ import {
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
-import type {TriggerPayload, WorkflowRun} from '#core/entities/workflow-run.js';
+import type {
+  TriggerPayload,
+  WorkflowRun,
+  WorkflowRunDefinitionSnapshot,
+} from '#core/entities/workflow-run.js';
 import {pgTable} from './common.js';
 
 export const workflowRunStatusEnum = pgEnum('workflows_run_status', [
@@ -32,6 +36,7 @@ export const workflowRuns = pgTable(
     triggerSource: text('trigger_source').notNull(),
     triggerEvent: text('trigger_event').notNull(),
     triggerPayload: jsonb('trigger_payload').notNull().$type<TriggerPayload>(),
+    definitionSnapshot: jsonb('definition_snapshot').$type<WorkflowRunDefinitionSnapshot>(),
     inputs: jsonb('inputs').$type<Record<string, unknown>>(),
     // Idempotency token for at-least-once outbox replays. Unique when set; NULL is unconstrained (Postgres default).
     triggerIdempotencyKey: text('trigger_idempotency_key'),
@@ -77,6 +82,7 @@ export function toWorkflowRun(row: WorkflowRunDb): WorkflowRun {
     triggerSource: row.triggerSource,
     triggerEvent: row.triggerEvent,
     triggerPayload: row.triggerPayload as TriggerPayload,
+    definitionSnapshot: row.definitionSnapshot ?? null,
     inputs: row.inputs ?? null,
     triggerIdempotencyKey: row.triggerIdempotencyKey,
     version: row.version,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -58,6 +58,7 @@ describe('workflow run queries', () => {
       expect(run.definitionId).toBe(definitionId);
       expect(run.status).toBe('pending');
       expect(run.triggerPayload).toMatchObject({source: 'manual', event: 'fire'});
+      expect(run.definitionSnapshot).toBeNull();
       expect(run.inputs).toBeNull();
       expect(run.version).toBe(1);
       expect(run.createdAt).toBeInstanceOf(Date);
@@ -77,6 +78,36 @@ describe('workflow run queries', () => {
         config: {},
       });
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
+    });
+
+    test('persists the definition snapshot with the run', async () => {
+      const model = buildModel();
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        definitionSnapshot: {
+          sourceYaml: 'name: Test\n',
+          document: {name: 'Test', jobs: {build: {steps: [{run: 'echo hello'}]}}},
+          model,
+        },
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const stored = await getWorkflowRunById(run.id);
+
+      expect(stored?.definitionSnapshot).toEqual({
+        sourceYaml: 'name: Test\n',
+        document: {name: 'Test', jobs: {build: {steps: [{run: 'echo hello'}]}}},
+        model,
+      });
     });
 
     test('writes workflows.run.created outbox event in same transaction', async () => {
@@ -333,12 +364,19 @@ describe('workflow run queries', () => {
       const subscriptionId = crypto.randomUUID();
       const eventId = crypto.randomUUID();
       const idempotencyKey = `${subscriptionId}:${eventId}`;
+      const firstModel = buildModel({name: 'First snapshot'});
+      const secondModel = buildModel({name: 'Second snapshot'});
 
       const first = await createWorkflowRun({
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel(),
+        model: firstModel,
+        definitionSnapshot: {
+          sourceYaml: 'name: First snapshot\n',
+          document: {name: 'First snapshot', jobs: {build: {steps: [{run: 'echo first'}]}}},
+          model: firstModel,
+        },
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -351,7 +389,12 @@ describe('workflow run queries', () => {
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel(),
+        model: secondModel,
+        definitionSnapshot: {
+          sourceYaml: 'name: Second snapshot\n',
+          document: {name: 'Second snapshot', jobs: {build: {steps: [{run: 'echo second'}]}}},
+          model: secondModel,
+        },
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -363,6 +406,7 @@ describe('workflow run queries', () => {
 
       expect(second.id).toBe(first.id);
       expect(second.triggerIdempotencyKey).toBe(idempotencyKey);
+      expect(second.definitionSnapshot).toEqual(first.definitionSnapshot);
 
       const allJobs = await getJobsByRunId(first.id);
       expect(allJobs).toHaveLength(1);

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -11,7 +11,12 @@ import {and, asc, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql} fro
 import type {Job, JobStatus} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
-import type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from '#core/entities/workflow-run.js';
+import type {
+  TriggerPayload,
+  WorkflowRun,
+  WorkflowRunDefinitionSnapshot,
+  WorkflowRunStatus,
+} from '#core/entities/workflow-run.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import {materializeWorkflowModel} from '#core/workflow-runtime/index.js';
@@ -28,6 +33,7 @@ export interface CreateWorkflowRunParams {
   definitionId: string;
   name?: string | undefined;
   model: WorkflowModel;
+  definitionSnapshot?: WorkflowRunDefinitionSnapshot | null | undefined;
   triggerPayload: TriggerPayload;
   inputs?: Record<string, unknown> | undefined;
   triggerIdempotencyKey?: string | undefined;
@@ -48,6 +54,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
         triggerSource: params.triggerPayload.source,
         triggerEvent: params.triggerPayload.event,
         triggerPayload: params.triggerPayload,
+        definitionSnapshot: params.definitionSnapshot ?? null,
         inputs: params.inputs ?? null,
         triggerIdempotencyKey: params.triggerIdempotencyKey ?? null,
       })

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -98,6 +98,9 @@ describe('GET /api/workflows/runs/:id', () => {
     const body = res.json();
     expect(body.id).toBe(run.id);
     expect(body.duration_ms).toBe(0);
+    expect(body.workflow_source_yaml).toBeNull();
+    expect(body.workflow_document).toBeNull();
+    expect(body.workflow_model).toBeNull();
     expect(body.jobs).toHaveLength(1);
     expect(body.jobs[0].name).toBe('build');
     expect(body.jobs[0].duration_ms).toBe(0);
@@ -107,6 +110,78 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(body.jobs[0].steps[0].duration_ms).toBe(0);
     expect(body.jobs[0].steps[1].name).toBe('Install');
     expect(body.jobs[0].steps[2].name).toBeNull();
+  });
+
+  test('returns the immutable definition snapshot when present', async () => {
+    const projectId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+    const model = workflowModel({name: 'Snapshot source'});
+    const document = {name: 'Snapshot source', jobs: {build: {steps: [{run: 'echo hello'}]}}};
+
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model,
+      definitionSnapshot: {
+        sourceYaml: 'name: Snapshot source\n',
+        document,
+        model,
+      },
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${run.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workflow_source_yaml).toBe('name: Snapshot source\n');
+    expect(body.workflow_document).toEqual(document);
+    expect(body.workflow_model).toEqual(model);
+  });
+
+  test('returns null source YAML without dropping document and model snapshot fields', async () => {
+    const projectId = crypto.randomUUID();
+    const definitionId = crypto.randomUUID();
+    const model = workflowModel({name: 'Generated definition'});
+    const document = {name: 'Generated definition', jobs: {build: {steps: [{run: 'echo hello'}]}}};
+
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model,
+      definitionSnapshot: {
+        sourceYaml: null,
+        document,
+        model,
+      },
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/workflows/runs/${run.id}`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.workflow_source_yaml).toBeNull();
+    expect(body.workflow_document).toEqual(document);
+    expect(body.workflow_model).toEqual(model);
   });
 
   test('exposes per-step error and cancelled status after a failed per-step report', async () => {

--- a/libs/api/workflows/src/presentation/routes/get-run.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.ts
@@ -56,6 +56,9 @@ export const getRunRoute = defineRoute({
 
     return {
       ...toRunDto(run),
+      workflow_source_yaml: run.definitionSnapshot?.sourceYaml ?? null,
+      workflow_document: run.definitionSnapshot?.document ?? null,
+      workflow_model: run.definitionSnapshot?.model ?? null,
       jobs: jobDtos,
     };
   },

--- a/libs/api/workflows/test/factories/workflow-run.ts
+++ b/libs/api/workflows/test/factories/workflow-run.ts
@@ -15,6 +15,7 @@ export const workflowRunFactory = Factory.define<WorkflowRun>(({onCreate}) => {
       definitionId: run.definitionId,
       name: run.name,
       model: workflowModel({name: run.name}),
+      definitionSnapshot: run.definitionSnapshot,
       triggerPayload: run.triggerPayload,
       inputs: run.inputs ?? undefined,
     });
@@ -36,6 +37,7 @@ export const workflowRunFactory = Factory.define<WorkflowRun>(({onCreate}) => {
       userId: crypto.randomUUID(),
     },
     inputs: null,
+    definitionSnapshot: null,
     triggerIdempotencyKey: null,
     version: 1,
     createdAt: new Date(),

--- a/libs/client/projects/src/hooks/api/workflow-runs.test.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.test.ts
@@ -71,6 +71,9 @@ describe('getWorkflowRun', () => {
           trigger_payload: {source: 'manual', event: 'fire'},
           inputs: null,
           duration_ms: 0,
+          workflow_source_yaml: 'name: Deploy\n',
+          workflow_document: {name: 'Deploy', jobs: {}},
+          workflow_model: {kind: 'workflow', name: 'Deploy'},
           created_at: '2026-05-13T00:00:00.000Z',
           updated_at: '2026-05-13T00:00:00.000Z',
           jobs: [],
@@ -89,5 +92,6 @@ describe('getWorkflowRun', () => {
     );
     expect(request.method).toBe('GET');
     expect(result.duration_ms).toBe(0);
+    expect(result.workflow_source_yaml).toBe('name: Deploy\n');
   });
 });

--- a/libs/client/projects/src/pages/project-runs-page.test.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.test.tsx
@@ -154,6 +154,7 @@ function definitionsDto() {
         sha: 'abc123',
         ref: 'main',
         name: 'Deploy production',
+        workflow_source_yaml: 'name: Deploy production\n',
         workflow_document: {
           name: 'Deploy production',
           jobs: {deploy: {steps: [{run: './deploy.sh'}]}},

--- a/libs/client/projects/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.test.tsx
@@ -230,6 +230,7 @@ function baseDefinitionsDto() {
         sha: 'abc123',
         ref: 'main',
         name: 'Deploy production',
+        workflow_source_yaml: 'name: Deploy production\n',
         workflow_document: {
           name: 'Deploy production',
           triggers: {on_demand: {source: 'manual', event: 'fire'}},


### PR DESCRIPTION
Adds immutable workflow source snapshots for execution dashboard source inspection.

Definitions now carry `workflow_source_yaml` alongside `workflow_document` and `workflow_model`, and run creation snapshots the source YAML, parsed document, and normalized model onto `workflow_runs`. Run detail returns only that run snapshot bundle, preserving legacy rows as `null` rather than reading mutable current definition state.

This keeps the upcoming JSX-port `SourceTab` backed by the exact source that produced the run. Line-range highlighting (`yamlLines` in the design export) remains an explicit adapter/UI follow-up.

Reviewed with Claude consult before commit: `/Users/thierry.abalea/dev/claude-consult-kit/consults/workflow-dashboard-jsx-port-phase-2-source-snapshot-review/agent-reviewer.md`. Applied the snapshot-construction finding so `runWorkflow` assembles the full immutable snapshot and the DB layer stores it verbatim.

Note: the affected test gate initially exposed a `@shipfox/runner-execution` SIGKILL timing flake under parallel Turbo execution. The package passed in isolation, and the same affected gate passed with `--concurrency=1`.

<!-- stk:begin -->
## Stack

Part 1 of 2.

Depends on: none
Next: #201

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #200 | `workflow-dashboard-jsx-port/02-source-snapshot-contract` | `workflow-dashboard-jsx-port/01-run-detail-contract` |
| 2 | #201 | `workflow-dashboard-jsx-port/03-design-component-port` | `workflow-dashboard-jsx-port/02-source-snapshot-contract` |

<!-- stk:end -->