### PR TITLE
Add workflow run dashboard

### DIFF
--- a/libs/client/projects/src/pages/workflow-dashboard/components/dashboard-shell.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/dashboard-shell.tsx
@@ -1,0 +1,62 @@
+import {Avatar, Button, Code, Icon, Kbd, Logo, Text} from '@shipfox/react-ui';
+import type {ReactNode} from 'react';
+import {WorkflowDashboardProjectTabs} from './project-tabs.js';
+
+export function WorkflowDashboardShell({
+  children,
+  footerAction,
+}: {
+  children: ReactNode;
+  footerAction?: ReactNode;
+}) {
+  return (
+    <div className="grid h-screen grid-rows-[56px_40px_1fr] overflow-hidden bg-background-neutral-background text-foreground-neutral-base">
+      <WorkflowDashboardTopNav />
+      <WorkflowDashboardProjectTabs />
+      <div className="min-h-0 overflow-hidden">{children}</div>
+      {footerAction}
+    </div>
+  );
+}
+
+function WorkflowDashboardTopNav() {
+  return (
+    <header className="flex items-center justify-between gap-12 border-border-neutral-base border-b bg-background-components-base px-16">
+      <div className="flex min-w-0 items-center gap-8">
+        <Logo className="h-18 w-auto shrink-0" variant="wordmark" />
+        <span className="text-foreground-neutral-disabled text-lg">/</span>
+        <button
+          className="flex h-28 items-center gap-4 rounded-6 px-6 text-foreground-neutral-base text-sm hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+          type="button"
+        >
+          <Text as="span" size="sm" bold>
+            Acme
+          </Text>
+          <Icon name="arrowDownSLine" className="size-14 text-foreground-neutral-muted" />
+        </button>
+        <span className="text-foreground-neutral-disabled text-lg">/</span>
+        <button
+          className="flex h-28 min-w-0 items-center gap-4 rounded-6 px-6 text-foreground-neutral-base hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+          type="button"
+        >
+          <Code as="span" variant="label" className="truncate">
+            checkout-api
+          </Code>
+          <Icon name="arrowDownSLine" className="size-14 shrink-0 text-foreground-neutral-muted" />
+        </button>
+      </div>
+      <div className="flex items-center gap-6">
+        <button
+          className="hidden h-28 items-center gap-8 rounded-6 border border-border-neutral-base bg-background-components-base px-10 text-foreground-neutral-muted text-xs shadow-button-neutral hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none sm:flex"
+          type="button"
+        >
+          <Icon name="searchLine" className="size-14" />
+          <span>Search runs, steps, commits...</span>
+          <Kbd className="h-18 min-w-18 px-3">/</Kbd>
+        </button>
+        <Button size="sm" variant="transparentMuted" iconLeft="bookOpen" aria-label="Docs" />
+        <Avatar size="sm" content="letters" fallback="TA" />
+      </div>
+    </header>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/components/history-rail.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/history-rail.tsx
@@ -1,0 +1,158 @@
+import {Button, Code, cn, Icon, Text} from '@shipfox/react-ui';
+import {useMemo, useState} from 'react';
+import {formatDuration, formatRelativeTime} from '../lib/workflow-dashboard-format.js';
+import {workflowStatusBorderClass} from '../lib/workflow-dashboard-status.js';
+import type {WorkflowDashboardRun} from '../workflow-dashboard-types.js';
+import {StatusDot, WorkflowStatusBadge} from './status-badge.js';
+
+type HistoryFilter = 'all' | 'failed' | 'running';
+
+export function HistoryRail({
+  onCollapse,
+  onSelect,
+  runKey,
+  runOrder,
+  runs,
+}: {
+  onCollapse: () => void;
+  onSelect: (key: string) => void;
+  runKey: string;
+  runOrder: string[];
+  runs: Record<string, WorkflowDashboardRun>;
+}) {
+  const [filter, setFilter] = useState<HistoryFilter>('all');
+  const [query, setQuery] = useState('');
+  const visibleRuns = useMemo(
+    () =>
+      runOrder.flatMap((key) => {
+        const run = runs[key];
+        if (!run) return [];
+        if (filter === 'failed' && run.status !== 'failed') return [];
+        if (filter === 'running' && run.status !== 'running') return [];
+        const haystack = `#${run.number} ${run.trigger.incident}`.toLowerCase();
+        if (query && !haystack.includes(query.toLowerCase())) return [];
+        return [{key, run}];
+      }),
+    [filter, query, runOrder, runs],
+  );
+
+  return (
+    <aside className="flex min-w-0 flex-1 flex-col overflow-y-auto border-border-neutral-base border-r bg-background-components-base">
+      <div className="sticky top-0 z-10 border-border-neutral-base border-b bg-background-components-base px-12 pt-14 pb-10">
+        <div className="mb-10 flex items-center justify-between">
+          <Text
+            as="span"
+            size="xs"
+            bold
+            className="uppercase tracking-[0.06em] text-foreground-neutral-muted"
+          >
+            Runs
+          </Text>
+          <Button
+            aria-label="Collapse runs panel"
+            iconLeft="arrowLeftDoubleLine"
+            onClick={onCollapse}
+            size="xs"
+            variant="transparentMuted"
+          />
+        </div>
+        <label className="mb-8 flex h-28 items-center gap-6 rounded-6 border border-border-neutral-base bg-background-field-base px-8 text-foreground-neutral-muted">
+          <Icon name="searchLine" className="size-14" />
+          <input
+            className="min-w-0 flex-1 bg-transparent text-foreground-neutral-base text-sm outline-none placeholder:text-foreground-neutral-muted"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Run id or trigger..."
+            value={query}
+          />
+        </label>
+        <div className="flex gap-4">
+          {[
+            {label: 'All', value: 'all'},
+            {label: 'Failed', value: 'failed'},
+            {label: 'Running', value: 'running'},
+          ].map((item) => (
+            <button
+              className={cn(
+                'h-24 rounded-4 border border-transparent px-7 text-foreground-neutral-muted text-xs font-medium hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+                filter === item.value &&
+                  'border-tag-warning-border bg-background-highlight-base text-foreground-highlight-interactive',
+              )}
+              key={item.value}
+              onClick={() => setFilter(item.value as HistoryFilter)}
+              type="button"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-4 p-6">
+        {visibleRuns.map(({key, run}) => (
+          <button
+            className={cn(
+              'relative flex flex-col gap-6 rounded-8 border border-transparent px-10 py-9 text-left hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+              runKey === key &&
+                'border-tag-warning-border bg-background-highlight-base before:absolute before:top-8 before:bottom-8 before:left-0 before:w-3 before:rounded-full before:bg-background-highlight-interactive before:content-[""]',
+              workflowStatusBorderClass(run.status),
+            )}
+            key={key}
+            onClick={() => onSelect(key)}
+            type="button"
+          >
+            <div className="flex items-center gap-7">
+              <StatusDot pulse status={run.status} />
+              <Code as="span" variant="paragraph" bold>
+                #{run.number}
+              </Code>
+              <WorkflowStatusBadge status={run.status} />
+              <span className="flex-1" />
+              <Code as="span" variant="label" className="text-foreground-neutral-muted">
+                {formatDuration(run.duration)}
+                {run.status === 'running' ? '...' : ''}
+              </Code>
+            </div>
+            <div className="flex items-center gap-6">
+              <Icon name="sentry" className="size-12 text-foreground-neutral-muted" />
+              <Code as="span" variant="label" className="text-foreground-neutral-subtle">
+                {run.trigger.incident}
+              </Code>
+              <span className="flex-1" />
+              <Code as="span" variant="label" className="text-foreground-neutral-disabled">
+                {formatRelativeTime(run.observedUntil, previewNowIso)}
+              </Code>
+            </div>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}
+
+export function CollapsedHistoryRail({count, onExpand}: {count: number; onExpand: () => void}) {
+  return (
+    <div className="flex w-full flex-col items-center gap-12 border-border-neutral-base border-r bg-background-components-base py-10">
+      <Button
+        aria-label="Show runs"
+        iconLeft="panelRightLine"
+        onClick={onExpand}
+        size="sm"
+        variant="secondary"
+      />
+      <div className="flex items-center gap-8 [writing-mode:vertical-rl]">
+        <Text
+          as="span"
+          size="xs"
+          bold
+          className="uppercase tracking-[0.06em] text-foreground-neutral-muted"
+        >
+          Runs
+        </Text>
+        <Code as="span" variant="label" className="text-foreground-neutral-subtle">
+          {count}
+        </Code>
+      </div>
+    </div>
+  );
+}
+
+const previewNowIso = '2026-06-12T12:10:00Z';

--- a/libs/client/projects/src/pages/workflow-dashboard/components/job-graph.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/job-graph.tsx
@@ -1,0 +1,132 @@
+import {Code, cn, Icon} from '@shipfox/react-ui';
+import {formatDuration} from '../lib/workflow-dashboard-format.js';
+import {
+  workflowStatusBorderClass,
+  workflowStatusTextClass,
+} from '../lib/workflow-dashboard-status.js';
+import type {WorkflowDashboardJob, WorkflowDashboardRun} from '../workflow-dashboard-types.js';
+import {StatusDot, WorkflowStatusBadge} from './status-badge.js';
+
+export function JobGraph({
+  onSelectJob,
+  onTrigger,
+  run,
+  selectedJob,
+}: {
+  onSelectJob: (job: string) => void;
+  onTrigger: () => void;
+  run: WorkflowDashboardRun;
+  selectedJob: string | null;
+}) {
+  return (
+    <div className="flex items-stretch overflow-x-auto px-2 py-4">
+      <TriggerNode onClick={onTrigger} run={run} />
+      <Connector wide />
+      {run.jobs.map((job, index) => (
+        <div className="flex items-stretch" key={job.name}>
+          {index > 0 && <Connector wide />}
+          <JobNode
+            job={job}
+            onSelect={() => onSelectJob(job.name)}
+            selected={selectedJob === job.name}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TriggerNode({onClick, run}: {onClick: () => void; run: WorkflowDashboardRun}) {
+  return (
+    <button
+      className="flex shrink-0 items-center gap-9 self-center rounded-8 border border-border-neutral-base bg-background-components-base px-11 py-9 text-left transition-colors hover:border-border-neutral-strong hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+      onClick={onClick}
+      title="View alert details"
+      type="button"
+    >
+      <span className="flex size-26 items-center justify-center rounded-6 border border-border-neutral-base bg-background-neutral-base text-foreground-neutral-subtle">
+        <Icon name="sentry" className="size-16" />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <Code as="span" variant="label" className="uppercase text-foreground-neutral-muted">
+          sentry - trigger
+        </Code>
+        <Code as="span" variant="label" className="font-medium text-foreground-neutral-base">
+          {run.trigger.incident}
+        </Code>
+      </span>
+    </button>
+  );
+}
+
+function Connector({wide}: {wide?: boolean}) {
+  const width = wide ? 40 : 26;
+  const lineEnd = wide ? 30 : 18;
+  const arrowX = wide ? 28 : 16;
+
+  return (
+    <div className="flex shrink-0 items-center justify-center self-center text-foreground-neutral-disabled">
+      <svg aria-hidden="true" fill="none" height="16" viewBox={`0 0 ${width} 16`} width={width}>
+        <line stroke="currentColor" strokeWidth="1.5" x1="0" x2={lineEnd} y1="8" y2="8" />
+        <path
+          d={`M${arrowX} 4l5 4-5 4`}
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+      </svg>
+    </div>
+  );
+}
+
+function JobNode({
+  job,
+  onSelect,
+  selected,
+}: {
+  job: WorkflowDashboardJob;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  return (
+    <button
+      className={cn(
+        'flex w-204 shrink-0 flex-col gap-9 overflow-hidden rounded-10 border bg-background-components-base px-12 py-11 text-left shadow-card transition-colors hover:border-border-neutral-strong focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+        selected ? 'border-foreground-neutral-subtle' : 'border-border-neutral-base',
+        workflowStatusBorderClass(job.status),
+      )}
+      onClick={onSelect}
+      type="button"
+    >
+      <div className="flex items-center gap-8">
+        <StatusDot pulse status={job.status} />
+        <Code as="span" variant="label" bold className="min-w-0 flex-1 truncate">
+          {job.name}
+        </Code>
+      </div>
+      <div>
+        <WorkflowStatusBadge status={job.status} />
+      </div>
+      <div className="flex min-w-0 items-baseline justify-between gap-8">
+        <Code as="span" variant="label" className={workflowStatusTextClass(job.status)}>
+          {job.duration != null
+            ? formatDuration(job.duration)
+            : job.status === 'running'
+              ? 'running'
+              : '-'}
+        </Code>
+        {job.needs && (
+          <Code
+            as="span"
+            variant="label"
+            className="min-w-0 flex-1 truncate text-right text-foreground-neutral-muted"
+            title={`needs ${job.needs}`}
+          >
+            needs {job.needs}
+          </Code>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/components/project-tabs.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/project-tabs.tsx
@@ -1,0 +1,22 @@
+import {cn} from '@shipfox/react-ui';
+
+const tabs = ['Overview', 'Runs', 'Workflows', 'Triggers', 'Settings'];
+
+export function WorkflowDashboardProjectTabs() {
+  return (
+    <nav className="flex h-40 items-center gap-4 border-border-neutral-base border-b bg-background-components-base px-16">
+      {tabs.map((tab) => (
+        <button
+          className={cn(
+            'flex h-40 items-center border-transparent border-b-2 px-10 text-foreground-neutral-muted text-sm transition-colors hover:text-foreground-neutral-base focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+            tab === 'Runs' && 'border-border-highlights-interactive text-foreground-neutral-base',
+          )}
+          key={tab}
+          type="button"
+        >
+          {tab}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/components/run-header.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/run-header.tsx
@@ -1,0 +1,81 @@
+import {Button, Code, Header, Icon, Text} from '@shipfox/react-ui';
+import {formatDuration, formatRelativeTime} from '../lib/workflow-dashboard-format.js';
+import type {WorkflowDashboardRun} from '../workflow-dashboard-types.js';
+import {StatusDot, WorkflowStatusBadge} from './status-badge.js';
+
+const previewNowIso = '2026-06-12T12:10:00Z';
+
+export function RunHeader({
+  onJumpToFocus,
+  onSource,
+  run,
+}: {
+  onJumpToFocus: () => void;
+  onSource: () => void;
+  run: WorkflowDashboardRun;
+}) {
+  const focusLabel =
+    run.status === 'failed'
+      ? 'Go to root cause'
+      : run.status === 'running'
+        ? 'Go to active step'
+        : null;
+
+  return (
+    <div className="sticky top-0 z-20 border-border-neutral-base border-b bg-background-components-base px-22 py-13">
+      <div className="flex flex-wrap items-center gap-12">
+        <StatusDot pulse status={run.status} />
+        <Header variant="h3" as="h1" className="font-code">
+          Run #{run.number}
+        </Header>
+        <WorkflowStatusBadge status={run.status} size="xs" />
+        <span className="h-18 w-1 bg-border-neutral-base" />
+        <button
+          className="inline-flex h-28 items-center gap-6 rounded-4 border border-transparent px-6 text-foreground-neutral-subtle hover:border-border-neutral-base hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+          title="View alert details"
+          type="button"
+        >
+          <Icon name="sentry" className="size-14 text-foreground-neutral-muted" />
+          <Code as="span" variant="label">
+            {run.trigger.incident}
+          </Code>
+          <Icon name="externalLinkLine" className="size-12 text-foreground-neutral-muted" />
+        </button>
+        <span className="inline-flex items-center gap-6 text-foreground-neutral-subtle">
+          <Icon name="timeLine" className="size-14 text-foreground-neutral-muted" />
+          <Code as="span" variant="label">
+            {formatDuration(run.duration)}
+          </Code>
+        </span>
+        {run.status !== 'running' && (
+          <Text as="span" size="xs" className="text-foreground-neutral-muted">
+            updated{' '}
+            <Code as="span" variant="label">
+              {formatRelativeTime(run.observedUntil, previewNowIso)}
+            </Code>
+          </Text>
+        )}
+        <span className="flex-1" />
+        <div className="flex items-center gap-8">
+          {focusLabel && (
+            <Button size="sm" iconRight="arrowRightLine" onClick={onJumpToFocus}>
+              {focusLabel}
+            </Button>
+          )}
+          <Button size="sm" variant="secondary" iconLeft="fileCodeLine" onClick={onSource}>
+            Workflow source
+          </Button>
+          {run.status === 'running' ? (
+            <Button size="sm" variant="danger" iconLeft="stopCircleLine">
+              Cancel run
+            </Button>
+          ) : (
+            <Button size="sm" variant="secondary" iconLeft="refreshLine">
+              Re-run
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/components/status-badge.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/status-badge.tsx
@@ -1,0 +1,45 @@
+import {Badge, cn} from '@shipfox/react-ui';
+import {
+  workflowStatusDotClass,
+  workflowStatusLabel,
+  workflowStatusVariant,
+} from '../lib/workflow-dashboard-status.js';
+import type {WorkflowDashboardStatus} from '../workflow-dashboard-types.js';
+
+export function WorkflowStatusBadge({
+  size = '2xs',
+  status,
+}: {
+  size?: '2xs' | 'xs';
+  status: WorkflowDashboardStatus;
+}) {
+  return (
+    <Badge variant={workflowStatusVariant(status)} size={size} className="gap-5">
+      <StatusDot status={status} size={size === 'xs' ? 'md' : 'sm'} />
+      {workflowStatusLabel(status)}
+    </Badge>
+  );
+}
+
+export function StatusDot({
+  pulse,
+  size = 'md',
+  status,
+}: {
+  pulse?: boolean;
+  size?: 'sm' | 'md';
+  status: WorkflowDashboardStatus;
+}) {
+  const shouldPulse = pulse && status === 'running';
+  return (
+    <span
+      className={cn(
+        'relative inline-block shrink-0 rounded-full',
+        size === 'sm' ? 'size-6' : 'size-8',
+        workflowStatusDotClass(status),
+        shouldPulse &&
+          'after:absolute after:inset-[-4px] after:rounded-full after:border-2 after:border-tag-blue-icon after:opacity-50 after:content-[""]',
+      )}
+    />
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/components/step-detail-panel.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/step-detail-panel.tsx
@@ -1,0 +1,372 @@
+import {Button, Code, cn, Icon, Text} from '@shipfox/react-ui';
+import {formatClock, formatDuration} from '../lib/workflow-dashboard-format.js';
+import {workflowStatusTextClass} from '../lib/workflow-dashboard-status.js';
+import type {
+  WorkflowDashboardAttempt,
+  WorkflowDashboardLogStream,
+  WorkflowDashboardRun,
+  WorkflowDashboardStep,
+  WorkflowDashboardViewModel,
+} from '../workflow-dashboard-types.js';
+import {WorkflowStatusBadge} from './status-badge.js';
+
+export type WorkflowDashboardViewMode = 'logs' | 'overview' | 'source';
+export type WorkflowDashboardLogFilter = 'all' | WorkflowDashboardLogStream;
+
+const commitOutputKeyPattern = /commit/i;
+
+export function StepDetailPanel({
+  attempt,
+  fixture,
+  logFilter,
+  logQuery,
+  run,
+  step,
+  viewMode,
+}: {
+  attempt: WorkflowDashboardAttempt | null;
+  fixture: WorkflowDashboardViewModel;
+  logFilter: WorkflowDashboardLogFilter;
+  logQuery: string;
+  run: WorkflowDashboardRun;
+  step: WorkflowDashboardStep;
+  viewMode: WorkflowDashboardViewMode;
+}) {
+  if (viewMode === 'logs') {
+    return <LogsPanel filter={logFilter} query={logQuery} run={run} step={step} />;
+  }
+  if (viewMode === 'source') {
+    return <SourcePanel fixture={fixture} />;
+  }
+  return <OverviewPanel attempt={attempt} run={run} step={step} />;
+}
+
+export function OverviewPanel({
+  attempt,
+  run,
+  step,
+}: {
+  attempt: WorkflowDashboardAttempt | null;
+  run: WorkflowDashboardRun;
+  step: WorkflowDashboardStep;
+}) {
+  const visibleOutput = attempt?.output
+    ? Object.entries(attempt.output).filter(([key]) => !commitOutputKeyPattern.test(key))
+    : [];
+
+  return (
+    <div className="flex flex-col gap-14 overflow-auto border-border-neutral-base border-t bg-background-components-base px-18 py-16">
+      <RootCauseCard attempt={attempt} run={run} step={step} />
+      <CommandBlock command={step.command} />
+      {step.gate && (
+        <div
+          className={cn(
+            'rounded-8 border px-12 py-10',
+            attempt?.gateResult?.passed
+              ? 'border-tag-success-border bg-tag-success-bg'
+              : attempt?.gateResult
+                ? 'border-tag-error-border bg-tag-error-bg'
+                : 'border-tag-blue-border bg-tag-blue-bg',
+          )}
+        >
+          <div className="mb-8 flex items-center gap-8">
+            <Icon
+              name={attempt?.gateResult?.passed ? 'shieldCheckLine' : 'shieldLine'}
+              className="size-14"
+            />
+            <Text as="span" size="sm" bold>
+              Gate
+            </Text>
+            <WorkflowStatusBadge status={attempt?.gateResult?.passed ? 'succeeded' : 'failed'} />
+          </div>
+          <Code variant="label" className="block text-foreground-neutral-subtle">
+            success_if: {step.gateInfo?.expr}
+          </Code>
+          <Code
+            variant="label"
+            className="mt-4 flex items-center gap-4 text-foreground-neutral-subtle"
+          >
+            <Icon name="restartLine" className="size-12" />
+            {'on_failure -> restart_from '}
+            {step.gateInfo?.restartFrom}
+          </Code>
+        </div>
+      )}
+      {visibleOutput.length > 0 && (
+        <section>
+          <div className="mb-8 flex items-center justify-between">
+            <Text
+              as="span"
+              size="xs"
+              bold
+              className="uppercase tracking-[0.06em] text-foreground-neutral-muted"
+            >
+              Output
+            </Text>
+            <CopyButton text={JSON.stringify(Object.fromEntries(visibleOutput), null, 2)} />
+          </div>
+          <div className="grid gap-1 overflow-hidden rounded-6 border border-border-neutral-base">
+            {visibleOutput.map(([key, value]) => (
+              <div
+                className="grid grid-cols-[140px_1fr] border-border-neutral-base border-t first:border-t-0"
+                key={key}
+              >
+                <Code
+                  variant="label"
+                  className="bg-background-neutral-subtle px-10 py-6 text-foreground-neutral-muted"
+                >
+                  {key}
+                </Code>
+                <Code variant="label" className="px-10 py-6 text-foreground-neutral-base">
+                  {String(value)}
+                </Code>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+export function LogsPanel({
+  filter,
+  query,
+  run,
+  step,
+}: {
+  filter: WorkflowDashboardLogFilter;
+  query: string;
+  run: WorkflowDashboardRun;
+  step: WorkflowDashboardStep;
+}) {
+  if (step.attemptCount === 0) {
+    return (
+      <div className="flex min-h-160 items-center justify-center border-border-neutral-base border-t bg-background-components-base px-24 py-32 text-center">
+        <div className="flex max-w-320 flex-col items-center gap-8">
+          <Icon
+            name={step.status === 'pending' ? 'hourglassLine' : 'prohibitedLine'}
+            className="size-20 text-foreground-neutral-muted"
+          />
+          <Text size="sm" bold>
+            {step.status === 'pending' ? 'Step not started' : 'Step not run'}
+          </Text>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            {step.notRunLog?.[0]?.message ?? 'No attempts were executed for this step.'}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-12 overflow-auto border-border-neutral-base border-t bg-background-components-base px-18 py-16">
+      {step.attempts.map((attempt) => {
+        const lines = attempt.logs.filter(
+          (line) =>
+            (filter === 'all' || line.stream === filter) &&
+            (!query || line.message.toLowerCase().includes(query.toLowerCase())),
+        );
+
+        return (
+          <div
+            className="overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base"
+            key={attempt.number}
+          >
+            <div className="flex items-center justify-between gap-12 border-border-neutral-strong border-b px-12 py-8">
+              <Code variant="label" className="truncate text-foreground-neutral-on-inverted">
+                $ {step.command}
+              </Code>
+              <Code variant="label" className="shrink-0 text-foreground-neutral-muted">
+                {step.attemptCount > 1 ? `attempt #${attempt.number} - ` : ''}
+                {attempt.status === 'running' ? 'live' : `exit ${attempt.exitCode}`} -{' '}
+                {formatDuration(attempt.duration)}
+              </Code>
+            </div>
+            <div className="overflow-auto py-4">
+              {lines.map((line) => (
+                <LogLine line={line} key={`${line.at}-${line.message}`} />
+              ))}
+              {attempt.status === 'running' && (
+                <LogLine
+                  line={{
+                    at: run.observedUntil,
+                    message: '| streaming',
+                    stream: 'system',
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function SourcePanel({fixture}: {fixture: WorkflowDashboardViewModel}) {
+  const lines = fixture.workflow.yaml.split('\n').map((line, index) => ({
+    key: `${index + 1}:${line}`,
+    line,
+    lineNumber: index + 1,
+  }));
+
+  return (
+    <div className="overflow-auto border-border-neutral-base border-t bg-background-components-base px-18 py-16">
+      <div className="overflow-hidden rounded-8 border border-border-neutral-base bg-background-contrast-base">
+        <div className="overflow-auto py-6">
+          {lines.map(({key, line, lineNumber}) => (
+            <div className="grid grid-cols-[52px_1fr] gap-12 px-12" key={key}>
+              <Code
+                variant="label"
+                className="select-none text-right text-foreground-neutral-muted"
+              >
+                {lineNumber}
+              </Code>
+              <Code
+                variant="paragraph"
+                className="whitespace-pre text-foreground-neutral-on-inverted"
+              >
+                {line || ' '}
+              </Code>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RootCauseCard({
+  attempt,
+  run,
+  step,
+}: {
+  attempt: WorkflowDashboardAttempt | null;
+  run: WorkflowDashboardRun;
+  step: WorkflowDashboardStep;
+}) {
+  if (run.focus.step !== step.name || (run.status !== 'failed' && run.status !== 'running')) {
+    return null;
+  }
+
+  const running = step.status === 'running';
+  const lastFailedAttempt =
+    attempt?.status === 'failed'
+      ? attempt
+      : [...step.attempts].reverse().find((item) => item.status === 'failed');
+  const summary = running
+    ? 'Currently running - no result yet.'
+    : lastFailedAttempt?.gateResult?.passed === false
+      ? `Gate ${lastFailedAttempt.gateResult.source} rejected the result - exit code ${lastFailedAttempt.exitCode}.`
+      : `Failed with exit code ${lastFailedAttempt?.exitCode ?? 'unknown'}.`;
+  const stderrLines = attempt?.logs.filter((line) => line.stream === 'stderr') ?? [];
+
+  return (
+    <div
+      className={cn(
+        'rounded-8 border px-12 py-10',
+        running
+          ? 'border-tag-blue-border bg-tag-blue-bg'
+          : 'border-tag-error-border bg-tag-error-bg',
+      )}
+    >
+      <div className="mb-6 flex items-center gap-8">
+        <Icon
+          name={running ? 'loader4Line' : 'alertLine'}
+          className={cn('size-14', running && 'animate-spin')}
+        />
+        <Text as="span" size="sm" bold>
+          {running ? 'Active step' : 'Root cause'}
+        </Text>
+      </div>
+      <Text size="sm" className="text-foreground-neutral-subtle">
+        {summary}
+      </Text>
+      {stderrLines.length > 0 && (
+        <div className="mt-10 rounded-6 bg-background-contrast-base px-10 py-8">
+          <Code variant="label" className="mb-4 block uppercase text-tag-error-text">
+            stderr
+          </Code>
+          {stderrLines.map((line) => (
+            <Code
+              variant="paragraph"
+              className="block text-tag-error-text"
+              key={`${line.at}-${line.message}`}
+            >
+              {line.message}
+            </Code>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CommandBlock({command}: {command: string}) {
+  return (
+    <div className="flex items-center gap-10 rounded-8 border border-border-neutral-base bg-background-contrast-base px-12 py-10">
+      <Code variant="label" className="uppercase text-foreground-neutral-muted">
+        code
+      </Code>
+      <Code
+        variant="paragraph"
+        className="min-w-0 flex-1 truncate text-foreground-neutral-on-inverted"
+      >
+        {command}
+      </Code>
+      <CopyButton text={command} />
+    </div>
+  );
+}
+
+function CopyButton({text}: {text: string}) {
+  return (
+    <Button
+      aria-label="Copy"
+      iconLeft="copy"
+      onClick={() => {
+        void navigator.clipboard?.writeText(text);
+      }}
+      size="xs"
+      variant="transparentMuted"
+    />
+  );
+}
+
+function LogLine({
+  line,
+}: {
+  line: {
+    at: string;
+    diagnostic?: boolean;
+    gate?: boolean;
+    message: string;
+    stream: WorkflowDashboardLogStream;
+  };
+}) {
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-[76px_64px_1fr] gap-10 border-transparent border-l-2 px-12 py-2',
+        line.diagnostic && 'border-tag-error-border bg-tag-error-bg/10',
+        line.gate && 'border-tag-warning-border bg-tag-warning-bg/10',
+      )}
+    >
+      <Code variant="label" className="text-foreground-neutral-muted">
+        {formatClock(line.at)}
+      </Code>
+      <Code
+        variant="label"
+        className={workflowStatusTextClass(
+          line.stream === 'stderr' ? 'failed' : line.stream === 'stdout' ? 'succeeded' : 'queued',
+        )}
+      >
+        {line.gate ? 'gate' : line.stream}
+      </Code>
+      <Code variant="paragraph" className="whitespace-pre-wrap text-foreground-neutral-on-inverted">
+        {line.message}
+      </Code>
+    </div>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/components/step-list.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/components/step-list.tsx
@@ -1,0 +1,165 @@
+import {Button, Code, cn, Icon, Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
+import type {ReactNode} from 'react';
+import {formatDuration} from '../lib/workflow-dashboard-format.js';
+import {workflowStatusLabel, workflowStatusTextClass} from '../lib/workflow-dashboard-status.js';
+import type {
+  WorkflowDashboardAttempt,
+  WorkflowDashboardJob,
+  WorkflowDashboardStep,
+} from '../workflow-dashboard-types.js';
+import {StatusDot} from './status-badge.js';
+
+export function StepList({
+  attemptByStep,
+  expanded,
+  job,
+  onSelectAttempt,
+  onToggle,
+  renderPanel,
+}: {
+  attemptByStep: Record<string, number>;
+  expanded: Set<string>;
+  job: WorkflowDashboardJob;
+  onSelectAttempt: (step: string, attempt: number) => void;
+  onToggle: (step: string) => void;
+  renderPanel: (step: WorkflowDashboardStep) => ReactNode;
+}) {
+  const restartTargets = new Set(
+    job.steps.flatMap((step) => (step.gateInfo ? [step.gateInfo.restartFrom] : [])),
+  );
+
+  return (
+    <div className="relative flex flex-col gap-6 pl-18">
+      <div
+        className="absolute top-0 bottom-0 left-8 w-1 bg-border-neutral-base"
+        aria-hidden="true"
+      />
+      {job.steps.map((step, index) => {
+        const isExpanded = expanded.has(step.name);
+        const selectedAttempt = attemptByStep[step.name] ?? step.attempts.at(-1)?.number ?? null;
+        const isRestartSource = Boolean(step.gateInfo);
+        const isRestartTarget = restartTargets.has(step.name);
+
+        return (
+          <div className="relative" key={step.name}>
+            <div
+              className={cn(
+                'grid w-full grid-cols-[18px_34px_8px_minmax(120px,1fr)_auto_auto] items-center gap-10 rounded-8 border px-12 py-9 text-left shadow-sm transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+                isExpanded
+                  ? 'border-border-neutral-strong bg-background-components-base'
+                  : 'border-border-neutral-base bg-background-components-base',
+                step.status === 'running' && 'border-tag-blue-border',
+              )}
+            >
+              <button
+                aria-expanded={isExpanded}
+                aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${step.name}`}
+                className="flex size-18 items-center justify-center rounded-4 text-foreground-neutral-muted hover:bg-background-neutral-muted focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+                onClick={() => onToggle(step.name)}
+                type="button"
+              >
+                <Icon
+                  name={isExpanded ? 'arrowDownSLine' : 'arrowRightSLine'}
+                  className="size-14"
+                />
+              </button>
+              <Code variant="label" className="text-foreground-neutral-muted">
+                {String(index + 1).padStart(2, '0')}
+              </Code>
+              <StatusDot pulse status={step.status} />
+              <div className="flex min-w-0 items-center gap-8">
+                <Code variant="paragraph" bold className="truncate">
+                  {step.name}
+                </Code>
+                {isRestartTarget && (
+                  <Code
+                    variant="label"
+                    className="rounded-4 bg-tag-warning-bg px-5 py-1 text-tag-warning-text"
+                  >
+                    restart target
+                  </Code>
+                )}
+                {isRestartSource && (
+                  <Code
+                    variant="label"
+                    className="hidden rounded-4 bg-tag-error-bg px-5 py-1 text-tag-error-text lg:inline"
+                  >
+                    restart_from {step.gateInfo?.restartFrom}
+                  </Code>
+                )}
+              </div>
+              {step.attempts.length > 0 ? (
+                <div className="flex items-center gap-4">
+                  {step.attempts.map((attempt) => (
+                    <AttemptChip
+                      attempt={attempt}
+                      key={attempt.number}
+                      onSelect={() => onSelectAttempt(step.name, attempt.number)}
+                      selected={isExpanded && selectedAttempt === attempt.number}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <Code variant="label" className="text-foreground-neutral-disabled">
+                  {step.status === 'pending' ? 'not started' : 'not run'}
+                </Code>
+              )}
+              <Code
+                variant="label"
+                className={cn(
+                  'text-right',
+                  step.status === 'running'
+                    ? 'text-tag-blue-text'
+                    : workflowStatusTextClass(step.status),
+                )}
+              >
+                {step.duration != null
+                  ? formatDuration(step.duration)
+                  : step.status === 'running'
+                    ? 'live'
+                    : workflowStatusLabel(step.status)}
+              </Code>
+            </div>
+            {isExpanded && <div className="ml-18">{renderPanel(step)}</div>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function AttemptChip({
+  attempt,
+  onSelect,
+  selected,
+}: {
+  attempt: WorkflowDashboardAttempt;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          className={cn(
+            'h-20 gap-3 px-5 font-code text-xs',
+            selected && 'ring-1 ring-foreground-neutral-base',
+          )}
+          onClick={(event) => {
+            event.stopPropagation();
+            onSelect();
+          }}
+          size="2xs"
+          type="button"
+          variant="secondary"
+        >
+          #{attempt.number}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        Attempt {attempt.number} - {workflowStatusLabel(attempt.status)} -{' '}
+        {formatDuration(attempt.duration)}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/lib/workflow-dashboard-format.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/lib/workflow-dashboard-format.ts
@@ -1,0 +1,31 @@
+export function formatDuration(seconds: number | null | undefined): string {
+  if (seconds == null) return '-';
+  const rounded = Math.round(seconds);
+  if (rounded < 60) return `${rounded}s`;
+  const minutes = Math.floor(rounded / 60);
+  const remainingSeconds = rounded % 60;
+  if (minutes < 60) return `${minutes}m${String(remainingSeconds).padStart(2, '0')}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h${String(remainingMinutes).padStart(2, '0')}m`;
+}
+
+export function formatClock(iso: string): string {
+  return new Date(iso).toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    hour12: false,
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export function formatRelativeTime(iso: string, nowIso?: string): string {
+  const now = nowIso ? new Date(nowIso).getTime() : Date.now();
+  const seconds = Math.max(0, Math.round((now - new Date(iso).getTime()) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/lib/workflow-dashboard-status.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/lib/workflow-dashboard-status.ts
@@ -1,0 +1,50 @@
+import type {BadgeVariant} from '@shipfox/react-ui';
+import type {WorkflowDashboardStatus} from '../workflow-dashboard-types.js';
+
+export function workflowStatusLabel(status: WorkflowDashboardStatus | string | undefined): string {
+  if (!status) return '-';
+  return (
+    {
+      'awaiting-runner': 'Awaiting runner',
+      cancelled: 'Cancelled',
+      failed: 'Failed',
+      pending: 'Pending',
+      queued: 'Queued',
+      running: 'Running',
+      succeeded: 'Succeeded',
+      'timed-out': 'Timed out',
+    }[status] ?? `${status[0]?.toUpperCase()}${status.slice(1)}`
+  );
+}
+
+export function workflowStatusVariant(status: WorkflowDashboardStatus | string): BadgeVariant {
+  if (status === 'succeeded') return 'success';
+  if (status === 'failed' || status === 'timed-out') return 'error';
+  if (status === 'running') return 'info';
+  if (status === 'awaiting-runner') return 'warning';
+  return 'neutral';
+}
+
+export function workflowStatusDotClass(status: WorkflowDashboardStatus | string): string {
+  if (status === 'succeeded') return 'bg-tag-success-icon';
+  if (status === 'failed' || status === 'timed-out') return 'bg-tag-error-icon';
+  if (status === 'running') return 'bg-tag-blue-icon';
+  if (status === 'awaiting-runner') return 'bg-tag-warning-icon';
+  return 'bg-tag-neutral-icon';
+}
+
+export function workflowStatusBorderClass(status: WorkflowDashboardStatus | string): string {
+  if (status === 'succeeded') return 'border-tag-success-border';
+  if (status === 'failed' || status === 'timed-out') return 'border-tag-error-border';
+  if (status === 'running') return 'border-tag-blue-border';
+  if (status === 'awaiting-runner') return 'border-tag-warning-border';
+  return 'border-border-neutral-base';
+}
+
+export function workflowStatusTextClass(status: WorkflowDashboardStatus | string): string {
+  if (status === 'succeeded') return 'text-tag-success-text';
+  if (status === 'failed' || status === 'timed-out') return 'text-tag-error-text';
+  if (status === 'running') return 'text-tag-blue-text';
+  if (status === 'awaiting-runner') return 'text-tag-warning-text';
+  return 'text-foreground-neutral-muted';
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-fixture.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-fixture.ts
@@ -1,0 +1,402 @@
+import type {
+  WorkflowDashboardJob,
+  WorkflowDashboardStep,
+  WorkflowDashboardViewModel,
+} from './workflow-dashboard-types.js';
+
+const now = '2026-06-12T12:10:00Z';
+
+function log(at: string, stream: 'stdout' | 'stderr' | 'system', message: string) {
+  return {at, message, stream};
+}
+
+function step(
+  overrides: Partial<WorkflowDashboardStep> & Pick<WorkflowDashboardStep, 'name' | 'status'>,
+): WorkflowDashboardStep {
+  return {
+    attemptCount: overrides.attempts?.length ?? 1,
+    attempts: [],
+    command: `shipfox run ${overrides.name}`,
+    duration: 12,
+    kind: 'command',
+    ...overrides,
+  };
+}
+
+const remediateCheckoutSteps: WorkflowDashboardStep[] = [
+  step({
+    attempts: [
+      {
+        duration: 18,
+        exitCode: 0,
+        logs: [
+          log('2026-06-12T12:02:06Z', 'system', 'activity started'),
+          log('2026-06-12T12:02:11Z', 'stdout', 'loaded Sentry event context'),
+        ],
+        number: 1,
+        output: {incident: 'SENTRY-9Z4K', release: 'checkout-api@8f13c4d'},
+        startedAt: '2026-06-12T12:02:06Z',
+        status: 'succeeded',
+      },
+    ],
+    command: 'sentry.issue.fetch --id SENTRY-9Z4K --include traces',
+    duration: 18,
+    kind: 'integration',
+    name: 'triage_alert',
+    status: 'succeeded',
+  }),
+  step({
+    attempts: [
+      {
+        duration: 33,
+        exitCode: 0,
+        logs: [
+          log('2026-06-12T12:02:25Z', 'stdout', 'found recent deploy checkout-api@8f13c4d'),
+          log('2026-06-12T12:02:34Z', 'stdout', 'regression window confirmed'),
+        ],
+        number: 1,
+        output: {commit: '8f13c4d', suspect: true},
+        startedAt: '2026-06-12T12:02:24Z',
+        status: 'succeeded',
+      },
+    ],
+    command: 'gh deployment list --env prod --limit 5',
+    duration: 33,
+    kind: 'command',
+    name: 'inspect_recent_deploys',
+    status: 'succeeded',
+  }),
+  step({
+    attempts: [
+      {
+        duration: 114,
+        exitCode: 0,
+        logs: [
+          log('2026-06-12T12:03:04Z', 'stdout', 'patched idempotency lookup'),
+          log('2026-06-12T12:04:38Z', 'stdout', 'opened PR shipfox/checkout-api#1182'),
+        ],
+        number: 1,
+        output: {pr: 1182, files_changed: 3},
+        startedAt: '2026-06-12T12:03:02Z',
+        status: 'succeeded',
+      },
+    ],
+    command: 'agent apply-fix --scope checkout-api --issue SENTRY-9Z4K',
+    duration: 114,
+    kind: 'agent',
+    name: 'produce_fix',
+    status: 'succeeded',
+  }),
+  step({
+    attempts: [
+      {
+        duration: 44,
+        exitCode: 1,
+        gateResult: {exitCode: 1, passed: false, source: 'exitCode'},
+        logs: [
+          log('2026-06-12T12:05:02Z', 'stdout', 'running payment regression suite'),
+          log(
+            '2026-06-12T12:05:42Z',
+            'stderr',
+            'expected checkout idempotency token to be persisted',
+          ),
+          log('2026-06-12T12:05:46Z', 'system', 'gate rejected result'),
+        ],
+        number: 1,
+        startedAt: '2026-06-12T12:05:01Z',
+        status: 'failed',
+      },
+      {
+        duration: 71,
+        exitCode: 0,
+        gateResult: {exitCode: 0, passed: true, source: 'exitCode'},
+        logs: [
+          log('2026-06-12T12:07:08Z', 'stdout', 'running payment regression suite'),
+          log('2026-06-12T12:08:18Z', 'stdout', '42 tests passed'),
+        ],
+        number: 2,
+        startedAt: '2026-06-12T12:07:07Z',
+        status: 'succeeded',
+      },
+    ],
+    attemptCount: 2,
+    command: 'pnpm test --filter checkout-api -- payment-regression.test.ts',
+    duration: 115,
+    gate: true,
+    gateInfo: {
+      expr: 'exitCode == 0',
+      reason: 'Unit regression must pass before deployment.',
+      restartFrom: 'produce_fix',
+    },
+    kind: 'command',
+    name: 'run_unit_tests',
+    status: 'succeeded',
+  }),
+  step({
+    attempts: [
+      {
+        duration: 66,
+        exitCode: 0,
+        logs: [
+          log('2026-06-12T12:08:26Z', 'stdout', 'deploying checkout-api canary'),
+          log('2026-06-12T12:09:16Z', 'stdout', 'canary reached healthy state'),
+        ],
+        number: 1,
+        startedAt: '2026-06-12T12:08:24Z',
+        status: 'succeeded',
+      },
+    ],
+    command: 'shipfox deploy checkout-api --canary 10',
+    duration: 66,
+    kind: 'deploy',
+    name: 'deploy_canary',
+    status: 'succeeded',
+  }),
+  step({
+    attempts: [
+      {
+        duration: 41,
+        exitCode: 0,
+        logs: [
+          log('2026-06-12T12:09:24Z', 'stdout', 'polling Sentry issue health'),
+          log('2026-06-12T12:10:04Z', 'stdout', 'error rate returned to baseline'),
+        ],
+        number: 1,
+        output: {error_rate: '0.01%', recovered: true},
+        startedAt: '2026-06-12T12:09:23Z',
+        status: 'succeeded',
+      },
+    ],
+    command: 'sentry.issue.monitor --id SENTRY-9Z4K --window 5m',
+    duration: 41,
+    kind: 'integration',
+    name: 'verify_sentry_recovery',
+    status: 'succeeded',
+  }),
+];
+
+const validateReleaseSteps: WorkflowDashboardStep[] = [
+  step({
+    attempts: [
+      {
+        duration: 23,
+        exitCode: 0,
+        logs: [log('2026-06-12T12:04:07Z', 'stdout', 'schema validation passed')],
+        number: 1,
+        startedAt: '2026-06-12T12:04:05Z',
+        status: 'succeeded',
+      },
+    ],
+    command: 'pnpm lint && pnpm typecheck',
+    duration: 23,
+    name: 'static_checks',
+    status: 'succeeded',
+  }),
+  step({
+    attempts: [],
+    attemptCount: 0,
+    command: 'notify #checkout-release',
+    duration: null,
+    kind: 'notify',
+    name: 'notify_release_channel',
+    notRunLog: [log(now, 'system', 'Skipped because remediation completed in the primary job.')],
+    status: 'cancelled',
+  }),
+];
+
+const failedUnitTestAttempt = remediateCheckoutSteps.find((s) => s.name === 'run_unit_tests')
+  ?.attempts[0];
+
+if (!failedUnitTestAttempt) {
+  throw new Error('Workflow dashboard fixture is missing the failed unit test attempt.');
+}
+
+const failedRunJobs: WorkflowDashboardJob[] = [
+  {
+    duration: 291,
+    name: 'remediate_checkout',
+    status: 'running',
+    steps: remediateCheckoutSteps.map((s) =>
+      s.name === 'verify_sentry_recovery'
+        ? {...s, attempts: [], attemptCount: 0, duration: null, status: 'pending'}
+        : s,
+    ),
+  },
+  {
+    duration: null,
+    name: 'validate_release',
+    needs: 'remediate_checkout',
+    status: 'pending',
+    steps: validateReleaseSteps.map((s) => ({
+      ...s,
+      attempts: [],
+      attemptCount: 0,
+      duration: null,
+      status: 'pending',
+    })),
+  },
+];
+
+const succeededRunJobs: WorkflowDashboardJob[] = [
+  {
+    duration: 427,
+    name: 'remediate_checkout',
+    status: 'succeeded',
+    steps: remediateCheckoutSteps,
+  },
+  {
+    duration: 23,
+    name: 'validate_release',
+    needs: 'remediate_checkout',
+    status: 'succeeded',
+    steps: validateReleaseSteps,
+  },
+];
+
+export const workflowDashboardFixture: WorkflowDashboardViewModel = {
+  runOrder: ['two-gates-retried', 'active-remediation', 'failed-release'],
+  runs: {
+    'two-gates-retried': {
+      duration: 1642,
+      focus: {attempt: 1, job: 'remediate_checkout', step: 'verify_sentry_recovery'},
+      jobs: succeededRunJobs.map((job) =>
+        job.name === 'remediate_checkout'
+          ? {...job, duration: 1400}
+          : job.name === 'validate_release'
+            ? {...job, duration: 242}
+            : job,
+      ),
+      number: 4288,
+      observedUntil: '2026-06-12T10:10:00Z',
+      status: 'succeeded',
+      trigger: {
+        alertAt: '2026-06-12T12:01:58Z',
+        event: 'issue.alert',
+        filter: 'environment:production service:checkout-api',
+        incident: 'SENTRY-CHKOUT-9002',
+        payload: {culprit: 'POST /checkout', level: 'error', project: 'checkout-api'},
+        runStartedAt: '2026-06-12T12:02:04Z',
+        source: 'sentry',
+      },
+    },
+    'active-remediation': {
+      duration: 366,
+      focus: {attempt: 1, job: 'remediate_checkout', step: 'deploy_canary'},
+      jobs: failedRunJobs.map((job) =>
+        job.name === 'remediate_checkout'
+          ? {
+              ...job,
+              status: 'running',
+              steps: job.steps.map((s) =>
+                s.name === 'deploy_canary'
+                  ? {
+                      ...s,
+                      attempts: [
+                        {
+                          duration: 87,
+                          exitCode: null,
+                          logs: [
+                            log('2026-06-12T12:09:09Z', 'stdout', 'deploying checkout-api canary'),
+                            log('2026-06-12T12:10:00Z', 'system', 'waiting for health checks'),
+                          ],
+                          number: 1,
+                          startedAt: '2026-06-12T12:09:08Z',
+                          status: 'running',
+                        },
+                      ],
+                      attemptCount: 1,
+                      duration: null,
+                      status: 'running',
+                    }
+                  : s,
+              ),
+            }
+          : job,
+      ),
+      number: 4289,
+      observedUntil: now,
+      status: 'running',
+      trigger: {
+        alertAt: '2026-06-12T12:01:58Z',
+        event: 'issue.alert',
+        filter: 'environment:production service:checkout-api',
+        incident: 'SENTRY-CHKOUT-9002',
+        payload: {culprit: 'POST /checkout', level: 'error', project: 'checkout-api'},
+        runStartedAt: '2026-06-12T12:02:04Z',
+        source: 'sentry',
+      },
+    },
+    'failed-release': {
+      duration: 233,
+      focus: {attempt: 1, job: 'remediate_checkout', step: 'run_unit_tests'},
+      jobs: failedRunJobs.map((job) =>
+        job.name === 'remediate_checkout'
+          ? {
+              ...job,
+              status: 'failed',
+              steps: job.steps.map((s) =>
+                s.name === 'run_unit_tests'
+                  ? {
+                      ...s,
+                      attempts: [failedUnitTestAttempt],
+                      attemptCount: 1,
+                      duration: 44,
+                      status: 'failed',
+                    }
+                  : s.name === 'deploy_canary' || s.name === 'verify_sentry_recovery'
+                    ? {...s, attempts: [], attemptCount: 0, duration: null, status: 'cancelled'}
+                    : s,
+              ),
+            }
+          : {...job, status: 'cancelled'},
+      ),
+      number: 4287,
+      observedUntil: '2026-06-12T12:05:47Z',
+      status: 'failed',
+      trigger: {
+        alertAt: '2026-06-12T12:01:58Z',
+        event: 'issue.alert',
+        filter: 'environment:production service:checkout-api',
+        incident: 'SENTRY-CHKOUT-9002',
+        payload: {culprit: 'POST /checkout', level: 'error', project: 'checkout-api'},
+        runStartedAt: '2026-06-12T12:02:04Z',
+        source: 'sentry',
+      },
+    },
+  },
+  workflow: {
+    sourcePath: '.shipfox/workflows/checkout-remediation.yaml',
+    yaml: `name: checkout-remediation
+on:
+  sentry:
+    project: checkout-api
+    environment: production
+
+jobs:
+  remediate_checkout:
+    steps:
+      - id: triage_alert
+        uses: sentry.issue.fetch
+      - id: inspect_recent_deploys
+        run: gh deployment list --env prod --limit 5
+      - id: produce_fix
+        uses: agent.apply-fix
+      - id: run_unit_tests
+        run: pnpm test --filter checkout-api -- payment-regression.test.ts
+        gate:
+          success_if: exitCode == 0
+          on_failure:
+            restartFrom: produce_fix
+      - id: deploy_canary
+        run: shipfox deploy checkout-api --canary 10
+      - id: verify_sentry_recovery
+        uses: sentry.issue.monitor
+  validate_release:
+    needs: remediate_checkout
+    steps:
+      - id: static_checks
+        run: pnpm lint && pnpm typecheck
+      - id: notify_release_channel
+        uses: slack.notify`,
+  },
+};

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-format.test.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-format.test.ts
@@ -1,0 +1,58 @@
+import {readdirSync, readFileSync, statSync} from 'node:fs';
+import {join} from 'node:path';
+import {formatDuration, formatRelativeTime} from './lib/workflow-dashboard-format.js';
+import {workflowStatusLabel, workflowStatusVariant} from './lib/workflow-dashboard-status.js';
+
+const cssImportPattern = /import\s+['"].*\.css['"]/;
+
+describe('workflow dashboard formatting', () => {
+  test.each([
+    [0, '0s'],
+    [59, '59s'],
+    [60, '1m00s'],
+    [65, '1m05s'],
+    [3599, '59m59s'],
+    [3600, '1h00m'],
+    [3660, '1h01m'],
+    [null, '-'],
+  ])('formats duration %s as %s', (seconds, expected) => {
+    expect(formatDuration(seconds)).toBe(expected);
+  });
+
+  test.each([
+    ['2026-06-12T12:09:45Z', '15s ago'],
+    ['2026-06-12T12:08:00Z', '2m ago'],
+    ['2026-06-12T10:10:00Z', '2h ago'],
+    ['2026-06-10T12:10:00Z', '2d ago'],
+  ])('formats relative time %s as %s', (iso, expected) => {
+    expect(formatRelativeTime(iso, '2026-06-12T12:10:00Z')).toBe(expected);
+  });
+
+  test.each([
+    ['succeeded', 'success', 'Succeeded'],
+    ['failed', 'error', 'Failed'],
+    ['running', 'info', 'Running'],
+    ['awaiting-runner', 'warning', 'Awaiting runner'],
+    ['unknown', 'neutral', 'Unknown'],
+  ])('maps status %s', (status, variant, label) => {
+    expect(workflowStatusVariant(status)).toBe(variant);
+    expect(workflowStatusLabel(status)).toBe(label);
+  });
+
+  test('dashboard source files do not import local CSS', () => {
+    const dashboardDir = new URL('.', import.meta.url);
+    const files = sourceFiles(dashboardDir.pathname);
+
+    expect(files.filter((file) => readFileSync(file, 'utf8').match(cssImportPattern))).toEqual([]);
+  });
+});
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) return sourceFiles(path);
+    if (path.endsWith('.ts') || path.endsWith('.tsx')) return [path];
+    return [];
+  });
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-types.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-types.ts
@@ -1,0 +1,94 @@
+export type WorkflowDashboardStatus =
+  | 'awaiting-runner'
+  | 'cancelled'
+  | 'failed'
+  | 'pending'
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'timed-out';
+
+export type WorkflowDashboardLogStream = 'stdout' | 'stderr' | 'system';
+
+export type WorkflowDashboardLogLine = {
+  at: string;
+  diagnostic?: boolean;
+  gate?: boolean;
+  message: string;
+  stream: WorkflowDashboardLogStream;
+};
+
+export type WorkflowDashboardGateResult = {
+  exitCode: number;
+  passed: boolean;
+  source: string;
+};
+
+export type WorkflowDashboardAttempt = {
+  duration: number;
+  exitCode: number | null;
+  gateResult?: WorkflowDashboardGateResult;
+  logs: WorkflowDashboardLogLine[];
+  number: number;
+  output?: Record<string, boolean | number | string>;
+  startedAt: string;
+  status: WorkflowDashboardStatus;
+};
+
+export type WorkflowDashboardGateInfo = {
+  expr: string;
+  reason: string;
+  restartFrom: string;
+};
+
+export type WorkflowDashboardStep = {
+  attemptCount: number;
+  attempts: WorkflowDashboardAttempt[];
+  command: string;
+  duration: number | null;
+  gate?: boolean;
+  gateInfo?: WorkflowDashboardGateInfo;
+  kind: 'agent' | 'command' | 'deploy' | 'integration' | 'notify';
+  name: string;
+  notRunLog?: WorkflowDashboardLogLine[];
+  status: WorkflowDashboardStatus;
+};
+
+export type WorkflowDashboardJob = {
+  duration: number | null;
+  name: string;
+  needs?: string;
+  status: WorkflowDashboardStatus;
+  steps: WorkflowDashboardStep[];
+};
+
+export type WorkflowDashboardRun = {
+  duration: number;
+  focus: {
+    attempt: number;
+    job: string;
+    step: string;
+  };
+  jobs: WorkflowDashboardJob[];
+  number: number | string;
+  observedUntil: string;
+  status: WorkflowDashboardStatus;
+  trigger: {
+    alertAt: string;
+    event: string;
+    filter: string;
+    incident: string;
+    payload: Record<string, unknown>;
+    runStartedAt: string;
+    source: string;
+  };
+};
+
+export type WorkflowDashboardViewModel = {
+  runOrder: string[];
+  runs: Record<string, WorkflowDashboardRun>;
+  workflow: {
+    sourcePath: string;
+    yaml: string;
+  };
+};

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-run-dashboard.test.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-run-dashboard.test.tsx
@@ -1,0 +1,28 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import {WorkflowRunDashboard} from './workflow-run-dashboard.js';
+
+const run4289Pattern = /#4289/i;
+
+describe('WorkflowRunDashboard', () => {
+  test('renders the workflow run dashboard with the default step list view', () => {
+    render(<WorkflowRunDashboard />);
+
+    expect(screen.getByRole('heading', {name: 'Run #4288'})).toBeInTheDocument();
+    expect(screen.getByText('Jobs graph')).toBeInTheDocument();
+    expect(screen.getAllByText('remediate_checkout')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('verify_sentry_recovery')[0]).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Workflow source'})).toBeInTheDocument();
+    expect(screen.getAllByText('SENTRY-CHKOUT-9002')[0]).toBeInTheDocument();
+    expect(screen.getByText('run_unit_tests')).toBeInTheDocument();
+  });
+
+  test('switches run scenarios through the history rail', () => {
+    render(<WorkflowRunDashboard />);
+
+    fireEvent.click(screen.getByRole('button', {name: run4289Pattern}));
+
+    expect(screen.getByRole('heading', {name: 'Run #4289'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Go to active step'})).toBeInTheDocument();
+    expect(screen.getAllByText('deploy_canary')[0]).toBeInTheDocument();
+  });
+});

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-run-dashboard.tsx
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-run-dashboard.tsx
@@ -1,0 +1,430 @@
+import {Button, Code, cn, Icon} from '@shipfox/react-ui';
+import {type ReactNode, useCallback, useState} from 'react';
+import {WorkflowDashboardShell} from './components/dashboard-shell.js';
+import {CollapsedHistoryRail, HistoryRail} from './components/history-rail.js';
+import {JobGraph} from './components/job-graph.js';
+import {RunHeader} from './components/run-header.js';
+import {
+  SourcePanel,
+  StepDetailPanel,
+  type WorkflowDashboardLogFilter,
+  type WorkflowDashboardViewMode,
+} from './components/step-detail-panel.js';
+import {StepList} from './components/step-list.js';
+import {workflowDashboardFixture} from './workflow-dashboard-fixture.js';
+import type {
+  WorkflowDashboardJob,
+  WorkflowDashboardRun,
+  WorkflowDashboardStep,
+  WorkflowDashboardViewModel,
+} from './workflow-dashboard-types.js';
+
+function interestingStep(job: WorkflowDashboardJob): WorkflowDashboardStep {
+  const selected =
+    job.steps.find((step) => step.status === 'failed') ??
+    job.steps.find((step) => step.status === 'running') ??
+    job.steps.filter((step) => step.attemptCount > 0).at(-1) ??
+    job.steps[0];
+
+  if (!selected) {
+    throw new Error(`Workflow dashboard job ${job.name} has no steps.`);
+  }
+
+  return selected;
+}
+
+function firstRun(viewModel: WorkflowDashboardViewModel): WorkflowDashboardRun {
+  const firstKey = viewModel.runOrder[0];
+  const run = firstKey ? viewModel.runs[firstKey] : undefined;
+
+  if (!run) {
+    throw new Error('Workflow dashboard has no runs.');
+  }
+
+  return run;
+}
+
+function firstRunKey(viewModel: WorkflowDashboardViewModel): string {
+  const key = viewModel.runOrder[0];
+  if (!key) {
+    throw new Error('Workflow dashboard has no run keys.');
+  }
+  return key;
+}
+
+function firstJob(run: WorkflowDashboardRun): WorkflowDashboardJob {
+  const job = run.jobs[0];
+
+  if (!job) {
+    throw new Error(`Workflow dashboard run #${run.number} has no jobs.`);
+  }
+
+  return job;
+}
+
+export function WorkflowRunDashboard({
+  initialRunKey,
+  onSelectRun,
+  viewModel = workflowDashboardFixture,
+}: {
+  initialRunKey?: string;
+  onSelectRun?: (runKey: string) => void;
+  viewModel?: WorkflowDashboardViewModel;
+}) {
+  const defaultRunKey = viewModel.runs['two-gates-retried']
+    ? 'two-gates-retried'
+    : firstRunKey(viewModel);
+  const [localRunKey, setLocalRunKey] = useState(initialRunKey ?? defaultRunKey);
+  const [railOpen, setRailOpen] = useState(true);
+  const runKey = initialRunKey ?? localRunKey;
+  const run = viewModel.runs[runKey] ?? firstRun(viewModel);
+  const [selectedJob, setSelectedJob] = useState<string | null>(
+    run.status === 'succeeded' ? null : run.focus.job,
+  );
+  const [viewMode, setViewMode] = useState<WorkflowDashboardViewMode>('overview');
+  const [logFilter, setLogFilter] = useState<WorkflowDashboardLogFilter>('all');
+  const [logQuery, setLogQuery] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(run.status === 'succeeded' ? [] : [run.focus.step]),
+  );
+  const [attemptByStep, setAttemptByStep] = useState<Record<string, number>>({});
+  const [sourceView, setSourceView] = useState(false);
+  const [graphOpen, setGraphOpen] = useState(true);
+  const [stepsOpen, setStepsOpen] = useState(true);
+
+  const job = run.jobs.find((item) => item.name === selectedJob) ?? firstJob(run);
+
+  const selectRun = useCallback(
+    (key: string) => {
+      const nextRun = viewModel.runs[key];
+      if (!nextRun) return;
+      setSourceView(false);
+      setLocalRunKey(key);
+      setSelectedJob(nextRun.status === 'succeeded' ? null : nextRun.focus.job);
+      setExpanded(new Set(nextRun.status === 'succeeded' ? [] : [nextRun.focus.step]));
+      setAttemptByStep({});
+      onSelectRun?.(key);
+    },
+    [onSelectRun, viewModel.runs],
+  );
+
+  const selectJob = useCallback(
+    (name: string) => {
+      const nextJob = run.jobs.find((item) => item.name === name);
+      setSelectedJob(name);
+      if (nextJob) setExpanded(new Set([interestingStep(nextJob).name]));
+    },
+    [run.jobs],
+  );
+
+  const toggleStep = useCallback((name: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
+
+  const setAttemptFor = useCallback((name: string, number: number) => {
+    setAttemptByStep((current) => ({...current, [name]: number}));
+    setExpanded((current) => new Set(current).add(name));
+  }, []);
+
+  const expandAll = useCallback(
+    () => setExpanded(new Set(job.steps.map((step) => step.name))),
+    [job.steps],
+  );
+  const collapseAll = useCallback(() => setExpanded(new Set()), []);
+  const jumpToFocus = useCallback(() => {
+    setSourceView(false);
+    setSelectedJob(run.focus.job);
+    setExpanded((current) => new Set(current).add(run.focus.step));
+  }, [run.focus.job, run.focus.step]);
+
+  const renderPanel = useCallback(
+    (step: WorkflowDashboardStep) => {
+      const attempt =
+        step.attempts.find((item) => item.number === attemptByStep[step.name]) ??
+        step.attempts.at(-1) ??
+        null;
+
+      return (
+        <StepDetailPanel
+          attempt={attempt}
+          fixture={viewModel}
+          logFilter={logFilter}
+          logQuery={logQuery}
+          run={run}
+          step={step}
+          viewMode={viewMode}
+        />
+      );
+    },
+    [attemptByStep, logFilter, logQuery, run, viewMode, viewModel],
+  );
+
+  return (
+    <WorkflowDashboardShell footerAction={<KeyboardShortcutButton />}>
+      <div className="flex h-full min-h-0 overflow-hidden">
+        <div
+          className={cn(
+            'flex shrink-0 overflow-hidden',
+            railOpen ? 'w-280 max-[1320px]:w-252' : 'w-41',
+          )}
+        >
+          {railOpen ? (
+            <HistoryRail
+              onCollapse={() => setRailOpen(false)}
+              onSelect={selectRun}
+              runKey={runKey}
+              runOrder={viewModel.runOrder}
+              runs={viewModel.runs}
+            />
+          ) : (
+            <CollapsedHistoryRail
+              count={viewModel.runOrder.length}
+              onExpand={() => setRailOpen(true)}
+            />
+          )}
+        </div>
+        <main className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+          <RunHeader onJumpToFocus={jumpToFocus} onSource={() => setSourceView(true)} run={run} />
+          {sourceView ? (
+            <WorkflowSourceView onBack={() => setSourceView(false)} viewModel={viewModel} />
+          ) : (
+            <>
+              <DashboardSection
+                open={graphOpen}
+                onToggle={() => setGraphOpen((open) => !open)}
+                title="Jobs graph"
+              >
+                <JobGraph
+                  onSelectJob={selectJob}
+                  onTrigger={() => undefined}
+                  run={run}
+                  selectedJob={selectedJob}
+                />
+              </DashboardSection>
+              <DashboardSection
+                controls={
+                  stepsOpen && (
+                    <StepControls
+                      logFilter={logFilter}
+                      logQuery={logQuery}
+                      onCollapseAll={collapseAll}
+                      onExpandAll={expandAll}
+                      onLogFilterChange={setLogFilter}
+                      onLogQueryChange={setLogQuery}
+                      onViewModeChange={setViewMode}
+                      viewMode={viewMode}
+                    />
+                  )
+                }
+                open={stepsOpen}
+                onToggle={() => setStepsOpen((open) => !open)}
+                title={`${job.name} - steps`}
+              >
+                <StepList
+                  attemptByStep={attemptByStep}
+                  expanded={expanded}
+                  job={job}
+                  onSelectAttempt={setAttemptFor}
+                  onToggle={toggleStep}
+                  renderPanel={renderPanel}
+                />
+              </DashboardSection>
+            </>
+          )}
+        </main>
+      </div>
+    </WorkflowDashboardShell>
+  );
+}
+
+function DashboardSection({
+  children,
+  controls,
+  onToggle,
+  open,
+  title,
+}: {
+  children: ReactNode;
+  controls?: ReactNode;
+  onToggle: () => void;
+  open: boolean;
+  title: string;
+}) {
+  return (
+    <section className="px-20 pt-18 pb-6">
+      <div className="sticky top-51 z-10 -mx-20 flex flex-wrap items-center justify-between gap-10 bg-background-neutral-background px-20 py-10">
+        <button
+          className="flex items-center gap-7 text-left focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+          onClick={onToggle}
+          type="button"
+        >
+          <Icon
+            name={open ? 'arrowDownSLine' : 'arrowRightSLine'}
+            className="size-14 text-foreground-neutral-muted"
+          />
+          <Code
+            as="span"
+            variant="label"
+            className="uppercase tracking-[0.06em] text-foreground-neutral-muted"
+          >
+            {title}
+          </Code>
+        </button>
+        {controls}
+      </div>
+      {open && children}
+    </section>
+  );
+}
+
+function StepControls({
+  logFilter,
+  logQuery,
+  onCollapseAll,
+  onExpandAll,
+  onLogFilterChange,
+  onLogQueryChange,
+  onViewModeChange,
+  viewMode,
+}: {
+  logFilter: WorkflowDashboardLogFilter;
+  logQuery: string;
+  onCollapseAll: () => void;
+  onExpandAll: () => void;
+  onLogFilterChange: (filter: WorkflowDashboardLogFilter) => void;
+  onLogQueryChange: (query: string) => void;
+  onViewModeChange: (mode: WorkflowDashboardViewMode) => void;
+  viewMode: WorkflowDashboardViewMode;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-8">
+      {viewMode === 'logs' && (
+        <label className="flex h-28 items-center gap-6 rounded-6 border border-border-neutral-base bg-background-field-base px-8 text-foreground-neutral-muted">
+          <Icon name="searchLine" className="size-14" />
+          <input
+            className="w-160 bg-transparent text-foreground-neutral-base text-sm outline-none placeholder:text-foreground-neutral-muted"
+            onChange={(event) => onLogQueryChange(event.target.value)}
+            placeholder="Filter logs..."
+            value={logQuery}
+          />
+        </label>
+      )}
+      {viewMode === 'logs' && (
+        <SegmentedControl
+          onChange={onLogFilterChange}
+          options={[
+            {label: 'All', value: 'all'},
+            {label: 'stdout', value: 'stdout'},
+            {label: 'stderr', value: 'stderr'},
+            {label: 'system', value: 'system'},
+          ]}
+          value={logFilter}
+        />
+      )}
+      <SegmentedControl
+        onChange={(value) => {
+          onViewModeChange(value);
+          if (value === 'logs') onLogFilterChange('all');
+        }}
+        options={[
+          {label: 'Overview', value: 'overview'},
+          {label: 'Logs', value: 'logs'},
+          {label: 'Source', value: 'source'},
+        ]}
+        value={viewMode}
+      />
+      <div className="flex items-center gap-4">
+        <Button
+          aria-label="Expand all"
+          iconLeft="arrowDownDoubleLine"
+          onClick={onExpandAll}
+          size="xs"
+          variant="transparentMuted"
+        />
+        <Button
+          aria-label="Collapse all"
+          iconLeft="arrowUpDoubleLine"
+          onClick={onCollapseAll}
+          size="xs"
+          variant="transparentMuted"
+        />
+      </div>
+    </div>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  onChange,
+  options,
+  value,
+}: {
+  onChange: (value: T) => void;
+  options: Array<{label: string; value: T}>;
+  value: T;
+}) {
+  return (
+    <div className="inline-flex h-28 items-center rounded-6 border border-border-neutral-base bg-background-components-base p-2">
+      {options.map((option) => (
+        <button
+          aria-pressed={value === option.value}
+          className={cn(
+            'h-22 rounded-4 px-8 text-foreground-neutral-muted text-xs font-medium hover:text-foreground-neutral-base focus-visible:shadow-button-neutral-focus focus-visible:outline-none',
+            value === option.value &&
+              'bg-background-highlight-base text-foreground-highlight-interactive',
+          )}
+          key={option.value}
+          onClick={() => onChange(option.value)}
+          type="button"
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function WorkflowSourceView({
+  onBack,
+  viewModel,
+}: {
+  onBack: () => void;
+  viewModel: WorkflowDashboardViewModel;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col px-20 pb-20">
+      <div className="sticky top-51 z-10 -mx-20 flex items-center justify-between bg-background-neutral-background px-20 py-10">
+        <Code
+          as="span"
+          variant="label"
+          className="uppercase tracking-[0.06em] text-foreground-neutral-muted"
+        >
+          Workflow source{' '}
+          <span className="text-foreground-neutral-disabled">
+            - {viewModel.workflow.sourcePath}
+          </span>
+        </Code>
+        <Button iconLeft="arrowLeftLine" onClick={onBack} size="sm" variant="secondary">
+          Back to run
+        </Button>
+      </div>
+      <SourcePanel fixture={viewModel} />
+    </div>
+  );
+}
+
+function KeyboardShortcutButton() {
+  return (
+    <button
+      className="fixed right-16 bottom-16 z-30 flex size-32 items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base text-foreground-neutral-muted shadow-card hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+      title="Keyboard shortcuts (?)"
+      type="button"
+    >
+      <Icon name="commandLine" className="size-16" />
+    </button>
+  );
+}


### PR DESCRIPTION
Add the workflow run dashboard surface for monitoring workflow executions.

The dashboard gives reviewers and operators a single view of recent runs, the selected run status, trigger metadata, duration, job dependencies, step execution state, restart context, logs, and workflow source. It uses fixture-backed workflow execution data so the frontend can exercise the complete monitoring experience before live route data is connected.

The page is split into reusable dashboard components and uses the shared Shipfox React UI primitives and Tailwind token classes throughout, keeping styling consistent with the rest of the client.