### PR TITLE
Wire workflow run dashboard route

### DIFF
--- a/libs/client/projects/src/components/run-row.test.tsx
+++ b/libs/client/projects/src/components/run-row.test.tsx
@@ -1,13 +1,41 @@
 import type {RunDto} from '@shipfox/api-workflows-dto';
 import {render, screen} from '@testing-library/react';
+import type {ReactNode} from 'react';
 import {RelativeTimeProvider} from '#lib/relative-time.js';
 import {RunRow} from './run-row.js';
 
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+const DEPLOY_PRODUCTION_RE = /Deploy production/;
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    params,
+    to,
+    ...props
+  }: {
+    children: ReactNode;
+    params: Record<string, string>;
+    to: string;
+  }) => {
+    const href = Object.entries(params).reduce(
+      (path, [key, value]) => path.replace(`$${key}`, value),
+      to,
+    );
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  },
+}));
+
 function makeRun(overrides: Partial<RunDto> = {}): RunDto {
   return {
-    id: 'abcd1234-0000-0000-0000-000000000000',
-    project_id: 'p',
-    definition_id: 'd',
+    id: 'abcd1234-0000-4000-8000-000000000000',
+    project_id: PROJECT_ID,
+    definition_id: '33333333-3333-4333-8333-333333333333',
     name: 'Deploy production',
     status: 'succeeded',
     trigger_source: 'manual',
@@ -24,7 +52,7 @@ function makeRun(overrides: Partial<RunDto> = {}): RunDto {
 function renderRow(run: RunDto) {
   return render(
     <RelativeTimeProvider>
-      <RunRow run={run} />
+      <RunRow projectId={PROJECT_ID} run={run} workspaceId={WORKSPACE_ID} />
     </RelativeTimeProvider>,
   );
 }
@@ -57,11 +85,12 @@ describe('RunRow', () => {
     vi.useRealTimers();
   });
 
-  test('is not interactive — no role=button, no tabindex on the row', () => {
-    const {container} = renderRow(makeRun());
+  test('links to the run detail route', () => {
+    renderRow(makeRun());
 
-    const row = container.firstChild as HTMLElement;
-    expect(row.getAttribute('role')).not.toBe('button');
-    expect(row.getAttribute('tabindex')).toBe(null);
+    expect(screen.getByRole('link', {name: DEPLOY_PRODUCTION_RE})).toHaveAttribute(
+      'href',
+      `/workspaces/${WORKSPACE_ID}/projects/${PROJECT_ID}/runs/abcd1234-0000-4000-8000-000000000000`,
+    );
   });
 });

--- a/libs/client/projects/src/components/run-row.tsx
+++ b/libs/client/projects/src/components/run-row.tsx
@@ -1,5 +1,6 @@
 import type {RunDto, RunStatusDto} from '@shipfox/api-workflows-dto';
 import {Code, Text} from '@shipfox/react-ui';
+import {Link} from '@tanstack/react-router';
 import {humanDuration} from '#lib/human-duration.js';
 import {RelativeTime} from '#lib/relative-time.js';
 import {StatusDot, type StatusDotVariant} from './status-dot.js';
@@ -8,8 +9,7 @@ import {StatusDot, type StatusDotVariant} from './status-dot.js';
  * Single Vercel-style row for a workflow run.
  *
  * Four zones at md+ (id+trigger / status+duration / workflow name / time)
- * collapse to a 2-line stack on sm. Rows are presentational only — no
- * click target until the run-detail surface ships (TODOS.md defers this).
+ * collapse to a 2-line stack on sm.
  *
  *  md+:
  *  ┌─────────────┬──────────────────┬────────────────────────────┬───────────┐
@@ -30,18 +30,25 @@ const variantByStatus: Record<RunStatusDto, StatusDotVariant> = {
   cancelled: 'neutral',
 };
 
-export function RunRow({run}: {run: RunDto}) {
+export function RunRow({
+  projectId,
+  run,
+  workspaceId,
+}: {
+  projectId: string;
+  run: RunDto;
+  workspaceId: string;
+}) {
   const isActive = !TERMINAL_STATUSES.has(run.status);
   const duration = humanDuration(run.created_at, isActive ? undefined : run.updated_at);
   const durationLabel = isActive && run.status === 'running' ? `running ${duration}` : duration;
   const shortId = run.id.slice(0, 8);
 
   return (
-    <div
-      // Presentational row. Not interactive in this PR (see TODOS.md
-      // "Workflow run detail page"). No tabindex, no role=button — when
-      // run-detail ships, swap to a Link and add the chevron.
+    <Link
       className="flex flex-col gap-6 px-12 py-10 transition-colors hover:bg-background-components-hover md:h-44 md:flex-row md:items-center md:gap-12 md:py-0"
+      params={{wid: workspaceId, pid: projectId, rid: run.id}}
+      to="/workspaces/$wid/projects/$pid/runs/$rid"
     >
       <div className="flex shrink-0 flex-col gap-2 md:w-140">
         <Code variant="label" className="text-foreground-neutral-muted">
@@ -70,6 +77,6 @@ export function RunRow({run}: {run: RunDto}) {
           <RelativeTime value={run.created_at} />
         </Text>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -6,6 +6,7 @@ export * from './hooks/api/workflow-runs.js';
 export * from './pages/create-project-page.js';
 export * from './pages/home-router.js';
 export * from './pages/project-runs-page.js';
+export * from './pages/project-workflow-run-page.js';
 export * from './pages/project-workflows-page.js';
 export * from './pages/projects-hub-page.js';
 export * from './project-error.js';

--- a/libs/client/projects/src/pages/project-runs-page.test.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.test.tsx
@@ -6,6 +6,7 @@ import {ProjectRunsPage} from './project-runs-page.js';
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
 const REFRESH_BUTTON_RE = /refresh/i;
+const DEPLOY_PRODUCTION_RE = /Deploy production/;
 
 describe('ProjectRunsPage', () => {
   test('renders run history, counts, and paginated load more', async () => {
@@ -24,6 +25,22 @@ describe('ProjectRunsPage', () => {
 
     expect((await screen.findAllByText('Cleanup staging'))[0]).toBeInTheDocument();
     expect(screen.getByText('Loaded 2 of 2')).toBeInTheDocument();
+  });
+
+  test('navigates from a run row to the run detail route', async () => {
+    configureApiClient({fetchImpl: createRunsFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs`,
+      <ProjectRunsPage projectId={PROJECT_ID} />,
+    );
+
+    const runLink = await screen.findByRole('link', {name: DEPLOY_PRODUCTION_RE});
+    fireEvent.click(runLink);
+
+    expect(
+      await screen.findByText('Run detail route 66666666-6666-4666-8666-666666666666'),
+    ).toBeInTheDocument();
   });
 
   test('does not render a manual Refresh button (polling is silent)', async () => {
@@ -124,6 +141,7 @@ function runDto(overrides: Partial<{id: string; name: string; status: string}> =
     trigger_event: 'fire',
     trigger_payload: {source: 'manual', event: 'fire'},
     inputs: null,
+    duration_ms: 0,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
   };

--- a/libs/client/projects/src/pages/project-runs-page.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.tsx
@@ -51,6 +51,9 @@ function ProjectRunsPageInner({projectId}: {projectId: string}) {
   // data and renders.
   const runsQuery = useWorkflowRunsInfiniteQuery(projectId, filters);
   const params = useParams({strict: false}) as {wid?: string};
+  if (!params.wid) {
+    throw new Error('ProjectRunsPage must render under a workspace route.');
+  }
   const aggregatesQuery = useWorkflowRunAggregatesQuery(projectId, filters);
   const definitionsQuery = useDefinitionsInfiniteQuery(projectId);
 
@@ -104,7 +107,7 @@ function ProjectRunsPageInner({projectId}: {projectId: string}) {
 
       {runsQuery.data !== undefined && runs.length === 0 ? (
         <RunsEmptyState
-          workspaceId={params.wid ?? ''}
+          workspaceId={params.wid}
           projectId={projectId}
           filtered={hasActiveFilters}
           onClear={() => setSearchState({date: 'all'})}
@@ -113,7 +116,7 @@ function ProjectRunsPageInner({projectId}: {projectId: string}) {
 
       {runs.length > 0 ? (
         <>
-          <RunsList runs={runs} />
+          <RunsList projectId={projectId} runs={runs} workspaceId={params.wid} />
           {runsQuery.isFetchNextPageError ? (
             <Alert variant="error" animated={false}>
               <div className="flex items-center justify-between gap-12">
@@ -332,11 +335,19 @@ function RunsEmptyState({
   );
 }
 
-function RunsList({runs}: {runs: RunDto[]}) {
+function RunsList({
+  projectId,
+  runs,
+  workspaceId,
+}: {
+  projectId: string;
+  runs: RunDto[];
+  workspaceId: string;
+}) {
   return (
     <div className="flex flex-col divide-y divide-border-neutral-base rounded-8 border border-border-neutral-base bg-background-neutral-base">
       {runs.map((run) => (
-        <RunRow key={run.id} run={run} />
+        <RunRow key={run.id} projectId={projectId} run={run} workspaceId={workspaceId} />
       ))}
     </div>
   );

--- a/libs/client/projects/src/pages/project-workflow-run-page.tsx
+++ b/libs/client/projects/src/pages/project-workflow-run-page.tsx
@@ -1,0 +1,95 @@
+import {QueryLoadError} from '@shipfox/client-ui';
+import {Alert, Skeleton, Text} from '@shipfox/react-ui';
+import {useNavigate} from '@tanstack/react-router';
+import {type ReactNode, useMemo} from 'react';
+import {
+  useWorkflowRunQuery,
+  useWorkflowRunsInfiniteQuery,
+  type WorkflowRunFilters,
+} from '#hooks/api/workflow-runs.js';
+import {toWorkflowDashboardViewModel} from './workflow-dashboard/workflow-dashboard-view-model.js';
+import {WorkflowRunDashboard} from './workflow-dashboard/workflow-run-dashboard.js';
+
+const emptyFilters: WorkflowRunFilters = {};
+
+export function ProjectWorkflowRunPage({
+  projectId,
+  runId,
+  workspaceId,
+}: {
+  projectId: string;
+  runId: string;
+  workspaceId: string;
+}) {
+  const navigate = useNavigate();
+  const detailQuery = useWorkflowRunQuery(runId);
+  const runsQuery = useWorkflowRunsInfiniteQuery(projectId, emptyFilters);
+  const history = useMemo(
+    () => runsQuery.data?.pages.flatMap((page) => page.runs) ?? [],
+    [runsQuery.data],
+  );
+  const viewModel = useMemo(() => {
+    if (!detailQuery.data) return null;
+    return toWorkflowDashboardViewModel({detail: detailQuery.data, history});
+  }, [detailQuery.data, history]);
+
+  if (detailQuery.isPending) {
+    return (
+      <WorkflowRunDashboardFrame>
+        <WorkflowRunDashboardLoading />
+      </WorkflowRunDashboardFrame>
+    );
+  }
+
+  if (detailQuery.isError || !viewModel) {
+    return (
+      <WorkflowRunDashboardFrame>
+        <div className="p-24">
+          <QueryLoadError query={detailQuery} subject="workflow run" />
+        </div>
+      </WorkflowRunDashboardFrame>
+    );
+  }
+
+  return (
+    <WorkflowRunDashboardFrame>
+      {runsQuery.isError ? (
+        <Alert animated={false} variant="error" className="absolute left-16 right-16 top-16 z-[60]">
+          <Text size="sm">Could not load run history. Showing the selected run only.</Text>
+        </Alert>
+      ) : null}
+      <WorkflowRunDashboard
+        initialRunKey={runId}
+        onSelectRun={(nextRunId) =>
+          navigate({
+            to: '/workspaces/$wid/projects/$pid/runs/$rid',
+            params: {wid: workspaceId, pid: projectId, rid: nextRunId},
+          })
+        }
+        viewModel={viewModel}
+      />
+    </WorkflowRunDashboardFrame>
+  );
+}
+
+function WorkflowRunDashboardFrame({children}: {children: ReactNode}) {
+  return <div className="fixed inset-0 z-50 bg-background-neutral-base">{children}</div>;
+}
+
+function WorkflowRunDashboardLoading() {
+  return (
+    <div className="flex h-screen flex-col gap-12 bg-background-neutral-base p-16">
+      <div className="flex items-center gap-8">
+        <Skeleton className="h-22 w-120" />
+        <Skeleton className="h-22 w-72" />
+      </div>
+      <div className="flex min-h-0 flex-1 gap-12">
+        <Skeleton className="h-full w-260" />
+        <div className="flex flex-1 flex-col gap-12">
+          <Skeleton className="h-96 w-full" />
+          <Skeleton className="h-full w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-view-model.test.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-view-model.test.ts
@@ -1,0 +1,179 @@
+import type {RunDetailResponseDto, RunDto} from '@shipfox/api-workflows-dto';
+import {toWorkflowDashboardViewModel} from './workflow-dashboard-view-model.js';
+
+const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
+const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+const RUN_ID = '66666666-6666-4666-8666-666666666666';
+const JOB_ID = '77777777-7777-4777-8777-777777777777';
+const STEP_ID = '88888888-8888-4888-8888-888888888888';
+const ATTEMPT_ID = '99999999-9999-4999-8999-999999999999';
+
+describe('toWorkflowDashboardViewModel', () => {
+  test('maps run detail DTOs into the workflow dashboard view model', () => {
+    const detail = runDetailDto();
+
+    const viewModel = toWorkflowDashboardViewModel({detail, history: [historyRunDto()]});
+
+    expect(viewModel.runOrder).toEqual([RUN_ID, 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa']);
+    expect(viewModel.workflow.yaml).toBe('name: Deploy production\n');
+    expect(viewModel.runs[RUN_ID]?.duration).toBe(42);
+    expect(viewModel.runs[RUN_ID]?.focus).toEqual({attempt: 1, job: 'deploy', step: 'ship'});
+    expect(viewModel.runs[RUN_ID]?.trigger.incident).toBe('SENTRY-123');
+    expect(viewModel.runs[RUN_ID]?.jobs[0]?.steps[0]?.command).toBe('./deploy.sh');
+    expect(viewModel.runs[RUN_ID]?.jobs[0]?.steps[0]?.attempts[0]?.gateResult).toEqual({
+      exitCode: 1,
+      passed: false,
+      source: 'quality_gate',
+    });
+    expect(viewModel.runs[RUN_ID]?.jobs[0]?.steps[0]?.attempts[0]?.output).toEqual({
+      commit: 'abc123',
+      deployed: false,
+    });
+  });
+
+  test('keeps zero durations human-readable by preserving numeric seconds', () => {
+    const detail = runDetailDto({
+      duration_ms: 0,
+      jobs: [],
+      status: 'pending',
+    });
+
+    const viewModel = toWorkflowDashboardViewModel({detail, history: []});
+
+    expect(viewModel.runs[RUN_ID]?.duration).toBe(0);
+    expect(viewModel.runs[RUN_ID]?.jobs[0]?.duration).toBe(0);
+    expect(viewModel.runs[RUN_ID]?.jobs[0]?.steps[0]?.duration).toBe(0);
+  });
+
+  test('preserves list order and creates placeholder rows for history-only runs', () => {
+    const selected = runDetailDto();
+    const older = historyRunDto({id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'});
+
+    const viewModel = toWorkflowDashboardViewModel({detail: selected, history: [older, selected]});
+
+    expect(viewModel.runOrder).toEqual(['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', RUN_ID]);
+    expect(viewModel.runs['bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb']?.jobs[0]?.steps[0]?.name).toBe(
+      'pending',
+    );
+  });
+
+  test('focuses the running step when the run has no failed step', () => {
+    const detail = runDetailDto({
+      status: 'running',
+      jobs: [
+        jobDto({
+          status: 'running',
+          steps: [
+            stepDto({name: 'build', status: 'succeeded', position: 0}),
+            stepDto({name: 'deploy', status: 'running', position: 1}),
+          ],
+        }),
+      ],
+    });
+
+    const viewModel = toWorkflowDashboardViewModel({detail, history: []});
+
+    expect(viewModel.runs[RUN_ID]?.focus).toEqual({attempt: 1, job: 'deploy', step: 'deploy'});
+    expect(viewModel.runs[RUN_ID]?.jobs[0]?.steps[1]?.attempts[0]?.logs[1]?.message).toBe(
+      'Step is still running.',
+    );
+  });
+});
+
+function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailResponseDto {
+  return {
+    id: RUN_ID,
+    project_id: PROJECT_ID,
+    definition_id: DEFINITION_ID,
+    name: 'Deploy production',
+    status: 'failed',
+    trigger_source: 'sentry',
+    trigger_event: 'alert',
+    trigger_payload: {incident: 'SENTRY-123', filter: 'production'},
+    inputs: null,
+    duration_ms: 42_000,
+    workflow_source_yaml: 'name: Deploy production\n',
+    workflow_document: null,
+    workflow_model: null,
+    jobs: [jobDto()],
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+    ...overrides,
+  };
+}
+
+function historyRunDto(overrides: Partial<RunDto> = {}): RunDto {
+  return {
+    id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    project_id: PROJECT_ID,
+    definition_id: DEFINITION_ID,
+    name: 'Deploy production',
+    status: 'succeeded',
+    trigger_source: 'manual',
+    trigger_event: 'fire',
+    trigger_payload: {source: 'manual'},
+    inputs: null,
+    duration_ms: 10_000,
+    created_at: '2026-05-06T01:01:00.000Z',
+    updated_at: '2026-05-06T01:02:00.000Z',
+    ...overrides,
+  };
+}
+
+function jobDto(
+  overrides: Partial<RunDetailResponseDto['jobs'][number]> = {},
+): RunDetailResponseDto['jobs'][number] {
+  return {
+    id: JOB_ID,
+    run_id: RUN_ID,
+    name: 'deploy',
+    status: 'failed',
+    dependencies: [],
+    position: 0,
+    duration_ms: 42_000,
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+    steps: [stepDto()],
+    ...overrides,
+  };
+}
+
+function stepDto(
+  overrides: Partial<RunDetailResponseDto['jobs'][number]['steps'][number]> = {},
+): RunDetailResponseDto['jobs'][number]['steps'][number] {
+  return {
+    id: STEP_ID,
+    job_id: JOB_ID,
+    name: 'ship',
+    status: 'failed',
+    type: 'command',
+    config: {run: './deploy.sh'},
+    error: null,
+    position: 0,
+    current_attempt: 1,
+    duration_ms: 42_000,
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+    attempts: [
+      {
+        id: ATTEMPT_ID,
+        step_id: STEP_ID,
+        job_id: JOB_ID,
+        attempt: 1,
+        status: overrides.status ?? 'failed',
+        exit_code: overrides.status === 'running' ? null : 1,
+        output: {commit: 'abc123', deployed: false, metadata: {region: 'us-east1'}},
+        error: overrides.status === 'running' ? null : {message: 'Deployment failed'},
+        gate_result:
+          overrides.status === 'running'
+            ? null
+            : {passed: false, exit_code: 1, source: 'quality_gate'},
+        restart_reason: null,
+        duration_ms: 42_000,
+        started_at: '2026-05-07T01:01:00.000Z',
+        finished_at: overrides.status === 'running' ? null : '2026-05-07T01:02:00.000Z',
+      },
+    ],
+    ...overrides,
+  };
+}

--- a/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-view-model.ts
+++ b/libs/client/projects/src/pages/workflow-dashboard/workflow-dashboard-view-model.ts
@@ -1,0 +1,318 @@
+import type {RunDetailResponseDto, RunDto} from '@shipfox/api-workflows-dto';
+import type {
+  WorkflowDashboardAttempt,
+  WorkflowDashboardGateResult,
+  WorkflowDashboardJob,
+  WorkflowDashboardLogLine,
+  WorkflowDashboardRun,
+  WorkflowDashboardStatus,
+  WorkflowDashboardStep,
+  WorkflowDashboardViewModel,
+} from './workflow-dashboard-types.js';
+
+type DetailJob = RunDetailResponseDto['jobs'][number];
+type DetailStep = DetailJob['steps'][number];
+type DetailAttempt = DetailStep['attempts'][number];
+
+const fallbackYaml =
+  'name: Workflow\njobs:\n  workflow:\n    steps:\n      - run: echo "Waiting for execution data"';
+
+export function toWorkflowDashboardViewModel({
+  detail,
+  history,
+}: {
+  detail: RunDetailResponseDto;
+  history: RunDto[];
+}): WorkflowDashboardViewModel {
+  const runs: Record<string, WorkflowDashboardRun> = {};
+  const historyRuns = uniqueRuns(history);
+  const orderedHistory = historyRuns.some((run) => run.id === detail.id)
+    ? historyRuns
+    : [detail, ...historyRuns];
+
+  for (const run of orderedHistory) {
+    runs[run.id] = run.id === detail.id ? detailRun(detail) : historyRun(run);
+  }
+
+  return {
+    runOrder: orderedHistory.map((run) => run.id),
+    runs,
+    workflow: {
+      sourcePath: '.shipfox/workflows/workflow.yml',
+      yaml: detail.workflow_source_yaml ?? fallbackYaml,
+    },
+  };
+}
+
+function uniqueRuns(runs: RunDto[]): RunDto[] {
+  const seen = new Set<string>();
+  return runs.filter((run) => {
+    if (seen.has(run.id)) return false;
+    seen.add(run.id);
+    return true;
+  });
+}
+
+function detailRun(run: RunDetailResponseDto): WorkflowDashboardRun {
+  const jobs = run.jobs
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map(toDashboardJob);
+  const nonEmptyJobs = jobs.length > 0 ? jobs : [placeholderJob(run)];
+  const focus = focusFor(nonEmptyJobs);
+
+  return {
+    duration: seconds(run.duration_ms),
+    focus,
+    jobs: nonEmptyJobs,
+    number: run.id.slice(0, 8),
+    observedUntil: run.updated_at,
+    status: toDashboardStatus(run.status),
+    trigger: triggerFor(run),
+  };
+}
+
+function historyRun(run: RunDto): WorkflowDashboardRun {
+  return {
+    duration: seconds(run.duration_ms),
+    focus: {attempt: 1, job: 'workflow', step: 'pending'},
+    jobs: [placeholderJob(run)],
+    number: run.id.slice(0, 8),
+    observedUntil: run.updated_at,
+    status: toDashboardStatus(run.status),
+    trigger: triggerFor(run),
+  };
+}
+
+function toDashboardJob(job: DetailJob): WorkflowDashboardJob {
+  const steps = job.steps
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .map(toDashboardStep);
+  const needs = job.dependencies.length > 0 ? job.dependencies.join(', ') : undefined;
+
+  return {
+    duration: seconds(job.duration_ms),
+    name: job.name,
+    ...(needs ? {needs} : {}),
+    status: toDashboardStatus(job.status),
+    steps: steps.length > 0 ? steps : [placeholderStep(job.name, job.status, job.updated_at)],
+  };
+}
+
+function toDashboardStep(step: DetailStep): WorkflowDashboardStep {
+  const attempts = step.attempts
+    .slice()
+    .sort((a, b) => a.attempt - b.attempt)
+    .map((attempt) => toDashboardAttempt(attempt, step));
+  const hasGate = attempts.some((attempt) => attempt.gateResult);
+  const notRunLog: WorkflowDashboardLogLine[] | undefined =
+    attempts.length === 0
+      ? [
+          {
+            at: step.updated_at,
+            message: step.status === 'pending' ? 'Step has not started yet.' : 'Step did not run.',
+            stream: 'system',
+          },
+        ]
+      : undefined;
+
+  return {
+    attemptCount: step.current_attempt,
+    attempts,
+    command: commandFor(step),
+    duration: seconds(step.duration_ms),
+    gate: hasGate,
+    kind: kindFor(step.type),
+    name: step.name ?? `step-${step.position + 1}`,
+    ...(notRunLog ? {notRunLog} : {}),
+    status: toDashboardStatus(step.status),
+  };
+}
+
+function toDashboardAttempt(attempt: DetailAttempt, step: DetailStep): WorkflowDashboardAttempt {
+  const status = toDashboardStatus(attempt.status);
+  const gate = gateResult(attempt.gate_result);
+  const output = outputFor(attempt.output);
+
+  return {
+    duration: seconds(attempt.duration_ms),
+    exitCode: attempt.exit_code,
+    ...(gate ? {gateResult: gate} : {}),
+    logs: logsFor(attempt, step),
+    number: attempt.attempt,
+    ...(output ? {output} : {}),
+    startedAt: attempt.started_at,
+    status,
+  };
+}
+
+function placeholderJob(
+  run: Pick<RunDto, 'duration_ms' | 'name' | 'status' | 'updated_at'>,
+): WorkflowDashboardJob {
+  return {
+    duration: seconds(run.duration_ms),
+    name: run.name || 'workflow',
+    status: toDashboardStatus(run.status),
+    steps: [placeholderStep('pending', run.status, run.updated_at)],
+  };
+}
+
+function placeholderStep(name: string, status: string, at: string): WorkflowDashboardStep {
+  return {
+    attemptCount: 0,
+    attempts: [],
+    command: 'waiting for execution data',
+    duration: 0,
+    kind: 'command',
+    name,
+    notRunLog: [{at, message: 'Execution details are not available yet.', stream: 'system'}],
+    status: toDashboardStatus(status),
+  };
+}
+
+function triggerFor(
+  run: Pick<RunDto, 'created_at' | 'trigger_event' | 'trigger_payload' | 'trigger_source'>,
+) {
+  return {
+    alertAt: run.created_at,
+    event: run.trigger_event,
+    filter: triggerValue(run.trigger_payload, 'filter') ?? run.trigger_event,
+    incident:
+      triggerValue(run.trigger_payload, 'incident') ??
+      triggerValue(run.trigger_payload, 'issue') ??
+      triggerValue(run.trigger_payload, 'deliveryId') ??
+      run.trigger_event,
+    payload: run.trigger_payload,
+    runStartedAt: run.created_at,
+    source: run.trigger_source,
+  };
+}
+
+function focusFor(jobs: WorkflowDashboardJob[]) {
+  const focusedJob =
+    jobs.find((job) => job.status === 'failed') ??
+    jobs.find((job) => job.status === 'running') ??
+    jobs[0];
+  const focusedStep =
+    focusedJob?.steps.find((step) => step.status === 'failed') ??
+    focusedJob?.steps.find((step) => step.status === 'running') ??
+    focusedJob?.steps[0];
+
+  return {
+    attempt: focusedStep?.attempts.at(-1)?.number ?? 1,
+    job: focusedJob?.name ?? 'workflow',
+    step: focusedStep?.name ?? 'pending',
+  };
+}
+
+function commandFor(step: DetailStep): string {
+  const command = stringValue(step.config, 'command') ?? stringValue(step.config, 'run');
+  if (command) return command;
+  if (step.type) return step.type;
+  return 'run step';
+}
+
+function kindFor(type: string): WorkflowDashboardStep['kind'] {
+  if (type === 'agent') return 'agent';
+  if (type === 'deploy') return 'deploy';
+  if (type === 'integration') return 'integration';
+  if (type === 'notify') return 'notify';
+  return 'command';
+}
+
+function logsFor(attempt: DetailAttempt, step: DetailStep): WorkflowDashboardLogLine[] {
+  const lines: WorkflowDashboardLogLine[] = [
+    {
+      at: attempt.started_at,
+      message: `$ ${commandFor(step)}`,
+      stream: 'system',
+    },
+  ];
+
+  if (attempt.error) {
+    lines.push({
+      at: attempt.finished_at ?? attempt.started_at,
+      diagnostic: true,
+      message: errorMessage(attempt.error),
+      stream: 'stderr',
+    });
+  } else if (attempt.status === 'running') {
+    lines.push({
+      at: attempt.started_at,
+      message: 'Step is still running.',
+      stream: 'stdout',
+    });
+  } else {
+    lines.push({
+      at: attempt.finished_at ?? attempt.started_at,
+      message: `Step ${attempt.status}.`,
+      stream: attempt.status === 'failed' ? 'stderr' : 'stdout',
+    });
+  }
+
+  return lines;
+}
+
+function gateResult(
+  value: Record<string, unknown> | null,
+): WorkflowDashboardGateResult | undefined {
+  if (!value) return undefined;
+  const passed = booleanValue(value, 'passed');
+  return {
+    exitCode: numberValue(value, 'exit_code') ?? numberValue(value, 'exitCode') ?? 0,
+    passed: passed ?? false,
+    source: stringValue(value, 'source') ?? 'gate',
+  };
+}
+
+function outputFor(value: Record<string, unknown> | null) {
+  if (!value) return undefined;
+  const output = Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, boolean | number | string] =>
+      ['boolean', 'number', 'string'].includes(typeof entry[1]),
+    ),
+  );
+  return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function errorMessage(value: Record<string, unknown>): string {
+  return stringValue(value, 'message') ?? JSON.stringify(value);
+}
+
+function toDashboardStatus(status: string): WorkflowDashboardStatus {
+  if (
+    status === 'pending' ||
+    status === 'running' ||
+    status === 'succeeded' ||
+    status === 'failed' ||
+    status === 'cancelled'
+  ) {
+    return status;
+  }
+  return 'pending';
+}
+
+function seconds(ms: number): number {
+  return Math.floor(Math.max(0, ms) / 1000);
+}
+
+function triggerValue(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function stringValue(payload: Record<string, unknown>, key: string): string | undefined {
+  const value = payload[key];
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function numberValue(payload: Record<string, unknown>, key: string): number | undefined {
+  const value = payload[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function booleanValue(payload: Record<string, unknown>, key: string): boolean | undefined {
+  const value = payload[key];
+  return typeof value === 'boolean' ? value : undefined;
+}

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -91,6 +91,11 @@ function createTestRouter(path: string, element: ReactElement) {
   const projectRunsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/projects/$pid/runs',
+    component: Outlet,
+  });
+  const projectRunsIndexRoute = createRoute({
+    getParentRoute: () => projectRunsRoute,
+    path: '/',
     component: () => {
       const params = useParams({strict: false}) as {pid?: string};
       if (initialPath === `/workspaces/${PROJECT_TEST_WID}/projects/${params.pid}/runs`) {
@@ -98,6 +103,20 @@ function createTestRouter(path: string, element: ReactElement) {
       }
 
       return <ProjectRunsPage projectId={params.pid ?? 'p-1'} />;
+    },
+  });
+  const projectWorkflowRunRoute = createRoute({
+    getParentRoute: () => projectRunsRoute,
+    path: '$rid',
+    component: () => {
+      const params = useParams({strict: false}) as {pid?: string; rid?: string};
+      if (
+        initialPath === `/workspaces/${PROJECT_TEST_WID}/projects/${params.pid}/runs/${params.rid}`
+      ) {
+        return element;
+      }
+
+      return <div>Run detail route {params.rid}</div>;
     },
   });
   const projectWorkflowsRoute = createRoute({
@@ -121,7 +140,7 @@ function createTestRouter(path: string, element: ReactElement) {
       workspaceNewProjectRoute,
       integrationsRoute,
       projectDetailRoute,
-      projectRunsRoute,
+      projectRunsRoute.addChildren([projectRunsIndexRoute, projectWorkflowRunRoute]),
       projectWorkflowsRoute,
     ]),
   });

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -35,6 +35,8 @@ import { Route as WorkspacesWidLayoutProjectsPidLayoutRouteImport } from './rout
 import { Route as WorkspacesWidLayoutProjectsPidLayoutIndexRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/index'
 import { Route as WorkspacesWidLayoutProjectsPidLayoutWorkflowsRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/workflows'
 import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs'
+import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsIndexRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs/index'
+import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsRidRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -183,6 +185,18 @@ const WorkspacesWidLayoutProjectsPidLayoutRunsRoute =
     path: '/runs',
     getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRoute,
   } as any)
+const WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute =
+  WorkspacesWidLayoutProjectsPidLayoutRunsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRunsRoute,
+  } as any)
+const WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute =
+  WorkspacesWidLayoutProjectsPidLayoutRunsRidRouteImport.update({
+    id: '/$rid',
+    path: '/$rid',
+    getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRunsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -208,9 +222,11 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/integrations/': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/settings/': typeof WorkspacesWidLayoutSettingsIndexRoute
   '/workspaces/$wid/projects/$pid': typeof WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren
-  '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
+  '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRouteWithChildren
   '/workspaces/$wid/projects/$pid/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/projects/$pid/': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/projects/$pid/runs/$rid': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
+  '/workspaces/$wid/projects/$pid/runs/': typeof WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -234,9 +250,10 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/integrations': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/settings': typeof WorkspacesWidLayoutSettingsIndexRoute
-  '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/projects/$pid/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/projects/$pid': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/projects/$pid/runs/$rid': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
+  '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -263,9 +280,11 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/integrations/': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/_layout/settings/': typeof WorkspacesWidLayoutSettingsIndexRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout': typeof WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren
-  '/workspaces/$wid/_layout/projects/$pid/_layout/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
+  '/workspaces/$wid/_layout/projects/$pid/_layout/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRouteWithChildren
   '/workspaces/$wid/_layout/projects/$pid/_layout/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout/': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
+  '/workspaces/$wid/_layout/projects/$pid/_layout/runs/': typeof WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -296,6 +315,8 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/projects/$pid/runs'
     | '/workspaces/$wid/projects/$pid/workflows'
     | '/workspaces/$wid/projects/$pid/'
+    | '/workspaces/$wid/projects/$pid/runs/$rid'
+    | '/workspaces/$wid/projects/$pid/runs/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -319,9 +340,10 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/settings/runners'
     | '/workspaces/$wid/integrations'
     | '/workspaces/$wid/settings'
-    | '/workspaces/$wid/projects/$pid/runs'
     | '/workspaces/$wid/projects/$pid/workflows'
     | '/workspaces/$wid/projects/$pid'
+    | '/workspaces/$wid/projects/$pid/runs/$rid'
+    | '/workspaces/$wid/projects/$pid/runs'
   id:
     | '__root__'
     | '/'
@@ -350,6 +372,8 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/projects/$pid/_layout/runs'
     | '/workspaces/$wid/_layout/projects/$pid/_layout/workflows'
     | '/workspaces/$wid/_layout/projects/$pid/_layout/'
+    | '/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid'
+    | '/workspaces/$wid/_layout/projects/$pid/_layout/runs/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -550,6 +574,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRouteImport
       parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRoute
     }
+    '/workspaces/$wid/_layout/projects/$pid/_layout/runs/': {
+      id: '/workspaces/$wid/_layout/projects/$pid/_layout/runs/'
+      path: '/'
+      fullPath: '/workspaces/$wid/projects/$pid/runs/'
+      preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsIndexRouteImport
+      parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
+    }
+    '/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid': {
+      id: '/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid'
+      path: '/$rid'
+      fullPath: '/workspaces/$wid/projects/$pid/runs/$rid'
+      preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRouteImport
+      parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
+    }
   }
 }
 
@@ -565,8 +603,26 @@ const SetupLayoutRouteWithChildren = SetupLayoutRoute._addFileChildren(
   SetupLayoutRouteChildren,
 )
 
+interface WorkspacesWidLayoutProjectsPidLayoutRunsRouteChildren {
+  WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute
+  WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute
+}
+
+const WorkspacesWidLayoutProjectsPidLayoutRunsRouteChildren: WorkspacesWidLayoutProjectsPidLayoutRunsRouteChildren =
+  {
+    WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute:
+      WorkspacesWidLayoutProjectsPidLayoutRunsRidRoute,
+    WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute:
+      WorkspacesWidLayoutProjectsPidLayoutRunsIndexRoute,
+  }
+
+const WorkspacesWidLayoutProjectsPidLayoutRunsRouteWithChildren =
+  WorkspacesWidLayoutProjectsPidLayoutRunsRoute._addFileChildren(
+    WorkspacesWidLayoutProjectsPidLayoutRunsRouteChildren,
+  )
+
 interface WorkspacesWidLayoutProjectsPidLayoutRouteChildren {
-  WorkspacesWidLayoutProjectsPidLayoutRunsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
+  WorkspacesWidLayoutProjectsPidLayoutRunsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRouteWithChildren
   WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   WorkspacesWidLayoutProjectsPidLayoutIndexRoute: typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
 }
@@ -574,7 +630,7 @@ interface WorkspacesWidLayoutProjectsPidLayoutRouteChildren {
 const WorkspacesWidLayoutProjectsPidLayoutRouteChildren: WorkspacesWidLayoutProjectsPidLayoutRouteChildren =
   {
     WorkspacesWidLayoutProjectsPidLayoutRunsRoute:
-      WorkspacesWidLayoutProjectsPidLayoutRunsRoute,
+      WorkspacesWidLayoutProjectsPidLayoutRunsRouteWithChildren,
     WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute:
       WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute,
     WorkspacesWidLayoutProjectsPidLayoutIndexRoute:

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs.tsx
@@ -1,11 +1,9 @@
-import {ProjectRunsPage} from '@shipfox/client-projects';
-import {createFileRoute} from '@tanstack/react-router';
+import {createFileRoute, Outlet} from '@tanstack/react-router';
 
 export const Route = createFileRoute('/workspaces/$wid/_layout/projects/$pid/_layout/runs')({
   component: ProjectRunsRoute,
 });
 
 function ProjectRunsRoute() {
-  const {pid} = Route.useParams();
-  return <ProjectRunsPage projectId={pid} />;
+  return <Outlet />;
 }

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid.tsx
@@ -1,0 +1,11 @@
+import {ProjectWorkflowRunPage} from '@shipfox/client-projects';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/projects/$pid/_layout/runs/$rid')({
+  component: ProjectWorkflowRunRoute,
+});
+
+function ProjectWorkflowRunRoute() {
+  const {pid, rid, wid} = Route.useParams();
+  return <ProjectWorkflowRunPage projectId={pid} runId={rid} workspaceId={wid} />;
+}

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs/index.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs/index.tsx
@@ -1,0 +1,11 @@
+import {ProjectRunsPage} from '@shipfox/client-projects';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/projects/$pid/_layout/runs/')({
+  component: ProjectRunsIndexRoute,
+});
+
+function ProjectRunsIndexRoute() {
+  const {pid} = Route.useParams();
+  return <ProjectRunsPage projectId={pid} />;
+}


### PR DESCRIPTION
Wire the workflow run dashboard into the project runs route.

Run rows now link to an individual workflow run page, and the runs route is split into an index route plus a run-detail route. The detail route loads the selected run and recent run history, maps the API DTOs into the dashboard view model, and keeps run-history selection synchronized with URL navigation.

The run page includes loading and error states for the selected run, plus a non-blocking history warning when the selected run can load but the surrounding run list cannot.