### PR TITLE
[client-projects] Mount workflow run page shell

### DIFF
--- a/libs/client/projects/src/components/run-row.test.tsx
+++ b/libs/client/projects/src/components/run-row.test.tsx
@@ -56,11 +56,11 @@ describe('RunRow', () => {
     vi.useRealTimers();
   });
 
-  test('is not interactive — no role=button, no tabindex on the row', () => {
+  test('is presentational — the row itself carries no link/button role (RunsList owns navigation)', () => {
     const {container} = renderRow(makeRun());
 
     const row = container.firstChild as HTMLElement;
     expect(row.getAttribute('role')).not.toBe('button');
-    expect(row.getAttribute('tabindex')).toBe(null);
+    expect(row.tagName).not.toBe('A');
   });
 });

--- a/libs/client/projects/src/components/run-row.tsx
+++ b/libs/client/projects/src/components/run-row.tsx
@@ -1,23 +1,21 @@
 import type {RunDto, RunStatusDto} from '@shipfox/api-workflows-dto';
-import {Code, Text} from '@shipfox/react-ui';
+import {Code, Icon, Text} from '@shipfox/react-ui';
 import {humanDuration} from '#lib/human-duration.js';
 import {RelativeTime} from '#lib/relative-time.js';
 import {StatusDot, type StatusDotVariant} from './status-dot.js';
 
 /**
- * Single Vercel-style row for a workflow run.
+ * Single Vercel-style row for a workflow run (presentational).
  *
- * Four zones at md+ (id+trigger / status+duration / workflow name / time)
- * collapse to a 2-line stack on sm. Rows are presentational only — no
- * click target until the run-detail surface ships (TODOS.md defers this).
+ * `RunsList` wraps each row in a router Link to the run detail page, so the row itself
+ * stays render-only; the trailing chevron marks it as navigable. Four zones at md+
+ * (id+trigger / status+duration / workflow name / time) collapse to a 2-line stack on sm.
  *
  *  md+:
- *  ┌─────────────┬──────────────────┬────────────────────────────┬───────────┐
- *  │ id8         │ ● running 12s    │ Workflow name (truncate)   │   3m ago  │
- *  │ manual      │                  │                            │           │
- *  └─────────────┴──────────────────┴────────────────────────────┴───────────┘
- *
- *  sm: status dot + name on row 1; id8 · trigger · time · duration on row 2.
+ *  ┌─────────────┬──────────────────┬────────────────────────────┬──────────────┐
+ *  │ id8         │ ● running 12s    │ Workflow name (truncate)   │  3m ago    › │
+ *  │ manual      │                  │                            │              │
+ *  └─────────────┴──────────────────┴────────────────────────────┴──────────────┘
  */
 
 const TERMINAL_STATUSES = new Set<RunStatusDto>(['succeeded', 'failed', 'cancelled']);
@@ -37,12 +35,7 @@ export function RunRow({run}: {run: RunDto}) {
   const shortId = run.id.slice(0, 8);
 
   return (
-    <div
-      // Presentational row. Not interactive in this PR (see TODOS.md
-      // "Workflow run detail page"). No tabindex, no role=button — when
-      // run-detail ships, swap to a Link and add the chevron.
-      className="flex flex-col gap-6 px-12 py-10 transition-colors hover:bg-background-components-hover md:h-44 md:flex-row md:items-center md:gap-12 md:py-0"
-    >
+    <div className="flex flex-col gap-6 px-12 py-10 transition-colors hover:bg-background-components-hover md:h-44 md:flex-row md:items-center md:gap-12 md:py-0">
       <div className="flex shrink-0 flex-col gap-2 md:w-140">
         <Code variant="label" className="text-foreground-neutral-muted">
           {shortId}
@@ -65,10 +58,15 @@ export function RunRow({run}: {run: RunDto}) {
         </Text>
       </div>
 
-      <div className="shrink-0 md:w-100 md:text-right">
+      <div className="flex shrink-0 items-center justify-between gap-8 md:w-110 md:justify-end">
         <Text size="xs" className="text-foreground-neutral-muted">
           <RelativeTime value={run.created_at} />
         </Text>
+        <Icon
+          name="arrowRightSLine"
+          className="size-16 shrink-0 text-foreground-neutral-muted"
+          aria-hidden
+        />
       </div>
     </div>
   );

--- a/libs/client/projects/src/hooks/api/workflow-runs.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.ts
@@ -1,8 +1,12 @@
 import type {
+  JobDto,
   RunAggregatesResponseDto,
   RunDto,
   RunListResponseDto,
+  RunResponseDto,
   RunStatusDto,
+  StepAttemptDto,
+  StepDto,
 } from '@shipfox/api-workflows-dto';
 import {apiRequest} from '@shipfox/client-api';
 import {
@@ -29,6 +33,7 @@ export const workflowRunsQueryKeys = {
     [...workflowRunsQueryKeys.lists(projectId), normalizeFilters(filters)] as const,
   aggregates: (projectId: string, filters: WorkflowRunFilters) =>
     [...workflowRunsQueryKeys.all, 'aggregates', projectId, normalizeFilters(filters)] as const,
+  detail: (runId: string) => [...workflowRunsQueryKeys.all, 'detail', runId] as const,
 };
 
 function normalizeFilters(filters: WorkflowRunFilters) {
@@ -165,6 +170,41 @@ export function useWorkflowRunAggregatesQuery(
     queryFn: ({signal}) => getWorkflowRunAggregates({projectId: projectId ?? '', filters, signal}),
     staleTime: 2_000,
     refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * The run detail read model returned by `GET /workflows/runs/:id`: a run plus its jobs,
+ * each job's steps, and each step's attempt history. The canonical response schema lives
+ * inline in the API route today; this mirrors it from the shared run/job/step DTOs until a
+ * dedicated run-detail DTO is exported.
+ */
+export type WorkflowRunStepDetailDto = StepDto & {attempts: StepAttemptDto[]};
+export type WorkflowRunJobDetailDto = JobDto & {steps: WorkflowRunStepDetailDto[]};
+export type WorkflowRunDetailDto = RunResponseDto & {jobs: WorkflowRunJobDetailDto[]};
+
+export async function getWorkflowRun({runId, signal}: {runId: string; signal?: AbortSignal}) {
+  return await apiRequest<WorkflowRunDetailDto>(`/workflows/runs/${runId}`, {signal});
+}
+
+export function useWorkflowRunQuery(runId: string | undefined) {
+  // Poll a non-terminal run so the open run detail stays live (same cadence as the run
+  // list); stop once the run is terminal. Tab-hidden polling pauses via
+  // refetchIntervalInBackground: false.
+  return useQuery({
+    queryKey: runId
+      ? workflowRunsQueryKeys.detail(runId)
+      : [...workflowRunsQueryKeys.all, 'detail'],
+    enabled: Boolean(runId),
+    queryFn: ({signal}) => getWorkflowRun({runId: runId ?? '', signal}),
+    staleTime: 2_000,
+    refetchOnWindowFocus: true,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      if (!status) return false;
+      return TERMINAL_RUN_STATUSES.has(status) ? false : ACTIVE_POLL_MS;
+    },
+    refetchIntervalInBackground: false,
   });
 }
 

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -8,4 +8,5 @@ export * from './pages/home-router.js';
 export * from './pages/project-runs-page.js';
 export * from './pages/project-workflows-page.js';
 export * from './pages/projects-hub-page.js';
+export * from './pages/workflow-run-page.js';
 export * from './project-error.js';

--- a/libs/client/projects/src/pages/project-runs-page.test.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.test.tsx
@@ -6,6 +6,7 @@ import {ProjectRunsPage} from './project-runs-page.js';
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
 const REFRESH_BUTTON_RE = /refresh/i;
+const RUN_NAME_RE = /Deploy production/;
 
 describe('ProjectRunsPage', () => {
   test('renders run history, counts, and paginated load more', async () => {
@@ -62,6 +63,22 @@ describe('ProjectRunsPage', () => {
     fireEvent.click(clearFiltersButton);
 
     expect(await screen.findAllByText('Deploy production')).not.toHaveLength(0);
+  });
+
+  test('links each run row to its run detail page', async () => {
+    configureApiClient({fetchImpl: createRunsFetch()});
+
+    renderProjectPage(
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs`,
+      <ProjectRunsPage projectId={PROJECT_ID} />,
+    );
+
+    const runLink = await screen.findByRole('link', {name: RUN_NAME_RE});
+
+    expect(runLink).toHaveAttribute(
+      'href',
+      `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/66666666-6666-4666-8666-666666666666`,
+    );
   });
 });
 

--- a/libs/client/projects/src/pages/project-runs-page.tsx
+++ b/libs/client/projects/src/pages/project-runs-page.tsx
@@ -113,7 +113,7 @@ function ProjectRunsPageInner({projectId}: {projectId: string}) {
 
       {runs.length > 0 ? (
         <>
-          <RunsList runs={runs} />
+          <RunsList runs={runs} workspaceId={params.wid ?? ''} projectId={projectId} />
           {runsQuery.isFetchNextPageError ? (
             <Alert variant="error" animated={false}>
               <div className="flex items-center justify-between gap-12">
@@ -332,12 +332,33 @@ function RunsEmptyState({
   );
 }
 
-function RunsList({runs}: {runs: RunDto[]}) {
+function RunsList({
+  runs,
+  workspaceId,
+  projectId,
+}: {
+  runs: RunDto[];
+  workspaceId: string;
+  projectId: string;
+}) {
   return (
     <div className="flex flex-col divide-y divide-border-neutral-base rounded-8 border border-border-neutral-base bg-background-neutral-base">
-      {runs.map((run) => (
-        <RunRow key={run.id} run={run} />
-      ))}
+      {runs.map((run) =>
+        run.id.startsWith('temp-') ? (
+          // Optimistic manual runs (temp-<uuid>) have no detail page until the canonical
+          // row replaces them on the next poll, so they render non-interactively.
+          <RunRow key={run.id} run={run} />
+        ) : (
+          <Link
+            key={run.id}
+            to="/workspaces/$wid/projects/$pid/runs/$runId"
+            params={{wid: workspaceId, pid: projectId, runId: run.id}}
+            className="block outline-none focus-visible:shadow-border-interactive-with-active"
+          >
+            <RunRow run={run} />
+          </Link>
+        ),
+      )}
     </div>
   );
 }

--- a/libs/client/projects/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.test.tsx
@@ -7,6 +7,7 @@ const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const OTHER_RUN_ID = '77777777-7777-4777-8777-777777777777';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+const INLINE_MODE_HINT_RE = /Overview \| Source render inline/;
 
 describe('WorkflowRunPage', () => {
   test('renders a loading shell while run history loads', async () => {
@@ -39,27 +40,33 @@ describe('WorkflowRunPage', () => {
     ).toBeInTheDocument();
   });
 
-  test('renders selected run identity, status, and section placeholders', async () => {
+  test('renders run identity, status, and the rail + center section slots', async () => {
     configureApiClient({fetchImpl: createWorkflowRunFetch()});
 
     renderWorkflowRunPage(RUN_ID, {selectedJobId: 'job-build', selectedStepId: 'step-checkout'});
 
-    expect(await screen.findByRole('heading', {name: 'Deploy production'})).toBeInTheDocument();
+    expect(await screen.findByText('Deploy production')).toBeInTheDocument();
     expect(screen.getAllByText(RUN_ID)).not.toHaveLength(0);
     expect(screen.getByText('Running')).toBeInTheDocument();
     expect(screen.getAllByText('job-build')).not.toHaveLength(0);
     expect(screen.getAllByText('step-checkout')).not.toHaveLength(0);
 
-    for (const section of [
-      'Runs list',
-      'Run summary',
-      'Jobs visualization',
-      'Step list',
-      'Step overview',
-      'Source view',
-    ]) {
+    for (const section of ['Runs list', 'Run summary', 'Jobs visualization', 'Step list']) {
       expect(screen.getByRole('heading', {name: section})).toBeInTheDocument();
     }
+  });
+
+  test('keeps step overview/source inline in the step list, not a right-side inspector', async () => {
+    configureApiClient({fetchImpl: createWorkflowRunFetch()});
+
+    renderWorkflowRunPage(RUN_ID, {selectedStepId: 'step-checkout'});
+
+    expect(await screen.findByText('Deploy production')).toBeInTheDocument();
+    // The composition contract: overview/source are inline content modes of the step
+    // list, never standalone inspector regions.
+    expect(screen.getByText(INLINE_MODE_HINT_RE)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Step overview'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: 'Source view'})).not.toBeInTheDocument();
   });
 });
 

--- a/libs/client/projects/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.test.tsx
@@ -1,0 +1,110 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {screen} from '@testing-library/react';
+import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
+import {WorkflowRunPage} from './workflow-run-page.js';
+
+const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
+const RUN_ID = '66666666-6666-4666-8666-666666666666';
+const OTHER_RUN_ID = '77777777-7777-4777-8777-777777777777';
+const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+
+describe('WorkflowRunPage', () => {
+  test('renders a loading shell while run history loads', async () => {
+    configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
+
+    renderWorkflowRunPage(RUN_ID);
+
+    expect(await screen.findByLabelText('Loading workflow run')).toBeInTheDocument();
+    expect(screen.getByText(RUN_ID)).toBeInTheDocument();
+  });
+
+  test('renders an error state when run history cannot load', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}))),
+    });
+
+    renderWorkflowRunPage(RUN_ID);
+
+    expect(await screen.findByText("Couldn't load workflow run")).toBeInTheDocument();
+  });
+
+  test('renders not found when the selected run is absent from loaded history', async () => {
+    configureApiClient({fetchImpl: createWorkflowRunFetch({runs: [runDto({id: OTHER_RUN_ID})]})});
+
+    renderWorkflowRunPage(RUN_ID);
+
+    expect(await screen.findByText('Run not found')).toBeInTheDocument();
+    expect(
+      screen.getByText(`This run is not available in the current run history: ${RUN_ID}.`),
+    ).toBeInTheDocument();
+  });
+
+  test('renders selected run identity, status, and section placeholders', async () => {
+    configureApiClient({fetchImpl: createWorkflowRunFetch()});
+
+    renderWorkflowRunPage(RUN_ID, {selectedJobId: 'job-build', selectedStepId: 'step-checkout'});
+
+    expect(await screen.findByRole('heading', {name: 'Deploy production'})).toBeInTheDocument();
+    expect(screen.getAllByText(RUN_ID)).not.toHaveLength(0);
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getAllByText('job-build')).not.toHaveLength(0);
+    expect(screen.getAllByText('step-checkout')).not.toHaveLength(0);
+
+    for (const section of [
+      'Runs list',
+      'Run summary',
+      'Jobs visualization',
+      'Step list',
+      'Step overview',
+      'Source view',
+    ]) {
+      expect(screen.getByRole('heading', {name: section})).toBeInTheDocument();
+    }
+  });
+});
+
+function renderWorkflowRunPage(
+  runId: string,
+  options: {selectedJobId?: string; selectedStepId?: string} = {},
+) {
+  renderProjectPage(
+    `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${runId}`,
+    <WorkflowRunPage projectId={PROJECT_ID} runId={runId} {...options} />,
+  );
+}
+
+function createWorkflowRunFetch({runs = [runDto()]}: {runs?: unknown[]} = {}) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+
+    if (url.pathname === '/workflows/runs') {
+      return Promise.resolve(
+        jsonResponse({runs, next_cursor: null, filtered_total_count: runs.length}),
+      );
+    }
+
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function requestInputUrl(input: RequestInfo | URL) {
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+function runDto(overrides: Partial<{id: string; name: string; status: string}> = {}) {
+  return {
+    id: overrides.id ?? RUN_ID,
+    project_id: PROJECT_ID,
+    definition_id: DEFINITION_ID,
+    name: overrides.name ?? 'Deploy production',
+    status: overrides.status ?? 'running',
+    trigger_source: 'manual',
+    trigger_event: 'fire',
+    trigger_payload: {source: 'manual', event: 'fire'},
+    inputs: null,
+    source_snapshot: null,
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+  };
+}

--- a/libs/client/projects/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.test.tsx
@@ -8,9 +8,10 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const OTHER_RUN_ID = '77777777-7777-4777-8777-777777777777';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
 const INLINE_MODE_HINT_RE = /Overview \| Source render inline/;
+const RUN_COUNTS_RE = /1 job · 2 steps/;
 
 describe('WorkflowRunPage', () => {
-  test('renders a loading shell while run history loads', async () => {
+  test('renders a loading shell while the run detail loads', async () => {
     configureApiClient({fetchImpl: vi.fn(() => new Promise<Response>(() => undefined))});
 
     renderWorkflowRunPage(RUN_ID);
@@ -19,7 +20,7 @@ describe('WorkflowRunPage', () => {
     expect(screen.getByText(RUN_ID)).toBeInTheDocument();
   });
 
-  test('renders an error state when run history cannot load', async () => {
+  test('renders an error state when the run detail cannot load', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() => Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}))),
     });
@@ -29,18 +30,19 @@ describe('WorkflowRunPage', () => {
     expect(await screen.findByText("Couldn't load workflow run")).toBeInTheDocument();
   });
 
-  test('renders not found when the selected run is absent from loaded history', async () => {
-    configureApiClient({fetchImpl: createWorkflowRunFetch({runs: [runDto({id: OTHER_RUN_ID})]})});
+  test('renders not found when the run detail returns 404', async () => {
+    configureApiClient({fetchImpl: createWorkflowRunFetch()});
 
-    renderWorkflowRunPage(RUN_ID);
+    // The fetch only serves RUN_ID; any other id 404s from the detail endpoint.
+    renderWorkflowRunPage(OTHER_RUN_ID);
 
     expect(await screen.findByText('Run not found')).toBeInTheDocument();
     expect(
-      screen.getByText(`This run is not available in the current run history: ${RUN_ID}.`),
+      screen.getByText(`This run does not exist or is no longer available: ${OTHER_RUN_ID}.`),
     ).toBeInTheDocument();
   });
 
-  test('renders run identity, status, and the rail + center section slots', async () => {
+  test('renders run identity, status, job/step counts, and the rail + center slots', async () => {
     configureApiClient({fetchImpl: createWorkflowRunFetch()});
 
     renderWorkflowRunPage(RUN_ID, {selectedJobId: 'job-build', selectedStepId: 'step-checkout'});
@@ -48,6 +50,8 @@ describe('WorkflowRunPage', () => {
     expect(await screen.findByText('Deploy production')).toBeInTheDocument();
     expect(screen.getAllByText(RUN_ID)).not.toHaveLength(0);
     expect(screen.getByText('Running')).toBeInTheDocument();
+    // Real run-detail data (jobs + steps) flows into the shell.
+    expect(screen.getByText(RUN_COUNTS_RE)).toBeInTheDocument();
     expect(screen.getAllByText('job-build')).not.toHaveLength(0);
     expect(screen.getAllByText('step-checkout')).not.toHaveLength(0);
 
@@ -80,14 +84,12 @@ function renderWorkflowRunPage(
   );
 }
 
-function createWorkflowRunFetch({runs = [runDto()]}: {runs?: unknown[]} = {}) {
+function createWorkflowRunFetch({detail = runDetailDto()}: {detail?: unknown} = {}) {
   return vi.fn((input: RequestInfo | URL) => {
     const url = new URL(requestInputUrl(input));
 
-    if (url.pathname === '/workflows/runs') {
-      return Promise.resolve(
-        jsonResponse({runs, next_cursor: null, filtered_total_count: runs.length}),
-      );
+    if (url.pathname === `/workflows/runs/${RUN_ID}`) {
+      return Promise.resolve(jsonResponse(detail));
     }
 
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
@@ -99,7 +101,9 @@ function requestInputUrl(input: RequestInfo | URL) {
   return String(input);
 }
 
-function runDto(overrides: Partial<{id: string; name: string; status: string}> = {}) {
+// Mirrors GET /workflows/runs/:id: a run plus one job with two steps (so the shell shows
+// "1 job · 2 steps"). Only the fields the shell reads are populated.
+function runDetailDto(overrides: Partial<{id: string; name: string; status: string}> = {}) {
   return {
     id: overrides.id ?? RUN_ID,
     project_id: PROJECT_ID,
@@ -110,8 +114,18 @@ function runDto(overrides: Partial<{id: string; name: string; status: string}> =
     trigger_event: 'fire',
     trigger_payload: {source: 'manual', event: 'fire'},
     inputs: null,
-    source_snapshot: null,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
+    jobs: [
+      {
+        id: 'job-build',
+        name: 'build',
+        status: 'succeeded',
+        steps: [
+          {id: 'step-checkout', name: 'checkout', status: 'succeeded', attempts: []},
+          {id: 'step-test', name: 'test', status: 'succeeded', attempts: []},
+        ],
+      },
+    ],
   };
 }

--- a/libs/client/projects/src/pages/workflow-run-page.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.tsx
@@ -1,6 +1,6 @@
 import type {RunDto, RunStatusDto} from '@shipfox/api-workflows-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Code, EmptyState, Header, Skeleton, StatusBadge, Text} from '@shipfox/react-ui';
+import {Code, cn, EmptyState, Header, Skeleton, StatusBadge, Text} from '@shipfox/react-ui';
 import {useMemo} from 'react';
 import {useWorkflowRunsInfiniteQuery} from '#hooks/api/workflow-runs.js';
 
@@ -30,15 +30,6 @@ const statusLabelByStatus: Record<RunStatusDto, string> = {
   cancelled: 'Cancelled',
 };
 
-const placeholderSections = [
-  {title: 'Runs list', selection: 'run'},
-  {title: 'Run summary', selection: 'run'},
-  {title: 'Jobs visualization', selection: 'job'},
-  {title: 'Step list', selection: 'step'},
-  {title: 'Step overview', selection: 'step'},
-  {title: 'Source view', selection: 'step'},
-] as const;
-
 export function WorkflowRunPage(props: WorkflowRunPageProps) {
   const {projectId, runId} = props;
   const filters = useMemo(() => ({}), []);
@@ -61,20 +52,133 @@ export function WorkflowRunPage(props: WorkflowRunPageProps) {
   return <WorkflowRunSuccessState {...props} run={selectedRun} />;
 }
 
+/**
+ * Page layout contract for the Workflow Run Page (component PRs mount real sections into
+ * these slots):
+ *
+ *   ┌──────────┬───────────────────────────────────────────┐
+ *   │ Runs     │  Run summary                               │
+ *   │ list     │  Jobs visualization                        │
+ *   │ (rail)   │  Step list  ── Overview | Source render    │
+ *   │          │               INLINE in the expanded row   │
+ *   └──────────┴───────────────────────────────────────────┘
+ *
+ * Step overview and source are NOT a persistent right-side inspector: they are content
+ * modes the step list renders inside the selected step's expanded row. The shell keeps no
+ * right column so later composition cannot regress into one.
+ */
+function WorkflowRunSuccessState({
+  run,
+  selectedJobId,
+  selectedStepId,
+}: WorkflowRunPageProps & {run: RunDto}) {
+  return (
+    <div className="grid gap-16 lg:grid-cols-[280px_minmax(0,1fr)]">
+      <aside aria-label="Runs" className="min-w-0 lg:sticky lg:top-16 lg:self-start">
+        <ShellSlot title="Runs list" hint="Run navigation rail mounts here.">
+          <SelectionHint label="Selected run" value={run.id} />
+        </ShellSlot>
+      </aside>
+
+      <div className="flex min-w-0 flex-col gap-16">
+        <ShellSlot title="Run summary">
+          <RunIdentity run={run} />
+        </ShellSlot>
+
+        <ShellSlot title="Jobs visualization" hint="Jobs execution graph mounts here.">
+          <SelectionHint label="Selected job" value={selectedJobId} />
+        </ShellSlot>
+
+        <ShellSlot
+          title="Step list"
+          hint="Overview | Source render inline inside the expanded step row — no separate inspector panel."
+        >
+          <SelectionHint label="Selected step" value={selectedStepId} />
+        </ShellSlot>
+      </div>
+    </div>
+  );
+}
+
+function RunIdentity({run}: {run: RunDto}) {
+  return (
+    <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+      <div className="flex min-w-0 flex-col gap-6">
+        <Text size="lg" bold className="truncate">
+          {run.name}
+        </Text>
+        <div className="flex flex-wrap items-center gap-8">
+          <Code variant="label" className="text-foreground-neutral-muted">
+            {run.id}
+          </Code>
+          <Text size="xs" className="text-foreground-neutral-muted">
+            Run ID
+          </Text>
+        </div>
+      </div>
+      <StatusBadge variant={statusBadgeVariantByStatus[run.status]} className="shrink-0">
+        {statusLabelByStatus[run.status]}
+      </StatusBadge>
+    </div>
+  );
+}
+
+function ShellSlot({
+  title,
+  hint,
+  children,
+  className,
+}: {
+  title: string;
+  hint?: string;
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <section
+      aria-label={title}
+      className={cn(
+        'flex min-h-120 flex-col gap-12 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16',
+        className,
+      )}
+    >
+      <Header variant="h4">{title}</Header>
+      {hint ? (
+        <Text size="xs" className="text-foreground-neutral-muted">
+          {hint}
+        </Text>
+      ) : null}
+      {children}
+    </section>
+  );
+}
+
+function SelectionHint({label, value}: {label: string; value?: string | undefined}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <Text size="xs" className="text-foreground-neutral-muted">
+        {label}
+      </Text>
+      <Code variant="label" className="truncate text-foreground-neutral-base">
+        {value ?? 'None'}
+      </Code>
+    </div>
+  );
+}
+
 function WorkflowRunLoadingState({runId}: {runId: string}) {
   return (
-    <section className="flex flex-col gap-24" aria-label="Loading workflow run">
-      <header className="flex flex-col gap-8">
-        <Skeleton className="h-28 w-260" />
-        <Skeleton className="h-16 w-360 max-w-full" />
-        <Code variant="label" className="text-foreground-neutral-muted">
-          {runId}
-        </Code>
-      </header>
-      <div className="grid gap-16 lg:grid-cols-[260px_minmax(0,1fr)]">
-        {placeholderSections.map((section) => (
-          <Skeleton key={section.title} className="min-h-120 rounded-8" />
-        ))}
+    <section className="flex flex-col gap-16" aria-label="Loading workflow run">
+      <Code variant="label" className="text-foreground-neutral-muted">
+        {runId}
+      </Code>
+      <div className="grid gap-16 lg:grid-cols-[280px_minmax(0,1fr)]">
+        <Skeleton className="min-h-120 rounded-8" />
+        <div className="flex flex-col gap-16">
+          <Skeleton className="min-h-120 rounded-8" />
+          <Skeleton className="min-h-120 rounded-8" />
+          <Skeleton className="min-h-200 rounded-8" />
+        </div>
       </div>
     </section>
   );
@@ -87,91 +191,5 @@ function WorkflowRunNotFoundState({runId}: {runId: string}) {
       title="Run not found"
       description={`This run is not available in the current run history: ${runId}.`}
     />
-  );
-}
-
-function WorkflowRunSuccessState({
-  run,
-  selectedJobId,
-  selectedStepId,
-}: WorkflowRunPageProps & {run: RunDto}) {
-  return (
-    <div className="flex flex-col gap-24">
-      <header className="flex flex-col gap-16 md:flex-row md:items-start md:justify-between">
-        <div className="flex min-w-0 flex-col gap-6">
-          <Header variant="h2" className="truncate">
-            {run.name}
-          </Header>
-          <div className="flex flex-wrap items-center gap-8">
-            <Code variant="label" className="text-foreground-neutral-muted">
-              {run.id}
-            </Code>
-            <Text size="xs" className="text-foreground-neutral-muted">
-              Run ID
-            </Text>
-          </div>
-        </div>
-        <StatusBadge variant={statusBadgeVariantByStatus[run.status]} className="shrink-0">
-          {statusLabelByStatus[run.status]}
-        </StatusBadge>
-      </header>
-
-      <section
-        aria-label="Workflow run selection"
-        className="grid gap-12 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16 md:grid-cols-3"
-      >
-        <SelectionValue label="Run" value={run.id} />
-        <SelectionValue label="Job" value={selectedJobId ?? 'None'} />
-        <SelectionValue label="Step" value={selectedStepId ?? 'None'} />
-      </section>
-
-      <section
-        aria-label="Workflow run sections"
-        className="grid gap-16 lg:grid-cols-[260px_minmax(0,1fr)]"
-      >
-        {placeholderSections.map((section) => (
-          <PlaceholderSection
-            key={section.title}
-            title={section.title}
-            selectedId={
-              section.selection === 'run'
-                ? run.id
-                : section.selection === 'job'
-                  ? selectedJobId
-                  : selectedStepId
-            }
-          />
-        ))}
-      </section>
-    </div>
-  );
-}
-
-function SelectionValue({label, value}: {label: string; value: string}) {
-  return (
-    <div className="min-w-0">
-      <Text size="xs" className="text-foreground-neutral-muted">
-        {label}
-      </Text>
-      <Code variant="label" className="truncate text-foreground-neutral-base">
-        {value}
-      </Code>
-    </div>
-  );
-}
-
-function PlaceholderSection({title, selectedId}: {title: string; selectedId?: string | undefined}) {
-  return (
-    <article className="flex min-h-120 flex-col justify-between gap-16 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
-      <div className="flex flex-col gap-4">
-        <Header variant="h4">{title}</Header>
-        <Text size="sm" className="text-foreground-neutral-muted">
-          Placeholder
-        </Text>
-      </div>
-      <Code variant="label" className="truncate text-foreground-neutral-muted">
-        {selectedId ?? 'No selection'}
-      </Code>
-    </article>
   );
 }

--- a/libs/client/projects/src/pages/workflow-run-page.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.tsx
@@ -1,0 +1,177 @@
+import type {RunDto, RunStatusDto} from '@shipfox/api-workflows-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {Code, EmptyState, Header, Skeleton, StatusBadge, Text} from '@shipfox/react-ui';
+import {useMemo} from 'react';
+import {useWorkflowRunsInfiniteQuery} from '#hooks/api/workflow-runs.js';
+
+export interface WorkflowRunPageProps {
+  projectId: string;
+  runId: string;
+  selectedJobId?: string | undefined;
+  selectedStepId?: string | undefined;
+  onSelectRun?: ((runId: string) => void) | undefined;
+  onSelectJob?: ((jobId: string | undefined) => void) | undefined;
+  onSelectStep?: ((stepId: string | undefined) => void) | undefined;
+}
+
+const statusBadgeVariantByStatus: Record<RunStatusDto, 'neutral' | 'info' | 'success' | 'error'> = {
+  pending: 'neutral',
+  running: 'info',
+  succeeded: 'success',
+  failed: 'error',
+  cancelled: 'neutral',
+};
+
+const statusLabelByStatus: Record<RunStatusDto, string> = {
+  pending: 'Pending',
+  running: 'Running',
+  succeeded: 'Succeeded',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+};
+
+const placeholderSections = [
+  {title: 'Runs list', selection: 'run'},
+  {title: 'Run summary', selection: 'run'},
+  {title: 'Jobs visualization', selection: 'job'},
+  {title: 'Step list', selection: 'step'},
+  {title: 'Step overview', selection: 'step'},
+  {title: 'Source view', selection: 'step'},
+] as const;
+
+export function WorkflowRunPage(props: WorkflowRunPageProps) {
+  const {projectId, runId} = props;
+  const filters = useMemo(() => ({}), []);
+  const runsQuery = useWorkflowRunsInfiniteQuery(projectId, filters);
+  const runs = runsQuery.data?.pages.flatMap((page) => page.runs) ?? [];
+  const selectedRun = runs.find((run) => run.id === runId);
+
+  if (runsQuery.isPending) {
+    return <WorkflowRunLoadingState runId={runId} />;
+  }
+
+  if (runsQuery.isError && runsQuery.data === undefined) {
+    return <QueryLoadError query={runsQuery} subject="workflow run" icon="pulseLine" />;
+  }
+
+  if (!selectedRun) {
+    return <WorkflowRunNotFoundState runId={runId} />;
+  }
+
+  return <WorkflowRunSuccessState {...props} run={selectedRun} />;
+}
+
+function WorkflowRunLoadingState({runId}: {runId: string}) {
+  return (
+    <section className="flex flex-col gap-24" aria-label="Loading workflow run">
+      <header className="flex flex-col gap-8">
+        <Skeleton className="h-28 w-260" />
+        <Skeleton className="h-16 w-360 max-w-full" />
+        <Code variant="label" className="text-foreground-neutral-muted">
+          {runId}
+        </Code>
+      </header>
+      <div className="grid gap-16 lg:grid-cols-[260px_minmax(0,1fr)]">
+        {placeholderSections.map((section) => (
+          <Skeleton key={section.title} className="min-h-120 rounded-8" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function WorkflowRunNotFoundState({runId}: {runId: string}) {
+  return (
+    <EmptyState
+      icon="pulseLine"
+      title="Run not found"
+      description={`This run is not available in the current run history: ${runId}.`}
+    />
+  );
+}
+
+function WorkflowRunSuccessState({
+  run,
+  selectedJobId,
+  selectedStepId,
+}: WorkflowRunPageProps & {run: RunDto}) {
+  return (
+    <div className="flex flex-col gap-24">
+      <header className="flex flex-col gap-16 md:flex-row md:items-start md:justify-between">
+        <div className="flex min-w-0 flex-col gap-6">
+          <Header variant="h2" className="truncate">
+            {run.name}
+          </Header>
+          <div className="flex flex-wrap items-center gap-8">
+            <Code variant="label" className="text-foreground-neutral-muted">
+              {run.id}
+            </Code>
+            <Text size="xs" className="text-foreground-neutral-muted">
+              Run ID
+            </Text>
+          </div>
+        </div>
+        <StatusBadge variant={statusBadgeVariantByStatus[run.status]} className="shrink-0">
+          {statusLabelByStatus[run.status]}
+        </StatusBadge>
+      </header>
+
+      <section
+        aria-label="Workflow run selection"
+        className="grid gap-12 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16 md:grid-cols-3"
+      >
+        <SelectionValue label="Run" value={run.id} />
+        <SelectionValue label="Job" value={selectedJobId ?? 'None'} />
+        <SelectionValue label="Step" value={selectedStepId ?? 'None'} />
+      </section>
+
+      <section
+        aria-label="Workflow run sections"
+        className="grid gap-16 lg:grid-cols-[260px_minmax(0,1fr)]"
+      >
+        {placeholderSections.map((section) => (
+          <PlaceholderSection
+            key={section.title}
+            title={section.title}
+            selectedId={
+              section.selection === 'run'
+                ? run.id
+                : section.selection === 'job'
+                  ? selectedJobId
+                  : selectedStepId
+            }
+          />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function SelectionValue({label, value}: {label: string; value: string}) {
+  return (
+    <div className="min-w-0">
+      <Text size="xs" className="text-foreground-neutral-muted">
+        {label}
+      </Text>
+      <Code variant="label" className="truncate text-foreground-neutral-base">
+        {value}
+      </Code>
+    </div>
+  );
+}
+
+function PlaceholderSection({title, selectedId}: {title: string; selectedId?: string | undefined}) {
+  return (
+    <article className="flex min-h-120 flex-col justify-between gap-16 rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
+      <div className="flex flex-col gap-4">
+        <Header variant="h4">{title}</Header>
+        <Text size="sm" className="text-foreground-neutral-muted">
+          Placeholder
+        </Text>
+      </div>
+      <Code variant="label" className="truncate text-foreground-neutral-muted">
+        {selectedId ?? 'No selection'}
+      </Code>
+    </article>
+  );
+}

--- a/libs/client/projects/src/pages/workflow-run-page.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.tsx
@@ -1,8 +1,8 @@
-import type {RunDto, RunStatusDto} from '@shipfox/api-workflows-dto';
+import type {RunResponseDto, RunStatusDto} from '@shipfox/api-workflows-dto';
+import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Code, cn, EmptyState, Header, Skeleton, StatusBadge, Text} from '@shipfox/react-ui';
-import {useMemo} from 'react';
-import {useWorkflowRunsInfiniteQuery} from '#hooks/api/workflow-runs.js';
+import {useWorkflowRunQuery, type WorkflowRunDetailDto} from '#hooks/api/workflow-runs.js';
 
 export interface WorkflowRunPageProps {
   projectId: string;
@@ -31,25 +31,21 @@ const statusLabelByStatus: Record<RunStatusDto, string> = {
 };
 
 export function WorkflowRunPage(props: WorkflowRunPageProps) {
-  const {projectId, runId} = props;
-  const filters = useMemo(() => ({}), []);
-  const runsQuery = useWorkflowRunsInfiniteQuery(projectId, filters);
-  const runs = runsQuery.data?.pages.flatMap((page) => page.runs) ?? [];
-  const selectedRun = runs.find((run) => run.id === runId);
+  const {runId} = props;
+  const runQuery = useWorkflowRunQuery(runId);
 
-  if (runsQuery.isPending) {
+  if (runQuery.isPending) {
     return <WorkflowRunLoadingState runId={runId} />;
   }
 
-  if (runsQuery.isError && runsQuery.data === undefined) {
-    return <QueryLoadError query={runsQuery} subject="workflow run" icon="pulseLine" />;
+  if (runQuery.isError) {
+    if (runQuery.error instanceof ApiError && runQuery.error.status === 404) {
+      return <WorkflowRunNotFoundState runId={runId} />;
+    }
+    return <QueryLoadError query={runQuery} subject="workflow run" icon="pulseLine" />;
   }
 
-  if (!selectedRun) {
-    return <WorkflowRunNotFoundState runId={runId} />;
-  }
-
-  return <WorkflowRunSuccessState {...props} run={selectedRun} />;
+  return <WorkflowRunSuccessState {...props} run={runQuery.data} />;
 }
 
 /**
@@ -71,7 +67,10 @@ function WorkflowRunSuccessState({
   run,
   selectedJobId,
   selectedStepId,
-}: WorkflowRunPageProps & {run: RunDto}) {
+}: WorkflowRunPageProps & {run: WorkflowRunDetailDto}) {
+  const jobCount = run.jobs.length;
+  const stepCount = run.jobs.reduce((total, job) => total + job.steps.length, 0);
+
   return (
     <div className="grid gap-16 lg:grid-cols-[280px_minmax(0,1fr)]">
       <aside aria-label="Runs" className="min-w-0 lg:sticky lg:top-16 lg:self-start">
@@ -83,6 +82,10 @@ function WorkflowRunSuccessState({
       <div className="flex min-w-0 flex-col gap-16">
         <ShellSlot title="Run summary">
           <RunIdentity run={run} />
+          <Text size="xs" className="text-foreground-neutral-muted">
+            {jobCount} {jobCount === 1 ? 'job' : 'jobs'} · {stepCount}{' '}
+            {stepCount === 1 ? 'step' : 'steps'}
+          </Text>
         </ShellSlot>
 
         <ShellSlot title="Jobs visualization" hint="Jobs execution graph mounts here.">
@@ -100,7 +103,7 @@ function WorkflowRunSuccessState({
   );
 }
 
-function RunIdentity({run}: {run: RunDto}) {
+function RunIdentity({run}: {run: RunResponseDto}) {
   return (
     <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
       <div className="flex min-w-0 flex-col gap-6">
@@ -189,7 +192,7 @@ function WorkflowRunNotFoundState({runId}: {runId: string}) {
     <EmptyState
       icon="pulseLine"
       title="Run not found"
-      description={`This run is not available in the current run history: ${runId}.`}
+      description={`This run does not exist or is no longer available: ${runId}.`}
     />
   );
 }

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -48,6 +48,16 @@ export function jsonResponse(body: unknown, init: ResponseInit = {}) {
   });
 }
 
+// The param-carrying routes below declare `$pid`/`$runId` in their path, so the value is
+// always present when their fallback page renders. A missing param means the harness
+// wired a route wrong — fail loudly instead of rendering a page with a fabricated id.
+function requireParam(value: string | undefined, name: string): string {
+  if (value === undefined) {
+    throw new Error(`Test router: route param "${name}" is missing`);
+  }
+  return value;
+}
+
 function createTestRouter(path: string, element: ReactElement) {
   const initialPath = path.split('?')[0] ?? path;
   const rootRoute = createRootRoute({component: Outlet});
@@ -86,7 +96,7 @@ function createTestRouter(path: string, element: ReactElement) {
         return element;
       }
 
-      return <ProjectRunsPage projectId={params.pid ?? 'p-1'} />;
+      return <ProjectRunsPage projectId={requireParam(params.pid, 'pid')} />;
     },
   });
   const projectRunsRoute = createRoute({
@@ -98,7 +108,7 @@ function createTestRouter(path: string, element: ReactElement) {
         return element;
       }
 
-      return <ProjectRunsPage projectId={params.pid ?? 'p-1'} />;
+      return <ProjectRunsPage projectId={requireParam(params.pid, 'pid')} />;
     },
   });
   const workflowRunRoute = createRoute({
@@ -113,7 +123,12 @@ function createTestRouter(path: string, element: ReactElement) {
         return element;
       }
 
-      return <WorkflowRunPage projectId={params.pid ?? 'p-1'} runId={params.runId ?? 'r-1'} />;
+      return (
+        <WorkflowRunPage
+          projectId={requireParam(params.pid, 'pid')}
+          runId={requireParam(params.runId, 'runId')}
+        />
+      );
     },
   });
   const projectWorkflowsRoute = createRoute({
@@ -125,7 +140,7 @@ function createTestRouter(path: string, element: ReactElement) {
         return element;
       }
 
-      return <ProjectWorkflowsPage projectId={params.pid ?? 'p-1'} />;
+      return <ProjectWorkflowsPage projectId={requireParam(params.pid, 'pid')} />;
     },
   });
 

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -18,6 +18,7 @@ import {CreateProjectPage} from '#pages/create-project-page.js';
 import {ProjectRunsPage} from '#pages/project-runs-page.js';
 import {ProjectWorkflowsPage} from '#pages/project-workflows-page.js';
 import {ProjectsHubPage} from '#pages/projects-hub-page.js';
+import {WorkflowRunPage} from '#pages/workflow-run-page.js';
 
 // All test renders that exercise pages requiring `useActiveWorkspace()` mount
 // under `/workspaces/$wid`. The seeded workspace id (see authState) is the wid
@@ -100,6 +101,21 @@ function createTestRouter(path: string, element: ReactElement) {
       return <ProjectRunsPage projectId={params.pid ?? 'p-1'} />;
     },
   });
+  const workflowRunRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/projects/$pid/runs/$runId',
+    component: () => {
+      const params = useParams({strict: false}) as {pid?: string; runId?: string};
+      if (
+        initialPath ===
+        `/workspaces/${PROJECT_TEST_WID}/projects/${params.pid}/runs/${params.runId}`
+      ) {
+        return element;
+      }
+
+      return <WorkflowRunPage projectId={params.pid ?? 'p-1'} runId={params.runId ?? 'r-1'} />;
+    },
+  });
   const projectWorkflowsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/projects/$pid/workflows',
@@ -122,6 +138,7 @@ function createTestRouter(path: string, element: ReactElement) {
       integrationsRoute,
       projectDetailRoute,
       projectRunsRoute,
+      workflowRunRoute,
       projectWorkflowsRoute,
     ]),
   });

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as WorkspacesWidLayoutProjectsPidLayoutRouteImport } from './rout
 import { Route as WorkspacesWidLayoutProjectsPidLayoutIndexRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/index'
 import { Route as WorkspacesWidLayoutProjectsPidLayoutWorkflowsRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/workflows'
 import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs'
+import { Route as WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRouteImport } from './routes/workspaces/$wid/_layout/projects/$pid/_layout/runs_.$runId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -183,6 +184,12 @@ const WorkspacesWidLayoutProjectsPidLayoutRunsRoute =
     path: '/runs',
     getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRoute,
   } as any)
+const WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute =
+  WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRouteImport.update({
+    id: '/runs_/$runId',
+    path: '/runs/$runId',
+    getParentRoute: () => WorkspacesWidLayoutProjectsPidLayoutRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -211,6 +218,7 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/projects/$pid/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/projects/$pid/': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/projects/$pid/runs/$runId': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -237,6 +245,7 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/projects/$pid/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/projects/$pid': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/projects/$pid/runs/$runId': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -266,6 +275,7 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/projects/$pid/_layout/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout/workflows': typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout/': typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$runId': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -296,6 +306,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/projects/$pid/runs'
     | '/workspaces/$wid/projects/$pid/workflows'
     | '/workspaces/$wid/projects/$pid/'
+    | '/workspaces/$wid/projects/$pid/runs/$runId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -322,6 +333,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/projects/$pid/runs'
     | '/workspaces/$wid/projects/$pid/workflows'
     | '/workspaces/$wid/projects/$pid'
+    | '/workspaces/$wid/projects/$pid/runs/$runId'
   id:
     | '__root__'
     | '/'
@@ -350,6 +362,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/projects/$pid/_layout/runs'
     | '/workspaces/$wid/_layout/projects/$pid/_layout/workflows'
     | '/workspaces/$wid/_layout/projects/$pid/_layout/'
+    | '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$runId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -550,6 +563,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRouteImport
       parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRoute
     }
+    '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$runId': {
+      id: '/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$runId'
+      path: '/runs/$runId'
+      fullPath: '/workspaces/$wid/projects/$pid/runs/$runId'
+      preLoaderRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRouteImport
+      parentRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRoute
+    }
   }
 }
 
@@ -569,6 +589,7 @@ interface WorkspacesWidLayoutProjectsPidLayoutRouteChildren {
   WorkspacesWidLayoutProjectsPidLayoutRunsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
   WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute: typeof WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute
   WorkspacesWidLayoutProjectsPidLayoutIndexRoute: typeof WorkspacesWidLayoutProjectsPidLayoutIndexRoute
+  WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute
 }
 
 const WorkspacesWidLayoutProjectsPidLayoutRouteChildren: WorkspacesWidLayoutProjectsPidLayoutRouteChildren =
@@ -579,6 +600,8 @@ const WorkspacesWidLayoutProjectsPidLayoutRouteChildren: WorkspacesWidLayoutProj
       WorkspacesWidLayoutProjectsPidLayoutWorkflowsRoute,
     WorkspacesWidLayoutProjectsPidLayoutIndexRoute:
       WorkspacesWidLayoutProjectsPidLayoutIndexRoute,
+    WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute:
+      WorkspacesWidLayoutProjectsPidLayoutRunsRunIdRoute,
   }
 
 const WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren =

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs_.$runId.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/projects/$pid/_layout/runs_.$runId.tsx
@@ -1,0 +1,13 @@
+import {WorkflowRunPage} from '@shipfox/client-projects';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/projects/$pid/_layout/runs_/$runId')(
+  {
+    component: WorkflowRunRoute,
+  },
+);
+
+function WorkflowRunRoute() {
+  const {pid, runId} = Route.useParams();
+  return <WorkflowRunPage projectId={pid} runId={runId} />;
+}


### PR DESCRIPTION
Mounts the project workflow run detail URL and adds a thin WorkflowRunPage shell for the Workflow Run Page project.

The page uses the existing run-history query instead of introducing new backend behavior, renders loading/error/not-found states, and shows the selected run name, id, and status when the run is present in loaded history. It also establishes the run/job/step selection props and placeholder regions for the later runs list, run summary, jobs visualization, step list, step overview, and source view sections.

Validation covered focused page tests for loading, error, not-found, and success states; package check/type coverage for the touched client packages; the origin/main-filtered build, test, and check workflows; and a local client app smoke that verified the deep route served without browser console errors.

Closes ENG-462

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the project workflow run detail route with a thin `WorkflowRunPage` shell, wires the `/runs` list to open it, and loads real run detail via the API with live polling for active runs. Satisfies ENG-462 with load/error/not-found states, selection plumbing, and a locked layout contract.

- **New Features**
  - Adds route `/workspaces/:wid/projects/:pid/runs/:runId` via `@tanstack/react-router`, wired to `WorkflowRunPage` in `@shipfox/client-projects`.
  - Links `/runs` rows to the run detail page; optimistic `temp-*` rows stay non-interactive; `RunRow` remains presentational with a trailing chevron.
  - Introduces `useWorkflowRunQuery` to fetch run detail from `GET /workflows/runs/:id` and polls until terminal; renders loading, error, and 404 not-found.
  - Locks composition: left runs rail; center has run summary, jobs visualization, and step list; step overview/source render inline within the step list (no right inspector). Shows run name/id/status and real job/step counts from detail.
  - Adds tests for list→detail linking and loading/error/not-found/success paths; test router now throws on missing `$pid`/`$runId` params.

<sup>Written for commit 141666083c2cabb77f5030634d7a81e68ac6679f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

