### PR TITLE
[api-workflows] Add typed workflow gate result DTOs

### DIFF
--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -40,11 +40,15 @@ export {
   type StepErrorCategory,
   type StepErrorDtoShape,
   type StepErrorReason,
+  type StepGateResultDto,
+  type StepRestartResultDto,
   stepAttemptDtoSchema,
   stepDtoSchema,
   stepErrorCategorySchema,
   stepErrorDtoSchema,
   stepErrorReasonSchema,
+  stepGateResultDtoSchema,
+  stepRestartResultDtoSchema,
 } from '#schemas/index.js';
 export {type WorkflowSourceSnapshotDto, workflowSourceSnapshotSchema} from '#schemas/run.js';
 export {type StepSourceLocationDto, stepSourceLocationSchema} from '#schemas/step.js';

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -46,9 +46,13 @@ export {
   type StepErrorCategory,
   type StepErrorDtoShape,
   type StepErrorReason,
+  type StepGateResultDto,
+  type StepRestartResultDto,
   stepAttemptDtoSchema,
   stepDtoSchema,
   stepErrorCategorySchema,
   stepErrorDtoSchema,
   stepErrorReasonSchema,
+  stepGateResultDtoSchema,
+  stepRestartResultDtoSchema,
 } from './step.js';

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -1,0 +1,103 @@
+import {stepAttemptDtoSchema} from './step.js';
+
+const baseAttempt = {
+  id: '11111111-1111-4111-8111-111111111111',
+  step_id: '22222222-2222-4222-8222-222222222222',
+  job_id: '33333333-3333-4333-8333-333333333333',
+  attempt: 1,
+  status: 'succeeded',
+  exit_code: 0,
+  output: null,
+  error: null,
+  restart_reason: null,
+  restart_result: null,
+  started_at: '2026-01-01T00:00:00.000Z',
+  finished_at: '2026-01-01T00:01:00.000Z',
+};
+
+describe('stepAttemptDtoSchema', () => {
+  it('accepts an attempt with no gate or restart result', () => {
+    const attempt = {...baseAttempt, gate_result: null};
+
+    const result = stepAttemptDtoSchema.parse(attempt);
+
+    expect(result.gate_result).toBeNull();
+    expect(result.restart_result).toBeNull();
+  });
+
+  it('accepts typed gate and restart results', () => {
+    const attempt = {
+      ...baseAttempt,
+      status: 'failed',
+      exit_code: 1,
+      gate_result: {
+        kind: 'failed',
+        passed: false,
+        source: 'exit_code == 0',
+        exit_code: 1,
+      },
+      restart_reason: 'gate condition not met',
+      restart_result: {
+        kind: 'restart_enqueued',
+        reason: 'gate condition not met',
+      },
+    };
+
+    const result = stepAttemptDtoSchema.parse(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'failed',
+      passed: false,
+      source: 'exit_code == 0',
+      exit_code: 1,
+    });
+    expect(result.restart_result).toEqual({
+      kind: 'restart_enqueued',
+      reason: 'gate condition not met',
+    });
+  });
+
+  it('accepts an explicit unknown gate result for legacy data', () => {
+    const attempt = {
+      ...baseAttempt,
+      gate_result: {
+        kind: 'unknown',
+        data: {passed: 'yes'},
+      },
+    };
+
+    const result = stepAttemptDtoSchema.parse(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'unknown',
+      data: {passed: 'yes'},
+    });
+  });
+
+  it('rejects inconsistent typed gate results', () => {
+    const result = stepAttemptDtoSchema.safeParse({
+      ...baseAttempt,
+      gate_result: {
+        kind: 'passed',
+        passed: false,
+        source: 'exit_code == 0',
+        exit_code: 1,
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unsupported restart result kinds', () => {
+    const result = stepAttemptDtoSchema.safeParse({
+      ...baseAttempt,
+      gate_result: null,
+      restart_result: {
+        kind: 'restart_exhausted',
+        reason: 'too many attempts',
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -5,6 +5,7 @@ const baseAttempt = {
   step_id: '22222222-2222-4222-8222-222222222222',
   job_id: '33333333-3333-4333-8333-333333333333',
   attempt: 1,
+  execution_order: 1,
   status: 'succeeded',
   exit_code: 0,
   output: null,
@@ -17,12 +18,34 @@ const baseAttempt = {
 
 describe('stepAttemptDtoSchema', () => {
   it('accepts an attempt with no gate or restart result', () => {
-    const attempt = {...baseAttempt, gate_result: null};
+    const attempt = {...baseAttempt, gate_result: {kind: 'none'}};
 
     const result = stepAttemptDtoSchema.parse(attempt);
 
-    expect(result.gate_result).toBeNull();
+    expect(result.gate_result).toEqual({kind: 'none'});
     expect(result.restart_result).toBeNull();
+  });
+
+  it('accepts not-evaluated and evaluation-error gate results', () => {
+    const notEvaluated = stepAttemptDtoSchema.parse({
+      ...baseAttempt,
+      gate_result: {kind: 'not_evaluated'},
+    });
+    const evaluationError = stepAttemptDtoSchema.parse({
+      ...baseAttempt,
+      gate_result: {
+        kind: 'evaluation_error',
+        reason: 'gate expression evaluation failed',
+        exit_code: 1,
+      },
+    });
+
+    expect(notEvaluated.gate_result).toEqual({kind: 'not_evaluated'});
+    expect(evaluationError.gate_result).toEqual({
+      kind: 'evaluation_error',
+      reason: 'gate expression evaluation failed',
+      exit_code: 1,
+    });
   });
 
   it('accepts typed gate and restart results', () => {
@@ -88,16 +111,21 @@ describe('stepAttemptDtoSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('rejects unsupported restart result kinds', () => {
-    const result = stepAttemptDtoSchema.safeParse({
+  it('accepts restart-exhausted results', () => {
+    const result = stepAttemptDtoSchema.parse({
       ...baseAttempt,
       gate_result: null,
       restart_result: {
         kind: 'restart_exhausted',
-        reason: 'too many attempts',
+        max_attempts: 3,
+        restart_from: 'producer',
       },
     });
 
-    expect(result.success).toBe(false);
+    expect(result.restart_result).toEqual({
+      kind: 'restart_exhausted',
+      max_attempts: 3,
+      restart_from: 'producer',
+    });
   });
 });

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -73,6 +73,12 @@ export type StepDto = z.infer<typeof stepDtoSchema>;
 export const stepGateResultDtoSchema = z
   .discriminatedUnion('kind', [
     z.object({
+      kind: z.literal('none'),
+    }),
+    z.object({
+      kind: z.literal('not_evaluated'),
+    }),
+    z.object({
       kind: z.literal('passed'),
       passed: z.literal(true),
       source: z.string(),
@@ -92,6 +98,11 @@ export const stepGateResultDtoSchema = z
       exit_code: z.number().int().nullable(),
     }),
     z.object({
+      kind: z.literal('evaluation_error'),
+      reason: z.string(),
+      exit_code: z.number().int().nullable(),
+    }),
+    z.object({
       kind: z.literal('unknown'),
       data: z.record(z.string(), z.unknown()),
     }),
@@ -101,10 +112,17 @@ export const stepGateResultDtoSchema = z
 export type StepGateResultDto = z.infer<typeof stepGateResultDtoSchema>;
 
 export const stepRestartResultDtoSchema = z
-  .object({
-    kind: z.literal('restart_enqueued'),
-    reason: z.string(),
-  })
+  .discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('restart_enqueued'),
+      reason: z.string(),
+    }),
+    z.object({
+      kind: z.literal('restart_exhausted'),
+      max_attempts: z.number().int().positive(),
+      restart_from: z.string(),
+    }),
+  ])
   .nullable();
 
 export type StepRestartResultDto = z.infer<typeof stepRestartResultDtoSchema>;

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -70,6 +70,45 @@ export const stepDtoSchema = z.object({
 
 export type StepDto = z.infer<typeof stepDtoSchema>;
 
+export const stepGateResultDtoSchema = z
+  .discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('passed'),
+      passed: z.literal(true),
+      source: z.string(),
+      exit_code: z.number().int().nullable(),
+    }),
+    z.object({
+      kind: z.literal('failed'),
+      passed: z.literal(false),
+      source: z.string(),
+      exit_code: z.number().int().nullable(),
+    }),
+    z.object({
+      kind: z.literal('uncheckable'),
+      passed: z.literal(false),
+      uncheckable: z.literal(true),
+      reason: z.string(),
+      exit_code: z.number().int().nullable(),
+    }),
+    z.object({
+      kind: z.literal('unknown'),
+      data: z.record(z.string(), z.unknown()),
+    }),
+  ])
+  .nullable();
+
+export type StepGateResultDto = z.infer<typeof stepGateResultDtoSchema>;
+
+export const stepRestartResultDtoSchema = z
+  .object({
+    kind: z.literal('restart_enqueued'),
+    reason: z.string(),
+  })
+  .nullable();
+
+export type StepRestartResultDto = z.infer<typeof stepRestartResultDtoSchema>;
+
 // One execution attempt of a step (the durable history behind the current
 // projection). Surfaced in run details so a restarted step's attempts are visible.
 export const stepAttemptDtoSchema = z.object({
@@ -80,14 +119,17 @@ export const stepAttemptDtoSchema = z.object({
   execution_order: z.number().int().positive(),
   status: z.string(),
   exit_code: z.number().int().nullable(),
-  // `output`, `error`, and `gate_result` are opaque audit blobs: the raw jsonb
-  // persisted for the attempt, NOT snake_case-normalized (their nested keys may
-  // be camelCase, e.g. `error.exitCode`). Consume the top-level snake_case
-  // `exit_code` for the numeric code; treat these as display/debug payloads.
+  // `output` and `error` are opaque audit blobs: the raw jsonb persisted for the
+  // attempt, NOT snake_case-normalized (their nested keys may be camelCase, e.g.
+  // `error.exitCode`). Consume the top-level snake_case `exit_code` for the
+  // numeric code; treat these as display/debug payloads.
   output: z.record(z.string(), z.unknown()).nullable(),
   error: z.record(z.string(), z.unknown()).nullable(),
-  gate_result: z.record(z.string(), z.unknown()).nullable(),
+  // `unknown.data` is the raw jsonb gate payload for legacy or unrecognized
+  // rows; nested keys are not snake_case-normalized.
+  gate_result: stepGateResultDtoSchema,
   restart_reason: z.string().nullable(),
+  restart_result: stepRestartResultDtoSchema,
   started_at: z.string(),
   finished_at: z.string().nullable(),
 });

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -5,6 +5,12 @@ import {
 } from '@shipfox/expression';
 import type {GateOutcome, StepResult} from './decide-step-transition.js';
 
+// The exact `uncheckable` reason recorded when the gate's CEL expression itself
+// throws (as opposed to a missing exit code). The DTO mapper keys on this string to
+// surface a distinct `evaluation_error` gate result, so the producer and the mapper
+// must share this constant rather than duplicating the literal.
+export const GATE_EVALUATION_ERROR_REASON = 'gate expression evaluation failed';
+
 // The gate as parsed from a step's materialized `config.gate` (snake_case JSON).
 export interface StepGate {
   successIf?: WorkflowExpression;
@@ -65,7 +71,7 @@ export function evaluateGate(gate: StepGate | undefined, result: StepResult): Ga
     return passed ? {kind: 'passed', source} : {kind: 'failed', source};
   } catch (error) {
     if (error instanceof WorkflowExpressionEvaluationError) {
-      return {kind: 'uncheckable', reason: 'gate expression evaluation failed'};
+      return {kind: 'uncheckable', reason: GATE_EVALUATION_ERROR_REASON};
     }
     throw error;
   }

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -110,6 +110,7 @@ const baseAttempt: StepAttempt = {
   stepId: '22222222-2222-4222-8222-222222222222',
   jobId: '33333333-3333-4333-8333-333333333333',
   attempt: 1,
+  executionOrder: 1,
   status: 'failed',
   output: null,
   error: null,
@@ -173,13 +174,41 @@ describe('toStepAttemptDto', () => {
     });
   });
 
-  it('maps missing gate and restart payloads to null results', () => {
+  it('maps missing gate payloads to an explicit none result', () => {
     const attempt: StepAttempt = {...baseAttempt, gateResult: null};
 
     const result = toStepAttemptDto(attempt);
 
-    expect(result.gate_result).toBeNull();
+    expect(result.gate_result).toEqual({kind: 'none'});
     expect(result.restart_result).toBeNull();
+  });
+
+  it('maps running attempts without gate payloads to not evaluated', () => {
+    const attempt: StepAttempt = {...baseAttempt, status: 'running', gateResult: null};
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toEqual({kind: 'not_evaluated'});
+  });
+
+  it('maps gate expression failures to typed evaluation errors', () => {
+    const attempt: StepAttempt = {
+      ...baseAttempt,
+      gateResult: {
+        passed: false,
+        uncheckable: true,
+        reason: 'gate expression evaluation failed',
+        exit_code: 1,
+      },
+    };
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'evaluation_error',
+      reason: 'gate expression evaluation failed',
+      exit_code: 1,
+    });
   });
 
   it('maps restart reasons to typed restart results', () => {
@@ -190,6 +219,44 @@ describe('toStepAttemptDto', () => {
     expect(result.restart_result).toEqual({
       kind: 'restart_enqueued',
       reason: 'gate condition not met',
+    });
+  });
+
+  it('maps restart-exhausted errors to typed restart results', () => {
+    const attempt: StepAttempt = {
+      ...baseAttempt,
+      error: {
+        kind: 'restart_exhausted',
+        maxAttempts: 3,
+        restart_from: 'producer',
+      },
+    };
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.restart_result).toEqual({
+      kind: 'restart_exhausted',
+      max_attempts: 3,
+      restart_from: 'producer',
+    });
+  });
+
+  it('maps restart-exhausted errors with camelCase restart targets', () => {
+    const attempt: StepAttempt = {
+      ...baseAttempt,
+      error: {
+        kind: 'restart_exhausted',
+        max_attempts: 3,
+        restartFrom: 'producer',
+      },
+    };
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.restart_result).toEqual({
+      kind: 'restart_exhausted',
+      max_attempts: 3,
+      restart_from: 'producer',
     });
   });
 

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -1,5 +1,5 @@
-import type {Step} from '#core/entities/step.js';
-import {fromStepErrorDto, toStepDto} from './step.js';
+import type {Step, StepAttempt} from '#core/entities/step.js';
+import {fromStepErrorDto, toStepAttemptDto, toStepDto} from './step.js';
 
 function step(overrides: Partial<Step> & {type: string}): Step {
   return {
@@ -102,5 +102,105 @@ describe('toStepDto error category', () => {
     const dto = toStepDto(step({type: 'setup', sourceLocation: null, error: null}));
 
     expect(dto.source_location).toBeNull();
+  });
+});
+
+const baseAttempt: StepAttempt = {
+  id: '11111111-1111-4111-8111-111111111111',
+  stepId: '22222222-2222-4222-8222-222222222222',
+  jobId: '33333333-3333-4333-8333-333333333333',
+  attempt: 1,
+  status: 'failed',
+  output: null,
+  error: null,
+  exitCode: 1,
+  gateResult: {passed: 'yes'},
+  restartReason: null,
+  startedAt: new Date('2026-01-01T00:00:00.000Z'),
+  finishedAt: new Date('2026-01-01T00:01:00.000Z'),
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+};
+
+describe('toStepAttemptDto', () => {
+  it('maps passed gate payloads to typed gate results', () => {
+    const attempt: StepAttempt = {
+      ...baseAttempt,
+      status: 'succeeded',
+      exitCode: 0,
+      gateResult: {passed: true, source: 'exit_code == 0', exit_code: 0},
+    };
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'passed',
+      passed: true,
+      source: 'exit_code == 0',
+      exit_code: 0,
+    });
+  });
+
+  it('maps failed gate payloads to typed gate results', () => {
+    const attempt: StepAttempt = {
+      ...baseAttempt,
+      gateResult: {passed: false, source: 'exit_code == 0', exit_code: 1},
+    };
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'failed',
+      passed: false,
+      source: 'exit_code == 0',
+      exit_code: 1,
+    });
+  });
+
+  it('maps uncheckable gate payloads before generic failed payloads', () => {
+    const attempt: StepAttempt = {
+      ...baseAttempt,
+      gateResult: {passed: false, uncheckable: true, reason: 'missing output', exit_code: null},
+    };
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'uncheckable',
+      passed: false,
+      uncheckable: true,
+      reason: 'missing output',
+      exit_code: null,
+    });
+  });
+
+  it('maps missing gate and restart payloads to null results', () => {
+    const attempt: StepAttempt = {...baseAttempt, gateResult: null};
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toBeNull();
+    expect(result.restart_result).toBeNull();
+  });
+
+  it('maps restart reasons to typed restart results', () => {
+    const attempt: StepAttempt = {...baseAttempt, restartReason: 'gate condition not met'};
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.restart_result).toEqual({
+      kind: 'restart_enqueued',
+      reason: 'gate condition not met',
+    });
+  });
+
+  it('maps legacy gate payloads to an explicit unknown result', () => {
+    const attempt = baseAttempt;
+
+    const result = toStepAttemptDto(attempt);
+
+    expect(result.gate_result).toEqual({
+      kind: 'unknown',
+      data: {passed: 'yes'},
+    });
   });
 });

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -8,6 +8,7 @@ import {
   stepErrorReasonSchema,
 } from '@shipfox/api-workflows-dto';
 import type {Step, StepAttempt} from '#core/entities/step.js';
+import {GATE_EVALUATION_ERROR_REASON} from '#core/step-transition/evaluate-gate.js';
 
 // Domain `error` is loosely typed (jsonb), so narrow it to the fixed runner
 // contract rather than trusting whatever shape the row happens to hold. `category`
@@ -53,8 +54,13 @@ function isIntOrNull(value: unknown): value is number | null {
   return value === null || (typeof value === 'number' && Number.isInteger(value));
 }
 
-function toStepGateResultDto(gateResult: Record<string, unknown> | null): StepGateResultDto {
-  if (gateResult === null) return null;
+function toStepGateResultDto(
+  gateResult: Record<string, unknown> | null,
+  status: string,
+): StepGateResultDto {
+  if (gateResult === null) {
+    return status === 'running' || status === 'pending' ? {kind: 'not_evaluated'} : {kind: 'none'};
+  }
 
   const exitCode = gateResult.exit_code;
   const passed = gateResult.passed;
@@ -71,6 +77,9 @@ function toStepGateResultDto(gateResult: Record<string, unknown> | null): StepGa
     typeof reason === 'string' &&
     isIntOrNull(exitCode)
   ) {
+    if (reason === GATE_EVALUATION_ERROR_REASON) {
+      return {kind: 'evaluation_error', reason, exit_code: exitCode};
+    }
     return {kind: 'uncheckable', passed, uncheckable: true, reason, exit_code: exitCode};
   }
 
@@ -81,7 +90,26 @@ function toStepGateResultDto(gateResult: Record<string, unknown> | null): StepGa
   return {kind: 'unknown', data: gateResult};
 }
 
-function toStepRestartResultDto(restartReason: string | null): StepRestartResultDto {
+function toStepRestartResultDto(
+  restartReason: string | null,
+  error: Record<string, unknown> | null,
+): StepRestartResultDto {
+  const maxAttempts = error?.maxAttempts ?? error?.max_attempts;
+  const restartFrom = error?.restartFrom ?? error?.restart_from;
+  if (
+    error?.kind === 'restart_exhausted' &&
+    typeof restartFrom === 'string' &&
+    typeof maxAttempts === 'number' &&
+    Number.isInteger(maxAttempts) &&
+    maxAttempts > 0
+  ) {
+    return {
+      kind: 'restart_exhausted',
+      max_attempts: maxAttempts,
+      restart_from: restartFrom,
+    };
+  }
+
   if (restartReason === null) return null;
   return {kind: 'restart_enqueued', reason: restartReason};
 }
@@ -125,9 +153,9 @@ export function toStepAttemptDto(attempt: StepAttempt): StepAttemptDto {
     exit_code: attempt.exitCode,
     output: attempt.output,
     error: attempt.error,
-    gate_result: toStepGateResultDto(attempt.gateResult),
+    gate_result: toStepGateResultDto(attempt.gateResult, attempt.status),
     restart_reason: attempt.restartReason,
-    restart_result: toStepRestartResultDto(attempt.restartReason),
+    restart_result: toStepRestartResultDto(attempt.restartReason, attempt.error),
     started_at: attempt.startedAt.toISOString(),
     finished_at: attempt.finishedAt ? attempt.finishedAt.toISOString() : null,
   };

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -3,6 +3,8 @@ import {
   type StepDto,
   type StepErrorCategory,
   type StepErrorDtoShape,
+  type StepGateResultDto,
+  type StepRestartResultDto,
   stepErrorReasonSchema,
 } from '@shipfox/api-workflows-dto';
 import type {Step, StepAttempt} from '#core/entities/step.js';
@@ -47,6 +49,43 @@ export function fromStepErrorDto(
   };
 }
 
+function isIntOrNull(value: unknown): value is number | null {
+  return value === null || (typeof value === 'number' && Number.isInteger(value));
+}
+
+function toStepGateResultDto(gateResult: Record<string, unknown> | null): StepGateResultDto {
+  if (gateResult === null) return null;
+
+  const exitCode = gateResult.exit_code;
+  const passed = gateResult.passed;
+  const source = gateResult.source;
+  const reason = gateResult.reason;
+
+  if (passed === true && typeof source === 'string' && isIntOrNull(exitCode)) {
+    return {kind: 'passed', passed, source, exit_code: exitCode};
+  }
+
+  if (
+    passed === false &&
+    gateResult.uncheckable === true &&
+    typeof reason === 'string' &&
+    isIntOrNull(exitCode)
+  ) {
+    return {kind: 'uncheckable', passed, uncheckable: true, reason, exit_code: exitCode};
+  }
+
+  if (passed === false && typeof source === 'string' && isIntOrNull(exitCode)) {
+    return {kind: 'failed', passed, source, exit_code: exitCode};
+  }
+
+  return {kind: 'unknown', data: gateResult};
+}
+
+function toStepRestartResultDto(restartReason: string | null): StepRestartResultDto {
+  if (restartReason === null) return null;
+  return {kind: 'restart_enqueued', reason: restartReason};
+}
+
 export function toStepDto(step: Step): StepDto {
   return {
     id: step.id,
@@ -86,8 +125,9 @@ export function toStepAttemptDto(attempt: StepAttempt): StepAttemptDto {
     exit_code: attempt.exitCode,
     output: attempt.output,
     error: attempt.error,
-    gate_result: attempt.gateResult,
+    gate_result: toStepGateResultDto(attempt.gateResult),
     restart_reason: attempt.restartReason,
+    restart_result: toStepRestartResultDto(attempt.restartReason),
     started_at: attempt.startedAt.toISOString(),
     finished_at: attempt.finishedAt ? attempt.finishedAt.toISOString() : null,
   };

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -338,7 +338,14 @@ jobs:
     const [step0, step1] = res.json().jobs[0].steps;
     expect(step0.current_attempt).toBe(1);
     expect(step0.attempts).toHaveLength(1);
-    expect(step0.attempts[0]).toMatchObject({attempt: 1, status: 'succeeded', exit_code: 0});
+    expect(step0.attempts[0]).toMatchObject({
+      attempt: 1,
+      status: 'succeeded',
+      exit_code: 0,
+      gate_result: null,
+      restart_reason: null,
+      restart_result: null,
+    });
     // A never-dispatched step has no attempt history yet.
     expect(step1.current_attempt).toBe(1);
     expect(step1.attempts).toEqual([]);
@@ -410,13 +417,30 @@ jobs:
       exit_code: number | null;
       gate_result: unknown;
       restart_reason: string | null;
+      restart_result: unknown;
     }>;
     expect(reviewerAttempts.map((a) => a.attempt)).toEqual([1, 2]); // ordered by attempt
     expect(reviewerAttempts[0]?.status).toBe('failed');
     expect(reviewerAttempts[0]?.exit_code).toBe(1);
-    expect(reviewerAttempts[0]?.gate_result).toMatchObject({passed: false});
-    expect(reviewerAttempts[0]?.restart_reason).toBeTruthy();
+    expect(reviewerAttempts[0]?.gate_result).toEqual({
+      kind: 'failed',
+      passed: false,
+      source: 'exit_code == 0',
+      exit_code: 1,
+    });
+    expect(reviewerAttempts[0]?.restart_reason).toBe('gate condition not met');
+    expect(reviewerAttempts[0]?.restart_result).toEqual({
+      kind: 'restart_enqueued',
+      reason: 'gate condition not met',
+    });
     expect(reviewerAttempts[1]?.status).toBe('succeeded');
     expect(reviewerAttempts[1]?.exit_code).toBe(0);
+    expect(reviewerAttempts[1]?.gate_result).toEqual({
+      kind: 'passed',
+      passed: true,
+      source: 'exit_code == 0',
+      exit_code: 0,
+    });
+    expect(reviewerAttempts[1]?.restart_result).toBeNull();
   });
 });

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -342,7 +342,7 @@ jobs:
       attempt: 1,
       status: 'succeeded',
       exit_code: 0,
-      gate_result: null,
+      gate_result: {kind: 'none'},
       restart_reason: null,
       restart_result: null,
     });

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -234,6 +234,7 @@ function attemptDto(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
     error: null,
     gate_result: null,
     restart_reason: null,
+    restart_result: null,
     started_at: '2026-05-07T01:01:10.000Z',
     finished_at: '2026-05-07T01:01:20.000Z',
     ...overrides,

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.test.ts
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.test.ts
@@ -201,7 +201,7 @@ describe('buildWorkflowStepListModel', () => {
         makeAttempt({
           error: {message: 'Opaque nested value', exitCode: 127},
           output: {tail: 'do not parse'},
-          gate_result: {status: 'do not parse'},
+          gate_result: {kind: 'unknown', data: {status: 'do not parse'}},
         }),
       ],
     });
@@ -289,6 +289,7 @@ function makeAttempt(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
     error: null,
     gate_result: null,
     restart_reason: null,
+    restart_result: null,
     started_at: '2026-06-21T12:00:00.000Z',
     finished_at: null,
     ...overrides,

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -391,6 +391,7 @@ function makeAttempt(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
     error: null,
     gate_result: null,
     restart_reason: null,
+    restart_result: null,
     started_at: '2026-06-21T12:00:00.000Z',
     finished_at: null,
     ...overrides,

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -217,6 +217,7 @@ function makeAttempt(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
     error: null,
     gate_result: null,
     restart_reason: null,
+    restart_result: null,
     started_at: '2026-06-21T12:00:00.000Z',
     finished_at: null,
     ...overrides,


### PR DESCRIPTION
Adds typed gate and restart result fields to workflow step attempt responses while preserving unknown legacy gate payloads for compatibility.

Workflow run consumers need a stable contract for gate and restart visualization instead of branching on opaque JSON blobs. This introduces discriminated DTO shapes for passed, failed, uncheckable, and unknown gate results, plus an additive restart result derived from the existing restart reason.

Existing `restart_reason` remains in the response for compatibility. Unknown persisted gate payloads are retained as raw data so older rows can still be inspected without trusting their shape.

Closes ENG-458

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed gate and restart result DTOs for workflow step attempts and ensures `gate_result` is explicit in route responses. Updates mappers and tests so the Workflow Run page gets a stable, clear contract (ENG-458).

- New Features
  - Export `StepGateResultDto`/`stepGateResultDtoSchema` and `StepRestartResultDto`/`stepRestartResultDtoSchema` from `@shipfox/api-workflows-dto`.
  - `gate_result` is a discriminated union: `none`, `not_evaluated`, `passed`, `failed`, `uncheckable`, `evaluation_error` (via shared reason), or `unknown` (for legacy payloads). Running/pending map to `not_evaluated`; route responses always return an explicit value.
  - `restart_result` is typed: `restart_enqueued` (from `restart_reason`) or `restart_exhausted` (derived from error; supports camelCase/snake_case).
  - `toStepAttemptDto` maps raw gate/restart data to these types and uses the shared evaluation error constant; updated DTO, mapper, route, and client tests assert typed shapes.

- Migration
  - No breaking changes. `restart_reason` remains for compatibility.

<sup>Written for commit a773f5b63e92a9829b531911d0e317aa76766485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

