### PR TITLE
[client-projects] Add workflow source view

### DIFF
--- a/libs/client/projects/src/components/workflow-source-view.test.tsx
+++ b/libs/client/projects/src/components/workflow-source-view.test.tsx
@@ -123,6 +123,43 @@ describe('WorkflowSourceView', () => {
     expect(screen.getByText('jobs:').textContent).toBe('jobs:');
   });
 
+  describe('inline variant', () => {
+    test('renders the line-numbered body with a highlighted range and no card header', () => {
+      render(
+        <WorkflowSourceView
+          source={workflowSourceFixture}
+          selectedRange={workflowSourceFixtureRange}
+          variant="inline"
+        />,
+      );
+
+      expect(screen.getByRole('region', {name: 'Workflow source'})).toBeInTheDocument();
+      expect(screen.queryByText('Source')).not.toBeInTheDocument();
+      expect(screen.queryByText('.shipfox/workflows/deploy.yml')).not.toBeInTheDocument();
+      expect(screen.getByText('name: deploy-production')).toBeInTheDocument();
+      expect(screen.getByText('Selected step: Build')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-highlighted="true"]')).toHaveLength(4);
+    });
+
+    test('renders the missing-location state without highlighted lines', () => {
+      render(
+        <WorkflowSourceView source={workflowSourceFixture} selectedRange={null} variant="inline" />,
+      );
+
+      expect(screen.getByText('No step source location')).toBeInTheDocument();
+      expect(document.querySelectorAll('[data-highlighted="true"]')).toHaveLength(0);
+    });
+
+    test('renders the missing-source state for empty source content', () => {
+      render(<WorkflowSourceView source={{content: '', format: 'yaml'}} variant="inline" />);
+
+      expect(screen.getByText('No source document')).toBeInTheDocument();
+      expect(
+        screen.getByText('The workflow source snapshot is not available for this run.'),
+      ).toBeInTheDocument();
+    });
+  });
+
   test('keeps long source lines intact for horizontal scrolling', () => {
     render(
       <WorkflowSourceView

--- a/libs/client/projects/src/components/workflow-source-view.test.tsx
+++ b/libs/client/projects/src/components/workflow-source-view.test.tsx
@@ -1,0 +1,145 @@
+import {render, screen, within} from '@testing-library/react';
+import {
+  type WorkflowSourceDocument,
+  type WorkflowSourceLineRange,
+  WorkflowSourceView,
+} from './workflow-source-view.js';
+
+const workflowSourceFixture: WorkflowSourceDocument = {
+  path: '.shipfox/workflows/deploy.yml',
+  format: 'yaml',
+  content: [
+    'name: deploy-production',
+    'on:',
+    '  push:',
+    '    branches:',
+    '      - main',
+    '',
+    'jobs:',
+    '  build:',
+    '    runs-on: ubuntu-latest',
+    '    steps:',
+    '      - uses: actions/checkout@v4',
+    '      - name: Install dependencies',
+    '        run: pnpm install --frozen-lockfile',
+    '      - name: Build',
+    '        run: pnpm turbo build --filter=@shipfox/client...',
+    '  deploy:',
+    '    needs: build',
+    '    steps:',
+    '      - name: Publish image',
+    '        run: ./scripts/publish-image.sh production',
+  ].join('\n'),
+};
+
+const workflowSourceFixtureRange: WorkflowSourceLineRange = {
+  startLine: 12,
+  endLine: 15,
+  label: 'Selected step: Build',
+};
+
+function WorkflowSourceViewFixture({
+  selectedRange = workflowSourceFixtureRange,
+}: {
+  selectedRange?: WorkflowSourceLineRange | null;
+}) {
+  return <WorkflowSourceView source={workflowSourceFixture} selectedRange={selectedRange} />;
+}
+
+describe('WorkflowSourceView', () => {
+  test('renders source metadata, line count, and line numbers', () => {
+    render(<WorkflowSourceViewFixture />);
+
+    expect(screen.getByRole('region', {name: 'Workflow source'})).toBeInTheDocument();
+    expect(screen.getByText('.shipfox/workflows/deploy.yml')).toBeInTheDocument();
+    expect(screen.getByText('yaml')).toBeInTheDocument();
+    expect(screen.getByText('20 lines')).toBeInTheDocument();
+    expect(screen.getByText('name: deploy-production')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+  });
+
+  test('highlights the selected source range', () => {
+    render(<WorkflowSourceViewFixture />);
+
+    expect(screen.getByText('Selected step: Build')).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Workflow source code'})).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
+
+    const highlightedLines = document.querySelectorAll('[data-highlighted="true"]');
+    expect(highlightedLines).toHaveLength(4);
+    expect(within(highlightedLines[0] as HTMLElement).getByText('12')).toBeInTheDocument();
+    expect(highlightedLines[3]?.textContent).toBe(
+      '15        run: pnpm turbo build --filter=@shipfox/client...',
+    );
+  });
+
+  test('uses a line-range label when selected range metadata has no label', () => {
+    render(<WorkflowSourceViewFixture selectedRange={{startLine: 12, endLine: 15}} />);
+
+    expect(screen.getByText('Lines 12-15')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-highlighted="true"]')).toHaveLength(4);
+  });
+
+  test('renders the missing-location state without highlighted lines', () => {
+    render(<WorkflowSourceViewFixture selectedRange={null} />);
+
+    expect(screen.getByText('No step source location')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-highlighted="true"]')).toHaveLength(0);
+  });
+
+  test('does not highlight a stale source range outside the document', () => {
+    render(<WorkflowSourceViewFixture selectedRange={{startLine: 100, endLine: 104}} />);
+
+    expect(screen.getByText('No step source location')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-highlighted="true"]')).toHaveLength(0);
+  });
+
+  test('renders the missing-source state for empty source content', () => {
+    render(<WorkflowSourceView source={{content: '', format: 'yaml'}} />);
+
+    expect(screen.getByText('No source document')).toBeInTheDocument();
+    expect(
+      screen.getByText('The workflow source snapshot is not available for this run.'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders a single-line source without adding a trailing blank line', () => {
+    render(<WorkflowSourceView source={{content: 'name: deploy-production\n', format: 'yaml'}} />);
+
+    expect(screen.getByText('1 line')).toBeInTheDocument();
+    expect(screen.getByText('name: deploy-production')).toBeInTheDocument();
+    expect(screen.queryByText('2')).not.toBeInTheDocument();
+  });
+
+  test('normalizes CRLF source content', () => {
+    render(
+      <WorkflowSourceView source={{content: 'name: deploy\r\njobs:\r\n  test:', format: 'yaml'}} />,
+    );
+
+    expect(screen.getByText('3 lines')).toBeInTheDocument();
+    expect(screen.getByText('name: deploy').textContent).toBe('name: deploy');
+    expect(screen.getByText('jobs:').textContent).toBe('jobs:');
+  });
+
+  test('keeps long source lines intact for horizontal scrolling', () => {
+    render(
+      <WorkflowSourceView
+        source={{
+          ...workflowSourceFixture,
+          content: [
+            workflowSourceFixture.content,
+            '      - run: node ./scripts/deploy.js --environment production --region us-east-1 --image ghcr.io/shipfox/platform/worker:sha-0123456789abcdef',
+          ].join('\n'),
+        }}
+        selectedRange={{...workflowSourceFixtureRange, startLine: 21, endLine: 21}}
+      />,
+    );
+
+    expect(screen.getByText('21').closest('[data-highlighted="true"]')?.textContent).toBe(
+      '21      - run: node ./scripts/deploy.js --environment production --region us-east-1 --image ghcr.io/shipfox/platform/worker:sha-0123456789abcdef',
+    );
+    expect(screen.getByText('21 lines')).toBeInTheDocument();
+  });
+});

--- a/libs/client/projects/src/components/workflow-source-view.tsx
+++ b/libs/client/projects/src/components/workflow-source-view.tsx
@@ -1,0 +1,187 @@
+import {Code, EmptyState, Text} from '@shipfox/react-ui';
+
+export type WorkflowSourceLineRange = {
+  startLine: number;
+  endLine: number;
+  label?: string;
+};
+
+export type WorkflowSourceDocument = {
+  content: string | null | undefined;
+  format?: string;
+  path?: string | null;
+};
+
+export type WorkflowSourceViewProps = {
+  source: WorkflowSourceDocument | null | undefined;
+  selectedRange?: WorkflowSourceLineRange | null;
+  className?: string;
+};
+
+type SourceLine = {
+  number: number;
+  text: string;
+};
+
+const TRAILING_NEWLINE_REGEX = /\n$/;
+const CRLF_REGEX = /\r\n/g;
+
+export function WorkflowSourceView({source, selectedRange, className}: WorkflowSourceViewProps) {
+  const sourceContent = source?.content ?? '';
+  const hasSourceContent = sourceContent.trim().length > 0;
+
+  return (
+    <section
+      aria-label="Workflow source"
+      className={`overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base${
+        className ? ` ${className}` : ''
+      }`}
+    >
+      <div className="flex h-44 items-center justify-between gap-16 border-border-neutral-base border-b px-16">
+        <div className="min-w-0">
+          <Text size="sm" bold className="truncate">
+            Source
+          </Text>
+          {source?.path ? (
+            <Code variant="label" className="truncate text-foreground-neutral-muted">
+              {source.path}
+            </Code>
+          ) : null}
+        </div>
+        <Code
+          as="span"
+          variant="label"
+          className="shrink-0 rounded-4 border border-border-neutral-base bg-background-components-base px-6 py-2 text-foreground-neutral-muted uppercase"
+        >
+          {source?.format ?? 'source'}
+        </Code>
+      </div>
+
+      {hasSourceContent ? (
+        <SourceCodePanel content={sourceContent} selectedRange={selectedRange} />
+      ) : (
+        <div className="min-h-220">
+          <EmptyState
+            icon="fileDamageLine"
+            title="No source document"
+            description="The workflow source snapshot is not available for this run."
+            variant="default"
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SourceCodePanel({
+  content,
+  selectedRange,
+}: {
+  content: string;
+  selectedRange: WorkflowSourceLineRange | null | undefined;
+}) {
+  const lines = splitSourceLines(content);
+  const normalizedRange = normalizeRange(selectedRange, lines.length);
+
+  return (
+    <div>
+      <div className="flex h-36 items-center justify-between gap-12 border-border-neutral-base border-b bg-background-neutral-background px-16">
+        <Text size="xs" className="text-foreground-neutral-muted">
+          {normalizedRange
+            ? (selectedRange?.label ??
+              `Lines ${normalizedRange.startLine}-${normalizedRange.endLine}`)
+            : 'No step source location'}
+        </Text>
+        <Text size="xs" className="text-foreground-neutral-muted tabular-nums">
+          {lines.length} {lines.length === 1 ? 'line' : 'lines'}
+        </Text>
+      </div>
+      <section
+        aria-label="Workflow source code"
+        className="max-h-520 overflow-auto bg-background-contrast-base py-8 scrollbar"
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need focus to scroll long source documents.
+        tabIndex={0}
+      >
+        <pre>
+          <code className="block min-w-max font-code text-sm leading-20">
+            {lines.map((line) => (
+              <SourceCodeLine
+                key={line.number}
+                line={line}
+                isHighlighted={isLineInRange(line.number, normalizedRange)}
+              />
+            ))}
+          </code>
+        </pre>
+      </section>
+    </div>
+  );
+}
+
+function SourceCodeLine({line, isHighlighted}: {line: SourceLine; isHighlighted: boolean}) {
+  return (
+    <span
+      className={`grid grid-cols-[56px_minmax(0,1fr)] border-l-2 pr-16${
+        isHighlighted
+          ? ' border-border-highlights-interactive bg-background-highlight-base'
+          : ' border-transparent'
+      }`}
+      data-highlighted={isHighlighted ? 'true' : undefined}
+    >
+      <span
+        className={`select-none px-12 text-right tabular-nums${
+          isHighlighted
+            ? ' text-foreground-highlight-interactive'
+            : ' text-foreground-neutral-muted'
+        }`}
+        aria-hidden="true"
+      >
+        {line.number}
+      </span>
+      <span
+        className={
+          isHighlighted
+            ? 'whitespace-pre text-foreground-neutral-base'
+            : 'whitespace-pre text-foreground-neutral-on-inverted dark:text-foreground-neutral-base'
+        }
+      >
+        {line.text || ' '}
+      </span>
+    </span>
+  );
+}
+
+function splitSourceLines(content: string): SourceLine[] {
+  const lines = content.replace(CRLF_REGEX, '\n').replace(TRAILING_NEWLINE_REGEX, '').split('\n');
+  return lines.map((text, index) => ({number: index + 1, text}));
+}
+
+function normalizeRange(
+  range: WorkflowSourceLineRange | null | undefined,
+  lineCount: number,
+): WorkflowSourceLineRange | null {
+  if (!range) return null;
+
+  const startLine = Math.floor(range.startLine);
+  const endLine = Math.floor(range.endLine);
+
+  if (
+    !Number.isFinite(startLine) ||
+    !Number.isFinite(endLine) ||
+    startLine < 1 ||
+    endLine < startLine ||
+    startLine > lineCount
+  ) {
+    return null;
+  }
+
+  return {
+    startLine,
+    endLine: Math.min(lineCount, endLine),
+    ...(range.label ? {label: range.label} : {}),
+  };
+}
+
+function isLineInRange(lineNumber: number, range: WorkflowSourceLineRange | null) {
+  return range ? lineNumber >= range.startLine && lineNumber <= range.endLine : false;
+}

--- a/libs/client/projects/src/components/workflow-source-view.tsx
+++ b/libs/client/projects/src/components/workflow-source-view.tsx
@@ -12,9 +12,12 @@ export type WorkflowSourceDocument = {
   path?: string | null;
 };
 
+export type WorkflowSourceViewVariant = 'panel' | 'inline';
+
 export type WorkflowSourceViewProps = {
   source: WorkflowSourceDocument | null | undefined;
   selectedRange?: WorkflowSourceLineRange | null;
+  variant?: WorkflowSourceViewVariant | undefined;
   className?: string;
 };
 
@@ -26,9 +29,35 @@ type SourceLine = {
 const TRAILING_NEWLINE_REGEX = /\n$/;
 const CRLF_REGEX = /\r\n/g;
 
-export function WorkflowSourceView({source, selectedRange, className}: WorkflowSourceViewProps) {
+export function WorkflowSourceView({
+  source,
+  selectedRange,
+  variant = 'panel',
+  className,
+}: WorkflowSourceViewProps) {
   const sourceContent = source?.content ?? '';
   const hasSourceContent = sourceContent.trim().length > 0;
+
+  const body = hasSourceContent ? (
+    <SourceCodePanel content={sourceContent} selectedRange={selectedRange} />
+  ) : (
+    <div className="min-h-220">
+      <EmptyState
+        icon="fileDamageLine"
+        title="No source document"
+        description="The workflow source snapshot is not available for this run."
+        variant="default"
+      />
+    </div>
+  );
+
+  if (variant === 'inline') {
+    return (
+      <section aria-label="Workflow source" className={className}>
+        {body}
+      </section>
+    );
+  }
 
   return (
     <section
@@ -57,18 +86,7 @@ export function WorkflowSourceView({source, selectedRange, className}: WorkflowS
         </Code>
       </div>
 
-      {hasSourceContent ? (
-        <SourceCodePanel content={sourceContent} selectedRange={selectedRange} />
-      ) : (
-        <div className="min-h-220">
-          <EmptyState
-            icon="fileDamageLine"
-            title="No source document"
-            description="The workflow source snapshot is not available for this run."
-            variant="default"
-          />
-        </div>
-      )}
+      {body}
     </section>
   );
 }


### PR DESCRIPTION
Add a reusable Workflow Run Page source view component for inspecting the workflow document behind a run.

The component renders source content with stable line numbers, preserves long YAML lines inside a scrollable code surface, and highlights the selected step range when line-location data is available. It also shows explicit states when the source snapshot is missing or when no step source location is available.

This keeps the source view ready for the later workflow source snapshot and line-location contracts without wiring to those DTOs in this component PR. Real run DTO integration and page-level visual capture belong with the source contract and final Workflow Run Page composition work.

Validation covered the source-present, missing-source, missing-location, stale range, no-label range, single-line, CRLF, trailing-newline, long-line, and keyboard-scroll states, plus dependency-aware build/type/check runs for the affected client surface.

Closes ENG-457

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `WorkflowSourceView` for the Workflow Run Page that renders the workflow document with line numbers, shows path/format, and highlights an optional step range. Adds an `inline` variant for embedding in step lists. Supports ENG-457 and readies the UI for source snapshots and line-location data.

- **New Features**
  - Renders source with stable line numbers in a scrollable code area; shows file path and format tag.
  - Highlights a selected line range with label fallback; ignores invalid/out-of-bounds ranges; clear missing-source and missing-location states; keyboard-focusable with line count; normalizes CRLF and trailing newline; keeps long lines intact.
  - Adds `inline` variant (no outer card/header) that keeps the line-numbered body and all states; built with `@shipfox/react-ui` and covered by component tests.

<sup>Written for commit 503fd842fd4b2364aeff0c725620731cecd5ce66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

