### PR TITLE
Propagate projectId end-to-end via the job lease

### DIFF
--- a/.changeset/eng-467-projectid-lease-claim.md
+++ b/.changeset/eng-467-projectid-lease-claim.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-auth-dto": patch
+"@shipfox/api-auth": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-workflows": patch
+---
+
+Propagates `projectId` end-to-end into the job lease token. Workflows sources the `{workspaceId, projectId, runId}` identity tuple from the loaded run and threads `projectId` through the runner pending/running job tables and the lease claims, so a claimed job's lease now carries a signed `projectId` alongside `runId`, `workspaceId`, and `jobId`. This is lease-shape groundwork for per-project log-ingest authorization; the stream-stamping consumer lands separately.

--- a/libs/api/auth-dto/src/schemas/job-lease-token.ts
+++ b/libs/api/auth-dto/src/schemas/job-lease-token.ts
@@ -10,6 +10,7 @@ export const JOB_LEASE_TOKEN_AUDIENCE = 'runner-job-lease';
 export const jobLeaseTokenClaimsSchema = z.object({
   jobId: z.string().uuid(),
   runId: z.string().uuid(),
+  projectId: z.string().uuid(),
   workspaceId: z.string().uuid(),
   runnerTokenId: z.string().uuid(),
   aud: z.literal(JOB_LEASE_TOKEN_AUDIENCE),

--- a/libs/api/auth/src/core/job-lease-token.test.ts
+++ b/libs/api/auth/src/core/job-lease-token.test.ts
@@ -9,6 +9,7 @@ function claims() {
   return {
     jobId: crypto.randomUUID(),
     runId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
     workspaceId: crypto.randomUUID(),
     runnerTokenId: crypto.randomUUID(),
   };
@@ -24,6 +25,7 @@ describe('job-lease-token', () => {
     expect(verified).not.toBeNull();
     expect(verified?.jobId).toBe(input.jobId);
     expect(verified?.runId).toBe(input.runId);
+    expect(verified?.projectId).toBe(input.projectId);
     expect(verified?.workspaceId).toBe(input.workspaceId);
     expect(verified?.runnerTokenId).toBe(input.runnerTokenId);
     expect(verified?.aud).toBe(JOB_LEASE_TOKEN_AUDIENCE);
@@ -35,6 +37,7 @@ describe('job-lease-token', () => {
     const input = {
       jobId: '018f6b1e-7e2a-7b3c-8d4e-5f6a7b8c9d0e',
       runId: '018f6b1e-7e2a-7b3c-8d4e-5f6a7b8c9d0f',
+      projectId: crypto.randomUUID(),
       workspaceId: crypto.randomUUID(),
       runnerTokenId: crypto.randomUUID(),
     };
@@ -113,12 +116,20 @@ describe('job-lease-token', () => {
 
   test('returns null for a token whose claims fail the schema (non-uuid jobId)', async () => {
     const token = await signHs256({
-      payload: {
-        jobId: 'not-a-uuid',
-        runId: crypto.randomUUID(),
-        workspaceId: crypto.randomUUID(),
-        runnerTokenId: crypto.randomUUID(),
-      },
+      payload: {...claims(), jobId: 'not-a-uuid'},
+      secret: SECRET,
+      expiresIn: '90m',
+      audience: JOB_LEASE_TOKEN_AUDIENCE,
+    });
+
+    const verified = await verifyJobLeaseToken(token);
+
+    expect(verified).toBeNull();
+  });
+
+  test('returns null for a token whose claims fail the schema (non-uuid projectId)', async () => {
+    const token = await signHs256({
+      payload: {...claims(), projectId: 'not-a-uuid'},
       secret: SECRET,
       expiresIn: '90m',
       audience: JOB_LEASE_TOKEN_AUDIENCE,

--- a/libs/api/auth/src/core/job-lease-token.ts
+++ b/libs/api/auth/src/core/job-lease-token.ts
@@ -14,6 +14,7 @@ export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Prom
     payload: {
       jobId: claims.jobId,
       runId: claims.runId,
+      projectId: claims.projectId,
       workspaceId: claims.workspaceId,
       runnerTokenId: claims.runnerTokenId,
     },

--- a/libs/api/auth/src/presentation/auth/lease-token-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/lease-token-auth.test.ts
@@ -33,6 +33,7 @@ describe('lease-token-auth', () => {
     const claims = {
       jobId: crypto.randomUUID(),
       runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
       workspaceId: crypto.randomUUID(),
       runnerTokenId: crypto.randomUUID(),
     };

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -11,6 +11,7 @@ CREATE TABLE "runners_pending_jobs" (
 	"workspace_id" uuid NOT NULL,
 	"job_id" uuid NOT NULL,
 	"run_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "runners_pending_jobs_job_id_unique" UNIQUE("job_id")
 );
@@ -20,6 +21,7 @@ CREATE TABLE "runners_running_jobs" (
 	"workspace_id" uuid NOT NULL,
 	"job_id" uuid NOT NULL,
 	"run_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
 	"runner_token" text NOT NULL,
 	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"last_heartbeat_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -95,6 +95,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp with time zone",
@@ -158,6 +164,12 @@
         },
         "run_id": {
           "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
           "type": "uuid",
           "primaryKey": false,
           "notNull": true

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -17,6 +17,7 @@ export async function claimJob(params: {
   const leaseToken = await issueJobLeaseToken({
     jobId: claimed.jobId,
     runId: claimed.runId,
+    projectId: claimed.projectId,
     workspaceId: params.workspaceId,
     runnerTokenId: params.runnerTokenId,
   });

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -27,20 +27,27 @@ describe('scheduleJob', () => {
     const jobId = crypto.randomUUID();
     const runId = crypto.randomUUID();
     const workspaceId = crypto.randomUUID();
+    const projectId = crypto.randomUUID();
 
-    await scheduleJob({workspaceId, jobId, runId});
+    await scheduleJob({workspaceId, jobId, runId, projectId});
 
     const rows = await db().select().from(pendingJobs);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.jobId).toBe(jobId);
     expect(rows[0]?.runId).toBe(runId);
+    expect(rows[0]?.projectId).toBe(projectId);
     expect(rows[0]?.workspaceId).toBe(workspaceId);
     expect(rows[0]).not.toHaveProperty('payload');
   });
 
   it('is idempotent: scheduling the same jobId twice is a no-op', async () => {
     const jobId = crypto.randomUUID();
-    const params = {workspaceId: crypto.randomUUID(), runId: crypto.randomUUID(), jobId};
+    const params = {
+      workspaceId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      jobId,
+    };
 
     await scheduleJob(params);
     await expect(scheduleJob(params)).resolves.toBeUndefined();
@@ -71,6 +78,7 @@ describe('claimPendingJob', () => {
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
     expect(claimed?.runId).toBe(created.runId);
+    expect(claimed?.projectId).toBe(created.projectId);
   });
 
   it('returns null when no jobs are pending', async () => {
@@ -102,7 +110,7 @@ describe('claimPendingJob', () => {
   });
 
   it('moves the job from pending to running', async () => {
-    await pendingJobFactory.create({workspaceId});
+    const created = await pendingJobFactory.create({workspaceId});
 
     await claimPendingJob({workspaceId, runnerTokenId});
 
@@ -111,6 +119,7 @@ describe('claimPendingJob', () => {
     expect(pending).toHaveLength(0);
     expect(running).toHaveLength(1);
     expect(running[0]?.runnerTokenId).toBe(runnerTokenId);
+    expect(running[0]?.projectId).toBe(created.projectId);
   });
 
   it('does not claim jobs from another workspace', async () => {
@@ -127,9 +136,12 @@ describe('claimPendingJob', () => {
     expect(first?.jobId).toBe(created.jobId);
 
     // Simulate an enqueue retry that re-inserts a pending row after the claim.
-    await db()
-      .insert(pendingJobs)
-      .values({workspaceId, jobId: created.jobId, runId: created.runId});
+    await db().insert(pendingJobs).values({
+      workspaceId,
+      jobId: created.jobId,
+      runId: created.runId,
+      projectId: created.projectId,
+    });
 
     const second = await claimPendingJob({workspaceId, runnerTokenId});
 
@@ -146,9 +158,12 @@ describe('claimPendingJob', () => {
 
     // A genuinely new pending job (older), then an orphan re-insert for the running job (newer).
     const real = await pendingJobFactory.create({workspaceId});
-    await db()
-      .insert(pendingJobs)
-      .values({workspaceId, jobId: alreadyRunning.jobId, runId: alreadyRunning.runId});
+    await db().insert(pendingJobs).values({
+      workspaceId,
+      jobId: alreadyRunning.jobId,
+      runId: alreadyRunning.runId,
+      projectId: alreadyRunning.projectId,
+    });
 
     const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
@@ -183,6 +198,7 @@ describe('claimJob', () => {
     expect(claims).toMatchObject({
       jobId: created.jobId,
       runId: created.runId,
+      projectId: created.projectId,
       workspaceId,
       runnerTokenId,
     });
@@ -238,7 +254,12 @@ describe('releaseJob', () => {
     // An orphan pending row left by a post-claim enqueue retry.
     await db()
       .insert(pendingJobs)
-      .values({workspaceId, jobId: claimed?.jobId as string, runId: claimed?.runId as string});
+      .values({
+        workspaceId,
+        jobId: claimed?.jobId as string,
+        runId: claimed?.runId as string,
+        projectId: claimed?.projectId as string,
+      });
 
     await releaseJob({jobId: claimed?.jobId as string});
 
@@ -380,7 +401,9 @@ describe('detectAndExpireStuckJobs', () => {
     runnerTokenId = runnerToken.id;
   });
 
-  async function makeStaleJob(staleSeconds: number): Promise<{jobId: string; runId: string}> {
+  async function makeStaleJob(
+    staleSeconds: number,
+  ): Promise<{jobId: string; runId: string; projectId: string}> {
     await pendingJobFactory.create({workspaceId});
     const claimed = await claimPendingJob({workspaceId, runnerTokenId});
     await db()
@@ -389,7 +412,11 @@ describe('detectAndExpireStuckJobs', () => {
         lastHeartbeatAt: sql`now() - (${staleSeconds} || ' seconds')::interval`,
       })
       .where(eq(runningJobs.jobId, claimed?.jobId as string));
-    return {jobId: claimed?.jobId as string, runId: claimed?.runId as string};
+    return {
+      jobId: claimed?.jobId as string,
+      runId: claimed?.runId as string,
+      projectId: claimed?.projectId as string,
+    };
   }
 
   async function runningJobsForTest() {
@@ -477,10 +504,10 @@ describe('detectAndExpireStuckJobs', () => {
   });
 
   it('sweeps an orphan pending row for the job it reaps (best-effort release may have failed)', async () => {
-    const {jobId, runId} = await makeStaleJob(600);
+    const {jobId, runId, projectId} = await makeStaleJob(600);
     // A post-claim enqueue retry left a pending row whose job is already running;
     // without this sweep it would stay re-claimable for an already-finished job.
-    await db().insert(pendingJobs).values({workspaceId, jobId, runId});
+    await db().insert(pendingJobs).values({workspaceId, jobId, runId, projectId});
 
     await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
@@ -491,8 +518,8 @@ describe('detectAndExpireStuckJobs', () => {
   });
 
   it('leaves the orphan pending row alone when the running row is not stale enough to reap', async () => {
-    const {jobId, runId} = await makeStaleJob(60);
-    await db().insert(pendingJobs).values({workspaceId, jobId, runId});
+    const {jobId, runId, projectId} = await makeStaleJob(60);
+    await db().insert(pendingJobs).values({workspaceId, jobId, runId, projectId});
 
     await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
@@ -538,9 +565,9 @@ describe('detectAndExpireStuckJobs', () => {
   });
 
   it('a reaper tick and a concurrent claim of the same orphan-pending job leave consistent state', async () => {
-    const {jobId, runId} = await makeStaleJob(600);
+    const {jobId, runId, projectId} = await makeStaleJob(600);
     // Orphan pending row from a post-claim enqueue retry for an already-running job.
-    await db().insert(pendingJobs).values({workspaceId, jobId, runId});
+    await db().insert(pendingJobs).values({workspaceId, jobId, runId, projectId});
 
     // The reaper locks running-then-pending while the claim locks pending-then-running;
     // a deadlock loser rolls back, so either side may settle as rejected.

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -11,6 +11,7 @@ export interface ScheduleJobParams {
   workspaceId: string;
   jobId: string;
   runId: string;
+  projectId: string;
 }
 
 // Idempotent while the job is still pending: a duplicate jobId already in
@@ -27,6 +28,7 @@ export async function scheduleJob(params: ScheduleJobParams): Promise<void> {
       workspaceId: params.workspaceId,
       jobId: params.jobId,
       runId: params.runId,
+      projectId: params.projectId,
     })
     .onConflictDoNothing({target: pendingJobs.jobId});
 }
@@ -34,6 +36,7 @@ export async function scheduleJob(params: ScheduleJobParams): Promise<void> {
 export interface ClaimedJob {
   jobId: string;
   runId: string;
+  projectId: string;
 }
 
 export async function claimPendingJob(params: {
@@ -67,6 +70,7 @@ export async function claimPendingJob(params: {
         workspaceId: row.workspaceId,
         jobId: row.jobId,
         runId: row.runId,
+        projectId: row.projectId,
         runnerTokenId: params.runnerTokenId,
       })
       .onConflictDoNothing({target: runningJobs.jobId})
@@ -77,6 +81,7 @@ export async function claimPendingJob(params: {
     return {
       jobId: row.jobId,
       runId: row.runId,
+      projectId: row.projectId,
     };
   });
 }

--- a/libs/api/runners/src/db/schema/pending-jobs.ts
+++ b/libs/api/runners/src/db/schema/pending-jobs.ts
@@ -9,6 +9,7 @@ export const pendingJobs = pgTable(
     workspaceId: uuid('workspace_id').notNull(),
     jobId: uuid('job_id').notNull().unique(),
     runId: uuid('run_id').notNull(),
+    projectId: uuid('project_id').notNull(),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
   },
   (table) => [

--- a/libs/api/runners/src/db/schema/running-jobs.ts
+++ b/libs/api/runners/src/db/schema/running-jobs.ts
@@ -9,6 +9,7 @@ export const runningJobs = pgTable(
     workspaceId: uuid('workspace_id').notNull(),
     jobId: uuid('job_id').notNull().unique(),
     runId: uuid('run_id').notNull(),
+    projectId: uuid('project_id').notNull(),
     runnerTokenId: uuid('runner_token_id').notNull(),
     startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
     lastHeartbeatAt: timestamp('last_heartbeat_at', {withTimezone: true}).notNull().defaultNow(),

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -89,6 +89,7 @@ describe('POST /runners/jobs/request', () => {
     expect(claims).toMatchObject({
       jobId: created.jobId,
       runId: created.runId,
+      projectId: created.projectId,
       workspaceId,
       runnerTokenId,
     });

--- a/libs/api/runners/test/factories/pending-job.ts
+++ b/libs/api/runners/test/factories/pending-job.ts
@@ -5,18 +5,21 @@ interface PendingJobAttrs {
   workspaceId: string;
   jobId: string;
   runId: string;
+  projectId: string;
 }
 
 export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) => {
   const jobId = crypto.randomUUID();
   const runId = crypto.randomUUID();
   const workspaceId = crypto.randomUUID();
+  const projectId = crypto.randomUUID();
 
   onCreate(async (attrs) => {
     await scheduleJob({
       workspaceId: attrs.workspaceId,
       jobId: attrs.jobId,
       runId: attrs.runId,
+      projectId: attrs.projectId,
     });
     return attrs;
   });
@@ -25,5 +28,6 @@ export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) =>
     workspaceId,
     jobId,
     runId,
+    projectId,
   };
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
@@ -2,7 +2,7 @@ import {ApplicationFailure} from '@temporalio/common';
 import {createWorkflowRun, getJobsByRunId, updateJobStatus} from '#db/index.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
-import {resolveLeaseExpiredJobActivity} from './orchestration-activities.js';
+import {loadRunDag, resolveLeaseExpiredJobActivity} from './orchestration-activities.js';
 
 describe('resolveLeaseExpiredJobActivity', () => {
   let workspaceId: string;
@@ -56,5 +56,30 @@ describe('resolveLeaseExpiredJobActivity', () => {
     const result = await resolveLeaseExpiredJobActivity({jobId, expectedVersion: runningVersion});
 
     expect(result.status).toBe('failed');
+  });
+});
+
+describe('loadRunDag', () => {
+  test('surfaces the run workspace, project, and run ids on the dag', async () => {
+    const workspaceId = crypto.randomUUID();
+    const projectId = crypto.randomUUID();
+    const run = await createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId: crypto.randomUUID(),
+      model: workflowModel({jobs: {build: {steps: [{run: 'step1'}]}}}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+
+    const dag = await loadRunDag(run.id);
+
+    expect(dag.runId).toBe(run.id);
+    expect(dag.workspaceId).toBe(workspaceId);
+    expect(dag.projectId).toBe(projectId);
   });
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -34,6 +34,7 @@ export interface DagJob extends RuntimeDagJob {
 export interface RunDag {
   runId: string;
   workspaceId: string;
+  projectId: string;
   runVersion: number;
   jobs: DagJob[];
 }
@@ -56,6 +57,7 @@ export async function loadRunDag(runId: string): Promise<RunDag> {
   return {
     runId: run.id,
     workspaceId: run.workspaceId,
+    projectId: run.projectId,
     runVersion: run.version,
     jobs: jobs.map((job) => ({
       id: job.id,
@@ -138,11 +140,13 @@ export async function enqueueJobForRunner(params: {
   workspaceId: string;
   jobId: string;
   runId: string;
+  projectId: string;
 }): Promise<void> {
   await scheduleJob({
     workspaceId: params.workspaceId,
     jobId: params.jobId,
     runId: params.runId,
+    projectId: params.projectId,
   });
 }
 

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
@@ -36,7 +36,13 @@ beforeAll(async () => {
     taskQueue: TASK_QUEUE,
     workflowsPath: WORKFLOWS_PATH,
     activities: {
-      loadRunDag: () => ({runId: 'run-1', workspaceId: 'workspace-1', runVersion: 1, jobs: []}),
+      loadRunDag: () => ({
+        runId: 'run-1',
+        workspaceId: 'workspace-1',
+        projectId: 'project-1',
+        runVersion: 1,
+        jobs: [],
+      }),
       setRunStatus: (params: unknown) => {
         calls.push({name: 'setRunStatus', params});
         return {newVersion: nextVersion()};
@@ -92,6 +98,7 @@ const defaultJobInput = {
   workspaceId: 'workspace-1',
   jobId: 'job-timeout',
   runId: 'run-1',
+  projectId: 'project-1',
   jobVersion: 1,
 };
 

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
@@ -27,6 +27,7 @@ const defaultJobInput = {
   workspaceId: 'workspace-1',
   jobId: 'job-1',
   runId: 'run-1',
+  projectId: 'project-1',
   jobVersion: 1,
 };
 

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
@@ -52,6 +52,7 @@ export interface JobOrchestrationInput {
   workspaceId: string;
   jobId: string;
   runId: string;
+  projectId: string;
   jobVersion: number;
 }
 
@@ -82,6 +83,7 @@ async function markJobRunningAndEnqueue(input: JobOrchestrationInput): Promise<n
     workspaceId: input.workspaceId,
     jobId: input.jobId,
     runId: input.runId,
+    projectId: input.projectId,
   });
 
   return runningVersion;

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
@@ -51,7 +51,16 @@ describe('runOrchestration', () => {
 
     const runStatuses = setRunStatusCalls().map((c) => c.params.status);
     expect(runStatuses).toEqual(['running', 'succeeded']);
-    expect(callsNamed('enqueueJobForRunner')).toHaveLength(3);
+    const enqueueCalls = callsNamed('enqueueJobForRunner');
+    expect(enqueueCalls).toHaveLength(3);
+    // The lease tuple is sourced from the loaded dag (workspace/project/run together).
+    for (const call of enqueueCalls) {
+      expect(call.params).toMatchObject({
+        workspaceId: 'workspace-1',
+        projectId: 'project-1',
+        runId: 'r1',
+      });
+    }
   });
 
   test('parallel roots both succeed', async () => {

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -4,7 +4,7 @@ import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import {scheduleRuntimeDag} from '#core/workflow-runtime/index.js';
 
 import type {createOrchestrationActivities} from '../activities/index.js';
-import type {DagJob} from '../activities/orchestration-activities.js';
+import type {DagJob, RunDag} from '../activities/orchestration-activities.js';
 import {jobOrchestration} from './job-orchestration.js';
 
 const {loadRunDag, setRunStatus, setJobStatus} = proxyActivities<
@@ -47,7 +47,7 @@ export async function runOrchestration(input: RunOrchestrationInput): Promise<vo
     const jobsToStart = commands.flatMap((command) =>
       command.kind === 'start-job' ? [command.job] : [],
     );
-    const results = await launchJobs(jobsToStart, input, jobVersions);
+    const results = await launchJobs(jobsToStart, dag, jobVersions);
     for (const [job, result] of jobsToStart.map((j, i) => [j, results[i]] as const)) {
       if (!result) continue;
       completed.set(job.name, result.status);
@@ -83,7 +83,7 @@ interface LaunchResult {
 
 function launchJobs(
   jobs: DagJob[],
-  input: RunOrchestrationInput,
+  run: RunDag,
   jobVersions: Map<string, number>,
 ): Promise<LaunchResult[]> {
   return Promise.all(
@@ -92,9 +92,10 @@ function launchJobs(
         workflowId: `job:${job.id}`,
         args: [
           {
-            workspaceId: input.workspaceId,
+            workspaceId: run.workspaceId,
+            projectId: run.projectId,
             jobId: job.id,
-            runId: input.runId,
+            runId: run.runId,
             jobVersion: jobVersions.get(job.id) ?? job.version,
           },
         ],

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -95,7 +95,7 @@ export function dagJob(id: string, name: string, deps: string[] = []): RunDag['j
 }
 
 export function makeDag(jobs: RunDag['jobs'], runId = 'run-1'): RunDag {
-  return {runId, workspaceId: 'workspace-1', runVersion: 1, jobs};
+  return {runId, workspaceId: 'workspace-1', projectId: 'project-1', runVersion: 1, jobs};
 }
 
 // ---------------------------------------------------------------------------
@@ -154,7 +154,12 @@ function createMockActivities() {
     // Scheduling is step-less. The mock runner reports the job outcome by signalling
     // the per-step terminal-completion signal (job-finished) and/or the lease-expiry
     // signal, reproducing the outbox → subscriber → signal rail.
-    enqueueJobForRunner: async (params: {workspaceId: string; jobId: string; runId: string}) => {
+    enqueueJobForRunner: async (params: {
+      workspaceId: string;
+      jobId: string;
+      runId: string;
+      projectId: string;
+    }) => {
       calls.push({name: 'enqueueJobForRunner', params});
 
       if (cfg.enqueueError) {

--- a/libs/api/workflows/test/fixtures/lease-token.ts
+++ b/libs/api/workflows/test/fixtures/lease-token.ts
@@ -7,8 +7,9 @@ const SECRET = process.env.AUTH_JOB_LEASE_TOKEN_SECRET ?? 'test-lease-secret';
 export interface MintLeaseTokenParams {
   jobId: string;
   // Override the informational claims to pair a job with a chosen (possibly
-  // mismatched) run/workspace — used by the hostile-claims checkout test.
+  // mismatched) run/project/workspace — used by the hostile-claims checkout test.
   runId?: string;
+  projectId?: string;
   workspaceId?: string;
   secret?: string;
   expiresIn?: string;
@@ -20,6 +21,7 @@ export function mintLeaseToken(params: MintLeaseTokenParams): Promise<string> {
     payload: {
       jobId: params.jobId,
       runId: params.runId ?? crypto.randomUUID(),
+      projectId: params.projectId ?? crypto.randomUUID(),
       workspaceId: params.workspaceId ?? crypto.randomUUID(),
       runnerTokenId: crypto.randomUUID(),
     },


### PR DESCRIPTION
Threads `projectId` from the workflow run through the runner job tables into the signed job-lease token, so a claimed job's lease now carries `(workspaceId, projectId, runId, jobId)` instead of only `(workspaceId, runId, jobId, runnerTokenId)`.

## Why

Log-ingest will need to authorize and stamp per-project on every access. With `projectId` absent from the lease and the runner job rows, that means joining back to `workflows` at ingest time. Putting `projectId` on the signed lease makes the identifier set self-contained: a claimed job's lease names its project, determined at mint time from server state.

`projectId` is functionally determined by `jobId` via immutable `workflows` FKs (`workflow_runs.project_id` → run → job). So the signed claim is denormalization for self-contained authorization and signed defense-in-depth, **not** a fix for an existing forgery path. The runtime value is belt-and-suspenders, and this PR intentionally does not oversell it.

## What changed

- **auth / auth-dto** — `projectId` added to `jobLeaseTokenClaimsSchema` and signed by `issueJobLeaseToken`. It surfaces on `LeasedJobContext` automatically (the context is the claims type).
- **runners** — `project_id NOT NULL` on `runners_pending_jobs` and `runners_running_jobs`; threaded through `scheduleJob` → `claimPendingJob` (carried pending → running on the claim) → `claimJob` → lease. The migration is hand-edited into the initial migration since the DB is recreated.
- **workflows** — `loadRunDag` surfaces `run.projectId`, and `launchJobs` now sources the whole `{workspaceId, projectId, runId}` identity tuple from the loaded run (rather than mixing the run-start input with the loaded `projectId`), threading it through `JobOrchestrationInput` → `enqueueJobForRunner`.

## Scope / review notes

- **Producer-side only.** The `attempt_streams` consumer (stamp `run_id`/`project_id` at create, assert against the lease, `LeaseStreamMismatchError`) is deferred to the logs-module PR — that module does not exist in the repo yet. The deferred consumer work will be tracked under a separate ticket.
- **Immutability assumption.** This relies on a run never being re-parented to a different project. That holds today; the short-lived lease (and recreated rows) keep any future staleness window tiny.
- **Source-of-truth coherence.** `launchJobs` was changed to source `workspaceId`/`runId` from the loaded dag too (not just `projectId`), so the whole signed tuple is server-derived.

Closes ENG-467

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates `projectId` end-to-end and adds it to the signed runner job lease so each claimed job now includes `{workspaceId, projectId, runId, jobId}`. This enables per‑project log‑ingest authorization without joining back to workflows. Closes ENG-467.

- **New Features**
  - `@shipfox/api-auth-dto`, `@shipfox/api-auth`: added `projectId` to `jobLeaseTokenClaimsSchema`; `issueJobLeaseToken` now signs it.
  - `@shipfox/api-runners`: added `project_id` to `runners_pending_jobs` and `runners_running_jobs`; threaded `projectId` through `scheduleJob` → `claimPendingJob` → `claimJob` into the lease token.
  - `@shipfox/api-workflows`: `loadRunDag` now returns `{workspaceId, projectId, runId}`; `runOrchestration` and `enqueueJobForRunner` use these run‑derived ids when scheduling.

- **Bug Fixes**
  - `@shipfox/api-runners`: synced Drizzle meta snapshot with `project_id` to match the initial SQL and prevent drift/redundant migrations.

<sup>Written for commit d37cad73a2caec25034771d03968a60d8ee3345c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

