### PR TITLE
Compose workflow run page sections

### DIFF
--- a/libs/client/projects/src/hooks/api/workflow-runs.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.ts
@@ -1,12 +1,9 @@
 import type {
-  JobDto,
   RunAggregatesResponseDto,
+  RunDetailResponseDto,
   RunDto,
   RunListResponseDto,
-  RunResponseDto,
   RunStatusDto,
-  StepAttemptDto,
-  StepDto,
 } from '@shipfox/api-workflows-dto';
 import {apiRequest} from '@shipfox/client-api';
 import {
@@ -175,13 +172,13 @@ export function useWorkflowRunAggregatesQuery(
 
 /**
  * The run detail read model returned by `GET /workflows/runs/:id`: a run plus its jobs,
- * each job's steps, and each step's attempt history. The canonical response schema lives
- * inline in the API route today; this mirrors it from the shared run/job/step DTOs until a
- * dedicated run-detail DTO is exported.
+ * each job's steps, and each step's attempt history. Backed by the canonical run-detail
+ * contract, so the run's `source_snapshot`, each step's `source_location`, and the typed
+ * gate/restart fields on attempts are all available to the page.
  */
-export type WorkflowRunStepDetailDto = StepDto & {attempts: StepAttemptDto[]};
-export type WorkflowRunJobDetailDto = JobDto & {steps: WorkflowRunStepDetailDto[]};
-export type WorkflowRunDetailDto = RunResponseDto & {jobs: WorkflowRunJobDetailDto[]};
+export type WorkflowRunDetailDto = RunDetailResponseDto;
+export type WorkflowRunJobDetailDto = RunDetailResponseDto['jobs'][number];
+export type WorkflowRunStepDetailDto = WorkflowRunJobDetailDto['steps'][number];
 
 export async function getWorkflowRun({runId, signal}: {runId: string; signal?: AbortSignal}) {
   return await apiRequest<WorkflowRunDetailDto>(`/workflows/runs/${runId}`, {signal});

--- a/libs/client/projects/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {screen} from '@testing-library/react';
+import {fireEvent, screen, within} from '@testing-library/react';
 import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
 import {WorkflowRunPage} from './workflow-run-page.js';
 
@@ -8,7 +8,7 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const OTHER_RUN_ID = '77777777-7777-4777-8777-777777777777';
 const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
 const INLINE_MODE_HINT_RE = /Overview \| Source render inline/;
-const RUN_COUNTS_RE = /1 job · 2 steps/;
+const CHECKOUT_ROW_RE = /checkout/;
 
 describe('WorkflowRunPage', () => {
   test('renders a loading shell while the run detail loads', async () => {
@@ -49,11 +49,12 @@ describe('WorkflowRunPage', () => {
 
     expect(await screen.findByText('Deploy production')).toBeInTheDocument();
     expect(screen.getAllByText(RUN_ID)).not.toHaveLength(0);
-    expect(screen.getByText('Running')).toBeInTheDocument();
-    // Real run-detail data (jobs + steps) flows into the shell.
-    expect(screen.getByText(RUN_COUNTS_RE)).toBeInTheDocument();
-    expect(screen.getAllByText('job-build')).not.toHaveLength(0);
-    expect(screen.getAllByText('step-checkout')).not.toHaveLength(0);
+    expect(screen.getAllByText('Running')).not.toHaveLength(0);
+    // Real run-detail data flows into the live sections: the jobs visualization shows the
+    // job by name and the step list shows the steps by name.
+    expect(screen.getAllByText('build')).not.toHaveLength(0);
+    expect(screen.getAllByText('checkout')).not.toHaveLength(0);
+    expect(screen.getAllByText('test')).not.toHaveLength(0);
 
     for (const section of ['Runs list', 'Run summary', 'Jobs visualization', 'Step list']) {
       expect(screen.getByRole('heading', {name: section})).toBeInTheDocument();
@@ -71,6 +72,39 @@ describe('WorkflowRunPage', () => {
     expect(screen.getByText(INLINE_MODE_HINT_RE)).toBeInTheDocument();
     expect(screen.queryByRole('heading', {name: 'Step overview'})).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', {name: 'Source view'})).not.toBeInTheDocument();
+  });
+
+  test('renders the real source view inline when a step row switches to source mode', async () => {
+    configureApiClient({fetchImpl: createWorkflowRunFetch()});
+
+    renderWorkflowRunPage(RUN_ID);
+
+    const checkoutRow = await screen.findByRole('button', {name: CHECKOUT_ROW_RE});
+    fireEvent.click(checkoutRow);
+    fireEvent.click(screen.getByRole('tab', {name: 'Source'}));
+
+    // The source mode mounts the real WorkflowSourceView, not a placeholder note: the
+    // snapshot content renders inside its labelled source-code region with line numbers.
+    const sourceView = await screen.findByLabelText('Workflow source');
+    const sourceCode = within(sourceView).getByLabelText('Workflow source code');
+    expect(within(sourceCode).getByText('jobs:')).toBeInTheDocument();
+    expect(within(sourceCode).getByText('1')).toBeInTheDocument();
+    // The selected step's source_location drives the highlighted line range label.
+    expect(within(sourceView).getByText('checkout')).toBeInTheDocument();
+  });
+
+  test('shows the source view empty state when the run has no source snapshot', async () => {
+    configureApiClient({
+      fetchImpl: createWorkflowRunFetch({detail: runDetailDto({sourceSnapshot: null})}),
+    });
+
+    renderWorkflowRunPage(RUN_ID);
+
+    const checkoutRow = await screen.findByRole('button', {name: CHECKOUT_ROW_RE});
+    fireEvent.click(checkoutRow);
+    fireEvent.click(screen.getByRole('tab', {name: 'Source'}));
+
+    expect(await screen.findByText('No source document')).toBeInTheDocument();
   });
 });
 
@@ -101,9 +135,25 @@ function requestInputUrl(input: RequestInfo | URL) {
   return String(input);
 }
 
-// Mirrors GET /workflows/runs/:id: a run plus one job with two steps (so the shell shows
-// "1 job · 2 steps"). Only the fields the shell reads are populated.
-function runDetailDto(overrides: Partial<{id: string; name: string; status: string}> = {}) {
+const SOURCE_YAML = [
+  'name: deploy',
+  'jobs:',
+  '  build:',
+  '    steps:',
+  '      - run: pnpm test',
+].join('\n');
+
+// Mirrors GET /workflows/runs/:id: a run plus one job with two steps, carrying the source
+// snapshot and per-step source locations the page feeds into the inline overview and source
+// view.
+function runDetailDto(
+  overrides: Partial<{
+    id: string;
+    name: string;
+    status: string;
+    sourceSnapshot: {content: string; format: 'yaml'} | null;
+  }> = {},
+) {
   return {
     id: overrides.id ?? RUN_ID,
     project_id: PROJECT_ID,
@@ -114,18 +164,71 @@ function runDetailDto(overrides: Partial<{id: string; name: string; status: stri
     trigger_event: 'fire',
     trigger_payload: {source: 'manual', event: 'fire'},
     inputs: null,
+    source_snapshot:
+      overrides.sourceSnapshot === undefined
+        ? {content: SOURCE_YAML, format: 'yaml'}
+        : overrides.sourceSnapshot,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
     jobs: [
       {
         id: 'job-build',
+        run_id: RUN_ID,
         name: 'build',
         status: 'succeeded',
+        dependencies: [],
+        position: 0,
+        created_at: '2026-05-07T01:01:00.000Z',
+        updated_at: '2026-05-07T01:02:00.000Z',
         steps: [
-          {id: 'step-checkout', name: 'checkout', status: 'succeeded', attempts: []},
-          {id: 'step-test', name: 'test', status: 'succeeded', attempts: []},
+          stepDto({
+            id: 'step-checkout',
+            name: 'checkout',
+            position: 0,
+            sourceLocation: {
+              start_line: 2,
+              end_line: 4,
+            },
+          }),
+          stepDto({
+            id: 'step-test',
+            name: 'test',
+            position: 1,
+            sourceLocation: {
+              start_line: 5,
+              end_line: 5,
+            },
+          }),
         ],
       },
     ],
+  };
+}
+
+function stepDto({
+  id,
+  name,
+  position,
+  sourceLocation,
+}: {
+  id: string;
+  name: string;
+  position: number;
+  sourceLocation: {start_line: number; end_line: number} | null;
+}) {
+  return {
+    id,
+    job_id: 'job-build',
+    name,
+    source_location: sourceLocation,
+    status: 'succeeded',
+    type: 'run',
+    config: {run: 'pnpm test'},
+    error: null,
+    position,
+    current_attempt: 1,
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+    attempts: [],
   };
 }

--- a/libs/client/projects/src/pages/workflow-run-page.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.tsx
@@ -1,8 +1,20 @@
-import type {RunResponseDto, RunStatusDto} from '@shipfox/api-workflows-dto';
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Code, cn, EmptyState, Header, Skeleton, StatusBadge, Text} from '@shipfox/react-ui';
-import {useWorkflowRunQuery, type WorkflowRunDetailDto} from '#hooks/api/workflow-runs.js';
+import {Code, cn, EmptyState, Header, Skeleton, Text} from '@shipfox/react-ui';
+import {useMemo} from 'react';
+import {WorkflowJobsVisualization} from '#components/workflow-jobs-visualization.js';
+import {WorkflowRunSummary} from '#components/workflow-run-summary.js';
+import {
+  type WorkflowSourceLineRange,
+  WorkflowSourceView,
+} from '#components/workflow-source-view.js';
+import {type WorkflowStepDetailMode, WorkflowStepList} from '#components/workflow-step-list.js';
+import {WorkflowStepOverview} from '#components/workflow-step-overview.js';
+import {
+  useWorkflowRunQuery,
+  type WorkflowRunDetailDto,
+  type WorkflowRunStepDetailDto,
+} from '#hooks/api/workflow-runs.js';
 
 export interface WorkflowRunPageProps {
   projectId: string;
@@ -13,22 +25,6 @@ export interface WorkflowRunPageProps {
   onSelectJob?: ((jobId: string | undefined) => void) | undefined;
   onSelectStep?: ((stepId: string | undefined) => void) | undefined;
 }
-
-const statusBadgeVariantByStatus: Record<RunStatusDto, 'neutral' | 'info' | 'success' | 'error'> = {
-  pending: 'neutral',
-  running: 'info',
-  succeeded: 'success',
-  failed: 'error',
-  cancelled: 'neutral',
-};
-
-const statusLabelByStatus: Record<RunStatusDto, string> = {
-  pending: 'Pending',
-  running: 'Running',
-  succeeded: 'Succeeded',
-  failed: 'Failed',
-  cancelled: 'Cancelled',
-};
 
 export function WorkflowRunPage(props: WorkflowRunPageProps) {
   const {runId} = props;
@@ -49,8 +45,7 @@ export function WorkflowRunPage(props: WorkflowRunPageProps) {
 }
 
 /**
- * Page layout contract for the Workflow Run Page (component PRs mount real sections into
- * these slots):
+ * Page layout contract for the Workflow Run Page:
  *
  *   ┌──────────┬───────────────────────────────────────────┐
  *   │ Runs     │  Run summary                               │
@@ -61,15 +56,39 @@ export function WorkflowRunPage(props: WorkflowRunPageProps) {
  *
  * Step overview and source are NOT a persistent right-side inspector: they are content
  * modes the step list renders inside the selected step's expanded row. The shell keeps no
- * right column so later composition cannot regress into one.
+ * right column so composition cannot regress into one.
  */
 function WorkflowRunSuccessState({
   run,
   selectedJobId,
   selectedStepId,
+  onSelectJob,
+  onSelectStep,
 }: WorkflowRunPageProps & {run: WorkflowRunDetailDto}) {
-  const jobCount = run.jobs.length;
-  const stepCount = run.jobs.reduce((total, job) => total + job.steps.length, 0);
+  const stepIndex = useMemo(() => indexStepsByJob(run), [run]);
+
+  const source = run.source_snapshot;
+
+  function renderExpandedStep({stepId, mode}: {stepId: string; mode: WorkflowStepDetailMode}) {
+    const located = stepIndex.get(stepId);
+
+    if (mode === 'source') {
+      return (
+        <WorkflowSourceView
+          variant="inline"
+          source={source}
+          selectedRange={toSelectedRange(located?.step ?? null)}
+        />
+      );
+    }
+
+    return (
+      <WorkflowStepOverview
+        variant="inline"
+        selection={located ? {jobName: located.jobName, step: located.step} : null}
+      />
+    );
+  }
 
   return (
     <div className="grid gap-16 lg:grid-cols-[280px_minmax(0,1fr)]">
@@ -81,49 +100,58 @@ function WorkflowRunSuccessState({
 
       <div className="flex min-w-0 flex-col gap-16">
         <ShellSlot title="Run summary">
-          <RunIdentity run={run} />
-          <Text size="xs" className="text-foreground-neutral-muted">
-            {jobCount} {jobCount === 1 ? 'job' : 'jobs'} · {stepCount}{' '}
-            {stepCount === 1 ? 'step' : 'steps'}
-          </Text>
+          <WorkflowRunSummary run={run} />
         </ShellSlot>
 
-        <ShellSlot title="Jobs visualization" hint="Jobs execution graph mounts here.">
-          <SelectionHint label="Selected job" value={selectedJobId} />
+        <ShellSlot title="Jobs visualization">
+          <WorkflowJobsVisualization
+            jobs={run.jobs}
+            {...(selectedJobId !== undefined ? {selectedJobId} : {})}
+            {...(onSelectJob ? {onSelectJob: (jobId: string) => onSelectJob(jobId)} : {})}
+          />
         </ShellSlot>
 
         <ShellSlot
           title="Step list"
           hint="Overview | Source render inline inside the expanded step row — no separate inspector panel."
         >
-          <SelectionHint label="Selected step" value={selectedStepId} />
+          {run.jobs.map((job) => (
+            <WorkflowStepList
+              key={job.id}
+              job={job}
+              {...(selectedStepId !== undefined ? {selectedStepId} : {})}
+              {...(onSelectStep
+                ? {onSelectedStepChange: (stepId: string) => onSelectStep(stepId)}
+                : {})}
+              renderExpandedStep={renderExpandedStep}
+            />
+          ))}
         </ShellSlot>
       </div>
     </div>
   );
 }
 
-function RunIdentity({run}: {run: RunResponseDto}) {
-  return (
-    <div className="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
-      <div className="flex min-w-0 flex-col gap-6">
-        <Text size="lg" bold className="truncate">
-          {run.name}
-        </Text>
-        <div className="flex flex-wrap items-center gap-8">
-          <Code variant="label" className="text-foreground-neutral-muted">
-            {run.id}
-          </Code>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            Run ID
-          </Text>
-        </div>
-      </div>
-      <StatusBadge variant={statusBadgeVariantByStatus[run.status]} className="shrink-0">
-        {statusLabelByStatus[run.status]}
-      </StatusBadge>
-    </div>
-  );
+type LocatedStep = {jobName: string; step: WorkflowRunStepDetailDto};
+
+function indexStepsByJob(run: WorkflowRunDetailDto): Map<string, LocatedStep> {
+  const index = new Map<string, LocatedStep>();
+  for (const job of run.jobs) {
+    for (const step of job.steps) {
+      index.set(step.id, {jobName: job.name, step});
+    }
+  }
+  return index;
+}
+
+function toSelectedRange(step: WorkflowRunStepDetailDto | null): WorkflowSourceLineRange | null {
+  if (!step?.source_location) return null;
+  const {start_line, end_line} = step.source_location;
+  return {
+    startLine: start_line,
+    endLine: end_line,
+    ...(step.name ? {label: step.name} : {}),
+  };
 }
 
 function ShellSlot({


### PR DESCRIPTION
Compose the Workflow Run Page from the reviewed run list, run summary, jobs visualization, step list, step overview, and source view sections.

The page previously mounted a detail shell with placeholders. This wires the shell to the run detail endpoint and renders the sections together so the final integration can validate layout, selection flow, and desktop fidelity across the full page.

This PR intentionally keeps cross-section interactions minimal; follow-up integration PRs will refine coordinated selection, fidelity gaps, and end-to-end coverage on top of the same shim branch.

Refs ENG-464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composed the real Workflow Run Page by wiring sections to the canonical run-detail API. Completes ENG-464 by rendering Overview | Source inline using the run’s source snapshot and per-step source locations (no right-side inspector).

- **New Features**
  - Switched run detail to `RunDetailResponseDto`; removed ad hoc types in favor of the canonical contract.
  - Mounted live `WorkflowRunSummary`, `WorkflowJobsVisualization`, and `WorkflowStepList` with inline `WorkflowStepOverview` and `WorkflowSourceView`.
  - Source mode feeds `source_snapshot` and step `source_location` to highlight lines; shows an empty state when the snapshot is missing.
  - Page owns `selectedJobId` and `selectedStepId` and passes typed `@shipfox/api-workflows-dto` data to all sections.
  - Tests updated to cover live sections and inline source behavior.

<sup>Written for commit 11f502f215ce8d6f3169d27b3e78e2683fa48864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- stk:begin -->
## Stack

Part 1 of 2.

Depends on: none
Next: #218

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 (current) | #217 | `codex/eng-464-compose-page-sections` | `codex/workflow-run-page-integration-shim` |
| 2 | #218 | `codex/eng-465-cross-section-interactions` | `codex/eng-464-compose-page-sections` |

<!-- stk:end -->