### PR TITLE
[client-projects] Add workflow run page E2E coverage

### DIFF
--- a/e2e/client/projects/package.json
+++ b/e2e/client/projects/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@shipfox/e2e-client-projects",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "e2e/client/projects"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./tests/*"
+  },
+  "scripts": {
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test:e2e": "shipfox-playwright-test",
+    "type": "shipfox-tsc-check"
+  },
+  "devDependencies": {
+    "@shipfox/api-workflows": "workspace:*",
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/client-projects": "workspace:*",
+    "@shipfox/client-router": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-workflows": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/client/projects/playwright.config.ts
+++ b/e2e/client/projects/playwright.config.ts
@@ -1,0 +1,33 @@
+import {config} from '@shipfox/e2e-core';
+import {defineConfig, devices} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  globalSetup: './tests/global-setup.ts',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        [
+          '@argos-ci/playwright/reporter',
+          {
+            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
+            buildName: 'client-projects',
+            ignoreUploadFailures: true,
+          },
+        ],
+      ]
+    : 'list',
+  use: {
+    baseURL: config.CLIENT_URL,
+    trace: 'retain-on-failure',
+    timezoneId: 'UTC',
+    contextOptions: {reducedMotion: 'reduce'},
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/e2e/client/projects/tests/global-setup.ts
+++ b/e2e/client/projects/tests/global-setup.ts
@@ -1,0 +1,5 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck();
+}

--- a/e2e/client/projects/tests/test.ts
+++ b/e2e/client/projects/tests/test.ts
@@ -1,0 +1,11 @@
+import {test as base, expect} from '@shipfox/e2e-core/playwright';
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type WorkflowsFixtures, workflowsHelper} from '@shipfox/e2e-helper-workflows';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+export const test = base.extend<AuthFixtures & WorkspacesFixtures & WorkflowsFixtures>({
+  ...authHelper,
+  ...workspacesHelper,
+  ...workflowsHelper,
+});
+export {expect};

--- a/e2e/client/projects/tests/workflow-run-page.e2e.ts
+++ b/e2e/client/projects/tests/workflow-run-page.e2e.ts
@@ -1,0 +1,72 @@
+import {argosScreenshot} from '@shipfox/playwright';
+import {expect, test} from './test.js';
+
+const testJobName = /^Test\b/u;
+const browserSmokeStepName = /\bBrowser smoke\b/u;
+const buildJobName = /^Build\b/u;
+const installDependenciesStepName = /\bInstall dependencies\b/u;
+const jobSearchParamUrl = /[?&]job=/u;
+const succeededRunName = /Deploy pipeline succeeded/u;
+const runningRunName = /Deploy pipeline running/u;
+
+test('renders real workflow run page scenarios and keeps section interactions in sync', async ({
+  page,
+  auth,
+  workspaces,
+  workflows,
+}) => {
+  const user = await auth.createUser();
+  const workspace = await workspaces.create({
+    userId: user.user.id,
+    name: 'Workflow Run Page Workspace',
+  });
+  const fixture = await workflows.createRunPageFixture({
+    workspaceId: workspace.id,
+    projectName: 'Checkout Automation',
+  });
+  await auth.loginAs(page, user);
+
+  await page.goto(
+    projectRunUrl(fixture.project.workspace_id, fixture.project.id, fixture.runs.failed.id),
+  );
+
+  const runSummary = page.getByRole('region', {name: 'Workflow run summary'});
+  const jobsRegion = page.getByRole('region', {name: 'Workflow jobs'});
+  const stepOverview = page.getByLabel('Step overview');
+
+  await expect(page.getByRole('complementary', {name: 'Workflow runs'})).toBeVisible();
+  await expect(page.getByRole('main', {name: 'Workflow run details'})).toBeVisible();
+  await expect(jobsRegion).toContainText('3 jobs across 1 stage');
+  await expect(runSummary.getByText('Deploy pipeline failed')).toBeVisible();
+  await expect(jobsRegion.getByRole('button', {name: testJobName})).toBeVisible();
+  await expect(page.getByRole('button', {name: browserSmokeStepName})).toBeVisible();
+  await expect(stepOverview.getByText('Browser smoke failed on checkout summary')).toBeVisible();
+  await expect(
+    stepOverview.getByText('turbo test:e2e --filter=@shipfox/e2e-client-projects'),
+  ).toBeVisible();
+  await argosScreenshot(page, 'projects/workflow-run-page/failed-run');
+
+  await jobsRegion.getByRole('button', {name: buildJobName}).click();
+  await expect(page.getByRole('button', {name: installDependenciesStepName})).toHaveAttribute(
+    'aria-current',
+    'true',
+  );
+  await expect(stepOverview.getByText('pnpm install --frozen-lockfile')).toBeVisible();
+  await expect(page).toHaveURL(jobSearchParamUrl);
+  await argosScreenshot(page, 'projects/workflow-run-page/selected-build-job');
+
+  await page.getByRole('button', {name: succeededRunName}).click();
+  await expect(runSummary.getByText('Deploy pipeline succeeded')).toBeVisible();
+  await expect(page.getByText('Succeeded').first()).toBeVisible();
+  await argosScreenshot(page, 'projects/workflow-run-page/succeeded-run');
+
+  await page.getByRole('button', {name: runningRunName}).click();
+  await expect(runSummary.getByText('Deploy pipeline running')).toBeVisible();
+  await expect(page.getByText('Running').first()).toBeVisible();
+  await expect(page.getByText('Browser smoke')).toBeVisible();
+  await argosScreenshot(page, 'projects/workflow-run-page/running-run');
+});
+
+function projectRunUrl(workspaceId: string, projectId: string, runId: string): string {
+  return `/workspaces/${workspaceId}/projects/${projectId}/runs/${runId}`;
+}

--- a/e2e/client/projects/tests/workflow-run-page.e2e.ts
+++ b/e2e/client/projects/tests/workflow-run-page.e2e.ts
@@ -63,7 +63,8 @@ test('renders real workflow run page scenarios and keeps section interactions in
   await page.getByRole('button', {name: runningRunName}).click();
   await expect(runSummary.getByText('Deploy pipeline running')).toBeVisible();
   await expect(page.getByText('Running').first()).toBeVisible();
-  await expect(page.getByText('Browser smoke')).toBeVisible();
+  await jobsRegion.getByRole('button', {name: testJobName}).click();
+  await expect(page.getByRole('button', {name: browserSmokeStepName})).toBeVisible();
   await argosScreenshot(page, 'projects/workflow-run-page/running-run');
 });
 

--- a/e2e/client/projects/tsconfig.json
+++ b/e2e/client/projects/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/e2e/core/src/api/client.ts
+++ b/e2e/core/src/api/client.ts
@@ -26,7 +26,13 @@ function e2eUrl(path: string): URL {
 }
 
 async function parseErrorDetails(response: Response): Promise<unknown> {
-  const text = await response.text();
+  let text: string;
+  try {
+    text = await response.clone().text();
+  } catch {
+    return undefined;
+  }
+
   if (!text) return undefined;
 
   try {

--- a/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.test.ts
+++ b/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.test.ts
@@ -59,7 +59,9 @@ describe('POST /__e2e/workflows/run-page-fixture', () => {
     const failedSteps = stepsFor(body.runs.failed);
     expect(failedSteps.some((step) => step.status === 'failed')).toBe(true);
     expect(body.runs.failed.jobs.some((job) => job.status === 'cancelled')).toBe(true);
-    expect(failedSteps.find((step) => step.status === 'failed')?.error).toEqual({
+    const failedStep = failedSteps.find((step) => step.status === 'failed');
+    expect(failedStep?.name).toBe('Browser smoke');
+    expect(failedStep?.error).toEqual({
       message: 'Browser smoke failed on checkout summary',
       exit_code: 1,
       category: 'user',
@@ -73,7 +75,9 @@ describe('POST /__e2e/workflows/run-page-fixture', () => {
     ]);
     const runningSteps = stepsFor(body.runs.running);
     expect(runningSteps.filter((step) => step.status === 'running')).toHaveLength(1);
-    expect(runningSteps.find((step) => step.status === 'running')?.attempts).toEqual([
+    const runningStep = runningSteps.find((step) => step.status === 'running');
+    expect(runningStep?.name).toBe('Browser smoke');
+    expect(runningStep?.attempts).toEqual([
       expect.objectContaining({status: 'running', finished_at: null}),
     ]);
     expect(body.deferred.gated_restart).toBe('typed-gate-restart-contract-not-on-main');

--- a/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.test.ts
+++ b/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.test.ts
@@ -58,7 +58,7 @@ describe('POST /__e2e/workflows/run-page-fixture', () => {
     ]);
     const failedSteps = stepsFor(body.runs.failed);
     expect(failedSteps.some((step) => step.status === 'failed')).toBe(true);
-    expect(failedSteps.some((step) => step.status === 'cancelled')).toBe(true);
+    expect(body.runs.failed.jobs.some((job) => job.status === 'cancelled')).toBe(true);
     expect(failedSteps.find((step) => step.status === 'failed')?.error).toEqual({
       message: 'Browser smoke failed on checkout summary',
       exit_code: 1,

--- a/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.ts
+++ b/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.ts
@@ -214,6 +214,7 @@ async function createFailedRun(params: {workspaceId: string; projectId: string})
 
   const testVersion = await startJob(test.id);
   await finishNextStep({jobId: test.id, status: 'succeeded', exitCode: 0});
+  await finishNextStep({jobId: test.id, status: 'succeeded', exitCode: 0});
   await finishNextStep({
     jobId: test.id,
     status: 'failed',

--- a/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.ts
+++ b/libs/api/workflows/src/presentation/e2eRoutes/create-run-page-fixture.ts
@@ -248,6 +248,7 @@ async function createRunningRun(params: {workspaceId: string; projectId: string}
 
   await startJob(test.id);
   await finishNextStep({jobId: test.id, status: 'succeeded', exitCode: 0});
+  await finishNextStep({jobId: test.id, status: 'succeeded', exitCode: 0});
   await dispatchInFlightStep(test.id);
 
   return await toRunDetailDto(run);

--- a/libs/client/projects/src/pages/workflow-run-page.tsx
+++ b/libs/client/projects/src/pages/workflow-run-page.tsx
@@ -206,7 +206,9 @@ function selectJob(
   selectedJobId: string | undefined,
 ): RunDetailJobDto | null {
   if (jobs.length === 0) return null;
-  return jobs.find((job) => job.id === selectedJobId) ?? jobs[0] ?? null;
+  return (
+    jobs.find((job) => job.id === selectedJobId) ?? jobs.find(hasAttentionStatus) ?? jobs[0] ?? null
+  );
 }
 
 function selectStep(
@@ -214,7 +216,17 @@ function selectStep(
   selectedStepId: string | undefined,
 ): RunDetailStepDto | null {
   if (!job || job.steps.length === 0) return null;
-  return job.steps.find((step) => step.id === selectedStepId) ?? job.steps[0] ?? null;
+  return (
+    job.steps.find((step) => step.id === selectedStepId) ??
+    job.steps.find(hasAttentionStatus) ??
+    job.steps.find((step) => step.type !== 'setup') ??
+    job.steps[0] ??
+    null
+  );
+}
+
+function hasAttentionStatus(item: {status: string}): boolean {
+  return item.status === 'failed' || item.status === 'running';
 }
 
 function toSourceRange(step: RunDetailStepDto | null): WorkflowSourceLineRange | null {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,42 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/client/projects:
+    devDependencies:
+      '@shipfox/api-workflows':
+        specifier: workspace:*
+        version: link:../../../libs/api/workflows
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/client-projects':
+        specifier: workspace:*
+        version: link:../../../libs/client/projects
+      '@shipfox/client-router':
+        specifier: workspace:*
+        version: link:../../../libs/client/router
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../../helpers/auth
+      '@shipfox/e2e-helper-workflows':
+        specifier: workspace:*
+        version: link:../../helpers/workflows
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/client/runners:
     devDependencies:
       '@shipfox/api-runners':


### PR DESCRIPTION
Adds browser-level coverage for the workflow run page using real persisted fixture data. The scenario exercises failed, selected job, succeeded, and running run states through the mounted client route so the integrated page has regression coverage across its primary sections.

This also tightens the final integration behavior around default job/step selection, typed restart-result fixtures, and the canonical run-page E2E fixture. The page now lands on failed or running work by default when there is no explicit selection, which keeps troubleshooting context visible without requiring an extra click.

Reviewers should focus on the E2E fixture shape, the selected job/step fallback behavior, and the new `client-projects` Argos build coverage.

Refs ENG-466

<!-- stk:begin -->
## Stack

Part 2 of 2.

Depends on: #218
Next: none

| Part | PR | Branch | Base |
| --- | --- | --- | --- |
| 1 | #218 | `codex/eng-465-cross-section-interactions` | `codex/eng-464-compose-page-sections` |
| 2 (current) | #219 | `codex/eng-466-final-fidelity-e2e-polish` | `codex/eng-465-cross-section-interactions` |

<!-- stk:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright E2E coverage for the Workflow Run page on the real client route using a backend run-page fixture. Covers failed, selected job, succeeded, and running scenarios with Argos snapshots, tightens default selection, and stabilizes the running fixture for ENG-466.

- **New Features**
  - New E2E package `@shipfox/e2e-client-projects` with Playwright config and Argos reporter.
  - Real-route tests for failed, selected build job, succeeded, and running runs; desktop Chromium snapshots uploaded to Argos.

- **Bug Fixes**
  - Default selection now prefers failed/running jobs and steps, then first non-setup, then first.
  - Stabilized fixture and test: extra succeeded step; running advanced to “Browser smoke”; cancelled state asserted at job level; select “Test” job before step checks.
  - Hardened error parsing in `@shipfox/e2e-core` by cloning the response and handling unreadable bodies.

<sup>Written for commit e94ada856833d9af1952349c13bf8cc4794799f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

