### PR TITLE
Treat compose.yml as a global Turbo cache dependency

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["mise.toml", "biome.json"],
+  "globalDependencies": ["mise.toml", "biome.json", "compose.yml"],
   "globalPassThroughEnv": [
     "GITHUB_*",
     "ACTIONS_*",


### PR DESCRIPTION
Adds `compose.yml` to `globalDependencies` in `turbo.jsonc` so that editing it (most notably bumping a container image tag) busts the global Turbo hash and forces affected tasks to re-run.

The Docker image tags in `compose.yml` (Postgres, Temporal) feed the real infrastructure our `test` tasks run against. But Turbo never hashed the file: it lives at the repo root and was not in `globalDependencies`, so it was not part of any package's input set either. That meant a container version bump left every task hash unchanged, and Turbo would happily serve cached test results produced against a *different* Postgres or Temporal version than the one actually running — a silent correctness gap for anything that depends on container behavior (a Postgres major upgrade, a Temporal breaking change).

The tradeoff is that any edit to `compose.yml` — including changes irrelevant to build/test output, like ports or volumes — now busts the cache for every task. Given the team bumps these image tags directly in this file (e.g. the recent v1.7.2 Temporal bump), a full rebuild on an infra change is cheaper than debugging stale results.

No changeset: this is a root build-config change, not a published `libs/`/`tools/` package change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `compose.yml` as a global Turbo cache dependency so infra changes (e.g., Postgres/Temporal image tag bumps) invalidate the cache and re-run affected tasks. This prevents stale test results from mismatched container versions; note that any edit to `compose.yml` will trigger a full rebuild.

<sup>Written for commit d45c848f104df47fe0d6d5241c9d03875caa48e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

