### PR TITLE
Let agent steps select their pi provider

### DIFF
--- a/.changeset/eng-489-agent-provider-field.md
+++ b/.changeset/eng-489-agent-provider-field.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/workflow-document": patch
+"@shipfox/api-definitions": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-workflows-dto": patch
+"@shipfox/runner-agent": patch
+---
+
+Let an agent workflow step pick its pi provider with an optional free-text `provider` field (default `anthropic`), threaded to the runner's pi model lookup, and split agent-step failures into a user-fixable `agent_config_invalid` reason (unknown provider, missing runner credentials, wrong provider/model pair) versus `agent_invocation_failed` for genuine provider/API errors.

--- a/libs/api/definitions/src/core/entities/workflow-model.ts
+++ b/libs/api/definitions/src/core/entities/workflow-model.ts
@@ -42,6 +42,7 @@ export interface WorkflowModelRunStep extends WorkflowModelStepBase {
 export interface WorkflowModelAgentStep extends WorkflowModelStepBase {
   readonly kind: 'agent';
   readonly model: string;
+  readonly provider: string;
   readonly thinking: AgentThinking;
   readonly prompt: string;
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -69,7 +69,7 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
-  it('normalizes an inline agent step, applying the thinking default and keeping gates', () => {
+  it('normalizes an inline agent step, applying the thinking and provider defaults and keeping gates', () => {
     const document: WorkflowDocument = {
       name: 'agent build',
       jobs: {
@@ -78,7 +78,8 @@ describe('normalizeWorkflowDocument', () => {
             {name: 'implement', model: 'claude-opus-4-8', prompt: 'Fix the failing tests.'},
             {
               name: 'review',
-              model: 'claude-opus-4-8',
+              model: 'gpt-5.1',
+              provider: 'openai',
               prompt: 'Review the fix.',
               thinking: 'low',
               gate: {success_if: 'exit_code == 0', on_failure: {restart_from: 'implement'}},
@@ -95,12 +96,14 @@ describe('normalizeWorkflowDocument', () => {
       sourceName: 'implement',
       kind: 'agent',
       model: 'claude-opus-4-8',
+      provider: 'anthropic',
       thinking: 'high',
       prompt: 'Fix the failing tests.',
     });
     expect(model.jobs[0]?.steps[1]).toMatchObject({
       id: 'fix-review',
       kind: 'agent',
+      provider: 'openai',
       thinking: 'low',
       gate: {onFailure: {restartFrom: 'implement'}},
     });

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -4,6 +4,7 @@ import {
   type WorkflowExpression,
 } from '@shipfox/expression';
 import {
+  DEFAULT_AGENT_PROVIDER,
   DEFAULT_AGENT_THINKING,
   type WorkflowDocument,
   type WorkflowDocumentJob,
@@ -194,6 +195,7 @@ function normalizeJobs(
           ...stepBase,
           kind: 'agent',
           model: step.model,
+          provider: step.provider ?? DEFAULT_AGENT_PROVIDER,
           prompt: step.prompt,
           thinking: step.thinking ?? DEFAULT_AGENT_THINKING,
         };

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -2,9 +2,12 @@ import {z} from 'zod';
 
 // Machine-readable cause of a step failure, for DB troubleshooting. The runner
 // reports it and the server stores it as-is. The `checkout_*`, `git_unavailable`,
-// `workspace_prep_failed`, and `setup_aborted` values cover setup-phase failures;
-// `agent_invocation_failed` covers an agent step whose harness could not run it to
-// completion. (Aborts are never reported: the step loop stops before reporting.)
+// `workspace_prep_failed`, and `setup_aborted` values cover setup-phase failures.
+// For agent steps the cause is split: `agent_config_invalid` is a user-fixable
+// configuration error (unknown provider, missing provider credentials on the runner,
+// wrong provider/model pair, missing model or prompt), while `agent_invocation_failed`
+// covers a genuine provider/API failure once the config is valid (network, 5xx, auth
+// rejected at call time). (Aborts are never reported: the step loop stops before reporting.)
 export const stepErrorReasonSchema = z.enum([
   'checkout_failed',
   'checkout_auth_failed',
@@ -12,6 +15,7 @@ export const stepErrorReasonSchema = z.enum([
   'git_unavailable',
   'workspace_prep_failed',
   'setup_aborted',
+  'agent_config_invalid',
   'agent_invocation_failed',
 ]);
 

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -103,11 +103,13 @@ describe('materializeWorkflowModel', () => {
             {
               name: 'implement',
               model: 'claude-opus-4-8',
+              provider: 'anthropic',
               thinking: 'high',
               prompt: 'Fix the tests.',
             },
             {
-              model: 'claude-opus-4-8',
+              model: 'gpt-5.1',
+              provider: 'openai',
               thinking: 'low',
               prompt: 'Review it.',
               gate: {
@@ -126,7 +128,12 @@ describe('materializeWorkflowModel', () => {
       sourceName: 'implement',
       status: 'pending',
       type: 'agent',
-      config: {model: 'claude-opus-4-8', thinking: 'high', prompt: 'Fix the tests.'},
+      config: {
+        model: 'claude-opus-4-8',
+        provider: 'anthropic',
+        thinking: 'high',
+        prompt: 'Fix the tests.',
+      },
       position: 2,
     });
     expect(rows[0]?.steps[3]).toEqual({
@@ -134,7 +141,8 @@ describe('materializeWorkflowModel', () => {
       status: 'pending',
       type: 'agent',
       config: {
-        model: 'claude-opus-4-8',
+        model: 'gpt-5.1',
+        provider: 'openai',
         thinking: 'low',
         prompt: 'Review it.',
         gate: {

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -71,7 +71,13 @@ function stepConfig(step: WorkflowModelStep): Record<string, unknown> {
   const gate = step.gate === undefined ? {} : {gate: stepGateConfig(step.gate)};
   return step.kind === 'run'
     ? {run: step.command.value, ...gate}
-    : {model: step.model, thinking: step.thinking, prompt: step.prompt, ...gate};
+    : {
+        model: step.model,
+        provider: step.provider,
+        thinking: step.thinking,
+        prompt: step.prompt,
+        ...gate,
+      };
 }
 
 function stepGateConfig(gate: NonNullable<WorkflowModelStep['gate']>): Record<string, unknown> {

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -67,6 +67,21 @@ describe('toStepDto error category', () => {
     });
   });
 
+  it("derives category 'user' for an agent config error and surfaces the reason", () => {
+    const dto = toStepDto(
+      step({
+        type: 'agent',
+        error: {message: 'Unknown provider "foo" for agent step.', reason: 'agent_config_invalid'},
+      }),
+    );
+
+    expect(dto.error).toEqual({
+      message: 'Unknown provider "foo" for agent step.',
+      reason: 'agent_config_invalid',
+      category: 'user',
+    });
+  });
+
   it('renders no error (and no category) for a successful step', () => {
     const dto = toStepDto(step({type: 'run', status: 'succeeded', error: null}));
 

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -14,6 +14,7 @@ interface TestRunStep extends TestWorkflowStepBase {
 
 interface TestAgentStep extends TestWorkflowStepBase {
   readonly model: string;
+  readonly provider: string;
   readonly prompt: string;
   readonly thinking: AgentThinking;
 }
@@ -64,7 +65,14 @@ function normalizeStep(step: TestWorkflowStep, jobId: string, stepIndex: number)
   const base = stepBase(step, jobId, stepIndex);
   return 'run' in step
     ? {...base, kind: 'run', command: {kind: 'shell', value: step.run}}
-    : {...base, kind: 'agent', model: step.model, thinking: step.thinking, prompt: step.prompt};
+    : {
+        ...base,
+        kind: 'agent',
+        model: step.model,
+        provider: step.provider,
+        thinking: step.thinking,
+        prompt: step.prompt,
+      };
 }
 
 function stepBase(step: TestWorkflowStep, jobId: string, stepIndex: number) {

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * A user-fixable agent-step configuration failure: an unknown provider, a
+ * provider/model pair pi does not know, or no credentials on the runner for the
+ * requested provider. The step layer translates this to the `agent_config_invalid`
+ * reason, distinct from a genuine provider/API failure (`agent_invocation_failed`).
+ */
+export class AgentConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentConfigError';
+  }
+}

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -95,7 +95,18 @@ describe('runAgent', () => {
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
+  it('throws an AgentConfigError without a hint when no provider carries the model', async () => {
+    findMock.mockReturnValue(undefined);
+    getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
+
+    await expect(runAgent(invocation({provider: 'anthropic', model: 'gpt-5.1'}))).rejects.toThrow(
+      new AgentConfigError('Model "gpt-5.1" is not available for provider "anthropic".'),
+    );
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
   it('throws an AgentConfigError when the provider has no credentials on the runner', async () => {
+    findMock.mockReturnValue({provider: 'openai', id: 'gpt-5.1'});
     hasConfiguredAuthMock.mockReturnValue(false);
 
     await expect(runAgent(invocation({provider: 'openai', model: 'gpt-5.1'}))).rejects.toThrow(

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -1,22 +1,33 @@
-const {createAgentSessionMock, findMock, promptMock, abortMock} = vi.hoisted(() => ({
-  createAgentSessionMock: vi.fn(),
-  findMock: vi.fn(),
-  promptMock: vi.fn(),
-  abortMock: vi.fn(),
-}));
+const {createAgentSessionMock, findMock, getAllMock, hasConfiguredAuthMock, promptMock, abortMock} =
+  vi.hoisted(() => ({
+    createAgentSessionMock: vi.fn(),
+    findMock: vi.fn(),
+    getAllMock: vi.fn(),
+    hasConfiguredAuthMock: vi.fn(),
+    promptMock: vi.fn(),
+    abortMock: vi.fn(),
+  }));
 
 vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSession: createAgentSessionMock,
   AuthStorage: {create: () => ({})},
-  ModelRegistry: {create: () => ({find: findMock})},
+  ModelRegistry: {
+    create: () => ({
+      find: findMock,
+      getAll: getAllMock,
+      hasConfiguredAuth: hasConfiguredAuthMock,
+    }),
+  },
 }));
 
+import {AgentConfigError} from '#core/errors.js';
 import {type AgentInvocation, runAgent} from '#core/run-agent.js';
 
 function invocation(overrides: Partial<AgentInvocation> = {}): AgentInvocation {
   return {
     cwd: '/work',
     model: 'claude-opus-4-8',
+    provider: 'anthropic',
     thinking: 'high',
     prompt: 'Fix it.',
     signal: new AbortController().signal,
@@ -28,22 +39,26 @@ describe('runAgent', () => {
   beforeEach(() => {
     createAgentSessionMock.mockReset();
     findMock.mockReset();
+    getAllMock.mockReset();
+    hasConfiguredAuthMock.mockReset();
     promptMock.mockReset();
     abortMock.mockReset();
     findMock.mockReturnValue({provider: 'anthropic', id: 'claude-opus-4-8'});
+    getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
+    hasConfiguredAuthMock.mockReturnValue(true);
     promptMock.mockResolvedValue(undefined);
     createAgentSessionMock.mockResolvedValue({
       session: {prompt: promptMock, abort: abortMock, messages: []},
     });
   });
 
-  it('resolves the configured model under the anthropic provider and runs the prompt', async () => {
-    const model = {provider: 'anthropic', id: 'claude-opus-4-8'};
+  it('resolves the configured model under the requested provider and runs the prompt', async () => {
+    const model = {provider: 'openai', id: 'gpt-5.1'};
     findMock.mockReturnValue(model);
 
-    const result = await runAgent(invocation());
+    const result = await runAgent(invocation({provider: 'openai', model: 'gpt-5.1'}));
 
-    expect(findMock).toHaveBeenCalledWith('anthropic', 'claude-opus-4-8');
+    expect(findMock).toHaveBeenCalledWith('openai', 'gpt-5.1');
     expect(createAgentSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({cwd: '/work', thinkingLevel: 'high', model}),
     );
@@ -51,10 +66,44 @@ describe('runAgent', () => {
     expect(result).toEqual({});
   });
 
-  it('throws when the configured model is not a known anthropic model', async () => {
+  it('throws an AgentConfigError naming the provider when it is unknown', async () => {
     findMock.mockReturnValue(undefined);
+    getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
 
-    await expect(runAgent(invocation({model: 'bogus'}))).rejects.toThrow('Unknown agent model');
+    await expect(runAgent(invocation({provider: 'bogus', model: 'gpt-5.1'}))).rejects.toThrow(
+      new AgentConfigError(
+        'Unknown provider "bogus" for agent step. ' +
+          'Known providers are pi built-ins plus any from models.json.',
+      ),
+    );
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('throws an AgentConfigError with a did-you-mean hint when the model is on another provider', async () => {
+    findMock.mockReturnValue(undefined);
+    getAllMock.mockReturnValue([
+      {provider: 'anthropic', id: 'claude-opus-4-8'},
+      {provider: 'openai', id: 'gpt-5.1'},
+    ]);
+
+    await expect(runAgent(invocation({provider: 'anthropic', model: 'gpt-5.1'}))).rejects.toThrow(
+      new AgentConfigError(
+        'Model "gpt-5.1" is not available for provider "anthropic". ' +
+          'Did you mean to set provider: openai?',
+      ),
+    );
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('throws an AgentConfigError when the provider has no credentials on the runner', async () => {
+    hasConfiguredAuthMock.mockReturnValue(false);
+
+    await expect(runAgent(invocation({provider: 'openai', model: 'gpt-5.1'}))).rejects.toThrow(
+      new AgentConfigError(
+        'No credentials configured for provider "openai" on this runner. ' +
+          "Set the provider's API key in the runner environment.",
+      ),
+    );
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 

--- a/libs/runner/agent/src/core/run-agent.ts
+++ b/libs/runner/agent/src/core/run-agent.ts
@@ -4,17 +4,17 @@ import {
   createAgentSession,
   ModelRegistry,
 } from '@earendil-works/pi-coding-agent';
+import {AgentConfigError} from '#core/errors.js';
 
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions['thinkingLevel']>;
-
-// pi resolves a model from its registry by (provider, modelId), so a bare id is
-// ambiguous on its own. v1 targets Anthropic, so we pin the provider and treat the
-// workflow `model` as the Anthropic model id; selecting other providers comes later.
-const PROVIDER = 'anthropic';
 
 export interface AgentInvocation {
   readonly cwd: string;
   readonly model: string;
+  // pi resolves a model from its registry by (provider, modelId), so a bare id is
+  // ambiguous on its own; the provider selects which built-in (or models.json) set the
+  // model id is looked up in. Free-text, defaulted upstream to anthropic.
+  readonly provider: string;
   readonly thinking: string;
   readonly prompt: string;
   readonly signal: AbortSignal;
@@ -29,7 +29,7 @@ export interface AgentInvocation {
  * observability and never sent to the API, so it is optional.
  */
 export async function runAgent(invocation: AgentInvocation): Promise<{summary?: string}> {
-  const {cwd, model: modelId, thinking, prompt, signal} = invocation;
+  const {cwd, model: modelId, provider, thinking, prompt, signal} = invocation;
 
   // A listener added to an already-aborted signal never fires, so an abort that lands
   // before this point (or during the awaits below) would leave pi running and burning
@@ -39,9 +39,15 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
 
   const authStorage = AuthStorage.create();
   const modelRegistry = ModelRegistry.create(authStorage);
-  const model = modelRegistry.find(PROVIDER, modelId);
-  if (!model) {
-    throw new Error(`Unknown agent model "${modelId}" for provider "${PROVIDER}"`);
+  const model = resolveModel(modelRegistry, provider, modelId);
+
+  // Surface a missing key up front as a config error: otherwise it fails deep inside the
+  // provider call as an opaque invocation failure, hiding that the fix is on the runner.
+  if (!modelRegistry.hasConfiguredAuth(model)) {
+    throw new AgentConfigError(
+      `No credentials configured for provider "${provider}" on this runner. ` +
+        "Set the provider's API key in the runner environment.",
+    );
   }
 
   const {session} = await createAgentSession({
@@ -70,4 +76,36 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
   } finally {
     signal.removeEventListener('abort', abortSession);
   }
+}
+
+type ResolvedModel = NonNullable<ReturnType<ModelRegistry['find']>>;
+
+// pi's `find` returns undefined for both an unknown provider and a known provider that
+// lacks the model, so split them on the registry's provider set to give an actionable
+// message (and, when another provider carries the same id, a did-you-mean hint).
+function resolveModel(
+  modelRegistry: ModelRegistry,
+  provider: string,
+  modelId: string,
+): ResolvedModel {
+  const model = modelRegistry.find(provider, modelId);
+  if (model) return model;
+
+  const all = modelRegistry.getAll();
+  const knownProviders = new Set(all.map((entry) => entry.provider));
+  if (!knownProviders.has(provider)) {
+    throw new AgentConfigError(
+      `Unknown provider "${provider}" for agent step. ` +
+        'Known providers are pi built-ins plus any from models.json.',
+    );
+  }
+
+  const alternativeProvider = all.find((entry) => entry.id === modelId)?.provider;
+  const hint =
+    alternativeProvider === undefined
+      ? ''
+      : ` Did you mean to set provider: ${alternativeProvider}?`;
+  throw new AgentConfigError(
+    `Model "${modelId}" is not available for provider "${provider}".${hint}`,
+  );
 }

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -3,6 +3,7 @@ const {runAgentMock} = vi.hoisted(() => ({runAgentMock: vi.fn()}));
 vi.mock('#core/run-agent.js', () => ({runAgent: runAgentMock}));
 
 import type {StepDto} from '@shipfox/api-workflows-dto';
+import {AgentConfigError} from '#core/errors.js';
 import type {AgentInvocation} from '#core/run-agent.js';
 import {executeAgentStep} from '#core/step.js';
 
@@ -44,22 +45,50 @@ describe('executeAgentStep', () => {
     );
   });
 
-  it('defaults thinking to high when the config omits it', async () => {
+  it('defaults thinking to high and provider to anthropic when the config omits them', async () => {
     runAgentMock.mockResolvedValue({});
 
     await executeAgentStep(buildAgentStep({config: {model: 'm', prompt: 'p'}}), {});
 
-    expect(runAgentMock).toHaveBeenCalledWith(expect.objectContaining({thinking: 'high'}));
+    expect(runAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({thinking: 'high', provider: 'anthropic'}),
+    );
   });
 
-  it('fails with agent_invocation_failed when the agent run throws', async () => {
-    runAgentMock.mockRejectedValue(new Error('model not found'));
+  it('forwards an explicit provider from the config', async () => {
+    runAgentMock.mockResolvedValue({});
+
+    await executeAgentStep(
+      buildAgentStep({config: {model: 'gpt-5.1', prompt: 'p', provider: 'openai'}}),
+      {},
+    );
+
+    expect(runAgentMock).toHaveBeenCalledWith(expect.objectContaining({provider: 'openai'}));
+  });
+
+  it('fails with agent_invocation_failed when the agent run throws a generic error', async () => {
+    runAgentMock.mockRejectedValue(new Error('provider returned 503'));
 
     const result = await executeAgentStep(buildAgentStep(), {});
 
     expect(result.success).toBe(false);
-    expect(result.error).toEqual({message: 'model not found', reason: 'agent_invocation_failed'});
+    expect(result.error).toEqual({
+      message: 'provider returned 503',
+      reason: 'agent_invocation_failed',
+    });
     expect(result.exit_code).toBeNull();
+  });
+
+  it('fails with agent_config_invalid when the agent run throws an AgentConfigError', async () => {
+    runAgentMock.mockRejectedValue(new AgentConfigError('Unknown provider "foo" for agent step.'));
+
+    const result = await executeAgentStep(buildAgentStep(), {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({
+      message: 'Unknown provider "foo" for agent step.',
+      reason: 'agent_config_invalid',
+    });
   });
 
   it('rejects a non-agent step type without running the agent', async () => {
@@ -70,11 +99,11 @@ describe('executeAgentStep', () => {
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 
-  it('fails when the config is missing model or prompt', async () => {
+  it('fails with agent_config_invalid when the config is missing model or prompt', async () => {
     const result = await executeAgentStep(buildAgentStep({config: {model: 'm'}}), {});
 
     expect(result.success).toBe(false);
-    expect(result.error?.reason).toBe('agent_invocation_failed');
+    expect(result.error?.reason).toBe('agent_config_invalid');
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -1,8 +1,13 @@
-import type {StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
+import type {StepDto, StepErrorDtoShape, StepErrorReason} from '@shipfox/api-workflows-dto';
 import type {StepResult} from '@shipfox/runner-execution';
+import {AgentConfigError} from '#core/errors.js';
 import {runAgent} from '#core/run-agent.js';
 
 const DEFAULT_THINKING = 'high';
+// Matches DEFAULT_AGENT_PROVIDER upstream; kept local so the runner stays decoupled from
+// the workflow-document package, and so a config materialized before `provider` existed
+// still resolves to anthropic.
+const DEFAULT_PROVIDER = 'anthropic';
 
 export function executeAgentStep(
   step: StepDto,
@@ -12,9 +17,11 @@ export function executeAgentStep(
     return Promise.resolve(agentFailure(`Unsupported step type: ${step.type}`));
   }
 
-  const {model, prompt, thinking} = step.config;
+  const {model, prompt, thinking, provider} = step.config;
   if (typeof model !== 'string' || model === '' || typeof prompt !== 'string' || prompt === '') {
-    return Promise.resolve(agentFailure('Agent step config is missing model or prompt'));
+    return Promise.resolve(
+      agentFailure('Agent step config is missing model or prompt', 'agent_config_invalid'),
+    );
   }
 
   return runAgentStep({
@@ -22,6 +29,7 @@ export function executeAgentStep(
     model,
     prompt,
     thinking: typeof thinking === 'string' ? thinking : DEFAULT_THINKING,
+    provider: typeof provider === 'string' && provider !== '' ? provider : DEFAULT_PROVIDER,
     signal: options.signal,
   });
 }
@@ -31,16 +39,22 @@ async function runAgentStep(params: {
   model: string;
   prompt: string;
   thinking: string;
+  provider: string;
   signal: AbortSignal | undefined;
 }): Promise<StepResult> {
-  const {cwd, model, prompt, thinking} = params;
+  const {cwd, model, prompt, thinking, provider} = params;
   const signal = params.signal ?? new AbortController().signal;
 
   try {
-    const {summary} = await raceAbort(runAgent({cwd, model, thinking, prompt, signal}), signal);
+    const {summary} = await raceAbort(
+      runAgent({cwd, model, provider, thinking, prompt, signal}),
+      signal,
+    );
     return {success: true, output: summary ?? '', error: null, exit_code: 0};
   } catch (error) {
-    return agentFailure(error instanceof Error ? error.message : String(error));
+    const reason: StepErrorReason =
+      error instanceof AgentConfigError ? 'agent_config_invalid' : 'agent_invocation_failed';
+    return agentFailure(error instanceof Error ? error.message : String(error), reason);
   }
 }
 
@@ -77,10 +91,14 @@ function abortError(): Error {
   return error;
 }
 
-// All agent-step failures are `agent_invocation_failed` in v1 (the server derives
-// the `user` category from the step type). An aborted step never reaches the API:
-// the step loop returns before reporting once the signal fires.
-function agentFailure(message: string): StepResult {
-  const error: StepErrorDtoShape = {message, reason: 'agent_invocation_failed'};
+// Agent-step failures split into a user-fixable config error (`agent_config_invalid`)
+// and a genuine provider/API failure (`agent_invocation_failed`, the default); the
+// server derives the `user` category from the step type for both. An aborted step never
+// reaches the API: the step loop returns before reporting once the signal fires.
+function agentFailure(
+  message: string,
+  reason: StepErrorReason = 'agent_invocation_failed',
+): StepResult {
+  const error: StepErrorDtoShape = {message, reason};
   return {success: false, output: '', error, exit_code: null};
 }

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -10,8 +10,8 @@ Input shape for Shipfox workflow authoring.
 - `WorkflowDocumentRunStepGate` describes the step `gate` block with `success_if`
   and `on_failure`.
 - A job step is either a **run step** (`run: <shell command>`) or an inline
-  **agent step** (`model` + `prompt`, with an optional `thinking` level). A step
-  carries one or the other, never both.
+  **agent step** (`model` + `prompt`, with an optional `thinking` level and an
+  optional `provider`). A step carries one or the other, never both.
 
 Use this package where Shipfox accepts a workflow object from a file, tool, or
 API call. It checks the shape only. It does not add defaults, pick runners,
@@ -61,9 +61,12 @@ try {
 ```
 
 A step can also be an inline agent step. It declares a `model` and a `prompt`
-(no `run`), with an optional `thinking` level that defaults to `high`. The
-recommended pattern is an agent step that produces a change, followed by a `run`
-step whose `gate` judges the result:
+(no `run`), with an optional `thinking` level that defaults to `high` and an
+optional `provider` that defaults to `anthropic`. The `provider` names the
+model's provider (for example `anthropic` or `openai`); pairing it with `model`
+lets a step target a non-Anthropic model. The recommended pattern is an agent
+step that produces a change, followed by a `run` step whose `gate` judges the
+result:
 
 ```ts
 parseWorkflowDocument({
@@ -72,6 +75,7 @@ parseWorkflowDocument({
     fix: {
       steps: [
         {model: 'claude-opus-4-8', prompt: 'Fix the failing tests.'},
+        {model: 'gpt-5.1', provider: 'openai', prompt: 'Review the fix.'},
         {run: 'npm test', gate: {success_if: 'exit_code == 0'}},
       ],
     },
@@ -87,11 +91,13 @@ parseWorkflowDocument({
   target checks belong to definitions-owned model code.
 - A step is discriminated by which keys it carries: `run` marks a run step;
   `model` + `prompt` (both required) mark an agent step; declaring both, or
-  neither, is rejected. `thinking` is optional and validated against a fixed set
-  (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`); the `high` default is
-  applied later in the model layer, not here. `model` is free text, so an unknown
-  model is accepted at parse time and fails later at runtime. The `agent` key is
-  reserved for a future step kind and is rejected today.
+  neither, is rejected. `thinking` and `provider` are optional and valid only on
+  an agent step; using either on a run step is rejected. `thinking` is validated
+  against a fixed set (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`).
+  `model` and `provider` are free text, so an unknown value is accepted at parse
+  time and fails later at runtime. The `high` and `anthropic` defaults are
+  applied later in the model layer, not here. The `agent` key is reserved for a
+  future step kind and is rejected today.
 - Rules that need a project, user, runner, database row, or saved state belong
   outside this package.
 

--- a/libs/shared/workflow/document/src/document/index.ts
+++ b/libs/shared/workflow/document/src/document/index.ts
@@ -1,4 +1,9 @@
-export {type AgentThinking, agentThinkingSchema, DEFAULT_AGENT_THINKING} from './step-enums.js';
+export {
+  type AgentThinking,
+  agentThinkingSchema,
+  DEFAULT_AGENT_PROVIDER,
+  DEFAULT_AGENT_THINKING,
+} from './step-enums.js';
 export {
   type WorkflowDocument,
   type WorkflowDocumentJob,

--- a/libs/shared/workflow/document/src/document/step-enums.ts
+++ b/libs/shared/workflow/document/src/document/step-enums.ts
@@ -8,3 +8,8 @@ export const agentThinkingSchema = z.enum(['off', 'minimal', 'low', 'medium', 'h
 export type AgentThinking = z.infer<typeof agentThinkingSchema>;
 
 export const DEFAULT_AGENT_THINKING = 'high' as const satisfies AgentThinking;
+
+// pi resolves a model by (provider, modelId). `provider` is free-text like `model`
+// (no Zod enum) so new and custom providers work without a schema change; an unknown
+// provider fails at runtime in the runner, not at parse time. Defaults to anthropic.
+export const DEFAULT_AGENT_PROVIDER = 'anthropic' as const;

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -166,6 +166,7 @@ describe('workflowDocumentSchema', () => {
   it.each([
     ['inline agent step', {model: 'claude-opus-4-8', prompt: 'Fix the failing tests.'}],
     ['agent step with thinking', {model: 'claude-opus-4-8', prompt: 'Fix it.', thinking: 'low'}],
+    ['agent step with provider', {model: 'gpt-5.1', prompt: 'Fix it.', provider: 'openai'}],
     ['agent step with name', {name: 'fix', model: 'claude-opus-4-8', prompt: 'Fix it.'}],
     [
       'agent step with gate',
@@ -188,8 +189,10 @@ describe('workflowDocumentSchema', () => {
     ['neither run nor agent', {name: 'noop'}],
     ['reserved agent keyword', {agent: 'producer', model: 'claude-opus-4-8', prompt: 'Fix.'}],
     ['thinking on a run step', {run: 'npm test', thinking: 'high'}],
+    ['provider on a run step', {run: 'npm test', provider: 'openai'}],
     ['unknown thinking value', {model: 'claude-opus-4-8', prompt: 'Fix.', thinking: 'ultra'}],
     ['empty model string', {model: '', prompt: 'Fix.'}],
+    ['empty provider string', {model: 'gpt-5.1', prompt: 'Fix.', provider: ''}],
   ])('rejects %s', (_label, step) => {
     const result = workflowDocumentSchema.safeParse({
       name: 'agent build',

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -45,6 +45,7 @@ export const workflowDocumentStepSchema = z
     model: z.string().min(1).optional(),
     prompt: z.string().min(1).optional(),
     thinking: agentThinkingSchema.optional(),
+    provider: z.string().min(1).optional(),
     agent: z.unknown().optional(),
     gate: workflowDocumentStepGateSchema.optional(),
   })
@@ -92,7 +93,7 @@ export const workflowDocumentStepSchema = z
       return;
     }
 
-    for (const key of ['model', 'prompt', 'thinking'] as const) {
+    for (const key of ['model', 'prompt', 'thinking', 'provider'] as const) {
       if (step[key] !== undefined) {
         ctx.addIssue({
           code: 'custom',

--- a/libs/shared/workflow/document/src/index.ts
+++ b/libs/shared/workflow/document/src/index.ts
@@ -1,6 +1,7 @@
 export {
   type AgentThinking,
   agentThinkingSchema,
+  DEFAULT_AGENT_PROVIDER,
   DEFAULT_AGENT_THINKING,
   InvalidWorkflowDocumentError,
   invalidWorkflowDocumentErrorCode,


### PR DESCRIPTION
Adds an optional, free-text `provider` field on agent workflow steps and threads it to the runner's pi model lookup (`modelRegistry.find(provider, modelId)`).

Agent steps previously hardcoded the provider to `anthropic`, so only Anthropic models were reachable even though the embedded pi harness already knows every built-in provider (openai, google, deepseek, groq, xai, openrouter, bedrock, vertex, ...). The field mirrors how `thinking` already flows end to end: optional, defaulted at normalize time, carried on the opaque `step.config` jsonb with no runner/backend protocol change. The default stays `anthropic`, so existing workflows and already-materialized configs are unchanged.

Unlike `thinking` (a validated enum), `provider` is free-text with no allowlist, symmetric with `model` — a sibling field, not a namespaced `provider/model` string, since real pi model ids contain slashes. It is an agent-only modifier: rejected on `run` steps and never flips a run step into an agent step.

## Error handling

The provider path adds new, common, user-fixable failure modes, so agent-step failures are now split into two machine-readable reasons (both still resolving to the `user` category):

- `agent_config_invalid` — unknown provider, missing runner credentials for the provider, wrong provider/model pair, or a config missing `model`/`prompt`. Each carries an actionable message (e.g. a known-providers hint, a did-you-mean-provider hint, or "set the provider's API key in the runner environment").
- `agent_invocation_failed` — genuine provider/API failures once the config is valid (network, 5xx, auth rejected at call time).

pi's `find()` returns `undefined` (it does not throw) for both an unknown provider and a model not in a known provider's set, so the runner splits them using the registry's `getAll()` provider set, and pre-checks credentials with `hasConfiguredAuth` before opening the session. Classification lives in the runner: `run-agent.ts` throws a typed `AgentConfigError`, and `step.ts` translates it to the reason at the boundary.

## Review notes

The substantive logic is in `libs/runner/agent/src/core/run-agent.ts` (`resolveModel` + the credential pre-check) and `step.ts` (reason mapping). The other four packages are the field plumbing.

Out of scope (separate tickets): self-hosted custom providers / `models.json` (ENG-490), runner model/provider discovery (ENG-491).

Refs ENG-489

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let agent steps choose their PI provider via an optional `provider` field (default `anthropic`) to unlock non-Anthropic models. Split agent-step errors into config issues vs real provider failures to guide fixes (ENG-489).

**New Features**
- Add `provider` to agent steps in `@shipfox/workflow-document` and `@shipfox/api-definitions`; default at normalize time and carry through materialization/DTOs in `@shipfox/api-workflows` and `@shipfox/api-workflows-dto`. Reject `provider` on `run` steps. Documented with examples in the `@shipfox/workflow-document` README.
- Update `@shipfox/runner-agent` to resolve models with `ModelRegistry.find(provider, modelId)` and pre-check credentials. Classify user-fixable issues as `agent_config_invalid` (unknown provider, wrong provider/model pair, missing runner credentials) via `AgentConfigError`; keep other failures as `agent_invocation_failed`. Add tests for resolve branches and missing credentials.
- No breaking changes: default `anthropic` preserves existing workflows and stored configs.

<sup>Written for commit 25641781a79a99fdc1d25cf25f68f2441c0f7c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

