### PR TITLE
Add shared @shipfox/redact credential-redaction package

### DIFF
--- a/.changeset/eng-506-shared-redact.md
+++ b/.changeset/eng-506-shared-redact.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/redact": patch
+"@shipfox/api-integration-core": patch
+"@shipfox/api-integration-core-dto": patch
+---
+
+Add the `@shipfox/redact` package with shared credential-redaction helpers: `redactUrlCredentials` (scheme-agnostic free-text scrubber), `stripUrlCredentials` (structured single-URL stripper), `redactSecrets` (literal-secret scrubber), and the `REDACTION_PLACEHOLDER` constant. Move `redactCheckoutSpec` from `@shipfox/api-integration-core-dto` into `@shipfox/api-integration-core` so it can reuse the shared `stripUrlCredentials` without breaking the dto-only-dependency rule; its public export path (`@shipfox/api-integration-core`) is unchanged. No behavior change.

--- a/libs/api/integration/core-dto/src/contracts/index.ts
+++ b/libs/api/integration/core-dto/src/contracts/index.ts
@@ -27,5 +27,4 @@ export {
   IntegrationProviderError,
   MAX_REPOSITORY_FILE_BYTES,
   parseProviderRepositoryId,
-  redactCheckoutSpec,
 } from './integrations.js';

--- a/libs/api/integration/core-dto/src/contracts/integrations.test.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.test.ts
@@ -1,77 +1,64 @@
-import {type CheckoutSpec, redactCheckoutSpec} from './integrations.js';
+import {
+  buildProviderRepositoryId,
+  IntegrationProviderError,
+  parseProviderRepositoryId,
+} from './integrations.js';
 
-describe('redactCheckoutSpec', () => {
-  it('masks the credential token while keeping the other fields intact', () => {
-    const expiresAt = new Date('2026-06-10T12:00:00.000Z');
-    const spec: CheckoutSpec = {
-      repositoryUrl: 'https://github.com/shipfox/platform.git',
-      ref: 'main',
-      credentials: {username: 'x-access-token', token: 'ghs_supersecret', expiresAt},
-    };
+const MISSING_PREFIX = /missing a provider prefix/;
+const WRONG_PROVIDER = /not owned by provider github/;
+const MISSING_VALUE = /missing a provider-owned value/;
 
-    const redacted = redactCheckoutSpec(spec);
+describe('buildProviderRepositoryId', () => {
+  it('joins the provider and value with a colon', () => {
+    const result = buildProviderRepositoryId('github', '42');
 
-    expect(redacted).toEqual({
-      repositoryUrl: 'https://github.com/shipfox/platform.git',
-      ref: 'main',
-      credentials: {username: 'x-access-token', token: '***', expiresAt},
-    });
+    expect(result).toBe('github:42');
+  });
+});
+
+describe('parseProviderRepositoryId', () => {
+  it('returns the provider-owned value for a well-formed id', () => {
+    const result = parseProviderRepositoryId('github:42', 'github');
+
+    expect(result).toBe('42');
   });
 
-  it('does not mutate the original spec', () => {
-    const spec: CheckoutSpec = {
-      repositoryUrl: 'https://github.com/shipfox/platform.git',
-      ref: 'main',
-      credentials: {
-        username: 'x-access-token',
-        token: 'ghs_supersecret',
-        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
-      },
-    };
+  it('keeps colons inside the value (splits only on the first separator)', () => {
+    const result = parseProviderRepositoryId('github:org/repo:extra', 'github');
 
-    redactCheckoutSpec(spec);
-
-    expect(spec.credentials?.token).toBe('ghs_supersecret');
+    expect(result).toBe('org/repo:extra');
   });
 
-  it('returns the spec unchanged when there are no credentials and the url is clean', () => {
-    const spec: CheckoutSpec = {
-      repositoryUrl: 'https://debug.local/debug-owner/platform.git',
-      ref: 'main',
-    };
+  it.each([
+    ['42', 'no provider prefix'],
+    [':42', 'an empty provider prefix'],
+  ])('rejects %s (%s)', (externalRepositoryId) => {
+    const parse = () => parseProviderRepositoryId(externalRepositoryId, 'github');
 
-    const redacted = redactCheckoutSpec(spec);
-
-    expect(redacted).toBe(spec);
+    expect(parse).toThrow(IntegrationProviderError);
+    expect(parse).toThrow(MISSING_PREFIX);
   });
 
-  it('strips credentials embedded in repositoryUrl as a defense in depth', () => {
-    const spec: CheckoutSpec = {
-      repositoryUrl: 'https://x-access-token:ghs_supersecret@github.com/shipfox/platform.git',
-      ref: 'main',
-      credentials: {
-        username: 'x-access-token',
-        token: 'ghs_supersecret',
-        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
-      },
-    };
+  it('rejects an id owned by a different provider', () => {
+    const parse = () => parseProviderRepositoryId('gitlab:42', 'github');
 
-    const redacted = redactCheckoutSpec(spec);
-
-    expect(redacted.repositoryUrl).toBe('https://github.com/shipfox/platform.git');
-    expect(redacted.repositoryUrl).not.toContain('ghs_supersecret');
-    expect(redacted.credentials?.token).toBe('***');
+    expect(parse).toThrow(IntegrationProviderError);
+    expect(parse).toThrow(WRONG_PROVIDER);
   });
 
-  it('strips embedded credentials even when the spec has no credentials field', () => {
-    const spec: CheckoutSpec = {
-      repositoryUrl: 'https://x-access-token:ghs_supersecret@github.com/shipfox/platform.git',
-      ref: 'main',
-    };
+  it('rejects an id with a prefix but no value', () => {
+    const parse = () => parseProviderRepositoryId('github:', 'github');
 
-    const redacted = redactCheckoutSpec(spec);
+    expect(parse).toThrow(IntegrationProviderError);
+    expect(parse).toThrow(MISSING_VALUE);
+  });
 
-    expect(redacted.repositoryUrl).toBe('https://github.com/shipfox/platform.git');
-    expect(redacted.repositoryUrl).not.toContain('ghs_supersecret');
+  it('surfaces the repository-not-found reason on the thrown error', () => {
+    expect.assertions(1);
+    try {
+      parseProviderRepositoryId('42', 'github');
+    } catch (error) {
+      expect((error as IntegrationProviderError).reason).toBe('repository-not-found');
+    }
   });
 });

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -89,9 +89,9 @@ export interface CheckoutCredentials {
 export interface CheckoutSpec {
   /**
    * Clone URL that must never embed authentication material. Credentials live
-   * only in `credentials` so `redactCheckoutSpec()` can mask them; a provider
-   * that embeds a token in this URL would bypass redaction and leak it into
-   * logs, `git remote -v`, and persisted job rows.
+   * only in `credentials` so a redaction helper can mask them; a provider that
+   * embeds a token in this URL would bypass redaction and leak it into logs,
+   * `git remote -v`, and persisted job rows.
    */
   repositoryUrl: string;
   ref: string;
@@ -169,36 +169,6 @@ export class IntegrationProviderError extends Error {
 }
 
 export const MAX_REPOSITORY_FILE_BYTES = 1_000_000;
-
-const REDACTED_TOKEN = '***';
-
-export function redactCheckoutSpec(spec: CheckoutSpec): CheckoutSpec {
-  const repositoryUrl = stripUrlCredentials(spec.repositoryUrl);
-  if (!spec.credentials) {
-    return repositoryUrl === spec.repositoryUrl ? spec : {...spec, repositoryUrl};
-  }
-  return {
-    ...spec,
-    repositoryUrl,
-    credentials: {...spec.credentials, token: REDACTED_TOKEN},
-  };
-}
-
-// Defense in depth: providers must keep `repositoryUrl` credential-free, but a
-// helper whose job is to make a spec safe to log must also strip any userinfo
-// (e.g. `https://x-access-token:<token>@host/...`) so a provider mistake cannot
-// leak a token through the URL.
-function stripUrlCredentials(repositoryUrl: string): string {
-  try {
-    const url = new URL(repositoryUrl);
-    if (!url.username && !url.password) return repositoryUrl;
-    url.username = '';
-    url.password = '';
-    return url.toString();
-  } catch {
-    return repositoryUrl;
-  }
-}
 
 export function buildProviderRepositoryId(
   provider: IntegrationProviderKind,

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -50,6 +50,7 @@
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",
+    "@shipfox/redact": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "zod": "^4.4.3"
   },

--- a/libs/api/integration/core/src/core/providers/redact-checkout-spec.test.ts
+++ b/libs/api/integration/core/src/core/providers/redact-checkout-spec.test.ts
@@ -1,0 +1,78 @@
+import type {CheckoutSpec} from '@shipfox/api-integration-core-dto';
+import {redactCheckoutSpec} from './redact-checkout-spec.js';
+
+describe('redactCheckoutSpec', () => {
+  it('masks the credential token while keeping the other fields intact', () => {
+    const expiresAt = new Date('2026-06-10T12:00:00.000Z');
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {username: 'x-access-token', token: 'ghs_supersecret', expiresAt},
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted).toEqual({
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {username: 'x-access-token', token: '***', expiresAt},
+    });
+  });
+
+  it('does not mutate the original spec', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {
+        username: 'x-access-token',
+        token: 'ghs_supersecret',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      },
+    };
+
+    redactCheckoutSpec(spec);
+
+    expect(spec.credentials?.token).toBe('ghs_supersecret');
+  });
+
+  it('returns the spec unchanged when there are no credentials and the url is clean', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://debug.local/debug-owner/platform.git',
+      ref: 'main',
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted).toBe(spec);
+  });
+
+  it('strips credentials embedded in repositoryUrl as a defense in depth', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://x-access-token:ghs_supersecret@github.com/shipfox/platform.git',
+      ref: 'main',
+      credentials: {
+        username: 'x-access-token',
+        token: 'ghs_supersecret',
+        expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      },
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted.repositoryUrl).toBe('https://github.com/shipfox/platform.git');
+    expect(redacted.repositoryUrl).not.toContain('ghs_supersecret');
+    expect(redacted.credentials?.token).toBe('***');
+  });
+
+  it('strips embedded credentials even when the spec has no credentials field', () => {
+    const spec: CheckoutSpec = {
+      repositoryUrl: 'https://x-access-token:ghs_supersecret@github.com/shipfox/platform.git',
+      ref: 'main',
+    };
+
+    const redacted = redactCheckoutSpec(spec);
+
+    expect(redacted.repositoryUrl).toBe('https://github.com/shipfox/platform.git');
+    expect(redacted.repositoryUrl).not.toContain('ghs_supersecret');
+  });
+});

--- a/libs/api/integration/core/src/core/providers/redact-checkout-spec.ts
+++ b/libs/api/integration/core/src/core/providers/redact-checkout-spec.ts
@@ -1,0 +1,20 @@
+import type {CheckoutSpec} from '@shipfox/api-integration-core-dto';
+import {REDACTION_PLACEHOLDER, stripUrlCredentials} from '@shipfox/redact';
+
+/**
+ * Returns a copy of `spec` that is safe to log: the credential token is masked
+ * and any userinfo a provider mistakenly left in `repositoryUrl` is stripped.
+ * Returns the original spec unchanged when it has no credentials and the URL is
+ * already clean.
+ */
+export function redactCheckoutSpec(spec: CheckoutSpec): CheckoutSpec {
+  const repositoryUrl = stripUrlCredentials(spec.repositoryUrl);
+  if (!spec.credentials) {
+    return repositoryUrl === spec.repositoryUrl ? spec : {...spec, repositoryUrl};
+  }
+  return {
+    ...spec,
+    repositoryUrl,
+    credentials: {...spec.credentials, token: REDACTION_PLACEHOLDER},
+  };
+}

--- a/libs/api/integration/core/src/core/providers/source-control.ts
+++ b/libs/api/integration/core/src/core/providers/source-control.ts
@@ -14,4 +14,3 @@ export type {
   ResolveRepositoryInput,
   SourceControlProvider,
 } from '@shipfox/api-integration-core-dto';
-export {redactCheckoutSpec} from '@shipfox/api-integration-core-dto';

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -57,6 +57,7 @@ export {
   IntegrationProviderError,
   IntegrationProviderUnavailableError,
 } from '#core/errors.js';
+export {redactCheckoutSpec} from '#core/providers/redact-checkout-spec.js';
 export type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 export type {
   CheckoutCredentials,
@@ -74,7 +75,6 @@ export type {
   ResolveRepositoryInput,
   SourceControlProvider,
 } from '#core/providers/source-control.js';
-export {redactCheckoutSpec} from '#core/providers/source-control.js';
 export type {IntegrationSourceControlService} from '#core/source-control-service.js';
 export {createSourceControlIntegrationService} from '#core/source-control-service.js';
 export type {GetIntegrationConnectionByIdFn} from '#db/connections.js';

--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -10,7 +10,10 @@ across Shipfox so they cannot drift.
   git, ssh, ...). Use it on log lines and command stderr.
 - **`stripUrlCredentials(url)`** removes the userinfo from a single known URL via
   `new URL()`, returning a clean URL with no `***@` residue. Use it on one URL
-  field you control. Returns the input unchanged when it does not parse.
+  field you control. When the value does not parse as a URL it falls back to
+  `redactUrlCredentials`, so a credential with a malformed authority is still
+  masked; a credential-free non-URL (scp-style `git@host:path`) is returned
+  unchanged.
 - **`redactSecrets(text, secrets)`** removes every occurrence of each literal
   secret, then applies `redactUrlCredentials`. Pass every wire form a secret
   takes (e.g. the base64 of `user:token`); the helper only removes the literals

--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -1,0 +1,56 @@
+# Shipfox Redact
+
+Shared credential-redaction helpers. One home for the redaction techniques used
+across Shipfox so they cannot drift.
+
+## What it does
+
+- **`redactUrlCredentials(text)`** scrubs `user:pass@` (and bare `user@`)
+  credentials from free text, for every `scheme://` URL it finds (http, https,
+  git, ssh, ...). Use it on log lines and command stderr.
+- **`stripUrlCredentials(url)`** removes the userinfo from a single known URL via
+  `new URL()`, returning a clean URL with no `***@` residue. Use it on one URL
+  field you control. Returns the input unchanged when it does not parse.
+- **`redactSecrets(text, secrets)`** removes every occurrence of each literal
+  secret, then applies `redactUrlCredentials`. Pass every wire form a secret
+  takes (e.g. the base64 of `user:token`); the helper only removes the literals
+  it is given.
+- **`REDACTION_PLACEHOLDER`** is the `'***'` string every redaction writes.
+
+scp-style remotes (`git@host:path`) are left untouched on purpose: an scp URL
+carrying a password is not a real git form, and redacting it would corrupt
+structurally identical strings (Docker digests, `host:port`). Literal secrets are
+the backstop for those.
+
+## Installation
+
+```bash
+pnpm add @shipfox/redact
+```
+
+## Usage
+
+```ts
+import {redactSecrets, redactUrlCredentials, stripUrlCredentials} from "@shipfox/redact";
+
+redactUrlCredentials("fatal: clone of https://x:tok@github.com/o/r.git failed");
+// -> "fatal: clone of https://***@github.com/o/r.git failed"
+
+stripUrlCredentials("https://x-access-token:tok@github.com/o/r.git");
+// -> "https://github.com/o/r.git"
+
+redactSecrets("Authorization: Basic dXNlcjp0b2tlbg==", ["dXNlcjp0b2tlbg=="]);
+// -> "Authorization: Basic ***"
+```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/redact
+turbo type --filter=@shipfox/redact
+turbo test --filter=@shipfox/redact
+```
+
+## License
+
+MIT

--- a/libs/shared/common/redact/package.json
+++ b/libs/shared/common/redact/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@shipfox/redact",
+  "license": "MIT",
+  "private": true,
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/shared/common/redact"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -1,0 +1,137 @@
+import {
+  REDACTION_PLACEHOLDER,
+  redactSecrets,
+  redactUrlCredentials,
+  stripUrlCredentials,
+} from './index.js';
+
+describe('redactUrlCredentials', () => {
+  it.each([
+    ['https://user:pass@github.com/o/r.git', 'https://***@github.com/o/r.git'],
+    ['http://user:pass@host/p', 'http://***@host/p'],
+    ['git://user:pass@host/p', 'git://***@host/p'],
+    ['ssh://git:key@host/p', 'ssh://***@host/p'],
+  ])('redacts userinfo for scheme URL %s', (input, expected) => {
+    const result = redactUrlCredentials(input);
+
+    expect(result).toBe(expected);
+  });
+
+  it('redacts a bare user@ with no password', () => {
+    const result = redactUrlCredentials('https://user@github.com/o/r.git');
+
+    expect(result).toBe('https://***@github.com/o/r.git');
+  });
+
+  it('redacts credentials on a URL with a port', () => {
+    const result = redactUrlCredentials('https://user:pass@host:8080/p');
+
+    expect(result).toBe('https://***@host:8080/p');
+  });
+
+  it('redacts credentials on a URL with an IPv6 host', () => {
+    const result = redactUrlCredentials('https://user:pass@[::1]:443/p');
+
+    expect(result).toBe('https://***@[::1]:443/p');
+  });
+
+  it('redacts every occurrence in a line with mixed schemes', () => {
+    const input = 'a https://u:p@h1/x and b git://u2:p2@h2/y end';
+
+    const result = redactUrlCredentials(input);
+
+    expect(result).toBe('a https://***@h1/x and b git://***@h2/y end');
+  });
+
+  it.each([
+    'git@github.com:org/repo.git',
+    'myapp:1.2.3@sha256:abcdef',
+    'a:b@host:1',
+    'https://github.com/o/r.git',
+    'no credentials here at all',
+    '',
+  ])('leaves %s unchanged', (input) => {
+    const result = redactUrlCredentials(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('stays linear on long adversarial input (ReDoS guard)', () => {
+    const noColon = 'a'.repeat(200_000);
+    const schemeNoAt = `https://${'a'.repeat(200_000)}`;
+
+    const start = performance.now();
+    const a = redactUrlCredentials(noColon);
+    const b = redactUrlCredentials(schemeNoAt);
+    const elapsed = performance.now() - start;
+
+    expect(a).toBe(noColon);
+    expect(b).toBe(schemeNoAt);
+    expect(elapsed).toBeLessThan(1000);
+  });
+});
+
+describe('stripUrlCredentials', () => {
+  it('strips userinfo and leaves no *** residue', () => {
+    const result = stripUrlCredentials('https://x-access-token:ghs_secret@github.com/o/r.git');
+
+    expect(result).toBe('https://github.com/o/r.git');
+    expect(result).not.toContain('ghs_secret');
+    expect(result).not.toContain('***');
+  });
+
+  it('strips credentials on a URL with a port', () => {
+    const result = stripUrlCredentials('https://user:pass@host:8080/p');
+
+    expect(result).toBe('https://host:8080/p');
+  });
+
+  it.each([
+    'https://github.com/o/r.git',
+    'git@github.com:org/repo.git',
+    'not a url',
+    '',
+  ])('returns %s unchanged', (input) => {
+    const result = stripUrlCredentials(input);
+
+    expect(result).toBe(input);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('removes every occurrence of each literal secret', () => {
+    const result = redactSecrets('token=abc and again abc', ['abc']);
+
+    expect(result).toBe('token=*** and again ***');
+  });
+
+  it('redacts a base64 basic-auth credential', () => {
+    const base64 = Buffer.from('x-access-token:ghs_secret').toString('base64');
+
+    const result = redactSecrets(`Authorization: Basic ${base64}`, [base64]);
+
+    expect(result).toBe('Authorization: Basic ***');
+  });
+
+  it('composes URL credential scrubbing after literal removal', () => {
+    const result = redactSecrets('clone https://user:pass@github.com/x.git failed', []);
+
+    expect(result).toBe('clone https://***@github.com/x.git failed');
+  });
+
+  it('ignores empty strings in the secrets array', () => {
+    const result = redactSecrets('keep this text', ['']);
+
+    expect(result).toBe('keep this text');
+  });
+
+  it('returns empty text unchanged', () => {
+    const result = redactSecrets('', ['secret']);
+
+    expect(result).toBe('');
+  });
+
+  it('exposes the placeholder it writes', () => {
+    expect(REDACTION_PLACEHOLDER).toBe('***');
+  });
+});

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -48,6 +48,7 @@ describe('redactUrlCredentials', () => {
     'myapp:1.2.3@sha256:abcdef',
     'a:b@host:1',
     'https://github.com/o/r.git',
+    'notify user@example.com about the build',
     'no credentials here at all',
     '',
   ])('leaves %s unchanged', (input) => {
@@ -59,15 +60,24 @@ describe('redactUrlCredentials', () => {
   it('stays linear on long adversarial input (ReDoS guard)', () => {
     const noColon = 'a'.repeat(200_000);
     const schemeNoAt = `https://${'a'.repeat(200_000)}`;
+    const time = (fn: () => void): number => {
+      const start = performance.now();
+      fn();
+      return performance.now() - start;
+    };
 
-    const start = performance.now();
-    const a = redactUrlCredentials(noColon);
-    const b = redactUrlCredentials(schemeNoAt);
-    const elapsed = performance.now() - start;
+    // Machine-relative budget: a plain linear scan over the same input scales
+    // with the runner's speed, so this avoids the flakiness of an absolute
+    // millisecond cap. A catastrophic-backtracking regex would run orders of
+    // magnitude slower than this baseline (the bounded scheme prevents it).
+    const linearScan = time(() => noColon.replace(/a/g, 'a'));
+    const baseline = Math.max(linearScan, 1);
+    const elapsed = time(() => {
+      expect(redactUrlCredentials(noColon)).toBe(noColon);
+      expect(redactUrlCredentials(schemeNoAt)).toBe(schemeNoAt);
+    });
 
-    expect(a).toBe(noColon);
-    expect(b).toBe(schemeNoAt);
-    expect(elapsed).toBeLessThan(1000);
+    expect(elapsed).toBeLessThan(baseline * 100);
   });
 });
 
@@ -84,6 +94,13 @@ describe('stripUrlCredentials', () => {
     const result = stripUrlCredentials('https://user:pass@host:8080/p');
 
     expect(result).toBe('https://host:8080/p');
+  });
+
+  it('scrubs credentials when the authority is malformed and the URL does not parse', () => {
+    const result = stripUrlCredentials('https://x-access-token:ghs_secret@github.com:bad/o/r.git');
+
+    expect(result).toBe('https://***@github.com:bad/o/r.git');
+    expect(result).not.toContain('ghs_secret');
   });
 
   it.each([
@@ -103,6 +120,15 @@ describe('redactSecrets', () => {
     const result = redactSecrets('token=abc and again abc', ['abc']);
 
     expect(result).toBe('token=*** and again ***');
+  });
+
+  it.each([
+    [['abcdef', 'abc']],
+    [['abc', 'abcdef']],
+  ])('fully redacts overlapping secrets regardless of order: %j', (secrets) => {
+    const result = redactSecrets('token=abcdef', secrets);
+
+    expect(result).toBe('token=***');
   });
 
   it('redacts a base64 basic-auth credential', () => {

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -1,0 +1,61 @@
+/** Replacement written in place of any redacted secret or URL credential. */
+export const REDACTION_PLACEHOLDER = '***';
+
+// Bounded scheme length keeps the match linear: an unbounded `*` before the
+// `://` literal backtracks O(n) per start position (O(n^2) overall) on long
+// adversarial input, while a capped repetition stays O(n). No real URL scheme
+// approaches this length.
+const SCHEME_URL_CREDENTIALS = /([a-z][a-z0-9+.-]{0,31}:\/\/)[^@\s/?#]+@/gi;
+
+/**
+ * Strips inline `user:pass@` (or bare `user@`) credentials from free text such
+ * as log lines or git command stderr, for every `scheme://` URL it contains
+ * (http, https, git, ssh, ...). The whole userinfo is replaced, matching the
+ * runner's prior behaviour where a bare `user@` is scrubbed too.
+ *
+ * scp-style remotes (`git@host:path`) are intentionally left untouched: an scp
+ * URL carrying a password is not a real git form, so redacting it buys no
+ * security but would corrupt structurally identical strings (Docker digests
+ * `name:tag@sha256:...`, `user:pass@host:port`). Literal secrets are removed by
+ * {@link redactSecrets}; this pass only handles `://` URLs.
+ */
+export function redactUrlCredentials(text: string): string {
+  return text.replace(SCHEME_URL_CREDENTIALS, `$1${REDACTION_PLACEHOLDER}@`);
+}
+
+/**
+ * Removes a single known URL's `user:pass@` userinfo, returning a clean URL with
+ * no `***@` residue. Falls back to the input unchanged when it is not a parseable
+ * URL (e.g. scp-style `git@host:path`) or carries no credentials.
+ *
+ * Defense in depth: callers must keep credential-free URLs, but a helper whose
+ * job is to make a value safe to log must also strip any userinfo a mistake left
+ * in (e.g. `https://x-access-token:<token>@host/...`).
+ */
+export function stripUrlCredentials(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.username && !parsed.password) return url;
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Removes every occurrence of each literal secret plus any `scheme://` URL
+ * credential from `text`, so an error never carries token material into a log or
+ * result. Literal secrets are scrubbed first, then URL userinfo.
+ *
+ * Only the literal secrets passed are removed; deriving every wire form a
+ * credential takes (e.g. the base64 of `user:token`) is the caller's job.
+ */
+export function redactSecrets(text: string, secrets: string[]): string {
+  let redacted = text;
+  for (const secret of secrets) {
+    if (secret) redacted = redacted.split(secret).join(REDACTION_PLACEHOLDER);
+  }
+  return redactUrlCredentials(redacted);
+}

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -18,15 +18,27 @@ const SCHEME_URL_CREDENTIALS = /([a-z][a-z0-9+.-]{0,31}:\/\/)[^@\s/?#]+@/gi;
  * security but would corrupt structurally identical strings (Docker digests
  * `name:tag@sha256:...`, `user:pass@host:port`). Literal secrets are removed by
  * {@link redactSecrets}; this pass only handles `://` URLs.
+ *
+ * This pass redacts userinfo up to the first `@` and treats `/`, `?`, and `#` as
+ * userinfo boundaries so it never bleeds into a path or query that contains an
+ * `@`. A credential whose userinfo itself contains a raw `@`, `/`, `?`, or `#`
+ * (all invalid unencoded per RFC 3986, but git can echo them) is therefore only
+ * partially masked here; {@link redactSecrets}'s literal pass is the backstop
+ * that removes such values in full.
  */
 export function redactUrlCredentials(text: string): string {
   return text.replace(SCHEME_URL_CREDENTIALS, `$1${REDACTION_PLACEHOLDER}@`);
 }
 
 /**
- * Removes a single known URL's `user:pass@` userinfo, returning a clean URL with
- * no `***@` residue. Falls back to the input unchanged when it is not a parseable
- * URL (e.g. scp-style `git@host:path`) or carries no credentials.
+ * Removes a single known URL's `user:pass@` userinfo. For a parseable URL it
+ * returns a clean URL with no `***@` residue; with no credentials it returns the
+ * input unchanged. When the value does not parse as a URL it falls back to the
+ * inline {@link redactUrlCredentials} scrubber, so a credential-bearing value
+ * whose authority is malformed (bad port, broken IPv6) is still masked (to
+ * `***@`) instead of being logged verbatim. A credential-free non-URL such as an
+ * scp-style remote (`git@host:path`) has no `scheme://`, so the fallback leaves
+ * it untouched.
  *
  * Defense in depth: callers must keep credential-free URLs, but a helper whose
  * job is to make a value safe to log must also strip any userinfo a mistake left
@@ -40,7 +52,7 @@ export function stripUrlCredentials(url: string): string {
     parsed.password = '';
     return parsed.toString();
   } catch {
-    return url;
+    return redactUrlCredentials(url);
   }
 }
 
@@ -51,11 +63,19 @@ export function stripUrlCredentials(url: string): string {
  *
  * Only the literal secrets passed are removed; deriving every wire form a
  * credential takes (e.g. the base64 of `user:token`) is the caller's job.
+ *
+ * Longer secrets are removed first, so when one secret is a substring of another
+ * the output is the same no matter what order the caller lists them in. Pass
+ * real, high-entropy secrets only; a trivially short literal (e.g. a single
+ * character) would scrub unrelated text.
  */
 export function redactSecrets(text: string, secrets: string[]): string {
   let redacted = text;
-  for (const secret of secrets) {
-    if (secret) redacted = redacted.split(secret).join(REDACTION_PLACEHOLDER);
+  // Remove longer secrets first: scrubbing a shorter secret that is a substring
+  // of a longer one would otherwise leave the longer secret's tail visible.
+  const longestFirst = [...secrets].filter(Boolean).sort((a, b) => b.length - a.length);
+  for (const secret of longestFirst) {
+    redacted = redacted.split(secret).join(REDACTION_PLACEHOLDER);
   }
   return redactUrlCredentials(redacted);
 }

--- a/libs/shared/common/redact/tsconfig.build.json
+++ b/libs/shared/common/redact/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/shared/common/redact/tsconfig.json
+++ b/libs/shared/common/redact/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/shared/common/redact/tsconfig.test.json
+++ b/libs/shared/common/redact/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/shared/common/redact/vitest.config.ts
+++ b/libs/shared/common/redact/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -764,6 +764,9 @@ importers:
       '@shipfox/node-temporal':
         specifier: workspace:*
         version: link:../../../shared/node/temporal
+      '@shipfox/redact':
+        specifier: workspace:*
+        version: link:../../../shared/common/redact
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
@@ -2629,6 +2632,24 @@ importers:
       envalid:
         specifier: ^8.0.0
         version: 8.1.1
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
+  libs/shared/common/redact:
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Introduces `@shipfox/redact`, a single home for Shipfox's credential-redaction helpers, and migrates the API onto it. First PR of the ENG-408 security-hardening split (1 issue = 1 PR); lands before the runner PR (ENG-507), which will import the package.

## Why

Credential-redaction logic was duplicated and divergent across two security-critical sites: the runner's regex `redactSecrets` (`libs/runner/workspace/src/checkout.ts`) and the API's `new URL()`-based `redactCheckoutSpec` / private `stripUrlCredentials` (`libs/api/integration/core-dto`). Two copies of security-sensitive code free to drift.

## What

- New `@shipfox/redact` (`libs/shared/common/redact`, private, zero deps):
  - `redactUrlCredentials(text)` — scheme-agnostic free-text scrubber (http/https/git/ssh) for log lines and command stderr.
  - `stripUrlCredentials(url)` — structured single-URL stripper (`new URL()`), no `***@` residue.
  - `redactSecrets(text, secrets)` — literal-secret scrubber composing the above.
  - `REDACTION_PLACEHOLDER` — the shared `'***'` sentinel.
- Migrates the API: `redactCheckoutSpec` now reuses the shared `stripUrlCredentials`. Its public export path (`@shipfox/api-integration-core`) and output are unchanged.

## Notes for reviewers

- `redactCheckoutSpec` moved from the `*-dto` package into `@shipfox/api-integration-core` because the `dto-only-dependencies` dependency-cruiser rule forbids a `*-dto` package from importing the new lib. Its relocated test keeps identical assertions, proving no behavior change. core-dto gains focused tests for its remaining pure exports (`buildProviderRepositoryId` / `parseProviderRepositoryId`).
- scp-style credential redaction was deliberately NOT added: an scp URL carrying a password is not a real git form and has no call site, while redacting it would corrupt structurally identical strings (Docker digests, `host:port`). The literal-secret pass is the backstop.
- The runner keeps its local redaction copy in this PR; it adopts `@shipfox/redact` (gaining git/ssh coverage) in ENG-507. Full de-duplication completes there.

Closes ENG-506

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@shipfox/redact`, a shared credential-redaction package, and migrate the API to use it with no behavior changes. Hardened redaction to avoid edge-case leaks: fallback scrubbing when URL parsing fails and stable overlapping-secret removal per ENG-506 (ENG-408 split).

- **New Features**
  - `redactUrlCredentials(text)` — scrub inline URL credentials in free text across schemes.
  - `stripUrlCredentials(url)` — remove `user:pass@` from one URL, with no `***@` residue; falls back to scrubbing if `new URL()` fails.
  - `redactSecrets(text, secrets)` — scrub literal secrets (longest-first), then URL credentials.
  - `REDACTION_PLACEHOLDER` — the shared `'***'` token.

- **Refactors**
  - Moved `redactCheckoutSpec` from `@shipfox/api-integration-core-dto` to `@shipfox/api-integration-core` to reuse `stripUrlCredentials`.
  - Kept public export path and output unchanged; tests relocated and still pass, with ReDoS guard added.
  - Added `@shipfox/redact` as a dependency of `@shipfox/api-integration-core`. Runner migration lands in ENG-507.

<sup>Written for commit 35f568cf2ac2331d97723ca1ad352a774b70243b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

