### PR TITLE
[api/integration-debug] Fix debug integration workflow fixtures

### DIFF
--- a/libs/api/integration/debug/package.json
+++ b/libs/api/integration/debug/package.json
@@ -52,8 +52,11 @@
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@shipfox/workflow-document": "workspace:*",
+    "@types/js-yaml": "^4.0.9",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.3.3",
-    "fastify-type-provider-zod": "^6.0.0"
+    "fastify-type-provider-zod": "^6.0.0",
+    "js-yaml": "^4.1.0"
   }
 }

--- a/libs/api/integration/debug/src/core/source-control.test.ts
+++ b/libs/api/integration/debug/src/core/source-control.test.ts
@@ -1,4 +1,10 @@
-import {DebugIntegrationProviderError, DebugSourceControlProvider} from '#core/source-control.js';
+import {parseWorkflowDocument} from '@shipfox/workflow-document';
+import yaml from 'js-yaml';
+import {
+  DEBUG_FILES,
+  DebugIntegrationProviderError,
+  DebugSourceControlProvider,
+} from '#core/source-control.js';
 
 const connection = {
   id: crypto.randomUUID(),
@@ -69,8 +75,9 @@ describe('DebugSourceControlProvider', () => {
     });
 
     expect(result.files.map((file) => file.path)).toEqual([
-      '.shipfox/workflows/ci.yml',
-      '.shipfox/workflows/deploy.yaml',
+      '.shipfox/workflows/agent.yml',
+      '.shipfox/workflows/build-and-deploy.yaml',
+      '.shipfox/workflows/hello-world.yml',
     ]);
   });
 
@@ -81,10 +88,10 @@ describe('DebugSourceControlProvider', () => {
       connection,
       externalRepositoryId: 'debug:platform',
       ref: 'main',
-      path: '.shipfox/workflows/ci.yml',
+      path: '.shipfox/workflows/hello-world.yml',
     });
 
-    expect(result.content).toContain('name: CI');
+    expect(result.content).toContain('name: Hello world');
   });
 
   it('creates a credential-free checkout spec for the requested ref', async () => {
@@ -112,5 +119,23 @@ describe('DebugSourceControlProvider', () => {
     });
 
     expect(result.ref).toBe('main');
+  });
+});
+
+const workflowFixtures = [...DEBUG_FILES.entries()].flatMap(([repository, files]) =>
+  Object.entries(files)
+    .filter(([path]) => path.endsWith('.yml') || path.endsWith('.yaml'))
+    .map(([path, content]) => ({repository, path, content})),
+);
+
+describe('debug workflow fixtures', () => {
+  it.each(workflowFixtures)('parses $repository/$path as a valid workflow document', ({
+    content,
+  }) => {
+    const parsed = yaml.load(content);
+
+    const document = parseWorkflowDocument(parsed);
+
+    expect(document.name).not.toBe('');
   });
 });

--- a/libs/api/integration/debug/src/core/source-control.ts
+++ b/libs/api/integration/debug/src/core/source-control.ts
@@ -56,52 +56,83 @@ const DEBUG_REPOSITORIES: RepositorySnapshot[] = [
   },
 ];
 
-const DEBUG_FILES = new Map<string, Record<string, string>>([
+// Fake workflow definitions returned by the debug integration. They double as
+// fixtures for sync/definition tests, so each one exercises a different slice of
+// the workflow language and must stay a valid workflow document (see the parsing
+// test in source-control.test.ts).
+export const DEBUG_FILES = new Map<string, Record<string, string>>([
   [
     'platform',
     {
-      '.shipfox/workflows/ci.yml': `
-name: CI
+      '.shipfox/workflows/hello-world.yml': `
+name: Hello world
+runner:
+  - ubuntu-latest
+  - node-22
 triggers:
   on_demand:
     source: manual
-jobs:
-  build:
-    steps:
-      - run: pnpm test
-`,
-      '.shipfox/workflows/deploy.yaml': `
-name: Deploy
-triggers:
-  on_demand:
-    source: manual
+    event: fire
   on_push:
     source: github
     event: push
-    on: main
+    filter: 'event.ref == "refs/heads/main"'
 jobs:
+  build:
+    steps:
+      - run: echo "hello world"
+      - name: test
+        run: pnpm test
+        gate:
+          success_if: exit_code == 0
+`,
+      '.shipfox/workflows/build-and-deploy.yaml': `
+name: Build and deploy
+triggers:
+  on_push:
+    source: github
+    event: push
+    filter: 'event.ref == "refs/heads/main"'
+jobs:
+  build:
+    steps:
+      - run: pnpm install
+      - run: pnpm build
   deploy:
+    needs: build
+    runner: ubuntu-latest
     steps:
       - run: pnpm deploy
+`,
+      '.shipfox/workflows/agent.yml': `
+name: Agent
+triggers:
+  on_demand:
+    source: manual
+    event: fire
+jobs:
+  fix:
+    steps:
+      - name: implement
+        model: claude-opus-4-8
+        prompt: Fix the failing tests.
+      - name: review
+        model: gpt-5.1
+        provider: openai
+        prompt: Review the fix.
+        thinking: low
+        gate:
+          success_if: exit_code == 0
+          on_failure:
+            restart_from: implement
+      - run: pnpm test
+        gate:
+          success_if: exit_code == 0
 `,
       'README.md': '# Debug platform\n',
     },
   ],
-  [
-    'api',
-    {
-      '.shipfox/workflows/api.yml': `
-name: API
-triggers:
-  on_demand:
-    source: manual
-jobs:
-  test:
-    steps:
-      - run: turbo test --filter=@shipfox/api
-`,
-    },
-  ],
+  ['api', {}],
   ['runner', {}],
 ]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -890,6 +890,12 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../../tools/vitest
+      '@shipfox/workflow-document':
+        specifier: workspace:*
+        version: link:../../../shared/workflow/document
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
@@ -899,6 +905,9 @@ importers:
       fastify-type-provider-zod:
         specifier: ^6.0.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.2.0
 
   libs/api/integration/debug-dto:
     dependencies:


### PR DESCRIPTION
Syncing a project from the `debug` integration failed with `Workflow sync failed: Invalid workflow definition at .shipfox/workflows/deploy.yaml: Invalid input: expected string, received undefined`.

The debug integration serves hardcoded workflow YAML (its fake source-control data, which doubles as sync/definition test fixtures). Two recent schema changes left that data invalid:

- Triggers now require an `event` field, but the fake `on_demand` triggers only set `source: manual`. That missing required string is the `expected string, received undefined` error.
- The trigger schema is a strict object, so the fake `deploy.yaml`'s non-schema `on: main` key would also have been rejected.

This adds `event: fire` to the manual triggers and replaces `on: main` with the canonical `filter: 'event.ref == "refs/heads/main"'` expression. While here, the fixtures are expanded so each one exercises a distinct slice of the workflow language and matches the documented examples in `libs/shared/workflow/document/README.md`:

- `ci.yml` - run steps + `echo "hello world"`, manual + filtered push triggers, top-level runner array, a named step, and a `success_if` gate.
- `deploy.yaml` - a two-job DAG (`deploy` needs `build`) with a job-level runner.
- `agent-fix.yml` (new) - agent steps (default-provider and OpenAI with `thinking`), an `on_failure`/`restart_from` gate, then a verifying run step.
- `api.yml` - `echo "hello world"` plus a real test command.

To stop this from regressing silently, a test now parses every fixture through the real `parseWorkflowDocument`, so a future schema tightening fails the debug package's own tests rather than surfacing as a runtime sync failure. The new test needs `@shipfox/workflow-document`, `js-yaml`, and `@types/js-yaml` as devDeps (all already in the workspace).

I also verified every fixture passes the full sync pipeline (`validateDefinition` = yaml to document to normalize) so they hold up against normalization rules (DAG cycles, gate `restart_from`, `success_if` CEL typing, single-manual-trigger).

No changeset: `@shipfox/api-integration-debug` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sync failures in the `debug` integration by updating workflow fixtures to the latest trigger schema and renaming them for clarity. Adds a regression test that parses every fixture so schema changes fail in CI, not at runtime.

- **Bug Fixes**
  - Require trigger `event`; add `event: fire` to manual triggers; replace `on: main` with `filter: 'event.ref == "refs/heads/main"'`.
  - Rework fixtures: `hello-world.yml` (runner array, named step, `success_if`), `build-and-deploy.yaml` (build→deploy DAG with job runner), `agent.yml` (agent steps with provider, thinking, `on_failure`/`restart_from`); remove `api.yml`.
  - Export `DEBUG_FILES`; test enumerates all YAML fixtures and validates with `parseWorkflowDocument`.

- **Dependencies**
  - Add dev deps: `@shipfox/workflow-document`, `js-yaml`, `@types/js-yaml`.

<sup>Written for commit 8231cf6ca7ce2412cce87269a818d811753547dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

