### PR TITLE
[api/integration] Move source-event translation into the integration module

### DIFF
--- a/.changeset/calm-foxes-share.md
+++ b/.changeset/calm-foxes-share.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-integration-core-dto": minor
+"@shipfox/api-integration-core": minor
+"@shipfox/api-integration-github": patch
+"@shipfox/api-projects": patch
+---
+
+Moves source-event translation to the integration module: source-control providers emit a typed, provider-agnostic `INTEGRATION_SOURCE_COMMIT_PUSHED` event via one transactional publisher, projects subscribes to it instead of decoding GitHub payloads, and branch-deletion pushes are dropped at the source.

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -10,12 +10,30 @@ export interface IntegrationEventReceivedEvent {
   payload: unknown;
 }
 
-export interface GithubPushPayload {
+// A source-control push, normalized by the producing provider. Carried both as the
+// generic `INTEGRATION_EVENT_RECEIVED` envelope payload (consumed opaquely by triggers)
+// and nested inside `INTEGRATION_SOURCE_COMMIT_PUSHED` (consumed by domain modules).
+export interface SourcePushPayload {
   externalRepositoryId: string;
   ref: string;
   headCommitSha: string;
   defaultBranch: string;
   isDefaultBranch: boolean;
+}
+
+export const INTEGRATION_SOURCE_COMMIT_PUSHED =
+  'integrations.source_control.commit_pushed' as const;
+
+// Typed, provider-agnostic source-control event. The producing provider owns the
+// translation from its raw webhook into this shape, so domain consumers never decode
+// provider payloads. `isDefaultBranch` is a fact; the branch policy lives in the consumer.
+export interface IntegrationSourceCommitPushedEvent {
+  provider: string;
+  workspaceId: string;
+  connectionId: string;
+  deliveryId: string;
+  receivedAt: string;
+  push: SourcePushPayload;
 }
 
 export interface SentryIssuePayload {
@@ -49,4 +67,5 @@ export type SentryIssueAction = (typeof SENTRY_ISSUE_ACTIONS)[number];
 
 export interface IntegrationsEventMap {
   [INTEGRATION_EVENT_RECEIVED]: IntegrationEventReceivedEvent;
+  [INTEGRATION_SOURCE_COMMIT_PUSHED]: IntegrationSourceCommitPushedEvent;
 }

--- a/libs/api/integration/core-dto/src/ports.ts
+++ b/libs/api/integration/core-dto/src/ports.ts
@@ -2,7 +2,7 @@ import type {
   IntegrationConnection,
   IntegrationConnectionLifecycleStatus,
 } from '#contracts/index.js';
-import type {IntegrationEventReceivedEvent} from '#events.js';
+import type {IntegrationEventReceivedEvent, SourcePushPayload} from '#events.js';
 
 // The persistence seam between the integrations core and a provider package.
 // `@shipfox/api-integration-core` implements these against its own tables and
@@ -22,6 +22,19 @@ export type IntegrationTx = any;
 export type PublishIntegrationEventReceivedFn = (params: {
   tx: IntegrationTx;
   event: IntegrationEventReceivedEvent;
+}) => Promise<{published: boolean}>;
+
+// Emitted by source-control providers for a single push. Writes both the generic
+// envelope (for triggers) and the typed source event (for domain consumers) under one
+// delivery-dedup, so it must run inside a transaction — never a bare connection.
+export type PublishSourcePushFn = (params: {
+  tx: IntegrationTx;
+  provider: string;
+  workspaceId: string;
+  connectionId: string;
+  deliveryId: string;
+  receivedAt: string;
+  push: SourcePushPayload;
 }) => Promise<{published: boolean}>;
 
 export type RecordDeliveryOnlyFn = (params: {

--- a/libs/api/integration/core-dto/src/ports.ts
+++ b/libs/api/integration/core-dto/src/ports.ts
@@ -24,9 +24,8 @@ export type PublishIntegrationEventReceivedFn = (params: {
   event: IntegrationEventReceivedEvent;
 }) => Promise<{published: boolean}>;
 
-// Emitted by source-control providers for a single push. Writes both the generic
-// envelope (for triggers) and the typed source event (for domain consumers) under one
-// delivery-dedup, so it must run inside a transaction — never a bare connection.
+// Emitted by source-control providers for a single push. The delivery dedup and the outbox
+// rows it writes must commit together, so it requires a transaction, never a bare connection.
 export type PublishSourcePushFn = (params: {
   tx: IntegrationTx;
   provider: string;

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -1,12 +1,18 @@
 import {
   INTEGRATION_EVENT_RECEIVED,
+  INTEGRATION_SOURCE_COMMIT_PUSHED,
   type IntegrationEventReceivedEvent,
+  type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
 import {and, eq, sql} from 'drizzle-orm';
 import {db} from './db.js';
 import {integrationsOutbox} from './schema/outbox.js';
 import {integrationsWebhookDeliveries} from './schema/webhook-deliveries.js';
-import {publishIntegrationEventReceived, recordDeliveryOnly} from './webhook-deliveries.js';
+import {
+  publishIntegrationEventReceived,
+  publishSourcePush,
+  recordDeliveryOnly,
+} from './webhook-deliveries.js';
 
 function buildEvent(
   overrides: Partial<IntegrationEventReceivedEvent> = {},
@@ -26,6 +32,28 @@ function buildEvent(
       isDefaultBranch: true,
     },
     ...overrides,
+  };
+}
+
+function buildPush(overrides: Partial<SourcePushPayload> = {}): SourcePushPayload {
+  return {
+    externalRepositoryId: 'github:42',
+    ref: 'main',
+    headCommitSha: 'abc123',
+    defaultBranch: 'main',
+    isDefaultBranch: true,
+    ...overrides,
+  };
+}
+
+function buildSourcePushParams() {
+  return {
+    provider: 'github',
+    workspaceId: crypto.randomUUID(),
+    connectionId: crypto.randomUUID(),
+    deliveryId: crypto.randomUUID(),
+    receivedAt: new Date().toISOString(),
+    push: buildPush(),
   };
 }
 
@@ -95,5 +123,51 @@ describe('integration webhook delivery persistence', () => {
     await recordDeliveryOnly({tx: db(), provider: 'github', deliveryId});
 
     expect(await deliveriesFor('github', deliveryId)).toHaveLength(1);
+  });
+});
+
+describe('publishSourcePush', () => {
+  it('writes the delivery row plus both outbox events for a new delivery', async () => {
+    const params = buildSourcePushParams();
+
+    const result = await db().transaction((tx) => publishSourcePush({tx, ...params}));
+
+    expect(result.published).toBe(true);
+    expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(1);
+    const types = (await outboxFor(params.deliveryId)).map((row) => row.eventType).sort();
+    expect(types).toEqual([INTEGRATION_EVENT_RECEIVED, INTEGRATION_SOURCE_COMMIT_PUSHED].sort());
+  });
+
+  it('emits the generic envelope (for triggers) and the typed event (for projects)', async () => {
+    const params = buildSourcePushParams();
+
+    await db().transaction((tx) => publishSourcePush({tx, ...params}));
+
+    const outbox = await outboxFor(params.deliveryId);
+    const envelope = outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED);
+    const typed = outbox.find((row) => row.eventType === INTEGRATION_SOURCE_COMMIT_PUSHED);
+    expect(envelope?.payload).toMatchObject({
+      source: 'github',
+      event: 'push',
+      deliveryId: params.deliveryId,
+      payload: {externalRepositoryId: 'github:42', isDefaultBranch: true},
+    });
+    expect(typed?.payload).toMatchObject({
+      provider: 'github',
+      deliveryId: params.deliveryId,
+      push: {externalRepositoryId: 'github:42', ref: 'main', headCommitSha: 'abc123'},
+    });
+  });
+
+  it('writes nothing for a duplicate delivery', async () => {
+    const params = buildSourcePushParams();
+
+    const first = await db().transaction((tx) => publishSourcePush({tx, ...params}));
+    const second = await db().transaction((tx) => publishSourcePush({tx, ...params}));
+
+    expect(first.published).toBe(true);
+    expect(second.published).toBe(false);
+    expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(1);
+    expect(await outboxFor(params.deliveryId)).toHaveLength(2);
   });
 });

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -1,8 +1,11 @@
 import {
   INTEGRATION_EVENT_RECEIVED,
+  INTEGRATION_SOURCE_COMMIT_PUSHED,
   type IntegrationEventReceivedEvent,
+  type IntegrationsEventMap,
+  type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
-import {writeOutboxEvent} from '@shipfox/node-outbox';
+import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
 import {lt} from 'drizzle-orm';
 import {db} from './db.js';
 import {integrationsOutbox} from './schema/outbox.js';
@@ -45,6 +48,66 @@ export async function publishIntegrationEventReceived(
   return {published: true};
 }
 
+export interface PublishSourcePushParams {
+  tx: IntegrationTx;
+  provider: string;
+  workspaceId: string;
+  connectionId: string;
+  deliveryId: string;
+  receivedAt: string;
+  push: SourcePushPayload;
+}
+
+// Emits a single source-control push as two outbox rows: the generic
+// `INTEGRATION_EVENT_RECEIVED` envelope (consumed opaquely by triggers) and the typed
+// `INTEGRATION_SOURCE_COMMIT_PUSHED` event (consumed by domain modules). One delivery-dedup
+// gates both, so a redelivered webhook writes nothing. Requires a transaction: the dedup
+// insert and both outbox rows must commit or roll back together.
+export async function publishSourcePush(
+  params: PublishSourcePushParams,
+): Promise<{published: boolean}> {
+  const inserted = await params.tx
+    .insert(integrationsWebhookDeliveries)
+    .values({
+      provider: params.provider,
+      deliveryId: params.deliveryId,
+    })
+    .onConflictDoNothing({
+      target: [integrationsWebhookDeliveries.provider, integrationsWebhookDeliveries.deliveryId],
+    })
+    .returning({deliveryId: integrationsWebhookDeliveries.deliveryId});
+
+  if (inserted.length === 0) return {published: false};
+
+  await writeOutboxEvents<IntegrationsEventMap>(params.tx, integrationsOutbox, [
+    {
+      type: INTEGRATION_EVENT_RECEIVED,
+      payload: {
+        source: params.provider,
+        event: 'push',
+        workspaceId: params.workspaceId,
+        connectionId: params.connectionId,
+        deliveryId: params.deliveryId,
+        receivedAt: params.receivedAt,
+        payload: params.push,
+      },
+    },
+    {
+      type: INTEGRATION_SOURCE_COMMIT_PUSHED,
+      payload: {
+        provider: params.provider,
+        workspaceId: params.workspaceId,
+        connectionId: params.connectionId,
+        deliveryId: params.deliveryId,
+        receivedAt: params.receivedAt,
+        push: params.push,
+      },
+    },
+  ]);
+
+  return {published: true};
+}
+
 export interface RecordDeliveryOnlyParams {
   tx: Executor;
   provider: string;
@@ -77,4 +140,5 @@ export async function pruneWebhookDeliveries(
 }
 
 export type PublishIntegrationEventReceivedFn = typeof publishIntegrationEventReceived;
+export type PublishSourcePushFn = typeof publishSourcePush;
 export type RecordDeliveryOnlyFn = typeof recordDeliveryOnly;

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -22,7 +22,11 @@ import {
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
-import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import {
+  publishIntegrationEventReceived,
+  publishSourcePush,
+  recordDeliveryOnly,
+} from '#db/webhook-deliveries.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
 import {createIntegrationsMaintenanceActivities} from '#temporal/activities/index.js';
 import {INTEGRATIONS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
@@ -82,6 +86,8 @@ export type {
   PublishIntegrationEventReceivedFn,
   PublishIntegrationEventReceivedParams,
   PublishIntegrationEventReceivedResult,
+  PublishSourcePushFn,
+  PublishSourcePushParams,
   RecordDeliveryOnlyFn,
   RecordDeliveryOnlyParams,
 } from '#db/webhook-deliveries.js';
@@ -168,7 +174,7 @@ async function loadGithubModuleParts(): Promise<GithubModuleParts> {
     provider: createGithubIntegrationProvider({
       getExistingGithubConnection,
       connectGithubInstallation,
-      publishIntegrationEventReceived,
+      publishSourcePush,
       recordDeliveryOnly,
       getIntegrationConnectionById,
       coreDb: db,

--- a/libs/api/integration/github/src/connection-external-url.test.ts
+++ b/libs/api/integration/github/src/connection-external-url.test.ts
@@ -39,7 +39,7 @@ function createProvider(lookup: (connectionId: string) => Promise<GithubInstalla
     getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
     connectGithubInstallation: vi.fn() as never,
     coreDb: vi.fn() as never,
-    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+    publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
     getGithubInstallationByConnectionId: lookup,

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -31,7 +31,6 @@ export type HandleGithubPushOutcome =
   | 'unknown-installation'
   | 'no-installation-id';
 
-// A branch deletion is not a commit, so we never emit a source-push event for it.
 function isBranchDeletion(after: string): boolean {
   return after === DELETED_BRANCH_SHA;
 }
@@ -39,6 +38,9 @@ function isBranchDeletion(after: string): boolean {
 export async function handleGithubPush(
   params: HandleGithubPushParams,
 ): Promise<{outcome: HandleGithubPushOutcome}> {
+  // A branch deletion is not a commit. Dropping it here, before `publishSourcePush`,
+  // emits neither the typed source-commit event (projects) nor the generic
+  // `INTEGRATION_EVENT_RECEIVED` envelope (triggers), so a deletion triggers nothing.
   if (isBranchDeletion(params.payload.after)) {
     return {outcome: 'deleted'};
   }

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -1,10 +1,10 @@
 import {
   buildProviderRepositoryId,
   type GetIntegrationConnectionByIdFn,
-  type GithubPushPayload,
   type IntegrationTx,
-  type PublishIntegrationEventReceivedFn,
+  type PublishSourcePushFn,
   type RecordDeliveryOnlyFn,
+  type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
 import type {GithubPushPayloadDto} from '@shipfox/api-integration-github-dto';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -12,13 +12,14 @@ import {getGithubInstallationByInstallationId} from '#db/installations.js';
 
 const REFS_HEADS_PREFIX = 'refs/heads/';
 const GITHUB_SOURCE = 'github';
-const PUSH_EVENT = 'push';
+// GitHub sends a `push` webhook for a branch deletion with `after` set to this all-zero SHA.
+const DELETED_BRANCH_SHA = '0'.repeat(40);
 
 export interface HandleGithubPushParams {
   tx: IntegrationTx;
   deliveryId: string;
   payload: GithubPushPayloadDto;
-  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
 }
@@ -26,12 +27,22 @@ export interface HandleGithubPushParams {
 export type HandleGithubPushOutcome =
   | 'published'
   | 'duplicate'
+  | 'deleted'
   | 'unknown-installation'
   | 'no-installation-id';
+
+// A branch deletion is not a commit, so we never emit a source-push event for it.
+function isBranchDeletion(after: string): boolean {
+  return after === DELETED_BRANCH_SHA;
+}
 
 export async function handleGithubPush(
   params: HandleGithubPushParams,
 ): Promise<{outcome: HandleGithubPushOutcome}> {
+  if (isBranchDeletion(params.payload.after)) {
+    return {outcome: 'deleted'};
+  }
+
   const installationId = params.payload.installation?.id;
   if (installationId === undefined) {
     return {outcome: 'no-installation-id'};
@@ -71,7 +82,7 @@ export async function handleGithubPush(
 
   const ref = stripRefsHeads(params.payload.ref);
   const defaultBranch = params.payload.repository.default_branch;
-  const pushPayload: GithubPushPayload = {
+  const push: SourcePushPayload = {
     externalRepositoryId: buildProviderRepositoryId(
       GITHUB_SOURCE,
       String(params.payload.repository.id),
@@ -81,17 +92,14 @@ export async function handleGithubPush(
     defaultBranch,
     isDefaultBranch: ref === defaultBranch,
   };
-  const result = await params.publishIntegrationEventReceived({
+  const result = await params.publishSourcePush({
     tx: params.tx,
-    event: {
-      source: GITHUB_SOURCE,
-      event: PUSH_EVENT,
-      workspaceId: connection.workspaceId,
-      connectionId: connection.id,
-      deliveryId: params.deliveryId,
-      receivedAt: new Date().toISOString(),
-      payload: pushPayload,
-    },
+    provider: GITHUB_SOURCE,
+    workspaceId: connection.workspaceId,
+    connectionId: connection.id,
+    deliveryId: params.deliveryId,
+    receivedAt: new Date().toISOString(),
+    push,
   });
 
   return {outcome: result.published ? 'published' : 'duplicate'};

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -1,6 +1,6 @@
 import type {
   GetIntegrationConnectionByIdFn,
-  PublishIntegrationEventReceivedFn,
+  PublishSourcePushFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
@@ -34,7 +34,7 @@ export interface CreateGithubIntegrationProviderOptions
   extends Omit<CreateGithubIntegrationRoutesOptions, 'github'> {
   github?: GithubApiClient | undefined;
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
-  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
   getGithubInstallationByConnectionId?: typeof getGithubInstallationByConnectionId | undefined;
@@ -69,7 +69,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
       }),
       createGithubWebhookRoutes({
         coreDb: options.coreDb,
-        publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+        publishSourcePush: options.publishSourcePush,
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,
       }),

--- a/libs/api/integration/github/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/install.test.ts
@@ -96,7 +96,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
     ),
     // Webhook receiver dependencies — install/OAuth tests don't exercise them.
     coreDb: vi.fn() as never,
-    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
+    publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),
   });

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -10,7 +10,7 @@ import {createGithubWebhookRoutes} from './webhooks.js';
 
 const WEBHOOK_SECRET = 'test-webhook-secret';
 
-// The route persists through injected core functions (publishIntegrationEventReceived,
+// The route persists through injected core functions (publishSourcePush,
 // recordDeliveryOnly, getIntegrationConnectionById) that @shipfox/api-integration-core
 // owns and wires in production. github only orchestrates them, so here we fake that
 // interface with spies and assert the route's own behavior: signature/payload
@@ -32,26 +32,26 @@ function fakeConnection(overrides: Partial<IntegrationConnection> = {}): Integra
 
 interface TestApp {
   app: FastifyInstance;
-  publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
+  publishSourcePush: ReturnType<typeof vi.fn>;
   recordDeliveryOnly: ReturnType<typeof vi.fn>;
   getIntegrationConnectionById: ReturnType<typeof vi.fn>;
 }
 
 async function createTestApp(options: {connection?: IntegrationConnection} = {}): Promise<TestApp> {
-  const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+  const publishSourcePush = vi.fn(() => Promise.resolve({published: true}));
   const recordDeliveryOnly = vi.fn(() => Promise.resolve());
   const getIntegrationConnectionById = vi.fn(() =>
     Promise.resolve(options.connection ?? fakeConnection()),
   );
   const routes = createGithubWebhookRoutes({
     coreDb: db,
-    publishIntegrationEventReceived,
+    publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,
   });
   const app = await createApp({routes: [routes], swagger: false});
   await app.ready();
-  return {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById};
+  return {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById};
 }
 
 async function seedInstallation(installationId: number, connectionId?: string): Promise<void> {
@@ -95,7 +95,7 @@ describe('GitHub webhook route', () => {
     const installationId = 7777;
     const connection = fakeConnection();
     await seedInstallation(installationId, connection.id);
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById} =
+    const {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById} =
       await createTestApp({connection});
     const deliveryId = randomUUID();
     const body = JSON.stringify(
@@ -122,16 +122,15 @@ describe('GitHub webhook route', () => {
       connection.id,
       expect.objectContaining({tx: expect.anything()}),
     );
-    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
-    const call = publishIntegrationEventReceived.mock.calls[0]?.[0];
+    expect(publishSourcePush).toHaveBeenCalledTimes(1);
+    const call = publishSourcePush.mock.calls[0]?.[0];
     expect(call.tx).toBeDefined();
-    expect(call.event).toMatchObject({
-      source: 'github',
-      event: 'push',
+    expect(call).toMatchObject({
+      provider: 'github',
       deliveryId,
       workspaceId: connection.workspaceId,
       connectionId: connection.id,
-      payload: {
+      push: {
         externalRepositoryId: 'github:42',
         ref: 'main',
         headCommitSha: 'abc123',
@@ -143,7 +142,7 @@ describe('GitHub webhook route', () => {
   it('publishes with isDefaultBranch=false when ref is not the default branch', async () => {
     const installationId = 7780;
     await seedInstallation(installationId);
-    const {app, publishIntegrationEventReceived} = await createTestApp();
+    const {app, publishSourcePush} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify(
       githubPushPayload({
@@ -163,15 +162,43 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
-    expect(publishIntegrationEventReceived.mock.calls[0]?.[0].event.payload).toMatchObject({
+    expect(publishSourcePush).toHaveBeenCalledTimes(1);
+    expect(publishSourcePush.mock.calls[0]?.[0].push).toMatchObject({
       ref: 'feature/x',
       isDefaultBranch: false,
     });
   });
 
+  it('ignores a branch deletion (all-zero after SHA) without publishing', async () => {
+    const installationId = 7783;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp({connection});
+    const deliveryId = randomUUID();
+    const body = JSON.stringify(
+      githubPushPayload({
+        installationId,
+        repositoryId: 42,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: '0000000000000000000000000000000000000000',
+      }),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/github',
+      headers: signedHeaders(body, 'push', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
   it('records the delivery only for non-push events', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify({zen: 'Practicality beats purity.'});
 
@@ -183,13 +210,13 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
   it('records the delivery only for pushes from unknown installations', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById} =
+    const {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById} =
       await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify(
@@ -210,7 +237,7 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(getIntegrationConnectionById).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
@@ -218,7 +245,7 @@ describe('GitHub webhook route', () => {
 
   it('records the delivery only when the installation has no connection', async () => {
     const installationId = 7781;
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly, getIntegrationConnectionById} =
+    const {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById} =
       await createTestApp();
     getIntegrationConnectionById.mockResolvedValue(undefined);
     await seedInstallation(installationId);
@@ -242,13 +269,13 @@ describe('GitHub webhook route', () => {
 
     expect(res.statusCode).toBe(204);
     expect(getIntegrationConnectionById).toHaveBeenCalledTimes(1);
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
   it('ignores pushes whose payload has no installation id', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify({
       ref: 'refs/heads/main',
@@ -264,12 +291,12 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
   it('rejects an invalid signature with 401 and persists nothing', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const body = JSON.stringify(
       githubPushPayload({
         installationId: 7779,
@@ -293,12 +320,12 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(401);
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
   it('rejects malformed signature headers (verify throws) with 401', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const body = JSON.stringify(
       githubPushPayload({
         installationId: 7782,
@@ -322,12 +349,12 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(401);
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
   it('rejects malformed JSON after a valid signature with 400', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const body = '{not valid json';
 
     const res = await app.inject({
@@ -339,12 +366,12 @@ describe('GitHub webhook route', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({error: 'malformed JSON'});
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
   it('rejects push payloads that fail schema validation with 400', async () => {
-    const {app, publishIntegrationEventReceived, recordDeliveryOnly} = await createTestApp();
+    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const body = JSON.stringify({ref: 'refs/heads/main'});
 
     const res = await app.inject({
@@ -356,7 +383,7 @@ describe('GitHub webhook route', () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.json()).toMatchObject({error: 'malformed push payload'});
-    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/integration/github/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.ts
@@ -2,7 +2,7 @@ import {Buffer} from 'node:buffer';
 import {Webhooks} from '@octokit/webhooks';
 import type {
   GetIntegrationConnectionByIdFn,
-  PublishIntegrationEventReceivedFn,
+  PublishSourcePushFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
 import {githubPushPayloadSchema} from '@shipfox/api-integration-github-dto';
@@ -24,7 +24,7 @@ const GITHUB_PROVIDER = 'github';
 
 export interface CreateGithubWebhookRoutesOptions {
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
-  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
 }
@@ -111,7 +111,7 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
           tx,
           deliveryId,
           payload: validated.data,
-          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+          publishSourcePush: options.publishSourcePush,
           recordDeliveryOnly: options.recordDeliveryOnly,
           getIntegrationConnectionById: options.getIntegrationConnectionById,
         });

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -1,11 +1,11 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {INTEGRATION_EVENT_RECEIVED} from '@shipfox/api-integration-core-dto';
+import {INTEGRATION_SOURCE_COMMIT_PUSHED} from '@shipfox/api-integration-core-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath, projectsOutbox} from '#db/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
-import {onIntegrationEventReceived} from '#presentation/subscribers/index.js';
+import {onSourceCommitPushed} from '#presentation/subscribers/index.js';
 import {createProjectsMaintenanceActivities} from '#temporal/activities/index.js';
 import {PROJECTS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
@@ -42,7 +42,7 @@ export function createProjectsModule({sourceControl}: CreateProjectsModuleOption
     database: {db, migrationsPath},
     routes: createProjectRoutes(sourceControl),
     publishers: [{name: 'projects', table: projectsOutbox, db}],
-    subscribers: [{event: INTEGRATION_EVENT_RECEIVED, handler: onIntegrationEventReceived}],
+    subscribers: [{event: INTEGRATION_SOURCE_COMMIT_PUSHED, handler: onSourceCommitPushed}],
     workers: [
       {
         taskQueue: PROJECTS_MAINTENANCE_TASK_QUEUE,

--- a/libs/api/projects/src/presentation/subscribers/index.ts
+++ b/libs/api/projects/src/presentation/subscribers/index.ts
@@ -1,1 +1,1 @@
-export {onIntegrationEventReceived} from './on-integration-event-received.js';
+export {onSourceCommitPushed} from './on-source-commit-pushed.js';

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
@@ -1,6 +1,7 @@
-import type {
-  GithubPushPayload,
-  IntegrationEventReceivedEvent,
+import {
+  INTEGRATION_SOURCE_COMMIT_PUSHED,
+  type IntegrationSourceCommitPushedEvent,
+  type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
 import {PROJECT_SOURCE_COMMIT_OBSERVED} from '@shipfox/api-projects-dto';
 import type {DomainEvent} from '@shipfox/node-outbox';
@@ -8,9 +9,10 @@ import {and, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
 import {projectFactory} from '#test/index.js';
-import {onIntegrationEventReceived} from './on-integration-event-received.js';
+import {createProjectsModule} from '../../index.js';
+import {onSourceCommitPushed} from './on-source-commit-pushed.js';
 
-function buildPushPayload(overrides: Partial<GithubPushPayload> = {}): GithubPushPayload {
+function buildPush(overrides: Partial<SourcePushPayload> = {}): SourcePushPayload {
   return {
     externalRepositoryId: 'github:42',
     ref: 'main',
@@ -21,28 +23,24 @@ function buildPushPayload(overrides: Partial<GithubPushPayload> = {}): GithubPus
   };
 }
 
-function buildEnvelope(
-  overrides: Partial<IntegrationEventReceivedEvent> = {},
-  pushOverrides: Partial<GithubPushPayload> = {},
-): IntegrationEventReceivedEvent {
-  return {
-    source: 'github',
-    event: 'push',
-    workspaceId: overrides.workspaceId ?? crypto.randomUUID(),
-    connectionId: overrides.connectionId ?? crypto.randomUUID(),
-    deliveryId: overrides.deliveryId ?? crypto.randomUUID(),
-    receivedAt: new Date().toISOString(),
-    payload: buildPushPayload(pushOverrides),
-    ...overrides,
-  };
-}
-
-function buildEvent(payload: IntegrationEventReceivedEvent, id = crypto.randomUUID()): DomainEvent {
+function buildEvent(
+  overrides: Partial<IntegrationSourceCommitPushedEvent> = {},
+  pushOverrides: Partial<SourcePushPayload> = {},
+  id = crypto.randomUUID(),
+): DomainEvent {
   return {
     id,
-    type: 'integrations.event.received',
+    type: INTEGRATION_SOURCE_COMMIT_PUSHED,
     createdAt: new Date(),
-    payload,
+    payload: {
+      provider: 'github',
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      deliveryId: crypto.randomUUID(),
+      receivedAt: new Date().toISOString(),
+      push: buildPush(pushOverrides),
+      ...overrides,
+    },
   };
 }
 
@@ -58,8 +56,8 @@ async function listCommitObservedEvents(externalRepositoryId: string) {
     );
 }
 
-describe('onIntegrationEventReceived', () => {
-  it('publishes a project source commit event for a default-branch github push', async () => {
+describe('onSourceCommitPushed', () => {
+  it('publishes a project source commit event for a default-branch push', async () => {
     const sourceConnectionId = crypto.randomUUID();
     const workspaceId = crypto.randomUUID();
     const externalRepositoryId = `github:${crypto.randomUUID()}`;
@@ -68,12 +66,12 @@ describe('onIntegrationEventReceived', () => {
       sourceConnectionId,
       sourceExternalRepositoryId: externalRepositoryId,
     });
-    const envelope = buildEnvelope(
+    const event = buildEvent(
       {workspaceId, connectionId: sourceConnectionId},
       {externalRepositoryId},
     );
 
-    await onIntegrationEventReceived(buildEvent(envelope));
+    await onSourceCommitPushed(event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(1);
@@ -97,52 +95,12 @@ describe('onIntegrationEventReceived', () => {
       sourceConnectionId,
       sourceExternalRepositoryId: externalRepositoryId,
     });
-    const envelope = buildEnvelope(
+    const event = buildEvent(
       {workspaceId, connectionId: sourceConnectionId},
       {externalRepositoryId, ref: 'feature/x', isDefaultBranch: false},
     );
 
-    await onIntegrationEventReceived(buildEvent(envelope));
-
-    const rows = await listCommitObservedEvents(externalRepositoryId);
-    expect(rows).toHaveLength(0);
-  });
-
-  it('ignores non-github sources', async () => {
-    const sourceConnectionId = crypto.randomUUID();
-    const workspaceId = crypto.randomUUID();
-    const externalRepositoryId = `gitlab:${crypto.randomUUID()}`;
-    await projectFactory.create({
-      workspaceId,
-      sourceConnectionId,
-      sourceExternalRepositoryId: externalRepositoryId,
-    });
-    const envelope = buildEnvelope(
-      {source: 'gitlab', workspaceId, connectionId: sourceConnectionId},
-      {externalRepositoryId},
-    );
-
-    await onIntegrationEventReceived(buildEvent(envelope));
-
-    const rows = await listCommitObservedEvents(externalRepositoryId);
-    expect(rows).toHaveLength(0);
-  });
-
-  it('ignores non-push events', async () => {
-    const sourceConnectionId = crypto.randomUUID();
-    const workspaceId = crypto.randomUUID();
-    const externalRepositoryId = `github:${crypto.randomUUID()}`;
-    await projectFactory.create({
-      workspaceId,
-      sourceConnectionId,
-      sourceExternalRepositoryId: externalRepositoryId,
-    });
-    const envelope = buildEnvelope(
-      {event: 'issue_comment', workspaceId, connectionId: sourceConnectionId},
-      {externalRepositoryId},
-    );
-
-    await onIntegrationEventReceived(buildEvent(envelope));
+    await onSourceCommitPushed(event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(0);
@@ -150,15 +108,15 @@ describe('onIntegrationEventReceived', () => {
 
   it('does not publish when no project is bound to the pushed repository', async () => {
     const externalRepositoryId = `github:${crypto.randomUUID()}`;
-    const envelope = buildEnvelope({}, {externalRepositoryId});
+    const event = buildEvent({}, {externalRepositoryId});
 
-    await onIntegrationEventReceived(buildEvent(envelope));
+    await onSourceCommitPushed(event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(0);
   });
 
-  it('deduplicates the same integration event for the same project', async () => {
+  it('deduplicates the same source event for the same project', async () => {
     const sourceConnectionId = crypto.randomUUID();
     const workspaceId = crypto.randomUUID();
     const externalRepositoryId = `github:${crypto.randomUUID()}`;
@@ -167,16 +125,25 @@ describe('onIntegrationEventReceived', () => {
       sourceConnectionId,
       sourceExternalRepositoryId: externalRepositoryId,
     });
-    const envelope = buildEnvelope(
+    const event = buildEvent(
       {workspaceId, connectionId: sourceConnectionId},
       {externalRepositoryId},
     );
-    const event = buildEvent(envelope);
 
-    await onIntegrationEventReceived(event);
-    await onIntegrationEventReceived(event);
+    await onSourceCommitPushed(event);
+    await onSourceCommitPushed(event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(1);
+  });
+
+  // The source/event filter is now the subscription itself (projects only receives the
+  // typed source event), so this registration replaces the old non-github/non-push tests.
+  it('registers the projects module on INTEGRATION_SOURCE_COMMIT_PUSHED', () => {
+    const module = createProjectsModule({sourceControl: {} as never});
+
+    const events = module.subscribers?.map((subscriber) => subscriber.event);
+
+    expect(events).toContain(INTEGRATION_SOURCE_COMMIT_PUSHED);
   });
 });

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.ts
@@ -1,7 +1,4 @@
-import type {
-  GithubPushPayload,
-  IntegrationEventReceivedEvent,
-} from '@shipfox/api-integration-core-dto';
+import type {IntegrationSourceCommitPushedEvent} from '@shipfox/api-integration-core-dto';
 import {PROJECT_SOURCE_COMMIT_OBSERVED} from '@shipfox/api-projects-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {type DomainEvent, writeOutboxEvent} from '@shipfox/node-outbox';
@@ -10,34 +7,28 @@ import {recordIntegrationEventForProject} from '#db/integration-event-dedup.js';
 import {getProjectBySource} from '#db/projects.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
 
-const GITHUB_SOURCE = 'github';
-const PUSH_EVENT = 'push';
+export async function onSourceCommitPushed(event: DomainEvent): Promise<void> {
+  const {provider, workspaceId, connectionId, push} =
+    event.payload as IntegrationSourceCommitPushedEvent;
 
-export async function onIntegrationEventReceived(event: DomainEvent): Promise<void> {
-  const envelope = event.payload as IntegrationEventReceivedEvent;
-
-  if (envelope.source !== GITHUB_SOURCE || envelope.event !== PUSH_EVENT) {
-    return;
-  }
-
-  const pushPayload = envelope.payload as GithubPushPayload;
-  if (!pushPayload.isDefaultBranch) {
+  // Projects only track the default branch; other branches are someone else's policy.
+  if (!push.isDefaultBranch) {
     return;
   }
 
   const project = await getProjectBySource({
-    workspaceId: envelope.workspaceId,
-    sourceConnectionId: envelope.connectionId,
-    sourceExternalRepositoryId: pushPayload.externalRepositoryId,
+    workspaceId,
+    sourceConnectionId: connectionId,
+    sourceExternalRepositoryId: push.externalRepositoryId,
   });
   if (!project) {
     logger().info(
       {
         eventId: event.id,
-        connectionId: envelope.connectionId,
-        externalRepositoryId: pushPayload.externalRepositoryId,
+        connectionId,
+        externalRepositoryId: push.externalRepositoryId,
       },
-      'integration event received: no project bound to source, dropping',
+      'source commit pushed: no project bound to source, dropping',
     );
     return;
   }
@@ -56,10 +47,10 @@ export async function onIntegrationEventReceived(event: DomainEvent): Promise<vo
         workspaceId: project.workspaceId,
         projectId: project.id,
         sourceConnectionId: project.sourceConnectionId,
-        provider: envelope.source,
-        externalRepositoryId: pushPayload.externalRepositoryId,
-        ref: pushPayload.ref,
-        headCommitSha: pushPayload.headCommitSha,
+        provider,
+        externalRepositoryId: push.externalRepositoryId,
+        ref: push.ref,
+        headCommitSha: push.headCommitSha,
       },
     });
   });


### PR DESCRIPTION
Source-control providers now own the translation of their webhooks into a typed, provider-agnostic domain event, instead of the `projects` module decoding GitHub-specific payloads.

## Why

`projects`' subscriber read the generic `INTEGRATION_EVENT_RECEIVED` envelope and hard-coded provider knowledge (`source === 'github'`, `event === 'push'`, a cast to `GithubPushPayload`, `isDefaultBranch`). That put "how to interpret each integration's push webhook" inside the projects domain: every new provider (GitLab, Bitbucket) would grow a `(source, event)` switch there, and every other domain consumer that wanted to react to a commit would repeat the same decoding.

The key constraint is that `triggers` also consumes `INTEGRATION_EVENT_RECEIVED`, but on purpose: it is a source-agnostic pass-through that fans `(source, event, payload)` out to user-configured workspace subscriptions. So the fix is not to remove the generic envelope, but to give *domain* consumers a typed event while keeping the raw stream for the pass-through consumer.

## What changed

- **`core-dto`**: renamed `GithubPushPayload` -> `SourcePushPayload` (provider-agnostic); added `INTEGRATION_SOURCE_COMMIT_PUSHED` + `IntegrationSourceCommitPushedEvent` (nests the push) and a `PublishSourcePushFn` port (kept in `core-dto` so providers don't depend on `core`, avoiding a cycle).
- **`integration/core`**: new `publishSourcePush` does the delivery-dedup once and writes **both** outbox rows — the generic envelope (for `triggers`) and the typed event (for `projects`) — in one transaction. It is transaction-only so the three writes can't partially commit.
- **`integration/github`**: `handleGithubPush` builds a `SourcePushPayload` and calls `publishSourcePush`; the injected dependency is swapped through the route -> factory -> core seam. Branch deletions (all-zero `after` SHA) are dropped at the normalizer rather than surfacing as observed commits.
- **`projects`**: `onSourceCommitPushed` (renamed from `onIntegrationEventReceived`) reads the typed event, applies the default-branch policy, resolves the project, dedups, and emits `PROJECT_SOURCE_COMMIT_OBSERVED` — no provider knowledge. `triggers` is unchanged.

## Notes for review

- `defaultBranch` filtering stays in `projects` (a consumer policy), so the integration event carries every push and a future consumer (e.g. PR checks) can react to non-default branches.
- Tests are per-layer: the "both rows / duplicate writes neither" assertions live in the `integration/core` publisher test (real DB), since the github route test mocks the publisher; `projects` gains a module-registration assertion in place of the removed non-github/non-push filter tests.
- Out of scope (follow-ups): a typed Sentry event when a domain consumer needs one, and making `writeOutboxEvent` generic over the event map repo-wide so consumer-side payload drift is a compile error too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved webhook translation into the integration module so providers emit typed, provider-agnostic events. A transactional publisher writes both the typed `INTEGRATION_SOURCE_COMMIT_PUSHED` and the generic `INTEGRATION_EVENT_RECEIVED`; `projects` now consumes the typed event while `triggers` still reads the generic stream.

- New Features
  - Added `INTEGRATION_SOURCE_COMMIT_PUSHED` and `publishSourcePush` to dedup by delivery and write both events in one transaction.
  - Introduced `SourcePushPayload`; GitHub normalizer drops branch-deletion pushes (all-zero SHA) so neither the typed event nor the generic envelope is emitted.

- Refactors
  - `projects` replaces provider-specific decoding with `onSourceCommitPushed`; default-branch filtering remains in `projects`.
  - Renamed `GithubPushPayload` to `SourcePushPayload`; tests updated per layer.

<sup>Written for commit c5d79e8cbe9d3b3cc764833332a3eb5d97716bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

