### PR TITLE
Add a single reliable job-terminal event

### DIFF
--- a/.changeset/lively-comets-terminate.md
+++ b/.changeset/lively-comets-terminate.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-workflows-dto": minor
+"@shipfox/api-workflows": minor
+---
+
+Add a single reliable job-terminal event: `workflows.job.terminated` is now written in the same transaction as every terminal job-status flip (normal completion, DAG cancellation, lease-expiry resolution, and timeout), and the run-level `workflows.workflow_run.terminated` is emitted the same way. All workflows event names are aligned on one `WORKFLOWS_<entity>_<verb>` scheme, so the run and job terminal events read as the same event at two scopes.
+
+Internal breaking change (`WORKFLOWS_JOB_COMPLETED` → `WORKFLOWS_JOB_STEPS_SETTLED`, `WORKFLOW_RUN_*` → `WORKFLOWS_WORKFLOW_RUN_*`, with matching DTO type renames) consumed only within this monorepo.

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -1,10 +1,20 @@
-export const WORKFLOW_RUN_CREATED = 'workflows.run.created' as const;
-export const WORKFLOW_RUN_FINISHED = 'workflows.run.finished' as const;
+export const WORKFLOWS_WORKFLOW_RUN_CREATED = 'workflows.workflow_run.created' as const;
+// Public terminal fact for a workflow run: written in the same transaction that
+// flips the run's status to a terminal value (succeeded/failed/cancelled).
+export const WORKFLOWS_WORKFLOW_RUN_TERMINATED = 'workflows.workflow_run.terminated' as const;
 export const WORKFLOWS_JOB_TIMED_OUT = 'workflows.job.timed_out' as const;
-// Written in the same transaction as the final per-step result that makes a job
-// terminal, so per-step execution signals job completion exactly once (the
-// at-least-once outbox + workflow-side signal dedupe make it safe).
-export const WORKFLOWS_JOB_COMPLETED = 'workflows.job.completed' as const;
+// Public terminal fact for a job, and the single reliable "this job is over"
+// signal: written in the same transaction that flips the job's status to a terminal
+// value (succeeded/failed/cancelled), across every terminal path — normal
+// completion, DAG cancellation, lease-expiry resolution, and the timeout backstop.
+export const WORKFLOWS_JOB_TERMINATED = 'workflows.job.terminated' as const;
+// Internal orchestration signal, NOT a terminal fact: all of a job's steps have
+// settled into terminal states. Written in the same transaction as the final
+// per-step result (before the job row itself is terminal), succeeded/failed only;
+// the `on-job-steps-settled` subscriber raises the Temporal JOB_FINISHED_SIGNAL so
+// the workflow finalizes the job. Use WORKFLOWS_JOB_TERMINATED to observe the job's
+// outcome.
+export const WORKFLOWS_JOB_STEPS_SETTLED = 'workflows.job.steps_settled' as const;
 // Written in the same transaction as a durable gate restart (the failed attempt
 // + the rewind of the projection from `restart_from`), as a durable audit record
 // of the restart. The pull-based runner re-dispatches the rewound step on its
@@ -12,14 +22,14 @@ export const WORKFLOWS_JOB_COMPLETED = 'workflows.job.completed' as const;
 // now; any future consumer must be idempotent (the outbox is at-least-once).
 export const WORKFLOWS_STEP_RESTART_ENQUEUED = 'workflows.step.restart_enqueued' as const;
 
-export interface WorkflowRunCreatedEvent {
+export interface WorkflowsWorkflowRunCreatedEvent {
   runId: string;
   workspaceId: string;
   projectId: string;
   definitionId: string;
 }
 
-export interface WorkflowRunFinishedEvent {
+export interface WorkflowsWorkflowRunTerminatedEvent {
   runId: string;
   projectId: string;
   status: 'succeeded' | 'failed' | 'cancelled';
@@ -30,7 +40,13 @@ export interface WorkflowsJobTimedOutEvent {
   runId: string;
 }
 
-export interface WorkflowsJobCompletedEvent {
+export interface WorkflowsJobTerminatedEvent {
+  jobId: string;
+  runId: string;
+  status: 'succeeded' | 'failed' | 'cancelled';
+}
+
+export interface WorkflowsJobStepsSettledEvent {
   jobId: string;
   runId: string;
   status: 'succeeded' | 'failed';
@@ -46,9 +62,10 @@ export interface WorkflowsStepRestartEnqueuedEvent {
 }
 
 export interface WorkflowsEventMap {
-  [WORKFLOW_RUN_CREATED]: WorkflowRunCreatedEvent;
-  [WORKFLOW_RUN_FINISHED]: WorkflowRunFinishedEvent;
+  [WORKFLOWS_WORKFLOW_RUN_CREATED]: WorkflowsWorkflowRunCreatedEvent;
+  [WORKFLOWS_WORKFLOW_RUN_TERMINATED]: WorkflowsWorkflowRunTerminatedEvent;
   [WORKFLOWS_JOB_TIMED_OUT]: WorkflowsJobTimedOutEvent;
-  [WORKFLOWS_JOB_COMPLETED]: WorkflowsJobCompletedEvent;
+  [WORKFLOWS_JOB_TERMINATED]: WorkflowsJobTerminatedEvent;
+  [WORKFLOWS_JOB_STEPS_SETTLED]: WorkflowsJobStepsSettledEvent;
   [WORKFLOWS_STEP_RESTART_ENQUEUED]: WorkflowsStepRestartEnqueuedEvent;
 }

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -1,19 +1,13 @@
 export const WORKFLOWS_WORKFLOW_RUN_CREATED = 'workflows.workflow_run.created' as const;
-// Public terminal fact for a workflow run: written in the same transaction that
-// flips the run's status to a terminal value (succeeded/failed/cancelled).
+// Terminal fact for a workflow run, written in the same transaction as the status flip.
 export const WORKFLOWS_WORKFLOW_RUN_TERMINATED = 'workflows.workflow_run.terminated' as const;
 export const WORKFLOWS_JOB_TIMED_OUT = 'workflows.job.timed_out' as const;
-// Public terminal fact for a job, and the single reliable "this job is over"
-// signal: written in the same transaction that flips the job's status to a terminal
-// value (succeeded/failed/cancelled), across every terminal path — normal
-// completion, DAG cancellation, lease-expiry resolution, and the timeout backstop.
+// Terminal fact for a job: the single reliable "this job is over" signal, written in
+// the same transaction as the status flip, on every terminal path.
 export const WORKFLOWS_JOB_TERMINATED = 'workflows.job.terminated' as const;
-// Internal orchestration signal, NOT a terminal fact: all of a job's steps have
-// settled into terminal states. Written in the same transaction as the final
-// per-step result (before the job row itself is terminal), succeeded/failed only;
-// the `on-job-steps-settled` subscriber raises the Temporal JOB_FINISHED_SIGNAL so
-// the workflow finalizes the job. Use WORKFLOWS_JOB_TERMINATED to observe the job's
-// outcome.
+// Internal signal, not a terminal fact: a job's steps have all settled, so the
+// on-job-steps-settled subscriber can raise the Temporal JOB_FINISHED_SIGNAL. Fires
+// before the job row is terminal; observe WORKFLOWS_JOB_TERMINATED for the outcome.
 export const WORKFLOWS_JOB_STEPS_SETTLED = 'workflows.job.steps_settled' as const;
 // Written in the same transaction as a durable gate restart (the failed attempt
 // + the rewind of the projection from `restart_from`), as a durable audit record

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -39,15 +39,17 @@ export {
   stepErrorReasonSchema,
 } from '#schemas/index.js';
 export {
-  WORKFLOW_RUN_CREATED,
-  WORKFLOW_RUN_FINISHED,
-  WORKFLOWS_JOB_COMPLETED,
+  WORKFLOWS_JOB_STEPS_SETTLED,
+  WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
-  type WorkflowRunCreatedEvent,
-  type WorkflowRunFinishedEvent,
+  WORKFLOWS_WORKFLOW_RUN_CREATED,
+  WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMap,
-  type WorkflowsJobCompletedEvent,
+  type WorkflowsJobStepsSettledEvent,
+  type WorkflowsJobTerminatedEvent,
   type WorkflowsJobTimedOutEvent,
   type WorkflowsStepRestartEnqueuedEvent,
+  type WorkflowsWorkflowRunCreatedEvent,
+  type WorkflowsWorkflowRunTerminatedEvent,
 } from './events.js';

--- a/libs/api/workflows/src/core/entities/job.ts
+++ b/libs/api/workflows/src/core/entities/job.ts
@@ -21,3 +21,11 @@ export interface Job {
   updatedAt: Date;
   timedOutAt: Date | null;
 }
+
+export type TerminalJobStatus = Extract<JobStatus, 'succeeded' | 'failed' | 'cancelled'>;
+
+const TERMINAL_JOB_STATUSES = new Set<JobStatus>(['succeeded', 'failed', 'cancelled']);
+
+export function isJobTerminal(status: JobStatus): status is TerminalJobStatus {
+  return TERMINAL_JOB_STATUSES.has(status);
+}

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -1,5 +1,22 @@
 export type WorkflowRunStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
+export type TerminalWorkflowRunStatus = Extract<
+  WorkflowRunStatus,
+  'succeeded' | 'failed' | 'cancelled'
+>;
+
+const TERMINAL_WORKFLOW_RUN_STATUSES = new Set<WorkflowRunStatus>([
+  'succeeded',
+  'failed',
+  'cancelled',
+]);
+
+export function isWorkflowRunTerminal(
+  status: WorkflowRunStatus,
+): status is TerminalWorkflowRunStatus {
+  return TERMINAL_WORKFLOW_RUN_STATUSES.has(status);
+}
+
 export type TriggerPayload =
   | {
       source: 'manual';

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -1,5 +1,5 @@
 import {
-  WORKFLOWS_JOB_COMPLETED,
+  WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
   type WorkflowsStepRestartEnqueuedEvent,
 } from '@shipfox/api-workflows-dto';
@@ -18,13 +18,13 @@ import {
 } from './errors.js';
 import {nextStepForJob, recordStepResult} from './job-execution.js';
 
-async function jobCompletedEvents(jobId: string): Promise<Array<{status: string}>> {
+async function jobStepsSettledEvents(jobId: string): Promise<Array<{status: string}>> {
   const rows = await db()
     .select({payload: workflowsOutbox.payload})
     .from(workflowsOutbox)
     .where(
       and(
-        eq(workflowsOutbox.eventType, WORKFLOWS_JOB_COMPLETED),
+        eq(workflowsOutbox.eventType, WORKFLOWS_JOB_STEPS_SETTLED),
         sql`${workflowsOutbox.payload}->>'jobId' = ${jobId}`,
       ),
     );
@@ -226,7 +226,7 @@ describe('recordStepResult', () => {
     expect(after[0]?.status).toBe('failed');
     expect(after[1]?.status).toBe('cancelled');
     expect(after[2]?.status).toBe('cancelled');
-    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
   });
 });
 
@@ -260,7 +260,7 @@ describe('recordStepResult job-completion event', () => {
     });
 
     expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
-    const events = await jobCompletedEvents(jobId);
+    const events = await jobStepsSettledEvents(jobId);
     expect(events).toHaveLength(1);
     expect(events[0]?.status).toBe('succeeded');
   });
@@ -276,7 +276,7 @@ describe('recordStepResult job-completion event', () => {
     });
 
     expect(outcome).toEqual({jobFinished: false});
-    expect(await jobCompletedEvents(jobId)).toHaveLength(0);
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(0);
   });
 
   test('a failed final step enqueues one completion event with status failed', async () => {
@@ -290,7 +290,7 @@ describe('recordStepResult job-completion event', () => {
       error: {message: 'boom'},
     });
 
-    const events = await jobCompletedEvents(jobId);
+    const events = await jobStepsSettledEvents(jobId);
     expect(events).toHaveLength(1);
     expect(events[0]?.status).toBe('failed');
   });
@@ -307,7 +307,7 @@ describe('recordStepResult job-completion event', () => {
     });
 
     expect(duplicate).toEqual({jobFinished: true, status: 'succeeded'});
-    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
   });
 
   test('concurrent final reports enqueue exactly one completion event', async () => {
@@ -324,7 +324,7 @@ describe('recordStepResult job-completion event', () => {
       {jobFinished: true, status: 'succeeded'},
       {jobFinished: true, status: 'succeeded'},
     ]);
-    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
   });
 });
 
@@ -523,7 +523,7 @@ describe('step attempts', () => {
 
     expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
     // The applied-gated outbox write must not fire on the stale path.
-    expect(await jobCompletedEvents(jobId)).toHaveLength(1);
+    expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
   });
 });
 

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
@@ -5,7 +5,7 @@ import {
   finishStepAttempt,
   getStepsByJobIdForUpdate,
   rewindStepsToPending,
-  writeJobCompletedOutbox,
+  writeJobStepsSettledOutbox,
   writeStepRestartEnqueuedOutbox,
 } from '#db/workflow-runs.js';
 import {
@@ -120,12 +120,12 @@ export async function applyStepTransition(
   }
 
   // Re-derive completion from the post-apply projection so the outcome is robust
-  // to the cancel sweep above; emit the completion event exactly once, here on
+  // to the cancel sweep above; emit the steps-settled signal exactly once, here on
   // the applied path.
   const after = await getStepsByJobIdForUpdate(ctx.jobId, tx);
   if (after.every((step) => isTerminal(step.status))) {
     const status = deriveCompletion(after);
-    await writeJobCompletedOutbox(tx, {jobId: ctx.jobId, status});
+    await writeJobStepsSettledOutbox(tx, {jobId: ctx.jobId, status});
     return {jobFinished: true, status};
   }
   return {jobFinished: false};

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1,5 +1,10 @@
-import {WORKFLOW_RUN_CREATED, WORKFLOWS_JOB_TIMED_OUT} from '@shipfox/api-workflows-dto';
-import {eq, sql} from 'drizzle-orm';
+import {
+  WORKFLOWS_JOB_TERMINATED,
+  WORKFLOWS_JOB_TIMED_OUT,
+  WORKFLOWS_WORKFLOW_RUN_CREATED,
+  WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+} from '@shipfox/api-workflows-dto';
+import {and, eq, sql} from 'drizzle-orm';
 import {JobNotFoundError} from '#core/errors.js';
 import {recordStepResult} from '#core/job-execution.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
@@ -25,6 +30,47 @@ type TestWorkflowModelInput = Parameters<typeof workflowModel>[0];
 
 function buildModel(overrides?: TestWorkflowModelInput) {
   return workflowModel(overrides);
+}
+
+function createTestRun(scope: {workspaceId: string; projectId: string; definitionId: string}) {
+  return createWorkflowRun({
+    workspaceId: scope.workspaceId,
+    projectId: scope.projectId,
+    definitionId: scope.definitionId,
+    model: buildModel(),
+    triggerPayload: {
+      source: 'manual',
+      event: 'fire',
+      subscriptionId: crypto.randomUUID(),
+      userId: crypto.randomUUID(),
+    },
+  });
+}
+
+async function jobTerminatedEvents(jobId: string) {
+  const rows = await db()
+    .select({payload: workflowsOutbox.payload})
+    .from(workflowsOutbox)
+    .where(
+      and(
+        eq(workflowsOutbox.eventType, WORKFLOWS_JOB_TERMINATED),
+        sql`${workflowsOutbox.payload}->>'jobId' = ${jobId}`,
+      ),
+    );
+  return rows.map((row) => row.payload as {jobId: string; runId: string; status: string});
+}
+
+async function runTerminatedEvents(runId: string) {
+  const rows = await db()
+    .select({payload: workflowsOutbox.payload})
+    .from(workflowsOutbox)
+    .where(
+      and(
+        eq(workflowsOutbox.eventType, WORKFLOWS_WORKFLOW_RUN_TERMINATED),
+        sql`${workflowsOutbox.payload}->>'runId' = ${runId}`,
+      ),
+    );
+  return rows.map((row) => row.payload as {runId: string; projectId: string; status: string});
 }
 
 describe('workflow run queries', () => {
@@ -79,7 +125,7 @@ describe('workflow run queries', () => {
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
     });
 
-    test('writes workflows.run.created outbox event in same transaction', async () => {
+    test('writes workflows.workflow_run.created outbox event in same transaction', async () => {
       const run = await createWorkflowRun({
         workspaceId,
         projectId,
@@ -96,7 +142,7 @@ describe('workflow run queries', () => {
       const outboxRows = await db()
         .select()
         .from(workflowsOutbox)
-        .where(eq(workflowsOutbox.eventType, WORKFLOW_RUN_CREATED));
+        .where(eq(workflowsOutbox.eventType, WORKFLOWS_WORKFLOW_RUN_CREATED));
 
       const matchingRow = outboxRows.find(
         (row) => (row.payload as Record<string, unknown>).runId === run.id,
@@ -118,7 +164,7 @@ describe('workflow run queries', () => {
       try {
         await db().transaction(async (tx) => {
           await tx.insert(workflowsOutbox).values({
-            eventType: WORKFLOW_RUN_CREATED,
+            eventType: WORKFLOWS_WORKFLOW_RUN_CREATED,
             payload: {runId: marker, projectId, definitionId},
           });
           throw new Error('Simulated failure');
@@ -590,6 +636,42 @@ describe('workflow run queries', () => {
         }),
       ).rejects.toThrow('Optimistic lock failure');
     });
+
+    test('writes one run-terminated event when the status becomes terminal', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+
+      await updateWorkflowRunStatus({runId: run.id, status: 'succeeded', expectedVersion: 1});
+
+      const events = await runTerminatedEvents(run.id);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({runId: run.id, projectId: run.projectId, status: 'succeeded'});
+    });
+
+    test('writes no run-terminated event for a non-terminal transition', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+
+      await updateWorkflowRunStatus({runId: run.id, status: 'running', expectedVersion: 1});
+
+      expect(await runTerminatedEvents(run.id)).toHaveLength(0);
+    });
+
+    test('idempotent retry: a second terminal update at the stale version emits once', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+
+      const first = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+      const retry = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      expect(retry.version).toBe(first.version);
+      expect(await runTerminatedEvents(run.id)).toHaveLength(1);
+    });
   });
 
   describe('updateJobStatus', () => {
@@ -671,6 +753,78 @@ describe('workflow run queries', () => {
 
       expect(retry.status).toBe('running');
       expect(retry.version).toBe(first.version);
+    });
+  });
+
+  describe('job terminal event (WORKFLOWS_JOB_TERMINATED)', () => {
+    async function seedPendingJob() {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const jobId = (await getJobsByRunId(run.id))[0]?.id as string;
+      return {run, jobId};
+    }
+
+    test.each([
+      'succeeded',
+      'failed',
+      'cancelled',
+    ] as const)('writes one terminated event when a job becomes %s', async (status) => {
+      const {run, jobId} = await seedPendingJob();
+
+      await updateJobStatus({jobId, status, expectedVersion: 1});
+
+      const events = await jobTerminatedEvents(jobId);
+      expect(events).toHaveLength(1);
+      expect(events[0]).toEqual({jobId, runId: run.id, status});
+    });
+
+    test('writes no terminated event for a non-terminal transition', async () => {
+      const {jobId} = await seedPendingJob();
+
+      await updateJobStatus({jobId, status: 'running', expectedVersion: 1});
+
+      expect(await jobTerminatedEvents(jobId)).toHaveLength(0);
+    });
+
+    test('idempotent retry: a second terminal update at the stale version emits once', async () => {
+      const {jobId} = await seedPendingJob();
+
+      const first = await updateJobStatus({jobId, status: 'succeeded', expectedVersion: 1});
+      const retry = await updateJobStatus({jobId, status: 'succeeded', expectedVersion: 1});
+
+      expect(retry.version).toBe(first.version);
+      expect(await jobTerminatedEvents(jobId)).toHaveLength(1);
+    });
+
+    test('failJobAsTimedOut writes both the timed-out and terminated events', async () => {
+      const {run, jobId} = await seedPendingJob();
+
+      await failJobAsTimedOut({jobId, runId: run.id, expectedVersion: 1});
+
+      const terminated = await jobTerminatedEvents(jobId);
+      expect(terminated).toHaveLength(1);
+      expect(terminated[0]).toEqual({jobId, runId: run.id, status: 'failed'});
+
+      const timedOut = await db()
+        .select()
+        .from(workflowsOutbox)
+        .where(
+          and(
+            eq(workflowsOutbox.eventType, WORKFLOWS_JOB_TIMED_OUT),
+            sql`${workflowsOutbox.payload}->>'jobId' = ${jobId}`,
+          ),
+        );
+      expect(timedOut).toHaveLength(1);
+    });
+
+    test('lease-expiry resolution of a running job writes one terminated event', async () => {
+      const {jobId} = await seedPendingJob();
+      const running = await updateJobStatus({jobId, status: 'running', expectedVersion: 1});
+
+      await resolveJobAfterLeaseExpiry({jobId, expectedVersion: running.version});
+
+      const events = await jobTerminatedEvents(jobId);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.status).toBe('failed');
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -637,14 +637,18 @@ describe('workflow run queries', () => {
       ).rejects.toThrow('Optimistic lock failure');
     });
 
-    test('writes one run-terminated event when the status becomes terminal', async () => {
+    test.each([
+      'succeeded',
+      'failed',
+      'cancelled',
+    ] as const)('writes one run-terminated event when the status becomes %s', async (status) => {
       const run = await createTestRun({workspaceId, projectId, definitionId});
 
-      await updateWorkflowRunStatus({runId: run.id, status: 'succeeded', expectedVersion: 1});
+      await updateWorkflowRunStatus({runId: run.id, status, expectedVersion: 1});
 
       const events = await runTerminatedEvents(run.id);
       expect(events).toHaveLength(1);
-      expect(events[0]).toEqual({runId: run.id, projectId: run.projectId, status: 'succeeded'});
+      expect(events[0]).toEqual({runId: run.id, projectId: run.projectId, status});
     });
 
     test('writes no run-terminated event for a non-terminal transition', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1,17 +1,24 @@
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {
-  WORKFLOW_RUN_CREATED,
-  WORKFLOWS_JOB_COMPLETED,
+  WORKFLOWS_JOB_STEPS_SETTLED,
+  WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
+  WORKFLOWS_WORKFLOW_RUN_CREATED,
+  WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMap,
 } from '@shipfox/api-workflows-dto';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, asc, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql} from 'drizzle-orm';
-import type {Job, JobStatus} from '#core/entities/job.js';
+import {isJobTerminal, type Job, type JobStatus} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
-import type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from '#core/entities/workflow-run.js';
+import {
+  isWorkflowRunTerminal,
+  type TriggerPayload,
+  type WorkflowRun,
+  type WorkflowRunStatus,
+} from '#core/entities/workflow-run.js';
 import {JobNotFoundError} from '#core/errors.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import {materializeWorkflowModel} from '#core/workflow-runtime/index.js';
@@ -113,7 +120,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     }
 
     await writeOutboxEvent<WorkflowsEventMap>(tx, workflowsOutbox, {
-      type: WORKFLOW_RUN_CREATED,
+      type: WORKFLOWS_WORKFLOW_RUN_CREATED,
       payload: {
         runId: runRow.id,
         workspaceId: runRow.workspaceId,
@@ -339,22 +346,54 @@ export interface UpdateWorkflowRunStatusParams {
 export async function updateWorkflowRunStatus(
   params: UpdateWorkflowRunStatusParams,
 ): Promise<WorkflowRun> {
-  const rows = await db()
-    .update(workflowRuns)
-    .set({
-      status: params.status,
-      version: sql`${workflowRuns.version} + 1`,
-      updatedAt: new Date(),
-    })
-    .where(and(eq(workflowRuns.id, params.runId), eq(workflowRuns.version, params.expectedVersion)))
-    .returning();
+  return await db().transaction(async (tx) => {
+    const rows = await tx
+      .update(workflowRuns)
+      .set({
+        status: params.status,
+        version: sql`${workflowRuns.version} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(workflowRuns.id, params.runId), eq(workflowRuns.version, params.expectedVersion)),
+      )
+      .returning();
 
-  const row = rows[0];
-  if (!row)
-    throw new Error(
-      `Optimistic lock failure: run ${params.runId} version ${params.expectedVersion}`,
-    );
-  return toWorkflowRun(row);
+    const row = rows[0];
+    if (!row) {
+      // Idempotent under Temporal activity retry: a lost result after a committed
+      // status update leaves the row at version+1, so the retried expected-version
+      // UPDATE matches 0 rows. If the row already holds the requested status, the
+      // prior attempt of this same transition won — return it without re-emitting
+      // the terminal event, instead of throwing an optimistic-lock error that would
+      // wedge the workflow. run-orchestration is the sole writer of run status, so a
+      // mismatch only ever happens on retry-after-commit.
+      const existing = await tx
+        .select()
+        .from(workflowRuns)
+        .where(eq(workflowRuns.id, params.runId))
+        .limit(1);
+      const existingRow = existing[0];
+      if (existingRow && existingRow.status === params.status) return toWorkflowRun(existingRow);
+      throw new Error(
+        `Optimistic lock failure: run ${params.runId} version ${params.expectedVersion}`,
+      );
+    }
+
+    const run = toWorkflowRun(row);
+
+    // Mirror updateJobStatusAtVersion: emit the canonical run-terminal fact in the
+    // same transaction as the status flip, gated on the guarded UPDATE so it fires
+    // exactly once.
+    if (isWorkflowRunTerminal(run.status)) {
+      await writeOutboxEvent<WorkflowsEventMap>(tx, workflowsOutbox, {
+        type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+        payload: {runId: run.id, projectId: run.projectId, status: run.status},
+      });
+    }
+
+    return run;
+  });
 }
 
 export interface UpdateJobStatusAtVersionParams {
@@ -382,7 +421,21 @@ async function updateJobStatusAtVersion(
 
   const row = rows[0];
   if (!row) return null;
-  return toJob(row);
+  const job = toJob(row);
+
+  // Single chokepoint: every terminal job-status write funnels through this guarded
+  // UPDATE, and the version match means only one caller can win the transition.
+  // Emit the canonical terminal fact here, in the same transaction as the status
+  // flip, so it fires exactly once across all terminal paths (normal completion,
+  // DAG cancellation, lease-expiry resolution, timeout).
+  if (isJobTerminal(job.status)) {
+    await writeOutboxEvent<WorkflowsEventMap>(tx, workflowsOutbox, {
+      type: WORKFLOWS_JOB_TERMINATED,
+      payload: {jobId: job.id, runId: job.runId, status: job.status},
+    });
+  }
+
+  return job;
 }
 
 export interface UpdateJobStatusParams {
@@ -461,7 +514,7 @@ export async function failJobAsTimedOut(params: FailJobAsTimedOutParams): Promis
  *   recordStepResult, so the two never deadlock)
  *        │
  *        ├─ all steps terminal ─► the job finished concurrently (e.g. a lagging
- *        │                        WORKFLOWS_JOB_COMPLETED). Adopt deriveCompletion.
+ *        │                        WORKFLOWS_JOB_STEPS_SETTLED). Adopt deriveCompletion.
  *        └─ otherwise ──────────► the runner died mid-job: fail it + cancel the
  *                                 remaining (non-terminal) steps.
  *
@@ -506,12 +559,14 @@ export async function resolveJobAfterLeaseExpiry(params: {
   });
 }
 
-// Enqueue the terminal-completion signal in the SAME transaction as the final
-// per-step result that made the job terminal. Mirrors failJobAsTimedOut: the
-// state change and its signal intent commit together, so per-step execution
-// observes job completion exactly once (the outbox is at-least-once; the job
-// workflow dedupes the signal).
-export async function writeJobCompletedOutbox(
+// Enqueue the steps-settled signal in the SAME transaction as the final per-step
+// result that made the job's steps all terminal. This is the internal signal that
+// drives the Temporal JOB_FINISHED_SIGNAL (via on-job-steps-settled); the job's own
+// terminal fact is emitted later by updateJobStatusAtVersion when the workflow flips
+// the job status. Mirrors failJobAsTimedOut: the state change and its signal intent
+// commit together, so per-step execution observes the signal exactly once (the
+// outbox is at-least-once; the job workflow dedupes the signal).
+export async function writeJobStepsSettledOutbox(
   tx: Tx,
   params: {jobId: string; status: 'succeeded' | 'failed'},
 ): Promise<void> {
@@ -522,11 +577,11 @@ export async function writeJobCompletedOutbox(
     .limit(1);
   const runId = rows[0]?.runId;
   if (!runId) {
-    throw new Error(`Cannot enqueue job-completed event: job ${params.jobId} not found`);
+    throw new Error(`Cannot enqueue job-steps-settled event: job ${params.jobId} not found`);
   }
 
   await writeOutboxEvent<WorkflowsEventMap>(tx, workflowsOutbox, {
-    type: WORKFLOWS_JOB_COMPLETED,
+    type: WORKFLOWS_JOB_STEPS_SETTLED,
     payload: {jobId: params.jobId, runId, status: params.status},
   });
 }
@@ -701,7 +756,7 @@ export async function rewindStepsToPending(
 }
 
 // Enqueue the durable audit record of a restart, in the same transaction as the
-// rewind. Looks up the run id like writeJobCompletedOutbox.
+// rewind. Looks up the run id like writeJobStepsSettledOutbox.
 export async function writeStepRestartEnqueuedOutbox(
   tx: Tx,
   params: {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -361,13 +361,10 @@ export async function updateWorkflowRunStatus(
 
     const row = rows[0];
     if (!row) {
-      // Idempotent under Temporal activity retry: a lost result after a committed
-      // status update leaves the row at version+1, so the retried expected-version
-      // UPDATE matches 0 rows. If the row already holds the requested status, the
-      // prior attempt of this same transition won — return it without re-emitting
-      // the terminal event, instead of throwing an optimistic-lock error that would
-      // wedge the workflow. run-orchestration is the sole writer of run status, so a
-      // mismatch only ever happens on retry-after-commit.
+      // Idempotent under Temporal retry-after-commit: the committed first attempt
+      // left the row at version+1, so this retry matches 0 rows. run-orchestration is
+      // the sole writer, so an already-matching status means the prior attempt won;
+      // return it without re-emitting, rather than throw and wedge the run.
       const existing = await tx
         .select()
         .from(workflowRuns)
@@ -382,9 +379,8 @@ export async function updateWorkflowRunStatus(
 
     const run = toWorkflowRun(row);
 
-    // Mirror updateJobStatusAtVersion: emit the canonical run-terminal fact in the
-    // same transaction as the status flip, gated on the guarded UPDATE so it fires
-    // exactly once.
+    // Same as updateJobStatusAtVersion: emitting in the same transaction as the
+    // guarded status flip makes the run-terminal fact fire exactly once.
     if (isWorkflowRunTerminal(run.status)) {
       await writeOutboxEvent<WorkflowsEventMap>(tx, workflowsOutbox, {
         type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
@@ -423,11 +419,9 @@ async function updateJobStatusAtVersion(
   if (!row) return null;
   const job = toJob(row);
 
-  // Single chokepoint: every terminal job-status write funnels through this guarded
-  // UPDATE, and the version match means only one caller can win the transition.
-  // Emit the canonical terminal fact here, in the same transaction as the status
-  // flip, so it fires exactly once across all terminal paths (normal completion,
-  // DAG cancellation, lease-expiry resolution, timeout).
+  // Every terminal job-status write funnels through this one guarded UPDATE, where the
+  // version match lets a single caller win. Emitting here, in the same transaction,
+  // makes the terminal fact fire exactly once across all paths.
   if (isJobTerminal(job.status)) {
     await writeOutboxEvent<WorkflowsEventMap>(tx, workflowsOutbox, {
       type: WORKFLOWS_JOB_TERMINATED,
@@ -559,13 +553,10 @@ export async function resolveJobAfterLeaseExpiry(params: {
   });
 }
 
-// Enqueue the steps-settled signal in the SAME transaction as the final per-step
-// result that made the job's steps all terminal. This is the internal signal that
-// drives the Temporal JOB_FINISHED_SIGNAL (via on-job-steps-settled); the job's own
-// terminal fact is emitted later by updateJobStatusAtVersion when the workflow flips
-// the job status. Mirrors failJobAsTimedOut: the state change and its signal intent
-// commit together, so per-step execution observes the signal exactly once (the
-// outbox is at-least-once; the job workflow dedupes the signal).
+// Enqueue the steps-settled signal in the same transaction as the final per-step
+// result, so per-step execution observes it exactly once (the outbox is at-least-once;
+// the job workflow dedupes the signal). Drives the Temporal JOB_FINISHED_SIGNAL; the
+// job's terminal fact is emitted separately by updateJobStatusAtVersion.
 export async function writeJobStepsSettledOutbox(
   tx: Tx,
   params: {jobId: string; status: 'succeeded' | 'failed'},

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -1,11 +1,14 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {RUNNER_JOB_LEASE_EXPIRED} from '@shipfox/api-runners-dto';
-import {WORKFLOW_RUN_CREATED, WORKFLOWS_JOB_COMPLETED} from '@shipfox/api-workflows-dto';
+import {
+  WORKFLOWS_JOB_STEPS_SETTLED,
+  WORKFLOWS_WORKFLOW_RUN_CREATED,
+} from '@shipfox/api-workflows-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 import {
-  onJobCompleted,
+  onJobStepsSettled,
   onRunnerJobLeaseExpired,
   onWorkflowRunCreated,
   routes,
@@ -27,8 +30,8 @@ export const workflowsModule: ShipfoxModule = {
   routes,
   publishers: [{name: 'workflows', table: workflowsOutbox, db}],
   subscribers: [
-    {event: WORKFLOW_RUN_CREATED, handler: onWorkflowRunCreated},
-    {event: WORKFLOWS_JOB_COMPLETED, handler: onJobCompleted},
+    {event: WORKFLOWS_WORKFLOW_RUN_CREATED, handler: onWorkflowRunCreated},
+    {event: WORKFLOWS_JOB_STEPS_SETTLED, handler: onJobStepsSettled},
     {event: RUNNER_JOB_LEASE_EXPIRED, handler: onRunnerJobLeaseExpired},
   ],
   workers: [

--- a/libs/api/workflows/src/presentation/index.ts
+++ b/libs/api/workflows/src/presentation/index.ts
@@ -1,6 +1,6 @@
 export {workflowRoutes as routes} from './routes/index.js';
 export {
-  onJobCompleted,
+  onJobStepsSettled,
   onRunnerJobLeaseExpired,
   onWorkflowRunCreated,
 } from './subscribers/index.js';

--- a/libs/api/workflows/src/presentation/subscribers/index.ts
+++ b/libs/api/workflows/src/presentation/subscribers/index.ts
@@ -1,3 +1,3 @@
-export {onJobCompleted} from './on-job-completed.js';
+export {onJobStepsSettled} from './on-job-steps-settled.js';
 export {onRunnerJobLeaseExpired} from './on-runner-job-lease-expired.js';
 export {onWorkflowRunCreated} from './on-workflow-run-created.js';

--- a/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.ts
@@ -1,4 +1,4 @@
-import type {WorkflowsJobCompletedEvent} from '@shipfox/api-workflows-dto';
+import type {WorkflowsJobStepsSettledEvent} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {temporalClient} from '@shipfox/node-temporal';
@@ -6,11 +6,11 @@ import {JOB_FINISHED_SIGNAL} from '#temporal/constants.js';
 import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
 
 // Per-step execution finishes a job inside recordStepResult (no runner /complete
-// call), which enqueues WORKFLOWS_JOB_COMPLETED in the same transaction. The
+// call), which enqueues WORKFLOWS_JOB_STEPS_SETTLED in the same transaction. The
 // persisted per-step projection is already terminal, so the workflow only flips
 // the job status — no steps are carried.
-export async function onJobCompleted(event: DomainEvent): Promise<void> {
-  const payload = event.payload as WorkflowsJobCompletedEvent;
+export async function onJobStepsSettled(event: DomainEvent): Promise<void> {
+  const payload = event.payload as WorkflowsJobStepsSettledEvent;
   logger().info({jobId: payload.jobId, status: payload.status}, 'Signaling job finished');
   const handle = temporalClient().workflow.getHandle(`job:${payload.jobId}`);
   try {

--- a/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.ts
@@ -1,11 +1,11 @@
-import type {WorkflowRunCreatedEvent} from '@shipfox/api-workflows-dto';
+import type {WorkflowsWorkflowRunCreatedEvent} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {temporalClient} from '@shipfox/node-temporal';
 import {WORKFLOWS_TASK_QUEUE} from '#temporal/constants.js';
 
 export async function onWorkflowRunCreated(event: DomainEvent): Promise<void> {
-  const payload = event.payload as WorkflowRunCreatedEvent;
+  const payload = event.payload as WorkflowsWorkflowRunCreatedEvent;
   logger().info({runId: payload.runId}, 'Starting workflow run orchestration');
   try {
     await temporalClient().workflow.start('runOrchestration', {


### PR DESCRIPTION
Adds one authoritative "this job is over" event so downstream consumers can react to a single signal instead of stitching together partial ones.

## Why

There was no single reliable job-terminal event. Normal completion emitted `workflows.job.completed` (succeeded/failed only), the timeout backstop emitted `workflows.job.timed_out`, but **DAG cancellation and lease-expiry resolution emitted nothing**. The only roughly-universal "job is over" fact was the deletion of the runner's `running_jobs` lease row — but that is the wrong primitive: it lives in the runners layer (no job outcome/status), it is best-effort and silent, and it is absent entirely for a job the DAG cancels before any runner claims it.

## What

The right primitive already exists: every terminal `jobs.status` write funnels through one private DB function, `updateJobStatusAtVersion` (`libs/api/workflows/src/db/workflow-runs.ts`). All four paths reach it — normal completion, DAG cancellation, lease-expiry resolution, and the timeout backstop.

- Emit a new `workflows.job.terminated` `{jobId, runId, status}` there, in the same transaction as the status flip, gated on a terminal status. Exactly-once is inherited from the existing version-guard + idempotent re-read; no new machinery.
- Wire up the run-level `workflows.workflow_run.terminated` the same way in `updateWorkflowRunStatus` (now wrapped in a transaction, with a matching idempotent re-read so a Temporal retry-after-commit no longer throws).
- Align every workflows-dto event name on one `WORKFLOWS_<entity>_<verb>` scheme so the run and job terminal events read as the same event at two scopes.

## Naming alignment (breaking, internal-only)

| Before | After |
| --- | --- |
| `WORKFLOW_RUN_CREATED` | `WORKFLOWS_WORKFLOW_RUN_CREATED` |
| `WORKFLOW_RUN_FINISHED` (defined, never emitted) | `WORKFLOWS_WORKFLOW_RUN_TERMINATED` (now emitted) |
| `WORKFLOWS_JOB_COMPLETED` | `WORKFLOWS_JOB_STEPS_SETTLED` |
| — | `WORKFLOWS_JOB_TERMINATED` (new) |

`WORKFLOWS_JOB_STEPS_SETTLED` is deliberately kept distinct from the new terminal event: it is the internal "all steps settled → finalize" signal that drives the Temporal `JOB_FINISHED_SIGNAL` (via the renamed `on-job-steps-settled` subscriber), emitted in the step-result transaction before the job row is terminal. The renames are breaking but consumed only within this monorepo, and all in-repo consumers are updated in this PR.

## Scope notes

- No new consumers — the goal is to establish the reliable signal for future use (agent-sessions / log finalization, billing, notifications). Unconsumed outbox events are safe: the dispatcher marks a zero-subscriber event dispatched, so there is no redelivery loop or backlog.
- A runner-side "lease released" event was considered and deliberately left out; it belongs in the runners layer and should be driven by an actual resource-cleanup consumer.

## Review focus

- `updateJobStatusAtVersion` / `updateWorkflowRunStatus` in `libs/api/workflows/src/db/workflow-runs.ts` — the exactly-once reasoning and the new transactional run-status path with idempotent re-read.

Verified with `turbo build`/`test`/`check --filter '...[origin/main]'` (type, 251 workflows tests incl. new terminal-event coverage, lint/format). The end-to-end smoke (driving each terminal path against local services) was not run headlessly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds one authoritative terminal event for jobs and runs. Emits `workflows.job.terminated` and `workflows.workflow_run.terminated` exactly once in the same transaction as terminal status updates, and clarifies the distinction from the steps-settled signal.

- **New Features**
  - Emit `WORKFLOWS_JOB_TERMINATED` (`workflows.job.terminated`) with {jobId, runId, status} on all terminal paths: completion, DAG cancellation, lease-expiry resolution, and timeout.
  - Emit `WORKFLOWS_WORKFLOW_RUN_TERMINATED` (`workflows.workflow_run.terminated`) in `updateWorkflowRunStatus`; transaction + idempotent re-read make retries safe and exactly-once (covers succeeded/failed/cancelled).

- **Refactors**
  - Align event names to `WORKFLOWS_<entity>_<verb>`:
    - `WORKFLOW_RUN_CREATED` → `WORKFLOWS_WORKFLOW_RUN_CREATED`
    - `WORKFLOW_RUN_FINISHED` → `WORKFLOWS_WORKFLOW_RUN_TERMINATED`
    - `WORKFLOWS_JOB_COMPLETED` → `WORKFLOWS_JOB_STEPS_SETTLED` (internal steps-settled signal)
    - New: `WORKFLOWS_JOB_TERMINATED`
  - Rename subscriber `on-job-completed` → `on-job-steps-settled` and wire to `WORKFLOWS_JOB_STEPS_SETTLED`.

<sup>Written for commit 6f2aa9094b8ff9f76771a1bca9edb3ad308c24a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

