### PR TITLE
Mask secrets and detect group markers in runner step logs

### DIFF
--- a/.changeset/eng-441-runner-secret-masking.md
+++ b/.changeset/eng-441-runner-secret-masking.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/redact": minor
+"@shipfox/runner-logs": minor
+"@shipfox/runner-protocol": minor
+"@shipfox/runner-orchestration": patch
+---
+
+Add the runner log transform stage between capture and the spool: a streaming secret masker and GitHub-style group-marker detection. Captured output is masked before any byte reaches the plaintext spool, replacing the runner's own credentials (runner token and job lease token) plus every base64, base64url, URL-encoded, and hex form with `***` through a rolling lookbehind that never emits a secret split across capture-chunk or flush boundaries, and `::group::`/`::endgroup::` lines become `group_start`/`group_end` control records with the marker line swallowed. Output streams continuously (complete lines flush immediately, unterminated lines stream their masked safe prefix) so live tail, stream order, and frame timestamps are preserved. `@shipfox/redact` gains `secretWireForms` to derive a secret's wire forms, and `@shipfox/runner-protocol` exposes `runnerToken` so the orchestrator can assemble the mask set.

--- a/libs/runner/logs/package.json
+++ b/libs/runner/logs/package.json
@@ -40,6 +40,7 @@
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/redact": "workspace:*",
     "@shipfox/regex": "workspace:*",
     "@shipfox/runner-protocol": "workspace:*"
   },

--- a/libs/runner/logs/src/core/framing.test.ts
+++ b/libs/runner/logs/src/core/framing.test.ts
@@ -1,7 +1,10 @@
-import {type LogRecord, logRecordSchema, MAX_RECORD_DATA_BYTES} from '@shipfox/api-logs-dto';
+import {
+  type LogRecord,
+  logRecordSchema,
+  MAX_RECORD_DATA_BYTES,
+  MAX_RECORD_NAME_BYTES,
+} from '@shipfox/api-logs-dto';
 import {StreamFramer, splitByUtf8Bytes} from '#core/framing.js';
-
-const REPLACEMENT = '�';
 
 function parseRecords(bytes: Buffer): LogRecord[] {
   const text = bytes.toString('utf8');
@@ -19,22 +22,31 @@ function outputData(records: LogRecord[]): string {
     .join('');
 }
 
-describe('StreamFramer.frameOutput', () => {
-  it('frames a chunk into a single output record with origin and stamped ts', () => {
+describe('StreamFramer.frameOutputText', () => {
+  it('frames text into a single output record with origin and stamped ts', () => {
     const framer = new StreamFramer(() => 1000);
 
-    const framed = framer.frameOutput(Buffer.from('hello world\n'), 'stdout');
+    const framed = framer.frameOutputText('hello world\n', 'stdout');
     const [record] = parseRecords(framed.bytes);
 
     expect(record).toEqual({v: 1, ts: 1000, type: 'output', src: 'stdout', data: 'hello world\n'});
     expect(framed.payloadBytes).toBe(Buffer.byteLength('hello world\n'));
   });
 
-  it('preserves ANSI escape bytes verbatim', () => {
+  it('returns an empty frame for empty text', () => {
+    const framer = new StreamFramer(() => 1);
+
+    const framed = framer.frameOutputText('', 'stdout');
+
+    expect(framed.bytes.length).toBe(0);
+    expect(framed.payloadBytes).toBe(0);
+  });
+
+  it('preserves ANSI escape sequences verbatim', () => {
     const framer = new StreamFramer(() => 1);
     const ansi = '[31mred[0m';
 
-    const framed = framer.frameOutput(Buffer.from(ansi), 'stdout');
+    const framed = framer.frameOutputText(ansi, 'stdout');
 
     expect(outputData(parseRecords(framed.bytes))).toBe(ansi);
   });
@@ -43,7 +55,7 @@ describe('StreamFramer.frameOutput', () => {
     const framer = new StreamFramer(() => 1);
     const long = 'a'.repeat(MAX_RECORD_DATA_BYTES + 5000);
 
-    const framed = framer.frameOutput(Buffer.from(long), 'stdout');
+    const framed = framer.frameOutputText(long, 'stdout');
     const records = parseRecords(framed.bytes);
 
     expect(records.length).toBe(2);
@@ -53,62 +65,6 @@ describe('StreamFramer.frameOutput', () => {
     }
     expect(outputData(records)).toBe(long);
     expect(framed.payloadBytes).toBe(long.length);
-  });
-
-  it('replaces invalid UTF-8 with the replacement character', () => {
-    const framer = new StreamFramer(() => 1);
-
-    const framed = framer.frameOutput(Buffer.from([0xff, 0xfe]), 'stdout');
-
-    expect(outputData(parseRecords(framed.bytes))).toBe(`${REPLACEMENT}${REPLACEMENT}`);
-  });
-
-  it('reassembles a multi-byte char split across two chunks on the same pipe', () => {
-    const framer = new StreamFramer(() => 1);
-    const euro = Buffer.from('€', 'utf8'); // 0xE2 0x82 0xAC
-
-    const first = framer.frameOutput(euro.subarray(0, 2), 'stdout');
-    const second = framer.frameOutput(euro.subarray(2), 'stdout');
-
-    // The decoder holds the partial sequence, so the first chunk yields nothing.
-    expect(first.bytes.length).toBe(0);
-    expect(outputData(parseRecords(second.bytes))).toBe('€');
-  });
-
-  it('reassembles a 4-byte code point split across two chunks on the same pipe', () => {
-    const framer = new StreamFramer(() => 1);
-    const grin = Buffer.from('😀', 'utf8'); // 4 bytes: F0 9F 98 80 (a surrogate pair)
-
-    const first = framer.frameOutput(grin.subarray(0, 2), 'stdout');
-    const second = framer.frameOutput(grin.subarray(2), 'stdout');
-
-    // The decoder holds the partial 4-byte sequence, so the first chunk yields nothing.
-    expect(first.bytes.length).toBe(0);
-    expect(outputData(parseRecords(second.bytes))).toBe('😀');
-  });
-
-  it('does not complete a stdout partial sequence with stderr bytes', () => {
-    const framer = new StreamFramer(() => 1);
-    const euro = Buffer.from('€', 'utf8');
-
-    framer.frameOutput(euro.subarray(0, 2), 'stdout');
-    const stderrFramed = framer.frameOutput(euro.subarray(2), 'stderr');
-
-    // The trailing byte arrives on stderr, whose decoder never saw the lead bytes,
-    // so it is invalid there and must not reconstruct '€'.
-    expect(outputData(parseRecords(stderrFramed.bytes))).toBe(REPLACEMENT);
-  });
-});
-
-describe('StreamFramer.flushDecoders', () => {
-  it('flushes a held incomplete sequence as the replacement character', () => {
-    const framer = new StreamFramer(() => 1);
-    const euro = Buffer.from('€', 'utf8');
-
-    framer.frameOutput(euro.subarray(0, 2), 'stdout');
-    const flushed = framer.flushDecoders();
-
-    expect(outputData(parseRecords(flushed.bytes))).toBe(REPLACEMENT);
   });
 });
 
@@ -141,6 +97,44 @@ describe('StreamFramer control records', () => {
       kind: 'gap',
       dropped_bytes: 4096,
     });
+  });
+
+  it('frames a group_start record with its name', () => {
+    const framer = new StreamFramer(() => 7);
+
+    const [record] = parseRecords(framer.frameGroupStart('Install deps'));
+
+    expect(record).toEqual({
+      v: 1,
+      ts: 7,
+      type: 'control',
+      src: 'system',
+      kind: 'group_start',
+      name: 'Install deps',
+    });
+  });
+
+  it('frames a group_end record', () => {
+    const framer = new StreamFramer(() => 7);
+
+    const [record] = parseRecords(framer.frameGroupEnd());
+
+    expect(record).toEqual({v: 1, ts: 7, type: 'control', src: 'system', kind: 'group_end'});
+  });
+
+  it('byte-truncates an over-long group name on a code-point boundary', () => {
+    const framer = new StreamFramer(() => 7);
+    const name = '€'.repeat(MAX_RECORD_NAME_BYTES); // 3 bytes each, far over the cap
+
+    const [record] = parseRecords(framer.frameGroupStart(name));
+
+    if (record?.type !== 'control' || record.kind !== 'group_start') {
+      throw new Error('expected a group_start control record');
+    }
+    expect(Buffer.byteLength(record.name)).toBeLessThanOrEqual(MAX_RECORD_NAME_BYTES);
+    expect(name.startsWith(record.name)).toBe(true);
+    // A torn multi-byte char would not survive a UTF-8 round-trip.
+    expect(Buffer.from(record.name, 'utf8').toString('utf8')).toBe(record.name);
   });
 });
 

--- a/libs/runner/logs/src/core/framing.ts
+++ b/libs/runner/logs/src/core/framing.ts
@@ -1,20 +1,28 @@
-import {TextDecoder} from 'node:util';
 import {
   type ControlRecord,
   type LogRecord,
   MAX_RECORD_DATA_BYTES,
+  MAX_RECORD_NAME_BYTES,
   type OutputRecord,
 } from '@shipfox/api-logs-dto';
 
 /** A pipe origin for captured output. */
 export type OutputSource = 'stdout' | 'stderr';
 
-const PIPES: readonly OutputSource[] = ['stdout', 'stderr'];
+export const PIPES: readonly OutputSource[] = ['stdout', 'stderr'];
 
 // v1 record builders. The DTO owns the schema and validation; the runner is the only
 // component that frames records, so the constructors live here at the framing layer.
 function outputRecord(args: {ts: number; src: OutputSource; data: string}): OutputRecord {
   return {v: 1, ts: args.ts, type: 'output', src: args.src, data: args.data};
+}
+
+function groupStartRecord(args: {ts: number; name: string}): ControlRecord {
+  return {v: 1, ts: args.ts, type: 'control', src: 'system', kind: 'group_start', name: args.name};
+}
+
+function groupEndRecord(args: {ts: number}): ControlRecord {
+  return {v: 1, ts: args.ts, type: 'control', src: 'system', kind: 'group_end'};
 }
 
 function gapRecord(args: {ts: number; droppedBytes: number}): ControlRecord {
@@ -89,49 +97,17 @@ export function splitByUtf8Bytes(text: string, maxBytes: number): string[] {
 }
 
 /**
- * Turns captured output chunks into NDJSON records. Holds one streaming UTF-8
- * decoder per pipe so invalid bytes become U+FFFD and a multi-byte character
- * split across capture chunks is reassembled from that pipe's own bytes (never
- * completed by the other pipe). Records are not line-aligned; consumers
- * reconstruct text by concatenating `data`. `ts` is stamped at frame time.
+ * Encodes already-decoded, already-masked text and control markers into NDJSON records.
+ * Decoding and masking happen upstream in the transform; this layer only frames: it splits
+ * long output into <= 16KB records (so a single entry's size is bounded), stamps `ts` at
+ * frame time, and emits the system control records. `data` is reconstructed by concatenating
+ * output records, so callers keep newlines in the text they pass.
  */
 export class StreamFramer {
-  private readonly decoders: Record<OutputSource, TextDecoder> = {
-    stdout: new TextDecoder('utf-8', {ignoreBOM: true, fatal: false}),
-    stderr: new TextDecoder('utf-8', {ignoreBOM: true, fatal: false}),
-  };
-
   constructor(private readonly now: () => number = Date.now) {}
 
-  frameOutput(chunk: Buffer, source: OutputSource): FramedOutput {
-    const text = this.decoders[source].decode(chunk, {stream: true});
+  frameOutputText(text: string, source: OutputSource): FramedOutput {
     if (text.length === 0) return EMPTY_FRAME;
-    return this.frameText(text, source);
-  }
-
-  /** Flushes any trailing partial multi-byte sequence held by each decoder. */
-  flushDecoders(): FramedOutput {
-    const buffers: Buffer[] = [];
-    let payloadBytes = 0;
-    for (const source of PIPES) {
-      const tail = this.decoders[source].decode();
-      if (tail.length === 0) continue;
-      const framed = this.frameText(tail, source);
-      buffers.push(framed.bytes);
-      payloadBytes += framed.payloadBytes;
-    }
-    return {bytes: Buffer.concat(buffers), payloadBytes};
-  }
-
-  frameGap(droppedBytes: number): Buffer {
-    return encodeRecord(gapRecord({ts: this.now(), droppedBytes}));
-  }
-
-  frameEnd(totalBytes: number): Buffer {
-    return encodeRecord(endRecord({ts: this.now(), totalBytes}));
-  }
-
-  private frameText(text: string, source: OutputSource): FramedOutput {
     const parts = splitByUtf8Bytes(text, MAX_RECORD_DATA_BYTES);
     const buffers: Buffer[] = [];
     let payloadBytes = 0;
@@ -141,5 +117,26 @@ export class StreamFramer {
       payloadBytes += Buffer.byteLength(part, 'utf8');
     }
     return {bytes: Buffer.concat(buffers), payloadBytes};
+  }
+
+  // The group name is masked upstream; here it is byte-truncated to the DTO cap (which
+  // measures UTF-8 bytes, not string length) so framing never emits a record the schema
+  // rejects. splitByUtf8Bytes cuts on a code-point boundary, so the truncation never tears
+  // a multi-byte character.
+  frameGroupStart(name: string): Buffer {
+    const [truncated = ''] = splitByUtf8Bytes(name, MAX_RECORD_NAME_BYTES);
+    return encodeRecord(groupStartRecord({ts: this.now(), name: truncated}));
+  }
+
+  frameGroupEnd(): Buffer {
+    return encodeRecord(groupEndRecord({ts: this.now()}));
+  }
+
+  frameGap(droppedBytes: number): Buffer {
+    return encodeRecord(gapRecord({ts: this.now(), droppedBytes}));
+  }
+
+  frameEnd(totalBytes: number): Buffer {
+    return encodeRecord(endRecord({ts: this.now(), totalBytes}));
   }
 }

--- a/libs/runner/logs/src/core/markers.test.ts
+++ b/libs/runner/logs/src/core/markers.test.ts
@@ -1,4 +1,4 @@
-import {type MarkerEvent, parseMarker} from '#core/markers.js';
+import {couldBeMarker, type MarkerEvent, parseMarker} from '#core/markers.js';
 
 describe('parseMarker', () => {
   it('parses a group_start with its name', () => {
@@ -44,5 +44,33 @@ describe('parseMarker', () => {
       kind: 'group_start',
       name: 'token=sf_rt_abc and spaces  ',
     });
+  });
+});
+
+describe('couldBeMarker', () => {
+  it.each([
+    ['empty', ''],
+    ['a partial marker sigil', '::'],
+    ['a partial group prefix', '::gro'],
+    ['a partial endgroup', '::endgr'],
+    ['a complete group_start with a name', '::group::Install deps'],
+    ['a complete endgroup awaiting its newline', '::endgroup::'],
+  ])('holds %s', (_label, prefix) => {
+    expect(couldBeMarker(prefix)).toBe(true);
+  });
+
+  it.each([
+    ['a CRLF endgroup awaiting its LF', '::endgroup::\r'],
+    ['a CRLF group_start awaiting its LF', '::group::Build\r'],
+  ])('holds %s so the marker is not released before its newline', (_label, prefix) => {
+    expect(couldBeMarker(prefix)).toBe(true);
+  });
+
+  it.each([
+    ['plain output', 'installing'],
+    ['a diverged sigil', '::x'],
+    ['endgroup with a trailing argument', '::endgroup:: extra'],
+  ])('releases %s', (_label, prefix) => {
+    expect(couldBeMarker(prefix)).toBe(false);
   });
 });

--- a/libs/runner/logs/src/core/markers.test.ts
+++ b/libs/runner/logs/src/core/markers.test.ts
@@ -1,0 +1,48 @@
+import {type MarkerEvent, parseMarker} from '#core/markers.js';
+
+describe('parseMarker', () => {
+  it('parses a group_start with its name', () => {
+    expect(parseMarker('::group::Install deps')).toEqual({
+      kind: 'group_start',
+      name: 'Install deps',
+    });
+  });
+
+  it('parses a group_end', () => {
+    expect(parseMarker('::endgroup::')).toEqual({kind: 'group_end'});
+  });
+
+  it('strips a trailing CR so CRLF lines match', () => {
+    expect(parseMarker('::group::Build\r')).toEqual({kind: 'group_start', name: 'Build'});
+    expect(parseMarker('::endgroup::\r')).toEqual({kind: 'group_end'});
+  });
+
+  it('strips a trailing LF (or CRLF) when the line still carries it', () => {
+    expect(parseMarker('::group::Build\n')).toEqual({kind: 'group_start', name: 'Build'});
+    expect(parseMarker('::endgroup::\r\n')).toEqual({kind: 'group_end'});
+  });
+
+  it('treats an empty group name as a group_start with an empty name', () => {
+    expect(parseMarker('::group::')).toEqual({kind: 'group_start', name: ''});
+  });
+
+  it.each([
+    ['endgroup with a trailing argument', '::endgroup:: extra'],
+    ['leading whitespace before the marker', '  ::group::Build'],
+    ['marker not at line start', 'see ::group::Build'],
+    ['a near-miss prefix', '::groupx Build'],
+    ['plain output', 'installing dependencies...'],
+    ['an empty line', ''],
+  ])('returns undefined for %s', (_label, line) => {
+    expect(parseMarker(line)).toBeUndefined();
+  });
+
+  it('keeps the group name verbatim (downstream masks and truncates it)', () => {
+    const result = parseMarker('::group::token=sf_rt_abc and spaces  ');
+
+    expect(result).toEqual<MarkerEvent>({
+      kind: 'group_start',
+      name: 'token=sf_rt_abc and spaces  ',
+    });
+  });
+});

--- a/libs/runner/logs/src/core/markers.ts
+++ b/libs/runner/logs/src/core/markers.ts
@@ -1,0 +1,48 @@
+/** A recognised GitHub Actions group marker, derived from one captured line. */
+export type MarkerEvent = {kind: 'group_start'; name: string} | {kind: 'group_end'};
+
+const GROUP_START_PREFIX = '::group::';
+const GROUP_END_LINE = '::endgroup::';
+
+/**
+ * Recognises GitHub Actions group markers in a single captured line (the line content,
+ * with or without a trailing CR/LF). `::group::<name>` and `::endgroup::` are the only two;
+ * everything else returns undefined and stays normal output.
+ *
+ * The `::` must start the line — GitHub treats workflow commands as line-leading, so a `::`
+ * mid-line or after whitespace is plain text. `::endgroup::` must match exactly, so a
+ * trailing argument (`::endgroup:: x`) is not a marker. The name is returned verbatim;
+ * secret masking and the DTO's byte cap are applied downstream (the transform masks it, the
+ * framer truncates it), so this stays a pure, side-effect-free parser.
+ */
+export function parseMarker(line: string): MarkerEvent | undefined {
+  const content = stripLineEnding(line);
+  if (content === GROUP_END_LINE) return {kind: 'group_end'};
+  if (content.startsWith(GROUP_START_PREFIX)) {
+    return {kind: 'group_start', name: content.slice(GROUP_START_PREFIX.length)};
+  }
+  return undefined;
+}
+
+/**
+ * Whether an unterminated line prefix could still become a marker once more bytes arrive.
+ * The transform uses this to hold a `::`-leading partial line until its newline (so the
+ * marker can be swallowed) while streaming all other output live. Returns false as soon as
+ * the prefix diverges from both markers, so a `::not-a-marker` line stops being held after
+ * three characters.
+ */
+export function couldBeMarker(linePrefix: string): boolean {
+  return (
+    GROUP_START_PREFIX.startsWith(linePrefix) ||
+    linePrefix.startsWith(GROUP_START_PREFIX) ||
+    GROUP_END_LINE.startsWith(linePrefix)
+  );
+}
+
+// Drops a single trailing LF and/or CR so a CRLF line and an already-split line both match.
+function stripLineEnding(line: string): string {
+  let end = line.length;
+  if (end > 0 && line[end - 1] === '\n') end--;
+  if (end > 0 && line[end - 1] === '\r') end--;
+  return line.slice(0, end);
+}

--- a/libs/runner/logs/src/core/markers.ts
+++ b/libs/runner/logs/src/core/markers.ts
@@ -32,10 +32,14 @@ export function parseMarker(line: string): MarkerEvent | undefined {
  * three characters.
  */
 export function couldBeMarker(linePrefix: string): boolean {
+  // A CRLF marker reaches here as `...\r` one byte before its `\n`. Treat a trailing CR as
+  // not-yet-divergent so a split `::endgroup::\r` keeps being held until the `\n` that
+  // completes and swallows it, instead of being released as an output line.
+  const prefix = linePrefix.endsWith('\r') ? linePrefix.slice(0, -1) : linePrefix;
   return (
-    GROUP_START_PREFIX.startsWith(linePrefix) ||
-    linePrefix.startsWith(GROUP_START_PREFIX) ||
-    GROUP_END_LINE.startsWith(linePrefix)
+    GROUP_START_PREFIX.startsWith(prefix) ||
+    prefix.startsWith(GROUP_START_PREFIX) ||
+    GROUP_END_LINE.startsWith(prefix)
   );
 }
 

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -347,4 +347,118 @@ describe('createStepLogStream', () => {
 
     appendSpy.mockRestore();
   });
+
+  it('never writes an unmasked secret or any encoded form to the spool', async () => {
+    const secret = 'sf_rt_SECRET123456';
+    const forms = {
+      literal: secret,
+      base64: Buffer.from(secret).toString('base64'),
+      base64url: Buffer.from(secret).toString('base64url'),
+      hex: Buffer.from(secret).toString('hex'),
+      url: encodeURIComponent(secret),
+    };
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 11,
+      append: hangingAppend, // the spool is written synchronously; no drain needed to inspect it
+      secrets: [secret],
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from(`literal=${forms.literal}\n`), 'stdout');
+    stream.write(Buffer.from(`base64=${forms.base64}\n`), 'stdout');
+    stream.write(Buffer.from(`base64url=${forms.base64url}\n`), 'stderr');
+    stream.write(Buffer.from(`hex=${forms.hex}\n`), 'stdout');
+    stream.write(Buffer.from(`url=${forms.url}\n`), 'stdout');
+    await stream.close();
+    stream.dispose();
+
+    // Read the plaintext spool file directly: not one secret form may have reached disk.
+    const raw = await readFile(join(dir, 'logs', `${STEP_ID}-11.ndjson`), 'utf8');
+    for (const form of Object.values(forms)) {
+      expect(raw).not.toContain(form);
+    }
+    expect(raw).toContain('***');
+  });
+
+  it('counts masked bytes (not the raw secret) in the end record total', async () => {
+    const secret = 'sf_rt_SECRET123456';
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 12,
+      append: hangingAppend,
+      secrets: [secret],
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from(`x=${secret}\n`), 'stdout'); // masked to 'x=***\n'
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(12);
+    const end = records.find((r) => r.type === 'control' && r.kind === 'end');
+    expect(end).toEqual({
+      v: 1,
+      ts: 1,
+      type: 'control',
+      src: 'system',
+      kind: 'end',
+      total_bytes: Buffer.byteLength('x=***\n'),
+    });
+  });
+
+  it('writes group markers as control records and swallows the marker lines', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 13,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('::group::Install\nbuilding\n::endgroup::\n'), 'stdout');
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(13);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'group_start', name: 'Install'},
+      {v: 1, ts: 1, type: 'output', src: 'stdout', data: 'building\n'},
+      {v: 1, ts: 1, type: 'control', src: 'system', kind: 'group_end'},
+      {
+        v: 1,
+        ts: 1,
+        type: 'control',
+        src: 'system',
+        kind: 'end',
+        total_bytes: Buffer.byteLength('building\n'),
+      },
+    ]);
+  });
+
+  it('drops a group record under backlog pressure rather than growing the spool unbounded', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 14,
+      append: hangingAppend, // never acks, so the backlog only grows
+      spoolMaxBytes: 60, // fits the first record, not the next
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.write(Buffer.from('a'.repeat(40)), 'stdout'); // spooled (~50-byte record)
+    stream.write(Buffer.from('::group::Build\n'), 'stdout'); // group_start over the cap -> dropped
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(14);
+    expect(records.some((r) => r.type === 'control' && r.kind === 'group_start')).toBe(false);
+    expect(records.some((r) => r.type === 'control' && r.kind === 'gap')).toBe(true);
+  });
 });

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -3,6 +3,7 @@ import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import type {LogRecord} from '@shipfox/api-logs-dto';
 import {logRecordSchema} from '@shipfox/api-logs-dto';
+import {secretWireForms} from '@shipfox/redact';
 import type {LogAppendFn} from '@shipfox/runner-protocol';
 import {AttemptSpool} from '#api/spool.js';
 import {createStepLogStream} from '#core/step-log-stream.js';
@@ -348,15 +349,11 @@ describe('createStepLogStream', () => {
     appendSpy.mockRestore();
   });
 
-  it('never writes an unmasked secret or any encoded form to the spool', async () => {
-    const secret = 'sf_rt_SECRET123456';
-    const forms = {
-      literal: secret,
-      base64: Buffer.from(secret).toString('base64'),
-      base64url: Buffer.from(secret).toString('base64url'),
-      hex: Buffer.from(secret).toString('hex'),
-      url: encodeURIComponent(secret),
-    };
+  it('never writes the secret or any of its wire forms to the spool', async () => {
+    // Reserved characters ('/', '+', '=') so the URL-encoded form genuinely differs from the
+    // literal — a base64url-shaped token's URL form equals the literal and would prove nothing.
+    const secret = 'sf/rt+SECRET=12';
+    const forms = secretWireForms(secret); // the exact set the masker derives, incl. the literal
     const stream = createStepLogStream({
       logsDir: join(dir, 'logs'),
       stepId: STEP_ID,
@@ -367,17 +364,20 @@ describe('createStepLogStream', () => {
       now: () => 1,
     });
 
-    stream.write(Buffer.from(`literal=${forms.literal}\n`), 'stdout');
-    stream.write(Buffer.from(`base64=${forms.base64}\n`), 'stdout');
-    stream.write(Buffer.from(`base64url=${forms.base64url}\n`), 'stderr');
-    stream.write(Buffer.from(`hex=${forms.hex}\n`), 'stdout');
-    stream.write(Buffer.from(`url=${forms.url}\n`), 'stdout');
+    // Emit every derived form, alternating pipes, so each must be masked before reaching disk.
+    for (const [i, form] of forms.entries()) {
+      stream.write(Buffer.from(`f${i}=${form}\n`), i % 2 === 0 ? 'stdout' : 'stderr');
+    }
     await stream.close();
     stream.dispose();
 
-    // Read the plaintext spool file directly: not one secret form may have reached disk.
+    // The URL form must be distinct, or this test would silently degrade to a literal check.
+    expect(forms).toContain(encodeURIComponent(secret));
+    expect(encodeURIComponent(secret)).not.toBe(secret);
+
+    // Read the plaintext spool file directly: not one wire form may have reached disk.
     const raw = await readFile(join(dir, 'logs', `${STEP_ID}-11.ndjson`), 'utf8');
-    for (const form of Object.values(forms)) {
+    for (const form of forms) {
       expect(raw).not.toContain(form);
     }
     expect(raw).toContain('***');

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -3,7 +3,8 @@ import type {LogAppendFn} from '@shipfox/runner-protocol';
 import {AttemptSpool} from '#api/spool.js';
 import {LogUploader} from '#api/uploader.js';
 import {config} from '#config.js';
-import {type OutputSource, StreamFramer} from '#core/framing.js';
+import {type FramedOutput, type OutputSource, StreamFramer} from '#core/framing.js';
+import {LogTransformer, type TransformEvent} from '#core/transform.js';
 
 export interface StepLogStreamOptions {
   /** The `<jobWorkspace>/logs` directory the spool file lives in. */
@@ -12,6 +13,12 @@ export interface StepLogStreamOptions {
   attempt: number;
   /** Append port bound to the lease client, step, and attempt by the caller. */
   append: LogAppendFn;
+  /**
+   * Secrets masked out of captured output before it reaches the spool, each replaced (with
+   * all its base64/base64url/url/hex forms) by `***`. v1 is the runner's own credentials;
+   * the set grows as step-level secrets are injected later. Empty disables masking.
+   */
+  secrets?: string[];
   flushIntervalMs?: number;
   flushBytes?: number;
   spoolMaxBytes?: number;
@@ -40,13 +47,15 @@ export interface StepLogStream {
 /**
  * Per step-attempt log pipeline:
  *
- *   write(chunk) ─▶ framer ─▶ [backlog cap?] ─▶ spool ─▶ uploader ─▶ /logs
- *                                  │ over cap
- *                                  └▶ drop + remember dropped bytes ─▶ gap marker
+ *   write(chunk) ─▶ transform ─▶ [backlog cap?] ─▶ spool ─▶ uploader ─▶ /logs
+ *                  (mask + markers)   │ over cap
+ *                                     └▶ drop + remember dropped bytes ─▶ gap marker
  *
- * The backlog cap bounds UNACKED bytes (spool length minus the server-acked
- * offset), not total output, so a healthy long stream never drops. Control
- * records (gap/end) bypass the cap so truncation is always visible.
+ * The transform decodes, masks secrets before any byte touches disk, and turns
+ * `::group::`/`::endgroup::` lines into control records. The backlog cap bounds UNACKED
+ * bytes (spool length minus the server-acked offset), not total output, so a healthy long
+ * stream never drops. Output and group records pass through the cap (a step controls both);
+ * runner-originated gap/end records bypass it so truncation is always visible.
  */
 export function createStepLogStream(options: StepLogStreamOptions): StepLogStream {
   const now = options.now ?? Date.now;
@@ -55,6 +64,7 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
   const intervalMs = options.flushIntervalMs ?? config.SHIPFOX_LOG_FLUSH_INTERVAL_MS;
 
   const framer = new StreamFramer(now);
+  const transformer = new LogTransformer(options.secrets ?? []);
   const spool = AttemptSpool.open(options.logsDir, options.stepId, options.attempt);
   const uploader = new LogUploader(spool, options.append, {intervalMs, flushBytes});
 
@@ -92,6 +102,29 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
     dropping = false;
   }
 
+  function frameEvent(event: TransformEvent): FramedOutput {
+    if (event.type === 'output') return framer.frameOutputText(event.data, event.src);
+    if (event.type === 'group_start') {
+      return {bytes: framer.frameGroupStart(event.name), payloadBytes: 0};
+    }
+    return {bytes: framer.frameGroupEnd(), payloadBytes: 0};
+  }
+
+  // Applies the backlog cap to one framed record and spools it, or drops it and remembers the
+  // dropped payload for the next gap marker.
+  function spoolFramed(framed: FramedOutput): void {
+    if (framed.bytes.length === 0) return;
+    const projectedBacklog = streamLength + framed.bytes.length - uploader.ackedOffset;
+    if (projectedBacklog > spoolMaxBytes) {
+      droppedPayload += framed.payloadBytes;
+      dropping = true;
+      return;
+    }
+    flushPendingGap();
+    spoolBytes(framed.bytes);
+    payloadTotal += framed.payloadBytes;
+  }
+
   uploader.start();
 
   return {
@@ -100,24 +133,22 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       // tombstone is server-side, so no gap is recorded here.
       if (closed || failed || uploader.isCapped() || uploader.isStopped()) return;
 
-      const framed = framer.frameOutput(chunk, source);
-      if (framed.bytes.length === 0) return;
-
-      const projectedBacklog = streamLength + framed.bytes.length - uploader.ackedOffset;
-      if (projectedBacklog > spoolMaxBytes) {
-        droppedPayload += framed.payloadBytes;
-        dropping = true;
+      let events: TransformEvent[];
+      try {
+        events = transformer.push(chunk, source);
+      } catch (err) {
+        // Decoding/masking is pure, but guard the boundary so a surprise never escapes
+        // into the child-output handler and crashes the runner.
+        failStream(err);
         return;
       }
 
       try {
-        flushPendingGap();
-        spoolBytes(framed.bytes);
+        for (const event of events) spoolFramed(frameEvent(event));
       } catch (err) {
         failStream(err);
         return;
       }
-      payloadTotal += framed.payloadBytes;
       uploader.notify();
     },
 
@@ -127,10 +158,14 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       if (failed) return Promise.resolve({streamLength});
 
       try {
-        const tail = framer.flushDecoders();
-        if (tail.bytes.length > 0) {
-          spoolBytes(tail.bytes);
-          payloadTotal += tail.payloadBytes;
+        // Flush held partial lines and decoder tails; these final bytes bypass the backlog cap
+        // (they are small and bounded) so the stream always ends cleanly.
+        for (const event of transformer.flush()) {
+          const framed = frameEvent(event);
+          if (framed.bytes.length === 0) continue;
+          flushPendingGap();
+          spoolBytes(framed.bytes);
+          payloadTotal += framed.payloadBytes;
         }
         flushPendingGap();
 

--- a/libs/runner/logs/src/core/transform.test.ts
+++ b/libs/runner/logs/src/core/transform.test.ts
@@ -1,0 +1,211 @@
+import {LogTransformer, type TransformEvent} from '#core/transform.js';
+
+const REPLACEMENT = '�';
+
+// An 18-byte (multiple-of-3) secret so its standalone base64 has no padding and the phase-0
+// wire form equals the full encoding — keeps the encoded-form assertions exact.
+const SECRET = 'sf_rt_SECRET123456';
+
+function outputText(events: TransformEvent[]): string {
+  return events
+    .filter((e) => e.type === 'output')
+    .map((e) => (e.type === 'output' ? e.data : ''))
+    .join('');
+}
+
+describe('LogTransformer decoding (relocated from StreamFramer)', () => {
+  it('reassembles a multi-byte char split across two pushes on the same pipe', () => {
+    const transformer = new LogTransformer([]);
+    const euro = Buffer.from('€', 'utf8'); // 0xE2 0x82 0xAC
+
+    const first = transformer.push(euro.subarray(0, 2), 'stdout');
+    const second = transformer.push(euro.subarray(2), 'stdout');
+
+    expect(first).toEqual([]); // the decoder holds the partial sequence
+    expect(outputText(second)).toBe('€');
+  });
+
+  it('reassembles a 4-byte code point split across two pushes on the same pipe', () => {
+    const transformer = new LogTransformer([]);
+    const grin = Buffer.from('😀', 'utf8'); // F0 9F 98 80
+
+    const first = transformer.push(grin.subarray(0, 2), 'stdout');
+    const second = transformer.push(grin.subarray(2), 'stdout');
+
+    expect(first).toEqual([]);
+    expect(outputText(second)).toBe('😀');
+  });
+
+  it('does not complete a stdout partial sequence with stderr bytes', () => {
+    const transformer = new LogTransformer([]);
+    const euro = Buffer.from('€', 'utf8');
+
+    transformer.push(euro.subarray(0, 2), 'stdout');
+    const stderr = transformer.push(euro.subarray(2), 'stderr');
+
+    // The trailing byte arrives on stderr, whose decoder never saw the lead bytes.
+    expect(outputText(stderr)).toBe(REPLACEMENT);
+  });
+
+  it('flushes a held incomplete sequence as the replacement character', () => {
+    const transformer = new LogTransformer([]);
+    const euro = Buffer.from('€', 'utf8');
+
+    transformer.push(euro.subarray(0, 2), 'stdout');
+    const flushed = transformer.flush();
+
+    expect(outputText(flushed)).toBe(REPLACEMENT);
+  });
+
+  it('replaces invalid UTF-8 with the replacement character', () => {
+    const transformer = new LogTransformer([]);
+
+    const events = transformer.push(Buffer.from([0xff, 0xfe]), 'stdout');
+
+    expect(outputText(events)).toBe(`${REPLACEMENT}${REPLACEMENT}`);
+  });
+});
+
+describe('LogTransformer secret masking', () => {
+  it('masks a secret split across two pushes within a line', () => {
+    const transformer = new LogTransformer([SECRET]);
+
+    transformer.push(Buffer.from('token=sf_rt_SE'), 'stdout');
+    const events = transformer.push(Buffer.from('CRET123456\n'), 'stdout');
+
+    expect(outputText(events)).toBe('token=***\n');
+  });
+
+  it('masks a secret wrapped in ANSI and preserves the escape sequences', () => {
+    const transformer = new LogTransformer([SECRET]);
+
+    const events = transformer.push(Buffer.from(`[32m${SECRET}[0m\n`), 'stdout');
+
+    expect(outputText(events)).toBe('[32m***[0m\n');
+  });
+
+  it.each([
+    ['base64', Buffer.from(SECRET).toString('base64')],
+    ['base64url', Buffer.from(SECRET).toString('base64url')],
+    ['hex', Buffer.from(SECRET).toString('hex')],
+    ['url-encoded', encodeURIComponent(SECRET)],
+  ])('masks the %s form of a secret', (_label, form) => {
+    const transformer = new LogTransformer([SECRET]);
+
+    const events = transformer.push(Buffer.from(`value=${form}\n`), 'stdout');
+
+    expect(outputText(events)).toBe('value=***\n');
+  });
+
+  it('masks a secret embedded inside a larger base64 blob', () => {
+    const transformer = new LogTransformer([SECRET]);
+    const blob = Buffer.concat([
+      Buffer.from('PREFIXAB'),
+      Buffer.from(SECRET),
+      Buffer.from('SUFFIXCD'),
+    ]).toString('base64');
+
+    const masked = outputText(transformer.push(Buffer.from(`body=${blob}\n`), 'stdout'));
+
+    expect(masked).toContain('***');
+    expect(masked).not.toContain(Buffer.from(SECRET).toString('base64').slice(0, 16));
+  });
+
+  it('masks a secret straddling a forced no-newline flush boundary', () => {
+    const transformer = new LogTransformer([SECRET]);
+    // A long unterminated line whose tail is the start of the secret. The lookbehind must hold
+    // the partial secret back, then mask it once the rest arrives — no plaintext on the way out.
+    const head = 'x'.repeat(40_000);
+
+    const first = transformer.push(Buffer.from(`${head}sf_rt_SE`), 'stdout');
+    const second = transformer.push(Buffer.from('CRET123456 done\n'), 'stdout');
+    const combined = outputText(first) + outputText(second);
+
+    expect(combined).toBe(`${head}*** done\n`);
+    expect(combined).not.toContain('sf_rt_SE');
+  });
+
+  it('passes output through unchanged when no secrets are registered', () => {
+    const transformer = new LogTransformer([]);
+
+    const events = transformer.push(Buffer.from('token=sf_rt_SECRET123456\n'), 'stdout');
+
+    expect(outputText(events)).toBe('token=sf_rt_SECRET123456\n');
+  });
+});
+
+describe('LogTransformer live streaming', () => {
+  it('streams a no-newline line without waiting for a newline (no secrets)', () => {
+    const transformer = new LogTransformer([]);
+
+    const events = transformer.push(Buffer.from('Progress: 50%'), 'stdout');
+
+    expect(outputText(events)).toBe('Progress: 50%');
+  });
+
+  it('streams the safe prefix of a no-newline line even with secrets registered', () => {
+    const transformer = new LogTransformer([SECRET]);
+
+    const events = transformer.push(Buffer.from('a'.repeat(200)), 'stdout');
+
+    // All but a small lookbehind tail is emitted live, rather than held until the line ends.
+    expect(outputText(events).length).toBeGreaterThan(150);
+    expect(outputText(events)).toBe('a'.repeat(outputText(events).length));
+  });
+
+  it('keeps stdout and stderr complete lines in push order', () => {
+    const transformer = new LogTransformer([]);
+
+    const out1 = transformer.push(Buffer.from('out1\n'), 'stdout');
+    const err1 = transformer.push(Buffer.from('err1\n'), 'stderr');
+    const out2 = transformer.push(Buffer.from('out2\n'), 'stdout');
+
+    expect(out1).toEqual([{type: 'output', src: 'stdout', data: 'out1\n'}]);
+    expect(err1).toEqual([{type: 'output', src: 'stderr', data: 'err1\n'}]);
+    expect(out2).toEqual([{type: 'output', src: 'stdout', data: 'out2\n'}]);
+  });
+});
+
+describe('LogTransformer markers', () => {
+  it('swallows group markers and keeps the lines between them as output', () => {
+    const transformer = new LogTransformer([]);
+
+    const events = transformer.push(
+      Buffer.from('::group::Install\nbuilding\n::endgroup::\n'),
+      'stdout',
+    );
+
+    expect(events).toEqual([
+      {type: 'group_start', name: 'Install'},
+      {type: 'output', src: 'stdout', data: 'building\n'},
+      {type: 'group_end'},
+    ]);
+  });
+
+  it('masks a secret inside a group name', () => {
+    const transformer = new LogTransformer([SECRET]);
+
+    const events = transformer.push(Buffer.from(`::group::run ${SECRET}\n`), 'stdout');
+
+    expect(events).toEqual([{type: 'group_start', name: 'run ***'}]);
+  });
+
+  it('holds a marker that spans two pushes until its newline, then swallows it', () => {
+    const transformer = new LogTransformer([]);
+
+    const first = transformer.push(Buffer.from('::gro'), 'stdout');
+    const second = transformer.push(Buffer.from('up::Build\n'), 'stdout');
+
+    expect(first).toEqual([]); // held: still a viable marker prefix
+    expect(second).toEqual([{type: 'group_start', name: 'Build'}]);
+  });
+
+  it('emits a trailing marker with no newline at flush', () => {
+    const transformer = new LogTransformer([]);
+
+    transformer.push(Buffer.from('::endgroup::'), 'stdout');
+    const flushed = transformer.flush();
+
+    expect(flushed).toEqual([{type: 'group_end'}]);
+  });
+});

--- a/libs/runner/logs/src/core/transform.test.ts
+++ b/libs/runner/logs/src/core/transform.test.ts
@@ -88,13 +88,25 @@ describe('LogTransformer secret masking', () => {
     ['base64', Buffer.from(SECRET).toString('base64')],
     ['base64url', Buffer.from(SECRET).toString('base64url')],
     ['hex', Buffer.from(SECRET).toString('hex')],
-    ['url-encoded', encodeURIComponent(SECRET)],
   ])('masks the %s form of a secret', (_label, form) => {
     const transformer = new LogTransformer([SECRET]);
 
     const events = transformer.push(Buffer.from(`value=${form}\n`), 'stdout');
 
     expect(outputText(events)).toBe('value=***\n');
+  });
+
+  it('masks the URL-encoded form of a secret with reserved characters', () => {
+    // '/', '+' and '=' all percent-encode, so the URL form genuinely differs from the literal
+    // (a base64url-shaped token's URL form equals the literal and would test nothing).
+    const secret = 'sf/rt+secret=99';
+    const encoded = encodeURIComponent(secret);
+    const transformer = new LogTransformer([secret]);
+
+    const events = transformer.push(Buffer.from(`q=${encoded}\n`), 'stdout');
+
+    expect(encoded).not.toBe(secret);
+    expect(outputText(events)).toBe('q=***\n');
   });
 
   it('masks a secret embedded inside a larger base64 blob', () => {
@@ -222,5 +234,30 @@ describe('LogTransformer markers', () => {
     const flushed = transformer.flush();
 
     expect(flushed).toEqual([{type: 'group_end'}]);
+  });
+
+  it('swallows a CRLF endgroup whose CR and LF arrive in separate pushes', () => {
+    const transformer = new LogTransformer([]);
+
+    const first = transformer.push(Buffer.from('::endgroup::\r'), 'stdout');
+    const second = transformer.push(Buffer.from('\n'), 'stdout');
+
+    expect(first).toEqual([]); // held across the CR, not released as output
+    expect(second).toEqual([{type: 'group_end'}]);
+  });
+
+  it('swallows CRLF group markers and keeps a CRLF body line as output', () => {
+    const transformer = new LogTransformer([]);
+
+    const events = transformer.push(
+      Buffer.from('::group::Install\r\nbuilding\r\n::endgroup::\r\n'),
+      'stdout',
+    );
+
+    expect(events).toEqual([
+      {type: 'group_start', name: 'Install'},
+      {type: 'output', src: 'stdout', data: 'building\r\n'},
+      {type: 'group_end'},
+    ]);
   });
 });

--- a/libs/runner/logs/src/core/transform.test.ts
+++ b/libs/runner/logs/src/core/transform.test.ts
@@ -125,6 +125,21 @@ describe('LogTransformer secret masking', () => {
     expect(combined).not.toContain('sf_rt_SE');
   });
 
+  it('masks a secret straddling the release of an over-long marker candidate', () => {
+    const transformer = new LogTransformer([SECRET]);
+    // A `::group::`-leading run with no newline that grows past MARKER_CANDIDATE_LIMIT (16KB):
+    // it stops being held as a marker and is released as output, and the lookbehind must still
+    // hold the secret that straddles that release boundary.
+    const head = `::group::${'x'.repeat(20_000)}`;
+
+    const first = transformer.push(Buffer.from(`${head}sf_rt_SE`), 'stdout');
+    const second = transformer.push(Buffer.from('CRET123456 done\n'), 'stdout');
+    const combined = outputText(first) + outputText(second);
+
+    expect(combined).toBe(`${head}*** done\n`);
+    expect(combined).not.toContain('sf_rt_SE');
+  });
+
   it('passes output through unchanged when no secrets are registered', () => {
     const transformer = new LogTransformer([]);
 

--- a/libs/runner/logs/src/core/transform.ts
+++ b/libs/runner/logs/src/core/transform.ts
@@ -1,0 +1,175 @@
+import {TextDecoder} from 'node:util';
+import {redactSecrets, secretWireForms} from '@shipfox/redact';
+import {type OutputSource, PIPES} from '#core/framing.js';
+import {couldBeMarker, parseMarker} from '#core/markers.js';
+
+/** What the transform hands the framer: masked output text, or a swallowed group marker. */
+export type TransformEvent =
+  | {type: 'output'; src: OutputSource; data: string}
+  | {type: 'group_start'; name: string}
+  | {type: 'group_end'};
+
+// A `::`-leading partial line is held until its newline so a real marker can be swallowed.
+// A group name is capped far below this by the DTO, so a `::`-leading run this long with no
+// newline is not a real marker and is released as output to keep the hold bounded.
+const MARKER_CANDIDATE_LIMIT = 16 * 1024;
+
+interface SourceState {
+  decoder: TextDecoder;
+  buffer: string;
+}
+
+/**
+ * The transform stage between capture and the spool. Per pipe it decodes bytes, masks
+ * secrets, and turns `::group::`/`::endgroup::` lines into control events. It streams output
+ * continuously rather than buffering whole lines: complete lines flush immediately (a `\n` is
+ * a safe secret boundary), and an unterminated line still streams its masked safe prefix with
+ * a rolling lookbehind, so no-newline output (progress bars) reaches the spool live and frame
+ * timestamps stay at capture time.
+ *
+ * Masking delegates to `@shipfox/redact`; the only streaming-specific logic here is the
+ * lookbehind boundary (safeEmitLength), which guarantees a secret split across chunk or flush
+ * boundaries is never emitted unmasked. Registered-secret masking is the hard guarantee;
+ * redactSecrets' URL-credential scrubbing needs a whole line and so is best-effort across a
+ * forced mid-line flush.
+ */
+export class LogTransformer {
+  private readonly variants: string[];
+  private readonly maxVariantLen: number;
+  private readonly sources: Record<OutputSource, SourceState>;
+
+  constructor(secrets: string[]) {
+    // One deduped, longest-first variant set shared across pipes (secrets are global). The
+    // per-pipe decoder and line buffer are independent: stdout and stderr are separate byte
+    // streams that must never complete each other's partial sequences or split secrets.
+    const variantSet = new Set<string>();
+    for (const secret of secrets) {
+      for (const form of secretWireForms(secret)) variantSet.add(form);
+    }
+    this.variants = [...variantSet].sort((a, b) => b.length - a.length);
+    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
+    this.sources = {
+      stdout: {decoder: newDecoder(), buffer: ''},
+      stderr: {decoder: newDecoder(), buffer: ''},
+    };
+  }
+
+  push(chunk: Buffer, source: OutputSource): TransformEvent[] {
+    const state = this.sources[source];
+    state.buffer += state.decoder.decode(chunk, {stream: true});
+    return this.drain(source, false);
+  }
+
+  /** Flushes each pipe's held partial line and trailing decoder state at stream close. */
+  flush(): TransformEvent[] {
+    const events: TransformEvent[] = [];
+    for (const source of PIPES) {
+      const state = this.sources[source];
+      state.buffer += state.decoder.decode(); // a trailing partial multi-byte becomes U+FFFD
+      this.drainInto(source, true, events);
+    }
+    return events;
+  }
+
+  private drain(source: OutputSource, final: boolean): TransformEvent[] {
+    const events: TransformEvent[] = [];
+    this.drainInto(source, final, events);
+    return events;
+  }
+
+  private drainInto(source: OutputSource, final: boolean, events: TransformEvent[]): void {
+    const state = this.sources[source];
+
+    // Complete lines flush immediately: '\n' is a safe secret boundary, so each line is masked
+    // whole with no carry, and markers (whole lines) are detected here.
+    let newline = state.buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = state.buffer.slice(0, newline);
+      state.buffer = state.buffer.slice(newline + 1);
+      this.emitLine(line, source, events, {newline: true});
+      newline = state.buffer.indexOf('\n');
+    }
+
+    if (state.buffer.length === 0) return;
+
+    if (final) {
+      // Stream closed: emit the remaining partial line masked, with no trailing newline.
+      this.emitLine(state.buffer, source, events, {newline: false});
+      state.buffer = '';
+      return;
+    }
+
+    // Hold a `::`-leading partial whole until its newline so a real marker can be swallowed,
+    // unless it has grown too large to be one.
+    if (couldBeMarker(state.buffer) && state.buffer.length <= MARKER_CANDIDATE_LIMIT) return;
+
+    // Otherwise stream the masked safe prefix and keep only the lookbehind carry.
+    const cut = this.safeEmitLength(state.buffer);
+    if (cut > 0) {
+      events.push({
+        type: 'output',
+        src: source,
+        data: redactSecrets(state.buffer.slice(0, cut), this.variants),
+      });
+      state.buffer = state.buffer.slice(cut);
+    }
+  }
+
+  // Masks one complete line and routes it. A ::group::/::endgroup:: line becomes a control
+  // event and is swallowed; everything else is an output event. Markers are matched on the raw
+  // line (masking cannot create or destroy a `::` marker); only the extracted group name is
+  // masked, so a secret in a name never reaches the record.
+  private emitLine(
+    line: string,
+    source: OutputSource,
+    events: TransformEvent[],
+    opts: {newline: boolean},
+  ): void {
+    const marker = parseMarker(line);
+    if (marker) {
+      if (marker.kind === 'group_start') {
+        events.push({type: 'group_start', name: redactSecrets(marker.name, this.variants)});
+      } else {
+        events.push({type: 'group_end'});
+      }
+      return;
+    }
+    const text = opts.newline ? `${line}\n` : line;
+    if (text.length === 0) return;
+    events.push({type: 'output', src: source, data: redactSecrets(text, this.variants)});
+  }
+
+  // The largest prefix length of `buffer` that is safe to mask and emit now: no secret variant
+  // occurrence crosses it, so the masked prefix can never change once later bytes arrive. Start
+  // by holding the last (maxVariantLen - 1) chars (any not-yet-complete secret begins there),
+  // then pull the cut back past any complete occurrence that would straddle it. Guarantees a
+  // split secret is never emitted unmasked.
+  private safeEmitLength(buffer: string): number {
+    const hold = Math.max(0, this.maxVariantLen - 1);
+    let cut = buffer.length - hold;
+    if (cut <= 0) return 0;
+    for (let moved = true; moved && cut > 0; ) {
+      moved = false;
+      // Only an occurrence starting in [cut - maxVariantLen + 1, cut) can straddle `cut`.
+      const windowStart = Math.max(0, cut - this.maxVariantLen + 1);
+      for (let start = windowStart; start < cut; start++) {
+        const straddles = this.variants.some(
+          (form) => start + form.length > cut && buffer.startsWith(form, start),
+        );
+        if (straddles) {
+          cut = start; // hold the whole occurrence
+          moved = true;
+          break;
+        }
+      }
+    }
+    return cut;
+  }
+}
+
+function newDecoder(): TextDecoder {
+  // Preserve ENG-440's exact decoder options: ignoreBOM keeps a leading BOM as data (a default
+  // decoder strips it), and fatal:false turns invalid sequences into U+FFFD instead of throwing
+  // inside the child-output handler, where it would crash the runner.
+  return new TextDecoder('utf-8', {ignoreBOM: true, fatal: false});
+}

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -25,6 +25,7 @@ vi.mock('#core/step-loop.js', () => ({
 vi.mock('@shipfox/runner-protocol', () => ({
   requestJob: vi.fn(),
   createLeaseClient: vi.fn(() => ({}) as never),
+  runnerToken: vi.fn(() => 'runner-token'),
   HTTPError: class HTTPError extends Error {},
 }));
 

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -1,6 +1,6 @@
 import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
 import {logger} from '@shipfox/node-opentelemetry';
-import {createLeaseClient, requestJob} from '@shipfox/runner-protocol';
+import {createLeaseClient, requestJob, runnerToken} from '@shipfox/runner-protocol';
 import {
   cleanupWorkspace,
   jobWorkspacePath,
@@ -83,7 +83,11 @@ export async function runJob(
 
   try {
     const leaseClient = createLeaseClient(job.lease_token);
-    await runJobSteps({jobId: job.job_id, leaseClient, signal: ac.signal, cwd});
+    // The v1 log mask set is the runner's own credentials: the long-lived runner token and
+    // this job's lease token. Both can reach a step's environment, so they are scrubbed from
+    // captured output before it touches the spool. The set grows as step-level secrets land.
+    const secrets = [runnerToken(), job.lease_token];
+    await runJobSteps({jobId: job.job_id, leaseClient, secrets, signal: ac.signal, cwd});
     logger().info({jobId: job.job_id}, 'Job step loop finished');
   } catch (stepLoopError) {
     // A non-retryable error surfaced (e.g. an unexpected throw from the loop).

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -92,7 +92,7 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(executeSetupStepMock).toHaveBeenCalledWith({
       cwd: '/work',
@@ -125,12 +125,13 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(createStepLogStreamMock).toHaveBeenCalledWith({
       logsDir: '/work/logs',
       stepId: run.id,
       attempt: 3,
+      secrets: [],
       append: expect.any(Function),
     });
     // No stream for the synthetic setup step.
@@ -160,7 +161,7 @@ describe('runJobSteps', () => {
     );
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(captured?.write).toHaveBeenCalledWith(Buffer.from('hello'), 'stdout');
   });
@@ -179,7 +180,7 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     // The step still runs and is reported succeeded; the stream failure does not fail the step.
     expect(executeRunStepMock).toHaveBeenCalled();
@@ -201,7 +202,7 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     // The first stream is drained and disposed before the second is created.
     expect(events.indexOf(`dispose:${run1.id}`)).toBeLessThan(events.indexOf(`create:${run2.id}`));
@@ -227,7 +228,7 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     // pull index 2 is the request that claims run2. run1's stream must be disposed before it,
     // so a slow drain delays only the (unclaimed) pull, never a freshly claimed step.
@@ -246,7 +247,7 @@ describe('runJobSteps', () => {
       return Promise.resolve({success: true, error: null, exit_code: 0});
     });
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     // Setup completed and was reported; the aborted run step is not.
     const reportedSteps = reportStepMock.mock.calls.map((call) => call[1].stepId);
@@ -263,7 +264,7 @@ describe('runJobSteps', () => {
     reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: setup.id,
@@ -284,7 +285,7 @@ describe('runJobSteps', () => {
     reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(executeRunStepMock).not.toHaveBeenCalled();
@@ -303,7 +304,7 @@ describe('runJobSteps', () => {
     requestNextStepMock.mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(reportStepMock).not.toHaveBeenCalled();
@@ -314,7 +315,7 @@ describe('runJobSteps', () => {
     const ac = new AbortController();
 
     await expect(
-      runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'}),
+      runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'}),
     ).resolves.toBeUndefined();
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
@@ -326,7 +327,7 @@ describe('runJobSteps', () => {
     const ac = new AbortController();
 
     await expect(
-      runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'}),
+      runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'}),
     ).rejects.toThrow();
 
     expect(requestNextStepMock).toHaveBeenCalledTimes(1);
@@ -345,7 +346,7 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: run.id,
@@ -371,7 +372,7 @@ describe('runJobSteps', () => {
     const ac = new AbortController();
 
     await expect(
-      runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'}),
+      runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'}),
     ).resolves.toBeUndefined();
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
@@ -393,7 +394,7 @@ describe('runJobSteps', () => {
       return Promise.resolve({success: true, error: null, exit_code: 0});
     });
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(executeSetupStepMock).toHaveBeenCalledTimes(1);
     expect(reportStepMock).not.toHaveBeenCalled();
@@ -403,7 +404,7 @@ describe('runJobSteps', () => {
     const ac = new AbortController();
     ac.abort();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(requestNextStepMock).not.toHaveBeenCalled();
   });
@@ -418,7 +419,7 @@ describe('runJobSteps', () => {
     executeAgentStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {signal: ac.signal, cwd: '/work'});
     expect(executeRunStepMock).not.toHaveBeenCalled();
@@ -450,7 +451,7 @@ describe('runJobSteps', () => {
       });
     });
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, signal: ac.signal, cwd: '/work'});
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(executeAgentStepMock).toHaveBeenCalledTimes(1);
     // Only the setup step is reported; the aborted agent step is not.

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -17,10 +17,12 @@ import type {KyInstance} from 'ky';
 export async function runJobSteps(params: {
   jobId: string;
   leaseClient: KyInstance;
+  /** Secrets masked out of every run step's captured output before it reaches the spool. */
+  secrets: string[];
   signal: AbortSignal;
   cwd: string;
 }): Promise<void> {
-  const {jobId, leaseClient, signal, cwd} = params;
+  const {jobId, leaseClient, secrets, signal, cwd} = params;
 
   // The setup step (position 0) prepares the workspace; every run step assumes it ran.
   // A run step pulled before a successful setup is failed cleanly rather than spawned
@@ -55,6 +57,7 @@ export async function runJobSteps(params: {
         attempt,
         cwd,
         leaseClient,
+        secrets,
         signal,
         workspacePrepared,
         jobId,
@@ -141,12 +144,14 @@ export async function executeStep(params: {
   attempt: number;
   cwd: string;
   leaseClient: KyInstance;
+  secrets: string[];
   signal: AbortSignal;
   workspacePrepared: boolean;
   jobId: string;
   stepLabel: string;
 }): Promise<StepExecution> {
-  const {step, attempt, cwd, leaseClient, signal, workspacePrepared, jobId, stepLabel} = params;
+  const {step, attempt, cwd, leaseClient, secrets, signal, workspacePrepared, jobId, stepLabel} =
+    params;
 
   let stream: StepLogStream | undefined;
   try {
@@ -184,6 +189,7 @@ export async function executeStep(params: {
         logsDir: join(cwd, 'logs'),
         stepId: step.id,
         attempt,
+        secrets,
         append: ({offset, body, signal: appendSignal}) =>
           appendStepLogs(leaseClient, {
             stepId: step.id,

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -57,6 +57,15 @@ const api = ky.create({
   },
 });
 
+/**
+ * The runner's long-lived bearer credential, exposed so the log masker can scrub it from
+ * captured step output: a step that echoes its environment must never leak it to the
+ * plaintext spool. For masking only — never log this value.
+ */
+export function runnerToken(): string {
+  return config.SHIPFOX_RUNNER_TOKEN;
+}
+
 // Scheduling is step-less: the claim returns only the job/run ids and the lease
 // token. Steps are pulled one at a time from the step API using that token.
 export async function requestJob(): Promise<ClaimedJobResponseDto | null> {

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -9,4 +9,5 @@ export {
   requestCheckoutToken,
   requestJob,
   requestNextStep,
+  runnerToken,
 } from '#api-client.js';

--- a/libs/shared/common/redact/README.md
+++ b/libs/shared/common/redact/README.md
@@ -15,9 +15,17 @@ across Shipfox so they cannot drift.
   masked; a credential-free non-URL (scp-style `git@host:path`) is returned
   unchanged.
 - **`redactSecrets(text, secrets)`** removes every occurrence of each literal
-  secret, then applies `redactUrlCredentials`. Pass every wire form a secret
-  takes (e.g. the base64 of `user:token`); the helper only removes the literals
-  it is given.
+  secret, then applies `redactUrlCredentials`. The helper only removes the
+  literals it is given, so pass every wire form a secret takes; use
+  `secretWireForms` to derive them.
+- **`secretWireForms(secret)`** derives every wire form one secret can appear as
+  in captured output: the literal, its base64 and base64url forms (all three
+  phase alignments, so a secret embedded in a larger encoded blob is masked too),
+  its URL-encoded form, and its lower- and upper-case hex. The result is
+  deduplicated and sorted longest-first, ready to hand straight to `redactSecrets`.
+  The literal is always included so a registered secret is never left unmasked;
+  its derived forms are dropped below 8 characters, because a short derivation
+  matches common encoded text and would scrub unrelated output.
 - **`REDACTION_PLACEHOLDER`** is the `'***'` string every redaction writes.
 
 scp-style remotes (`git@host:path`) are left untouched on purpose: an scp URL
@@ -34,7 +42,12 @@ pnpm add @shipfox/redact
 ## Usage
 
 ```ts
-import {redactSecrets, redactUrlCredentials, stripUrlCredentials} from "@shipfox/redact";
+import {
+  redactSecrets,
+  redactUrlCredentials,
+  secretWireForms,
+  stripUrlCredentials,
+} from "@shipfox/redact";
 
 redactUrlCredentials("fatal: clone of https://x:tok@github.com/o/r.git failed");
 // -> "fatal: clone of https://***@github.com/o/r.git failed"
@@ -44,6 +57,10 @@ stripUrlCredentials("https://x-access-token:tok@github.com/o/r.git");
 
 redactSecrets("Authorization: Basic dXNlcjp0b2tlbg==", ["dXNlcjp0b2tlbg=="]);
 // -> "Authorization: Basic ***"
+
+// Mask a token in every form it might appear as (base64, hex, URL-encoded, ...).
+redactSecrets("digest=" + tokenAsHex, secretWireForms(token));
+// -> "digest=***"
 ```
 
 ## Development

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -218,11 +218,25 @@ describe('secretWireForms', () => {
     expect(redactSecrets(`digest=${hex.toUpperCase()}`, forms)).toBe('digest=***');
   });
 
-  it('drops forms below the min length and never returns duplicates', () => {
-    const forms = secretWireForms('sk_live_TESTsecret123');
+  it('always keeps the literal but drops every too-short derived form', () => {
+    // 'abc' is 3 chars: the literal always masks, but every derived form (hex 6, base64 3-4,
+    // url-encoded 3) is under the 8-char floor and dropped, so no short derivation scrubs
+    // unrelated text.
+    const forms = secretWireForms('abc');
 
-    expect(forms.every((form) => form.length >= 8)).toBe(true);
-    expect(new Set(forms).size).toBe(forms.length);
+    expect(forms).toEqual(['abc']);
+  });
+
+  it('keeps a derived form that clears the floor while dropping the shorter ones', () => {
+    // 'wxyz' is 4 chars: the literal always masks and its 8-char hex clears the floor, but its
+    // base64 phase forms (5 chars or fewer) are dropped, since a short base64 substring
+    // over-matches common encoded text.
+    const forms = secretWireForms('wxyz');
+    const base64Phase0 = Buffer.from('wxyz').toString('base64').slice(0, 5);
+
+    expect(forms).toContain('wxyz');
+    expect(forms).toContain(Buffer.from('wxyz').toString('hex'));
+    expect(forms).not.toContain(base64Phase0);
   });
 
   it('returns forms sorted longest-first', () => {

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -2,6 +2,7 @@ import {
   REDACTION_PLACEHOLDER,
   redactSecrets,
   redactUrlCredentials,
+  secretWireForms,
   stripUrlCredentials,
 } from './index.js';
 
@@ -159,5 +160,78 @@ describe('redactSecrets', () => {
 
   it('exposes the placeholder it writes', () => {
     expect(REDACTION_PLACEHOLDER).toBe('***');
+  });
+});
+
+describe('secretWireForms', () => {
+  it('derives the exact deduped, longest-first form set for a token', () => {
+    const forms = secretWireForms('sk_live_TESTsecret123');
+
+    expect(forms).toEqual([
+      '736b5f6c6976655f54455354736563726574313233', // hex lower
+      '736B5F6C6976655F54455354736563726574313233', // hex upper
+      'c2tfbGl2ZV9URVNUc2VjcmV0MTIz', // base64 / base64url phase 0
+      'NrX2xpdmVfVEVTVHNlY3JldDEyM', // phase 1 (alphabets coincide here)
+      'za19saXZlX1RFU1RzZWNyZXQxMj', // phase 2
+      'sk_live_TESTsecret123', // literal
+    ]);
+  });
+
+  it.each([0, 1, 2])('masks a secret embedded at base64 phase alignment %i', (phase) => {
+    const secret = 'sk_live_TESTsecret123';
+    const forms = secretWireForms(secret);
+    const blob = Buffer.concat([
+      Buffer.alloc(phase, 0x41),
+      Buffer.from(secret),
+      Buffer.from('TAILTAIL'),
+    ]).toString('base64');
+
+    const masked = redactSecrets(blob, forms);
+
+    expect(forms.some((form) => blob.includes(form))).toBe(true);
+    expect(forms.some((form) => masked.includes(form))).toBe(false);
+    expect(masked).toContain('***');
+  });
+
+  it('derives distinct base64 and base64url forms when the alphabets diverge', () => {
+    const forms = secretWireForms('??>>secret<<??value');
+
+    expect(forms).toContain('Pz8+PnNlY3JldDw8Pz92YWx1Z'); // base64 phase 0 (+)
+    expect(forms).toContain('Pz8-PnNlY3JldDw8Pz92YWx1Z'); // base64url phase 0 (-)
+  });
+
+  it('masks the URL-encoded form when it differs from the literal', () => {
+    const secret = '??>>secret<<??value';
+    const forms = secretWireForms(secret);
+
+    const masked = redactSecrets(`GET /x?t=${encodeURIComponent(secret)}`, forms);
+
+    expect(masked).toBe('GET /x?t=***');
+  });
+
+  it('masks lower- and upper-case hex forms', () => {
+    const secret = 'sk_live_TESTsecret123';
+    const forms = secretWireForms(secret);
+    const hex = Buffer.from(secret).toString('hex');
+
+    expect(redactSecrets(`digest=${hex}`, forms)).toBe('digest=***');
+    expect(redactSecrets(`digest=${hex.toUpperCase()}`, forms)).toBe('digest=***');
+  });
+
+  it('drops forms below the min length and never returns duplicates', () => {
+    const forms = secretWireForms('sk_live_TESTsecret123');
+
+    expect(forms.every((form) => form.length >= 8)).toBe(true);
+    expect(new Set(forms).size).toBe(forms.length);
+  });
+
+  it('returns forms sorted longest-first', () => {
+    const lengths = secretWireForms('sk_live_TESTsecret123').map((form) => form.length);
+
+    expect(lengths).toEqual([...lengths].sort((a, b) => b - a));
+  });
+
+  it('returns no forms for an empty secret', () => {
+    expect(secretWireForms('')).toEqual([]);
   });
 });

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -83,10 +83,12 @@ export function redactSecrets(text: string, secrets: string[]): string {
 const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 const BASE64URL_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 
-// Forms shorter than this are dropped: a short, low-entropy derivation (e.g. the hex of a
-// one-byte secret) would scrub unrelated text. Real secrets are long, so this never drops
-// a genuine token's forms — it only guards against a degenerate registration.
-const MIN_WIRE_FORM_LENGTH = 8;
+// A derived form (base64/base64url phase substrings, hex, URL-encoding) is dropped below this
+// length: a short derivation matches common encoded text and would scrub unrelated output. The
+// literal secret is never dropped, because failing to mask a registered secret is a leak. A
+// derived form's length scales with the secret, so this only ever bites a short secret; a long
+// token keeps every form.
+const MIN_DERIVED_FORM_LENGTH = 8;
 
 // Self-contained, unpadded base64 so this stays a pure-JS (browser-safe) module: no
 // node:buffer, no btoa. Padding is irrelevant here because callers only ever slice the
@@ -135,28 +137,30 @@ function hexEncode(bytes: Uint8Array): string {
 /**
  * Every wire form a secret can appear as in captured output, ready to hand straight to
  * {@link redactSecrets}: the literal, its base64 and base64url forms (all three phase
- * alignments, so a secret embedded in a larger encoded blob is masked too), its
- * URL-encoded form, and its lower- and upper-case hex. Deduplicated and sorted
- * longest-first; forms under {@link MIN_WIRE_FORM_LENGTH} chars are dropped so a short
- * derivation never scrubs unrelated text.
+ * alignments, so a secret embedded in a larger encoded blob is masked too), its URL-encoded
+ * form, and its lower- and upper-case hex. Deduplicated and sorted longest-first.
  *
- * redactSecrets' contract still holds: pass real, high-entropy secrets. This is the
- * "deriving every wire form a credential takes" step that redactSecrets leaves to callers,
- * given one home so every masker derives the same set.
+ * The literal is always included so a registered secret is never left unmasked. Its derived
+ * forms are dropped below {@link MIN_DERIVED_FORM_LENGTH} chars, because a short derivation
+ * (e.g. the base64 substring of a tiny secret) matches common encoded text and would scrub
+ * unrelated output. A derived form's length scales with the secret, so this only bites a short
+ * secret; a genuine long token keeps every form.
+ *
+ * redactSecrets' contract still holds: pass real, high-entropy secrets. This is the "deriving
+ * every wire form a credential takes" step that redactSecrets leaves to callers, given one
+ * home so every masker derives the same set.
  */
 export function secretWireForms(secret: string): string[] {
   if (!secret) return [];
   const bytes = new TextEncoder().encode(secret);
   const hex = hexEncode(bytes);
-  const forms = new Set<string>([
-    secret,
+  const derived = [
     ...base64Alignments(bytes, BASE64_ALPHABET),
     ...base64Alignments(bytes, BASE64URL_ALPHABET),
     encodeURIComponent(secret),
     hex,
     hex.toUpperCase(),
-  ]);
-  return [...forms]
-    .filter((form) => form.length >= MIN_WIRE_FORM_LENGTH)
-    .sort((a, b) => b.length - a.length);
+  ].filter((form) => form.length >= MIN_DERIVED_FORM_LENGTH);
+  // The literal always masks; only its derived forms are length-gated.
+  return [...new Set([secret, ...derived])].sort((a, b) => b.length - a.length);
 }

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -79,3 +79,84 @@ export function redactSecrets(text: string, secrets: string[]): string {
   }
   return redactUrlCredentials(redacted);
 }
+
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const BASE64URL_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+// Forms shorter than this are dropped: a short, low-entropy derivation (e.g. the hex of a
+// one-byte secret) would scrub unrelated text. Real secrets are long, so this never drops
+// a genuine token's forms — it only guards against a degenerate registration.
+const MIN_WIRE_FORM_LENGTH = 8;
+
+// Self-contained, unpadded base64 so this stays a pure-JS (browser-safe) module: no
+// node:buffer, no btoa. Padding is irrelevant here because callers only ever slice the
+// stable middle of the output (see base64Alignments).
+function base64Encode(bytes: Uint8Array, alphabet: string): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i] as number;
+    const b1 = i + 1 < bytes.length ? (bytes[i + 1] as number) : 0;
+    const b2 = i + 2 < bytes.length ? (bytes[i + 2] as number) : 0;
+    out += alphabet[b0 >> 2];
+    out += alphabet[((b0 & 0b11) << 4) | (b1 >> 4)];
+    if (i + 1 < bytes.length) out += alphabet[((b1 & 0b1111) << 2) | (b2 >> 6)];
+    if (i + 2 < bytes.length) out += alphabet[b2 & 0b111111];
+  }
+  return out;
+}
+
+/**
+ * The three phase-aligned base64 substrings a secret yields when embedded at byte offset
+ * 0, 1, or 2 (mod 3) inside a larger base64 blob (e.g. a token inside a base64-encoded
+ * request body). For each phase we encode `phase` filler bytes followed by the secret,
+ * drop the `lead` chars the filler produced, and keep the `keep` chars that depend only on
+ * the secret's own bytes — the run that appears no matter what surrounds the secret.
+ */
+function base64Alignments(bytes: Uint8Array, alphabet: string): string[] {
+  const alignments: string[] = [];
+  for (let phase = 0; phase < 3; phase++) {
+    const padded = new Uint8Array(phase + bytes.length);
+    padded.set(bytes, phase);
+    const encoded = base64Encode(padded, alphabet);
+    const lead = Math.ceil((phase * 8) / 6);
+    const lostBits = lead * 6 - phase * 8;
+    const keep = Math.floor((bytes.length * 8 - lostBits) / 6);
+    alignments.push(encoded.slice(lead, lead + keep));
+  }
+  return alignments;
+}
+
+function hexEncode(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
+/**
+ * Every wire form a secret can appear as in captured output, ready to hand straight to
+ * {@link redactSecrets}: the literal, its base64 and base64url forms (all three phase
+ * alignments, so a secret embedded in a larger encoded blob is masked too), its
+ * URL-encoded form, and its lower- and upper-case hex. Deduplicated and sorted
+ * longest-first; forms under {@link MIN_WIRE_FORM_LENGTH} chars are dropped so a short
+ * derivation never scrubs unrelated text.
+ *
+ * redactSecrets' contract still holds: pass real, high-entropy secrets. This is the
+ * "deriving every wire form a credential takes" step that redactSecrets leaves to callers,
+ * given one home so every masker derives the same set.
+ */
+export function secretWireForms(secret: string): string[] {
+  if (!secret) return [];
+  const bytes = new TextEncoder().encode(secret);
+  const hex = hexEncode(bytes);
+  const forms = new Set<string>([
+    secret,
+    ...base64Alignments(bytes, BASE64_ALPHABET),
+    ...base64Alignments(bytes, BASE64URL_ALPHABET),
+    encodeURIComponent(secret),
+    hex,
+    hex.toUpperCase(),
+  ]);
+  return [...forms]
+    .filter((form) => form.length >= MIN_WIRE_FORM_LENGTH)
+    .sort((a, b) => b.length - a.length);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2587,6 +2587,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/redact':
+        specifier: workspace:*
+        version: link:../../shared/common/redact
       '@shipfox/regex':
         specifier: workspace:*
         version: link:../../shared/common/regex


### PR DESCRIPTION
Adds the runner log transform stage between capture and the spool: a streaming secret masker and GitHub-style group-marker detection. Completes ENG-441 (workstream 3 of the log capture & streaming project), the masking follow-up ENG-440 deferred.

The ENG-440 capture pipeline spooled and uploaded step output verbatim, so a step that echoed the runner's own credentials reached the plaintext spool and the dashboard unmasked, and `::group::` markers stayed inline instead of structuring the log. There is no feature gate, so masking has to be correct before this merges.

**What it does**

- **Streaming secret masker** replaces the runner token and job lease token (and every base64, base64url ×3 phase alignment, URL-encoded, and hex form) with `***` before any byte touches disk. A rolling lookbehind guarantees a secret is never emitted split across a capture-chunk or flush boundary. Masking delegates to `@shipfox/redact`, which gains `secretWireForms` to derive a secret's wire forms; the runner credential is exposed via a new `runnerToken` accessor.
- **GitHub markers**: `::group::name` / `::endgroup::` lines become `group_start` / `group_end` control records with the marker line swallowed. A secret inside a group name is masked too.

**Worth a careful review**

The transform streams output continuously rather than buffering whole lines: complete lines flush immediately, and an unterminated line streams its masked safe prefix. This was a deliberate choice (surfaced in review) so no-newline progress output still tails live, stdout/stderr stay in order, and frame timestamps stay at capture time. The bundled URL-credential scrubbing is best-effort across a forced mid-line flush; registered-secret masking is the hard guarantee.

The UTF-8 decoder moved out of `StreamFramer` (now a pure encoder) into the transform, and its multi-byte reassembly tests moved with it.

Closes ENG-441

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a transform stage between capture and the spool to mask secrets before disk and to convert GitHub-style `::group::` markers into control records. Completes ENG-441 and closes the ENG-440 gap so runner/job tokens never reach the plaintext spool.

- New Features
  - Streaming secret masker replaces the runner token and job lease token (plus base64/base64url phase substrings, URL-encoded, and hex forms) with `***` before any byte hits disk; uses `@shipfox/redact` `secretWireForms` (literal always masked; short derived forms are gated). Rolling lookbehind keeps split secrets from leaking across chunk/flush boundaries while output streams live.
  - Detects `::group::name` / `::endgroup::` and emits `group_start` / `group_end`; marker lines are swallowed, names are masked, and over-long names are byte-truncated to the DTO cap. UTF-8 decoding moved into the transform; `StreamFramer` now frames text and provides group helpers.
  - Orchestrator now passes `[runnerToken(), job.lease_token]` to the log stream; `@shipfox/runner-protocol` exposes `runnerToken`.

- Bug Fixes
  - Holds CRLF-split group markers until the final `\n` so they are swallowed, not emitted as output.

<sup>Written for commit ed31aeb16e14e50131398ede94a6f21c17e9a124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

