### PR TITLE
Fix invisible keyboard focus rings

### DIFF
--- a/.changeset/steady-links-focus.md
+++ b/.changeset/steady-links-focus.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-app-shell": patch
+"@shipfox/client-integrations": patch
+"@shipfox/client-projects": patch
+---
+
+Fixes invisible keyboard focus rings on the user menu, integration tiles, and project cards by using the existing neutral button focus token.

--- a/libs/client/app-shell/src/components/user-menu.test.tsx
+++ b/libs/client/app-shell/src/components/user-menu.test.tsx
@@ -32,7 +32,11 @@ describe('UserMenu', () => {
       </ThemeProvider>,
     );
 
-    fireEvent.pointerDown(screen.getByRole('button', {name: 'User menu'}), {
+    const trigger = screen.getByRole('button', {name: 'User menu'});
+    expect(trigger).toHaveClass('focus-visible:shadow-button-neutral-focus');
+    expect(trigger.className).not.toContain('shadow-button-secondary');
+
+    fireEvent.pointerDown(trigger, {
       button: 0,
       ctrlKey: false,
     });

--- a/libs/client/app-shell/src/components/user-menu.tsx
+++ b/libs/client/app-shell/src/components/user-menu.tsx
@@ -31,7 +31,7 @@ export function UserMenu() {
         <button
           type="button"
           aria-label="User menu"
-          className="rounded-full focus-visible:outline-none focus-visible:shadow-button-secondary-focus"
+          className="rounded-full focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
         >
           <Avatar size="sm" content="letters" fallback={email} />
         </button>

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -327,6 +327,8 @@ describe('IntegrationGallery — available section', () => {
 
     const link = await screen.findByRole('link', {name: 'Connect GitHub'});
 
+    expect(link).toHaveClass('focus-visible:shadow-button-neutral-focus');
+    expect(link.className).not.toContain('shadow-button-secondary');
     expect(within(link).queryByRole('button')).not.toBeInTheDocument();
   });
 

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -257,7 +257,7 @@ function AvailableCard({
       to={catalog.setupPath}
       params={{wid: workspaceId}}
       aria-label={`Connect ${provider.display_name}`}
-      className="group block h-full rounded-8 focus-visible:shadow-button-secondary-focus focus-visible:outline-none"
+      className="group block h-full rounded-8 focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
     >
       <Card className="h-full gap-8 p-16 transition-colors hover:bg-background-components-hover">
         <div className="flex min-w-0 items-center gap-12">

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -71,6 +71,10 @@ describe('ProjectsHubPage', () => {
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
     expect(await screen.findByText('Platform')).toBeInTheDocument();
+    const projectLink = screen.getByText('Platform').closest('a');
+    expect(projectLink).toHaveClass('focus-visible:shadow-button-neutral-focus');
+    expect(projectLink?.className).not.toContain('shadow-button-secondary');
+
     fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
 
     expect(await screen.findByText('API')).toBeInTheDocument();

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -181,7 +181,7 @@ function ProjectCard({project, workspaceId}: {project: ProjectResponseDto; works
       <Link
         to="/workspaces/$wid/projects/$pid"
         params={{wid: workspaceId, pid: project.id}}
-        className="block h-full rounded-8 focus-visible:outline-none focus-visible:shadow-button-secondary-focus"
+        className="block h-full rounded-8 focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
       >
         <Card className="p-20 h-full gap-12 hover:bg-background-components-hover transition-colors">
           <CardContent className="flex flex-col gap-8 p-0">


### PR DESCRIPTION
Fix invisible keyboard focus rings on project cards, integration tiles, and the user menu trigger.

These interactive surfaces removed the default outline but pointed at the non-existent `shadow-button-secondary-focus` token, leaving keyboard users without a visible focus state. This swaps them to the existing neutral button focus token and adds render-level regression assertions so the bad token does not come back.

Considered adding a secondary focus token, but the design system already defines `shadow-button-neutral-focus`, and PR #207 uses that same token for the nav logo fix. This keeps ENG-515 scoped to the remaining call sites.

Includes a patch changeset for the affected client packages.

Closes ENG-515

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix invisible keyboard focus rings on project cards, integration tiles, and the user menu by switching to the existing neutral focus token. Restores a clear focus state for keyboard users and adds tests to prevent regressions. Closes ENG-515.

- **Bug Fixes**
  - Replaced `focus-visible:shadow-button-secondary-focus` with `focus-visible:shadow-button-neutral-focus` on user menu, integration tiles, and project cards.
  - Added tests to assert the neutral focus class is present and the secondary token is not.
  - Published patch updates for `@shipfox/client-app-shell`, `@shipfox/client-integrations`, and `@shipfox/client-projects`.

<sup>Written for commit c0dd1f380c20ff7e763e1f0b884d8c219fca69bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

