### PR TITLE
[api/integration] Make adding an integration a one-file change

### DIFF
--- a/.changeset/calm-providers-compose.md
+++ b/.changeset/calm-providers-compose.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Restructures the integrations composition root so each provider owns its loader, adapter wiring, and migrations-table name in one file under `src/providers/`, registered through a single list; no behavior change.

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -1,10 +1,6 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import type {IntegrationConnection as CoreIntegrationConnection} from '@shipfox/api-integration-core-dto';
-import {createDebugIntegrationProvider} from '@shipfox/api-integration-debug';
-import type {ConnectGithubInstallationInput} from '@shipfox/api-integration-github';
-import type {ConnectSentryInstallationInput} from '@shipfox/api-integration-sentry';
-import type {ModuleDatabase, ModuleWorker, ShipfoxModule} from '@shipfox/node-module';
+import type {ShipfoxModule} from '@shipfox/node-module';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 import {
   createIntegrationProviderRegistry,
@@ -14,23 +10,15 @@ import {
   createSourceControlIntegrationService,
   type IntegrationSourceControlService,
 } from '#core/source-control-service.js';
-import {
-  getIntegrationConnectionById,
-  updateIntegrationConnectionLifecycleStatus,
-  upsertIntegrationConnection,
-} from '#db/connections.js';
+import {getIntegrationConnectionById} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
-import {
-  publishIntegrationEventReceived,
-  publishSourcePush,
-  recordDeliveryOnly,
-} from '#db/webhook-deliveries.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
+import {loadEnabledProviderModules} from '#providers/modules.js';
+import type {IntegrationModuleParts} from '#providers/types.js';
 import {createIntegrationsMaintenanceActivities} from '#temporal/activities/index.js';
 import {INTEGRATIONS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
-import {config} from './config.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const maintenanceWorkflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
@@ -107,177 +95,6 @@ export interface IntegrationsContext {
   sourceControl: IntegrationSourceControlService;
 }
 
-// Stable migration-tracking table names per provider database. These must NOT
-// depend on the provider's position in the module `database` array — a
-// positional name would shift if a provider is flag-disabled and silently
-// re-run migrations against existing tables.
-const GITHUB_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_github';
-const SENTRY_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_sentry';
-
-interface GithubModuleParts {
-  provider: IntegrationProvider;
-  database: ModuleDatabase;
-}
-
-interface SentryModuleParts {
-  provider: IntegrationProvider;
-  database: ModuleDatabase;
-  worker: ModuleWorker;
-}
-
-async function loadGithubModuleParts(): Promise<GithubModuleParts> {
-  const {
-    createGithubIntegrationProvider,
-    getGithubInstallationByInstallationId,
-    db: githubDb,
-    migrationsPath: githubMigrationsPath,
-    upsertGithubInstallation,
-  } = await import('@shipfox/api-integration-github');
-
-  async function getExistingGithubConnection(input: {
-    installationId: string;
-  }): Promise<CoreIntegrationConnection<'github'> | undefined> {
-    const installation = await getGithubInstallationByInstallationId(input.installationId);
-    if (!installation) return undefined;
-    const connection = await getIntegrationConnectionById(installation.connectionId);
-    if (!connection) return undefined;
-    return connection as CoreIntegrationConnection<'github'>;
-  }
-
-  async function connectGithubInstallation(
-    input: ConnectGithubInstallationInput,
-  ): Promise<CoreIntegrationConnection<'github'>> {
-    return await db().transaction(async (tx) => {
-      const connection = await upsertIntegrationConnection(
-        {
-          workspaceId: input.workspaceId,
-          provider: 'github',
-          externalAccountId: input.installationId,
-          displayName: input.displayName,
-          lifecycleStatus: 'active',
-        },
-        {tx},
-      );
-
-      await upsertGithubInstallation(
-        {
-          connectionId: connection.id,
-          ...input.installation,
-        },
-        {tx},
-      );
-
-      return connection as CoreIntegrationConnection<'github'>;
-    });
-  }
-
-  return {
-    provider: createGithubIntegrationProvider({
-      getExistingGithubConnection,
-      connectGithubInstallation,
-      publishSourcePush,
-      recordDeliveryOnly,
-      getIntegrationConnectionById,
-      coreDb: db,
-    }),
-    database: {db: githubDb, migrationsPath: githubMigrationsPath},
-  };
-}
-
-async function loadSentryModuleParts(): Promise<SentryModuleParts> {
-  const {
-    createSentryIntegrationProvider,
-    createSentryMaintenanceWorker,
-    getSentryInstallationByInstallationUuid,
-    persistVerifiedUnclaimedInstallation,
-    upsertSentryInstallation,
-    db: sentryDb,
-    migrationsPath: sentryMigrationsPath,
-  } = await import('@shipfox/api-integration-sentry');
-
-  async function getConnectionById(
-    id: string,
-  ): Promise<CoreIntegrationConnection<'sentry'> | undefined> {
-    const connection = await getIntegrationConnectionById(id);
-    if (!connection) return undefined;
-    return connection as CoreIntegrationConnection<'sentry'>;
-  }
-
-  async function connectSentryInstallation(
-    input: ConnectSentryInstallationInput,
-  ): Promise<CoreIntegrationConnection<'sentry'>> {
-    return await db().transaction(async (tx) => {
-      const connection = await upsertIntegrationConnection(
-        {
-          workspaceId: input.workspaceId,
-          provider: 'sentry',
-          externalAccountId: input.installationUuid,
-          displayName: input.displayName,
-          lifecycleStatus: 'active',
-        },
-        {tx},
-      );
-
-      // Promotes the verified-unclaimed row to claimed by setting connection_id.
-      await upsertSentryInstallation(
-        {
-          connectionId: connection.id,
-          installationUuid: input.installationUuid,
-          orgSlug: input.orgSlug,
-          status: 'installed',
-          codeHash: input.codeHash,
-          installerUserId: input.installerUserId,
-        },
-        {tx},
-      );
-
-      return connection as CoreIntegrationConnection<'sentry'>;
-    });
-  }
-
-  return {
-    provider: createSentryIntegrationProvider({
-      getSentryInstallation: ({installationUuid}) =>
-        getSentryInstallationByInstallationUuid(installationUuid),
-      getConnectionById,
-      connectSentryInstallation,
-      persistVerifiedUnclaimedInstallation,
-      coreDb: db,
-      publishIntegrationEventReceived,
-      recordDeliveryOnly,
-      getIntegrationConnectionById,
-      updateConnectionLifecycleStatus: updateIntegrationConnectionLifecycleStatus,
-    }),
-    database: {db: sentryDb, migrationsPath: sentryMigrationsPath},
-    worker: createSentryMaintenanceWorker(),
-  };
-}
-
-async function createConfiguredProviders(): Promise<{
-  providers: IntegrationProvider[];
-  github: GithubModuleParts | undefined;
-  sentry: SentryModuleParts | undefined;
-  workers: ModuleWorker[];
-}> {
-  const providers: IntegrationProvider[] = [];
-  const workers: ModuleWorker[] = [];
-  if (config.INTEGRATIONS_ENABLE_DEBUG_PROVIDER) {
-    providers.push(createDebugIntegrationProvider({upsertIntegrationConnection}));
-  }
-  let github: GithubModuleParts | undefined;
-  if (config.INTEGRATIONS_ENABLE_GITHUB_PROVIDER) {
-    github = await loadGithubModuleParts();
-    providers.push(github.provider);
-  }
-  let sentry: SentryModuleParts | undefined;
-  if (config.INTEGRATIONS_ENABLE_SENTRY_PROVIDER) {
-    sentry = await loadSentryModuleParts();
-    providers.push(sentry.provider);
-    workers.push(sentry.worker);
-  }
-  return {providers, github, sentry, workers};
-}
-
 export async function createIntegrationsModule(
   options: CreateIntegrationsModuleOptions = {},
 ): Promise<ShipfoxModule> {
@@ -287,17 +104,11 @@ export async function createIntegrationsModule(
 export async function createIntegrationsContext(
   options: CreateIntegrationsModuleOptions = {},
 ): Promise<IntegrationsContext> {
-  let providers: IntegrationProvider[];
-  let github: GithubModuleParts | undefined;
-  let sentry: SentryModuleParts | undefined;
-  let providerWorkers: ModuleWorker[] = [];
-  if (options.providers) {
-    providers = options.providers;
-  } else {
-    ({providers, github, sentry, workers: providerWorkers} = await createConfiguredProviders());
-  }
+  const parts: IntegrationModuleParts[] = options.providers
+    ? options.providers.map((provider) => ({provider}))
+    : await loadEnabledProviderModules();
 
-  const registry = createIntegrationProviderRegistry(providers);
+  const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
   const sourceControl = createSourceControlIntegrationService({
     registry,
     getIntegrationConnectionById,
@@ -307,8 +118,7 @@ export async function createIntegrationsContext(
     name: 'integrations',
     database: [
       {db, migrationsPath},
-      ...(github ? [{...github.database, migrationsTableName: GITHUB_MIGRATIONS_TABLE}] : []),
-      ...(sentry ? [{...sentry.database, migrationsTableName: SENTRY_MIGRATIONS_TABLE}] : []),
+      ...parts.flatMap((part) => (part.database ? [part.database] : [])),
     ],
     routes: createIntegrationRoutes(registry, sourceControl),
     publishers: [{name: 'integrations', table: integrationsOutbox, db}],
@@ -325,7 +135,7 @@ export async function createIntegrationsContext(
           },
         ],
       },
-      ...providerWorkers,
+      ...parts.flatMap((part) => part.workers ?? []),
     ],
   };
 

--- a/libs/api/integration/core/src/providers/debug.ts
+++ b/libs/api/integration/core/src/providers/debug.ts
@@ -1,0 +1,12 @@
+import {createDebugIntegrationProvider} from '@shipfox/api-integration-debug';
+import {config} from '#config.js';
+import {upsertIntegrationConnection} from '#db/connections.js';
+import type {IntegrationProviderModule} from '#providers/types.js';
+
+export const debugProviderModule: IntegrationProviderModule = {
+  id: 'debug',
+  enabled: config.INTEGRATIONS_ENABLE_DEBUG_PROVIDER,
+  load: async () => ({
+    provider: createDebugIntegrationProvider({upsertIntegrationConnection}),
+  }),
+};

--- a/libs/api/integration/core/src/providers/debug.ts
+++ b/libs/api/integration/core/src/providers/debug.ts
@@ -1,4 +1,3 @@
-import {createDebugIntegrationProvider} from '@shipfox/api-integration-debug';
 import {config} from '#config.js';
 import {upsertIntegrationConnection} from '#db/connections.js';
 import type {IntegrationProviderModule} from '#providers/types.js';
@@ -6,7 +5,8 @@ import type {IntegrationProviderModule} from '#providers/types.js';
 export const debugProviderModule: IntegrationProviderModule = {
   id: 'debug',
   enabled: config.INTEGRATIONS_ENABLE_DEBUG_PROVIDER,
-  load: async () => ({
-    provider: createDebugIntegrationProvider({upsertIntegrationConnection}),
-  }),
+  load: async () => {
+    const {createDebugIntegrationProvider} = await import('@shipfox/api-integration-debug');
+    return {provider: createDebugIntegrationProvider({upsertIntegrationConnection})};
+  },
 };

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -7,7 +7,7 @@ import {publishSourcePush, recordDeliveryOnly} from '#db/webhook-deliveries.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 // Stable migration-tracking table name for the GitHub provider database. This
-// must NOT depend on the provider's position in the module `database` array — a
+// must NOT depend on the provider's position in the module `database` array. A
 // positional name would shift if a provider is flag-disabled and silently
 // re-run migrations against existing tables.
 const GITHUB_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_github';

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -1,0 +1,82 @@
+import type {IntegrationConnection as CoreIntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {ConnectGithubInstallationInput} from '@shipfox/api-integration-github';
+import {config} from '#config.js';
+import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {publishSourcePush, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
+
+// Stable migration-tracking table name for the GitHub provider database. This
+// must NOT depend on the provider's position in the module `database` array — a
+// positional name would shift if a provider is flag-disabled and silently
+// re-run migrations against existing tables.
+const GITHUB_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_github';
+
+async function loadGithubModuleParts(): Promise<IntegrationModuleParts> {
+  const {
+    createGithubIntegrationProvider,
+    getGithubInstallationByInstallationId,
+    db: githubDb,
+    migrationsPath: githubMigrationsPath,
+    upsertGithubInstallation,
+  } = await import('@shipfox/api-integration-github');
+
+  async function getExistingGithubConnection(input: {
+    installationId: string;
+  }): Promise<CoreIntegrationConnection<'github'> | undefined> {
+    const installation = await getGithubInstallationByInstallationId(input.installationId);
+    if (!installation) return undefined;
+    const connection = await getIntegrationConnectionById(installation.connectionId);
+    if (!connection) return undefined;
+    return connection as CoreIntegrationConnection<'github'>;
+  }
+
+  async function connectGithubInstallation(
+    input: ConnectGithubInstallationInput,
+  ): Promise<CoreIntegrationConnection<'github'>> {
+    return await db().transaction(async (tx) => {
+      const connection = await upsertIntegrationConnection(
+        {
+          workspaceId: input.workspaceId,
+          provider: 'github',
+          externalAccountId: input.installationId,
+          displayName: input.displayName,
+          lifecycleStatus: 'active',
+        },
+        {tx},
+      );
+
+      await upsertGithubInstallation(
+        {
+          connectionId: connection.id,
+          ...input.installation,
+        },
+        {tx},
+      );
+
+      return connection as CoreIntegrationConnection<'github'>;
+    });
+  }
+
+  return {
+    provider: createGithubIntegrationProvider({
+      getExistingGithubConnection,
+      connectGithubInstallation,
+      publishSourcePush,
+      recordDeliveryOnly,
+      getIntegrationConnectionById,
+      coreDb: db,
+    }),
+    database: {
+      db: githubDb,
+      migrationsPath: githubMigrationsPath,
+      migrationsTableName: GITHUB_MIGRATIONS_TABLE,
+    },
+  };
+}
+
+export const githubProviderModule: IntegrationProviderModule = {
+  id: 'github',
+  enabled: config.INTEGRATIONS_ENABLE_GITHUB_PROVIDER,
+  load: loadGithubModuleParts,
+};

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -1,0 +1,21 @@
+import {debugProviderModule} from '#providers/debug.js';
+import {githubProviderModule} from '#providers/github.js';
+import {sentryProviderModule} from '#providers/sentry.js';
+import type {IntegrationModuleParts} from '#providers/types.js';
+
+/**
+ * Every integration the core module can compose. To add a provider, add its
+ * file under `#providers/` and append it here — nothing else in this package
+ * needs to change. Order is significant: databases are migrated in this order,
+ * so list a provider before any that depend on its tables.
+ */
+const providerModules = [debugProviderModule, githubProviderModule, sentryProviderModule];
+
+export async function loadEnabledProviderModules(): Promise<IntegrationModuleParts[]> {
+  const parts: IntegrationModuleParts[] = [];
+  for (const module of providerModules) {
+    if (!module.enabled) continue;
+    parts.push(await module.load());
+  }
+  return parts;
+}

--- a/libs/api/integration/core/src/providers/sentry.ts
+++ b/libs/api/integration/core/src/providers/sentry.ts
@@ -1,0 +1,96 @@
+import type {IntegrationConnection as CoreIntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {ConnectSentryInstallationInput} from '@shipfox/api-integration-sentry';
+import {config} from '#config.js';
+import {
+  getIntegrationConnectionById,
+  updateIntegrationConnectionLifecycleStatus,
+  upsertIntegrationConnection,
+} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
+
+// Stable migration-tracking table name for the Sentry provider database. This
+// must NOT depend on the provider's position in the module `database` array — a
+// positional name would shift if a provider is flag-disabled and silently
+// re-run migrations against existing tables.
+const SENTRY_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_sentry';
+
+async function loadSentryModuleParts(): Promise<IntegrationModuleParts> {
+  const {
+    createSentryIntegrationProvider,
+    createSentryMaintenanceWorker,
+    getSentryInstallationByInstallationUuid,
+    persistVerifiedUnclaimedInstallation,
+    upsertSentryInstallation,
+    db: sentryDb,
+    migrationsPath: sentryMigrationsPath,
+  } = await import('@shipfox/api-integration-sentry');
+
+  async function getConnectionById(
+    id: string,
+  ): Promise<CoreIntegrationConnection<'sentry'> | undefined> {
+    const connection = await getIntegrationConnectionById(id);
+    if (!connection) return undefined;
+    return connection as CoreIntegrationConnection<'sentry'>;
+  }
+
+  async function connectSentryInstallation(
+    input: ConnectSentryInstallationInput,
+  ): Promise<CoreIntegrationConnection<'sentry'>> {
+    return await db().transaction(async (tx) => {
+      const connection = await upsertIntegrationConnection(
+        {
+          workspaceId: input.workspaceId,
+          provider: 'sentry',
+          externalAccountId: input.installationUuid,
+          displayName: input.displayName,
+          lifecycleStatus: 'active',
+        },
+        {tx},
+      );
+
+      // Promotes the verified-unclaimed row to claimed by setting connection_id.
+      await upsertSentryInstallation(
+        {
+          connectionId: connection.id,
+          installationUuid: input.installationUuid,
+          orgSlug: input.orgSlug,
+          status: 'installed',
+          codeHash: input.codeHash,
+          installerUserId: input.installerUserId,
+        },
+        {tx},
+      );
+
+      return connection as CoreIntegrationConnection<'sentry'>;
+    });
+  }
+
+  return {
+    provider: createSentryIntegrationProvider({
+      getSentryInstallation: ({installationUuid}) =>
+        getSentryInstallationByInstallationUuid(installationUuid),
+      getConnectionById,
+      connectSentryInstallation,
+      persistVerifiedUnclaimedInstallation,
+      coreDb: db,
+      publishIntegrationEventReceived,
+      recordDeliveryOnly,
+      getIntegrationConnectionById,
+      updateConnectionLifecycleStatus: updateIntegrationConnectionLifecycleStatus,
+    }),
+    database: {
+      db: sentryDb,
+      migrationsPath: sentryMigrationsPath,
+      migrationsTableName: SENTRY_MIGRATIONS_TABLE,
+    },
+    workers: [createSentryMaintenanceWorker()],
+  };
+}
+
+export const sentryProviderModule: IntegrationProviderModule = {
+  id: 'sentry',
+  enabled: config.INTEGRATIONS_ENABLE_SENTRY_PROVIDER,
+  load: loadSentryModuleParts,
+};

--- a/libs/api/integration/core/src/providers/sentry.ts
+++ b/libs/api/integration/core/src/providers/sentry.ts
@@ -11,7 +11,7 @@ import {publishIntegrationEventReceived, recordDeliveryOnly} from '#db/webhook-d
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 // Stable migration-tracking table name for the Sentry provider database. This
-// must NOT depend on the provider's position in the module `database` array — a
+// must NOT depend on the provider's position in the module `database` array. A
 // positional name would shift if a provider is flag-disabled and silently
 // re-run migrations against existing tables.
 const SENTRY_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_sentry';

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -1,0 +1,24 @@
+import type {ModuleDatabase, ModuleWorker} from '@shipfox/node-module';
+import type {IntegrationProvider} from '#core/entities/provider.js';
+
+/**
+ * Everything one integration contributes to the composed integrations module:
+ * a registry provider, plus an optional dedicated database and background
+ * workers. Providers that own no database or workers simply omit them.
+ */
+export interface IntegrationModuleParts {
+  provider: IntegrationProvider;
+  database?: ModuleDatabase | undefined;
+  workers?: ModuleWorker[] | undefined;
+}
+
+/**
+ * A config-gated integration, registered once in `providerModules`. `load` is
+ * called lazily and only when `enabled`, so a disabled provider never imports
+ * its (potentially heavy) implementation package.
+ */
+export interface IntegrationProviderModule {
+  id: string;
+  enabled: boolean;
+  load(): Promise<IntegrationModuleParts>;
+}


### PR DESCRIPTION
Restructures the integrations composition root (`libs/api/integration/core/src/index.ts`) so adding a new integration is a one-file change instead of edits scattered across the file.

## Why

Each provider previously needed its own `*ModuleParts` interface, `load*` function, migrations-table constant, config-flag branch, and `database`/`workers` wiring — all interleaved in `index.ts`. Adding an integration meant touching ~6 places, and the file grew with every provider.

## What changed

- Introduces a uniform `IntegrationModuleParts` shape and an `IntegrationProviderModule` descriptor (`{id, enabled, load()}`) in `src/providers/types.ts`.
- Moves each provider's lazy loader, adapter-wiring closures, and its own `__drizzle_migrations_*` table name into its own file: `src/providers/{debug,github,sentry}.ts`. The migrations-table name now sits next to the database it tracks, with its explanatory comment.
- A single `providerModules` list in `src/providers/modules.ts` is the only registration point.
- `createIntegrationsContext` maps the parts generically (`flatMap` over `database`/`workers`), so `index.ts` no longer grows as integrations are added (334 -> ~140 lines).

To add a provider now: create `src/providers/foo.ts` and append `fooProviderModule` to the list.

No behavior change: the `options.providers` test path, lazy `import()` of disabled providers, stable migration table names, and database/worker ordering are all preserved. Type-check, lint, build, and all 48 package tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructured the integrations composition so each provider owns its loader and wiring in one file, registered via a single list. Adding a new integration is now a one-file change; runtime behavior stays the same.

- **Refactors**
  - Added `IntegrationModuleParts` and `IntegrationProviderModule` in `src/providers/types.ts`.
  - Moved GitHub, Sentry, and Debug loaders and migration-table names to `src/providers/{github,sentry,debug}.ts`.
  - Added `src/providers/modules.ts` to register providers and lazy-load only those enabled; the debug provider now uses dynamic import.
  - `createIntegrationsContext` composes `provider`, `database`, and `workers` generically; `index.ts` shrinks.
  - Preserved stable migration table names, provider ordering, and the `options.providers` path.
  - Standardized migration-table comments to match project style (no em dashes).

- **Migration**
  - To add a provider: create `src/providers/<name>.ts` and append its module to the list in `src/providers/modules.ts`.

<sup>Written for commit a876b8da68efce805e769ecef0a8bbcf769b0462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

