### PR TITLE
Type the event-to-payload match for outbox subscribers

### DIFF
--- a/.changeset/spry-falcons-gather.md
+++ b/.changeset/spry-falcons-gather.md
@@ -5,6 +5,7 @@
 "@shipfox/api-definitions": patch
 "@shipfox/api-projects": patch
 "@shipfox/api-runners": patch
+"@shipfox/api-logs": patch
 ---
 
 Adds a typed `subscriberFactory` that binds each outbox event name to its payload type at construction, so subscriber handlers receive a typed `(payload, event)` and the per-handler `event.payload as X` casts are gone; a private brand makes the factory the only way to build a module subscriber.

--- a/.changeset/spry-falcons-gather.md
+++ b/.changeset/spry-falcons-gather.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/node-module": minor
+"@shipfox/api-triggers": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-definitions": patch
+"@shipfox/api-projects": patch
+"@shipfox/api-runners": patch
+---
+
+Adds a typed `subscriberFactory` that binds each outbox event name to its payload type at construction, so subscriber handlers receive a typed `(payload, event)` and the per-handler `event.payload as X` casts are gone; a private brand makes the factory the only way to build a module subscriber.

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -1,9 +1,13 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {DEFINITION_RESOLVED} from '@shipfox/api-definitions-dto';
+import {DEFINITION_RESOLVED, type DefinitionsEventMap} from '@shipfox/api-definitions-dto';
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {PROJECT_SOURCE_BOUND, PROJECT_SOURCE_COMMIT_OBSERVED} from '@shipfox/api-projects-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {
+  PROJECT_SOURCE_BOUND,
+  PROJECT_SOURCE_COMMIT_OBSERVED,
+  type ProjectsEventMap,
+} from '@shipfox/api-projects-dto';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {db, definitionsOutbox, migrationsPath} from '#db/index.js';
 import {routes} from '#presentation/index.js';
@@ -25,6 +29,8 @@ export {routes} from '#presentation/index.js';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
+const subscriber = subscriberFactory<DefinitionsEventMap & ProjectsEventMap>();
+
 export interface CreateDefinitionsModuleOptions {
   sourceControl: IntegrationSourceControlService;
 }
@@ -38,15 +44,12 @@ export function createDefinitionsModule({
     routes,
     publishers: [{name: 'definitions', table: definitionsOutbox, db}],
     subscribers: [
-      {
-        event: DEFINITION_RESOLVED,
-        handler: (event) => {
-          logger().info({event}, 'Definition resolved');
-          return Promise.resolve();
-        },
-      },
-      {event: PROJECT_SOURCE_BOUND, handler: onProjectSourceBound},
-      {event: PROJECT_SOURCE_COMMIT_OBSERVED, handler: onProjectSourceCommitObserved},
+      subscriber(DEFINITION_RESOLVED, (_payload, event) => {
+        logger().info({event}, 'Definition resolved');
+        return Promise.resolve();
+      }),
+      subscriber(PROJECT_SOURCE_BOUND, onProjectSourceBound),
+      subscriber(PROJECT_SOURCE_COMMIT_OBSERVED, onProjectSourceCommitObserved),
     ],
     workers: [
       {

--- a/libs/api/definitions/src/presentation/subscribers/on-project-source-bound.test.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-project-source-bound.test.ts
@@ -1,5 +1,4 @@
 import type {ProjectSourceBoundEvent} from '@shipfox/api-projects-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {onProjectSourceBound} from './on-project-source-bound.js';
 
 const startMock = vi.fn();
@@ -23,15 +22,6 @@ function buildPayload(): ProjectSourceBoundEvent {
   };
 }
 
-function buildEvent(payload: ProjectSourceBoundEvent): DomainEvent {
-  return {
-    id: crypto.randomUUID(),
-    type: 'projects.project.source_bound',
-    createdAt: new Date(),
-    payload,
-  };
-}
-
 describe('onProjectSourceBound', () => {
   beforeEach(() => {
     startMock.mockReset();
@@ -41,7 +31,7 @@ describe('onProjectSourceBound', () => {
   it('starts a definition sync workflow keyed on project + bind', async () => {
     const payload = buildPayload();
 
-    const result = onProjectSourceBound(buildEvent(payload));
+    const result = onProjectSourceBound(payload);
     await result;
 
     expect(startMock).toHaveBeenCalledTimes(1);
@@ -68,7 +58,7 @@ describe('onProjectSourceBound', () => {
     startMock.mockRejectedValueOnce(failure);
     const payload = buildPayload();
 
-    const result = onProjectSourceBound(buildEvent(payload));
+    const result = onProjectSourceBound(payload);
 
     await expect(result).rejects.toBe(failure);
   });

--- a/libs/api/definitions/src/presentation/subscribers/on-project-source-bound.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-project-source-bound.ts
@@ -1,9 +1,7 @@
 import type {ProjectSourceBoundEvent} from '@shipfox/api-projects-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {startDefinitionSync} from './start-definition-sync.js';
 
-export async function onProjectSourceBound(event: DomainEvent): Promise<void> {
-  const payload = event.payload as ProjectSourceBoundEvent;
+export async function onProjectSourceBound(payload: ProjectSourceBoundEvent): Promise<void> {
   await startDefinitionSync({
     projectId: payload.projectId,
     workspaceId: payload.workspaceId,

--- a/libs/api/definitions/src/presentation/subscribers/on-project-source-commit-observed.test.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-project-source-commit-observed.test.ts
@@ -1,5 +1,4 @@
 import type {ProjectSourceCommitObservedEvent} from '@shipfox/api-projects-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {onProjectSourceCommitObserved} from './on-project-source-commit-observed.js';
 
 const startMock = vi.fn();
@@ -24,15 +23,6 @@ function buildPayload(): ProjectSourceCommitObservedEvent {
   };
 }
 
-function buildEvent(payload: ProjectSourceCommitObservedEvent): DomainEvent {
-  return {
-    id: crypto.randomUUID(),
-    type: 'projects.project.source_commit_observed',
-    createdAt: new Date(),
-    payload,
-  };
-}
-
 describe('onProjectSourceCommitObserved', () => {
   beforeEach(() => {
     startMock.mockReset();
@@ -42,7 +32,7 @@ describe('onProjectSourceCommitObserved', () => {
   it('starts a definition sync workflow keyed on project + source commit sha', async () => {
     const payload = buildPayload();
 
-    const result = onProjectSourceCommitObserved(buildEvent(payload));
+    const result = onProjectSourceCommitObserved(payload);
     await result;
 
     expect(startMock).toHaveBeenCalledTimes(1);

--- a/libs/api/definitions/src/presentation/subscribers/on-project-source-commit-observed.ts
+++ b/libs/api/definitions/src/presentation/subscribers/on-project-source-commit-observed.ts
@@ -1,9 +1,9 @@
 import type {ProjectSourceCommitObservedEvent} from '@shipfox/api-projects-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {startDefinitionSync} from './start-definition-sync.js';
 
-export async function onProjectSourceCommitObserved(event: DomainEvent): Promise<void> {
-  const payload = event.payload as ProjectSourceCommitObservedEvent;
+export async function onProjectSourceCommitObserved(
+  payload: ProjectSourceCommitObservedEvent,
+): Promise<void> {
   await startDefinitionSync({
     projectId: payload.projectId,
     workspaceId: payload.workspaceId,

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -1,7 +1,7 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {WORKFLOWS_JOB_TERMINATED} from '@shipfox/api-workflows-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {WORKFLOWS_JOB_TERMINATED, type WorkflowsEventMap} from '@shipfox/api-workflows-dto';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, logsOutbox, migrationsPath} from '#db/index.js';
 import {logsRoutes} from '#presentation/routes/index.js';
 import {onJobTerminated} from '#presentation/subscribers/on-job-terminated.js';
@@ -13,6 +13,8 @@ export {checkBucketReachable} from '#api/object-storage.js';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
+const subscriber = subscriberFactory<WorkflowsEventMap>();
+
 export const logsModule: ShipfoxModule = {
   name: 'logs',
   database: {db, migrationsPath},
@@ -20,7 +22,7 @@ export const logsModule: ShipfoxModule = {
   // `logs.stream.closed` is written by the close paths (drives compaction). The
   // job-terminated subscriber force-closes streams the runner never ended.
   publishers: [{name: 'logs', table: logsOutbox, db}],
-  subscribers: [{event: WORKFLOWS_JOB_TERMINATED, handler: onJobTerminated}],
+  subscribers: [subscriber(WORKFLOWS_JOB_TERMINATED, onJobTerminated)],
   workers: [
     {
       taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
@@ -1,5 +1,4 @@
 import type {WorkflowsJobTerminatedEvent} from '@shipfox/api-workflows-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {config} from '#config.js';
 import {LOGS_LIFECYCLE_TASK_QUEUE} from '#temporal/constants.js';
 import {onJobTerminated} from './on-job-terminated.js';
@@ -14,17 +13,11 @@ vi.mock('@shipfox/node-temporal', () => ({
   }),
 }));
 
-function buildEvent(jobId: string): DomainEvent {
-  const payload: WorkflowsJobTerminatedEvent = {
+function buildPayload(jobId: string): WorkflowsJobTerminatedEvent {
+  return {
     jobId,
     runId: crypto.randomUUID(),
     status: 'failed',
-  };
-  return {
-    id: crypto.randomUUID(),
-    type: 'workflows.job.terminated',
-    createdAt: new Date(),
-    payload,
   };
 }
 
@@ -43,7 +36,7 @@ describe('onJobTerminated', () => {
   it('arms the close-abandoned-streams workflow keyed on the job id', async () => {
     const jobId = crypto.randomUUID();
 
-    await onJobTerminated(buildEvent(jobId));
+    await onJobTerminated(buildPayload(jobId));
 
     expect(startMock).toHaveBeenCalledTimes(1);
     expect(startMock).toHaveBeenCalledWith('closeAbandonedStreams', {
@@ -56,13 +49,13 @@ describe('onJobTerminated', () => {
   it('swallows a redelivered event when the workflow is already started', async () => {
     startMock.mockRejectedValue(alreadyStartedError());
 
-    await expect(onJobTerminated(buildEvent(crypto.randomUUID()))).resolves.toBeUndefined();
+    await expect(onJobTerminated(buildPayload(crypto.randomUUID()))).resolves.toBeUndefined();
   });
 
   it('re-throws an unexpected start failure so the outbox retries delivery', async () => {
     startMock.mockRejectedValue(new Error('temporal unreachable'));
 
-    await expect(onJobTerminated(buildEvent(crypto.randomUUID()))).rejects.toThrow(
+    await expect(onJobTerminated(buildPayload(crypto.randomUUID()))).rejects.toThrow(
       'temporal unreachable',
     );
   });

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
@@ -1,6 +1,5 @@
 import type {WorkflowsJobTerminatedEvent} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {temporalClient} from '@shipfox/node-temporal';
 import {config} from '#config.js';
 import {LOGS_LIFECYCLE_TASK_QUEUE} from '#temporal/constants.js';
@@ -10,9 +9,7 @@ import {LOGS_LIFECYCLE_TASK_QUEUE} from '#temporal/constants.js';
  * timeout). Arm the grace-then-close workflow for any of its streams the runner never
  * ended itself. Deduped by workflow id, so a redelivered event is a no-op.
  */
-export async function onJobTerminated(event: DomainEvent): Promise<void> {
-  const payload = event.payload as WorkflowsJobTerminatedEvent;
-
+export async function onJobTerminated(payload: WorkflowsJobTerminatedEvent): Promise<void> {
   try {
     await temporalClient().workflow.start('closeAbandonedStreams', {
       taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -1,8 +1,11 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
-import {INTEGRATION_SOURCE_COMMIT_PUSHED} from '@shipfox/api-integration-core-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {
+  INTEGRATION_SOURCE_COMMIT_PUSHED,
+  type IntegrationsEventMap,
+} from '@shipfox/api-integration-core-dto';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, projectsOutbox} from '#db/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
 import {onSourceCommitPushed} from '#presentation/subscribers/index.js';
@@ -11,6 +14,8 @@ import {PROJECTS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const maintenanceWorkflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
+
+const subscriber = subscriberFactory<IntegrationsEventMap>();
 
 export type {Project} from '#core/index.js';
 export {
@@ -42,7 +47,7 @@ export function createProjectsModule({sourceControl}: CreateProjectsModuleOption
     database: {db, migrationsPath},
     routes: createProjectRoutes(sourceControl),
     publishers: [{name: 'projects', table: projectsOutbox, db}],
-    subscribers: [{event: INTEGRATION_SOURCE_COMMIT_PUSHED, handler: onSourceCommitPushed}],
+    subscribers: [subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed)],
     workers: [
       {
         taskQueue: PROJECTS_MAINTENANCE_TASK_QUEUE,

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
@@ -27,7 +27,7 @@ function buildEvent(
   overrides: Partial<IntegrationSourceCommitPushedEvent> = {},
   pushOverrides: Partial<SourcePushPayload> = {},
   id = crypto.randomUUID(),
-): DomainEvent {
+): DomainEvent<IntegrationSourceCommitPushedEvent> {
   return {
     id,
     type: INTEGRATION_SOURCE_COMMIT_PUSHED,
@@ -71,7 +71,7 @@ describe('onSourceCommitPushed', () => {
       {externalRepositoryId},
     );
 
-    await onSourceCommitPushed(event);
+    await onSourceCommitPushed(event.payload, event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(1);
@@ -100,7 +100,7 @@ describe('onSourceCommitPushed', () => {
       {externalRepositoryId, ref: 'feature/x', isDefaultBranch: false},
     );
 
-    await onSourceCommitPushed(event);
+    await onSourceCommitPushed(event.payload, event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(0);
@@ -110,7 +110,7 @@ describe('onSourceCommitPushed', () => {
     const externalRepositoryId = `github:${crypto.randomUUID()}`;
     const event = buildEvent({}, {externalRepositoryId});
 
-    await onSourceCommitPushed(event);
+    await onSourceCommitPushed(event.payload, event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(0);
@@ -130,8 +130,8 @@ describe('onSourceCommitPushed', () => {
       {externalRepositoryId},
     );
 
-    await onSourceCommitPushed(event);
-    await onSourceCommitPushed(event);
+    await onSourceCommitPushed(event.payload, event);
+    await onSourceCommitPushed(event.payload, event);
 
     const rows = await listCommitObservedEvents(externalRepositoryId);
     expect(rows).toHaveLength(1);

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.ts
@@ -7,9 +7,11 @@ import {recordIntegrationEventForProject} from '#db/integration-event-dedup.js';
 import {getProjectBySource} from '#db/projects.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
 
-export async function onSourceCommitPushed(event: DomainEvent): Promise<void> {
-  const {provider, workspaceId, connectionId, push} =
-    event.payload as IntegrationSourceCommitPushedEvent;
+export async function onSourceCommitPushed(
+  payload: IntegrationSourceCommitPushedEvent,
+  event: DomainEvent<IntegrationSourceCommitPushedEvent>,
+): Promise<void> {
+  const {provider, workspaceId, connectionId, push} = payload;
 
   // Projects only track the default branch; other branches are someone else's policy.
   if (!push.isDefaultBranch) {

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -1,7 +1,7 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {WORKFLOWS_JOB_TIMED_OUT} from '@shipfox/api-workflows-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {WORKFLOWS_JOB_TIMED_OUT, type WorkflowsEventMap} from '@shipfox/api-workflows-dto';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, runnersOutbox} from '#db/index.js';
 import {createRunnerTokenAuthMethod, onWorkflowsJobTimedOut, routes} from '#presentation/index.js';
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
@@ -12,13 +12,15 @@ export {releaseJob, type ScheduleJobParams, scheduleJob} from '#db/index.js';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
+const subscriber = subscriberFactory<WorkflowsEventMap>();
+
 export const runnersModule: ShipfoxModule = {
   name: 'runners',
   database: {db, migrationsPath},
   auth: [createRunnerTokenAuthMethod()],
   routes,
   publishers: [{name: 'runners', table: runnersOutbox, db}],
-  subscribers: [{event: WORKFLOWS_JOB_TIMED_OUT, handler: onWorkflowsJobTimedOut}],
+  subscribers: [subscriber(WORKFLOWS_JOB_TIMED_OUT, onWorkflowsJobTimedOut)],
   workers: [
     {
       taskQueue: RUNNERS_MAINTENANCE_TASK_QUEUE,

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
@@ -1,5 +1,4 @@
-import {WORKFLOWS_JOB_TIMED_OUT} from '@shipfox/api-workflows-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
+import type {WorkflowsJobTimedOutEvent} from '@shipfox/api-workflows-dto';
 import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {claimPendingJob} from '#db/jobs.js';
@@ -7,13 +6,8 @@ import {runningJobs} from '#db/schema/running-jobs.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {onWorkflowsJobTimedOut} from './on-workflows-job-timed-out.js';
 
-function buildEvent(jobId: string, runId: string): DomainEvent {
-  return {
-    id: crypto.randomUUID(),
-    type: WORKFLOWS_JOB_TIMED_OUT,
-    payload: {jobId, runId},
-    createdAt: new Date(),
-  };
+function buildPayload(jobId: string, runId: string): WorkflowsJobTimedOutEvent {
+  return {jobId, runId};
 }
 
 describe('onWorkflowsJobTimedOut', () => {
@@ -31,7 +25,7 @@ describe('onWorkflowsJobTimedOut', () => {
     const claimed = await claimPendingJob({workspaceId, runnerTokenId});
     expect(claimed).not.toBeNull();
 
-    await onWorkflowsJobTimedOut(buildEvent(claimed?.jobId as string, claimed?.runId as string));
+    await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
 
     const rows = await db()
       .select()
@@ -44,7 +38,7 @@ describe('onWorkflowsJobTimedOut', () => {
     await pendingJobFactory.create({workspaceId});
     const claimed = await claimPendingJob({workspaceId, runnerTokenId});
 
-    await onWorkflowsJobTimedOut(buildEvent(claimed?.jobId as string, claimed?.runId as string));
+    await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
     const after1 = await db()
       .select()
       .from(runningJobs)
@@ -52,7 +46,7 @@ describe('onWorkflowsJobTimedOut', () => {
     const firstTs = after1[0]?.cancellationRequestedAt;
 
     await new Promise((r) => setTimeout(r, 10));
-    await onWorkflowsJobTimedOut(buildEvent(claimed?.jobId as string, claimed?.runId as string));
+    await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
 
     const after2 = await db()
       .select()
@@ -64,7 +58,7 @@ describe('onWorkflowsJobTimedOut', () => {
   it('no-op when the running_jobs row is gone (already finalized)', async () => {
     // Row was finalized by another path before the event reached us.
     await expect(
-      onWorkflowsJobTimedOut(buildEvent(crypto.randomUUID(), crypto.randomUUID())),
+      onWorkflowsJobTimedOut(buildPayload(crypto.randomUUID(), crypto.randomUUID())),
     ).resolves.toBeUndefined();
   });
 });

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.ts
@@ -1,10 +1,8 @@
 import type {WorkflowsJobTimedOutEvent} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {requestJobCancellation} from '#db/jobs.js';
 
-export async function onWorkflowsJobTimedOut(event: DomainEvent): Promise<void> {
-  const payload = event.payload as WorkflowsJobTimedOutEvent;
+export async function onWorkflowsJobTimedOut(payload: WorkflowsJobTimedOutEvent): Promise<void> {
   logger().info({jobId: payload.jobId}, 'Requesting runner cancellation for timed-out job');
   await requestJobCancellation({jobId: payload.jobId});
 }

--- a/libs/api/triggers/src/index.ts
+++ b/libs/api/triggers/src/index.ts
@@ -1,6 +1,13 @@
-import {DEFINITION_DELETED, DEFINITION_RESOLVED} from '@shipfox/api-definitions-dto';
-import {INTEGRATION_EVENT_RECEIVED} from '@shipfox/api-integration-core-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {
+  DEFINITION_DELETED,
+  DEFINITION_RESOLVED,
+  type DefinitionsEventMap,
+} from '@shipfox/api-definitions-dto';
+import {
+  INTEGRATION_EVENT_RECEIVED,
+  type IntegrationsEventMap,
+} from '@shipfox/api-integration-core-dto';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, triggersOutbox} from '#db/index.js';
 import {routes} from '#presentation/index.js';
 import {
@@ -27,14 +34,16 @@ export {
   triggersOutbox,
 } from '#db/index.js';
 
+const subscriber = subscriberFactory<DefinitionsEventMap & IntegrationsEventMap>();
+
 export const triggersModule: ShipfoxModule = {
   name: 'triggers',
   database: {db, migrationsPath},
   routes,
   publishers: [{name: 'triggers', table: triggersOutbox, db}],
   subscribers: [
-    {event: DEFINITION_RESOLVED, handler: onDefinitionResolved},
-    {event: DEFINITION_DELETED, handler: onDefinitionDeleted},
-    {event: INTEGRATION_EVENT_RECEIVED, handler: onIntegrationEventReceived},
+    subscriber(DEFINITION_RESOLVED, onDefinitionResolved),
+    subscriber(DEFINITION_DELETED, onDefinitionDeleted),
+    subscriber(INTEGRATION_EVENT_RECEIVED, onIntegrationEventReceived),
   ],
 };

--- a/libs/api/triggers/src/presentation/subscribers/on-definition-deleted.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-definition-deleted.test.ts
@@ -1,0 +1,42 @@
+import type {DefinitionDeletedEvent} from '@shipfox/api-definitions-dto';
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {triggerSubscriptions} from '#db/schema/subscriptions.js';
+import {triggerSubscriptionFactory} from '#test/index.js';
+import {onDefinitionDeleted} from './on-definition-deleted.js';
+
+function buildPayload(definitionId: string): DefinitionDeletedEvent {
+  return {definitionId, projectId: crypto.randomUUID(), workspaceId: crypto.randomUUID()};
+}
+
+function listSubscriptions(workflowDefinitionId: string) {
+  return db()
+    .select()
+    .from(triggerSubscriptions)
+    .where(eq(triggerSubscriptions.workflowDefinitionId, workflowDefinitionId));
+}
+
+describe('onDefinitionDeleted', () => {
+  it('deletes every subscription for the definition', async () => {
+    const definitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workflowDefinitionId: definitionId, name: 'a'});
+    await triggerSubscriptionFactory.create({workflowDefinitionId: definitionId, name: 'b'});
+
+    await onDefinitionDeleted(buildPayload(definitionId));
+
+    const rows = await listSubscriptions(definitionId);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('leaves subscriptions for other definitions untouched', async () => {
+    const deletedId = crypto.randomUUID();
+    const keptId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workflowDefinitionId: deletedId, name: 'a'});
+    const kept = await triggerSubscriptionFactory.create({workflowDefinitionId: keptId, name: 'a'});
+
+    await onDefinitionDeleted(buildPayload(deletedId));
+
+    const rows = await listSubscriptions(keptId);
+    expect(rows.map((r) => r.id)).toEqual([kept.id]);
+  });
+});

--- a/libs/api/triggers/src/presentation/subscribers/on-definition-deleted.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-definition-deleted.ts
@@ -1,8 +1,6 @@
 import type {DefinitionDeletedEvent} from '@shipfox/api-definitions-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {deleteSubscriptionsForDefinition} from '#db/subscriptions.js';
 
-export async function onDefinitionDeleted(event: DomainEvent): Promise<void> {
-  const payload = event.payload as DefinitionDeletedEvent;
+export async function onDefinitionDeleted(payload: DefinitionDeletedEvent): Promise<void> {
   await deleteSubscriptionsForDefinition({workflowDefinitionId: payload.definitionId});
 }

--- a/libs/api/triggers/src/presentation/subscribers/on-definition-resolved.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-definition-resolved.test.ts
@@ -1,0 +1,67 @@
+import type {DefinitionResolvedEvent} from '@shipfox/api-definitions-dto';
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {triggerSubscriptions} from '#db/schema/subscriptions.js';
+import {triggerSubscriptionFactory} from '#test/index.js';
+import {onDefinitionResolved} from './on-definition-resolved.js';
+
+function buildPayload(overrides: Partial<DefinitionResolvedEvent> = {}): DefinitionResolvedEvent {
+  return {
+    definitionId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    configPath: '.shipfox/workflow.yml',
+    triggers: {onPush: {source: 'github', event: 'push'}},
+    ...overrides,
+  };
+}
+
+function listSubscriptions(workflowDefinitionId: string) {
+  return db()
+    .select()
+    .from(triggerSubscriptions)
+    .where(eq(triggerSubscriptions.workflowDefinitionId, workflowDefinitionId));
+}
+
+describe('onDefinitionResolved', () => {
+  it('persists a subscription for each declared trigger', async () => {
+    const payload = buildPayload({
+      triggers: {
+        onPush: {source: 'github', event: 'push', with: {env: 'staging'}},
+        onManual: {source: 'manual', event: 'fire'},
+      },
+    });
+
+    await onDefinitionResolved(payload);
+
+    const rows = await listSubscriptions(payload.definitionId);
+    expect(rows.map((r) => r.name).sort()).toEqual(['onManual', 'onPush']);
+    expect(rows.find((r) => r.name === 'onPush')?.config).toEqual({with: {env: 'staging'}});
+  });
+
+  it('removes subscriptions whose trigger is no longer declared', async () => {
+    const workflowDefinitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workflowDefinitionId, name: 'onPush'});
+    await triggerSubscriptionFactory.create({workflowDefinitionId, name: 'stale'});
+
+    await onDefinitionResolved(
+      buildPayload({
+        definitionId: workflowDefinitionId,
+        triggers: {onPush: {source: 'github', event: 'push'}},
+      }),
+    );
+
+    const rows = await listSubscriptions(workflowDefinitionId);
+    expect(rows.map((r) => r.name)).toEqual(['onPush']);
+  });
+
+  it('clears every subscription when the definition declares no triggers', async () => {
+    const workflowDefinitionId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({workflowDefinitionId, name: 'onPush'});
+
+    await onDefinitionResolved(buildPayload({definitionId: workflowDefinitionId, triggers: {}}));
+
+    const rows = await listSubscriptions(workflowDefinitionId);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/libs/api/triggers/src/presentation/subscribers/on-definition-resolved.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-definition-resolved.ts
@@ -1,10 +1,7 @@
 import type {DefinitionResolvedEvent} from '@shipfox/api-definitions-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {projectDefinitionTriggers} from '#db/subscriptions.js';
 
-export async function onDefinitionResolved(event: DomainEvent): Promise<void> {
-  const payload = event.payload as DefinitionResolvedEvent;
-
+export async function onDefinitionResolved(payload: DefinitionResolvedEvent): Promise<void> {
   await projectDefinitionTriggers({
     workspaceId: payload.workspaceId,
     projectId: payload.projectId,

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
@@ -26,13 +26,24 @@ function buildEnvelope(
   };
 }
 
-function buildEvent(payload: IntegrationEventReceivedEvent, id = crypto.randomUUID()): DomainEvent {
+function buildEvent(
+  payload: IntegrationEventReceivedEvent,
+  id = crypto.randomUUID(),
+): DomainEvent<IntegrationEventReceivedEvent> {
   return {
     id,
     type: 'integrations.event.received',
     createdAt: new Date(),
     payload,
   };
+}
+
+function dispatch(
+  overrides: Partial<IntegrationEventReceivedEvent> = {},
+  id = crypto.randomUUID(),
+): Promise<void> {
+  const envelope = buildEnvelope(overrides);
+  return onIntegrationEventReceived(envelope, buildEvent(envelope, id));
 }
 
 describe('onIntegrationEventReceived (triggers)', () => {
@@ -57,7 +68,7 @@ describe('onIntegrationEventReceived (triggers)', () => {
       config: {},
     });
 
-    await onIntegrationEventReceived(buildEvent(buildEnvelope({workspaceId})));
+    await dispatch({workspaceId});
 
     expect(runWorkflow).toHaveBeenCalledTimes(2);
     const firedProjects = runWorkflow.mock.calls.map(([params]) => params.projectId);
@@ -75,7 +86,7 @@ describe('onIntegrationEventReceived (triggers)', () => {
       config: {},
     });
 
-    await onIntegrationEventReceived(buildEvent(buildEnvelope({workspaceId, deliveryId, payload})));
+    await dispatch({workspaceId, deliveryId, payload});
 
     expect(runWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -93,9 +104,7 @@ describe('onIntegrationEventReceived (triggers)', () => {
       config: {},
     });
 
-    await onIntegrationEventReceived(
-      buildEvent(buildEnvelope({workspaceId, source: 'sentry', event: 'alert_triggered'})),
-    );
+    await dispatch({workspaceId, source: 'sentry', event: 'alert_triggered'});
 
     expect(runWorkflow).toHaveBeenCalledTimes(1);
     expect(runWorkflow).toHaveBeenCalledWith(
@@ -115,7 +124,7 @@ describe('onIntegrationEventReceived (triggers)', () => {
     });
     const eventId = crypto.randomUUID();
 
-    await onIntegrationEventReceived(buildEvent(buildEnvelope({workspaceId}), eventId));
+    await dispatch({workspaceId}, eventId);
 
     expect(runWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({triggerIdempotencyKey: `${subscription.id}:${eventId}`}),
@@ -131,7 +140,7 @@ describe('onIntegrationEventReceived (triggers)', () => {
       config: {with: {env: 'staging'}},
     });
 
-    await onIntegrationEventReceived(buildEvent(buildEnvelope({workspaceId})));
+    await dispatch({workspaceId});
 
     expect(runWorkflow).toHaveBeenCalledWith(expect.objectContaining({inputs: {env: 'staging'}}));
   });
@@ -145,9 +154,7 @@ describe('onIntegrationEventReceived (triggers)', () => {
       config: {},
     });
 
-    await onIntegrationEventReceived(
-      buildEvent(buildEnvelope({workspaceId, event: 'pull_request'})),
-    );
+    await dispatch({workspaceId, event: 'pull_request'});
 
     expect(runWorkflow).not.toHaveBeenCalled();
   });

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
@@ -7,9 +7,10 @@ import {findMatchingSubscriptions} from '#db/subscriptions.js';
 // Source-agnostic dispatcher: any inbound integration event fans out to every
 // workspace subscription registered for its (source, event), passing the raw
 // payload through untouched. The module knows nothing about github, gitlab, etc.
-export async function onIntegrationEventReceived(event: DomainEvent): Promise<void> {
-  const envelope = event.payload as IntegrationEventReceivedEvent;
-
+export async function onIntegrationEventReceived(
+  envelope: IntegrationEventReceivedEvent,
+  event: DomainEvent<IntegrationEventReceivedEvent>,
+): Promise<void> {
   const subscriptions = await findMatchingSubscriptions({
     workspaceId: envelope.workspaceId,
     source: envelope.source,

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -1,11 +1,12 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {RUNNER_JOB_LEASE_EXPIRED} from '@shipfox/api-runners-dto';
+import {RUNNER_JOB_LEASE_EXPIRED, type RunnersEventMap} from '@shipfox/api-runners-dto';
 import {
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
+  type WorkflowsEventMap,
 } from '@shipfox/api-workflows-dto';
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 import {
   onJobStepsSettled,
@@ -24,15 +25,17 @@ export {routes} from '#presentation/index.js';
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
+const subscriber = subscriberFactory<WorkflowsEventMap & RunnersEventMap>();
+
 export const workflowsModule: ShipfoxModule = {
   name: 'workflows',
   database: {db, migrationsPath},
   routes,
   publishers: [{name: 'workflows', table: workflowsOutbox, db}],
   subscribers: [
-    {event: WORKFLOWS_WORKFLOW_RUN_CREATED, handler: onWorkflowRunCreated},
-    {event: WORKFLOWS_JOB_STEPS_SETTLED, handler: onJobStepsSettled},
-    {event: RUNNER_JOB_LEASE_EXPIRED, handler: onRunnerJobLeaseExpired},
+    subscriber(WORKFLOWS_WORKFLOW_RUN_CREATED, onWorkflowRunCreated),
+    subscriber(WORKFLOWS_JOB_STEPS_SETTLED, onJobStepsSettled),
+    subscriber(RUNNER_JOB_LEASE_EXPIRED, onRunnerJobLeaseExpired),
   ],
   workers: [
     {

--- a/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.test.ts
@@ -1,0 +1,56 @@
+import type {WorkflowsJobStepsSettledEvent} from '@shipfox/api-workflows-dto';
+import {onJobStepsSettled} from './on-job-steps-settled.js';
+
+const signalMock = vi.fn();
+const getHandleMock = vi.fn(() => ({signal: signalMock}));
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({workflow: {getHandle: getHandleMock}}),
+}));
+
+function buildPayload(
+  overrides: Partial<WorkflowsJobStepsSettledEvent> = {},
+): WorkflowsJobStepsSettledEvent {
+  return {
+    jobId: crypto.randomUUID(),
+    runId: crypto.randomUUID(),
+    status: 'succeeded',
+    ...overrides,
+  };
+}
+
+describe('onJobStepsSettled', () => {
+  beforeEach(() => {
+    getHandleMock.mockClear();
+    signalMock.mockReset();
+    signalMock.mockResolvedValue(undefined);
+  });
+
+  it('signals the job workflow with the settled status', async () => {
+    const payload = buildPayload({status: 'failed'});
+
+    await onJobStepsSettled(payload);
+
+    expect(getHandleMock).toHaveBeenCalledWith(`job:${payload.jobId}`);
+    expect(signalMock).toHaveBeenCalledWith('job-finished', {status: 'failed'});
+  });
+
+  it('discards a late event when the job workflow already terminated', async () => {
+    const notFound = new Error('gone');
+    notFound.name = 'WorkflowNotFoundError';
+    signalMock.mockRejectedValueOnce(notFound);
+
+    const result = onJobStepsSettled(buildPayload());
+
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('rethrows a non-terminal signal failure', async () => {
+    const failure = new Error('temporal unavailable');
+    signalMock.mockRejectedValueOnce(failure);
+
+    const result = onJobStepsSettled(buildPayload());
+
+    await expect(result).rejects.toBe(failure);
+  });
+});

--- a/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.test.ts
@@ -43,6 +43,7 @@ describe('onJobStepsSettled', () => {
     const result = onJobStepsSettled(buildPayload());
 
     await expect(result).resolves.toBeUndefined();
+    expect(signalMock).toHaveBeenCalledTimes(1);
   });
 
   it('rethrows a non-terminal signal failure', async () => {

--- a/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-job-steps-settled.ts
@@ -1,6 +1,5 @@
 import type {WorkflowsJobStepsSettledEvent} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {temporalClient} from '@shipfox/node-temporal';
 import {JOB_FINISHED_SIGNAL} from '#temporal/constants.js';
 import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
@@ -9,8 +8,7 @@ import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
 // call), which enqueues WORKFLOWS_JOB_STEPS_SETTLED in the same transaction. The
 // persisted per-step projection is already terminal, so the workflow only flips
 // the job status — no steps are carried.
-export async function onJobStepsSettled(event: DomainEvent): Promise<void> {
-  const payload = event.payload as WorkflowsJobStepsSettledEvent;
+export async function onJobStepsSettled(payload: WorkflowsJobStepsSettledEvent): Promise<void> {
   logger().info({jobId: payload.jobId, status: payload.status}, 'Signaling job finished');
   const handle = temporalClient().workflow.getHandle(`job:${payload.jobId}`);
   try {

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-lease-expired.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-lease-expired.test.ts
@@ -38,6 +38,7 @@ describe('onRunnerJobLeaseExpired', () => {
     const result = onRunnerJobLeaseExpired(buildPayload());
 
     await expect(result).resolves.toBeUndefined();
+    expect(signalMock).toHaveBeenCalledTimes(1);
   });
 
   it('rethrows a non-terminal signal failure', async () => {

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-lease-expired.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-lease-expired.test.ts
@@ -1,0 +1,51 @@
+import type {RunnerJobLeaseExpiredEvent} from '@shipfox/api-runners-dto';
+import {onRunnerJobLeaseExpired} from './on-runner-job-lease-expired.js';
+
+const signalMock = vi.fn();
+const getHandleMock = vi.fn(() => ({signal: signalMock}));
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({workflow: {getHandle: getHandleMock}}),
+}));
+
+function buildPayload(
+  overrides: Partial<RunnerJobLeaseExpiredEvent> = {},
+): RunnerJobLeaseExpiredEvent {
+  return {jobId: crypto.randomUUID(), runId: crypto.randomUUID(), ...overrides};
+}
+
+describe('onRunnerJobLeaseExpired', () => {
+  beforeEach(() => {
+    getHandleMock.mockClear();
+    signalMock.mockReset();
+    signalMock.mockResolvedValue(undefined);
+  });
+
+  it('signals the job workflow that its lease expired', async () => {
+    const payload = buildPayload();
+
+    await onRunnerJobLeaseExpired(payload);
+
+    expect(getHandleMock).toHaveBeenCalledWith(`job:${payload.jobId}`);
+    expect(signalMock).toHaveBeenCalledWith('job-lease-expired');
+  });
+
+  it('discards a late event when the job workflow already terminated', async () => {
+    const notFound = new Error('gone');
+    notFound.name = 'WorkflowNotFoundError';
+    signalMock.mockRejectedValueOnce(notFound);
+
+    const result = onRunnerJobLeaseExpired(buildPayload());
+
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('rethrows a non-terminal signal failure', async () => {
+    const failure = new Error('temporal unavailable');
+    signalMock.mockRejectedValueOnce(failure);
+
+    const result = onRunnerJobLeaseExpired(buildPayload());
+
+    await expect(result).rejects.toBe(failure);
+  });
+});

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-lease-expired.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-lease-expired.ts
@@ -1,6 +1,5 @@
 import type {RunnerJobLeaseExpiredEvent} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {temporalClient} from '@shipfox/node-temporal';
 import {JOB_LEASE_EXPIRED_SIGNAL} from '#temporal/constants.js';
 import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
@@ -9,8 +8,7 @@ import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
 // goes stale. Wake the job workflow so it resolves the outcome from authoritative
 // server state (adopt the terminal status if the steps finished concurrently,
 // otherwise fail the job and cancel the remaining steps).
-export async function onRunnerJobLeaseExpired(event: DomainEvent): Promise<void> {
-  const payload = event.payload as RunnerJobLeaseExpiredEvent;
+export async function onRunnerJobLeaseExpired(payload: RunnerJobLeaseExpiredEvent): Promise<void> {
   logger().info(
     {jobId: payload.jobId, runId: payload.runId},
     'Signaling job orchestration of lease expiry',

--- a/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.test.ts
@@ -45,6 +45,7 @@ describe('onWorkflowRunCreated', () => {
     const result = onWorkflowRunCreated(buildPayload());
 
     await expect(result).resolves.toBeUndefined();
+    expect(startMock).toHaveBeenCalledTimes(1);
   });
 
   it('rethrows any other start failure', async () => {

--- a/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.test.ts
@@ -1,0 +1,58 @@
+import type {WorkflowsWorkflowRunCreatedEvent} from '@shipfox/api-workflows-dto';
+import {onWorkflowRunCreated} from './on-workflow-run-created.js';
+
+const startMock = vi.fn();
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({workflow: {start: startMock}}),
+}));
+
+function buildPayload(
+  overrides: Partial<WorkflowsWorkflowRunCreatedEvent> = {},
+): WorkflowsWorkflowRunCreatedEvent {
+  return {
+    runId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    definitionId: crypto.randomUUID(),
+    ...overrides,
+  };
+}
+
+describe('onWorkflowRunCreated', () => {
+  beforeEach(() => {
+    startMock.mockReset();
+    startMock.mockResolvedValue({});
+  });
+
+  it('starts the run orchestration keyed on the run id', async () => {
+    const payload = buildPayload();
+
+    await onWorkflowRunCreated(payload);
+
+    expect(startMock).toHaveBeenCalledWith('runOrchestration', {
+      taskQueue: 'workflows-orchestrator',
+      workflowId: `run:${payload.runId}`,
+      args: [{runId: payload.runId, workspaceId: payload.workspaceId}],
+    });
+  });
+
+  it('swallows an already-started orchestration (outbox is at-least-once)', async () => {
+    const alreadyStarted = new Error('already started');
+    alreadyStarted.name = 'WorkflowExecutionAlreadyStartedError';
+    startMock.mockRejectedValueOnce(alreadyStarted);
+
+    const result = onWorkflowRunCreated(buildPayload());
+
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('rethrows any other start failure', async () => {
+    const failure = new Error('temporal unavailable');
+    startMock.mockRejectedValueOnce(failure);
+
+    const result = onWorkflowRunCreated(buildPayload());
+
+    await expect(result).rejects.toBe(failure);
+  });
+});

--- a/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-workflow-run-created.ts
@@ -1,11 +1,11 @@
 import type {WorkflowsWorkflowRunCreatedEvent} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {temporalClient} from '@shipfox/node-temporal';
 import {WORKFLOWS_TASK_QUEUE} from '#temporal/constants.js';
 
-export async function onWorkflowRunCreated(event: DomainEvent): Promise<void> {
-  const payload = event.payload as WorkflowsWorkflowRunCreatedEvent;
+export async function onWorkflowRunCreated(
+  payload: WorkflowsWorkflowRunCreatedEvent,
+): Promise<void> {
   logger().info({runId: payload.runId}, 'Starting workflow run orchestration');
   try {
     await temporalClient().workflow.start('runOrchestration', {

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -32,7 +32,17 @@ startModuleWorkers({workers});
 ## Module Shape
 
 ```ts
-import type {ShipfoxModule} from '@shipfox/node-module';
+import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
+
+interface ExampleEventMap {
+  'example.created': {id: string};
+}
+
+const subscriber = subscriberFactory<ExampleEventMap>();
+
+async function handleExampleCreated(payload: ExampleEventMap['example.created']): Promise<void> {
+  console.log(payload.id);
+}
 
 export const exampleModule: ShipfoxModule = {
   name: 'example',
@@ -40,7 +50,7 @@ export const exampleModule: ShipfoxModule = {
   auth: [authMethod],
   routes: [routes],
   publishers: [{name: 'example', table: outbox, db}],
-  subscribers: [{event: 'example.created', handler}],
+  subscribers: [subscriber('example.created', handleExampleCreated)],
   workers: [{taskQueue: 'example', workflowsPath, activities, workflows: []}],
 };
 ```
@@ -50,6 +60,7 @@ export const exampleModule: ShipfoxModule = {
 ```sh
 turbo check --filter=@shipfox/node-module
 turbo type --filter=@shipfox/node-module
+turbo test --filter=@shipfox/node-module
 ```
 
 ## License

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -31,6 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -46,6 +48,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -12,10 +12,11 @@ export {
 } from './publisher-registry.js';
 export type {EventHandler} from './registry.js';
 export {getSubscribers, resetSubscribers, subscribe} from './registry.js';
+export type {ModuleSubscriber} from './subscriber.js';
+export {subscriberFactory} from './subscriber.js';
 export type {
   ModuleDatabase,
   ModulePublisher,
-  ModuleSubscriber,
   ModuleWorker,
   ShipfoxModule,
   WorkflowStart,

--- a/libs/shared/node/module/src/subscriber.test.ts
+++ b/libs/shared/node/module/src/subscriber.test.ts
@@ -1,0 +1,79 @@
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {type ModuleSubscriber, subscriberFactory} from './subscriber.js';
+
+interface TestEventMap {
+  'thing.created': {id: string};
+  'thing.deleted': {id: string; reason: string};
+}
+
+const subscriber = subscriberFactory<TestEventMap>();
+
+function domainEvent<T>(type: string, payload: T): DomainEvent<T> {
+  return {id: 'evt-1', type, payload, createdAt: new Date('2026-01-01T00:00:00Z')};
+}
+
+describe('subscriberFactory', () => {
+  it('forwards the event payload as the first handler argument', async () => {
+    const seen: Array<{id: string}> = [];
+    const sub = subscriber('thing.created', (payload) => {
+      seen.push(payload);
+      return Promise.resolve();
+    });
+
+    await sub.handler(domainEvent('thing.created', {id: 'a'}));
+
+    expect(seen).toEqual([{id: 'a'}]);
+  });
+
+  it('forwards the whole domain event as the second handler argument', async () => {
+    const event = domainEvent('thing.deleted', {id: 'b', reason: 'gone'});
+    let received: DomainEvent<{id: string; reason: string}> | undefined;
+    const sub = subscriber('thing.deleted', (_payload, e) => {
+      received = e;
+      return Promise.resolve();
+    });
+
+    await sub.handler(event);
+
+    expect(received).toBe(event);
+  });
+
+  it('registers the subscriber under the given event name', () => {
+    const sub = subscriber('thing.created', () => Promise.resolve());
+
+    expect(sub.event).toBe('thing.created');
+  });
+
+  it('accepts a payload-only handler', async () => {
+    let seenId: string | undefined;
+    const sub = subscriber('thing.created', ({id}) => {
+      seenId = id;
+      return Promise.resolve();
+    });
+
+    await sub.handler(domainEvent('thing.created', {id: 'c'}));
+
+    expect(seenId).toBe('c');
+  });
+});
+
+// These never run; the @ts-expect-error directives fail the build if the type
+// constraints ever stop holding, which is the real protection this file adds.
+describe('subscriberFactory type safety', () => {
+  it('rejects unknown events, mismatched payloads, and forged subscribers', () => {
+    // @ts-expect-error 'thing.unknown' is not a key of TestEventMap
+    subscriber('thing.unknown', () => Promise.resolve());
+
+    subscriber('thing.created', (payload) => {
+      // @ts-expect-error 'reason' exists only on 'thing.deleted', not 'thing.created'
+      void payload.reason;
+      return Promise.resolve();
+    });
+
+    // @ts-expect-error a raw literal cannot mint the private brand
+    const forged: ModuleSubscriber = {event: 'x', handler: () => Promise.resolve()};
+    void forged;
+
+    expect(true).toBe(true);
+  });
+});

--- a/libs/shared/node/module/src/subscriber.ts
+++ b/libs/shared/node/module/src/subscriber.ts
@@ -19,6 +19,10 @@ export interface ModuleSubscriber {
  * against the map and the handler's `payload` is typed to that exact event, so a wrong
  * event name or a mismatched payload fails to compile and no handler hand-casts.
  *
+ * The intersected maps must keep disjoint event names; the module-namespaced event
+ * strings (`definitions.*`, `workflows.*`, ...) already guarantee this. A shared key with
+ * differing payloads would silently intersect to `never` rather than failing to compile.
+ *
  * Curried because TypeScript has no partial type-argument inference: the outer call
  * fixes `TMap`, the inner call infers the event key `K` from the `event` argument.
  */

--- a/libs/shared/node/module/src/subscriber.ts
+++ b/libs/shared/node/module/src/subscriber.ts
@@ -1,0 +1,37 @@
+import type {DomainEvent, EventMapLike, EventType} from '@shipfox/node-outbox';
+
+// Nominal brand: only `subscriberFactory` can mint a ModuleSubscriber. The symbol is
+// module-private, so a raw `{event, handler}` literal in a feature package fails to
+// type-check (it cannot name the brand) and cannot reintroduce a hand-cast payload.
+const subscriberBrand: unique symbol = Symbol('moduleSubscriber');
+
+export interface ModuleSubscriber {
+  event: string;
+  handler: (event: DomainEvent) => Promise<void>;
+  readonly [subscriberBrand]: true;
+}
+
+/**
+ * Binds outbox event names to their payload types for one module's subscribers.
+ *
+ * Call once per module with the intersection of the event maps it subscribes to, then
+ * register each subscriber through the returned function. The event name is checked
+ * against the map and the handler's `payload` is typed to that exact event, so a wrong
+ * event name or a mismatched payload fails to compile and no handler hand-casts.
+ *
+ * Curried because TypeScript has no partial type-argument inference: the outer call
+ * fixes `TMap`, the inner call infers the event key `K` from the `event` argument.
+ */
+export function subscriberFactory<TMap extends EventMapLike>() {
+  return <K extends EventType<TMap>>(
+    event: K,
+    handler: (payload: TMap[K], event: DomainEvent<TMap[K]>) => Promise<void>,
+  ): ModuleSubscriber => ({
+    event,
+    // The single cast at the framework boundary: the drained payload is `unknown` from
+    // JSONB, narrowed here once instead of in every handler.
+    handler: (e: DomainEvent): Promise<void> =>
+      handler(e.payload as TMap[K], e as DomainEvent<TMap[K]>),
+    [subscriberBrand]: true,
+  });
+}

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -1,6 +1,7 @@
 import type {AuthMethod, RouteExport} from '@shipfox/node-fastify';
-import type {DomainEvent, OutboxTable} from '@shipfox/node-outbox';
+import type {OutboxTable} from '@shipfox/node-outbox';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import type {ModuleSubscriber} from './subscriber.js';
 
 export interface ModuleDatabase {
   db: () => NodePgDatabase<Record<string, unknown>>;
@@ -20,11 +21,6 @@ export interface ModulePublisher {
   name: string;
   table: OutboxTable;
   db: () => NodePgDatabase<Record<string, unknown>>;
-}
-
-export interface ModuleSubscriber {
-  event: string;
-  handler: (event: DomainEvent) => Promise<void>;
 }
 
 export interface WorkflowStart {

--- a/libs/shared/node/module/vitest.config.ts
+++ b/libs/shared/node/module/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2969,6 +2969,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
 
   libs/shared/node/opentelemetry:
     dependencies:


### PR DESCRIPTION
Outbox subscribers cast `event.payload as X` by hand in every handler, so a wrong event name or payload shape only surfaced at runtime. This adds a typed `subscriberFactory` in `@shipfox/node-module` that binds each event name to its payload type through the existing per-package event maps, the mirror image of the already-typed publish side (`writeOutboxEvent<TMap>`). Handlers now receive a typed `(payload, event)` and all 11 per-handler casts are gone.

Each module instantiates one factory bound to the intersection of the event maps it subscribes to, so a typo'd event name or a mismatched handler payload now fails to compile.

A module-private `Symbol` brands `ModuleSubscriber` so the factory is the only way to construct one. This was a deliberate call over leaving the helper opt-in: it stops a future raw `{event, handler}` literal from silently reintroducing an unchecked cast. The brand survives `.d.ts` emit (verified up front, since a type-only `unique symbol` would have broken it) and its blast radius is contained, as the five module declarations are the only places that construct subscribers.

Tests: a unit test for the factory (runtime forwarding plus `@ts-expect-error` guards that `turbo type` enforces), the five existing subscriber tests updated to the new call convention, and behavior tests backfilled for five handlers that previously had none.

### Review notes

- The payload cast still happens once inside the factory and is unchecked at runtime (the outbox stores JSONB). This is not a regression; the previous per-handler casts were equally unchecked. Validating the payload at the drain boundary is deferred to ENG-517.
- `@shipfox/node-module` is private, so the brand is an internal-only construction change and every call site is migrated in this PR.

Refs ENG-517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed `subscriberFactory` in `@shipfox/node-module` that binds outbox event names to payload types, removing per-handler casts and catching mismatches at compile time. Advances ENG-517; runtime payload validation at the drain boundary remains deferred.

- New Features
  - `subscriberFactory<TMap>()` returns subscribers typed by event maps; handlers receive `(payload, event)`.
  - `ModuleSubscriber` is branded with a private symbol so only the factory can construct it.
  - Centralizes the single payload cast at the factory boundary; no runtime behavior change.

- Refactors
  - Migrated subscribers in `@shipfox/api-definitions`, `@shipfox/api-projects`, `@shipfox/api-runners`, `@shipfox/api-triggers`, `@shipfox/api-workflows`, and `@shipfox/api-logs` to the factory; standardized handler signatures and removed casts.
  - Added a unit test for the factory and backfilled behavior tests; hardened idempotent swallow-path tests to assert Temporal is invoked once.
  - Added `@shipfox/vitest` and test scripts in `@shipfox/node-module`; updated the README example and documented the event-map disjointness constraint.

<sup>Written for commit d890ab07776ffda361c38a0ad51f7b5857e95e58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

