### PR TITLE
Add shared regex matchers

### DIFF
--- a/.changeset/clear-patterns-unify.md
+++ b/.changeset/clear-patterns-unify.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/regex": minor
+"@shipfox/node-opentelemetry": patch
+---
+
+Adds shared identifier regex helpers and migrates public OpenTelemetry UUID route normalization to the canonical matcher.

--- a/e2e/client/runners/package.json
+++ b/e2e/client/runners/package.json
@@ -27,6 +27,7 @@
     "@shipfox/e2e-helper-auth": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",
+    "@shipfox/regex": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"
   }

--- a/e2e/client/runners/tests/runner-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/runner-token-flows.e2e.ts
@@ -1,7 +1,8 @@
 import {argosScreenshot} from '@shipfox/playwright';
+import {createShipfoxTokenPrefixRegexes} from '@shipfox/regex';
 import {expect, test} from './test.js';
 
-const RUNNER_TOKEN_PREFIX_RE = /^sf_rt_/u;
+const RUNNER_TOKEN_PREFIX_RE = createShipfoxTokenPrefixRegexes(['rt']).unqualified;
 const VISUAL_TEST_NOW = new Date('2026-01-15T12:00:00Z');
 const VISUAL_TEST_RUNNER_TOKEN_PREFIX = 'sf_rt_visual';
 const VISUAL_TEST_RUNNER_TOKEN = 'sf_rt_visual_regression_token';

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/regex": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/api/definitions/src/core/sync-definitions.test.ts
+++ b/libs/api/definitions/src/core/sync-definitions.test.ts
@@ -5,6 +5,7 @@ import {
   IntegrationProviderError,
   type IntegrationSourceControlService,
 } from '@shipfox/api-integration-core';
+import {LOWERCASE_SHA256_HEX_RE} from '@shipfox/regex';
 import {DefinitionSyncPermanentError} from './errors.js';
 import {
   classifySyncFailure,
@@ -20,8 +21,6 @@ jobs:
     steps:
       - run: pnpm test
 `;
-
-const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 
 function sourceControl(
   overrides: Partial<IntegrationSourceControlService> = {},
@@ -150,7 +149,7 @@ describe('fetchAndParseWorkflows', () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.name).toBe('CI');
     expect(result[0]?.path).toBe('.shipfox/workflows/ci.yml');
-    expect(result[0]?.contentHash).toMatch(SHA256_HEX_RE);
+    expect(result[0]?.contentHash).toMatch(LOWERCASE_SHA256_HEX_RE);
   });
 
   it('produces stable content hashes for identical content', async () => {

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -50,6 +50,7 @@
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",
+    "@shipfox/regex": "workspace:*",
     "@shipfox/redact": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "zod": "^4.4.3"

--- a/libs/api/integration/core/src/core/providers/registry.ts
+++ b/libs/api/integration/core/src/core/providers/registry.ts
@@ -1,3 +1,4 @@
+import {isLowercaseAlphaSlug} from '@shipfox/regex';
 import type {
   IntegrationCapability,
   IntegrationProvider,
@@ -9,8 +10,6 @@ import {
   IntegrationCapabilityUnavailableError,
   IntegrationProviderUnavailableError,
 } from '#core/errors.js';
-
-const providerIdPattern = /^[a-z][a-z0-9_-]*$/;
 
 export interface IntegrationProviderRegistry {
   list(capability?: IntegrationCapability | undefined): RegisteredIntegrationProvider[];
@@ -37,7 +36,7 @@ class MapIntegrationProviderRegistry implements IntegrationProviderRegistry {
     this.providers = new Map();
 
     for (const provider of providers) {
-      if (!providerIdPattern.test(provider.provider)) {
+      if (!isLowercaseAlphaSlug(provider.provider)) {
         throw new Error(`Invalid integration provider id: ${provider.provider}`);
       }
       if (this.providers.has(provider.provider)) {

--- a/libs/client/projects/package.json
+++ b/libs/client/projects/package.json
@@ -45,6 +45,7 @@
     "@shipfox/client-auth": "workspace:*",
     "@shipfox/client-integrations": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
+    "@shipfox/regex": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",
     "@tanstack/react-query": "^5.101.0",

--- a/libs/client/projects/src/pages/project-runs-search.test.ts
+++ b/libs/client/projects/src/pages/project-runs-search.test.ts
@@ -44,6 +44,14 @@ describe('project runs search helpers', () => {
     expect(result).toEqual({date: 'all'});
   });
 
+  test('accepts structurally valid UUIDs without enforcing an RFC version nibble', () => {
+    const search = {definition_id: '99999999-9999-9999-9999-999999999999', date: 'all'};
+
+    const result = sanitizeRunsSearch(search);
+
+    expect(result.definitionId).toBe('99999999-9999-9999-9999-999999999999');
+  });
+
   test('accepts unknown but well-formed trigger sources', () => {
     const search = {trigger_source: 'gitlab', date: 'all'};
 

--- a/libs/client/projects/src/pages/project-runs-search.ts
+++ b/libs/client/projects/src/pages/project-runs-search.ts
@@ -1,12 +1,11 @@
 import type {RunStatusDto} from '@shipfox/api-workflows-dto';
+import {isAlnumSlug, isUuid} from '@shipfox/regex';
 import type {WorkflowRunFilters} from '#hooks/api/workflow-runs.js';
 
 const RUN_STATUSES: RunStatusDto[] = ['pending', 'running', 'succeeded', 'failed', 'cancelled'];
 const DATE_PRESETS = ['all', '24h', '7d', '30d'] as const;
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 // trigger_source is open-ended on the API; the URL sanitiser just keeps it well-formed.
 const TRIGGER_SOURCE_MAX_LENGTH = 64;
-const TRIGGER_SOURCE_RE = /^[a-z0-9][a-z0-9_-]*$/i;
 
 export type DatePreset = (typeof DATE_PRESETS)[number];
 
@@ -70,12 +69,6 @@ export function toWorkflowRunFilters(search: RunsSearchState): WorkflowRunFilter
   };
 }
 
-function isUuid(value: string) {
-  return UUID_RE.test(value);
-}
-
 function isTriggerSource(value: string) {
-  return (
-    value.length > 0 && value.length <= TRIGGER_SOURCE_MAX_LENGTH && TRIGGER_SOURCE_RE.test(value)
-  );
+  return value.length > 0 && value.length <= TRIGGER_SOURCE_MAX_LENGTH && isAlnumSlug(value);
 }

--- a/libs/runner/logs/src/api/spool.ts
+++ b/libs/runner/logs/src/api/spool.ts
@@ -1,8 +1,7 @@
 import {closeSync, mkdirSync, openSync, readSync, statSync, writeSync} from 'node:fs';
 import {dirname, join} from 'node:path';
+import {isUuid} from '@shipfox/regex';
 import {InvalidStepIdError} from '#core/errors.js';
-
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const EMPTY = Buffer.alloc(0);
 
@@ -39,7 +38,7 @@ export class AttemptSpool {
   }
 
   static open(logsDir: string, stepId: string, attempt: number): AttemptSpool {
-    if (!UUID_PATTERN.test(stepId)) throw new InvalidStepIdError(stepId);
+    if (!isUuid(stepId)) throw new InvalidStepIdError(stepId);
     return new AttemptSpool(join(logsDir, `${stepId}-${attempt}.ndjson`));
   }
 

--- a/libs/runner/protocol/package.json
+++ b/libs/runner/protocol/package.json
@@ -42,6 +42,7 @@
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/regex": "workspace:*",
     "ky": "^2.0.0"
   },
   "devDependencies": {

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -16,10 +16,9 @@ import {
   type StepErrorDtoShape,
 } from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
+import {isUuid} from '@shipfox/regex';
 import ky, {HTTPError, type KyInstance} from 'ky';
 import {config} from '#config.js';
-
-const STEP_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** Media type the append endpoint expects for the raw NDJSON request body. */
 const LOG_NDJSON_CONTENT_TYPE = 'application/x-ndjson';
@@ -152,7 +151,7 @@ export async function appendStepLogs(
     signal?: AbortSignal;
   },
 ): Promise<LogAppendOutcome> {
-  if (!STEP_ID_PATTERN.test(params.stepId)) {
+  if (!isUuid(params.stepId)) {
     throw new Error(`Invalid step id for log append: ${params.stepId}`);
   }
 

--- a/libs/runner/workspace/package.json
+++ b/libs/runner/workspace/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
-    "@shipfox/node-opentelemetry": "workspace:*"
+    "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/regex": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -2,6 +2,7 @@ import {mkdir, rm} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {join, parse, resolve} from 'node:path';
 import {logger} from '@shipfox/node-opentelemetry';
+import {isUuid} from '@shipfox/regex';
 import {config} from '#config.js';
 
 /**
@@ -58,11 +59,6 @@ export function resolveWorkspaceRootFromEnv(): string {
   return resolveWorkspaceRoot(config.SHIPFOX_RUNNER_WORKSPACE_ROOT);
 }
 
-// The job id is the only input to the per-job path; assert it is the UUID the
-// API contract guarantees rather than munging it, so a malformed id fails the
-// job loudly instead of silently reshaping the directory name.
-const JOB_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 /**
  * The deterministic per-job directory path. Pure: validates the id and builds the
  * path without touching the filesystem, so `runJob` can compute it up front (for
@@ -71,7 +67,7 @@ const JOB_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
  * contract guarantees, since it is the only input to the path.
  */
 export function jobWorkspacePath(jobId: string, root: string): string {
-  if (!JOB_ID_PATTERN.test(jobId)) {
+  if (!isUuid(jobId)) {
     throw new InvalidJobIdError(jobId);
   }
   return join(root, `job-${jobId}`);

--- a/libs/shared/common/regex/README.md
+++ b/libs/shared/common/regex/README.md
@@ -1,0 +1,51 @@
+# Shipfox Regex
+
+Shared regex matchers for stable Shipfox identifier shapes. One home for the
+small validation patterns that are used across multiple packages so they cannot
+drift.
+
+## What it does
+
+- **`isUuid(value)`** checks a dashed UUID-shaped identifier, case-insensitive.
+  It is structural on purpose: Shipfox stores internal IDs as UUIDs and should
+  not reject a future UUID version when the caller only needs a safe identifier
+  shape.
+- **`isLowercaseAlphaSlug(value)`** checks provider-style ids that start with a
+  lowercase ASCII letter and then use lowercase letters, numbers, `_`, or `-`.
+- **`isAlnumSlug(value)`** checks source-style ids that start with an ASCII
+  letter or number and then use letters, numbers, `_`, or `-`, case-insensitive.
+- **`isLowercaseSha256Hex(value)`** checks the lowercase 64-character hex form
+  emitted by Node's `crypto` SHA-256 digest.
+- **`createShipfoxTokenPrefixRegexes(tokenTypeParts)`** builds the unqualified
+  and environment-qualified Shipfox opaque-token prefix matchers from the token
+  type parts owned by `@shipfox/node-tokens`.
+
+The exported regexes intentionally do not use `g` or `y` flags, so repeated
+`.test()` calls are stable.
+
+## Installation
+
+```bash
+pnpm add @shipfox/regex
+```
+
+## Usage
+
+```ts
+import {isUuid, isLowercaseAlphaSlug} from '@shipfox/regex';
+
+isUuid('028b2a9a-800e-485e-b33a-9af4e238508b');
+isLowercaseAlphaSlug('github');
+```
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/regex
+turbo type --filter=@shipfox/regex
+turbo test --filter=@shipfox/regex
+```
+
+## License
+
+MIT

--- a/libs/shared/common/regex/package.json
+++ b/libs/shared/common/regex/package.json
@@ -1,18 +1,20 @@
 {
-  "name": "@shipfox/runner-logs",
+  "name": "@shipfox/regex",
   "license": "MIT",
-  "version": "0.0.0",
+  "private": false,
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/platform.git",
-    "directory": "libs/runner/logs"
+    "directory": "libs/shared/common/regex"
   },
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "imports": {
-    "#test/*": "./test/*",
     "#*": "./src/*"
   },
   "exports": {
@@ -35,13 +37,6 @@
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
-  },
-  "dependencies": {
-    "@shipfox/api-logs-dto": "workspace:*",
-    "@shipfox/config": "workspace:*",
-    "@shipfox/node-opentelemetry": "workspace:*",
-    "@shipfox/regex": "workspace:*",
-    "@shipfox/runner-protocol": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/shared/common/regex/src/index.test.ts
+++ b/libs/shared/common/regex/src/index.test.ts
@@ -1,0 +1,133 @@
+import {
+  ALNUM_SLUG_RE,
+  createShipfoxTokenPrefixRegexes,
+  isAlnumSlug,
+  isLowercaseAlphaSlug,
+  isLowercaseSha256Hex,
+  isUuid,
+  LOWERCASE_ALPHA_SLUG_RE,
+  LOWERCASE_SHA256_HEX_RE,
+  UUID_RE,
+} from './index.js';
+
+describe('UUID_RE', () => {
+  it.each([
+    '028b2a9a-800e-485e-b33a-9af4e238508b',
+    '028B2A9A-800E-485E-B33A-9AF4E238508B',
+    '99999999-9999-9999-9999-999999999999',
+  ])('accepts structural UUID %s', (value) => {
+    const result = isUuid(value);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    'not-a-uuid',
+    '028b2a9a800e485eb33a9af4e238508b',
+    '028b2a9a-800e-485e-b33a-9af4e238508',
+    '028b2a9a-800e-485e-b33a-9af4e238508z',
+    '../escape',
+  ])('rejects non-UUID %s', (value) => {
+    const result = isUuid(value);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('slug matchers', () => {
+  it.each(['github', 'debug_provider', 'sentry-2'])('accepts lowercase alpha slug %s', (value) => {
+    const result = isLowercaseAlphaSlug(value);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    'GitHub',
+    '2github',
+    '_github',
+    'github.provider',
+    '',
+  ])('rejects invalid lowercase alpha slug %s', (value) => {
+    const result = isLowercaseAlphaSlug(value);
+
+    expect(result).toBe(false);
+  });
+
+  it.each(['manual', 'GitHub', '2github', 'sentry_hook'])('accepts alnum slug %s', (value) => {
+    const result = isAlnumSlug(value);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    '_manual',
+    '-manual',
+    'has spaces',
+    'github.provider',
+    '',
+  ])('rejects invalid alnum slug %s', (value) => {
+    const result = isAlnumSlug(value);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('LOWERCASE_SHA256_HEX_RE', () => {
+  it('accepts lowercase SHA-256 hex digests', () => {
+    const result = isLowercaseSha256Hex('a'.repeat(64));
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    'a'.repeat(63),
+    'a'.repeat(65),
+    `${'a'.repeat(63)}z`,
+    'A'.repeat(64),
+  ])('rejects %s', (value) => {
+    const result = isLowercaseSha256Hex(value);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('createShipfoxTokenPrefixRegexes', () => {
+  it('matches unqualified and environment-qualified token prefixes', () => {
+    const regexes = createShipfoxTokenPrefixRegexes(['k', 'rt', 'pr']);
+
+    const unqualified = 'sf_rt_secret'.match(regexes.unqualified);
+    const qualified = 'sf_staging_k_secret'.match(regexes.qualified);
+
+    expect(unqualified?.[1]).toBe('rt');
+    expect(qualified?.[1]).toBe('staging');
+    expect(qualified?.[2]).toBe('k');
+  });
+
+  it('escapes token parts before building the regex', () => {
+    const regexes = createShipfoxTokenPrefixRegexes(['a+b']);
+
+    expect('sf_a+b_secret'.match(regexes.unqualified)?.[1]).toBe('a+b');
+    expect('sf_aaab_secret'.match(regexes.unqualified)).toBeNull();
+  });
+
+  it('rejects an empty token type part list', () => {
+    const create = () => createShipfoxTokenPrefixRegexes([]);
+
+    expect(create).toThrow('At least one Shipfox token type part is required');
+  });
+});
+
+describe('exported regexes', () => {
+  it.each([
+    ['UUID_RE', UUID_RE, '028b2a9a-800e-485e-b33a-9af4e238508b'],
+    ['LOWERCASE_ALPHA_SLUG_RE', LOWERCASE_ALPHA_SLUG_RE, 'github'],
+    ['ALNUM_SLUG_RE', ALNUM_SLUG_RE, 'GitHub'],
+    ['LOWERCASE_SHA256_HEX_RE', LOWERCASE_SHA256_HEX_RE, 'a'.repeat(64)],
+  ])('%s is stable across repeated test calls', (_name, regex, value) => {
+    const first = regex.test(value);
+    const second = regex.test(value);
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+  });
+});

--- a/libs/shared/common/regex/src/index.ts
+++ b/libs/shared/common/regex/src/index.ts
@@ -1,0 +1,43 @@
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const LOWERCASE_ALPHA_SLUG_RE = /^[a-z][a-z0-9_-]*$/;
+export const ALNUM_SLUG_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+export const LOWERCASE_SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+export interface ShipfoxTokenPrefixRegexes {
+  unqualified: RegExp;
+  qualified: RegExp;
+}
+
+export function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+export function isLowercaseAlphaSlug(value: string): boolean {
+  return LOWERCASE_ALPHA_SLUG_RE.test(value);
+}
+
+export function isAlnumSlug(value: string): boolean {
+  return ALNUM_SLUG_RE.test(value);
+}
+
+export function isLowercaseSha256Hex(value: string): boolean {
+  return LOWERCASE_SHA256_HEX_RE.test(value);
+}
+
+export function createShipfoxTokenPrefixRegexes(
+  tokenTypeParts: ReadonlyArray<string>,
+): ShipfoxTokenPrefixRegexes {
+  const tokenTypeAlternation = tokenTypeParts.map(escapeRegExpLiteral).join('|');
+  if (!tokenTypeAlternation) {
+    throw new Error('At least one Shipfox token type part is required');
+  }
+
+  return {
+    unqualified: new RegExp(`^sf_(${tokenTypeAlternation})_`, 'u'),
+    qualified: new RegExp(`^sf_([a-z0-9-]+)_(${tokenTypeAlternation})_`, 'u'),
+  };
+}
+
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/gu, '\\$&');
+}

--- a/libs/shared/common/regex/tsconfig.build.json
+++ b/libs/shared/common/regex/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/shared/common/regex/tsconfig.json
+++ b/libs/shared/common/regex/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/shared/common/regex/tsconfig.test.json
+++ b/libs/shared/common/regex/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/shared/common/regex/vitest.config.ts
+++ b/libs/shared/common/regex/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/shared/node/opentelemetry/package.json
+++ b/libs/shared/node/opentelemetry/package.json
@@ -59,7 +59,8 @@
     "@opentelemetry/sdk-trace-node": "^2.6.0",
     "@opentelemetry/semantic-conventions": "^1.33.0",
     "@shipfox/config": "workspace:*",
-    "@shipfox/node-log": "workspace:*"
+    "@shipfox/node-log": "workspace:*",
+    "@shipfox/regex": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/shared/node/opentelemetry/src/utils.ts
+++ b/libs/shared/node/opentelemetry/src/utils.ts
@@ -1,16 +1,13 @@
 import type {FastifyOtelInstrumentationOpts} from '@fastify/otel';
+import {isUuid} from '@shipfox/regex';
 
-// UUID (all versions, case-insensitive)
-const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 // Pure integers (numeric IDs)
 const NUMERIC_SEGMENT = /^\d+$/;
 
 export const normalizeRoutePath = (path: string): string =>
   path
     .split('/')
-    .map((segment) =>
-      UUID_SEGMENT.test(segment) || NUMERIC_SEGMENT.test(segment) ? ':id' : segment,
-    )
+    .map((segment) => (isUuid(segment) || NUMERIC_SEGMENT.test(segment) ? ':id' : segment))
     .join('/');
 
 export const fastifyRequestHook: Required<FastifyOtelInstrumentationOpts>['requestHook'] = (

--- a/libs/shared/node/tokens/package.json
+++ b/libs/shared/node/tokens/package.json
@@ -37,7 +37,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/config": "workspace:*"
+    "@shipfox/config": "workspace:*",
+    "@shipfox/regex": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/shared/node/tokens/src/index.ts
+++ b/libs/shared/node/tokens/src/index.ts
@@ -1,10 +1,9 @@
 import {createHash, randomBytes} from 'node:crypto';
+import {createShipfoxTokenPrefixRegexes} from '@shipfox/regex';
 import {config} from './config.js';
 
 const DISPLAY_PREFIX_LENGTH = 12;
 const TOKEN_PREFIX_NAMESPACE = 'sf';
-const UNQUALIFIED_TOKEN_PREFIX_RE = /^sf_(pr|rt|r|k|i|v)_/;
-const QUALIFIED_TOKEN_PREFIX_RE = /^sf_([a-z0-9-]+)_(pr|rt|r|k|i|v)_/;
 
 export const tokenTypeParts = {
   apiKey: 'k',
@@ -14,6 +13,8 @@ export const tokenTypeParts = {
   refreshToken: 'r',
   runnerToken: 'rt',
 } as const;
+
+const tokenPrefixRegexes = createShipfoxTokenPrefixRegexes(Object.values(tokenTypeParts));
 
 export type TokenType = keyof typeof tokenTypeParts;
 export type TokenEnvironment = 'production' | string;
@@ -69,12 +70,12 @@ function getTokenEnvironmentPart(): string | undefined {
 }
 
 function parseTokenPrefix(raw: string): {environment?: string; tokenTypePart: string} | undefined {
-  const unqualifiedMatch = raw.match(UNQUALIFIED_TOKEN_PREFIX_RE);
+  const unqualifiedMatch = raw.match(tokenPrefixRegexes.unqualified);
   if (unqualifiedMatch?.[1]) {
     return {tokenTypePart: unqualifiedMatch[1]};
   }
 
-  const qualifiedMatch = raw.match(QUALIFIED_TOKEN_PREFIX_RE);
+  const qualifiedMatch = raw.match(tokenPrefixRegexes.qualified);
   if (qualifiedMatch?.[1] && qualifiedMatch[2]) {
     return {environment: qualifiedMatch[1], tokenTypePart: qualifiedMatch[2]};
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../../libs/shared/common/regex
       '@shipfox/ts-config':
         specifier: workspace:*
         version: link:../../../tools/ts-config
@@ -603,6 +606,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../shared/common/regex
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc
@@ -767,6 +773,9 @@ importers:
       '@shipfox/redact':
         specifier: workspace:*
         version: link:../../../shared/common/redact
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../../shared/common/regex
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
@@ -2142,6 +2151,9 @@ importers:
       '@shipfox/react-ui':
         specifier: workspace:*
         version: link:../../shared/react/ui
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../shared/common/regex
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
@@ -2542,6 +2554,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../shared/common/regex
       '@shipfox/runner-protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -2625,6 +2640,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../shared/common/regex
       ky:
         specifier: ^2.0.0
         version: 2.0.2
@@ -2656,6 +2674,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../shared/common/regex
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*
@@ -2696,6 +2717,24 @@ importers:
         version: link:../../../../tools/vitest
 
   libs/shared/common/redact:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
+  libs/shared/common/regex:
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*
@@ -3008,6 +3047,9 @@ importers:
       '@shipfox/node-log':
         specifier: workspace:*
         version: link:../log
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../common/regex
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*
@@ -3114,6 +3156,9 @@ importers:
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../common/config
+      '@shipfox/regex':
+        specifier: workspace:*
+        version: link:../../common/regex
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Creates `@shipfox/regex` as the shared home for stable identifier matchers and migrates duplicated UUID, slug, SHA-256, and Shipfox token-prefix checks to that package.

The existing copies had drifted: project run search enforced UUID version bits while other callers only checked the dashed UUID shape. This makes the structural dashed UUID matcher canonical and keeps token type ownership in `@shipfox/node-tokens` by passing token type parts into the token-prefix regex factory.

Reviewers should pay particular attention to the intended UUID behavior: the shared matcher is structural and version-agnostic.

Closes ENG-492

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@shipfox/regex` to centralize UUID, slug, SHA-256, and Shipfox token prefix validation, and migrates callers to use it to prevent regex drift. UUID matching is now structural (any dashed UUID, case-insensitive) per ENG-492. Closes ENG-492.

- **New Features**
  - New `@shipfox/regex` helpers: `isUuid`, `isLowercaseAlphaSlug`, `isAlnumSlug`, `isLowercaseSha256Hex`, and `createShipfoxTokenPrefixRegexes`.
  - `@shipfox/node-tokens` builds/unifies token prefix parsing with `createShipfoxTokenPrefixRegexes` while keeping token type ownership there.
  - `@shipfox/node-opentelemetry` uses `isUuid` for route path normalization.

- **Refactors**
  - Client runs search accepts any dashed UUID and validates trigger sources via `isAlnumSlug`.
  - Runner logs/protocol/workspace validate step and job IDs with `isUuid`.
  - Provider registry uses `isLowercaseAlphaSlug`; workflow definition hashing checks use `LOWERCASE_SHA256_HEX_RE`; e2e token flows use shared token prefix regexes.

<sup>Written for commit 70b51dd72f51e331686d75b08c3b4b27dc99f206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

