### PR TITLE
[api/integration] Re-sync debug workflows on each API startup

### DIFF
--- a/.changeset/debug-startup-resync.md
+++ b/.changeset/debug-startup-resync.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-debug": patch
+"@shipfox/api-integration-core": patch
+---
+
+Debug integration: on each API startup (when the debug provider is enabled), emit an `INTEGRATION_SOURCE_COMMIT_PUSHED` for the debug `platform` repo on its main branch, for every active debug connection. This forces a re-sync of the debug workflow definitions on every boot. Only the typed event is emitted (not the generic `INTEGRATION_EVENT_RECEIVED` envelope), so it never re-runs `on_push` workflows.

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -49,6 +49,10 @@ export async function run(): Promise<void> {
       dispatcherModule,
     ],
   });
+  // Boot-time module tasks (post-migration). When the debug provider is enabled this forces
+  // a definitions re-sync of the debug fixtures; it is a no-op otherwise and never throws.
+  await integrations.runStartupTasks();
+
   const e2eAuth = config.E2E_ENABLED ? [createE2eAdminAuthMethod(config)] : [];
   const mountedE2eRoutes = createE2eRouteGroup(e2eRoutes, config);
 

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -49,8 +49,8 @@ export async function run(): Promise<void> {
       dispatcherModule,
     ],
   });
-  // Boot-time module tasks (post-migration). When the debug provider is enabled this forces
-  // a definitions re-sync of the debug fixtures; it is a no-op otherwise and never throws.
+  // Boot-time provider tasks (post-migration). No-op when no enabled provider contributes
+  // one; failures are isolated and logged, never thrown, so they cannot gate boot.
   await integrations.runStartupTasks();
 
   const e2eAuth = config.E2E_ENABLED ? [createE2eAdminAuthMethod(config)] : [];

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -47,6 +47,7 @@
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
     "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",

--- a/libs/api/integration/core/src/db/connections.test.ts
+++ b/libs/api/integration/core/src/db/connections.test.ts
@@ -2,6 +2,7 @@ import {upsertGithubInstallation} from '@shipfox/api-integration-github';
 import {
   getIntegrationConnectionById,
   listIntegrationConnections,
+  listIntegrationConnectionsByProvider,
   updateIntegrationConnectionLifecycleStatus,
   upsertIntegrationConnection,
 } from './connections.js';
@@ -80,6 +81,35 @@ describe('integration connection queries', () => {
       ['github', 'active'],
       ['github', 'disabled'],
     ]);
+  });
+
+  it('lists connections for a provider across all workspaces', async () => {
+    const otherWorkspaceId = crypto.randomUUID();
+    const debugA = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'debug',
+      externalAccountId: 'debug',
+      displayName: 'Debug',
+    });
+    const debugB = await upsertIntegrationConnection({
+      workspaceId: otherWorkspaceId,
+      provider: 'debug',
+      externalAccountId: 'debug',
+      displayName: 'Debug',
+    });
+    const github = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'github',
+      externalAccountId: 'gh-1',
+      displayName: 'GitHub',
+    });
+
+    const result = await listIntegrationConnectionsByProvider({provider: 'debug'});
+
+    const ids = result.map((connection) => connection.id);
+    expect(result.every((connection) => connection.provider === 'debug')).toBe(true);
+    expect(ids).toEqual(expect.arrayContaining([debugA.id, debugB.id]));
+    expect(ids).not.toContain(github.id);
   });
 
   it('updates a connection lifecycle status and returns the mapped connection', async () => {

--- a/libs/api/integration/core/src/db/connections.ts
+++ b/libs/api/integration/core/src/db/connections.ts
@@ -106,3 +106,19 @@ export async function listIntegrationConnections(
   const connections = rows.map(toIntegrationConnection);
   return connections;
 }
+
+export interface ListIntegrationConnectionsByProviderParams {
+  provider: IntegrationProviderKind;
+}
+
+export async function listIntegrationConnectionsByProvider(
+  params: ListIntegrationConnectionsByProviderParams,
+): Promise<IntegrationConnection[]> {
+  const rows = await db()
+    .select()
+    .from(integrationConnections)
+    .where(eq(integrationConnections.provider, params.provider))
+    .orderBy(integrationConnections.createdAt, integrationConnections.id);
+
+  return rows.map(toIntegrationConnection);
+}

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -10,6 +10,7 @@ import {integrationsOutbox} from './schema/outbox.js';
 import {integrationsWebhookDeliveries} from './schema/webhook-deliveries.js';
 import {
   publishIntegrationEventReceived,
+  publishSourceCommitPushed,
   publishSourcePush,
   recordDeliveryOnly,
 } from './webhook-deliveries.js';
@@ -169,5 +170,42 @@ describe('publishSourcePush', () => {
     expect(second.published).toBe(false);
     expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(1);
     expect(await outboxFor(params.deliveryId)).toHaveLength(2);
+  });
+});
+
+describe('publishSourceCommitPushed', () => {
+  function buildParams() {
+    return {
+      provider: 'debug',
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      deliveryId: crypto.randomUUID(),
+      receivedAt: new Date().toISOString(),
+      push: buildPush({externalRepositoryId: 'debug:platform'}),
+    };
+  }
+
+  it('writes only the typed event, never the generic envelope', async () => {
+    const params = buildParams();
+
+    await publishSourceCommitPushed(params);
+
+    const outbox = await outboxFor(params.deliveryId);
+    expect(outbox).toHaveLength(1);
+    expect(outbox[0]?.eventType).toBe(INTEGRATION_SOURCE_COMMIT_PUSHED);
+    expect(outbox.some((row) => row.eventType === INTEGRATION_EVENT_RECEIVED)).toBe(false);
+    expect(outbox[0]?.payload).toMatchObject({
+      provider: 'debug',
+      deliveryId: params.deliveryId,
+      push: {externalRepositoryId: 'debug:platform', isDefaultBranch: true},
+    });
+  });
+
+  it('does not write a webhook-delivery dedup row', async () => {
+    const params = buildParams();
+
+    await publishSourceCommitPushed(params);
+
+    expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(0);
   });
 });

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -108,6 +108,35 @@ export async function publishSourcePush(
   return {published: true};
 }
 
+export interface PublishSourceCommitPushedParams {
+  provider: string;
+  workspaceId: string;
+  connectionId: string;
+  deliveryId: string;
+  receivedAt: string;
+  push: SourcePushPayload;
+}
+
+// Emits ONLY the typed `INTEGRATION_SOURCE_COMMIT_PUSHED` event, intentionally skipping the
+// `INTEGRATION_EVENT_RECEIVED` envelope so triggers do not run workflows, and skipping the
+// delivery-dedup row so it is never suppressed. Used to force a definitions re-sync without
+// simulating an inbound webhook.
+export async function publishSourceCommitPushed(
+  params: PublishSourceCommitPushedParams,
+): Promise<void> {
+  await writeOutboxEvent<IntegrationsEventMap>(db(), integrationsOutbox, {
+    type: INTEGRATION_SOURCE_COMMIT_PUSHED,
+    payload: {
+      provider: params.provider,
+      workspaceId: params.workspaceId,
+      connectionId: params.connectionId,
+      deliveryId: params.deliveryId,
+      receivedAt: params.receivedAt,
+      push: params.push,
+    },
+  });
+}
+
 export interface RecordDeliveryOnlyParams {
   tx: Executor;
   provider: string;
@@ -141,4 +170,5 @@ export async function pruneWebhookDeliveries(
 
 export type PublishIntegrationEventReceivedFn = typeof publishIntegrationEventReceived;
 export type PublishSourcePushFn = typeof publishSourcePush;
+export type PublishSourceCommitPushedFn = typeof publishSourceCommitPushed;
 export type RecordDeliveryOnlyFn = typeof recordDeliveryOnly;

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -1,6 +1,8 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {emitDebugStartupResync} from '@shipfox/api-integration-debug';
 import type {ShipfoxModule} from '@shipfox/node-module';
+import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
 import {
   createIntegrationProviderRegistry,
@@ -10,10 +12,14 @@ import {
   createSourceControlIntegrationService,
   type IntegrationSourceControlService,
 } from '#core/source-control-service.js';
-import {getIntegrationConnectionById} from '#db/connections.js';
+import {
+  getIntegrationConnectionById,
+  listIntegrationConnectionsByProvider,
+} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
+import {publishSourceCommitPushed} from '#db/webhook-deliveries.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
 import {loadEnabledProviderModules} from '#providers/modules.js';
 import type {IntegrationModuleParts} from '#providers/types.js';
@@ -93,6 +99,12 @@ export interface IntegrationsContext {
     sourceControl: IntegrationSourceControlService;
   };
   sourceControl: IntegrationSourceControlService;
+  /**
+   * One-shot boot-time tasks, run by the app after modules are initialized (migrations done).
+   * Today: when the debug provider is enabled, force a definitions re-sync of the debug
+   * fixtures. No-op when debug is not registered. Never throws.
+   */
+  runStartupTasks: () => Promise<void>;
 }
 
 export async function createIntegrationsModule(
@@ -139,5 +151,26 @@ export async function createIntegrationsContext(
     ],
   };
 
-  return {module, registry, capabilities: {sourceControl}, sourceControl};
+  async function runStartupTasks(): Promise<void> {
+    // Gate = "debug provider registered". On the production boot path run.ts calls
+    // createIntegrationsContext() with no providers, so registration is driven by
+    // INTEGRATIONS_ENABLE_DEBUG_PROVIDER; the {providers} option is a test-only seam.
+    if (!registry.list().some((registered) => registered.provider === 'debug')) return;
+
+    // A debug-only convenience must never gate API boot. Mirrors startModuleWorkers, which
+    // catches per-worker errors and logs instead of throwing.
+    try {
+      await emitDebugStartupResync({
+        listConnections: async () =>
+          (await listIntegrationConnectionsByProvider({provider: 'debug'}))
+            .filter((connection) => connection.lifecycleStatus === 'active')
+            .map((connection) => ({id: connection.id, workspaceId: connection.workspaceId})),
+        publishSourceCommitPushed,
+      });
+    } catch (error) {
+      logger().error({err: error}, 'Debug integration: startup re-sync failed, continuing boot');
+    }
+  }
+
+  return {module, registry, capabilities: {sourceControl}, sourceControl, runStartupTasks};
 }

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -1,6 +1,5 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {emitDebugStartupResync} from '@shipfox/api-integration-debug';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
@@ -12,14 +11,10 @@ import {
   createSourceControlIntegrationService,
   type IntegrationSourceControlService,
 } from '#core/source-control-service.js';
-import {
-  getIntegrationConnectionById,
-  listIntegrationConnectionsByProvider,
-} from '#db/connections.js';
+import {getIntegrationConnectionById} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
-import {publishSourceCommitPushed} from '#db/webhook-deliveries.js';
 import {createIntegrationRoutes} from '#presentation/routes/index.js';
 import {loadEnabledProviderModules} from '#providers/modules.js';
 import type {IntegrationModuleParts} from '#providers/types.js';
@@ -90,6 +85,12 @@ export {integrationRouteErrorHandler} from '#presentation/routes/errors.js';
 
 export interface CreateIntegrationsModuleOptions {
   providers?: IntegrationProvider[] | undefined;
+  /**
+   * Pre-built module parts, bypassing config-gated provider loading. Test-only seam
+   * for exercising a provider's database, workers, or startup tasks directly. Takes
+   * precedence over `providers`.
+   */
+  parts?: IntegrationModuleParts[] | undefined;
 }
 
 export interface IntegrationsContext {
@@ -100,9 +101,9 @@ export interface IntegrationsContext {
   };
   sourceControl: IntegrationSourceControlService;
   /**
-   * One-shot boot-time tasks, run by the app after modules are initialized (migrations done).
-   * Today: when the debug provider is enabled, force a definitions re-sync of the debug
-   * fixtures. No-op when debug is not registered. Never throws.
+   * Runs every enabled provider's one-shot boot-time tasks, after modules are initialized
+   * (migrations done). Failures are isolated and logged, never rethrown, so a provider task
+   * can never gate API boot. No-op when no enabled provider contributes a task.
    */
   runStartupTasks: () => Promise<void>;
 }
@@ -116,9 +117,11 @@ export async function createIntegrationsModule(
 export async function createIntegrationsContext(
   options: CreateIntegrationsModuleOptions = {},
 ): Promise<IntegrationsContext> {
-  const parts: IntegrationModuleParts[] = options.providers
-    ? options.providers.map((provider) => ({provider}))
-    : await loadEnabledProviderModules();
+  const parts: IntegrationModuleParts[] =
+    options.parts ??
+    (options.providers
+      ? options.providers.map((provider) => ({provider}))
+      : await loadEnabledProviderModules());
 
   const registry = createIntegrationProviderRegistry(parts.map((part) => part.provider));
   const sourceControl = createSourceControlIntegrationService({
@@ -152,23 +155,14 @@ export async function createIntegrationsContext(
   };
 
   async function runStartupTasks(): Promise<void> {
-    // Gate = "debug provider registered". On the production boot path run.ts calls
-    // createIntegrationsContext() with no providers, so registration is driven by
-    // INTEGRATIONS_ENABLE_DEBUG_PROVIDER; the {providers} option is a test-only seam.
-    if (!registry.list().some((registered) => registered.provider === 'debug')) return;
-
-    // A debug-only convenience must never gate API boot. Mirrors startModuleWorkers, which
-    // catches per-worker errors and logs instead of throwing.
-    try {
-      await emitDebugStartupResync({
-        listConnections: async () =>
-          (await listIntegrationConnectionsByProvider({provider: 'debug'}))
-            .filter((connection) => connection.lifecycleStatus === 'active')
-            .map((connection) => ({id: connection.id, workspaceId: connection.workspaceId})),
-        publishSourceCommitPushed,
-      });
-    } catch (error) {
-      logger().error({err: error}, 'Debug integration: startup re-sync failed, continuing boot');
+    for (const task of parts.flatMap((part) => part.startupTasks ?? [])) {
+      // A provider convenience must never gate API boot. Mirrors startModuleWorkers, which
+      // catches per-worker errors and logs instead of throwing.
+      try {
+        await task();
+      } catch (error) {
+        logger().error({err: error}, 'Integration startup task failed, continuing boot');
+      }
     }
   }
 

--- a/libs/api/integration/core/src/providers/debug.ts
+++ b/libs/api/integration/core/src/providers/debug.ts
@@ -1,12 +1,30 @@
 import {config} from '#config.js';
-import {upsertIntegrationConnection} from '#db/connections.js';
+import {
+  listIntegrationConnectionsByProvider,
+  upsertIntegrationConnection,
+} from '#db/connections.js';
+import {publishSourceCommitPushed} from '#db/webhook-deliveries.js';
 import type {IntegrationProviderModule} from '#providers/types.js';
 
 export const debugProviderModule: IntegrationProviderModule = {
   id: 'debug',
   enabled: config.INTEGRATIONS_ENABLE_DEBUG_PROVIDER,
   load: async () => {
-    const {createDebugIntegrationProvider} = await import('@shipfox/api-integration-debug');
-    return {provider: createDebugIntegrationProvider({upsertIntegrationConnection})};
+    const {createDebugIntegrationProvider, emitDebugStartupResync} = await import(
+      '@shipfox/api-integration-debug'
+    );
+    return {
+      provider: createDebugIntegrationProvider({upsertIntegrationConnection}),
+      startupTasks: [
+        () =>
+          emitDebugStartupResync({
+            listConnections: async () =>
+              (await listIntegrationConnectionsByProvider({provider: 'debug'}))
+                .filter((connection) => connection.lifecycleStatus === 'active')
+                .map((connection) => ({id: connection.id, workspaceId: connection.workspaceId})),
+            publishSourceCommitPushed,
+          }),
+      ],
+    };
   },
 };

--- a/libs/api/integration/core/src/providers/types.ts
+++ b/libs/api/integration/core/src/providers/types.ts
@@ -3,13 +3,18 @@ import type {IntegrationProvider} from '#core/entities/provider.js';
 
 /**
  * Everything one integration contributes to the composed integrations module:
- * a registry provider, plus an optional dedicated database and background
- * workers. Providers that own no database or workers simply omit them.
+ * a registry provider, plus an optional dedicated database, background workers,
+ * and one-shot boot-time tasks. Providers that own none of these simply omit them.
+ *
+ * A startup task is run once after modules are initialized (migrations done). The
+ * provider owns its own wiring — core runs each task generically and isolates
+ * failures so a task can never gate API boot.
  */
 export interface IntegrationModuleParts {
   provider: IntegrationProvider;
   database?: ModuleDatabase | undefined;
   workers?: ModuleWorker[] | undefined;
+  startupTasks?: Array<() => Promise<void>> | undefined;
 }
 
 /**

--- a/libs/api/integration/core/src/startup-tasks.test.ts
+++ b/libs/api/integration/core/src/startup-tasks.test.ts
@@ -1,0 +1,91 @@
+import {INTEGRATION_SOURCE_COMMIT_PUSHED} from '@shipfox/api-integration-core-dto';
+import * as debugModule from '@shipfox/api-integration-debug';
+import {createDebugIntegrationProvider} from '@shipfox/api-integration-debug';
+import {sql} from 'drizzle-orm';
+import {upsertIntegrationConnection} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {integrationsOutbox} from '#db/schema/outbox.js';
+import {createIntegrationsContext} from './index.js';
+
+vi.mock('@shipfox/api-integration-debug', async (importActual) => {
+  const actual = await importActual<typeof import('@shipfox/api-integration-debug')>();
+  return {
+    ...actual,
+    emitDebugStartupResync: vi.fn(actual.emitDebugStartupResync),
+  };
+});
+
+function outboxForConnection(connectionId: string) {
+  return db()
+    .select()
+    .from(integrationsOutbox)
+    .where(sql`${integrationsOutbox.payload}->>'connectionId' = ${connectionId}`);
+}
+
+function debugProvider() {
+  return createDebugIntegrationProvider({upsertIntegrationConnection});
+}
+
+describe('createIntegrationsContext runStartupTasks', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('emits a debug source-commit-pushed for each active debug connection when enabled', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'debug',
+      externalAccountId: 'debug',
+      displayName: 'Debug',
+    });
+    const context = await createIntegrationsContext({providers: [debugProvider()]});
+
+    await context.runStartupTasks();
+
+    const outbox = await outboxForConnection(connection.id);
+    expect(outbox).toHaveLength(1);
+    expect(outbox[0]?.eventType).toBe(INTEGRATION_SOURCE_COMMIT_PUSHED);
+    expect(outbox[0]?.payload).toMatchObject({
+      provider: 'debug',
+      push: {externalRepositoryId: 'debug:platform', isDefaultBranch: true},
+    });
+  });
+
+  it('does nothing when the debug provider is not registered', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'debug',
+      externalAccountId: 'debug',
+      displayName: 'Debug',
+    });
+    const context = await createIntegrationsContext({providers: []});
+
+    await context.runStartupTasks();
+
+    expect(await outboxForConnection(connection.id)).toHaveLength(0);
+  });
+
+  it('skips disabled debug connections', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'debug',
+      externalAccountId: 'debug',
+      displayName: 'Debug',
+      lifecycleStatus: 'disabled',
+    });
+    const context = await createIntegrationsContext({providers: [debugProvider()]});
+
+    await context.runStartupTasks();
+
+    expect(await outboxForConnection(connection.id)).toHaveLength(0);
+  });
+
+  it('swallows and logs a re-sync failure instead of crashing boot', async () => {
+    vi.mocked(debugModule.emitDebugStartupResync).mockRejectedValueOnce(new Error('boom'));
+    const context = await createIntegrationsContext({providers: [debugProvider()]});
+
+    await expect(context.runStartupTasks()).resolves.toBeUndefined();
+  });
+});

--- a/libs/api/integration/core/src/startup-tasks.test.ts
+++ b/libs/api/integration/core/src/startup-tasks.test.ts
@@ -1,10 +1,10 @@
 import {INTEGRATION_SOURCE_COMMIT_PUSHED} from '@shipfox/api-integration-core-dto';
 import * as debugModule from '@shipfox/api-integration-debug';
-import {createDebugIntegrationProvider} from '@shipfox/api-integration-debug';
 import {sql} from 'drizzle-orm';
 import {upsertIntegrationConnection} from '#db/connections.js';
 import {db} from '#db/db.js';
 import {integrationsOutbox} from '#db/schema/outbox.js';
+import {debugProviderModule} from '#providers/debug.js';
 import {createIntegrationsContext} from './index.js';
 
 vi.mock('@shipfox/api-integration-debug', async (importActual) => {
@@ -22,10 +22,6 @@ function outboxForConnection(connectionId: string) {
     .where(sql`${integrationsOutbox.payload}->>'connectionId' = ${connectionId}`);
 }
 
-function debugProvider() {
-  return createDebugIntegrationProvider({upsertIntegrationConnection});
-}
-
 describe('createIntegrationsContext runStartupTasks', () => {
   let workspaceId: string;
 
@@ -40,7 +36,7 @@ describe('createIntegrationsContext runStartupTasks', () => {
       externalAccountId: 'debug',
       displayName: 'Debug',
     });
-    const context = await createIntegrationsContext({providers: [debugProvider()]});
+    const context = await createIntegrationsContext({parts: [await debugProviderModule.load()]});
 
     await context.runStartupTasks();
 
@@ -60,7 +56,7 @@ describe('createIntegrationsContext runStartupTasks', () => {
       externalAccountId: 'debug',
       displayName: 'Debug',
     });
-    const context = await createIntegrationsContext({providers: []});
+    const context = await createIntegrationsContext({parts: []});
 
     await context.runStartupTasks();
 
@@ -75,7 +71,7 @@ describe('createIntegrationsContext runStartupTasks', () => {
       displayName: 'Debug',
       lifecycleStatus: 'disabled',
     });
-    const context = await createIntegrationsContext({providers: [debugProvider()]});
+    const context = await createIntegrationsContext({parts: [await debugProviderModule.load()]});
 
     await context.runStartupTasks();
 
@@ -84,7 +80,7 @@ describe('createIntegrationsContext runStartupTasks', () => {
 
   it('swallows and logs a re-sync failure instead of crashing boot', async () => {
     vi.mocked(debugModule.emitDebugStartupResync).mockRejectedValueOnce(new Error('boom'));
-    const context = await createIntegrationsContext({providers: [debugProvider()]});
+    const context = await createIntegrationsContext({parts: [await debugProviderModule.load()]});
 
     await expect(context.runStartupTasks()).resolves.toBeUndefined();
   });

--- a/libs/api/integration/debug/src/core/source-control.ts
+++ b/libs/api/integration/debug/src/core/source-control.ts
@@ -23,7 +23,7 @@ function debugRepositoryId(name: string): string {
   return buildProviderRepositoryId(DEBUG_PROVIDER, name);
 }
 
-const DEBUG_REPOSITORIES: RepositorySnapshot[] = [
+export const DEBUG_REPOSITORIES: RepositorySnapshot[] = [
   {
     externalRepositoryId: debugRepositoryId('platform'),
     owner: 'debug-owner',

--- a/libs/api/integration/debug/src/core/startup-resync.test.ts
+++ b/libs/api/integration/debug/src/core/startup-resync.test.ts
@@ -51,6 +51,27 @@ describe('emitDebugStartupResync', () => {
     expect(publishSourceCommitPushed).not.toHaveBeenCalled();
   });
 
+  it('attempts every connection and aggregates failures when some publishes fail', async () => {
+    const published: PublishDebugSourceCommitPushedParams[] = [];
+    const deps: DebugStartupResyncDeps = {
+      listConnections: async () => [
+        {id: 'conn-1', workspaceId: 'ws-1'},
+        {id: 'conn-2', workspaceId: 'ws-2'},
+        {id: 'conn-3', workspaceId: 'ws-3'},
+      ],
+      publishSourceCommitPushed: (params) => {
+        if (params.connectionId === 'conn-2') return Promise.reject(new Error('boom'));
+        published.push(params);
+        return Promise.resolve();
+      },
+    };
+
+    const result = emitDebugStartupResync(deps);
+
+    await expect(result).rejects.toBeInstanceOf(AggregateError);
+    expect(published.map((entry) => entry.connectionId)).toEqual(['conn-1', 'conn-3']);
+  });
+
   it('uses a unique deliveryId per emission', async () => {
     const published: PublishDebugSourceCommitPushedParams[] = [];
     const deps: DebugStartupResyncDeps = {

--- a/libs/api/integration/debug/src/core/startup-resync.test.ts
+++ b/libs/api/integration/debug/src/core/startup-resync.test.ts
@@ -1,0 +1,72 @@
+import {
+  type DebugStartupResyncDeps,
+  emitDebugStartupResync,
+  type PublishDebugSourceCommitPushedParams,
+} from '#core/startup-resync.js';
+
+const DELIVERY_ID_PATTERN = /^debug-startup-resync:/;
+
+describe('emitDebugStartupResync', () => {
+  it('publishes one debug:platform default-branch push per connection', async () => {
+    const published: PublishDebugSourceCommitPushedParams[] = [];
+    const deps: DebugStartupResyncDeps = {
+      listConnections: async () => [
+        {id: 'conn-1', workspaceId: 'ws-1'},
+        {id: 'conn-2', workspaceId: 'ws-2'},
+      ],
+      publishSourceCommitPushed: (params) => {
+        published.push(params);
+        return Promise.resolve();
+      },
+    };
+
+    await emitDebugStartupResync(deps);
+
+    expect(published.map((entry) => [entry.connectionId, entry.workspaceId])).toEqual([
+      ['conn-1', 'ws-1'],
+      ['conn-2', 'ws-2'],
+    ]);
+    for (const entry of published) {
+      expect(entry.provider).toBe('debug');
+      expect(entry.deliveryId).toMatch(DELIVERY_ID_PATTERN);
+      expect(entry.push).toMatchObject({
+        externalRepositoryId: 'debug:platform',
+        ref: 'main',
+        defaultBranch: 'main',
+        isDefaultBranch: true,
+        headCommitSha: 'debug-startup-resync',
+      });
+    }
+  });
+
+  it('does not publish when there are no debug connections', async () => {
+    const publishSourceCommitPushed = vi.fn();
+    const deps: DebugStartupResyncDeps = {
+      listConnections: async () => [],
+      publishSourceCommitPushed,
+    };
+
+    await emitDebugStartupResync(deps);
+
+    expect(publishSourceCommitPushed).not.toHaveBeenCalled();
+  });
+
+  it('uses a unique deliveryId per emission', async () => {
+    const published: PublishDebugSourceCommitPushedParams[] = [];
+    const deps: DebugStartupResyncDeps = {
+      listConnections: async () => [
+        {id: 'conn-1', workspaceId: 'ws-1'},
+        {id: 'conn-1', workspaceId: 'ws-1'},
+      ],
+      publishSourceCommitPushed: (params) => {
+        published.push(params);
+        return Promise.resolve();
+      },
+    };
+
+    await emitDebugStartupResync(deps);
+
+    const deliveryIds = new Set(published.map((entry) => entry.deliveryId));
+    expect(deliveryIds.size).toBe(2);
+  });
+});

--- a/libs/api/integration/debug/src/core/startup-resync.ts
+++ b/libs/api/integration/debug/src/core/startup-resync.ts
@@ -1,0 +1,66 @@
+import type {SourcePushPayload} from '@shipfox/api-integration-core-dto';
+import {DEBUG_REPOSITORIES} from '#core/source-control.js';
+
+const DEBUG_PROVIDER = 'debug';
+// `platform` is the debug fixture that carries workflow files (see DEBUG_FILES); `api` and
+// `runner` ship none, so only `platform` needs a re-sync.
+const DEBUG_RESYNC_REPOSITORY = 'platform';
+// Clearly-synthetic commit marker, not a branch name. Debug content is ref-independent, so
+// this never points at a real commit. A stable value keeps the definition-sync workflow id
+// (`definition-sync:<projectId>:<sha>`) stable across boots, so Temporal's ALLOW_DUPLICATE
+// re-runs the sync each boot once the prior run closes. It does not guarantee exactly-once
+// across concurrent replicas, but duplicate runs are idempotent and fine for a dev provider.
+const DEBUG_RESYNC_COMMIT = 'debug-startup-resync';
+
+export interface DebugStartupResyncConnection {
+  id: string;
+  workspaceId: string;
+}
+
+export interface PublishDebugSourceCommitPushedParams {
+  provider: string;
+  workspaceId: string;
+  connectionId: string;
+  deliveryId: string;
+  receivedAt: string;
+  push: SourcePushPayload;
+}
+
+export interface DebugStartupResyncDeps {
+  listConnections: () => Promise<DebugStartupResyncConnection[]>;
+  publishSourceCommitPushed: (params: PublishDebugSourceCommitPushedParams) => Promise<void>;
+}
+
+/**
+ * Emits one `INTEGRATION_SOURCE_COMMIT_PUSHED` for the debug `platform` repo on its default
+ * branch, for every connection returned by `listConnections`. This re-drives the definitions
+ * sync so debug workflow fixtures are re-applied. All I/O is injected so the debug package
+ * stays free of core's database wiring.
+ */
+export async function emitDebugStartupResync(deps: DebugStartupResyncDeps): Promise<void> {
+  const connections = await deps.listConnections();
+  if (connections.length === 0) return;
+
+  const repository = DEBUG_REPOSITORIES.find((repo) => repo.name === DEBUG_RESYNC_REPOSITORY);
+  if (!repository) return;
+  const externalRepositoryId = repository.externalRepositoryId;
+
+  for (const connection of connections) {
+    await deps.publishSourceCommitPushed({
+      provider: DEBUG_PROVIDER,
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      // Unique per emission for traceable logs; the writer skips delivery-dedup, so a stable
+      // id would make every boot's events indistinguishable.
+      deliveryId: `debug-startup-resync:${crypto.randomUUID()}`,
+      receivedAt: new Date().toISOString(),
+      push: {
+        externalRepositoryId,
+        ref: repository.defaultBranch,
+        headCommitSha: DEBUG_RESYNC_COMMIT,
+        defaultBranch: repository.defaultBranch,
+        isDefaultBranch: true,
+      },
+    });
+  }
+}

--- a/libs/api/integration/debug/src/core/startup-resync.ts
+++ b/libs/api/integration/debug/src/core/startup-resync.ts
@@ -45,22 +45,36 @@ export async function emitDebugStartupResync(deps: DebugStartupResyncDeps): Prom
   if (!repository) return;
   const externalRepositoryId = repository.externalRepositoryId;
 
+  // Attempt every connection: a failure for one must not skip the rest. Collect errors and
+  // surface them together so the caller's boot-time handler still logs the failure.
+  const failures: unknown[] = [];
   for (const connection of connections) {
-    await deps.publishSourceCommitPushed({
-      provider: DEBUG_PROVIDER,
-      workspaceId: connection.workspaceId,
-      connectionId: connection.id,
-      // Unique per emission for traceable logs; the writer skips delivery-dedup, so a stable
-      // id would make every boot's events indistinguishable.
-      deliveryId: `debug-startup-resync:${crypto.randomUUID()}`,
-      receivedAt: new Date().toISOString(),
-      push: {
-        externalRepositoryId,
-        ref: repository.defaultBranch,
-        headCommitSha: DEBUG_RESYNC_COMMIT,
-        defaultBranch: repository.defaultBranch,
-        isDefaultBranch: true,
-      },
-    });
+    try {
+      await deps.publishSourceCommitPushed({
+        provider: DEBUG_PROVIDER,
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        // Unique per emission for traceable logs; the writer skips delivery-dedup, so a stable
+        // id would make every boot's events indistinguishable.
+        deliveryId: `debug-startup-resync:${crypto.randomUUID()}`,
+        receivedAt: new Date().toISOString(),
+        push: {
+          externalRepositoryId,
+          ref: repository.defaultBranch,
+          headCommitSha: DEBUG_RESYNC_COMMIT,
+          defaultBranch: repository.defaultBranch,
+          isDefaultBranch: true,
+        },
+      });
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Debug startup re-sync failed for ${failures.length} of ${connections.length} connection(s)`,
+    );
   }
 }

--- a/libs/api/integration/debug/src/index.ts
+++ b/libs/api/integration/debug/src/index.ts
@@ -5,6 +5,12 @@ import {
 } from '#presentation/routes/connections.js';
 
 export {DebugSourceControlProvider} from '#core/source-control.js';
+export {
+  type DebugStartupResyncConnection,
+  type DebugStartupResyncDeps,
+  emitDebugStartupResync,
+  type PublishDebugSourceCommitPushedParams,
+} from '#core/startup-resync.js';
 
 export function createDebugIntegrationProvider(options: CreateDebugIntegrationRoutesOptions) {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,6 +755,9 @@ importers:
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../../shared/node/opentelemetry
       '@shipfox/node-outbox':
         specifier: workspace:*
         version: link:../../../shared/node/outbox


### PR DESCRIPTION
When the debug integration provider is enabled, its repositories are static fixtures with no webhook, so workflow definitions never re-sync after the initial bind. Editing the debug fixtures (or changing the definitions schema) left no easy way to re-run the sync.

On each API startup, when the debug provider is enabled, the API now emits one `INTEGRATION_SOURCE_COMMIT_PUSHED` for the debug `platform` repo on its main branch, for every active debug connection. That re-drives the existing definitions-sync pipeline (projects subscriber, then definitions, then Temporal), so the debug workflows are re-discovered and re-applied on every boot. It is a no-op when the debug provider is disabled.

Key decisions:

- Only the typed event is emitted, never the generic `INTEGRATION_EVENT_RECEIVED` envelope, so triggers never re-run `on_push` workflows on restart.
- The re-sync logic lives in the debug provider package (`libs/api/integration/debug`); core only contributes the two injected DB primitives (list debug connections, write the typed outbox row) and the boot trigger on `IntegrationsContext`.
- The boot hook is error-isolated (try/catch + log), so a re-sync failure never blocks API startup, matching the existing `startModuleWorkers` posture.
- `headCommitSha` is a stable synthetic constant (`debug-startup-resync`), so the same `definition-sync` workflow id re-runs each boot via Temporal's `ALLOW_DUPLICATE`; `deliveryId` is unique per emission for log traceability.

Review notes: unit coverage asserts the emission contract, including the zero-envelope guarantee and the boot error isolation. Not exercised in CI: the full cross-module chain and the Docker end-to-end (enable the provider, bind a project to `debug:platform`, restart, confirm a sync runs while no `on_push` run fires).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-syncs debug workflow definitions on every API startup by emitting a typed commit-pushed event for the debug `platform` repo per active debug connection. No effect when the debug provider is disabled, and it never triggers `on_push` workflows.

- **New Features**
  - Adds generic provider `startupTasks` executed post-migrations via `integrations.runStartupTasks()`; the debug provider registers a re-sync task; no-op if the provider isn’t enabled.
  - Emits only `INTEGRATION_SOURCE_COMMIT_PUSHED` with `headCommitSha` `debug-startup-resync`, a unique `deliveryId`, and skips delivery dedup; never writes the generic envelope.
  - Logic lives in `@shipfox/api-integration-debug`; core injects `listIntegrationConnectionsByProvider` and `publishSourceCommitPushed`, filters to `active` connections, attempts every connection, and logs aggregated failures without blocking boot.

- **Dependencies**
  - Added `@shipfox/node-opentelemetry` for logging in `@shipfox/api-integration-core`.

<sup>Written for commit f535eb555850347dc2b1a7f01c397ef902eab9a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

