### PR TITLE
[api/logs] Close log streams on the runner's end record or job termination

### DIFF
--- a/.changeset/eng-518-logs-stream-close.md
+++ b/.changeset/eng-518-logs-stream-close.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": patch
+---
+
+Close a log stream so it becomes eligible for compaction. A committed `end` record declared-closes the stream inside the append transaction, and a `WORKFLOWS_JOB_TERMINATED` subscriber arms a grace-then-close Temporal workflow that force-closes any stream the runner never ended (appending a `runner_lost` tombstone and marking it truncated). Both paths route through one guarded close that writes a single `logs.stream.closed` outbox event, and a closed-stream guard drops later appends. Adds `closed_at` and three partial indexes to the stream table.

--- a/libs/api/logs/drizzle/0000_initial.sql
+++ b/libs/api/logs/drizzle/0000_initial.sql
@@ -13,7 +13,8 @@ CREATE TABLE "logs_attempt_streams" (
 	"truncated" boolean DEFAULT false NOT NULL,
 	"object_key" text,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"closed_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "logs_chunks" (
@@ -47,5 +48,8 @@ CREATE TABLE "logs_outbox" (
 --> statement-breakpoint
 ALTER TABLE "logs_chunks" ADD CONSTRAINT "logs_chunks_stream_id_logs_attempt_streams_id_fk" FOREIGN KEY ("stream_id") REFERENCES "public"."logs_attempt_streams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "logs_attempt_streams_identity_unique" ON "logs_attempt_streams" USING btree ("job_id","step_id","attempt");--> statement-breakpoint
+CREATE INDEX "logs_attempt_streams_open_by_job_idx" ON "logs_attempt_streams" USING btree ("job_id") WHERE "state" = 'open';--> statement-breakpoint
+CREATE INDEX "logs_attempt_streams_retention_idx" ON "logs_attempt_streams" USING btree ("closed_at") WHERE "state" = 'closed';--> statement-breakpoint
+CREATE INDEX "logs_attempt_streams_uncompacted_idx" ON "logs_attempt_streams" USING btree ("closed_at") WHERE "state" = 'closed' and "object_key" is null;--> statement-breakpoint
 CREATE INDEX "logs_chunks_stream_seq_idx" ON "logs_chunks" USING btree ("stream_id","seq");--> statement-breakpoint
 CREATE INDEX "logs_outbox_pending_idx" ON "logs_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;

--- a/libs/api/logs/drizzle/meta/0000_snapshot.json
+++ b/libs/api/logs/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "190939f9-0176-4071-b32c-7ab0d76b6498",
+  "id": "ba491684-be58-4cbd-bb86-49c89eea5872",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -103,6 +103,12 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
@@ -129,6 +135,54 @@
             }
           ],
           "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_open_by_job_idx": {
+          "name": "logs_attempt_streams_open_by_job_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'open'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_retention_idx": {
+          "name": "logs_attempt_streams_retention_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'closed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "logs_attempt_streams_uncompacted_idx": {
+          "name": "logs_attempt_streams_uncompacted_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" = 'closed' and \"object_key\" is null",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/logs/package.json
+++ b/libs/api/logs/package.json
@@ -37,8 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1070.0",
-    "@aws-sdk/lib-storage": "^3.1070.0",
+    "@aws-sdk/client-s3": "^3.1068.0",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",

--- a/libs/api/logs/package.json
+++ b/libs/api/logs/package.json
@@ -37,9 +37,11 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1068.0",
+    "@aws-sdk/client-s3": "^3.1070.0",
+    "@aws-sdk/lib-storage": "^3.1070.0",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
+    "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
@@ -47,6 +49,7 @@
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
+    "@shipfox/node-temporal": "workspace:*",
     "drizzle-orm": "^0.45.2",
     "zod": "^4.4.3"
   },
@@ -59,6 +62,12 @@
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@temporalio/activity": "^1.16.1",
+    "@temporalio/client": "^1.16.1",
+    "@temporalio/common": "^1.16.1",
+    "@temporalio/testing": "^1.16.1",
+    "@temporalio/worker": "^1.16.1",
+    "@temporalio/workflow": "^1.16.1",
     "@types/pg": "^8.15.5",
     "drizzle-kit": "^0.31.10",
     "fastify": "^5.3.3",

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -33,4 +33,12 @@ export const config = createConfig({
     desc: 'Stored bytes added to the per-job log budget for each minute since the first log append. Defaults to 1 MiB per minute.',
     default: 1_048_576,
   }),
+  LOG_STREAM_CLOSE_GRACE_SECONDS: num({
+    desc: 'How long to wait after a job reaches a terminal state before force-closing any of its log streams the runner never ended itself (it died, was capped, or its log spool failed). The wait lets a last in-flight chunk land before the stream is marked truncated. Defaults to 120 seconds.',
+    default: 120,
+  }),
+  LOG_RETENTION_DAYS: num({
+    desc: 'How many days a compacted log object and its stream row are kept before the retention worker deletes both. Counts from when the stream closed. Defaults to 90 days.',
+    default: 90,
+  }),
 });

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -37,8 +37,4 @@ export const config = createConfig({
     desc: 'How long to wait after a job reaches a terminal state before force-closing any of its log streams the runner never ended itself (it died, was capped, or its log spool failed). The wait lets a last in-flight chunk land before the stream is marked truncated. Defaults to 120 seconds.',
     default: 120,
   }),
-  LOG_RETENTION_DAYS: num({
-    desc: 'How many days a compacted log object and its stream row are kept before the retention worker deletes both. Counts from when the stream closed. Defaults to 90 days.',
-    default: 90,
-  }),
 });

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -2,7 +2,7 @@ import {appendLogs} from '#core/append-logs.js';
 import {LeaseStreamMismatchError, OffsetGapError} from '#core/errors.js';
 import {jobAccountingFactory} from '#test/factories/job-accounting.js';
 import {controlLine, ndjsonBody, outputLine, outputOfBytes} from '#test/fixtures/ndjson.js';
-import {findAccounting, findStream, listChunks} from '#test/queries.js';
+import {findAccounting, findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
 
 interface Ctx {
   jobId: string;
@@ -163,30 +163,51 @@ describe('appendLogs', () => {
   });
 
   describe('stream lifecycle', () => {
-    it('records declared_total_bytes from an end record without closing the stream', async () => {
+    it('declared-closes the stream and emits one stream-closed event on an end record', async () => {
       const ctx = newCtx();
       const body = ndjsonBody(outputLine('done\n'), controlLine({kind: 'end', total_bytes: 12345}));
 
       await appendLogs({...ctx, attempt: 1, offset: 0, body});
 
       const stream = await findStream({...ctx, attempt: 1});
+      expect(stream?.state).toBe('closed');
+      expect(stream?.closeReason).toBe('declared');
+      expect(stream?.truncated).toBe(false);
       expect(stream?.declaredTotalBytes).toBe(12345);
-      expect(stream?.state).toBe('open');
+      expect(stream?.closedAt).not.toBeNull();
+      expect(await listStreamClosedEvents(stream?.id as string)).toHaveLength(1);
     });
 
-    it('lets a later end record overwrite the declared total (last wins)', async () => {
+    it('is idempotent: a re-sent end body neither re-closes nor emits a second event', async () => {
       const ctx = newCtx();
-      const first = ndjsonBody(controlLine({kind: 'end', total_bytes: 100}));
-      await appendLogs({...ctx, attempt: 1, offset: 0, body: first});
+      const body = ndjsonBody(outputLine('done\n'), controlLine({kind: 'end', total_bytes: 10}));
+      await appendLogs({...ctx, attempt: 1, offset: 0, body});
+      const stream = await findStream({...ctx, attempt: 1});
 
-      await appendLogs({
+      await appendLogs({...ctx, attempt: 1, offset: 0, body});
+
+      expect(await listStreamClosedEvents(stream?.id as string)).toHaveLength(1);
+    });
+
+    it('drops further output once declared-closed (no new chunk, committed_length frozen)', async () => {
+      const ctx = newCtx();
+      // End-only body so the single stored chunk stays under the 100-byte test budget
+      // (an extra output line would trip the cap and add a tombstone chunk).
+      const end = ndjsonBody(controlLine({kind: 'end', total_bytes: 4}));
+      await appendLogs({...ctx, attempt: 1, offset: 0, body: end});
+      const closed = await findStream({...ctx, attempt: 1});
+
+      const result = await appendLogs({
         ...ctx,
         attempt: 1,
-        offset: first.length,
-        body: ndjsonBody(controlLine({kind: 'end', total_bytes: 200})),
+        offset: end.length,
+        body: ndjsonBody(outputLine('late\n')),
       });
 
-      expect((await findStream({...ctx, attempt: 1}))?.declaredTotalBytes).toBe(200);
+      expect(result.committedLength).toBe(end.length);
+      const after = await findStream({...ctx, attempt: 1});
+      expect(after?.committedLength).toBe(closed?.committedLength);
+      expect(await listChunks(after?.id as string)).toHaveLength(1);
     });
 
     it('keeps attempts of the same step on independent streams', async () => {

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -210,6 +210,49 @@ describe('appendLogs', () => {
       expect(await listChunks(after?.id as string)).toHaveLength(1);
     });
 
+    it('declared-closes when one body both crosses the budget and ends', async () => {
+      const ctx = newCtx();
+      // 150 payload bytes cross the 100-byte test budget, but the crossing chunk is still
+      // stored in full; the same body carries the end, so the stream declared-closes.
+      const body = ndjsonBody(
+        outputLine('x'.repeat(150)),
+        controlLine({kind: 'end', total_bytes: 4}),
+      );
+
+      const result = await appendLogs({...ctx, attempt: 1, offset: 0, body});
+
+      expect(result.capped).toBe(true);
+      const stream = await findStream({...ctx, attempt: 1});
+      expect(stream?.state).toBe('closed');
+      expect(stream?.closeReason).toBe('declared');
+      expect(stream?.truncated).toBe(false);
+      expect((await listChunks(stream?.id as string)).map((c) => c.kind)).toEqual([
+        'runner',
+        'control',
+      ]);
+      expect(await listStreamClosedEvents(stream?.id as string)).toHaveLength(1);
+    });
+
+    it('does not declared-close when an already-capped job drops the end body', async () => {
+      const ctx = newCtx();
+      // Cap the job first (150 payload bytes cross the 100-byte budget), then send the end
+      // body: it is dropped, so the stream is not whole and must stay open for the sweep.
+      const first = outputOfBytes(150);
+      await appendLogs({...ctx, attempt: 1, offset: 0, body: first});
+      const end = ndjsonBody(controlLine({kind: 'end', total_bytes: 4}));
+
+      const result = await appendLogs({...ctx, attempt: 1, offset: first.length, body: end});
+
+      expect(result.capped).toBe(true);
+      const stream = await findStream({...ctx, attempt: 1});
+      expect(stream?.state).toBe('open');
+      expect(stream?.closeReason).toBeNull();
+      expect(stream?.declaredTotalBytes).toBeNull();
+      // The dropped end body persisted nothing: still just the runner chunk + cap tombstone.
+      expect(await listChunks(stream?.id as string)).toHaveLength(2);
+      expect(await listStreamClosedEvents(stream?.id as string)).toHaveLength(0);
+    });
+
     it('keeps attempts of the same step on independent streams', async () => {
       const ctx = newCtx();
       const a1 = ndjsonBody(outputLine('one\n'));

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -1,5 +1,5 @@
-import {Buffer} from 'node:buffer';
-import {type LogRecord, parseLogRecordLine} from '@shipfox/api-logs-dto';
+import type {Buffer} from 'node:buffer';
+import {parseLogRecordLine} from '@shipfox/api-logs-dto';
 import {config} from '#config.js';
 import {accrueStoredBytes, claimCap, ensureJobAccounting, isJobCapped} from '#db/accounting.js';
 import {insertChunk} from '#db/chunks.js';
@@ -11,6 +11,7 @@ import {
   setDeclaredTotalBytes,
 } from '#db/streams.js';
 import {allowedBudget} from './budget.js';
+import {closeStream, controlTombstone} from './close-stream.js';
 import {MalformedLogChunkError, OffsetGapError} from './errors.js';
 
 export interface AppendLogsParams {
@@ -64,13 +65,6 @@ function parseAppendBody(body: Buffer): ParsedBody {
   }
 
   return declaredTotalBytes === undefined ? {} : {declaredTotalBytes};
-}
-
-function cappedTombstone(): Buffer {
-  // Typed against the shared v1 contract so an envelope change in the dto package
-  // breaks this at compile time rather than silently emitting an off-contract record.
-  const record: LogRecord = {v: 1, ts: Date.now(), src: 'system', type: 'control', kind: 'capped'};
-  return Buffer.from(`${JSON.stringify(record)}\n`, 'utf8');
 }
 
 /**
@@ -135,7 +129,7 @@ async function storeChunk(
   // bounded by one body). Claim the cap once and inject the tombstone for the winner.
   const won = await claimCap(tx, params.jobId);
   if (won) {
-    const tombstone = cappedTombstone();
+    const tombstone = controlTombstone('capped');
     await insertChunk(tx, {
       streamId,
       streamOffset: committedLength,
@@ -170,6 +164,13 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       runId: params.runId,
     });
 
+    // Closed stream (the runner's end already landed, or the job-terminated sweep ran):
+    // accept-and-drop so a late chunk can never race compaction. committed_length is
+    // frozen at close, so this reports the final offset and the runner stops cleanly.
+    if (stream.state === 'closed') {
+      return {committedLength: stream.committedLength, capped: await isJobCapped(tx, params.jobId)};
+    }
+
     const cas = await casExtendCommittedLength(tx, {
       streamId: stream.id,
       offset: params.offset,
@@ -180,12 +181,21 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       return {committedLength: cas.committedLength, capped: await isJobCapped(tx, params.jobId)};
     }
 
-    return storeChunk(tx, {
+    const result = await storeChunk(tx, {
       params,
       streamId: stream.id,
       byteLen,
       committedLength: cas.committedLength,
       declaredTotalBytes,
     });
+
+    // The runner's end record was committed in this append (offset-CAS guarantees
+    // everything before it is already committed), so the stream is whole. Declared-close
+    // it in-band so compaction starts at once instead of waiting for the timeout sweep.
+    if (declaredTotalBytes !== undefined) {
+      await closeStream(tx, {streamId: stream.id, reason: 'declared'});
+    }
+
+    return result;
   });
 }

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -91,6 +91,15 @@ interface StoreChunkParams {
   declaredTotalBytes: number | undefined;
 }
 
+interface StoreChunkResult extends AppendLogsResult {
+  /**
+   * Whether the runner chunk was persisted. False only when the job was already
+   * capped and the body (including any `end` record) was dropped, so the stream is
+   * not whole and must not be declared-closed.
+   */
+  stored: boolean;
+}
+
 /**
  * Accrues the stored bytes, persists the chunk, and trips the per-job cap when
  * this append crosses the budget. Runs only after the offset-CAS extended
@@ -99,13 +108,13 @@ interface StoreChunkParams {
 async function storeChunk(
   tx: Transaction,
   {params, streamId, byteLen, committedLength, declaredTotalBytes}: StoreChunkParams,
-): Promise<AppendLogsResult> {
+): Promise<StoreChunkResult> {
   await ensureJobAccounting(tx, {jobId: params.jobId, workspaceId: params.workspaceId});
   const accrued = await accrueStoredBytes(tx, {jobId: params.jobId, delta: byteLen});
 
   // Already capped: accept-and-drop. committed_length has advanced so the runner
   // drains its spool cleanly instead of retry-looping; nothing is stored.
-  if (!accrued) return {committedLength, capped: true};
+  if (!accrued) return {committedLength, capped: true, stored: false};
 
   await insertChunk(tx, {
     streamId,
@@ -123,7 +132,7 @@ async function storeChunk(
     ratePerMinuteBytes: config.LOG_BUDGET_RATE_BYTES_PER_MINUTE,
     elapsedMs: Date.now() - accrued.startedAt.getTime(),
   });
-  if (accrued.used <= allowed) return {committedLength, capped: false};
+  if (accrued.used <= allowed) return {committedLength, capped: false, stored: true};
 
   // Over budget. No hard ceiling: this crossing append is stored in full (overshoot
   // bounded by one body). Claim the cap once and inject the tombstone for the winner.
@@ -138,7 +147,7 @@ async function storeChunk(
       kind: 'control',
     });
   }
-  return {committedLength, capped: true};
+  return {committedLength, capped: true, stored: true};
 }
 
 /**
@@ -181,7 +190,7 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       return {committedLength: cas.committedLength, capped: await isJobCapped(tx, params.jobId)};
     }
 
-    const result = await storeChunk(tx, {
+    const {stored, ...result} = await storeChunk(tx, {
       params,
       streamId: stream.id,
       byteLen,
@@ -192,7 +201,10 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
     // The runner's end record was committed in this append (offset-CAS guarantees
     // everything before it is already committed), so the stream is whole. Declared-close
     // it in-band so compaction starts at once instead of waiting for the timeout sweep.
-    if (declaredTotalBytes !== undefined) {
+    // Only when the chunk was actually stored: an end body dropped because the job was
+    // already capped persists nothing, so the stream is not whole and stays open for the
+    // timeout sweep to close it as truncated.
+    if (declaredTotalBytes !== undefined && stored) {
       await closeStream(tx, {streamId: stream.id, reason: 'declared'});
     }
 

--- a/libs/api/logs/src/core/close-stream.ts
+++ b/libs/api/logs/src/core/close-stream.ts
@@ -1,0 +1,75 @@
+import {Buffer} from 'node:buffer';
+import {LOG_STREAM_CLOSED, type LogRecord, type LogsEventMap} from '@shipfox/api-logs-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
+import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
+import {insertChunk} from '#db/chunks.js';
+import type {Transaction} from '#db/db.js';
+import {logsOutbox} from '#db/schema/outbox.js';
+import {markStreamClosed} from '#db/streams.js';
+
+/** Server-originated control records the server injects into a stream as tombstone chunks. */
+export type TombstoneKind = 'capped' | 'runner_lost';
+
+/**
+ * Frames a server tombstone as one newline-terminated v1 NDJSON record. Typed
+ * against the shared contract so an envelope change breaks this at compile time.
+ * Stored as a `control` chunk; like every server record it does NOT advance
+ * `committed_length`, so the CAS axis stays equal to runner spool bytes.
+ */
+export function controlTombstone(kind: TombstoneKind): Buffer {
+  const record: LogRecord = {v: 1, ts: Date.now(), src: 'system', type: 'control', kind};
+  return Buffer.from(`${JSON.stringify(record)}\n`, 'utf8');
+}
+
+export interface CloseStreamParams {
+  streamId: string;
+  reason: StreamCloseReason;
+  /**
+   * When set, the stream is marked `truncated` and the tombstone is appended as a
+   * `control` chunk at the current offset (no `committed_length` advance). Used by
+   * the timeout path (`runner_lost`); the declared path passes none.
+   */
+  tombstone?: Buffer;
+}
+
+/**
+ * Closes a stream exactly once. The guarded UPDATE (`WHERE state='open'`) is the
+ * lock and the idempotency gate: a stream already closed by the other path (the
+ * append-time declared close vs the job-terminated timeout sweep) returns null,
+ * so no duplicate `LOG_STREAM_CLOSED` is written and no second tombstone lands.
+ * The event drives compaction; it is written in the same transaction as the flip.
+ */
+export async function closeStream(
+  tx: Transaction,
+  params: CloseStreamParams,
+): Promise<AttemptStream | null> {
+  const closed = await markStreamClosed(tx, {
+    streamId: params.streamId,
+    reason: params.reason,
+    markTruncated: params.tombstone !== undefined,
+  });
+  if (!closed) return null;
+
+  if (params.tombstone) {
+    await insertChunk(tx, {
+      streamId: closed.id,
+      streamOffset: closed.committedLength,
+      byteLen: params.tombstone.length,
+      data: params.tombstone,
+      kind: 'control',
+    });
+  }
+
+  await writeOutboxEvent<LogsEventMap>(tx, logsOutbox, {
+    type: LOG_STREAM_CLOSED,
+    payload: {
+      workspaceId: closed.workspaceId,
+      jobId: closed.jobId,
+      stepId: closed.stepId,
+      attempt: closed.attempt,
+      streamId: closed.id,
+    },
+  });
+
+  return closed;
+}

--- a/libs/api/logs/src/core/entities/attempt-stream.ts
+++ b/libs/api/logs/src/core/entities/attempt-stream.ts
@@ -28,4 +28,6 @@ export interface AttemptStream {
   objectKey: string | null;
   createdAt: Date;
   updatedAt: Date;
+  /** When the stream was closed (either close path); null while open. Retention anchor. */
+  closedAt: Date | null;
 }

--- a/libs/api/logs/src/db/schema/attempt-streams.ts
+++ b/libs/api/logs/src/db/schema/attempt-streams.ts
@@ -1,5 +1,15 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {bigint, boolean, integer, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {sql} from 'drizzle-orm';
+import {
+  bigint,
+  boolean,
+  index,
+  integer,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
 import type {AttemptStream} from '#core/entities/attempt-stream.js';
 import {pgTable} from './common.js';
 
@@ -39,6 +49,7 @@ export const attemptStreams = pgTable(
     objectKey: text('object_key'),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+    closedAt: timestamp('closed_at', {withTimezone: true}),
   },
   (table) => [
     uniqueIndex('logs_attempt_streams_identity_unique').on(
@@ -46,6 +57,16 @@ export const attemptStreams = pgTable(
       table.stepId,
       table.attempt,
     ),
+    // Timeout-close sweeps an open job's streams by job_id; the partial index keeps
+    // it off the closed tail.
+    index('logs_attempt_streams_open_by_job_idx').on(table.jobId).where(sql`"state" = 'open'`),
+    // Retention scans closed streams by close age; partial so it never carries the
+    // open (in-flight) set.
+    index('logs_attempt_streams_retention_idx').on(table.closedAt).where(sql`"state" = 'closed'`),
+    // Reconcile re-drives closed streams that never got an object key.
+    index('logs_attempt_streams_uncompacted_idx')
+      .on(table.closedAt)
+      .where(sql`"state" = 'closed' and "object_key" is null`),
   ],
 );
 
@@ -70,5 +91,6 @@ export function toAttemptStream(row: AttemptStreamDb): AttemptStream {
     objectKey: row.objectKey,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    closedAt: row.closedAt,
   };
 }

--- a/libs/api/logs/src/db/schema/outbox.ts
+++ b/libs/api/logs/src/db/schema/outbox.ts
@@ -1,7 +1,4 @@
 import {createOutboxTable} from '@shipfox/node-outbox';
 import {pgTable} from './common.js';
 
-// Table ships now so ENG-442 (stream-closed → compaction) only adds the event
-// write, not a migration to an already-shipped schema. No publisher is
-// registered on the module until that event exists.
 export const logsOutbox = createOutboxTable(pgTable);

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -131,7 +131,7 @@ export async function setDeclaredTotalBytes(
  * Guarded close: flips `open → closed` and stamps `closed_at` iff the stream is
  * still open, returning the closed row (or null when another path already closed
  * it). The `WHERE state='open'` predicate is both the row lock and the
- * exactly-once gate. `committed_length` is left untouched — it stays equal to the
+ * exactly-once gate. `committed_length` is left untouched; it stays equal to the
  * runner spool bytes. `truncated` is set only on the timeout path.
  */
 export async function markStreamClosed(

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -1,7 +1,7 @@
 import {and, eq, sql} from 'drizzle-orm';
-import type {AttemptStream} from '#core/entities/attempt-stream.js';
+import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
 import {LeaseStreamMismatchError} from '#core/errors.js';
-import type {Transaction} from './db.js';
+import {db, type Transaction} from './db.js';
 import {attemptStreams, toAttemptStream} from './schema/attempt-streams.js';
 
 export interface AttemptStreamIdentity {
@@ -125,4 +125,40 @@ export async function setDeclaredTotalBytes(
     .update(attemptStreams)
     .set({declaredTotalBytes: params.declaredTotalBytes, updatedAt: sql`now()`})
     .where(eq(attemptStreams.id, params.streamId));
+}
+
+/**
+ * Guarded close: flips `open → closed` and stamps `closed_at` iff the stream is
+ * still open, returning the closed row (or null when another path already closed
+ * it). The `WHERE state='open'` predicate is both the row lock and the
+ * exactly-once gate. `committed_length` is left untouched — it stays equal to the
+ * runner spool bytes. `truncated` is set only on the timeout path.
+ */
+export async function markStreamClosed(
+  tx: Transaction,
+  params: {streamId: string; reason: StreamCloseReason; markTruncated: boolean},
+): Promise<AttemptStream | null> {
+  const [row] = await tx
+    .update(attemptStreams)
+    .set({
+      state: 'closed',
+      closeReason: params.reason,
+      closedAt: sql`now()`,
+      updatedAt: sql`now()`,
+      ...(params.markTruncated ? {truncated: true} : {}),
+    })
+    .where(and(eq(attemptStreams.id, params.streamId), eq(attemptStreams.state, 'open')))
+    .returning();
+
+  return row ? toAttemptStream(row) : null;
+}
+
+/** Open streams of a job, for the timeout sweep to force-close after the grace period. */
+export async function listOpenStreamsByJob(jobId: string): Promise<AttemptStream[]> {
+  const rows = await db()
+    .select()
+    .from(attemptStreams)
+    .where(and(eq(attemptStreams.jobId, jobId), eq(attemptStreams.state, 'open')));
+
+  return rows.map(toAttemptStream);
 }

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -1,13 +1,32 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {WORKFLOWS_JOB_TERMINATED} from '@shipfox/api-workflows-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
-import {db, migrationsPath} from '#db/index.js';
+import {db, logsOutbox, migrationsPath} from '#db/index.js';
 import {logsRoutes} from '#presentation/routes/index.js';
+import {onJobTerminated} from '#presentation/subscribers/on-job-terminated.js';
+import {createLogsActivities} from '#temporal/activities/index.js';
+import {LOGS_LIFECYCLE_TASK_QUEUE} from '#temporal/constants.js';
 
 export {checkBucketReachable} from '#api/object-storage.js';
 
-// Publisher registration is deferred to ENG-442 (the first event, stream-closed,
-// is owned there); the outbox table ships now so that PR alters no shipped schema.
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
+
 export const logsModule: ShipfoxModule = {
   name: 'logs',
   database: {db, migrationsPath},
   routes: logsRoutes,
+  // `logs.stream.closed` is written by the close paths (drives compaction). The
+  // job-terminated subscriber force-closes streams the runner never ended.
+  publishers: [{name: 'logs', table: logsOutbox, db}],
+  subscribers: [{event: WORKFLOWS_JOB_TERMINATED, handler: onJobTerminated}],
+  workers: [
+    {
+      taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
+      workflowsPath,
+      activities: createLogsActivities,
+      workflows: [],
+    },
+  ],
 };

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.test.ts
@@ -1,0 +1,69 @@
+import type {WorkflowsJobTerminatedEvent} from '@shipfox/api-workflows-dto';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {config} from '#config.js';
+import {LOGS_LIFECYCLE_TASK_QUEUE} from '#temporal/constants.js';
+import {onJobTerminated} from './on-job-terminated.js';
+
+const startMock = vi.fn();
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({
+    workflow: {
+      start: startMock,
+    },
+  }),
+}));
+
+function buildEvent(jobId: string): DomainEvent {
+  const payload: WorkflowsJobTerminatedEvent = {
+    jobId,
+    runId: crypto.randomUUID(),
+    status: 'failed',
+  };
+  return {
+    id: crypto.randomUUID(),
+    type: 'workflows.job.terminated',
+    createdAt: new Date(),
+    payload,
+  };
+}
+
+function alreadyStartedError(): Error {
+  const error = new Error('Workflow execution already started');
+  error.name = 'WorkflowExecutionAlreadyStartedError';
+  return error;
+}
+
+describe('onJobTerminated', () => {
+  beforeEach(() => {
+    startMock.mockReset();
+    startMock.mockResolvedValue({});
+  });
+
+  it('arms the close-abandoned-streams workflow keyed on the job id', async () => {
+    const jobId = crypto.randomUUID();
+
+    await onJobTerminated(buildEvent(jobId));
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(startMock).toHaveBeenCalledWith('closeAbandonedStreams', {
+      taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
+      workflowId: `logs-close:${jobId}`,
+      args: [{jobId, graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS}],
+    });
+  });
+
+  it('swallows a redelivered event when the workflow is already started', async () => {
+    startMock.mockRejectedValue(alreadyStartedError());
+
+    await expect(onJobTerminated(buildEvent(crypto.randomUUID()))).resolves.toBeUndefined();
+  });
+
+  it('re-throws an unexpected start failure so the outbox retries delivery', async () => {
+    startMock.mockRejectedValue(new Error('temporal unreachable'));
+
+    await expect(onJobTerminated(buildEvent(crypto.randomUUID()))).rejects.toThrow(
+      'temporal unreachable',
+    );
+  });
+});

--- a/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
+++ b/libs/api/logs/src/presentation/subscribers/on-job-terminated.ts
@@ -1,0 +1,29 @@
+import type {WorkflowsJobTerminatedEvent} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {temporalClient} from '@shipfox/node-temporal';
+import {config} from '#config.js';
+import {LOGS_LIFECYCLE_TASK_QUEUE} from '#temporal/constants.js';
+
+/**
+ * A job reached a terminal state (any path: completion, cancellation, lease-expiry,
+ * timeout). Arm the grace-then-close workflow for any of its streams the runner never
+ * ended itself. Deduped by workflow id, so a redelivered event is a no-op.
+ */
+export async function onJobTerminated(event: DomainEvent): Promise<void> {
+  const payload = event.payload as WorkflowsJobTerminatedEvent;
+
+  try {
+    await temporalClient().workflow.start('closeAbandonedStreams', {
+      taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
+      workflowId: `logs-close:${payload.jobId}`,
+      args: [{jobId: payload.jobId, graceSeconds: config.LOG_STREAM_CLOSE_GRACE_SECONDS}],
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'WorkflowExecutionAlreadyStartedError') {
+      logger().debug({jobId: payload.jobId}, 'Close-abandoned-streams workflow already started');
+      return;
+    }
+    throw error;
+  }
+}

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.test.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.test.ts
@@ -1,0 +1,84 @@
+import {appendLogs} from '#core/append-logs.js';
+import {closeAbandonedStreamsActivity} from '#temporal/activities/close-abandoned-streams.js';
+import {controlLine, ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
+import {findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
+
+interface Ctx {
+  jobId: string;
+  stepId: string;
+  workspaceId: string;
+  projectId: string;
+  runId: string;
+}
+
+function newCtx(): Ctx {
+  return {
+    jobId: crypto.randomUUID(),
+    stepId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    runId: crypto.randomUUID(),
+  };
+}
+
+describe('closeAbandonedStreamsActivity', () => {
+  it('force-closes an open stream with a runner_lost tombstone and one event', async () => {
+    const ctx = newCtx();
+    await appendLogs({...ctx, attempt: 1, offset: 0, body: ndjsonBody(outputLine('partial\n'))});
+    const open = await findStream({...ctx, attempt: 1});
+
+    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+
+    expect(closed).toBe(1);
+    const after = await findStream({...ctx, attempt: 1});
+    expect(after?.state).toBe('closed');
+    expect(after?.closeReason).toBe('timeout');
+    expect(after?.truncated).toBe(true);
+    expect(after?.committedLength).toBe(open?.committedLength);
+    expect((await listChunks(after?.id as string)).map((c) => c.kind)).toEqual([
+      'runner',
+      'control',
+    ]);
+    expect(await listStreamClosedEvents(after?.id as string)).toHaveLength(1);
+  });
+
+  it('closes only the still-open streams, skipping ones already declared-closed', async () => {
+    const ctx = newCtx();
+    const stepOpen = crypto.randomUUID();
+    const stepDone = crypto.randomUUID();
+    await appendLogs({
+      ...ctx,
+      stepId: stepDone,
+      attempt: 1,
+      offset: 0,
+      body: ndjsonBody(outputLine('done\n'), controlLine({kind: 'end', total_bytes: 4})),
+    });
+    await appendLogs({
+      ...ctx,
+      stepId: stepOpen,
+      attempt: 1,
+      offset: 0,
+      body: ndjsonBody(outputLine('partial\n')),
+    });
+    const doneStream = await findStream({jobId: ctx.jobId, stepId: stepDone, attempt: 1});
+
+    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+
+    expect(closed).toBe(1);
+    const openAfter = await findStream({jobId: ctx.jobId, stepId: stepOpen, attempt: 1});
+    expect(openAfter?.closeReason).toBe('timeout');
+    expect(openAfter?.truncated).toBe(true);
+    const doneAfter = await findStream({jobId: ctx.jobId, stepId: stepDone, attempt: 1});
+    expect(doneAfter?.closeReason).toBe('declared');
+    expect(doneAfter?.truncated).toBe(false);
+    expect(await listStreamClosedEvents(doneStream?.id as string)).toHaveLength(1);
+  });
+
+  it('is a no-op for a job with no open streams', async () => {
+    const ctx = newCtx();
+
+    const {closed} = await closeAbandonedStreamsActivity({jobId: ctx.jobId});
+
+    expect(closed).toBe(0);
+  });
+});

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
@@ -1,0 +1,30 @@
+import {closeStream, controlTombstone} from '#core/close-stream.js';
+import {db} from '#db/db.js';
+import {listOpenStreamsByJob} from '#db/streams.js';
+
+/**
+ * Force-closes every stream still open for a terminated job — the runner died, was
+ * capped, or its spool failed, so it never sent an end record. Each stream closes in
+ * its own transaction through the guarded `closeStream`, so one that the declared
+ * path closed in the meantime is skipped (returns null). A `runner_lost` tombstone
+ * marks the truncation; the stream is left `truncated`.
+ */
+export async function closeAbandonedStreamsActivity(params: {
+  jobId: string;
+}): Promise<{closed: number}> {
+  const open = await listOpenStreamsByJob(params.jobId);
+
+  let closed = 0;
+  for (const stream of open) {
+    const result = await db().transaction((tx) =>
+      closeStream(tx, {
+        streamId: stream.id,
+        reason: 'timeout',
+        tombstone: controlTombstone('runner_lost'),
+      }),
+    );
+    if (result) closed += 1;
+  }
+
+  return {closed};
+}

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
@@ -3,7 +3,7 @@ import {db} from '#db/db.js';
 import {listOpenStreamsByJob} from '#db/streams.js';
 
 /**
- * Force-closes every stream still open for a terminated job — the runner died, was
+ * Force-closes every stream still open for a terminated job: the runner died, was
  * capped, or its spool failed, so it never sent an end record. Each stream closes in
  * its own transaction through the guarded `closeStream`, so one that the declared
  * path closed in the meantime is skipped (returns null). A `runner_lost` tombstone

--- a/libs/api/logs/src/temporal/activities/index.ts
+++ b/libs/api/logs/src/temporal/activities/index.ts
@@ -1,0 +1,7 @@
+import {closeAbandonedStreamsActivity} from './close-abandoned-streams.js';
+
+export function createLogsActivities() {
+  return {
+    closeAbandonedStreamsActivity,
+  };
+}

--- a/libs/api/logs/src/temporal/constants.ts
+++ b/libs/api/logs/src/temporal/constants.ts
@@ -1,0 +1,1 @@
+export const LOGS_LIFECYCLE_TASK_QUEUE = 'logs-lifecycle';

--- a/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
@@ -1,0 +1,25 @@
+import {log, proxyActivities, sleep} from '@temporalio/workflow';
+import type {createLogsActivities} from '../activities/index.js';
+
+const {closeAbandonedStreamsActivity} = proxyActivities<ReturnType<typeof createLogsActivities>>({
+  startToCloseTimeout: '5 minutes',
+});
+
+export interface CloseAbandonedStreamsInput {
+  jobId: string;
+  graceSeconds: number;
+}
+
+/**
+ * Started by the `WORKFLOWS_JOB_TERMINATED` subscriber, deduped per job. Waits out
+ * the grace period — so a last in-flight append can land and the runner's own
+ * declared close can win — then force-closes whatever is still open.
+ */
+export async function closeAbandonedStreams(input: CloseAbandonedStreamsInput): Promise<void> {
+  await sleep(input.graceSeconds * 1000);
+
+  const {closed} = await closeAbandonedStreamsActivity({jobId: input.jobId});
+  if (closed > 0) {
+    log.info('Force-closed abandoned log streams', {jobId: input.jobId, closed});
+  }
+}

--- a/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/workflows/close-abandoned-streams.ts
@@ -12,8 +12,8 @@ export interface CloseAbandonedStreamsInput {
 
 /**
  * Started by the `WORKFLOWS_JOB_TERMINATED` subscriber, deduped per job. Waits out
- * the grace period — so a last in-flight append can land and the runner's own
- * declared close can win — then force-closes whatever is still open.
+ * the grace period (so a last in-flight append can land and the runner's own
+ * declared close can win), then force-closes whatever is still open.
  */
 export async function closeAbandonedStreams(input: CloseAbandonedStreamsInput): Promise<void> {
   await sleep(input.graceSeconds * 1000);

--- a/libs/api/logs/src/temporal/workflows/index.ts
+++ b/libs/api/logs/src/temporal/workflows/index.ts
@@ -1,0 +1,1 @@
+export {closeAbandonedStreams} from './close-abandoned-streams.js';

--- a/libs/api/logs/test/index.ts
+++ b/libs/api/logs/test/index.ts
@@ -1,3 +1,9 @@
 export {jobAccountingFactory} from './factories/job-accounting.js';
 export {mintLeaseToken} from './fixtures/lease-token.js';
-export {findAccounting, findStream, listChunks, type StreamIdentity} from './queries.js';
+export {
+  findAccounting,
+  findStream,
+  listChunks,
+  listStreamClosedEvents,
+  type StreamIdentity,
+} from './queries.js';

--- a/libs/api/logs/test/queries.ts
+++ b/libs/api/logs/test/queries.ts
@@ -1,3 +1,4 @@
+import {LOG_STREAM_CLOSED, type LogStreamClosedEvent} from '@shipfox/api-logs-dto';
 import {and, asc, eq} from 'drizzle-orm';
 import type {AttemptStream} from '#core/entities/attempt-stream.js';
 import type {JobAccounting} from '#core/entities/job-accounting.js';
@@ -5,6 +6,7 @@ import {db} from '#db/db.js';
 import {attemptStreams, toAttemptStream} from '#db/schema/attempt-streams.js';
 import {type LogChunkDb, logChunks} from '#db/schema/chunks.js';
 import {jobAccounting, toJobAccounting} from '#db/schema/job-accounting.js';
+import {logsOutbox} from '#db/schema/outbox.js';
 
 export interface StreamIdentity {
   jobId: string;
@@ -37,4 +39,16 @@ export async function listChunks(streamId: string): Promise<LogChunkDb[]> {
     .from(logChunks)
     .where(eq(logChunks.streamId, streamId))
     .orderBy(asc(logChunks.seq));
+}
+
+/** The `logs.stream.closed` outbox events written for a given stream (filtered in memory; the table is not truncated between tests). */
+export async function listStreamClosedEvents(streamId: string): Promise<LogStreamClosedEvent[]> {
+  const rows = await db()
+    .select()
+    .from(logsOutbox)
+    .where(eq(logsOutbox.eventType, LOG_STREAM_CLOSED));
+
+  return rows
+    .map((row) => row.payload as LogStreamClosedEvent)
+    .filter((payload) => payload.streamId === streamId);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1145,14 +1145,20 @@ importers:
   libs/api/logs:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: ^3.1068.0
-        version: 3.1068.0
+        specifier: ^3.1070.0
+        version: 3.1070.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.1070.0
+        version: 3.1070.0(@aws-sdk/client-s3@3.1070.0)
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../auth-context
       '@shipfox/api-logs-dto':
         specifier: workspace:*
         version: link:../logs-dto
+      '@shipfox/api-workflows-dto':
+        specifier: workspace:*
+        version: link:../workflows-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
@@ -1174,6 +1180,9 @@ importers:
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../shared/node/postgres
+      '@shipfox/node-temporal':
+        specifier: workspace:*
+        version: link:../../shared/node/temporal
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
@@ -1205,6 +1214,24 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      '@temporalio/activity':
+        specifier: ^1.16.1
+        version: 1.17.2
+      '@temporalio/client':
+        specifier: ^1.16.1
+        version: 1.17.2
+      '@temporalio/common':
+        specifier: ^1.16.1
+        version: 1.17.2
+      '@temporalio/testing':
+        specifier: ^1.16.1
+        version: 1.17.2(@swc/helpers@0.5.23)(tslib@2.8.1)
+      '@temporalio/worker':
+        specifier: ^1.16.1
+        version: 1.17.2(@swc/helpers@0.5.23)(tslib@2.8.1)
+      '@temporalio/workflow':
+        specifier: ^1.16.1
+        version: 1.17.2
       '@types/pg':
         specifier: ^8.15.5
         version: 8.20.0
@@ -3556,20 +3583,16 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/checksums@3.1000.5':
-    resolution: {integrity: sha512-zOXUUnilC6lgCsQtp77p/QNPmRlTES9Xi6tlDwbR6kfC/kz5PCzZckgHWm5z+8DskdwuMAbFDq61x3zr10GEEQ==}
+  '@aws-sdk/checksums@3.1000.6':
+    resolution: {integrity: sha512-RMCrCteiUwYTEv2G9zfP/BEuKHv57665vVieJyp9cf8VgilWxP/KrWVtMdfdDlIH8nFhvu3rIMc29z3ebGEZ1w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-bedrock-runtime@3.1048.0':
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-s3@3.1068.0':
-    resolution: {integrity: sha512-lFgaIpxZvloNbJvQ337YPdMXhzI2zJdDw13nATVGnkAGNoNPx4ksD84AQAcuW75hsaaMaIuNmXU9sSx6+FTirA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/core@3.974.20':
-    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
+  '@aws-sdk/client-s3@3.1070.0':
+    resolution: {integrity: sha512-B/OUiCqGQ4Zr7v9gFFyiuitKN2c0PIgvOlQb5bYg1SM2y0F8a5JQ7FNsjRcl+d2PqYWLHwHx12CvZDyLn4KxIw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.21':
@@ -3580,48 +3603,86 @@ packages:
     resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.47':
+    resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.48':
     resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.49':
+    resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.53':
     resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.54':
+    resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.52':
     resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.53':
+    resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.55':
     resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.56':
+    resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.46':
     resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.47':
+    resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.52':
     resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.53':
+    resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.53':
+    resolution: {integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.22':
     resolution: {integrity: sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/lib-storage@3.1070.0':
+    resolution: {integrity: sha512-TMfkkBaLIlHhqt28wJp14EhATO9WbFwEheCi5K5gahYKQNWCUE4l4CmuWl1Wi8j0ZeVs/vCaSWxHv6DahrHOzQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1070.0
+
   '@aws-sdk/middleware-eventstream@3.972.18':
     resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.30':
-    resolution: {integrity: sha512-OaIhub+3yTgfFWPzKO8OzOZFIMUoJaiS5v67y3spQg7SoULGoMx4jKVBbE+uhnzkiZXQ+rEDS0RqrK4/aD1yJw==}
+  '@aws-sdk/middleware-flexible-checksums@3.974.31':
+    resolution: {integrity: sha512-Yzj6NRYVZdBaCp7o1BwHGyeDBfixdeToLIAMprshIITEdl9wKVSiidVOfeaiH8FyeC1hBmBfDZFvs/aH1Y3xpw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.51':
-    resolution: {integrity: sha512-keQgcIUTcHL0Qn7guhsuLaxQU36r9norCrxgaPH4DNCwon4TPtXdI/UdYuycl9vj3Dlwc3YR1dfL3U+6iIwJ6w==}
+  '@aws-sdk/middleware-sdk-s3@3.972.52':
+    resolution: {integrity: sha512-rerjP08onRqkBh0AcCqip6GkKvESapmLoTgi1xysZ4C6a1xMrIMtTBcEbUb6EY71oeajnigeUD4KwZjtIO+aWQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-websocket@3.972.29':
@@ -3632,8 +3693,16 @@ packages:
     resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.21':
+    resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -3644,8 +3713,8 @@ packages:
     resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.12':
-    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+  '@aws-sdk/token-providers@3.1069.0':
+    resolution: {integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.13':
@@ -3654,10 +3723,6 @@ packages:
 
   '@aws-sdk/util-locate-window@3.965.7':
     resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.29':
-    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.30':
@@ -7780,6 +7845,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -8597,6 +8665,9 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -9491,6 +9562,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -9783,6 +9858,9 @@ packages:
       vite-plus:
         optional: true
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -9797,6 +9875,9 @@ packages:
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -10169,6 +10250,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
@@ -10532,20 +10616,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -10555,7 +10639,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -10563,7 +10647,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -10572,17 +10656,17 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/checksums@3.1000.5':
+  '@aws-sdk/checksums@3.1000.6':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -10591,45 +10675,34 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/credential-provider-node': 3.972.55
       '@aws-sdk/eventstream-handler-node': 3.972.22
       '@aws-sdk/middleware-eventstream': 3.972.18
       '@aws-sdk/middleware-websocket': 3.972.29
       '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1068.0':
+  '@aws-sdk/client-s3@3.1070.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
-      '@aws-sdk/middleware-flexible-checksums': 3.974.30
-      '@aws-sdk/middleware-sdk-s3': 3.972.51
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-node': 3.972.56
+      '@aws-sdk/middleware-flexible-checksums': 3.974.31
+      '@aws-sdk/middleware-sdk-s3': 3.972.52
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/core@3.974.20':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/xml-builder': 3.972.29
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.7
-      '@smithy/signature-v4': 5.4.7
-      '@smithy/types': 4.14.4
-      bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/core@3.974.21':
@@ -10645,16 +10718,34 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.46':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.48':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/node-http-handler': 4.7.8
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
@@ -10663,7 +10754,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/credential-provider-env': 3.972.46
       '@aws-sdk/credential-provider-http': 3.972.48
       '@aws-sdk/credential-provider-login': 3.972.52
@@ -10671,7 +10762,23 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.52
       '@aws-sdk/credential-provider-web-identity': 3.972.52
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/credential-provider-imds': 4.3.9
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/credential-provider-env': 3.972.47
+      '@aws-sdk/credential-provider-http': 3.972.49
+      '@aws-sdk/credential-provider-login': 3.972.53
+      '@aws-sdk/credential-provider-process': 3.972.47
+      '@aws-sdk/credential-provider-sso': 3.972.53
+      '@aws-sdk/credential-provider-web-identity': 3.972.53
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/credential-provider-imds': 4.3.9
       '@smithy/types': 4.14.4
@@ -10679,9 +10786,18 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -10694,7 +10810,21 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.46
       '@aws-sdk/credential-provider-sso': 3.972.52
       '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/credential-provider-imds': 4.3.9
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.56':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.47
+      '@aws-sdk/credential-provider-http': 3.972.49
+      '@aws-sdk/credential-provider-ini': 3.972.54
+      '@aws-sdk/credential-provider-process': 3.972.47
+      '@aws-sdk/credential-provider-sso': 3.972.53
+      '@aws-sdk/credential-provider-web-identity': 3.972.53
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/credential-provider-imds': 4.3.9
       '@smithy/types': 4.14.4
@@ -10702,27 +10832,54 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.46':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.47':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/token-providers': 3.1066.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/token-providers': 3.1069.0
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -10734,6 +10891,16 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
+  '@aws-sdk/lib-storage@3.1070.0(@aws-sdk/client-s3@3.1070.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1070.0
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-eventstream@3.972.18':
     dependencies:
       '@aws-sdk/types': 3.973.13
@@ -10741,16 +10908,16 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.30':
+  '@aws-sdk/middleware-flexible-checksums@3.974.31':
     dependencies:
-      '@aws-sdk/checksums': 3.1000.5
+      '@aws-sdk/checksums': 3.1000.6
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.51':
+  '@aws-sdk/middleware-sdk-s3@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
@@ -10769,9 +10936,22 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
+      '@smithy/fetch-http-handler': 5.4.7
+      '@smithy/node-http-handler': 4.7.8
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.21':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
@@ -10780,31 +10960,42 @@ snapshots:
 
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
+      '@smithy/signature-v4': 5.4.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.35':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
       '@smithy/signature-v4': 5.4.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1066.0':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.973.12':
+  '@aws-sdk/token-providers@3.1069.0':
     dependencies:
+      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/nested-clients': 3.997.21
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -10815,12 +11006,6 @@ snapshots:
 
   '@aws-sdk/util-locate-window@3.965.7':
     dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.29':
-    dependencies:
-      '@smithy/types': 4.14.4
-      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.30':
@@ -14971,6 +15156,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -15799,6 +15989,8 @@ snapshots:
       module-details-from-path: 1.0.4
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
@@ -16654,6 +16846,12 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
@@ -16949,6 +17147,11 @@ snapshots:
       - react-dom
       - utf-8-validate
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -16974,6 +17177,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -17279,6 +17486,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1145,11 +1145,8 @@ importers:
   libs/api/logs:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: ^3.1070.0
+        specifier: ^3.1068.0
         version: 3.1070.0
-      '@aws-sdk/lib-storage':
-        specifier: ^3.1070.0
-        version: 3.1070.0(@aws-sdk/client-s3@3.1070.0)
       '@shipfox/api-auth-context':
         specifier: workspace:*
         version: link:../auth-context
@@ -3599,64 +3596,32 @@ packages:
     resolution: {integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.46':
-    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-env@3.972.47':
     resolution: {integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.49':
     resolution: {integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-ini@3.972.54':
     resolution: {integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-login@3.972.52':
-    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.53':
     resolution: {integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.55':
-    resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-node@3.972.56':
     resolution: {integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-process@3.972.46':
-    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.47':
     resolution: {integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.53':
     resolution: {integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.53':
@@ -3666,12 +3631,6 @@ packages:
   '@aws-sdk/eventstream-handler-node@3.972.22':
     resolution: {integrity: sha512-tqPJv0dz4+O0hWGm1a6YekcMZyPhDFs/zH73Von7icaVT5n0Jqvm86typ3jRrG+qoUdPhALOnboRLTmnWQTlYQ==}
     engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/lib-storage@3.1070.0':
-    resolution: {integrity: sha512-TMfkkBaLIlHhqt28wJp14EhATO9WbFwEheCi5K5gahYKQNWCUE4l4CmuWl1Wi8j0ZeVs/vCaSWxHv6DahrHOzQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-s3': ^3.1070.0
 
   '@aws-sdk/middleware-eventstream@3.972.18':
     resolution: {integrity: sha512-OHpk8YoZi3yexPq8aFt1vN1IxA2zLKvsIR5GpWYylX/ve6kQmY7wxHNSFy/D3t2apMZ16rs76Co4dJWcDyIk3A==}
@@ -3689,16 +3648,8 @@ packages:
     resolution: {integrity: sha512-Agv95NCgYyvuYUXt2PcFcOMrKCkhBFPhoH+nVMQh85RcXSCQrhAa4475plBOeomCihP26vKHT5KinVQT3iD14w==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.20':
-    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.997.21':
     resolution: {integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.35':
@@ -3707,10 +3658,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1048.0':
     resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/token-providers@3.1066.0':
-    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1069.0':
@@ -7845,9 +7792,6 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  buffer@5.6.0:
-    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
-
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -8665,9 +8609,6 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -9562,10 +9503,6 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
-
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -9858,9 +9795,6 @@ packages:
       vite-plus:
         optional: true
 
-  stream-browserify@3.0.0:
-    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
-
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -9875,9 +9809,6 @@ packages:
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
-
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -10249,9 +10180,6 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
@@ -10676,7 +10604,7 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.974.21
-      '@aws-sdk/credential-provider-node': 3.972.55
+      '@aws-sdk/credential-provider-node': 3.972.56
       '@aws-sdk/eventstream-handler-node': 3.972.22
       '@aws-sdk/middleware-eventstream': 3.972.18
       '@aws-sdk/middleware-websocket': 3.972.29
@@ -10716,29 +10644,11 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-env@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/fetch-http-handler': 5.4.7
-      '@smithy/node-http-handler': 4.7.8
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -10749,22 +10659,6 @@ snapshots:
       '@smithy/core': 3.24.7
       '@smithy/fetch-http-handler': 5.4.7
       '@smithy/node-http-handler': 4.7.8
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-login': 3.972.52
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/credential-provider-imds': 4.3.9
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -10784,35 +10678,12 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-login@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-ini': 3.972.53
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/credential-provider-imds': 4.3.9
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
@@ -10830,27 +10701,9 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.47':
     dependencies:
       '@aws-sdk/core': 3.974.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/token-providers': 3.1066.0
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
@@ -10861,15 +10714,6 @@ snapshots:
       '@aws-sdk/core': 3.974.21
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/token-providers': 3.1069.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
@@ -10889,16 +10733,6 @@ snapshots:
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/lib-storage@3.1070.0(@aws-sdk/client-s3@3.1070.0)':
-    dependencies:
-      '@aws-sdk/client-s3': 3.1070.0
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      buffer: 5.6.0
-      events: 3.3.0
-      stream-browserify: 3.0.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-eventstream@3.972.18':
@@ -10932,19 +10766,6 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.20':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/fetch-http-handler': 5.4.7
-      '@smithy/node-http-handler': 4.7.8
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/nested-clients@3.997.21':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -10958,13 +10779,6 @@ snapshots:
       '@smithy/types': 4.14.4
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@smithy/signature-v4': 5.4.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.35':
     dependencies:
       '@aws-sdk/types': 3.973.13
@@ -10975,16 +10789,7 @@ snapshots:
   '@aws-sdk/token-providers@3.1048.0':
     dependencies:
       '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.7
-      '@smithy/types': 4.14.4
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1066.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.21
-      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
       '@smithy/types': 4.14.4
@@ -15156,11 +14961,6 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  buffer@5.6.0:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -15989,8 +15789,6 @@ snapshots:
       module-details-from-path: 1.0.4
 
   indent-string@4.0.0: {}
-
-  inherits@2.0.4: {}
 
   ini@1.3.8: {}
 
@@ -16846,12 +16644,6 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
   readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
@@ -17147,11 +16939,6 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  stream-browserify@3.0.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -17177,10 +16964,6 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -17486,8 +17269,6 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
-
-  util-deprecate@1.0.2: {}
 
   uuid@11.1.1: {}
 


### PR DESCRIPTION
Adds stream close to the log module: a stream can now move out of `open` so it becomes eligible for compaction. This is the close behaviour of ENG-442; compaction (ENG-519) and retention deletion (ENG-520) are separate issues.

The log module (ENG-439) accepted chunks via the offset-CAS append endpoint but never moved a stream out of `open`, so nothing could be compacted and Postgres chunk volume was bounded only by retention.

Two ways a stream closes, both routed through one `closeStream` core that writes a single `logs.stream.closed` outbox event (the compaction trigger, handled by ENG-519):

- **Declared close** — a committed `end` record closes the stream inside the append transaction (the fast, common path). `end.total_bytes` is decoded payload bytes, a different axis from the raw-spool `committed_length`, so close triggers on *receiving* the record, not a byte comparison.
- **Timeout close** — a `WORKFLOWS_JOB_TERMINATED` subscriber (the single reliable job-terminal signal, from #236) arms a grace-then-close Temporal workflow that force-closes any stream the runner never ended itself. Machine death, budget cap, spool failure, and cancellation all leave a stream open with no `end`, and the runner is no liveness signal (a quiet step sends zero appends). It appends a `runner_lost` tombstone and marks the stream truncated.

A closed-stream guard drops later appends so compaction can never race a late chunk. Tombstones are stored as control chunks *without advancing* `committed_length`, keeping the offset-CAS axis equal to runner spool bytes (compaction orders by `seq`, so they still concatenate correctly).

Schema: adds `closed_at` plus three partial indexes. Since nothing is deployed yet, this folds into the initial migration in place rather than a new migration file.

**Review focus:** the exactly-once close — `closeStream`'s guarded `UPDATE … WHERE state='open'` is both the row lock and the idempotency gate, since the declared and timeout paths can race the same stream — and the tombstone no-advance invariant.

Fixes ENG-518
Refs ENG-442