### PR TITLE
[tools/docker] Add shipfox-docker build tool

### DIFF
--- a/.changeset/eng-532-docker-build-tool.md
+++ b/.changeset/eng-532-docker-build-tool.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/docker": minor
+---
+
+Add the `@shipfox/docker` tool exposing a `shipfox-docker` CLI that wraps `docker buildx`. It prepares the build context with `--setup-context` (turbo prune plus an overlay of each pruned package's prebuilt `dist/`, the "build outside Docker, ingest dist" approach) and runs a single multi-platform build that pushes a multi-arch image to multiple registries in one pass. It defaults `--platform`, `--push`, and the gha BuildKit cache only when the caller did not set them, so a PR can still build single-arch without pushing.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3387,6 +3387,25 @@ importers:
         specifier: 25.9.2
         version: 25.9.2
 
+  tools/docker:
+    dependencies:
+      '@shipfox/tool-utils':
+        specifier: workspace:*
+        version: link:../utils
+    devDependencies:
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../typescript
+      '@types/node':
+        specifier: 25.9.2
+        version: 25.9.2
+
   tools/playwright:
     dependencies:
       '@argos-ci/playwright':

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -5,8 +5,9 @@ Workspace wrapper around `docker buildx` for building Shipfox app images. It pre
 ## What it does
 
 - **`shipfox-docker`**: Runs `docker buildx build` for the current package, with sensible defaults for a multi-arch push.
-- **Context prep (`--setup-context`)**: Runs `turbo prune --docker --out-dir out <pkg>` and overlays each pruned package's prebuilt `dist/` into `out/full/`. This is the "build outside Docker, ingest `dist`" approach: the image never recompiles TypeScript, it ingests the turbo-cached build plus a real `node_modules`.
+- **Context prep (`--setup-context`)**: Runs `turbo prune --docker` into an `out/` directory under the package and overlays each pruned package's prebuilt `dist/` into `out/full/`. This is the "build outside Docker, ingest `dist`" approach: the image never recompiles TypeScript, it ingests the turbo-cached build plus a real `node_modules`.
 - **Single multi-platform build**: Defaults to `--platform linux/amd64,linux/arm64 --push`, so one invocation emits the multi-arch manifest (no per-arch tags, no `docker manifest` step). QEMU covers both arches.
+- **Clean manifest**: Defaults to `--provenance=false` so the pushed multi-arch index stays a clean per-arch manifest, without the `unknown/unknown` provenance entries some registries display. Pass your own `--provenance` to re-enable SLSA attestations.
 - **gha BuildKit cache**: Adds `--cache-from`/`--cache-to type=gha` (scoped per image) when running in GitHub Actions.
 
 The defaults are added only when you did not pass the flag yourself, so the caller stays in control. To validate a Dockerfile on a PR (single arch, no push), pass your own `--platform linux/amd64` and `--load`.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,53 @@
+# @shipfox/docker
+
+Workspace wrapper around `docker buildx` for building Shipfox app images. It prepares the build context and runs a single multi-platform build, so adding a new app image is a one-file change. It should be used with other packages from [Shipfox](https://www.shipfox.io/).
+
+## What it does
+
+- **`shipfox-docker`**: Runs `docker buildx build` for the current package, with sensible defaults for a multi-arch push.
+- **Context prep (`--setup-context`)**: Runs `turbo prune --docker --out-dir out <pkg>` and overlays each pruned package's prebuilt `dist/` into `out/full/`. This is the "build outside Docker, ingest `dist`" approach: the image never recompiles TypeScript, it ingests the turbo-cached build plus a real `node_modules`.
+- **Single multi-platform build**: Defaults to `--platform linux/amd64,linux/arm64 --push`, so one invocation emits the multi-arch manifest (no per-arch tags, no `docker manifest` step). QEMU covers both arches.
+- **gha BuildKit cache**: Adds `--cache-from`/`--cache-to type=gha` (scoped per image) when running in GitHub Actions.
+
+The defaults are added only when you did not pass the flag yourself, so the caller stays in control. To validate a Dockerfile on a PR (single arch, no push), pass your own `--platform linux/amd64` and `--load`.
+
+## Installation
+
+```bash
+pnpm add -D @shipfox/docker
+```
+
+> [!NOTE]
+> `shipfox-docker` calls `docker buildx`, so you need the Docker CLI with Buildx. A multi-arch build also needs QEMU. In CI, `docker/setup-qemu-action` and `docker/setup-buildx-action` set both up.
+
+## Usage
+
+Add an `image` script to the app's `package.json`. Tags target both registries in one build:
+
+```json
+{
+  "scripts": {
+    "image": "shipfox-docker --setup-context --tag ghcr.io/shipfoxhq/api:sha-abc1234 --tag shipfoxhq/api:sha-abc1234"
+  }
+}
+```
+
+Static apps (no `node_modules`) skip context prep and ingest a prebuilt artifact:
+
+```json
+{
+  "scripts": {
+    "image": "shipfox-docker --tag ghcr.io/shipfoxhq/client:sha-abc1234"
+  }
+}
+```
+
+### Environment
+
+- `NODE_VERSION` / `PNPM_VERSION` — forwarded as `--build-arg` for the base image.
+- `GITHUB_ACTIONS` — enables the gha BuildKit cache.
+- `npm_package_name` — the prune target for `--setup-context` (set by the package manager when run through a script).
+
+## License
+
+MIT

--- a/tools/docker/bin/docker.js
+++ b/tools/docker/bin/docker.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '../dist/docker.js';

--- a/tools/docker/package.json
+++ b/tools/docker/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@shipfox/docker",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "tools/docker"
+  },
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "bin": {
+    "shipfox-docker": "./bin/docker.js"
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/tool-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@types/node": "25.9.2"
+  }
+}

--- a/tools/docker/src/docker.ts
+++ b/tools/docker/src/docker.ts
@@ -1,0 +1,70 @@
+#! /usr/bin/env node
+
+import {execSync} from 'node:child_process';
+import {buildShellCommand, log} from '@shipfox/tool-utils';
+import {setupContext} from './turbo.js';
+
+const DEFAULT_PLATFORMS = 'linux/amd64,linux/arm64';
+
+// Everything after the bin name; `--setup-context` is consumed here, the rest is
+// forwarded verbatim to `docker buildx build` (tags, build-args, labels, ...).
+const passthrough = process.argv.slice(2);
+
+function hasFlag(...flags: string[]): boolean {
+  return passthrough.some((arg) =>
+    flags.some((flag) => arg === flag || arg.startsWith(`${flag}=`)),
+  );
+}
+
+function firstTag(): string | undefined {
+  const index = passthrough.indexOf('--tag');
+  if (index !== -1) return passthrough[index + 1];
+  return passthrough.find((arg) => arg.startsWith('--tag='))?.slice('--tag='.length);
+}
+
+// Keep each app's gha cache separate so the three images built in one workflow
+// run don't clobber each other. The scope is the image name (its last path
+// segment), which is stable across registries: e.g. ghcr.io/org/api -> api.
+function cacheScope(): string | undefined {
+  const image = firstTag()?.split(':')[0] ?? process.env.npm_package_name;
+  return image?.split('/').pop();
+}
+
+const setupIndex = passthrough.indexOf('--setup-context');
+if (setupIndex !== -1) {
+  const packageName = process.env.npm_package_name;
+  if (!packageName)
+    throw new Error(
+      '--setup-context needs npm_package_name; run shipfox-docker through a package "image" script.',
+    );
+  setupContext(packageName);
+  passthrough.splice(setupIndex, 1);
+}
+
+const args: string[] = [];
+
+// Drop provenance attestations so the pushed manifest stays a clean per-arch
+// index without the "unknown/unknown" entries some registries show otherwise.
+if (!hasFlag('--provenance')) args.push('--provenance=false');
+
+// A single buildx build emits the multi-arch manifest itself; QEMU covers both
+// arches in one pass, so there is no per-arch matrix or `docker manifest` step.
+if (!hasFlag('--platform')) args.push('--platform', DEFAULT_PLATFORMS);
+
+// A multi-platform build cannot `--load`, so default to pushing. The PR path
+// opts out by passing its own `--load`/`--output` (single-arch, validate only).
+if (!hasFlag('--push', '--load', '--output', '-o')) args.push('--push');
+
+if (process.env.GITHUB_ACTIONS) {
+  const scope = cacheScope();
+  const scoped = scope ? [`scope=${scope}`] : [];
+  args.push('--cache-from', ['type=gha', ...scoped].join(','));
+  args.push('--cache-to', ['type=gha', 'mode=max', 'ignore-error=true', ...scoped].join(','));
+}
+
+if (process.env.NODE_VERSION) args.push(`--build-arg=NODE_VERSION=${process.env.NODE_VERSION}`);
+if (process.env.PNPM_VERSION) args.push(`--build-arg=PNPM_VERSION=${process.env.PNPM_VERSION}`);
+
+const command = buildShellCommand(['docker', 'buildx', 'build', ...args, ...passthrough, '.']);
+log.info(command);
+execSync(command, {stdio: 'inherit'});

--- a/tools/docker/src/docker.ts
+++ b/tools/docker/src/docker.ts
@@ -6,6 +6,9 @@ import {setupContext} from './turbo.js';
 
 const DEFAULT_PLATFORMS = 'linux/amd64,linux/arm64';
 
+// Matches the :tag / @digest suffix of an image reference's final path segment.
+const TAG_OR_DIGEST_SUFFIX = /[:@].*$/;
+
 // Everything after the bin name; `--setup-context` is consumed here, the rest is
 // forwarded verbatim to `docker buildx build` (tags, build-args, labels, ...).
 const passthrough = process.argv.slice(2);
@@ -26,8 +29,10 @@ function firstTag(): string | undefined {
 // run don't clobber each other. The scope is the image name (its last path
 // segment), which is stable across registries: e.g. ghcr.io/org/api -> api.
 function cacheScope(): string | undefined {
-  const image = firstTag()?.split(':')[0] ?? process.env.npm_package_name;
-  return image?.split('/').pop();
+  const reference = firstTag() ?? process.env.npm_package_name;
+  // Take the final path segment first, then drop the :tag / @digest suffix, so a
+  // registry port (host:port/...) is never mistaken for the tag separator.
+  return reference?.split('/').pop()?.replace(TAG_OR_DIGEST_SUFFIX, '');
 }
 
 const setupIndex = passthrough.indexOf('--setup-context');

--- a/tools/docker/src/turbo.ts
+++ b/tools/docker/src/turbo.ts
@@ -1,12 +1,7 @@
 import {execSync} from 'node:child_process';
-import {cpSync, existsSync, readdirSync, rmSync, statSync} from 'node:fs';
+import {cpSync, existsSync, readdirSync, readFileSync, rmSync, statSync} from 'node:fs';
 import {dirname, join, relative} from 'node:path';
-import {
-  buildShellCommand,
-  getProjectFilePath,
-  getWorkspaceBinaryPath,
-  getWorkspaceRootPath,
-} from '@shipfox/tool-utils';
+import {buildShellCommand, getProjectFilePath, getWorkspaceRootPath} from '@shipfox/tool-utils';
 
 /**
  * Prepare the Docker build context for a node app the "build outside Docker,
@@ -21,7 +16,7 @@ export function setupContext(packageName: string) {
   rmSync(contextPath, {recursive: true, force: true});
 
   const prune = buildShellCommand([
-    getWorkspaceBinaryPath('turbo'),
+    'turbo',
     'prune',
     '--docker',
     '--out-dir',
@@ -38,10 +33,28 @@ function overlayDist(prunedRoot: string) {
 
   for (const packageJson of findPackageJsonFiles(prunedRoot)) {
     const packagePath = relative(prunedRoot, dirname(packageJson));
+    if (!packagePath) continue;
     const source = join(workspaceRoot, packagePath, 'dist');
-    if (!existsSync(source)) continue;
+    if (!existsSync(source)) {
+      // A package with a `build` script is expected to emit `dist/` (every build
+      // here transpiles to `dist/`). A missing one means the build did not run,
+      // so fail now instead of shipping an image that breaks at runtime.
+      if (buildsToDist(join(workspaceRoot, packagePath, 'package.json')))
+        throw new Error(
+          `${packagePath} has no built dist/ at ${source}. Build the workspace before "shipfox-docker --setup-context".`,
+        );
+      continue;
+    }
     cpSync(source, join(prunedRoot, packagePath, 'dist'), {recursive: true});
   }
+}
+
+function buildsToDist(packageJsonPath: string): boolean {
+  if (!existsSync(packageJsonPath)) return false;
+  const manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+    scripts?: Record<string, string>;
+  };
+  return Boolean(manifest.scripts?.build);
 }
 
 function findPackageJsonFiles(dir: string): string[] {

--- a/tools/docker/src/turbo.ts
+++ b/tools/docker/src/turbo.ts
@@ -1,0 +1,55 @@
+import {execSync} from 'node:child_process';
+import {cpSync, existsSync, readdirSync, rmSync, statSync} from 'node:fs';
+import {dirname, join, relative} from 'node:path';
+import {
+  buildShellCommand,
+  getProjectFilePath,
+  getWorkspaceBinaryPath,
+  getWorkspaceRootPath,
+} from '@shipfox/tool-utils';
+
+/**
+ * Prepare the Docker build context for a node app the "build outside Docker,
+ * ingest dist" way. `turbo prune` writes a self-contained workspace into `out/`,
+ * then each pruned package's already-built (turbo-cached) `dist/` is overlaid
+ * into `out/full/`. The image ingests those `dist/`s plus a real `node_modules`
+ * and never recompiles TypeScript — `shipfox-swc` transpiles per file and does
+ * not bundle, so the workspace `dist/`s are what the running app needs.
+ */
+export function setupContext(packageName: string) {
+  const contextPath = getProjectFilePath('out');
+  rmSync(contextPath, {recursive: true, force: true});
+
+  const prune = buildShellCommand([
+    getWorkspaceBinaryPath('turbo'),
+    'prune',
+    '--docker',
+    '--out-dir',
+    contextPath,
+    packageName,
+  ]);
+  execSync(prune, {stdio: 'inherit'});
+
+  overlayDist(join(contextPath, 'full'));
+}
+
+function overlayDist(prunedRoot: string) {
+  const workspaceRoot = getWorkspaceRootPath();
+
+  for (const packageJson of findPackageJsonFiles(prunedRoot)) {
+    const packagePath = relative(prunedRoot, dirname(packageJson));
+    const source = join(workspaceRoot, packagePath, 'dist');
+    if (!existsSync(source)) continue;
+    cpSync(source, join(prunedRoot, packagePath, 'dist'), {recursive: true});
+  }
+}
+
+function findPackageJsonFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const entryPath = join(dir, entry);
+    if (statSync(entryPath).isDirectory()) found.push(...findPackageJsonFiles(entryPath));
+    else if (entry === 'package.json') found.push(entryPath);
+  }
+  return found;
+}

--- a/tools/docker/tsconfig.build.json
+++ b/tools/docker/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/tools/docker/tsconfig.json
+++ b/tools/docker/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/tools/docker/tsconfig.json
+++ b/tools/docker/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+  "references": [{ "path": "tsconfig.build.json" }]
 }

--- a/tools/docker/tsconfig.json
+++ b/tools/docker/tsconfig.json
@@ -1,3 +1,4 @@
 {
+  "files": [],
   "references": [{ "path": "tsconfig.build.json" }]
 }

--- a/tools/docker/tsconfig.test.json
+++ b/tools/docker/tsconfig.test.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.build.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
-  "include": ["src"],
-  "exclude": []
-}

--- a/tools/docker/tsconfig.test.json
+++ b/tools/docker/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": []
+}


### PR DESCRIPTION
Adds a `tools/docker` package exposing a `shipfox-docker` CLI that wraps `docker buildx`, so containerizing an app becomes a one-file change. It is the shared build tool the app-publishing pipeline is built on, mirroring the previous `@shipfox/docker` tool but simplified for single multi-platform builds.

## What it does

- **Context prep (`--setup-context`)** — runs `turbo prune --docker --out-dir out <pkg>`, then overlays each pruned package's prebuilt `dist/` into `out/full/`. This is the "build outside Docker, ingest `dist`" approach: the image ingests the turbo-cached build plus a real `node_modules` and never recompiles TypeScript (`shipfox-swc` transpiles per file and does not bundle).
- **Single multi-platform build** — one `docker buildx build` emits the multi-arch manifest itself (QEMU covers both arches), so there is no per-arch matrix, no `BUILD_ARCH`, and no separate `docker manifest` step. Multi-registry is just multiple `--tag` flags in the one build.
- **gha BuildKit cache** — adds `--cache-from`/`--cache-to type=gha`, scoped per image, when running in GitHub Actions.

## Why this shape

`--platform linux/amd64,linux/arm64`, `--push`, `--provenance=false`, and the gha cache are injected **only when the caller did not pass them**. That keeps the documented PR path working through the same CLI: a PR validates the Dockerfile single-arch with no push (`--platform linux/amd64 --load`) while `main` does the full multi-arch push to GHCR + Docker Hub. Release tags (`vX.Y.Z`/`latest`) are applied later by the promotion workflow (crane copy by digest), so the build tool only forwards the caller's `sha-`/`build-`/`main` tags.

Replaces the old two-command split (`docker-build` + `docker-manifest`); the manifest command is gone because a single buildx build is already multi-platform.

This unblocks the three Dockerfile tickets (ENG-523/524/525) and the `ci.yml` per-commit build (ENG-526). Full strategy: [Release & Versioning Strategy](https://linear.app/shipfox/document/release-and-versioning-strategy-18a07503a3ba).

## Review notes

- The package is shaped like the existing `tools/*` (built by `shipfox-swc`, depends on `@shipfox/tool-utils`); closest sibling is `tools/depcruise`.
- New published package: `version: 0.0.0` + a `minor` changeset, so the first release lands at `0.1.0` (pre-release).

Refs ENG-532

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `@shipfox/docker` package with a `shipfox-docker` CLI to build and push multi-arch images in one command, replacing the old `docker-build` + `docker-manifest` flow. Hardens context prep and cache scoping, fixes `--setup-context` to resolve `turbo` on PATH, and updates tsconfig so type checks pass (ENG-532).

- **New Features**
  - Context prep (`--setup-context`): `turbo prune --docker` + overlay each pruned package’s built `dist/` into `out/full/` (build outside Docker, ingest `dist/`).
  - Single multi-platform build + smart defaults: injects `--platform linux/amd64,linux/arm64`, `--push`, and `--provenance=false` only if not provided; PRs can use `--platform linux/amd64 --load`; forwards `NODE_VERSION`/`PNPM_VERSION`; multi-registry via multiple `--tag`.
  - GitHub Actions cache: enables BuildKit `type=gha` cache when `GITHUB_ACTIONS` is set.

- **Bug Fixes**
  - Resolve `turbo` from PATH in `--setup-context`.
  - Fail fast if a package with a `build` script has no `dist/`; skip config-only packages.
  - Scope gha cache by image name (last path segment) and strip tag/digest to avoid collisions; ignore registry ports.
  - Make `tools/docker` tsconfig solution-only (`files: []`) so `shipfox-tsc-check` passes.

<sup>Written for commit a392c69f5b6bbada199b76d7ad72845b4f24e8c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

