### PR TITLE
Exclude apps from changesets versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@shipfox/api", "@shipfox/client", "@shipfox/runner"]
 }


### PR DESCRIPTION
Add the three app packages (`@shipfox/api`, `@shipfox/client`, `@shipfox/runner`) to the `ignore` list in `.changeset/config.json`.

The apps are versioned as a unified product via Docker tags and GitHub Releases, not by changesets, and must never appear in the libraries "Version packages" PR. Without this, giving an app a `version` field makes changesets cascade lib bumps into the app, producing a noisy hash-list changelog. Ignoring them keeps the two release systems cleanly separate: libraries keep the existing changesets to npm flow, apps ship as one product version.

The apps were already `private: true` with no changesets-managed `version` field, so this one-line config change is the only edit needed.

Verified with `changeset status`: none of the three app packages appear in the bump list (the `@shipfox/api-*` / `@shipfox/client-*` entries are libs, not the apps), and no app `CHANGELOG.md` exists or will be written.

Closes ENG-522

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the app packages `@shipfox/api`, `@shipfox/client`, and `@shipfox/runner` from changesets by adding them to the `ignore` list in `.changeset/config.json`. This keeps apps released as one product via Docker tags and GitHub Releases, and prevents noisy app bumps/changelogs in library “Version packages” PRs (ENG-522).

<sup>Written for commit 74f3636f64dca9a469a5acbe6105a83c8b028b78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

