### PR TITLE
[runner] Keep the checkout token out of process argv

### DIFF
--- a/.changeset/eng-507-checkout-token-argv.md
+++ b/.changeset/eng-507-checkout-token-argv.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/runner-workspace": patch
+---
+
+Keep the checkout credential out of the git process argv. The runner now injects the
+`http.extraHeader` Authorization through env-based git config (`GIT_CONFIG_*`, which requires
+git 2.31+) instead of a `-c` CLI argument, so the token is no longer readable via `ps` or
+`/proc/<pid>/cmdline` while a clone runs, and the inherited git config-injection environment is
+stripped from every git child. The setup step now fails with `git_unavailable` on git older
+than 2.31, and credential redaction adopts the shared `@shipfox/redact` helpers.

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -4,9 +4,9 @@ Polls the Shipfox API for jobs and executes their steps on the runner host.
 
 ## Host prerequisites
 
-- **`git`** must be installed on the runner host and on `PATH`. Each job is
-  executed against a checkout of its project repository, so a runner without
-  `git` cannot run repository-backed jobs.
+- **`git` 2.31 or newer** must be installed on the runner host and on `PATH`.
+  Each job is executed against a checkout of its project repository, so a
+  runner without a supported `git` cannot run repository-backed jobs.
 
 ## Workspace directories
 
@@ -18,9 +18,9 @@ During the synthetic "Set up job" step, the runner exchanges the job's lease for
 short-lived, read-only checkout credentials and shallow-clones the project
 repository into the per-job directory. The credentials are fetched only after the
 job is claimed, are never persisted to disk or `.git/config`, and never appear in
-logs or step errors. A setup failure (missing `git`, a denied credential, or an
-unreachable provider) fails the job before any step runs, with a machine-readable
-reason recorded on the step.
+logs or step errors. A setup failure (missing or unsupported `git`, a denied
+credential, or an unreachable provider) fails the job before any step runs, with
+a machine-readable reason recorded on the step.
 
 ### `SHIPFOX_RUNNER_WORKSPACE_ROOT` (optional)
 

--- a/libs/runner/workspace/package.json
+++ b/libs/runner/workspace/package.json
@@ -40,6 +40,7 @@
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/redact": "workspace:*",
     "@shipfox/regex": "workspace:*"
   },
   "devDependencies": {

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -9,6 +9,11 @@ import {assertGitAvailable, CheckoutError, checkoutRepository} from '#checkout.j
 // flag mistake a mock would accept fails here. git is a runner host prerequisite, so it is
 // present in CI. Only the network/auth/abort paths (which a local remote cannot produce)
 // stay mocked in checkout.test.ts.
+//
+// The file:// transport ignores http.extraHeader, so these tests prove the env-config syntax
+// is accepted, the clone succeeds, and the credential is never persisted to .git/config. They
+// do not prove the header reaches the HTTP wire; that transport-level check is out of unit
+// scope (covered end-to-end against a real provider).
 const execFileAsync = promisify(execFile);
 
 let workdir: string;

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -1,14 +1,18 @@
-// Mocked-execFile tests: assert the exact git argv, failure classification, and redaction
-// without spawning git. The real-git happy path lives in checkout.realgit.test.ts.
+// Mocked-execFile tests: assert the git argv, env-based credential injection, version gate,
+// failure classification, and redaction without spawning git. The real-git happy path lives
+// in checkout.realgit.test.ts.
 const execFileMock = vi.fn();
 
 vi.mock('node:child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-const {checkoutRepository, CheckoutError, redactSecrets} = await import('#checkout.js');
+const {assertGitAvailable, checkoutRepository, CheckoutError, GitUnavailableError} = await import(
+  '#checkout.js'
+);
 
 type ExecCallback = (error: unknown, result?: {stdout: string; stderr: string}) => void;
+type ExecOptions = {env: Record<string, string | undefined>};
 
 function callbackOf(args: unknown[]): ExecCallback {
   return args[args.length - 1] as ExecCallback;
@@ -20,6 +24,12 @@ function resolveExec() {
   );
 }
 
+function resolveExecWith(stdout: string) {
+  execFileMock.mockImplementation((...args: unknown[]) =>
+    callbackOf(args)(null, {stdout, stderr: ''}),
+  );
+}
+
 function rejectExec(error: unknown) {
   execFileMock.mockImplementation((...args: unknown[]) => callbackOf(args)(error));
 }
@@ -28,14 +38,27 @@ function gitError(stderr: string): Error & {stderr: string} {
   return Object.assign(new Error('Command failed'), {stderr});
 }
 
+function optionsOf(callIndex = 0): ExecOptions {
+  return execFileMock.mock.calls[callIndex]?.[2] as ExecOptions;
+}
+
 const BASE = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main', cwd: '/work/job-1'};
+const CLONE_ARGS = [
+  'clone',
+  '--depth=1',
+  '--single-branch',
+  '--branch',
+  'main',
+  'https://github.com/acme/repo.git',
+  '/work/job-1',
+];
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('checkoutRepository argv', () => {
-  it('shallow-clones the single branch with no -c when there is no auth', async () => {
+describe('checkoutRepository argv and env injection', () => {
+  it('shallow-clones the single branch with no credential when there is no auth', async () => {
     resolveExec();
 
     await checkoutRepository(BASE);
@@ -43,18 +66,11 @@ describe('checkoutRepository argv', () => {
     expect(execFileMock).toHaveBeenCalledOnce();
     const [file, args] = execFileMock.mock.calls[0] as [string, string[]];
     expect(file).toBe('git');
-    expect(args).toEqual([
-      'clone',
-      '--depth=1',
-      '--single-branch',
-      '--branch',
-      'main',
-      'https://github.com/acme/repo.git',
-      '/work/job-1',
-    ]);
+    expect(args).toEqual(CLONE_ARGS);
+    expect(optionsOf().env.GIT_CONFIG_COUNT).toBeUndefined();
   });
 
-  it('injects a bearer credential via a one-shot http.extraHeader', async () => {
+  it('keeps the bearer token out of argv and injects it via env GIT_CONFIG_*', async () => {
     resolveExec();
 
     await checkoutRepository({
@@ -63,15 +79,18 @@ describe('checkoutRepository argv', () => {
     });
 
     const [, args] = execFileMock.mock.calls[0] as [string, string[]];
-    expect(args.slice(0, 3)).toEqual([
-      '-c',
-      'http.extraHeader=Authorization: Bearer tok-123',
-      'clone',
-    ]);
+    expect(args).toEqual(CLONE_ARGS);
+    expect(args.join(' ')).not.toContain('tok-123');
+
+    const {env} = optionsOf();
+    expect(env.GIT_CONFIG_COUNT).toBe('1');
+    expect(env.GIT_CONFIG_KEY_0).toBe('http.extraHeader');
+    expect(env.GIT_CONFIG_VALUE_0).toBe('Authorization: Bearer tok-123');
   });
 
-  it('injects a basic credential as a base64 Authorization header', async () => {
+  it('keeps the basic token and its base64 form out of argv and injects via env', async () => {
     resolveExec();
+    const base64 = Buffer.from('x-token:tok-123').toString('base64');
 
     await checkoutRepository({
       ...BASE,
@@ -84,8 +103,11 @@ describe('checkoutRepository argv', () => {
     });
 
     const [, args] = execFileMock.mock.calls[0] as [string, string[]];
-    const expected = Buffer.from('x-token:tok-123').toString('base64');
-    expect(args[1]).toBe(`http.extraHeader=Authorization: Basic ${expected}`);
+    expect(args).toEqual(CLONE_ARGS);
+    expect(args.join(' ')).not.toContain('tok-123');
+    expect(args.join(' ')).not.toContain(base64);
+
+    expect(optionsOf().env.GIT_CONFIG_VALUE_0).toBe(`Authorization: Basic ${base64}`);
   });
 
   it('disables interactive credential prompts', async () => {
@@ -93,8 +115,63 @@ describe('checkoutRepository argv', () => {
 
     await checkoutRepository(BASE);
 
-    const options = execFileMock.mock.calls[0]?.[2] as {env: Record<string, string>};
-    expect(options.env.GIT_TERMINAL_PROMPT).toBe('0');
+    expect(optionsOf().env.GIT_TERMINAL_PROMPT).toBe('0');
+  });
+});
+
+describe('checkoutRepository git env sanitization', () => {
+  // Git reads injected config from GIT_CONFIG_COUNT/KEY_n/VALUE_n and GIT_CONFIG_PARAMETERS.
+  // A hostile or stale host environment must not leak into the clone.
+  const POISON: Record<string, string> = {
+    GIT_CONFIG_COUNT: '2',
+    GIT_CONFIG_KEY_0: 'core.sshCommand',
+    GIT_CONFIG_VALUE_0: 'ssh -i /tmp/evil',
+    GIT_CONFIG_KEY_1: 'http.proxy',
+    GIT_CONFIG_VALUE_1: 'http://evil',
+    GIT_CONFIG_PARAMETERS: "'core.pager=evil'",
+  };
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const [key, value] of Object.entries(POISON)) {
+      saved[key] = process.env[key];
+      process.env[key] = value;
+    }
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(POISON)) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('strips inherited GIT_CONFIG_* and GIT_CONFIG_PARAMETERS, keeping only our injected pair', async () => {
+    resolveExec();
+
+    await checkoutRepository({
+      ...BASE,
+      auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00Z'},
+    });
+
+    const {env} = optionsOf();
+    expect(env.GIT_CONFIG_COUNT).toBe('1');
+    expect(env.GIT_CONFIG_KEY_0).toBe('http.extraHeader');
+    expect(env.GIT_CONFIG_VALUE_0).toBe('Authorization: Bearer tok-123');
+    expect(env.GIT_CONFIG_KEY_1).toBeUndefined();
+    expect(env.GIT_CONFIG_VALUE_1).toBeUndefined();
+    expect(env.GIT_CONFIG_PARAMETERS).toBeUndefined();
+  });
+
+  it('strips inherited git config-injection env on the no-auth path too', async () => {
+    resolveExec();
+
+    await checkoutRepository(BASE);
+
+    const {env} = optionsOf();
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.GIT_CONFIG_KEY_0).toBeUndefined();
+    expect(env.GIT_CONFIG_PARAMETERS).toBeUndefined();
   });
 });
 
@@ -187,17 +264,12 @@ describe('checkoutRepository failure classification', () => {
     expect((error as Error).message).toContain('***');
   });
 
-  it('redacts a basic credential when stderr is empty and the argv leaks into error.message', async () => {
+  it('redacts a basic credential that leaks into error.message when stderr is empty', async () => {
     const base64 = Buffer.from('x-token:tok-123').toString('base64');
-    // No stderr: classifyCloneError falls back to the execFile error.message, which on
-    // Node carries the full argv including the Authorization header value.
+    // Defense in depth: even if a credential reaches error.message (e.g. git echoing it back),
+    // classifyCloneError scrubs it before the message rides into a logged step result.
     rejectExec(
-      Object.assign(
-        new Error(
-          `Command failed: git -c http.extraHeader=Authorization: Basic ${base64} clone --depth=1`,
-        ),
-        {stderr: ''},
-      ),
+      Object.assign(new Error(`Command failed: git clone with Basic ${base64}`), {stderr: ''}),
     );
 
     const error = await checkoutRepository({
@@ -216,10 +288,9 @@ describe('checkoutRepository failure classification', () => {
   });
 
   it('scrubs the token from the error cause so it cannot ride the cause chain into a log', async () => {
-    const raw = Object.assign(
-      new Error('Command failed: git -c http.extraHeader=Authorization: Bearer tok-123 clone ...'),
-      {stderr: 'fatal: Authentication failed'},
-    );
+    const raw = Object.assign(new Error('Command failed: git clone with Bearer tok-123'), {
+      stderr: 'fatal: Authentication failed',
+    });
     rejectExec(raw);
 
     const error = await checkoutRepository({
@@ -233,18 +304,64 @@ describe('checkoutRepository failure classification', () => {
   });
 });
 
-describe('redactSecrets', () => {
-  it('removes every occurrence of each secret', () => {
-    expect(redactSecrets('token=abc and again abc', ['abc'])).toBe('token=*** and again ***');
+describe('assertGitAvailable', () => {
+  it.each([
+    'git version 2.39.2',
+    'git version 2.31.0',
+    'git version 2.39.5 (Apple Git-154)',
+    'git version 2.45.1.windows.1',
+  ])('resolves for git >= 2.31 (%s)', async (stdout) => {
+    resolveExecWith(stdout);
+
+    await expect(assertGitAvailable()).resolves.toBeUndefined();
   });
 
-  it('strips URL-embedded credentials', () => {
-    expect(redactSecrets('clone https://user:pass@github.com/x.git failed', [])).toBe(
-      'clone https://***@github.com/x.git failed',
-    );
+  it.each([
+    'git version 2.30.9',
+    'git version 2.20.1',
+    'git version 1.9.5',
+  ])('rejects git older than 2.31 (%s)', async (stdout) => {
+    resolveExecWith(stdout);
+
+    const error = await assertGitAvailable().catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(GitUnavailableError);
+    expect((error as Error).message).toContain('2.31');
   });
 
-  it('ignores empty secrets', () => {
-    expect(redactSecrets('unchanged', [''])).toBe('unchanged');
+  it('rejects when git is not on PATH', async () => {
+    rejectExec(Object.assign(new Error('spawn git ENOENT'), {code: 'ENOENT'}));
+
+    const error = await assertGitAvailable().catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(GitUnavailableError);
+    expect((error as Error).cause).toBeDefined();
+  });
+
+  it('fails closed when the version output is unparseable', async () => {
+    resolveExecWith('not a version string');
+
+    const error = await assertGitAvailable().catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(GitUnavailableError);
+    expect((error as Error).message).toContain('2.31');
+  });
+
+  it('bounds and sanitizes hostile version output in the error message', async () => {
+    // Control bytes (NUL, BEL, ESC) built programmatically so the source carries no literal
+    // control characters; a wrapper `git` could emit these on its --version line.
+    const controls = String.fromCharCode(0, 7, 27);
+    const hostile = `git version ${controls}garbage ${'A'.repeat(200)}`;
+    resolveExecWith(hostile);
+
+    const error = await assertGitAvailable().catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(GitUnavailableError);
+    const message = (error as Error).message;
+    for (const code of [0, 7, 27]) {
+      expect(message).not.toContain(String.fromCharCode(code));
+    }
+    // The embedded snippet is bounded, so a 200-char run cannot flood the logged step error.
+    expect(message).not.toContain('A'.repeat(120));
   });
 });

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -49,6 +49,7 @@ const CLONE_ARGS = [
   '--single-branch',
   '--branch',
   'main',
+  '--',
   'https://github.com/acme/repo.git',
   '/work/job-1',
 ];
@@ -108,6 +109,17 @@ describe('checkoutRepository argv and env injection', () => {
     expect(args.join(' ')).not.toContain(base64);
 
     expect(optionsOf().env.GIT_CONFIG_VALUE_0).toBe(`Authorization: Basic ${base64}`);
+  });
+
+  it('passes the repository url after a `--` separator so a leading dash cannot inject an option', async () => {
+    resolveExec();
+
+    await checkoutRepository({...BASE, repositoryUrl: '--upload-pack=evil'});
+
+    const [, args] = execFileMock.mock.calls[0] as [string, string[]];
+    const separator = args.indexOf('--');
+    expect(separator).toBeGreaterThan(-1);
+    expect(args.slice(separator + 1)).toEqual(['--upload-pack=evil', '/work/job-1']);
   });
 
   it('disables interactive credential prompts', async () => {
@@ -310,6 +322,7 @@ describe('assertGitAvailable', () => {
     'git version 2.31.0',
     'git version 2.39.5 (Apple Git-154)',
     'git version 2.45.1.windows.1',
+    'git version 3.0.0',
   ])('resolves for git >= 2.31 (%s)', async (stdout) => {
     resolveExecWith(stdout);
 

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -1,13 +1,17 @@
 import {execFile} from 'node:child_process';
 import {promisify} from 'node:util';
 import type {CheckoutTokenAuthDto} from '@shipfox/api-workflows-dto';
+import {redactSecrets, secretWireForms} from '@shipfox/redact';
 
 const execFileAsync = promisify(execFile);
 
-/** Thrown when `git` is not on the runner host's PATH; surfaced as `git_unavailable`. */
+/**
+ * Thrown when `git` is unusable on the runner host: absent from PATH, or older than the
+ * minimum version the checkout requires. Surfaced as `git_unavailable` by the setup step.
+ */
 export class GitUnavailableError extends Error {
-  constructor(options?: ErrorOptions) {
-    super('git is not available on the runner host', options);
+  constructor(message = 'git is not available on the runner host', options?: ErrorOptions) {
+    super(message, options);
     this.name = 'GitUnavailableError';
   }
 }
@@ -29,25 +33,57 @@ export class CheckoutError extends Error {
   }
 }
 
-/** Throws {@link GitUnavailableError} when `git` cannot be invoked on the host. */
+// Env-based config injection (GIT_CONFIG_*) requires git 2.31; older git silently ignores it,
+// which would run the clone with no credential. Gate on the version so that failure surfaces
+// as a clear setup error before any step runs, not as a confusing downstream auth rejection.
+const MIN_GIT_VERSION = {major: 2, minor: 31} as const;
+
+// Matches major.minor only, tolerating trailing text ("2.39.5 (Apple Git-154)", "...windows.1").
+const GIT_VERSION = /git version (\d+)\.(\d+)/i;
+// Anything outside printable ASCII; replaced with a space when sanitizing host-controlled output.
+const NON_PRINTABLE_ASCII = /[^\x20-\x7e]/g;
+
+/**
+ * Resolves when `git` is present and at least {@link MIN_GIT_VERSION}; otherwise throws
+ * {@link GitUnavailableError}. Fails closed: an unparseable `git --version` is treated as
+ * unusable, since the checkout cannot prove the host supports `GIT_CONFIG_*` injection.
+ */
 export async function assertGitAvailable(): Promise<void> {
+  let stdout: string;
   try {
-    await execFileAsync('git', ['--version']);
+    ({stdout} = await execFileAsync('git', ['--version']));
   } catch (error) {
-    throw new GitUnavailableError({cause: error});
+    throw new GitUnavailableError(undefined, {cause: error});
+  }
+
+  const version = parseGitVersion(stdout);
+  if (!version || !meetsMinimum(version)) {
+    throw new GitUnavailableError(
+      `git ${MIN_GIT_VERSION.major}.${MIN_GIT_VERSION.minor} or newer is required on the runner ` +
+        'host (the checkout credential is injected via GIT_CONFIG_* environment variables, ' +
+        `supported since git ${MIN_GIT_VERSION.major}.${MIN_GIT_VERSION.minor}); found ` +
+        describeGitVersion(stdout),
+    );
   }
 }
 
-/**
- * Removes every occurrence of each secret plus any URL-embedded `user:pass@` credential
- * from `text`, so a clone error never carries token material into a log or step result.
- */
-export function redactSecrets(text: string, secrets: string[]): string {
-  let redacted = text;
-  for (const secret of secrets) {
-    if (secret) redacted = redacted.split(secret).join('***');
-  }
-  return redacted.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
+function parseGitVersion(output: string): {major: number; minor: number} | undefined {
+  const match = GIT_VERSION.exec(output);
+  if (!match) return undefined;
+  return {major: Number(match[1]), minor: Number(match[2])};
+}
+
+function meetsMinimum(version: {major: number; minor: number}): boolean {
+  if (version.major !== MIN_GIT_VERSION.major) return version.major > MIN_GIT_VERSION.major;
+  return version.minor >= MIN_GIT_VERSION.minor;
+}
+
+// `git --version` output is host-controlled (a wrapper or shim on PATH can emit anything), and
+// this string lands in a logged step-error message. Keep only printable ASCII and bound the
+// length so control bytes or a megabyte of garbage cannot poison the log.
+function describeGitVersion(output: string): string {
+  const sanitized = output.replace(NON_PRINTABLE_ASCII, ' ').trim().slice(0, 80);
+  return sanitized ? `"${sanitized}"` : 'an unrecognized version';
 }
 
 // git surfaces credential rejection and provider-availability failures only through
@@ -58,11 +94,29 @@ const AUTH_FAILURE =
 const PROVIDER_UNAVAILABLE =
   /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution|the requested url returned error: (?:429|5\d\d)/i;
 
+const GIT_CONFIG_INDEXED_KEY = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/;
+
+// Git reads injected config from two environment channels: the GIT_CONFIG_COUNT /
+// GIT_CONFIG_KEY_<n> / GIT_CONFIG_VALUE_<n> triples, and GIT_CONFIG_PARAMETERS (the channel
+// `-c` populates internally). Strip both from every git child so our injected header is the
+// only env-sourced config and a clone behaves identically regardless of the host environment.
+function gitChildEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {...process.env, GIT_TERMINAL_PROMPT: '0'};
+  for (const key of Object.keys(env)) {
+    if (GIT_CONFIG_INDEXED_KEY.test(key)) delete env[key];
+  }
+  delete env.GIT_CONFIG_PARAMETERS;
+  return env;
+}
+
 /**
  * Shallow-clones `ref` of `repositoryUrl` into `cwd` (which must already exist and be empty).
  *
- * The credential is injected with a one-shot `-c http.extraHeader`, never embedded in the
- * clone URL, so it is not persisted to `.git/config` where later user steps could read it.
+ * The credential rides a process-scoped `GIT_CONFIG_*` environment pair (`http.extraHeader`),
+ * never a CLI argument and never embedded in the clone URL. This keeps it out of the process
+ * argv (so it cannot be read via `ps` / `/proc/<pid>/cmdline` while the clone runs) and out of
+ * `.git/config`, where a later user step could read it. The child environment is first
+ * sanitized of any inherited git config-injection channels (see {@link gitChildEnv}).
  * `GIT_TERMINAL_PROMPT=0` turns a missing or denied credential into an immediate error
  * instead of a hang on an interactive prompt. Failures are classified into a
  * {@link CheckoutError} and have any token material redacted from their message.
@@ -76,17 +130,17 @@ export async function checkoutRepository(params: {
 }): Promise<void> {
   const {repositoryUrl, ref, auth, cwd, signal} = params;
 
-  const args: string[] = [];
+  const args = ['clone', '--depth=1', '--single-branch', '--branch', ref, repositoryUrl, cwd];
+
+  const env = gitChildEnv();
   if (auth) {
-    args.push('-c', `http.extraHeader=Authorization: ${authorizationValue(auth)}`);
+    env.GIT_CONFIG_COUNT = '1';
+    env.GIT_CONFIG_KEY_0 = 'http.extraHeader';
+    env.GIT_CONFIG_VALUE_0 = `Authorization: ${authorizationValue(auth)}`;
   }
-  args.push('clone', '--depth=1', '--single-branch', '--branch', ref, repositoryUrl, cwd);
 
   try {
-    await execFileAsync('git', args, {
-      env: {...process.env, GIT_TERMINAL_PROMPT: '0'},
-      ...(signal ? {signal} : {}),
-    });
+    await execFileAsync('git', args, {env, ...(signal ? {signal} : {})});
   } catch (error) {
     throw classifyCloneError(error, auth);
   }
@@ -101,13 +155,13 @@ function authorizationValue(auth: CheckoutTokenAuthDto): string {
   return `Basic ${basicCredential(auth)}`;
 }
 
-// Every form the credential takes on the wire is secret. For basic auth the raw token is
-// not a substring of the base64 the header carries, so redacting only the token would
-// leak the base64; include it explicitly.
+// Every form the credential takes on the wire is secret. `secretWireForms` derives the token's
+// encoded variants (base64/base64url/hex/url-encoded); the Basic header carries
+// `base64(username:token)`, which is not a wire form of the token alone, so add it explicitly.
 function secretsOf(auth: CheckoutTokenAuthDto | undefined): string[] {
   if (!auth) return [];
-  if (auth.kind === 'bearer') return [auth.token];
-  return [auth.token, basicCredential(auth)];
+  if (auth.kind === 'bearer') return secretWireForms(auth.token);
+  return [...secretWireForms(auth.token), basicCredential(auth)];
 }
 
 function classifyCloneError(error: unknown, auth: CheckoutTokenAuthDto | undefined): CheckoutError {
@@ -118,8 +172,8 @@ function classifyCloneError(error: unknown, auth: CheckoutTokenAuthDto | undefin
   const secrets = secretsOf(auth);
   const stderr = stderrOf(error);
   const message = redactSecrets(stderr.trim() || errorMessage(error), secrets);
-  // The raw execFile error carries the full argv (including the Authorization header) in
-  // its `message`/`cmd`, so it can never ride the cause chain into a logger un-redacted.
+  // Defense in depth: the credential no longer rides argv, but git stderr can still echo a
+  // credential-bearing URL, so scrub the cause too before it can reach a logger.
   const cause = secrets.length > 0 ? redactedCause(error, secrets) : error;
 
   if (AUTH_FAILURE.test(stderr)) return new CheckoutError('auth', message, {cause});

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -96,10 +96,12 @@ const PROVIDER_UNAVAILABLE =
 
 const GIT_CONFIG_INDEXED_KEY = /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/;
 
-// Git reads injected config from two environment channels: the GIT_CONFIG_COUNT /
+// Git injects arbitrary config from two environment channels: the GIT_CONFIG_COUNT /
 // GIT_CONFIG_KEY_<n> / GIT_CONFIG_VALUE_<n> triples, and GIT_CONFIG_PARAMETERS (the channel
-// `-c` populates internally). Strip both from every git child so our injected header is the
-// only env-sourced config and a clone behaves identically regardless of the host environment.
+// `-c` populates internally). Strip both from every git child so a stale or hostile host
+// environment cannot inject config keys that shadow our header or redirect the clone. Other
+// env that git honours (GIT_CONFIG_GLOBAL/SYSTEM, GIT_SSH_COMMAND, http(s)_proxy) is left
+// intact: it belongs to the runner's own trusted image, not to these injection channels.
 function gitChildEnv(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {...process.env, GIT_TERMINAL_PROMPT: '0'};
   for (const key of Object.keys(env)) {
@@ -130,7 +132,9 @@ export async function checkoutRepository(params: {
 }): Promise<void> {
   const {repositoryUrl, ref, auth, cwd, signal} = params;
 
-  const args = ['clone', '--depth=1', '--single-branch', '--branch', ref, repositoryUrl, cwd];
+  // `--` ends option parsing: a repositoryUrl beginning with `-` would otherwise be read as a
+  // git option (e.g. `--upload-pack=...`) rather than the clone source.
+  const args = ['clone', '--depth=1', '--single-branch', '--branch', ref, '--', repositoryUrl, cwd];
 
   const env = gitChildEnv();
   if (auth) {

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -4,7 +4,6 @@ export {
   type CheckoutFailureKind,
   checkoutRepository,
   GitUnavailableError,
-  redactSecrets,
 } from '#checkout.js';
 export {
   cleanupWorkspace,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2710,6 +2710,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/redact':
+        specifier: workspace:*
+        version: link:../../shared/common/redact
       '@shipfox/regex':
         specifier: workspace:*
         version: link:../../shared/common/regex


### PR DESCRIPTION
Moves the checkout credential out of the git process argv. The runner shallow-cloned each job's repo with `git -c "http.extraHeader=Authorization: …" clone …`, so the token was readable by any process on the host via `ps` / `/proc/<pid>/cmdline` while the clone ran. Log redaction did not cover this vector.

This is the runner-side PR of the ENG-408 security-hardening split (1 issue = 1 PR); its blocker ENG-506 (`@shipfox/redact`) is already merged.

## What changed
- **Token out of argv.** The `http.extraHeader` Authorization is now injected through env-based git config (`GIT_CONFIG_COUNT` / `GIT_CONFIG_KEY_0` / `GIT_CONFIG_VALUE_0`) instead of a `-c` CLI argument. The token never enters argv and is still never written to `.git/config`.
- **Env isolation.** The git child env is first stripped of both git config-injection channels (`GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` and `GIT_CONFIG_PARAMETERS`) on every clone, so ambient host config cannot leak in or shadow our header.
- **Require git ≥ 2.31.** Env-based config needs git 2.31, so `assertGitAvailable` now parses `git --version` and fails the setup step with `git_unavailable` on older versions. It **fails closed** on unparseable output, embedding a bounded, sanitized snippet (no raw control bytes) in the message.
- **Shared redaction.** Adopts `@shipfox/redact`, replacing the local `redactSecrets`; `secretsOf` now derives every wire form of the token via `secretWireForms`.

## Review notes
- The env-injection + sanitization path is the security-critical change. The new mocked tests assert the token (and the Basic base64 form) never appear in argv and that inherited `GIT_CONFIG_*` / `GIT_CONFIG_PARAMETERS` are stripped from the child env.
- `file://` ignores `http.extraHeader`, so the real-git tests prove env-syntax acceptance + clone success + no `.git/config` persistence; HTTP-wire transmission of the header is out of unit scope (covered end-to-end against a real provider).
- Resolves the project's open "minimum supported Git version" decision at 2.31. `@shipfox/runner-workspace` is private; the changeset follows the repo convention of tracking the private runner libs in the changelog.

Closes ENG-507

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the checkout credential out of git argv by injecting `http.extraHeader` via `GIT_CONFIG_*`, preventing token exposure via ps/cmdline, and adds a `--` separator to block option injection. Implements ENG-507 (part of ENG-408) and requires git ≥ 2.31.

- **New Features**
  - Inject Authorization through env `GIT_CONFIG_*` (no `-c`), keeping the token out of argv and `.git/config`.
  - Sanitize the git child env by stripping inherited `GIT_CONFIG_*` and `GIT_CONFIG_PARAMETERS`, and pass the repo URL after `--` to prevent git option injection.
  - Version gate: `assertGitAvailable` requires git ≥ 2.31; setup fails with `git_unavailable` and a bounded, sanitized message.
  - Adopt `@shipfox/redact` and `secretWireForms` for consistent credential redaction.

- **Migration**
  - Runner hosts must have git 2.31+. Older or unparseable `git --version` will fail the setup step.

<sup>Written for commit dad9672ed13b45064b3ef25d083d17130a5bc145. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

