### PR TITLE
Hide toasts in members invitation visual snapshots

### DIFF
--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -113,8 +113,8 @@ async function stableArgosScreenshot(
         const toaster = document.querySelector('[data-sonner-toaster]');
         if (toaster instanceof HTMLElement && visualWindow.__shipfoxToasterDisplay !== undefined) {
           toaster.style.display = visualWindow.__shipfoxToasterDisplay;
-          delete visualWindow.__shipfoxToasterDisplay;
         }
+        delete visualWindow.__shipfoxToasterDisplay;
 
         delete visualWindow.__shipfoxVisualRestore;
       });

--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -30,8 +30,21 @@ async function stableArgosScreenshot(
           | {kind: 'attribute'; target: Element; attribute: string; value: string}
           | {kind: 'text'; target: Text; value: string}
           | {kind: 'value'; target: HTMLInputElement | HTMLTextAreaElement; value: string};
-        const visualWindow = window as Window & {__shipfoxVisualRestore?: RestoreEntry[]};
+        const visualWindow = window as Window & {
+          __shipfoxVisualRestore?: RestoreEntry[];
+          __shipfoxToasterDisplay?: string;
+        };
         const restoreEntries: RestoreEntry[] = [];
+
+        // A prior action's success toast auto-dismisses after a few seconds, so whether
+        // it lingers into a later snapshot is a timing race. Hide the toaster region for
+        // the capture; afterScreenshot restores it so later toast assertions still see it.
+        const toaster = document.querySelector('[data-sonner-toaster]');
+        if (toaster instanceof HTMLElement) {
+          visualWindow.__shipfoxToasterDisplay = toaster.style.display;
+          toaster.style.display = 'none';
+        }
+
         const replaceValue = (value: string): string =>
           visualReplacements.reduce(
             (current, [source, replacement]) => current.split(source).join(replacement),
@@ -81,7 +94,10 @@ async function stableArgosScreenshot(
           | {kind: 'attribute'; target: Element; attribute: string; value: string}
           | {kind: 'text'; target: Text; value: string}
           | {kind: 'value'; target: HTMLInputElement | HTMLTextAreaElement; value: string};
-        const visualWindow = window as Window & {__shipfoxVisualRestore?: RestoreEntry[]};
+        const visualWindow = window as Window & {
+          __shipfoxVisualRestore?: RestoreEntry[];
+          __shipfoxToasterDisplay?: string;
+        };
         const restoreEntries = visualWindow.__shipfoxVisualRestore ?? [];
 
         for (const entry of restoreEntries.reverse()) {
@@ -92,6 +108,12 @@ async function stableArgosScreenshot(
           } else {
             entry.target.setAttribute(entry.attribute, entry.value);
           }
+        }
+
+        const toaster = document.querySelector('[data-sonner-toaster]');
+        if (toaster instanceof HTMLElement && visualWindow.__shipfoxToasterDisplay !== undefined) {
+          toaster.style.display = visualWindow.__shipfoxToasterDisplay;
+          delete visualWindow.__shipfoxToasterDisplay;
         }
 
         delete visualWindow.__shipfoxVisualRestore;


### PR DESCRIPTION
Fixes a flaky Argos snapshot in the members invitation E2E
(`e2e/client/workspaces/tests/invitations-members.e2e.ts`). The
`members/revoke-invitation-confirm` snapshot documents the revoke-confirmation
dialog, but a separate `Invitation sent to {email}.` sonner toast (raised ~30
lines earlier when the invitation was first created) was still on screen when
the snapshot was taken, so it got baked into the baseline.

Sonner auto-dismisses toasts after 4000ms (its default `TOAST_LIFETIME`; the
`react-ui` `Toaster` wrapper sets no `duration`). On a normal run, the steps
between sending the invitation and capturing the revoke dialog take under 4s, so
the toast is present. On the rare slow run (~<1%) the timer elapses first, the
toast disappears, and Argos flags a diff. The snapshot was racing a wall-clock
timer unrelated to what it captures.

The fix hides sonner's region (`[data-sonner-toaster]`) for the duration of each
`stableArgosScreenshot` capture and restores it in `afterScreenshot` (restoring
matters: a later step asserts the "revoked" toast is visible). This removes the
whole class of "a transient toast leaks into a snapshot" for every screenshot in
this spec, and is instant rather than the alternative of a multi-second
`waitForTimeout`. The helper is local to this file, so nothing else is affected.

Reviewer note: because the affected baselines were captured with the stray
toast, this is a deliberate visual change. Argos will flag toast-free baselines
for `revoke-invitation-confirm` (and possibly `pending-invitations-populated` /
`invite-member-modal-conflict`) on the next run; approve them once and they stay
stable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the `sonner` toaster during visual snapshots in the members invitations E2E to prevent transient toasts from leaking into screenshots, and ensure cleanup never leaks display state between captures. This removes a timing race and stabilizes Argos baselines for the revoke-confirmation dialog.

- **Bug Fixes**
  - In `e2e/client/workspaces/tests/invitations-members.e2e.ts`, hide `[data-sonner-toaster]` for each `stableArgosScreenshot`; `afterScreenshot` restores it and now always clears `__shipfoxToasterDisplay` even if the toaster unmounts.
  - Eliminates flakiness from the 4s auto-dismiss toast; Argos baselines will update on next run.
  - Change is scoped to this spec only.

<sup>Written for commit 3146f54d0c376b2ac3c71de5b8e4ba9b4e318543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

