### PR TITLE
Update repository URL to ShipfoxHQ/shipfox

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/api",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "apps/api"
   },
   "license": "MIT",

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/client",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "apps/client"
   },
   "license": "MIT",

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/runner",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "apps/runner"
   },
   "license": "MIT",

--- a/e2e/api/auth/package.json
+++ b/e2e/api/auth/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-api-auth",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/api/auth"
   },
   "license": "MIT",

--- a/e2e/client/auth/package.json
+++ b/e2e/client/auth/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-client-auth",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/client/auth"
   },
   "license": "MIT",

--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-client-integrations",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/client/integrations"
   },
   "license": "MIT",

--- a/e2e/client/runners/package.json
+++ b/e2e/client/runners/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-client-runners",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/client/runners"
   },
   "license": "MIT",

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-client-workspaces",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/client/workspaces"
   },
   "license": "MIT",

--- a/e2e/core/package.json
+++ b/e2e/core/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-core",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/core"
   },
   "license": "MIT",

--- a/e2e/helpers/auth/package.json
+++ b/e2e/helpers/auth/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-helper-auth",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/helpers/auth"
   },
   "license": "MIT",

--- a/e2e/helpers/workspaces/package.json
+++ b/e2e/helpers/workspaces/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/e2e-helper-workspaces",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "e2e/helpers/workspaces"
   },
   "license": "MIT",

--- a/libs/api/auth-context/package.json
+++ b/libs/api/auth-context/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/auth-context"
   },
   "private": true,

--- a/libs/api/auth-dto/package.json
+++ b/libs/api/auth-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/auth-dto"
   },
   "private": true,

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/auth"
   },
   "private": true,

--- a/libs/api/definitions-dto/package.json
+++ b/libs/api/definitions-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/definitions-dto"
   },
   "private": true,

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/definitions"
   },
   "private": true,

--- a/libs/api/dispatcher/package.json
+++ b/libs/api/dispatcher/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/dispatcher"
   },
   "private": true,

--- a/libs/api/integration/core-dto/package.json
+++ b/libs/api/integration/core-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/core-dto"
   },
   "private": true,

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/core"
   },
   "private": true,

--- a/libs/api/integration/debug-dto/package.json
+++ b/libs/api/integration/debug-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/debug-dto"
   },
   "private": true,

--- a/libs/api/integration/debug/package.json
+++ b/libs/api/integration/debug/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/debug"
   },
   "private": true,

--- a/libs/api/integration/github-dto/package.json
+++ b/libs/api/integration/github-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/github-dto"
   },
   "private": true,

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/github"
   },
   "private": true,

--- a/libs/api/integration/sentry-dto/package.json
+++ b/libs/api/integration/sentry-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/sentry-dto"
   },
   "private": true,

--- a/libs/api/integration/sentry/package.json
+++ b/libs/api/integration/sentry/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/integration/sentry"
   },
   "private": true,

--- a/libs/api/logs-dto/package.json
+++ b/libs/api/logs-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/logs-dto"
   },
   "private": true,

--- a/libs/api/logs/package.json
+++ b/libs/api/logs/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/logs"
   },
   "private": true,

--- a/libs/api/projects-dto/package.json
+++ b/libs/api/projects-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/projects-dto"
   },
   "private": true,

--- a/libs/api/projects/package.json
+++ b/libs/api/projects/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/projects"
   },
   "private": true,

--- a/libs/api/runners-dto/package.json
+++ b/libs/api/runners-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/runners-dto"
   },
   "private": true,

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/runners"
   },
   "private": true,

--- a/libs/api/triggers-dto/package.json
+++ b/libs/api/triggers-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/triggers-dto"
   },
   "private": true,

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/triggers"
   },
   "private": true,

--- a/libs/api/workflows-dto/package.json
+++ b/libs/api/workflows-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/workflows-dto"
   },
   "private": true,

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/workflows"
   },
   "private": true,

--- a/libs/api/workspaces-dto/package.json
+++ b/libs/api/workspaces-dto/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/workspaces-dto"
   },
   "private": true,

--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/api/workspaces"
   },
   "private": true,

--- a/libs/client/api/package.json
+++ b/libs/client/api/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/api"
   },
   "private": true,

--- a/libs/client/app-shell/package.json
+++ b/libs/client/app-shell/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/app-shell"
   },
   "private": true,

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/auth"
   },
   "private": true,

--- a/libs/client/integrations/package.json
+++ b/libs/client/integrations/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/integrations"
   },
   "private": true,

--- a/libs/client/invitations/package.json
+++ b/libs/client/invitations/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/invitations"
   },
   "private": true,

--- a/libs/client/projects/package.json
+++ b/libs/client/projects/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/projects"
   },
   "private": true,

--- a/libs/client/router/package.json
+++ b/libs/client/router/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/router"
   },
   "private": true,

--- a/libs/client/runners/package.json
+++ b/libs/client/runners/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/runners"
   },
   "private": true,

--- a/libs/client/ui/package.json
+++ b/libs/client/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/ui"
   },
   "private": true,

--- a/libs/client/workspace-settings/package.json
+++ b/libs/client/workspace-settings/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/workspace-settings"
   },
   "private": true,

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/runner/agent"
   },
   "private": true,

--- a/libs/runner/execution/package.json
+++ b/libs/runner/execution/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/runner/execution"
   },
   "private": true,

--- a/libs/runner/logs/package.json
+++ b/libs/runner/logs/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/runner/logs"
   },
   "private": true,

--- a/libs/runner/orchestration/package.json
+++ b/libs/runner/orchestration/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/runner/orchestration"
   },
   "private": true,

--- a/libs/runner/protocol/package.json
+++ b/libs/runner/protocol/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/runner/protocol"
   },
   "private": true,

--- a/libs/runner/workspace/package.json
+++ b/libs/runner/workspace/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/runner/workspace"
   },
   "private": true,

--- a/libs/shared/common/config/package.json
+++ b/libs/shared/common/config/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/common/config"
   },
   "type": "module",

--- a/libs/shared/common/redact/package.json
+++ b/libs/shared/common/redact/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/common/redact"
   },
   "type": "module",

--- a/libs/shared/common/regex/package.json
+++ b/libs/shared/common/regex/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/common/regex"
   },
   "type": "module",

--- a/libs/shared/node/drizzle/package.json
+++ b/libs/shared/node/drizzle/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/drizzle"
   },
   "private": true,

--- a/libs/shared/node/error-monitoring/package.json
+++ b/libs/shared/node/error-monitoring/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/error-monitoring"
   },
   "type": "module",

--- a/libs/shared/node/fastify/package.json
+++ b/libs/shared/node/fastify/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/fastify"
   },
   "type": "module",

--- a/libs/shared/node/jwt/package.json
+++ b/libs/shared/node/jwt/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/jwt"
   },
   "private": true,

--- a/libs/shared/node/log/package.json
+++ b/libs/shared/node/log/package.json
@@ -5,7 +5,7 @@
   "version": "0.3.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/log"
   },
   "type": "module",

--- a/libs/shared/node/mailer/package.json
+++ b/libs/shared/node/mailer/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/mailer"
   },
   "type": "module",

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/module"
   },
   "private": true,

--- a/libs/shared/node/opentelemetry/package.json
+++ b/libs/shared/node/opentelemetry/package.json
@@ -5,7 +5,7 @@
   "version": "0.4.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/opentelemetry"
   },
   "type": "module",

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/outbox"
   },
   "private": true,

--- a/libs/shared/node/postgres/package.json
+++ b/libs/shared/node/postgres/package.json
@@ -5,7 +5,7 @@
   "version": "0.3.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/postgres"
   },
   "type": "module",

--- a/libs/shared/node/temporal/package.json
+++ b/libs/shared/node/temporal/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/temporal"
   },
   "type": "module",

--- a/libs/shared/node/tokens/package.json
+++ b/libs/shared/node/tokens/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/node/tokens"
   },
   "private": true,

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/shared/react/ui"
   },
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@shipfox/workspace",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git"
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git"
   },
   "license": "MIT",
   "private": true,

--- a/tools/biome/package.json
+++ b/tools/biome/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/biome"
   },
   "license": "MIT",

--- a/tools/depcruise/package.json
+++ b/tools/depcruise/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/depcruise"
   },
   "license": "MIT",

--- a/tools/docker/package.json
+++ b/tools/docker/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/docker"
   },
   "license": "MIT",

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/playwright"
   },
   "license": "MIT",

--- a/tools/swc/package.json
+++ b/tools/swc/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.5",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/swc"
   },
   "license": "MIT",

--- a/tools/ts-config/package.json
+++ b/tools/ts-config/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.7",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/ts-config"
   },
   "license": "MIT",

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.5",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/typescript"
   },
   "license": "MIT",

--- a/tools/utils/package.json
+++ b/tools/utils/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.3",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/utils"
   },
   "license": "MIT",

--- a/tools/vite/package.json
+++ b/tools/vite/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.3",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/vite"
   },
   "license": "MIT",

--- a/tools/vitest/package.json
+++ b/tools/vitest/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.1",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "tools/vitest"
   },
   "license": "MIT",


### PR DESCRIPTION
Updates the `repository.url` field across all 80 `package.json` files (root, `apps/*`, `libs/**`, `tools/*`, `e2e/**`) from `github.com/ShipfoxHQ/platform.git` to `github.com/ShipfoxHQ/shipfox.git`.

The GitHub repository was renamed from `ShipfoxHQ/platform` to `ShipfoxHQ/shipfox`, so the published package metadata needs to point at the new location.

This is a metadata-only change: every diff is a single-line edit to `repository.url`, with no code, dependency, or behavior changes. The git remote already points at the new URL, and no other references (workflows, docs, lockfile) needed updating. The `ghcr.io/shipfoxhq/*` image names in `tools/docker/README.md` reference the org and app name, not the renamed repo, so they are left as-is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `repository.url` in 80 `package.json` files (root, `apps/*`, `libs/**`, `tools/*`, `e2e/**`) from `git+https://github.com/ShipfoxHQ/platform.git` to `git+https://github.com/ShipfoxHQ/shipfox.git` after the repo rename. Metadata-only change; no code, dependency, or behavior updates.

<sup>Written for commit 85048f737379218c04f3012ed6af1609035009e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

