### PR TITLE
[client] Add a self-hostable Docker image for the web client

### DIFF
--- a/apps/client/.dockerignore
+++ b/apps/client/.dockerignore
@@ -1,0 +1,11 @@
+# The image is assembled from the prebuilt static dist/ plus the nginx config
+# and the runtime-config entrypoint. Ignore everything else so stray files never
+# enter the context or bust the layer cache, then re-include what the Dockerfile
+# copies. The /** lines are required because re-including a directory does not
+# re-include its contents (moby/moby#30018).
+*
+!dist
+!dist/**
+!nginx.conf
+!docker-entrypoint.d
+!docker-entrypoint.d/**

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+
+# Production image for @shipfox/client: nginx serving the prebuilt Vite SPA.
+#
+# Unlike the api/runner images there is no prune and no node_modules: the client
+# is a static artifact built outside Docker by `turbo build` (dist/). Docker only
+# assembles. The API endpoint is NOT baked at build time; an entrypoint script
+# rewrites /config.js from environment at container start, so one image serves
+# any self-hosted deployment without a rebuild.
+#
+# Build context is this package directory; the build serves dist/ over nginx.
+
+ARG NGINX_VERSION=1.29
+
+FROM nginx:${NGINX_VERSION}-alpine
+
+# SPA routing + cache headers. Rarely changes, so copy before dist/ to keep the
+# layer cached across builds.
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# The stock nginx entrypoint runs every executable /docker-entrypoint.d/*.sh
+# before starting nginx; ours rewrites config.js from env on each container start.
+COPY docker-entrypoint.d/ /docker-entrypoint.d/
+RUN chmod +x /docker-entrypoint.d/*.sh
+
+# The Vite build output (built outside Docker by `turbo build`). Changes most, so
+# copy last.
+COPY dist/ /usr/share/nginx/html/
+
+# OCI metadata. The build/promotion workflows pass revision/created as build args.
+ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
+ARG IMAGE_REVISION
+ARG IMAGE_CREATED
+LABEL org.opencontainers.image.title="@shipfox/client" \
+      org.opencontainers.image.description="Shipfox web client" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source=$IMAGE_SOURCE \
+      org.opencontainers.image.revision=$IMAGE_REVISION \
+      org.opencontainers.image.created=$IMAGE_CREATED
+
+# The base image already sets the entrypoint (runs docker-entrypoint.d/ then
+# nginx) and the CMD, so neither is repeated here.

--- a/apps/client/docker-entrypoint.d/40-shipfox-runtime-config.sh
+++ b/apps/client/docker-entrypoint.d/40-shipfox-runtime-config.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Rewrite the client's runtime config from environment variables before nginx
+# starts, so one prebuilt image serves any deployment without a rebuild. The
+# stock nginx entrypoint runs every executable script in /docker-entrypoint.d/.
+set -eu
+
+config_file="/usr/share/nginx/html/config.js"
+
+# SHIPFOX_API_URL is the base URL of the Shipfox API the browser talks to (for
+# example https://api.example.com). Empty keeps same-origin relative requests.
+cat > "$config_file" <<EOF
+window.__SHIPFOX_CONFIG__ = {
+  apiUrl: "${SHIPFOX_API_URL:-}"
+};
+EOF
+
+echo "shipfox: wrote $config_file (apiUrl=\"${SHIPFOX_API_URL:-}\")"

--- a/apps/client/index.html
+++ b/apps/client/index.html
@@ -14,6 +14,10 @@
     <meta name="apple-mobile-web-app-title" content="Shipfox" />
     <meta name="msapplication-TileColor" content="#ff9300" />
     <meta name="theme-color" content="#ff9300" />
+
+    <!-- Runtime config, set before the app bundle loads. Served from public/ in
+         dev; the Docker image rewrites it from environment at container start. -->
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/client/nginx.conf
+++ b/apps/client/nginx.conf
@@ -1,0 +1,29 @@
+server {
+    listen       80;
+    listen       [::]:80;
+    server_name  _;
+
+    root   /usr/share/nginx/html;
+    index  index.html;
+
+    # Vite fingerprints asset filenames, so they can be cached forever.
+    location /assets/ {
+        try_files $uri =404;
+        expires    1y;
+        add_header  Cache-Control "public, immutable";
+    }
+
+    # Never cache the runtime config or the app shell, so an env change or a new
+    # deploy is picked up on the next load rather than from a stale cache.
+    location = /config.js {
+        add_header Cache-Control "no-store";
+    }
+    location = /index.html {
+        add_header Cache-Control "no-store";
+    }
+
+    # SPA fallback: unknown paths serve the app shell for client-side routing.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -13,6 +13,7 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "dev": "vite-dev",
+    "image": "shipfox-docker",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/docker": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vite": "workspace:*",

--- a/apps/client/public/config.js
+++ b/apps/client/public/config.js
@@ -1,0 +1,8 @@
+// Runtime configuration for the Shipfox client.
+//
+// This default ships inside the static build and leaves apiUrl empty, so the dev
+// server and tests fall back to the build-time VITE_API_URL. The Docker image
+// overwrites this file from environment variables at container start (see the
+// app's docker-entrypoint), so one prebuilt bundle serves any self-hosted
+// deployment without a rebuild.
+window.__SHIPFOX_CONFIG__ = {apiUrl: ''};

--- a/libs/client/api/src/env.d.ts
+++ b/libs/client/api/src/env.d.ts
@@ -6,3 +6,12 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface ShipfoxRuntimeConfig {
+  readonly apiUrl?: string;
+}
+
+// Injected by /config.js before the app bundle loads. The client Docker image
+// rewrites that file from environment at container start (see the app's
+// docker-entrypoint), so one prebuilt bundle serves any deployment.
+declare var __SHIPFOX_CONFIG__: ShipfoxRuntimeConfig | undefined;

--- a/libs/client/api/src/index.test.ts
+++ b/libs/client/api/src/index.test.ts
@@ -50,6 +50,21 @@ describe('apiRequest', () => {
     expect(request.headers.get('authorization')).toBe('Bearer access-token');
   });
 
+  test('falls back to the runtime config api url when no baseUrl is set', async () => {
+    globalThis.__SHIPFOX_CONFIG__ = {apiUrl: 'https://runtime.example.test'};
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ok: true}));
+    configureApiClient({baseUrl: undefined, fetchImpl});
+
+    try {
+      await apiRequest('/workspaces');
+
+      const request = fetchImpl.mock.calls[0]?.[0] as Request;
+      expect(request.url).toBe('https://runtime.example.test/workspaces');
+    } finally {
+      globalThis.__SHIPFOX_CONFIG__ = undefined;
+    }
+  });
+
   test('normalizes json API errors', async () => {
     const fetchImpl = vi
       .fn()

--- a/libs/client/api/src/index.ts
+++ b/libs/client/api/src/index.ts
@@ -1,7 +1,7 @@
 import ky, {type Options as KyOptions} from 'ky';
 
 export interface ApiClientOptions {
-  baseUrl?: string;
+  baseUrl?: string | undefined;
   getAccessToken?: (() => string | undefined) | undefined;
   refreshAccessToken?: (() => Promise<string | undefined> | string | undefined) | undefined;
   fetchImpl?: typeof fetch | undefined;
@@ -33,8 +33,16 @@ const TRAILING_SLASH_RE = /\/$/;
 const LEADING_SLASH_RE = /^\//;
 const AUTH_REFRESH_PATH_RE = /\/auth\/refresh\/?$/;
 
+// Set by /config.js before the app bundle loads. The client Docker image
+// rewrites that file from environment at container start, so one static build
+// serves any API endpoint. Empty/absent means "not configured at runtime", so
+// resolution falls through to the build-time VITE_API_URL used in dev.
+function runtimeApiUrl(): string | undefined {
+  return globalThis.__SHIPFOX_CONFIG__?.apiUrl || undefined;
+}
+
 function defaultBaseUrl(): string {
-  return apiOptions.baseUrl ?? import.meta.env.VITE_API_URL ?? '';
+  return apiOptions.baseUrl ?? runtimeApiUrl() ?? import.meta.env.VITE_API_URL ?? '';
 }
 
 export function configureApiClient(options: ApiClientOptions): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome
+      '@shipfox/docker':
+        specifier: workspace:*
+        version: link:../../tools/docker
       '@shipfox/ts-config':
         specifier: workspace:*
         version: link:../../tools/ts-config


### PR DESCRIPTION
Containerize `apps/client` as the end-user-facing image: nginx (alpine) serving the prebuilt Vite `dist/` that `turbo build` produces outside Docker. Unlike the api/runner images there is no `pnpm install` and no `turbo prune` — the client is a static artifact, so Docker only assembles it.

The defining requirement is **runtime config injection**: the API endpoint must not be baked at build time, so one redistributable image works for any self-hoster. A `/docker-entrypoint.d/` script rewrites `/config.js` from environment (`SHIPFOX_API_URL`) on each container start (the stock nginx entrypoint runs it before nginx). The client reads `window.__SHIPFOX_CONFIG__.apiUrl` and falls back to the build-time `VITE_API_URL`, so dev and tests are unchanged. nginx adds an SPA fallback and serves `config.js`/`index.html` with `no-store` so an env change or new deploy is picked up on the next load; fingerprinted `/assets/` stay immutable.

The `image` script wires `shipfox-docker` in plain (non-prune) context mode. Also adds the `.dockerignore` scoped to the static context and OCI labels, mirroring the api image (#248).

## Verification
- `turbo build --filter @shipfox/client` → `dist/config.js` present; built `index.html` loads `/config.js` before the app bundle.
- Built the image and ran it twice with **different** `SHIPFOX_API_URL` values on the **same image**: `/config.js` reflected each value (no rebuild), `/` and a deep route both served the SPA shell, `config.js` returned `Cache-Control: no-store`.
- `turbo build test check` and `turbo type --filter '...[origin/main]'` green across affected packages. The `ApiClientOptions.baseUrl` widening to `string | undefined` is backward-compatible.

## Note
The acceptance's `turbo image --filter @shipfox/client` needs the turbo `image` **task** in `turbo.jsonc`, which is owned by ENG-526 and not added here (the merged api PR followed the same boundary — script only). Verified via the `image` script directly; once ENG-526 lands the task, `turbo image` drives this script unchanged.

Refs ENG-524

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-hostable Docker image for `@shipfox/client`, served by nginx, with runtime API endpoint injection so one image works across environments without rebuilds. Improves SPA routing and caching; dev and tests remain unchanged. Refs ENG-524.

- New Features
  - Dockerfile: nginx (alpine) serves the prebuilt Vite `dist/`; no Node or install steps in the image.
  - Runtime config: entrypoint script writes `/config.js` from `SHIPFOX_API_URL`; app reads `window.__SHIPFOX_CONFIG__.apiUrl` and falls back to `VITE_API_URL`.
  - Nginx config: SPA fallback; `config.js` and `index.html` served with `Cache-Control: no-store`; `/assets/` cached immutable.
  - Client API: supports runtime base URL resolution; widened `ApiClientOptions.baseUrl`; added tests.
  - Tooling: minimal `.dockerignore`, OCI labels, and an `image` script using `@shipfox/docker` (ENG-526 will add the `turbo image` task).

<sup>Written for commit 2668a5e5666e8db6b15b23967587208769d218c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

