### PR TITLE
[api/integration] Scaffold the Gitea provider packages

### DIFF
--- a/.changeset/eng-535-scaffold-gitea-provider.md
+++ b/.changeset/eng-535-scaffold-gitea-provider.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-integration-gitea": patch
+"@shipfox/api-integration-gitea-dto": patch
+"@shipfox/api-integration-core": patch
+---
+
+Scaffold an empty `gitea` integration provider that mirrors the `github` package structure, ahead of any behavior.
+
+- New `@shipfox/api-integration-gitea` + `@shipfox/api-integration-gitea-dto` packages: `createGiteaIntegrationProvider()` returns an empty provider (`{provider: 'gitea', displayName: 'Gitea', adapters: {}, routes: []}`), plus a `src/config.ts` documenting the self-hoster variables (`GITEA_BASE_URL`, `GITEA_SERVICE_USERNAME`, `GITEA_SERVICE_TOKEN`, `GITEA_WEBHOOK_SECRET`, `GITEA_WEBHOOK_TARGET_URL`, `GITEA_CHECKOUT_TTL_SECONDS`) and an empty provider database wired with the stable migrations table `__drizzle_migrations_integrations_gitea`.
+- `@shipfox/api-integration-core`: register the Gitea provider behind `INTEGRATIONS_ENABLE_GITEA_PROVIDER` (default false). With the flag enabled, `gitea` appears in `GET /integration-providers`. Dormant scaffold; no runtime behavior yet.

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -40,6 +40,7 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
     "@shipfox/api-integration-debug": "workspace:*",
+    "@shipfox/api-integration-gitea": "workspace:*",
     "@shipfox/api-integration-github": "workspace:*",
     "@shipfox/api-integration-sentry": "workspace:*",
     "@shipfox/api-workspaces": "workspace:*",

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -5,6 +5,10 @@ export const config = createConfig({
     desc: 'Enables the debug integration provider, which is meant for testing. Keep it false in production.',
     default: false,
   }),
+  INTEGRATIONS_ENABLE_GITEA_PROVIDER: bool({
+    desc: 'Enables the Gitea integration provider so users can connect a Gitea instance.',
+    default: false,
+  }),
   INTEGRATIONS_ENABLE_GITHUB_PROVIDER: bool({
     desc: 'Enables the GitHub integration provider so users can connect GitHub.',
     default: false,

--- a/libs/api/integration/core/src/presentation/routes/list-providers.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/list-providers.test.ts
@@ -1,3 +1,4 @@
+import {giteaProviderModule} from '#providers/gitea.js';
 import {createTestApp, sourceProvider, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('GET /integration-providers', () => {
@@ -33,5 +34,21 @@ describe('GET /integration-providers', () => {
     expect(res.json().providers.map((provider: {provider: string}) => provider.provider)).toEqual([
       'debug',
     ]);
+  });
+
+  it('surfaces the gitea provider once its module is registered', async () => {
+    const {provider} = await giteaProviderModule.load();
+    const app = await createTestApp([provider]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/integration-providers',
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().providers.map((entry: {provider: string}) => entry.provider)).toContain(
+      'gitea',
+    );
   });
 });

--- a/libs/api/integration/core/src/providers/gitea.ts
+++ b/libs/api/integration/core/src/providers/gitea.ts
@@ -1,0 +1,31 @@
+import {config} from '#config.js';
+import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
+
+// Stable migration-tracking table name for the Gitea provider database. This
+// must NOT depend on the provider's position in the module `database` array. A
+// positional name would shift if a provider is flag-disabled and silently
+// re-run migrations against existing tables.
+const GITEA_MIGRATIONS_TABLE = '__drizzle_migrations_integrations_gitea';
+
+async function loadGiteaModuleParts(): Promise<IntegrationModuleParts> {
+  const {
+    createGiteaIntegrationProvider,
+    db: giteaDb,
+    migrationsPath: giteaMigrationsPath,
+  } = await import('@shipfox/api-integration-gitea');
+
+  return {
+    provider: createGiteaIntegrationProvider(),
+    database: {
+      db: giteaDb,
+      migrationsPath: giteaMigrationsPath,
+      migrationsTableName: GITEA_MIGRATIONS_TABLE,
+    },
+  };
+}
+
+export const giteaProviderModule: IntegrationProviderModule = {
+  id: 'gitea',
+  enabled: config.INTEGRATIONS_ENABLE_GITEA_PROVIDER,
+  load: loadGiteaModuleParts,
+};

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -1,4 +1,5 @@
 import {debugProviderModule} from '#providers/debug.js';
+import {giteaProviderModule} from '#providers/gitea.js';
 import {githubProviderModule} from '#providers/github.js';
 import {sentryProviderModule} from '#providers/sentry.js';
 import type {IntegrationModuleParts} from '#providers/types.js';
@@ -9,7 +10,12 @@ import type {IntegrationModuleParts} from '#providers/types.js';
  * needs to change. Order is significant: databases are migrated in this order,
  * so list a provider before any that depend on its tables.
  */
-const providerModules = [debugProviderModule, githubProviderModule, sentryProviderModule];
+const providerModules = [
+  debugProviderModule,
+  githubProviderModule,
+  sentryProviderModule,
+  giteaProviderModule,
+];
 
 export async function loadEnabledProviderModules(): Promise<IntegrationModuleParts[]> {
   const parts: IntegrationModuleParts[] = [];

--- a/libs/api/integration/gitea-dto/package.json
+++ b/libs/api/integration/gitea-dto/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@shipfox/api-integration-gitea-dto",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/integration/gitea-dto"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/integration/gitea-dto/src/index.ts
+++ b/libs/api/integration/gitea-dto/src/index.ts
@@ -1,0 +1,1 @@
+export const giteaProviderKind = 'gitea';

--- a/libs/api/integration/gitea-dto/tsconfig.build.json
+++ b/libs/api/integration/gitea-dto/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/integration/gitea-dto/tsconfig.json
+++ b/libs/api/integration/gitea-dto/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/integration/gitea-dto/tsconfig.test.json
+++ b/libs/api/integration/gitea-dto/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test", "**/*.test.ts"]
+}

--- a/libs/api/integration/gitea-dto/vitest.config.ts
+++ b/libs/api/integration/gitea-dto/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/api/integration/gitea/drizzle.config.ts
+++ b/libs/api/integration/gitea/drizzle.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema/*.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+});

--- a/libs/api/integration/gitea/drizzle/meta/_journal.json
+++ b/libs/api/integration/gitea/drizzle/meta/_journal.json
@@ -1,0 +1,5 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": []
+}

--- a/libs/api/integration/gitea/package.json
+++ b/libs/api/integration/gitea/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@shipfox/api-integration-gitea",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/integration/gitea"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-gitea-dto": "workspace:*",
+    "@shipfox/config": "workspace:*",
+    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/pg": "^8.15.5",
+    "drizzle-kit": "^0.31.10"
+  }
+}

--- a/libs/api/integration/gitea/src/config.ts
+++ b/libs/api/integration/gitea/src/config.ts
@@ -1,0 +1,23 @@
+import {createConfig, num, str, url} from '@shipfox/config';
+
+export const config = createConfig({
+  GITEA_BASE_URL: url({
+    desc: 'Base URL of the Gitea instance the provider connects to, including the scheme (for example https://gitea.example.com). Required.',
+  }),
+  GITEA_SERVICE_USERNAME: str({
+    desc: 'Username of the Gitea service account the provider authenticates as. Required.',
+  }),
+  GITEA_SERVICE_TOKEN: str({
+    desc: 'Access token or bot password of the Gitea service account, used for REST API and git-http basic auth. Required.',
+  }),
+  GITEA_WEBHOOK_SECRET: str({
+    desc: 'Secret used to verify the signature of incoming Gitea webhooks. Must match the secret set on the Gitea org webhook. Required.',
+  }),
+  GITEA_WEBHOOK_TARGET_URL: url({
+    desc: 'Public URL that Gitea delivers webhooks to. Points at this API and must be reachable from the Gitea instance. Required.',
+  }),
+  GITEA_CHECKOUT_TTL_SECONDS: num({
+    desc: 'Lifetime in seconds of the checkout credentials handed to the runner. Defaults to 300 (five minutes).',
+    default: 300,
+  }),
+});

--- a/libs/api/integration/gitea/src/db/db.ts
+++ b/libs/api/integration/gitea/src/db/db.ts
@@ -1,0 +1,15 @@
+import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
+import {pgClient} from '@shipfox/node-postgres';
+
+export const schema = {};
+
+let _db: NodePgDatabase<typeof schema> | undefined;
+
+export function db() {
+  if (!_db) _db = drizzle(pgClient(), {schema});
+  return _db;
+}
+
+export function closeDb(): void {
+  _db = undefined;
+}

--- a/libs/api/integration/gitea/src/db/migrations.ts
+++ b/libs/api/integration/gitea/src/db/migrations.ts
@@ -1,0 +1,4 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/integration/gitea/src/index.test.ts
+++ b/libs/api/integration/gitea/src/index.test.ts
@@ -1,0 +1,14 @@
+import {createGiteaIntegrationProvider} from '#index.js';
+
+describe('createGiteaIntegrationProvider', () => {
+  it('returns the empty gitea provider scaffold', () => {
+    const provider = createGiteaIntegrationProvider();
+
+    expect(provider).toEqual({
+      provider: 'gitea',
+      displayName: 'Gitea',
+      adapters: {},
+      routes: [],
+    });
+  });
+});

--- a/libs/api/integration/gitea/src/index.ts
+++ b/libs/api/integration/gitea/src/index.ts
@@ -1,0 +1,14 @@
+import {giteaProviderKind} from '@shipfox/api-integration-gitea-dto';
+import {closeDb, db} from '#db/db.js';
+import {migrationsPath} from '#db/migrations.js';
+
+export {closeDb, db, migrationsPath};
+
+export function createGiteaIntegrationProvider() {
+  return {
+    provider: giteaProviderKind,
+    displayName: 'Gitea',
+    adapters: {},
+    routes: [],
+  };
+}

--- a/libs/api/integration/gitea/tsconfig.build.json
+++ b/libs/api/integration/gitea/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/integration/gitea/tsconfig.json
+++ b/libs/api/integration/gitea/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/integration/gitea/tsconfig.test.json
+++ b/libs/api/integration/gitea/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test", "**/*.test.ts"]
+}

--- a/libs/api/integration/gitea/vitest.config.ts
+++ b/libs/api/integration/gitea/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,6 +746,9 @@ importers:
       '@shipfox/api-integration-debug':
         specifier: workspace:*
         version: link:../debug
+      '@shipfox/api-integration-gitea':
+        specifier: workspace:*
+        version: link:../gitea
       '@shipfox/api-integration-github':
         specifier: workspace:*
         version: link:../github
@@ -932,6 +935,64 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
+  libs/api/integration/gitea:
+    dependencies:
+      '@shipfox/api-integration-gitea-dto':
+        specifier: workspace:*
+        version: link:../gitea-dto
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../../shared/common/config
+      '@shipfox/node-drizzle':
+        specifier: workspace:*
+        version: link:../../../shared/node/drizzle
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../../shared/node/postgres
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+
+  libs/api/integration/gitea-dto:
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Stands up the empty `gitea` source-control provider so it registers and surfaces in the providers list, ahead of any behavior. The package structure mirrors the existing `github` provider so the follow-up issues (API client, connection flow, webhooks) drop into a familiar shape.

## What this adds

- **New `@shipfox/api-integration-gitea`**: `createGiteaIntegrationProvider()` returns an empty provider (`{provider: 'gitea', displayName: 'Gitea', adapters: {}, routes: []}`), plus a `src/config.ts` that documents the self-hoster variables (`GITEA_BASE_URL`, `GITEA_SERVICE_USERNAME`, `GITEA_SERVICE_TOKEN`, `GITEA_WEBHOOK_SECRET`, `GITEA_WEBHOOK_TARGET_URL`, `GITEA_CHECKOUT_TTL_SECONDS`) and an inert, schema-free provider database.
- **New `@shipfox/api-integration-gitea-dto`**: skeleton seeded with the shared `giteaProviderKind = 'gitea'` contract const, consumed by the provider package (the `github` → `github-dto` relationship).
- **`@shipfox/api-integration-core`**: registers the provider behind `INTEGRATIONS_ENABLE_GITEA_PROVIDER` (default false) via a new `src/providers/gitea.ts`, appended to the provider-modules list. With the flag enabled, `gitea` appears in `GET /integration-providers`.

## Why these choices

- The empty database carries the explicit migrations table `__drizzle_migrations_integrations_gitea` rather than a position-derived name, so a flag-disabled provider can never shift the table and silently re-run migrations against existing tables. The follow-up connection flow can add its first table with no churn here.
- No `apps/api` changes are needed: the app composes providers through `createIntegrationsContext()`, so enabling the flag picks up the provider transitively.

## Notes for review

- The provider is dormant; there is no runtime behavior to exercise yet. A core test loads the real `giteaProviderModule` and asserts `gitea` surfaces in `GET /integration-providers`, and a unit test pins the provider shape.
- Bump is `patch` for all three packages, matching the precedent for dormant scaffolds.

Closes ENG-535

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded the `gitea` integration provider and registered it behind `INTEGRATIONS_ENABLE_GITEA_PROVIDER` so it can appear in the providers list without any behavior. Supports ENG-535.

- **New Features**
  - New `@shipfox/api-integration-gitea`: `createGiteaIntegrationProvider()` returns an empty provider (`provider: 'gitea'`, `displayName: 'Gitea'`, `adapters: {}`, `routes: []`), with config for self-hosted vars and a schema-free DB using `__drizzle_migrations_integrations_gitea`.
  - New `@shipfox/api-integration-gitea-dto`: exports `giteaProviderKind`.
  - `@shipfox/api-integration-core`: registers the provider behind `INTEGRATIONS_ENABLE_GITEA_PROVIDER` (default false). When enabled, `gitea` shows up in `GET /integration-providers`.

<sup>Written for commit 11ec506788fc6de44baeb2de469d61e389c03ebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

