### PR TITLE
[runner] Add a self-hostable Docker image for the runner

### DIFF
--- a/apps/runner/.dockerignore
+++ b/apps/runner/.dockerignore
@@ -1,0 +1,8 @@
+# The image is assembled solely from the pruned context the build tool writes
+# under out/ (out/json for the prod install, out/full for the prebuilt dist).
+# Ignore everything else so stray files never enter the context or bust the
+# layer cache, then re-include out/. The /** line is required because
+# re-including a directory does not re-include its contents (moby/moby#30018).
+*
+!out
+!out/**

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -20,9 +20,10 @@ ARG PNPM_VERSION=11.6.0
 # Build stage: install the pruned workspace, then deploy only @shipfox/runner's
 # production closure into /prod. Workspace dependencies are copied in as real
 # directories (with their prebuilt dist/), and dev-only packages are dropped.
-# The official node image (Debian/glibc) carries corepack and a clean pnpm store;
-# the runner's prod closure is pure JS + wasm (no native addons), so /prod is
-# portable to the Ubuntu runtime below.
+# The official node image (Debian/glibc) carries corepack and a clean pnpm store.
+# The runner's prod closure is JS + wasm plus pi's lazily-loaded optional clipboard
+# native addon (glibc prebuilds, never loaded on the headless runner path), so /prod
+# is portable to the Ubuntu runtime below.
 FROM node:${NODE_VERSION}-slim AS build
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
@@ -46,6 +47,12 @@ RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
 FROM ubuntu:26.04 AS runtime
 ENV NODE_ENV=production
 
+# Match the UTF-8 environment user steps expect from ubuntu-latest: the Ubuntu
+# base leaves LANG unset, so tooling falls back to the byte-wise C locale and
+# mishandles non-ASCII. C.UTF-8 is built into glibc, so it needs no `locales`
+# package; a step can still override LANG for its own command.
+ENV LANG=C.UTF-8
+
 # System tooling the runner and the user steps it runs commonly need:
 #  - git: clones the repository for each job (the checkout step fails as
 #    `git_unavailable` without it); openssh-client covers git-over-ssh.
@@ -53,6 +60,13 @@ ENV NODE_ENV=production
 #    Node's own bundle, but these system tools use the OS store).
 #  - curl/wget, the archive tools, and jq: what user scripts reach for constantly.
 #  - build-essential + python3 + pkg-config: node-gyp and native build steps.
+#  - ripgrep (rg) + fd-find (fd): the pi agent's grep/find tools shell out to
+#    these. On PATH they let pi use the system binaries instead of downloading
+#    rg/fd from GitHub on first use. fd-find installs the binary as `fdfind`, so
+#    it is symlinked to `fd` after the install.
+#  - sudo: user steps get passwordless root inside the container, matching the
+#    GitHub ubuntu-latest environment (the container itself is the isolation
+#    boundary; see the sudoers drop-in below).
 #  - tini: PID 1. The runner spawns each user shell/agent step in its own
 #    detached process group; a step that orphans a grandchild re-parents it to
 #    PID 1, and Node would not reap it. tini reaps those zombies over the
@@ -75,8 +89,12 @@ RUN apt-get update \
         build-essential \
         python3 \
         pkg-config \
+        ripgrep \
+        fd-find \
+        sudo \
         tini \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s "$(command -v fdfind)" /usr/local/bin/fd
 
 # Node itself: copy the exact, pinned binary from the official image rather than
 # add an apt repo, so the runtime Node matches the build stage byte-for-byte and
@@ -90,11 +108,15 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 
 WORKDIR /app
 
-# Run unprivileged. Unlike the api the runner writes at runtime, so the user owns
-# a home directory: the pi coding agent persists its config under $HOME/.pi, and
-# per-job workspaces and shell scripts are created under the OS temp directory.
+# Run as the unprivileged shipfox user by default, with passwordless sudo for the
+# user steps that need root (à la ubuntu-latest; the container is the isolation
+# boundary). Unlike the api the runner writes at runtime, so the user owns a home
+# directory: the pi coding agent persists its config under $HOME/.pi, and per-job
+# workspaces and shell scripts are created under the OS temp directory.
 RUN groupadd --system shipfox \
-    && useradd --system --gid shipfox --create-home --home-dir /home/shipfox shipfox
+    && useradd --system --gid shipfox --create-home --home-dir /home/shipfox shipfox \
+    && echo 'shipfox ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/shipfox \
+    && chmod 0440 /etc/sudoers.d/shipfox
 ENV HOME=/home/shipfox
 
 COPY --from=build /prod ./

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -1,0 +1,120 @@
+# syntax=docker/dockerfile:1
+
+# Production image for @shipfox/runner.
+#
+# "Build outside Docker, ingest dist": `shipfox-docker --setup-context` prunes
+# the workspace and overlays the turbo-cached dist/. The build stage installs
+# the pruned workspace and runs `pnpm deploy` to extract @shipfox/runner's
+# production dependency closure into a self-contained tree; the runtime stage
+# ships only that, so the dev-only tools/* workspace packages (biome, vitest,
+# the swc/playwright toolchains) never reach the image. Docker never compiles
+# TypeScript.
+#
+# Build context is this package directory; the build tool writes the pruned
+# workspace under out/ (out/json = manifests + lockfile, out/full = full source
+# with each package's prebuilt dist/ overlaid).
+
+ARG NODE_VERSION=24.16.0
+ARG PNPM_VERSION=11.6.0
+
+# Build stage: install the pruned workspace, then deploy only @shipfox/runner's
+# production closure into /prod. Workspace dependencies are copied in as real
+# directories (with their prebuilt dist/), and dev-only packages are dropped.
+# The official node image (Debian/glibc) carries corepack and a clean pnpm store;
+# the runner's prod closure is pure JS + wasm (no native addons), so /prod is
+# portable to the Ubuntu runtime below.
+FROM node:${NODE_VERSION}-slim AS build
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+WORKDIR /app
+# Manifests + lockfile first (out/full carries the source but not the lockfile).
+COPY out/json/ ./
+COPY out/full/ ./
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm --filter=@shipfox/runner deploy --prod --legacy \
+      --store-dir=/pnpm/store --config.strict-peer-dependencies=false /prod
+
+# Runtime stage: Ubuntu (latest LTS), not the slim node base, because the runner
+# is a job executor. It checks out repositories and runs arbitrary user shell and
+# agent steps, so it should look like the CI environment users expect (à la
+# GitHub's ubuntu-latest): a glibc userland with the common system tools present.
+# The Node closure stays production-only (pnpm deploy --prod above); it is the OS
+# layer that is intentionally fuller here.
+FROM ubuntu:26.04 AS runtime
+ENV NODE_ENV=production
+
+# System tooling the runner and the user steps it runs commonly need:
+#  - git: clones the repository for each job (the checkout step fails as
+#    `git_unavailable` without it); openssh-client covers git-over-ssh.
+#  - ca-certificates: TLS trust for git/curl/wget HTTPS (the API client uses
+#    Node's own bundle, but these system tools use the OS store).
+#  - curl/wget, the archive tools, and jq: what user scripts reach for constantly.
+#  - build-essential + python3 + pkg-config: node-gyp and native build steps.
+#  - tini: PID 1. The runner spawns each user shell/agent step in its own
+#    detached process group; a step that orphans a grandchild re-parents it to
+#    PID 1, and Node would not reap it. tini reaps those zombies over the
+#    runner's long lifetime and forwards signals to its graceful-shutdown
+#    handlers.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        wget \
+        git \
+        openssh-client \
+        tar \
+        gzip \
+        xz-utils \
+        bzip2 \
+        zip \
+        unzip \
+        jq \
+        build-essential \
+        python3 \
+        pkg-config \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node itself: copy the exact, pinned binary from the official image rather than
+# add an apt repo, so the runtime Node matches the build stage byte-for-byte and
+# stays GPG-verified upstream. The bin/ wrappers are symlinks into node_modules,
+# so recreate them after copying the two real trees.
+COPY --from=build /usr/local/bin/node /usr/local/bin/node
+COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && ln -s ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack
+
+WORKDIR /app
+
+# Run unprivileged. Unlike the api the runner writes at runtime, so the user owns
+# a home directory: the pi coding agent persists its config under $HOME/.pi, and
+# per-job workspaces and shell scripts are created under the OS temp directory.
+RUN groupadd --system shipfox \
+    && useradd --system --gid shipfox --create-home --home-dir /home/shipfox shipfox
+ENV HOME=/home/shipfox
+
+COPY --from=build /prod ./
+
+USER shipfox
+
+# OCI metadata. The build/promotion workflows pass revision/created as build args.
+ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
+ARG IMAGE_REVISION
+ARG IMAGE_CREATED
+LABEL org.opencontainers.image.title="@shipfox/runner" \
+      org.opencontainers.image.description="Shipfox runner" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source=$IMAGE_SOURCE \
+      org.opencontainers.image.revision=$IMAGE_REVISION \
+      org.opencontainers.image.created=$IMAGE_CREATED
+
+# tini as PID 1; --enable-source-maps maps stack traces back to TypeScript.
+# OpenTelemetry is started in-process by startRunner(), so it needs no preload
+# flag. The flag stays on the entrypoint command (not NODE_OPTIONS) so it applies
+# to the runner only, not to the user step processes it spawns.
+ENTRYPOINT ["tini", "--"]
+CMD ["node", "--enable-source-maps", "./dist/index.js"]

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "shipfox-swc",
     "dev": "tsx watch --conditions=development --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts",
+    "image": "shipfox-docker --setup-context",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "type": "shipfox-tsc-check",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/docker": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome
+      '@shipfox/docker':
+        specifier: workspace:*
+        version: link:../../tools/docker
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../tools/swc


### PR DESCRIPTION
Containerizes `apps/runner` as a self-hostable image, completing the api/client/runner set. Same "build outside Docker, ingest `dist`" shape as the api image: `shipfox-docker --setup-context` prunes the workspace and overlays the turbo-cached `dist/`, the build stage runs `pnpm deploy --prod` so only the production Node closure ships, and Docker never compiles TypeScript.

## Why a non-slim Ubuntu base (deviation from the ticket's "Alpine slim")

The runner is a job executor: it checks out repositories and runs arbitrary user shell and agent steps. It should therefore look like the CI environment users expect (à la GitHub's `ubuntu-latest`), not a minimal base that silently breaks prebuilt-binary downloads and native build steps on musl. The runtime is **Ubuntu 26.04 LTS** (the current LTS) with a curated common-tool set: `git` + `openssh-client`, `ca-certificates`, `curl`/`wget`, the archive tools, `jq`, and a `build-essential` + `python3` + `pkg-config` toolchain for node-gyp. The Node dependency closure stays production-only; it is the OS layer that is intentionally fuller.

Node is copied in from the official pinned `node:24.16.0-slim` build stage (no apt repo, stays GPG-verified upstream, matches the build stage byte-for-byte). `tini` runs as PID 1 to reap orphaned grandchildren from user steps and forward `SIGTERM` to the runner's graceful-shutdown handlers. The non-root `shipfox` user owns a home directory because the pi coding agent persists config under `$HOME/.pi`.

## What's in the PR

- `apps/runner/Dockerfile`, `apps/runner/.dockerignore`
- `apps/runner/package.json`: `image` script (`shipfox-docker --setup-context`) + `@shipfox/docker` devDependency
- Runtime tooling the runner needs is documented inline in the Dockerfile (no docker socket or host mounts required; steps run in-container).

## Validation

Built and run locally for **linux/arm64 and linux/amd64**: boots from prebuilt `dist/` with no TS compile in Docker, fails fast on missing required env (`SHIPFOX_API_URL` / `SHIPFOX_RUNNER_TOKEN`), enters the poll loop with config, shuts down cleanly on `SIGTERM`, runs as non-root, and verifies certs on a `git` HTTPS clone. `turbo build`/`test`/`check` pass.

## Notes for review

- Image is ~795 MB; `build-essential` is ~250 MB of that. The "slim" acceptance criterion still holds for the Node closure (`pnpm deploy --prod`), but the OS layer is deliberately fuller. Easy to trim the compiler toolchain if we'd rather.
- The `turbo image` *task* that wraps the package `image` script is ENG-526's scope (the api shipped the same way); the package script itself is validated here.

Closes ENG-525

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a self-hostable Docker image for `@shipfox/runner`, built outside Docker and shipping only production deps for fast, reliable startup. Aligns the runtime with GitHub’s ubuntu-latest (UTF-8 locale, common tools, sudo). Fulfills ENG-525.

- **New Features**
  - New Dockerfile: builds from a pruned context via `shipfox-docker --setup-context` and `pnpm deploy --prod`; no TypeScript compile in Docker.
  - Ubuntu 26.04 LTS base with CI tools (git/ssh, curl/wget, archives, jq), node-gyp toolchain, `ripgrep`/`fd`, default `LANG=C.UTF-8`, and passwordless `sudo` for user steps.
  - Pinned Node 24.16.0 copied from the official image; `tini` as PID 1; runs as non-root `shipfox` with a home directory.
  - Adds `apps/runner/Dockerfile`, `.dockerignore`, an `image` script, and `@shipfox/docker` as a dev dependency.
  - Validated on `linux/amd64` and `linux/arm64`; fails fast on missing env and shuts down cleanly.

<sup>Written for commit 9d868b910d3c26f91d5daa110c5a4d868b2adbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

