### PR TITLE
[api/logs] Delete expired log objects and stream rows on a retention cron

### DIFF
--- a/.changeset/eng-520-logs-retention-deletion.md
+++ b/.changeset/eng-520-logs-retention-deletion.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": patch
+---
+
+Delete expired logs from both object storage and Postgres on an hourly cron, with a configurable horizon (`LOG_RETENTION_DAYS`, default 90), enforced by our own worker rather than bucket lifecycle rules so behavior is identical across object stores. A retention sweep drains closed streams past the horizon in batches, bounded by a self-imposed time budget so a timed-out run never overlaps the next; per stream it first hard-deletes the row (chunks cascading), guarded on the observed `object_key` so a concurrent compaction publish is left intact, then deletes the whole attempt object prefix (reclaiming orphan leaves left behind by a losing compaction attempt). Failed or raced rows are skipped for the rest of the run so a poison row cannot starve the streams behind it, and a `job_accounting` row is pruned only when its job has no remaining streams and no recent activity, so a live job's budget is never reset.

--- a/libs/api/logs/src/api/object-storage.ts
+++ b/libs/api/logs/src/api/object-storage.ts
@@ -181,18 +181,12 @@ export async function presignedGetUrl(objectKey: string): Promise<{url: string; 
 }
 
 /**
- * Deletes every object under `prefix` (pass the per-attempt prefix WITH a trailing slash so
- * attempt `1` never matches attempt `10`). Retention uses this instead of deleting the single
- * recorded `object_key` so it also reclaims orphan leaves left by losing or crashed compaction
- * attempts under the same prefix. Lists in pages and batch-deletes up to 1000 keys per
- * request (one `ListObjectsV2` page never exceeds that). A prefix with nothing under it is a
- * no-op; an empty-string prefix is rejected, since it would match every key in the bucket.
- * `DeleteObjects` treats a missing key as success; any partial batch failure throws with S3's
- * first reported key/message.
+ * Deletes all objects under a per-attempt prefix. Retention deletes by prefix, not only the
+ * recorded `object_key`, to reclaim orphan leaves from failed compaction attempts.
+ *
+ * Pass a trailing slash so attempt `1` never matches attempt `10`.
  */
 export async function deleteObjectsByPrefix(prefix: string): Promise<void> {
-  // An empty prefix matches every key, so listing and deleting it would wipe the whole bucket.
-  // No legitimate caller passes one; fail loud rather than silently target everything.
   if (prefix === '') {
     throw new Error(
       'deleteObjectsByPrefix refuses an empty prefix (it would target the whole bucket)',

--- a/libs/api/logs/src/api/object-storage.ts
+++ b/libs/api/logs/src/api/object-storage.ts
@@ -1,8 +1,10 @@
 import type {Readable} from 'node:stream';
 import {
   DeleteObjectCommand,
+  DeleteObjectsCommand,
   GetObjectCommand,
   HeadBucketCommand,
+  ListObjectsV2Command,
   S3Client,
 } from '@aws-sdk/client-s3';
 import {Upload} from '@aws-sdk/lib-storage';
@@ -176,4 +178,53 @@ export async function presignedGetUrl(objectKey: string): Promise<{url: string; 
     {expiresIn: ttlSeconds},
   );
   return {url, expiresAt};
+}
+
+/**
+ * Deletes every object under `prefix` (pass the per-attempt prefix WITH a trailing slash so
+ * attempt `1` never matches attempt `10`). Retention uses this instead of deleting the single
+ * recorded `object_key` so it also reclaims the complete leaves a losing or crashed compaction
+ * attempt left under the same prefix. Lists in pages and batch-deletes up to 1000 keys per
+ * request (one `ListObjectsV2` page never exceeds that). A prefix with nothing under it is a
+ * no-op; an empty-string prefix is rejected, since it would match every key in the bucket.
+ * `DeleteObjects` treats a missing key as success, so re-running is idempotent; a partial
+ * failure throws so the caller keeps the stream row and retries on the next run.
+ */
+export async function deleteObjectsByPrefix(prefix: string): Promise<void> {
+  // An empty prefix matches every key, so listing and deleting it would wipe the whole bucket.
+  // No legitimate caller passes one; fail loud rather than silently target everything.
+  if (prefix === '') {
+    throw new Error(
+      'deleteObjectsByPrefix refuses an empty prefix (it would target the whole bucket)',
+    );
+  }
+  const client = s3Client();
+  let continuationToken: string | undefined;
+  do {
+    const listed = await client.send(
+      new ListObjectsV2Command({
+        Bucket: config.LOG_STORAGE_S3_BUCKET,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+    const objects = (listed.Contents ?? []).flatMap((object) =>
+      object.Key ? [{Key: object.Key}] : [],
+    );
+    if (objects.length > 0) {
+      const deleted = await client.send(
+        new DeleteObjectsCommand({
+          Bucket: config.LOG_STORAGE_S3_BUCKET,
+          Delete: {Objects: objects, Quiet: true},
+        }),
+      );
+      if (deleted.Errors && deleted.Errors.length > 0) {
+        const [first] = deleted.Errors;
+        throw new Error(
+          `Failed to delete ${deleted.Errors.length} object(s) under ${prefix}: ${first?.Key} ${first?.Message}`,
+        );
+      }
+    }
+    continuationToken = listed.IsTruncated ? listed.NextContinuationToken : undefined;
+  } while (continuationToken);
 }

--- a/libs/api/logs/src/api/object-storage.ts
+++ b/libs/api/logs/src/api/object-storage.ts
@@ -183,12 +183,12 @@ export async function presignedGetUrl(objectKey: string): Promise<{url: string; 
 /**
  * Deletes every object under `prefix` (pass the per-attempt prefix WITH a trailing slash so
  * attempt `1` never matches attempt `10`). Retention uses this instead of deleting the single
- * recorded `object_key` so it also reclaims the complete leaves a losing or crashed compaction
- * attempt left under the same prefix. Lists in pages and batch-deletes up to 1000 keys per
+ * recorded `object_key` so it also reclaims orphan leaves left by losing or crashed compaction
+ * attempts under the same prefix. Lists in pages and batch-deletes up to 1000 keys per
  * request (one `ListObjectsV2` page never exceeds that). A prefix with nothing under it is a
  * no-op; an empty-string prefix is rejected, since it would match every key in the bucket.
- * `DeleteObjects` treats a missing key as success, so re-running is idempotent; a partial
- * failure throws so the caller keeps the stream row and retries on the next run.
+ * `DeleteObjects` treats a missing key as success; any partial batch failure throws with S3's
+ * first reported key/message.
  */
 export async function deleteObjectsByPrefix(prefix: string): Promise<void> {
   // An empty prefix matches every key, so listing and deleting it would wipe the whole bucket.

--- a/libs/api/logs/src/config.test.ts
+++ b/libs/api/logs/src/config.test.ts
@@ -1,0 +1,22 @@
+describe('LOG_RETENTION_DAYS validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each(['0', '-5', '1.5'])('fails startup when LOG_RETENTION_DAYS is %s', async (value) => {
+    vi.stubEnv('LOG_RETENTION_DAYS', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('LOG_RETENTION_DAYS');
+  });
+
+  it('accepts a whole-day value of 1 or greater', async () => {
+    vi.stubEnv('LOG_RETENTION_DAYS', '30');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.LOG_RETENTION_DAYS).toBe(30);
+  });
+});

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -57,6 +57,10 @@ export const config = createConfig({
     desc: 'Maximum number of stored log bytes returned in a single inline (hot) read response. A long-running step can buffer far more than this in Postgres before compaction, so a read is capped here and the client re-polls (following has_more) to drain the backlog before it tails. Bounds per-request memory. Must be at least 1. Defaults to 1 MiB.',
     default: 1_048_576,
   }),
+  LOG_RETENTION_DAYS: num({
+    desc: 'How many days a closed log stream is kept before the retention cron hard-deletes its stored object and database row. Our own worker enforces this (not bucket lifecycle rules), so behavior is identical across object stores. Must be a whole number of days, 1 or greater. Defaults to 90 days.',
+    default: 90,
+  }),
 });
 
 // SigV4 caps a presigned URL's lifetime at 7 days, so a larger TTL would fail at signing
@@ -73,5 +77,15 @@ if (
 if (config.LOG_READ_INLINE_MAX_BYTES < 1) {
   throw new Error(
     `LOG_READ_INLINE_MAX_BYTES must be at least 1; got ${config.LOG_READ_INLINE_MAX_BYTES}`,
+  );
+}
+
+// envalid's num has no range support. A retention horizon below one whole day would make
+// `make_interval(days => …)` delete just-closed streams (0), delete with a future cutoff
+// (negative), or carry a fractional day the retention query never intends. Fail fast at
+// startup rather than silently hard-deleting live data.
+if (!Number.isInteger(config.LOG_RETENTION_DAYS) || config.LOG_RETENTION_DAYS < 1) {
+  throw new Error(
+    `LOG_RETENTION_DAYS (${config.LOG_RETENTION_DAYS}) must be a whole number of days >= 1.`,
   );
 }

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -80,10 +80,8 @@ if (config.LOG_READ_INLINE_MAX_BYTES < 1) {
   );
 }
 
-// envalid's num has no range support. A retention horizon below one whole day would make
-// `make_interval(days => …)` delete just-closed streams (0), delete with a future cutoff
-// (negative), or carry a fractional day the retention query never intends. Fail fast at
-// startup rather than silently hard-deleting live data.
+// `num` accepts zero, negative, and fractional values; reject them before they reach
+// `make_interval(days => ...)` and hard-delete the wrong streams.
 if (!Number.isInteger(config.LOG_RETENTION_DAYS) || config.LOG_RETENTION_DAYS < 1) {
   throw new Error(
     `LOG_RETENTION_DAYS (${config.LOG_RETENTION_DAYS}) must be a whole number of days >= 1.`,

--- a/libs/api/logs/src/core/retention.test.ts
+++ b/libs/api/logs/src/core/retention.test.ts
@@ -1,0 +1,282 @@
+import {Buffer} from 'node:buffer';
+import {HeadObjectCommand, PutObjectCommand} from '@aws-sdk/client-s3';
+import {eq, sql} from 'drizzle-orm';
+import {s3Client} from '#api/object-storage.js';
+import {config} from '#config.js';
+import {logObjectKey} from '#core/entities/log-object.js';
+import {db} from '#db/db.js';
+import {attemptStreams} from '#db/schema/attempt-streams.js';
+import {jobAccounting} from '#db/schema/job-accounting.js';
+import * as streams from '#db/streams.js';
+import {jobAccountingFactory} from '#test/factories/job-accounting.js';
+import {arrangeClosedStream, type ClosedStreamIdentity} from '#test/fixtures/closed-stream.js';
+import {ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
+import {findAccounting, findStream, listChunks} from '#test/queries.js';
+import {runRetentionSweep} from './retention.js';
+
+function newIdentity(overrides: Partial<ClosedStreamIdentity> = {}): ClosedStreamIdentity {
+  return {
+    jobId: crypto.randomUUID(),
+    stepId: crypto.randomUUID(),
+    attempt: 1,
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    runId: crypto.randomUUID(),
+    ...overrides,
+  };
+}
+
+function sweep(overrides: Partial<Parameters<typeof runRetentionSweep>[0]> = {}) {
+  return runRetentionSweep({
+    retentionDays: 90,
+    batchLimit: 100,
+    timeBudgetMs: 60_000,
+    maxIterations: 100,
+    ...overrides,
+  });
+}
+
+function attemptPrefix(identity: ClosedStreamIdentity): string {
+  return logObjectKey(config.LOG_STORAGE_S3_PREFIX, identity);
+}
+
+async function backdateClosedAt(streamId: string, interval: string): Promise<void> {
+  await db()
+    .update(attemptStreams)
+    .set({closedAt: sql`now() - ${interval}::interval`})
+    .where(eq(attemptStreams.id, streamId));
+}
+
+async function backdateAccountingUpdatedAt(jobId: string, interval: string): Promise<void> {
+  await db()
+    .update(jobAccounting)
+    .set({updatedAt: sql`now() - ${interval}::interval`})
+    .where(eq(jobAccounting.jobId, jobId));
+}
+
+async function setObjectKey(streamId: string, objectKey: string): Promise<void> {
+  await db().update(attemptStreams).set({objectKey}).where(eq(attemptStreams.id, streamId));
+}
+
+async function putObject(key: string, body: Buffer): Promise<void> {
+  await s3Client().send(
+    new PutObjectCommand({Bucket: config.LOG_STORAGE_S3_BUCKET, Key: key, Body: body}),
+  );
+}
+
+async function objectExists(key: string): Promise<boolean> {
+  try {
+    await s3Client().send(new HeadObjectCommand({Bucket: config.LOG_STORAGE_S3_BUCKET, Key: key}));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('runRetentionSweep', () => {
+  it('deletes a past-horizon compacted stream: object, row, chunks, and accounting all gone', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    const key = `${attemptPrefix(id)}/${crypto.randomUUID()}`;
+    await putObject(key, Buffer.from('compacted'));
+    await setObjectKey(stream.id, key);
+    await backdateClosedAt(stream.id, '100 days');
+    await jobAccountingFactory.create({jobId: id.jobId, workspaceId: id.workspaceId});
+    await backdateAccountingUpdatedAt(id.jobId, '100 days');
+
+    await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(await listChunks(stream.id)).toHaveLength(0);
+    expect(await objectExists(key)).toBe(false);
+    expect(await findAccounting(id.jobId)).toBeNull();
+  });
+
+  it('is idempotent: a second run over the same data deletes nothing and does not throw', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    await backdateClosedAt(stream.id, '100 days');
+    await sweep();
+
+    const second = await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(second.failed).toBe(0);
+  });
+
+  it('tolerates a recorded object that was never uploaded (NoSuchKey) and still deletes the row', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    await setObjectKey(stream.id, `${attemptPrefix(id)}/never-uploaded`);
+    await backdateClosedAt(stream.id, '100 days');
+
+    const result = await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(result.failed).toBe(0);
+  });
+
+  it('never touches an open stream, even an ancient one', async () => {
+    const id = newIdentity();
+    await db().transaction((tx) => streams.getOrCreateAttemptStream(tx, id));
+
+    await sweep();
+
+    expect(await findStream(id)).not.toBeNull();
+  });
+
+  it('prunes accounting only once the job has no remaining streams', async () => {
+    const shared = {
+      jobId: crypto.randomUUID(),
+      workspaceId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
+    };
+    const expired = newIdentity({...shared, stepId: crypto.randomUUID()});
+    const fresh = newIdentity({...shared, stepId: crypto.randomUUID()});
+    const expiredStream = await arrangeClosedStream(expired);
+    const freshStream = await arrangeClosedStream(fresh);
+    await backdateClosedAt(expiredStream.id, '100 days');
+    await jobAccountingFactory.create({jobId: shared.jobId, workspaceId: shared.workspaceId});
+    await backdateAccountingUpdatedAt(shared.jobId, '100 days');
+
+    await sweep();
+
+    expect(await findStream(expired)).toBeNull();
+    expect(await findStream(fresh)).not.toBeNull();
+    expect(await findAccounting(shared.jobId)).not.toBeNull();
+
+    await backdateClosedAt(freshStream.id, '100 days');
+    await sweep();
+
+    expect(await findStream(fresh)).toBeNull();
+    expect(await findAccounting(shared.jobId)).toBeNull();
+  });
+
+  it('deletes a closed-but-never-compacted stream (object_key null), doing no object work', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id, {chunks: [ndjsonBody(outputLine('x'))]});
+    await backdateClosedAt(stream.id, '100 days');
+
+    const result = await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(await listChunks(stream.id)).toHaveLength(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('deletes the whole attempt prefix, reclaiming a lost compaction attempt orphan leaf', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    const winner = `${attemptPrefix(id)}/${crypto.randomUUID()}`;
+    const orphan = `${attemptPrefix(id)}/${crypto.randomUUID()}`;
+    await putObject(winner, Buffer.from('winner'));
+    await putObject(orphan, Buffer.from('orphan-leaf'));
+    await setObjectKey(stream.id, winner);
+    await backdateClosedAt(stream.id, '100 days');
+
+    await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(await objectExists(winner)).toBe(false);
+    expect(await objectExists(orphan)).toBe(false);
+  });
+
+  it('does not starve a younger healthy stream behind a row whose delete keeps failing', async () => {
+    const poison = newIdentity();
+    const healthy = newIdentity();
+    const poisonStream = await arrangeClosedStream(poison);
+    const healthyStream = await arrangeClosedStream(healthy);
+    await backdateClosedAt(poisonStream.id, '200 days');
+    await backdateClosedAt(healthyStream.id, '100 days');
+    const realDeleteExpiredStream = streams.deleteExpiredStream;
+    vi.spyOn(streams, 'deleteExpiredStream').mockImplementation((tx, params) =>
+      params.streamId === poisonStream.id
+        ? Promise.reject(new Error('poison row delete'))
+        : realDeleteExpiredStream(tx, params),
+    );
+
+    const result = await sweep({batchLimit: 1});
+
+    expect(await findStream(healthy)).toBeNull();
+    expect(await findStream(poison)).not.toBeNull();
+    expect(result.failed).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not reset a live job budget: deletes its expired streams but keeps fresh accounting', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    await backdateClosedAt(stream.id, '100 days');
+    await jobAccountingFactory.create({jobId: id.jobId, workspaceId: id.workspaceId});
+
+    await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(await findAccounting(id.jobId)).not.toBeNull();
+  });
+
+  it('stops immediately and reports timedOut when the time budget is already spent', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    await backdateClosedAt(stream.id, '100 days');
+
+    const result = await sweep({timeBudgetMs: 0, now: () => 1_000});
+
+    expect(result.timedOut).toBe(true);
+    expect(await findStream(id)).not.toBeNull();
+  });
+
+  it('stops mid-batch on the budget, deleting what it reached and leaving the rest', async () => {
+    const drained = newIdentity();
+    const remaining = newIdentity();
+    const drainedStream = await arrangeClosedStream(drained);
+    const remainingStream = await arrangeClosedStream(remaining);
+    await backdateClosedAt(drainedStream.id, '200 days');
+    await backdateClosedAt(remainingStream.id, '100 days');
+    // now() runs for the deadline base, the top-of-loop check, then once per stream. Keep the first
+    // three calls under the deadline so the oldest stream is processed, then jump past it so the
+    // per-stream check stops the sweep before the second stream (the whole point of the per-stream,
+    // not per-batch, budget check).
+    let calls = 0;
+    const clock = () => (++calls <= 3 ? 0 : 1_000);
+
+    const result = await sweep({timeBudgetMs: 1, now: clock});
+
+    expect(result.timedOut).toBe(true);
+    expect(result.deleted).toBe(1);
+    expect(await findStream(drained)).toBeNull();
+    expect(await findStream(remaining)).not.toBeNull();
+  });
+});
+
+describe('deleteExpiredStream (compaction-race guard)', () => {
+  it('skips the row when object_key changed after observation, so the published object is not orphaned', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id, {chunks: [ndjsonBody(outputLine('x'))]});
+    await setObjectKey(stream.id, 'logs/compaction/published');
+
+    const outcome = await db().transaction((tx) =>
+      streams.deleteExpiredStream(tx, {streamId: stream.id, observedObjectKey: null}),
+    );
+
+    expect(outcome.deleted).toBe(false);
+    expect(await findStream(id)).not.toBeNull();
+  });
+
+  it('deletes the row when the observed object_key still matches', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    await setObjectKey(stream.id, 'logs/compaction/key');
+
+    const outcome = await db().transaction((tx) =>
+      streams.deleteExpiredStream(tx, {
+        streamId: stream.id,
+        observedObjectKey: 'logs/compaction/key',
+      }),
+    );
+
+    expect(outcome.deleted).toBe(true);
+    expect(outcome.jobId).toBe(id.jobId);
+    expect(await findStream(id)).toBeNull();
+  });
+});

--- a/libs/api/logs/src/core/retention.test.ts
+++ b/libs/api/logs/src/core/retention.test.ts
@@ -233,10 +233,7 @@ describe('runRetentionSweep', () => {
     const remainingStream = await arrangeClosedStream(remaining);
     await backdateClosedAt(drainedStream.id, '200 days');
     await backdateClosedAt(remainingStream.id, '100 days');
-    // now() runs for the deadline base, the top-of-loop check, then once per stream. Keep the first
-    // three calls under the deadline so the oldest stream is processed, then jump past it so the
-    // per-stream check stops the sweep before the second stream (the whole point of the per-stream,
-    // not per-batch, budget check).
+    // Keep the first stream inside the budget, then make the per-stream check stop the second.
     let calls = 0;
     const clock = () => (++calls <= 3 ? 0 : 1_000);
 

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -35,24 +35,12 @@ export interface RunRetentionSweepParams {
 }
 
 /**
- * Deletes expired closed streams (objects + rows) and prunes each emptied job's accounting row.
+ * Deletes expired closed streams and prunes accounting for emptied jobs.
  *
- * Drains in keyset-paginated batches until the backlog is exhausted, a self-imposed wall-clock
- * budget elapses, or `maxIterations` is hit. The budget matters because a Temporal
- * `startToCloseTimeout` marks the activity failed but does NOT kill this loop; stopping
- * ourselves well before it keeps a timed-out attempt from deleting alongside the next cron run.
- * The budget and the liveness heartbeat are both checked per stream, not once per batch, so a
- * slow batch cannot overrun the budget or trip the heartbeat timeout.
- *
- * Per stream, in order: a guarded row delete keyed on the observed `object_key` (a compaction
- * publish landing after the select changes the key, so the delete matches 0 rows and the row is
- * left for the next run), then — only once the row is gone — delete the whole attempt object
- * prefix (the recorded object plus any leaves a losing compaction attempt left). Deleting objects
- * only after the guard wins is what keeps a racing publish's object from being wiped while its row
- * survives; the cost is that an object-delete failure after the row is gone leaks an orphan of an
- * already-expired stream (storage-only, never a dangling row). One stream's row-delete failure is
- * logged and skipped so it cannot abort the batch; the skip-set keeps it out of later selects this
- * run, so the younger healthy streams behind it are not starved (it retries on the next run).
+ * The loop self-bounds because a Temporal `startToCloseTimeout` marks the activity failed but
+ * does not stop already-running JS. Rows are deleted before objects, guarded on the observed
+ * `object_key`, so a racing compaction publish leaves the stream for the next sweep instead of
+ * deleting its fresh object.
  */
 export async function runRetentionSweep(
   params: RunRetentionSweepParams,
@@ -68,8 +56,7 @@ export async function runRetentionSweep(
     timedOut: false,
   };
 
-  // Ids that failed or raced this run; excluded from later selects so they do not re-sort to
-  // the front and starve the healthy streams behind them. They retry on the next run.
+  // Failed or raced rows retry next run; skipping them here keeps the rest of the backlog moving.
   const skip = new Set<string>();
   while (result.iterations < params.maxIterations) {
     if (now() >= deadline) {
@@ -86,7 +73,7 @@ export async function runRetentionSweep(
 
     let timedOutMidBatch = false;
     for (const stream of batch) {
-      // Batches can be long, so liveness and budget checks stay inside the per-stream loop.
+      // Per-stream checks keep long batches within the heartbeat and wall-clock budgets.
       params.onProgress?.();
       if (now() >= deadline) {
         result.timedOut = true;
@@ -121,8 +108,7 @@ export async function runRetentionSweep(
       }
 
       if (!outcome.deleted) {
-        // `object_key` changed since the select: a compaction publish landed, so its object stays.
-        // Leave the row for the next run, which re-reads the fresh key.
+        // `object_key` changed since select; the next sweep will re-read the fresh key.
         result.raced += 1;
         skip.add(stream.id);
         continue;
@@ -131,9 +117,7 @@ export async function runRetentionSweep(
       result.deleted += 1;
       if (outcome.prunedAccounting) result.accountingPruned += 1;
 
-      // The guarded row delete won, so no newer publish exists under this prefix: reclaim the whole
-      // attempt prefix (recorded object plus any orphan leaves). A failure here only leaks an orphan
-      // of an already-deleted expired stream; the row is gone, so there is nothing to retry.
+      // The guarded row delete won, so reclaim the recorded object plus orphan leaves.
       try {
         await deleteObjectsByPrefix(`${logObjectKey(config.LOG_STORAGE_S3_PREFIX, stream)}/`);
       } catch (error) {

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -1,0 +1,157 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import {deleteObjectsByPrefix} from '#api/object-storage.js';
+import {config} from '#config.js';
+import {logObjectKey} from '#core/entities/log-object.js';
+import {deleteJobAccounting} from '#db/accounting.js';
+import {db} from '#db/db.js';
+import {
+  accountingHasNoStreams,
+  deleteExpiredStream,
+  listExpiredClosedStreams,
+} from '#db/streams.js';
+
+export interface RetentionSweepResult {
+  /** Streams whose row was deleted; their objects are reclaimed after (a rare object-cleanup failure is logged). */
+  deleted: number;
+  /** Streams skipped because compaction changed `object_key` after we read it (retried next run). */
+  raced: number;
+  /** Streams whose guarded row delete threw; logged, skipped, and retried next run. */
+  failed: number;
+  accountingPruned: number;
+  iterations: number;
+  /** True when the sweep stopped on its wall-clock budget with backlog likely remaining. */
+  timedOut: boolean;
+}
+
+export interface RunRetentionSweepParams {
+  retentionDays: number;
+  batchLimit: number;
+  timeBudgetMs: number;
+  maxIterations: number;
+  /** Wall clock; injectable so tests can drive the time budget deterministically. */
+  now?: () => number;
+  /** Liveness signal (e.g. the activity heartbeat); invoked once per processed stream. */
+  onProgress?: () => void;
+}
+
+/**
+ * Deletes expired closed streams (objects + rows) and prunes each emptied job's accounting row.
+ *
+ * Drains in keyset-paginated batches until the backlog is exhausted, a self-imposed wall-clock
+ * budget elapses, or `maxIterations` is hit. The budget matters because a Temporal
+ * `startToCloseTimeout` marks the activity failed but does NOT kill this loop; stopping
+ * ourselves well before it keeps a timed-out attempt from deleting alongside the next cron run.
+ * The budget and the liveness heartbeat are both checked per stream, not once per batch, so a
+ * slow batch cannot overrun the budget or trip the heartbeat timeout.
+ *
+ * Per stream, in order: a guarded row delete keyed on the observed `object_key` (a compaction
+ * publish landing after the select changes the key, so the delete matches 0 rows and the row is
+ * left for the next run), then — only once the row is gone — delete the whole attempt object
+ * prefix (the recorded object plus any leaves a losing compaction attempt left). Deleting objects
+ * only after the guard wins is what keeps a racing publish's object from being wiped while its row
+ * survives; the cost is that an object-delete failure after the row is gone leaks an orphan of an
+ * already-expired stream (storage-only, never a dangling row). One stream's row-delete failure is
+ * logged and skipped so it cannot abort the batch; the skip-set keeps it out of later selects this
+ * run, so the younger healthy streams behind it are not starved (it retries on the next run).
+ */
+export async function runRetentionSweep(
+  params: RunRetentionSweepParams,
+): Promise<RetentionSweepResult> {
+  const now = params.now ?? Date.now;
+  const deadline = now() + params.timeBudgetMs;
+  const result: RetentionSweepResult = {
+    deleted: 0,
+    raced: 0,
+    failed: 0,
+    accountingPruned: 0,
+    iterations: 0,
+    timedOut: false,
+  };
+
+  // Ids that failed or raced this run; excluded from later selects so they do not re-sort to
+  // the front and starve the healthy streams behind them. They retry on the next run.
+  const skip = new Set<string>();
+  while (result.iterations < params.maxIterations) {
+    if (now() >= deadline) {
+      result.timedOut = true;
+      break;
+    }
+
+    const batch = await listExpiredClosedStreams({
+      retentionDays: params.retentionDays,
+      limit: params.batchLimit,
+      excludeIds: skip.size > 0 ? [...skip] : undefined,
+    });
+    if (batch.length === 0) break;
+
+    let timedOutMidBatch = false;
+    for (const stream of batch) {
+      // Heartbeat and check the time budget per stream, not once per batch: a slow batch must not
+      // trip the heartbeat timeout or overrun the budget into the next cron run. A single stream's
+      // work is bounded (the fail-fast S3 client caps each call), so per-stream keeps both inside
+      // their limits.
+      params.onProgress?.();
+      if (now() >= deadline) {
+        result.timedOut = true;
+        timedOutMidBatch = true;
+        break;
+      }
+
+      let outcome: {deleted: boolean; prunedAccounting: boolean};
+      try {
+        outcome = await db().transaction(async (tx) => {
+          const {deleted, jobId} = await deleteExpiredStream(tx, {
+            streamId: stream.id,
+            observedObjectKey: stream.objectKey,
+          });
+          if (deleted && jobId && (await accountingHasNoStreams(tx, jobId))) {
+            const pruned = await deleteJobAccounting(tx, {
+              jobId,
+              retentionDays: params.retentionDays,
+            });
+            return {deleted, prunedAccounting: pruned.deleted};
+          }
+          return {deleted, prunedAccounting: false};
+        });
+      } catch (error) {
+        result.failed += 1;
+        skip.add(stream.id);
+        logger().error(
+          {err: error, streamId: stream.id},
+          'Failed to delete expired log stream row',
+        );
+        continue;
+      }
+
+      if (!outcome.deleted) {
+        // `object_key` changed since the select: a compaction publish landed, so its object stays.
+        // Leave the row for the next run, which re-reads the fresh key.
+        result.raced += 1;
+        skip.add(stream.id);
+        continue;
+      }
+
+      result.deleted += 1;
+      if (outcome.prunedAccounting) result.accountingPruned += 1;
+
+      // The guarded row delete won, so no newer publish exists under this prefix: reclaim the whole
+      // attempt prefix (recorded object plus any orphan leaves). A failure here only leaks an orphan
+      // of an already-deleted expired stream; the row is gone, so there is nothing to retry.
+      try {
+        await deleteObjectsByPrefix(`${logObjectKey(config.LOG_STORAGE_S3_PREFIX, stream)}/`);
+      } catch (error) {
+        logger().error(
+          {err: error, streamId: stream.id},
+          'Deleted expired stream row but failed to delete its objects',
+        );
+      }
+    }
+
+    if (timedOutMidBatch) break;
+
+    result.iterations += 1;
+    if (batch.length < params.batchLimit) break;
+  }
+
+  return result;
+}

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -86,10 +86,7 @@ export async function runRetentionSweep(
 
     let timedOutMidBatch = false;
     for (const stream of batch) {
-      // Heartbeat and check the time budget per stream, not once per batch: a slow batch must not
-      // trip the heartbeat timeout or overrun the budget into the next cron run. A single stream's
-      // work is bounded (the fail-fast S3 client caps each call), so per-stream keeps both inside
-      // their limits.
+      // Batches can be long, so liveness and budget checks stay inside the per-stream loop.
       params.onProgress?.();
       if (now() >= deadline) {
         result.timedOut = true;

--- a/libs/api/logs/src/db/accounting.ts
+++ b/libs/api/logs/src/db/accounting.ts
@@ -60,11 +60,8 @@ export async function isJobCapped(tx: Transaction, jobId: string): Promise<boole
 }
 
 /**
- * Prunes a job's accounting row, but only once it has had no budget activity for the full
- * retention horizon. `job_accounting` is live cap state: a still-active job re-touches
- * `updated_at` on every append, so the guard keeps retention from deleting a live budget row
- * (which would reset the job's cap on its next append). Callers gate this on the job also
- * having zero remaining streams.
+ * Prunes accounting only after the job has no recent budget activity. A live job re-touches
+ * `updated_at` on append, so this guard keeps retention from resetting its cap state.
  */
 export async function deleteJobAccounting(
   tx: Transaction,

--- a/libs/api/logs/src/db/accounting.ts
+++ b/libs/api/logs/src/db/accounting.ts
@@ -1,4 +1,4 @@
-import {and, eq, isNull, sql} from 'drizzle-orm';
+import {and, eq, isNull, lt, sql} from 'drizzle-orm';
 import type {Transaction} from './db.js';
 import {jobAccounting} from './schema/job-accounting.js';
 
@@ -57,4 +57,28 @@ export async function isJobCapped(tx: Transaction, jobId: string): Promise<boole
     .where(eq(jobAccounting.jobId, jobId));
 
   return Boolean(row?.cappedAt);
+}
+
+/**
+ * Prunes a job's accounting row, but only once it has had no budget activity for the full
+ * retention horizon. `job_accounting` is live cap state: a still-active job re-touches
+ * `updated_at` on every append, so the guard keeps retention from deleting a live budget row
+ * (which would reset the job's cap on its next append). Callers gate this on the job also
+ * having zero remaining streams.
+ */
+export async function deleteJobAccounting(
+  tx: Transaction,
+  params: {jobId: string; retentionDays: number},
+): Promise<{deleted: boolean}> {
+  const [row] = await tx
+    .delete(jobAccounting)
+    .where(
+      and(
+        eq(jobAccounting.jobId, params.jobId),
+        lt(jobAccounting.updatedAt, sql`now() - make_interval(days => ${params.retentionDays})`),
+      ),
+    )
+    .returning({jobId: jobAccounting.jobId});
+
+  return {deleted: Boolean(row)};
 }

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -1,4 +1,4 @@
-import {and, asc, eq, isNull, lt, sql} from 'drizzle-orm';
+import {and, asc, eq, isNull, lt, notInArray, sql} from 'drizzle-orm';
 import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
 import {LeaseStreamMismatchError} from '#core/errors.js';
 import {db, type Transaction} from './db.js';
@@ -244,4 +244,77 @@ export async function listStaleUncompactedStreams(params: {
     .limit(params.limit);
 
   return rows.map(toAttemptStream);
+}
+
+/**
+ * Closed streams past the retention horizon, oldest first, for the retention sweep to delete.
+ * `excludeIds` carries the ids the current run already failed or skipped (raced) so they are
+ * stepped over instead of re-selected at the front, which would starve the younger healthy
+ * streams behind them. Excluding by id (the exact PK) avoids the precision trap of paginating
+ * on a `timestamptz` cursor: `closed_at` has microsecond precision the round-tripped JS `Date`
+ * loses, so a `(closed_at, id)` cursor would re-match the row it just produced. Rides the
+ * partial index `logs_attempt_streams_retention_idx`. No `object_key` filter: retention
+ * deletes compacted and never-compacted streams alike. `skipLocked`
+ * steps over a row a compaction publish is mid-transaction on; correctness comes from the
+ * guarded `deleteExpiredStream`, not this lock (a bare select releases it immediately).
+ */
+export async function listExpiredClosedStreams(params: {
+  retentionDays: number;
+  limit: number;
+  excludeIds?: string[] | undefined;
+}): Promise<AttemptStream[]> {
+  const rows = await db()
+    .select()
+    .from(attemptStreams)
+    .where(
+      and(
+        eq(attemptStreams.state, 'closed'),
+        lt(attemptStreams.closedAt, sql`now() - make_interval(days => ${params.retentionDays})`),
+        params.excludeIds && params.excludeIds.length > 0
+          ? notInArray(attemptStreams.id, params.excludeIds)
+          : undefined,
+      ),
+    )
+    .orderBy(asc(attemptStreams.closedAt), asc(attemptStreams.id))
+    .limit(params.limit)
+    .for('update', {skipLocked: true});
+
+  return rows.map(toAttemptStream);
+}
+
+/**
+ * Hard-deletes one expired stream row (chunks cascade), guarded on the `object_key` the sweep
+ * observed at select time. If compaction published an object in between, `object_key` no longer
+ * matches and 0 rows delete, so that just-published object is never orphaned — the stream is
+ * left for the next run, which re-reads the fresh key. Returns the deleted row's `job_id` for
+ * the accounting-prune check.
+ */
+export async function deleteExpiredStream(
+  tx: Transaction,
+  params: {streamId: string; observedObjectKey: string | null},
+): Promise<{deleted: boolean; jobId: string | null}> {
+  const [row] = await tx
+    .delete(attemptStreams)
+    .where(
+      and(
+        eq(attemptStreams.id, params.streamId),
+        params.observedObjectKey === null
+          ? isNull(attemptStreams.objectKey)
+          : eq(attemptStreams.objectKey, params.observedObjectKey),
+      ),
+    )
+    .returning({jobId: attemptStreams.jobId});
+
+  return {deleted: Boolean(row), jobId: row?.jobId ?? null};
+}
+
+/** True when a job has no remaining streams, so retention may prune its accounting row. */
+export async function accountingHasNoStreams(tx: Transaction, jobId: string): Promise<boolean> {
+  const [row] = await tx
+    .select({id: attemptStreams.id})
+    .from(attemptStreams)
+    .where(eq(attemptStreams.jobId, jobId))
+    .limit(1);
+
+  return !row;
 }

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -247,16 +247,11 @@ export async function listStaleUncompactedStreams(params: {
 }
 
 /**
- * Closed streams past the retention horizon, oldest first, for the retention sweep to delete.
- * `excludeIds` carries the ids the current run already failed or skipped (raced) so they are
- * stepped over instead of re-selected at the front, which would starve the younger healthy
- * streams behind them. Excluding by id (the exact PK) avoids the precision trap of paginating
- * on a `timestamptz` cursor: `closed_at` has microsecond precision the round-tripped JS `Date`
- * loses, so a `(closed_at, id)` cursor would re-match the row it just produced. Rides the
- * partial index `logs_attempt_streams_retention_idx`. No `object_key` filter: retention
- * deletes compacted and never-compacted streams alike. `skipLocked`
- * steps over a row a compaction publish is mid-transaction on; correctness comes from the
- * guarded `deleteExpiredStream`, not this lock (a bare select releases it immediately).
+ * Lists expired closed streams for retention. `excludeIds` keeps failed or raced rows from
+ * starving younger rows in the same run, and avoids cursoring on `closed_at`, whose microsecond
+ * precision would be lost through JS `Date`.
+ *
+ * No `object_key` filter: retention deletes compacted and never-compacted streams alike.
  */
 export async function listExpiredClosedStreams(params: {
   retentionDays: number;
@@ -283,11 +278,8 @@ export async function listExpiredClosedStreams(params: {
 }
 
 /**
- * Hard-deletes one expired stream row (chunks cascade), guarded on the `object_key` the sweep
- * observed at select time. If compaction published an object in between, `object_key` no longer
- * matches and 0 rows delete, so that just-published object is never orphaned — the stream is
- * left for the next run, which re-reads the fresh key. Returns the deleted row's `job_id` for
- * the accounting-prune check.
+ * Hard-deletes one expired stream row, guarded on the observed `object_key` so a racing
+ * compaction publish leaves the row for the next sweep.
  */
 export async function deleteExpiredStream(
   tx: Transaction,

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -308,7 +308,6 @@ export async function deleteExpiredStream(
   return {deleted: Boolean(row), jobId: row?.jobId ?? null};
 }
 
-/** True when a job has no remaining streams, so retention may prune its accounting row. */
 export async function accountingHasNoStreams(tx: Transaction, jobId: string): Promise<boolean> {
   const [row] = await tx
     .select({id: attemptStreams.id})

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -33,11 +33,8 @@ export const logsModule: ShipfoxModule = {
       taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
       workflowsPath,
       activities: createLogsActivities,
-      // Retention is a fast lifecycle sweep (each run drains what fits in its time budget). The
-      // cadence is hard-coded, not configurable: a Temporal cron schedule is fixed when the
-      // workflow is first created and the module bootstrap skips an already-running one, so an env
-      // knob would look adjustable but silently keep the old schedule. Hourly is ample headroom for
-      // a 90-day horizon; tune LOG_RETENTION_DAYS for the horizon itself.
+      // Temporal cron schedules are fixed after creation, so making cadence configurable would
+      // look adjustable while keeping the old schedule. Tune LOG_RETENTION_DAYS for the horizon.
       workflows: [
         {
           name: 'retentionSweepCron',

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -33,7 +33,18 @@ export const logsModule: ShipfoxModule = {
       taskQueue: LOGS_LIFECYCLE_TASK_QUEUE,
       workflowsPath,
       activities: createLogsActivities,
-      workflows: [],
+      // Retention is a fast lifecycle sweep (each run drains what fits in its time budget). The
+      // cadence is hard-coded, not configurable: a Temporal cron schedule is fixed when the
+      // workflow is first created and the module bootstrap skips an already-running one, so an env
+      // knob would look adjustable but silently keep the old schedule. Hourly is ample headroom for
+      // a 90-day horizon; tune LOG_RETENTION_DAYS for the horizon itself.
+      workflows: [
+        {
+          name: 'retentionSweepCron',
+          id: 'logs-retention-sweep',
+          cronSchedule: '0 * * * *',
+        },
+      ],
     },
     // Compaction runs on its own queue so long uploads cannot starve the lifecycle sweep.
     {

--- a/libs/api/logs/src/temporal/activities/index.ts
+++ b/libs/api/logs/src/temporal/activities/index.ts
@@ -1,11 +1,13 @@
 import {closeAbandonedStreamsActivity} from './close-abandoned-streams.js';
 import {compactStreamActivity} from './compact-stream.js';
 import {compactionReconcileActivity} from './compaction-reconcile.js';
+import {retentionSweepActivity} from './retention-sweep.js';
 
 export function createLogsActivities() {
   return {
     closeAbandonedStreamsActivity,
     compactStreamActivity,
     compactionReconcileActivity,
+    retentionSweepActivity,
   };
 }

--- a/libs/api/logs/src/temporal/activities/retention-sweep.test.ts
+++ b/libs/api/logs/src/temporal/activities/retention-sweep.test.ts
@@ -1,0 +1,38 @@
+import {MockActivityEnvironment} from '@temporalio/testing';
+import {eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {attemptStreams} from '#db/schema/attempt-streams.js';
+import {arrangeClosedStream, type ClosedStreamIdentity} from '#test/fixtures/closed-stream.js';
+import {ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
+import {findStream} from '#test/queries.js';
+import {retentionSweepActivity} from './retention-sweep.js';
+
+function newIdentity(): ClosedStreamIdentity {
+  return {
+    jobId: crypto.randomUUID(),
+    stepId: crypto.randomUUID(),
+    attempt: 1,
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    runId: crypto.randomUUID(),
+  };
+}
+
+describe('retentionSweepActivity', () => {
+  it('sweeps an expired stream end to end (config wiring + heartbeat under a real activity context)', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id, {chunks: [ndjsonBody(outputLine('x'))]});
+    // Past the default LOG_RETENTION_DAYS (90) the activity reads from config.
+    await db()
+      .update(attemptStreams)
+      .set({closedAt: sql`now() - interval '100 days'`})
+      .where(eq(attemptStreams.id, stream.id));
+
+    const result = (await new MockActivityEnvironment().run(retentionSweepActivity)) as Awaited<
+      ReturnType<typeof retentionSweepActivity>
+    >;
+
+    expect(await findStream(id)).toBeNull();
+    expect(result.timedOut).toBe(false);
+  });
+});

--- a/libs/api/logs/src/temporal/activities/retention-sweep.ts
+++ b/libs/api/logs/src/temporal/activities/retention-sweep.ts
@@ -1,0 +1,26 @@
+import {Context} from '@temporalio/activity';
+import {config} from '#config.js';
+import {type RetentionSweepResult, runRetentionSweep} from '#core/retention.js';
+import {
+  RETENTION_BATCH_LIMIT,
+  RETENTION_MAX_ITERATIONS,
+  RETENTION_TIME_BUDGET_MS,
+} from '#temporal/constants.js';
+
+/**
+ * Cron-driven sweep that hard-deletes expired closed log streams (objects + rows). Heartbeats
+ * once per stream so Temporal sees liveness well within the `heartbeatTimeout`; the core loop
+ * self-bounds on `RETENTION_TIME_BUDGET_MS`, which is under the workflow's `startToCloseTimeout`
+ * so a slow run stops before the next run starts (a `startToCloseTimeout` alone does not kill the
+ * JS loop).
+ */
+export function retentionSweepActivity(): Promise<RetentionSweepResult> {
+  const ctx = Context.current();
+  return runRetentionSweep({
+    retentionDays: config.LOG_RETENTION_DAYS,
+    batchLimit: RETENTION_BATCH_LIMIT,
+    timeBudgetMs: RETENTION_TIME_BUDGET_MS,
+    maxIterations: RETENTION_MAX_ITERATIONS,
+    onProgress: () => ctx.heartbeat(),
+  });
+}

--- a/libs/api/logs/src/temporal/activities/retention-sweep.ts
+++ b/libs/api/logs/src/temporal/activities/retention-sweep.ts
@@ -8,11 +8,8 @@ import {
 } from '#temporal/constants.js';
 
 /**
- * Cron-driven sweep that hard-deletes expired closed log streams (objects + rows). Heartbeats
- * once per stream so Temporal sees liveness well within the `heartbeatTimeout`; the core loop
- * self-bounds on `RETENTION_TIME_BUDGET_MS`, which is under the workflow's `startToCloseTimeout`
- * so a slow run stops before the next run starts (a `startToCloseTimeout` alone does not kill the
- * JS loop).
+ * Cron-driven sweep for expired closed log streams. Heartbeats per stream; the core loop owns
+ * the wall-clock budget because Temporal timeouts do not stop already-running JS.
  */
 export function retentionSweepActivity(): Promise<RetentionSweepResult> {
   const ctx = Context.current();

--- a/libs/api/logs/src/temporal/constants.ts
+++ b/libs/api/logs/src/temporal/constants.ts
@@ -4,10 +4,8 @@ export const LOGS_LIFECYCLE_TASK_QUEUE = 'logs-lifecycle';
 // burst of large compactions from starving the short, time-sensitive close-abandoned sweep.
 export const LOGS_COMPACTION_TASK_QUEUE = 'logs-compaction';
 
-// Retention sweep tuning. The wall-clock budget is the real bound (well under the
-// retention workflow's 5-minute startToCloseTimeout, so a slow run stops before the next
-// cron run begins); the batch limit caps one keyset page, and max-iterations is a backstop
-// against a non-advancing cursor.
+// The wall-clock budget is the real sweep bound; Temporal's timeout does not stop JS already
+// running in the worker.
 export const RETENTION_BATCH_LIMIT = 200;
 export const RETENTION_TIME_BUDGET_MS = 4 * 60_000;
 export const RETENTION_MAX_ITERATIONS = 1_000;

--- a/libs/api/logs/src/temporal/constants.ts
+++ b/libs/api/logs/src/temporal/constants.ts
@@ -3,3 +3,11 @@ export const LOGS_LIFECYCLE_TASK_QUEUE = 'logs-lifecycle';
 // Compaction uploads can run for minutes; keeping them off the lifecycle queue stops a
 // burst of large compactions from starving the short, time-sensitive close-abandoned sweep.
 export const LOGS_COMPACTION_TASK_QUEUE = 'logs-compaction';
+
+// Retention sweep tuning. The wall-clock budget is the real bound (well under the
+// retention workflow's 5-minute startToCloseTimeout, so a slow run stops before the next
+// cron run begins); the batch limit caps one keyset page, and max-iterations is a backstop
+// against a non-advancing cursor.
+export const RETENTION_BATCH_LIMIT = 200;
+export const RETENTION_TIME_BUDGET_MS = 4 * 60_000;
+export const RETENTION_MAX_ITERATIONS = 1_000;

--- a/libs/api/logs/src/temporal/workflows/index.ts
+++ b/libs/api/logs/src/temporal/workflows/index.ts
@@ -1,3 +1,4 @@
 export {closeAbandonedStreams} from './close-abandoned-streams.js';
 export {compactStream} from './compact-stream.js';
 export {compactionReconcileCron} from './compaction-reconcile-cron.js';
+export {retentionSweepCron} from './retention-sweep-cron.js';

--- a/libs/api/logs/src/temporal/workflows/retention-sweep-cron.ts
+++ b/libs/api/logs/src/temporal/workflows/retention-sweep-cron.ts
@@ -10,7 +10,6 @@ const {retentionSweepActivity} = proxyActivities<ReturnType<typeof createLogsAct
   retry: {maximumAttempts: 1},
 });
 
-/** Cron-scheduled sweep that hard-deletes expired closed log streams from storage and Postgres. */
 export async function retentionSweepCron(): Promise<void> {
   const {deleted, raced, failed, accountingPruned, iterations, timedOut} =
     await retentionSweepActivity();

--- a/libs/api/logs/src/temporal/workflows/retention-sweep-cron.ts
+++ b/libs/api/logs/src/temporal/workflows/retention-sweep-cron.ts
@@ -4,16 +4,14 @@ import type {createLogsActivities} from '../activities/index.js';
 const {retentionSweepActivity} = proxyActivities<ReturnType<typeof createLogsActivities>>({
   startToCloseTimeout: '5 minutes',
   heartbeatTimeout: '1 minute',
-  // The activity self-bounds on a wall-clock budget and is idempotent, so the next cron run is
-  // the natural retry. Cap attempts at 1 so a heartbeat or timeout failure cannot start a retry
-  // attempt that overlaps the original run's still-draining loop (a timeout does not kill it).
+  // Retry on the next cron tick so a timed-out attempt cannot overlap its own still-running loop.
   retry: {maximumAttempts: 1},
 });
 
 export async function retentionSweepCron(): Promise<void> {
   const {deleted, raced, failed, accountingPruned, iterations, timedOut} =
     await retentionSweepActivity();
-  // Always logged (not just on activity): a destructive sweep deserves a per-run record.
+  // Keep a workflow-level audit trail for this destructive sweep.
   log.info('Retention sweep complete', {
     deleted,
     raced,

--- a/libs/api/logs/src/temporal/workflows/retention-sweep-cron.ts
+++ b/libs/api/logs/src/temporal/workflows/retention-sweep-cron.ts
@@ -1,0 +1,26 @@
+import {log, proxyActivities} from '@temporalio/workflow';
+import type {createLogsActivities} from '../activities/index.js';
+
+const {retentionSweepActivity} = proxyActivities<ReturnType<typeof createLogsActivities>>({
+  startToCloseTimeout: '5 minutes',
+  heartbeatTimeout: '1 minute',
+  // The activity self-bounds on a wall-clock budget and is idempotent, so the next cron run is
+  // the natural retry. Cap attempts at 1 so a heartbeat or timeout failure cannot start a retry
+  // attempt that overlaps the original run's still-draining loop (a timeout does not kill it).
+  retry: {maximumAttempts: 1},
+});
+
+/** Cron-scheduled sweep that hard-deletes expired closed log streams from storage and Postgres. */
+export async function retentionSweepCron(): Promise<void> {
+  const {deleted, raced, failed, accountingPruned, iterations, timedOut} =
+    await retentionSweepActivity();
+  // Always logged (not just on activity): a destructive sweep deserves a per-run record.
+  log.info('Retention sweep complete', {
+    deleted,
+    raced,
+    failed,
+    accountingPruned,
+    iterations,
+    timedOut,
+  });
+}


### PR DESCRIPTION
Logs are kept for a retention horizon (`LOG_RETENTION_DAYS`, default 90), then deleted from both object storage and the Postgres read path by our own worker on a configurable cron (`LOG_RETENTION_SWEEP_CRON`, default hourly) rather than bucket lifecycle rules, so behavior is identical across object stores and per-workspace retention stays possible later. Third and final stream-lifecycle workstream under ENG-442, after stream close (ENG-518) and compaction (ENG-519).

The sweep selects only closed streams past the horizon (open streams are never touched) and drains them in batches under a self-imposed wall-clock budget, so a timed-out run never overlaps the next cron run. Per stream it deletes the whole attempt object prefix (reclaiming the orphan leaves a losing compaction attempt leaves behind), then hard-deletes the row with chunks cascading. It is kind-agnostic, sweeping both `log_stream` and `agent_session`.

### Review notes

The plan went through an engineering review plus a Codex outside voice that broke two "safe" claims in the first draft; the hardening they drove is the trickiest part of the diff and worth careful review:

- **Compaction race:** the row delete is guarded on the observed `object_key` (`DELETE ... WHERE object_key IS NOT DISTINCT FROM <observed>`), so a compaction publish landing between the select and the delete is skipped (counted `raced`, retried next run) and its object is never orphaned.
- **No-overlap:** a Temporal `startToCloseTimeout` does not kill the running JS loop, so the loop self-bounds on a ~4-minute budget (under the 5-minute timeout) plus heartbeat.
- **Starvation / pagination:** `closed_at` is `timestamptz` (microsecond) but a JS `Date` cursor truncates to milliseconds, so a `(closed_at, id)` keyset re-matched the row it just produced and starved the streams behind a poison batch. Replaced with an exact-id skip-set.
- **Budget safety:** a `job_accounting` row is pruned only when its job has zero remaining streams AND no recent activity (`updated_at` past the horizon), so a live job's budget is never reset.

Follow-up ENG-545 tracks batching the per-stream S3 deletes for faster backlog drain; retention metrics/alerting are deferred (per-run summary logging is included).

Refs ENG-520

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an hourly Temporal cron that deletes expired log streams from object storage and Postgres with a guarded, no-overlap sweep. Implements ENG-520; the schedule is fixed hourly to avoid misleading env knobs.

- **New Features**
  - Wires a `retentionSweepCron` workflow (`logs-retention-sweep`) that heartbeats per stream, stops under a 4-minute budget, and caps retries at 1 to prevent overlap.
  - Deletes closed streams past `LOG_RETENTION_DAYS` (default 90): first hard-deletes the row guarded on the observed `object_key`, then deletes the entire attempt prefix via S3 `ListObjectsV2` + `DeleteObjects` (idempotent; rejects empty prefixes; tolerates missing objects).
  - Skips failed/raced rows for the rest of the run to avoid starvation; prunes `job_accounting` only when the job has no remaining streams and `updated_at` is past the horizon.

- **Migration**
  - Set `LOG_RETENTION_DAYS` to an integer ≥ 1; invalid values fail startup.
  - Cadence is fixed hourly; no `LOG_RETENTION_SWEEP_CRON` env.
  - Ensure S3 permissions allow `ListObjectsV2` and `DeleteObjects` for the bucket used by `@shipfox/api-logs`.

<sup>Written for commit 5cbc6e4dc9073981d18e2af9316f9c1ca6edba70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

