### PR TITLE
[api/triggers] Add schema + migration for trigger event history tables

### DIFF
--- a/.changeset/eng-546-trigger-event-history-schema.md
+++ b/.changeset/eng-546-trigger-event-history-schema.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-triggers": patch
+---
+
+Add the append-only `triggers_received_events` and `triggers_decisions` tables that back the trigger event history. DB layer only: Drizzle schema, inferred types, and row→domain mappers, folded into the triggers module's baseline migration. No write or read path is wired yet.

--- a/libs/api/triggers/drizzle/0000_initial.sql
+++ b/libs/api/triggers/drizzle/0000_initial.sql
@@ -1,9 +1,39 @@
+CREATE TABLE "triggers_decisions" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"received_event_id" uuid NOT NULL,
+	"subscription_id" uuid NOT NULL,
+	"definition_id" uuid NOT NULL,
+	"project_id" uuid NOT NULL,
+	"decision" text NOT NULL,
+	"run_id" uuid,
+	"run_name" text,
+	"reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "triggers_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "triggers_received_events" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"event_ref" text NOT NULL,
+	"origin" text NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"source" text NOT NULL,
+	"event" text NOT NULL,
+	"delivery_id" text,
+	"connection_id" uuid,
+	"outcome" text DEFAULT 'received' NOT NULL,
+	"matched_count" integer DEFAULT 0 NOT NULL,
+	"payload" jsonb,
+	"received_at" timestamp with time zone NOT NULL,
+	"processed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "triggers_subscriptions" (
@@ -19,7 +49,13 @@ CREATE TABLE "triggers_subscriptions" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "triggers_decisions" ADD CONSTRAINT "triggers_decisions_received_event_id_triggers_received_events_id_fk" FOREIGN KEY ("received_event_id") REFERENCES "public"."triggers_received_events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "triggers_decisions_event_subscription_unique" ON "triggers_decisions" USING btree ("received_event_id","subscription_id");--> statement-breakpoint
+CREATE INDEX "triggers_decisions_run_idx" ON "triggers_decisions" USING btree ("run_id");--> statement-breakpoint
 CREATE INDEX "triggers_outbox_pending_idx" ON "triggers_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "triggers_received_events_event_ref_unique" ON "triggers_received_events" USING btree ("event_ref");--> statement-breakpoint
+CREATE INDEX "triggers_received_events_workspace_received_idx" ON "triggers_received_events" USING btree ("workspace_id","received_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "triggers_received_events_prune_idx" ON "triggers_received_events" USING btree ("created_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_subscriptions_definition_name_unique" ON "triggers_subscriptions" USING btree ("workflow_definition_id","name");--> statement-breakpoint
 CREATE INDEX "triggers_subscriptions_match_idx" ON "triggers_subscriptions" USING btree ("workspace_id","source","event");--> statement-breakpoint
 CREATE INDEX "triggers_subscriptions_definition_idx" ON "triggers_subscriptions" USING btree ("workflow_definition_id");

--- a/libs/api/triggers/drizzle/0000_initial.sql
+++ b/libs/api/triggers/drizzle/0000_initial.sql
@@ -2,7 +2,7 @@ CREATE TABLE "triggers_decisions" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"received_event_id" uuid NOT NULL,
 	"subscription_id" uuid NOT NULL,
-	"definition_id" uuid NOT NULL,
+	"workflow_definition_id" uuid NOT NULL,
 	"project_id" uuid NOT NULL,
 	"decision" text NOT NULL,
 	"run_id" uuid,

--- a/libs/api/triggers/drizzle/meta/0000_snapshot.json
+++ b/libs/api/triggers/drizzle/meta/0000_snapshot.json
@@ -27,8 +27,8 @@
           "primaryKey": false,
           "notNull": true
         },
-        "definition_id": {
-          "name": "definition_id",
+        "workflow_definition_id": {
+          "name": "workflow_definition_id",
           "type": "uuid",
           "primaryKey": false,
           "notNull": true

--- a/libs/api/triggers/drizzle/meta/0000_snapshot.json
+++ b/libs/api/triggers/drizzle/meta/0000_snapshot.json
@@ -1,9 +1,131 @@
 {
-  "id": "9ccc9e91-738b-4c9b-86ca-3d212cad605a",
+  "id": "ff04c76c-631e-4501-a6d3-fc0483cf97e2",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
+    "public.triggers_decisions": {
+      "name": "triggers_decisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "received_event_id": {
+          "name": "received_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_id": {
+          "name": "definition_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_name": {
+          "name": "run_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triggers_decisions_event_subscription_unique": {
+          "name": "triggers_decisions_event_subscription_unique",
+          "columns": [
+            {
+              "expression": "received_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_decisions_run_idx": {
+          "name": "triggers_decisions_run_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_decisions_received_event_id_triggers_received_events_id_fk": {
+          "name": "triggers_decisions_received_event_id_triggers_received_events_id_fk",
+          "tableFrom": "triggers_decisions",
+          "tableTo": "triggers_received_events",
+          "columnsFrom": ["received_event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.triggers_outbox": {
       "name": "triggers_outbox",
       "schema": "",
@@ -54,6 +176,159 @@
           ],
           "isUnique": false,
           "where": "\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triggers_received_events": {
+      "name": "triggers_received_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_ref": {
+          "name": "event_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triggers_received_events_event_ref_unique": {
+          "name": "triggers_received_events_event_ref_unique",
+          "columns": [
+            {
+              "expression": "event_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_received_events_workspace_received_idx": {
+          "name": "triggers_received_events_workspace_received_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triggers_received_events_prune_idx": {
+          "name": "triggers_received_events_prune_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/triggers/drizzle/meta/_journal.json
+++ b/libs/api/triggers/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1780991940299,
+      "when": 1781965912290,
       "tag": "0000_initial",
       "breakpoints": true
     }

--- a/libs/api/triggers/src/core/entities/decision.ts
+++ b/libs/api/triggers/src/core/entities/decision.ts
@@ -5,7 +5,7 @@ export interface TriggerDecision {
   id: string;
   receivedEventId: string;
   subscriptionId: string;
-  definitionId: string;
+  workflowDefinitionId: string;
   projectId: string;
   decision: TriggerDecisionOutcome;
   runId: string | null;

--- a/libs/api/triggers/src/core/entities/decision.ts
+++ b/libs/api/triggers/src/core/entities/decision.ts
@@ -1,0 +1,15 @@
+export const triggerDecisionOutcomes = ['triggered', 'errored'] as const;
+export type TriggerDecisionOutcome = (typeof triggerDecisionOutcomes)[number];
+
+export interface TriggerDecision {
+  id: string;
+  receivedEventId: string;
+  subscriptionId: string;
+  definitionId: string;
+  projectId: string;
+  decision: TriggerDecisionOutcome;
+  runId: string | null;
+  runName: string | null;
+  reason: string | null;
+  createdAt: Date;
+}

--- a/libs/api/triggers/src/core/entities/received-event.ts
+++ b/libs/api/triggers/src/core/entities/received-event.ts
@@ -1,0 +1,22 @@
+export const triggerEventOrigins = ['integration', 'manual'] as const;
+export type TriggerEventOrigin = (typeof triggerEventOrigins)[number];
+
+export const triggerEventOutcomes = ['received', 'routed', 'discarded', 'failed'] as const;
+export type TriggerEventOutcome = (typeof triggerEventOutcomes)[number];
+
+export interface TriggerReceivedEvent {
+  id: string;
+  eventRef: string;
+  origin: TriggerEventOrigin;
+  workspaceId: string;
+  source: string;
+  event: string;
+  deliveryId: string | null;
+  connectionId: string | null;
+  outcome: TriggerEventOutcome;
+  matchedCount: number;
+  payload: Record<string, unknown> | null;
+  receivedAt: Date;
+  processedAt: Date | null;
+  createdAt: Date;
+}

--- a/libs/api/triggers/src/db/db.ts
+++ b/libs/api/triggers/src/db/db.ts
@@ -1,9 +1,16 @@
 import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
+import {triggersDecisions} from './schema/decisions.js';
 import {triggersOutbox} from './schema/outbox.js';
+import {triggersReceivedEvents} from './schema/received-events.js';
 import {triggerSubscriptions} from './schema/subscriptions.js';
 
-export const schema = {triggerSubscriptions, triggersOutbox};
+export const schema = {
+  triggerSubscriptions,
+  triggersOutbox,
+  triggersReceivedEvents,
+  triggersDecisions,
+};
 
 let _db: NodePgDatabase<typeof schema> | undefined;
 

--- a/libs/api/triggers/src/db/schema/decisions.test.ts
+++ b/libs/api/triggers/src/db/schema/decisions.test.ts
@@ -14,7 +14,7 @@ describe('toTriggerDecision', () => {
       id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
       receivedEventId: '019e98ab-b90f-7265-b13c-8b441c991381',
       subscriptionId: '019e98ab-b90f-7265-b13c-8b441c991382',
-      definitionId: '019e98ab-b90f-7265-b13c-8b441c991383',
+      workflowDefinitionId: '019e98ab-b90f-7265-b13c-8b441c991383',
       projectId: '019e98ab-b90f-7265-b13c-8b441c991384',
       decision: 'triggered',
       runId: '019e98ab-b90f-7265-b13c-8b441c991385',
@@ -29,7 +29,7 @@ describe('toTriggerDecision', () => {
       id: row.id,
       receivedEventId: row.receivedEventId,
       subscriptionId: row.subscriptionId,
-      definitionId: row.definitionId,
+      workflowDefinitionId: row.workflowDefinitionId,
       projectId: row.projectId,
       decision: 'triggered',
       runId: row.runId,
@@ -44,7 +44,7 @@ describe('toTriggerDecision', () => {
       id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
       receivedEventId: '019e98ab-b90f-7265-b13c-8b441c991381',
       subscriptionId: '019e98ab-b90f-7265-b13c-8b441c991382',
-      definitionId: '019e98ab-b90f-7265-b13c-8b441c991383',
+      workflowDefinitionId: '019e98ab-b90f-7265-b13c-8b441c991383',
       projectId: '019e98ab-b90f-7265-b13c-8b441c991384',
       decision: 'errored',
       runId: null,
@@ -79,12 +79,47 @@ describe('triggers_decisions schema', () => {
     return event.id;
   }
 
+  test('applies defaults and maps an inserted row', async () => {
+    const receivedEventId = await insertEvent();
+    const values: TriggerDecisionInsertDb = {
+      receivedEventId,
+      subscriptionId: crypto.randomUUID(),
+      workflowDefinitionId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      decision: 'triggered',
+    };
+
+    const [inserted] = await db()
+      .insert(triggersDecisions)
+      .values(values)
+      .returning({id: triggersDecisions.id});
+    if (!inserted) throw new Error('insert returned no rows');
+    const [row] = await db()
+      .select()
+      .from(triggersDecisions)
+      .where(eq(triggersDecisions.id, inserted.id));
+    if (!row) throw new Error('select returned no rows');
+    const result = toTriggerDecision(row);
+
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(row.runId).toBeNull();
+    expect(row.runName).toBeNull();
+    expect(row.reason).toBeNull();
+    expect(result).toMatchObject({
+      receivedEventId,
+      subscriptionId: values.subscriptionId,
+      workflowDefinitionId: values.workflowDefinitionId,
+      projectId: values.projectId,
+      decision: 'triggered',
+    });
+  });
+
   test('cascades decision deletes when the parent event is removed', async () => {
     const receivedEventId = await insertEvent();
     await db().insert(triggersDecisions).values({
       receivedEventId,
       subscriptionId: crypto.randomUUID(),
-      definitionId: crypto.randomUUID(),
+      workflowDefinitionId: crypto.randomUUID(),
       projectId: crypto.randomUUID(),
       decision: 'triggered',
     });
@@ -103,7 +138,7 @@ describe('triggers_decisions schema', () => {
     const values: TriggerDecisionInsertDb = {
       receivedEventId,
       subscriptionId: crypto.randomUUID(),
-      definitionId: crypto.randomUUID(),
+      workflowDefinitionId: crypto.randomUUID(),
       projectId: crypto.randomUUID(),
       decision: 'triggered',
     };

--- a/libs/api/triggers/src/db/schema/decisions.test.ts
+++ b/libs/api/triggers/src/db/schema/decisions.test.ts
@@ -1,0 +1,116 @@
+import {eq} from 'drizzle-orm';
+import {db} from '../db.js';
+import {
+  type TriggerDecisionDb,
+  type TriggerDecisionInsertDb,
+  toTriggerDecision,
+  triggersDecisions,
+} from './decisions.js';
+import {triggersReceivedEvents} from './received-events.js';
+
+describe('toTriggerDecision', () => {
+  test('maps a fully populated row to the domain entity', () => {
+    const row: TriggerDecisionDb = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      receivedEventId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      subscriptionId: '019e98ab-b90f-7265-b13c-8b441c991382',
+      definitionId: '019e98ab-b90f-7265-b13c-8b441c991383',
+      projectId: '019e98ab-b90f-7265-b13c-8b441c991384',
+      decision: 'triggered',
+      runId: '019e98ab-b90f-7265-b13c-8b441c991385',
+      runName: 'Build and test',
+      reason: null,
+      createdAt: new Date('2026-06-09T10:00:02.000Z'),
+    };
+
+    const result = toTriggerDecision(row);
+
+    expect(result).toEqual({
+      id: row.id,
+      receivedEventId: row.receivedEventId,
+      subscriptionId: row.subscriptionId,
+      definitionId: row.definitionId,
+      projectId: row.projectId,
+      decision: 'triggered',
+      runId: row.runId,
+      runName: 'Build and test',
+      reason: null,
+      createdAt: row.createdAt,
+    });
+  });
+
+  test('passes through null run_id, run_name, and a populated reason', () => {
+    const row: TriggerDecisionDb = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      receivedEventId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      subscriptionId: '019e98ab-b90f-7265-b13c-8b441c991382',
+      definitionId: '019e98ab-b90f-7265-b13c-8b441c991383',
+      projectId: '019e98ab-b90f-7265-b13c-8b441c991384',
+      decision: 'errored',
+      runId: null,
+      runName: null,
+      reason: 'runWorkflow threw',
+      createdAt: new Date('2026-06-09T10:00:02.000Z'),
+    };
+
+    const result = toTriggerDecision(row);
+
+    expect(result.decision).toBe('errored');
+    expect(result.runId).toBeNull();
+    expect(result.runName).toBeNull();
+    expect(result.reason).toBe('runWorkflow threw');
+  });
+});
+
+describe('triggers_decisions schema', () => {
+  async function insertEvent(): Promise<string> {
+    const [event] = await db()
+      .insert(triggersReceivedEvents)
+      .values({
+        eventRef: crypto.randomUUID(),
+        origin: 'integration',
+        workspaceId: crypto.randomUUID(),
+        source: 'github',
+        event: 'push',
+        receivedAt: new Date(),
+      })
+      .returning();
+    if (!event) throw new Error('insert returned no rows');
+    return event.id;
+  }
+
+  test('cascades decision deletes when the parent event is removed', async () => {
+    const receivedEventId = await insertEvent();
+    await db().insert(triggersDecisions).values({
+      receivedEventId,
+      subscriptionId: crypto.randomUUID(),
+      definitionId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      decision: 'triggered',
+    });
+
+    await db().delete(triggersReceivedEvents).where(eq(triggersReceivedEvents.id, receivedEventId));
+
+    const rows = await db()
+      .select()
+      .from(triggersDecisions)
+      .where(eq(triggersDecisions.receivedEventId, receivedEventId));
+    expect(rows).toHaveLength(0);
+  });
+
+  test('rejects a duplicate (received_event_id, subscription_id)', async () => {
+    const receivedEventId = await insertEvent();
+    const values: TriggerDecisionInsertDb = {
+      receivedEventId,
+      subscriptionId: crypto.randomUUID(),
+      definitionId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      decision: 'triggered',
+    };
+    await db().insert(triggersDecisions).values(values);
+
+    const duplicate = db().insert(triggersDecisions).values(values);
+
+    await expect(duplicate).rejects.toThrow();
+  });
+});

--- a/libs/api/triggers/src/db/schema/decisions.ts
+++ b/libs/api/triggers/src/db/schema/decisions.ts
@@ -12,7 +12,7 @@ export const triggersDecisions = pgTable(
       .notNull()
       .references(() => triggersReceivedEvents.id, {onDelete: 'cascade'}),
     subscriptionId: uuid('subscription_id').notNull(),
-    definitionId: uuid('definition_id').notNull(),
+    workflowDefinitionId: uuid('workflow_definition_id').notNull(),
     projectId: uuid('project_id').notNull(),
     decision: text('decision', {enum: triggerDecisionOutcomes}).notNull(),
     runId: uuid('run_id'),
@@ -37,7 +37,7 @@ export function toTriggerDecision(row: TriggerDecisionDb): TriggerDecision {
     id: row.id,
     receivedEventId: row.receivedEventId,
     subscriptionId: row.subscriptionId,
-    definitionId: row.definitionId,
+    workflowDefinitionId: row.workflowDefinitionId,
     projectId: row.projectId,
     decision: row.decision,
     runId: row.runId,

--- a/libs/api/triggers/src/db/schema/decisions.ts
+++ b/libs/api/triggers/src/db/schema/decisions.ts
@@ -1,0 +1,48 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {type TriggerDecision, triggerDecisionOutcomes} from '#core/entities/decision.js';
+import {pgTable} from './common.js';
+import {triggersReceivedEvents} from './received-events.js';
+
+export const triggersDecisions = pgTable(
+  'decisions',
+  {
+    id: uuidv7PrimaryKey(),
+    receivedEventId: uuid('received_event_id')
+      .notNull()
+      .references(() => triggersReceivedEvents.id, {onDelete: 'cascade'}),
+    subscriptionId: uuid('subscription_id').notNull(),
+    definitionId: uuid('definition_id').notNull(),
+    projectId: uuid('project_id').notNull(),
+    decision: text('decision', {enum: triggerDecisionOutcomes}).notNull(),
+    runId: uuid('run_id'),
+    runName: text('run_name'),
+    reason: text('reason'),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('triggers_decisions_event_subscription_unique').on(
+      table.receivedEventId,
+      table.subscriptionId,
+    ),
+    index('triggers_decisions_run_idx').on(table.runId),
+  ],
+);
+
+export type TriggerDecisionDb = typeof triggersDecisions.$inferSelect;
+export type TriggerDecisionInsertDb = typeof triggersDecisions.$inferInsert;
+
+export function toTriggerDecision(row: TriggerDecisionDb): TriggerDecision {
+  return {
+    id: row.id,
+    receivedEventId: row.receivedEventId,
+    subscriptionId: row.subscriptionId,
+    definitionId: row.definitionId,
+    projectId: row.projectId,
+    decision: row.decision,
+    runId: row.runId,
+    runName: row.runName,
+    reason: row.reason,
+    createdAt: row.createdAt,
+  };
+}

--- a/libs/api/triggers/src/db/schema/received-events.test.ts
+++ b/libs/api/triggers/src/db/schema/received-events.test.ts
@@ -1,3 +1,4 @@
+import {eq} from 'drizzle-orm';
 import {db} from '../db.js';
 import {
   type TriggerReceivedEventDb,
@@ -73,7 +74,7 @@ describe('toTriggerReceivedEvent', () => {
 });
 
 describe('triggers_received_events schema', () => {
-  test('applies outcome, matched_count, and created_at defaults on insert', async () => {
+  test('applies defaults and maps an inserted row', async () => {
     const values: TriggerReceivedEventInsertDb = {
       eventRef: crypto.randomUUID(),
       origin: 'integration',
@@ -83,11 +84,30 @@ describe('triggers_received_events schema', () => {
       receivedAt: new Date(),
     };
 
-    const [row] = await db().insert(triggersReceivedEvents).values(values).returning();
+    const [inserted] = await db()
+      .insert(triggersReceivedEvents)
+      .values(values)
+      .returning({id: triggersReceivedEvents.id});
+    if (!inserted) throw new Error('insert returned no rows');
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, inserted.id));
+    if (!row) throw new Error('select returned no rows');
+    const result = toTriggerReceivedEvent(row);
 
-    expect(row?.outcome).toBe('received');
-    expect(row?.matchedCount).toBe(0);
-    expect(row?.createdAt).toBeInstanceOf(Date);
+    expect(row.outcome).toBe('received');
+    expect(row.matchedCount).toBe(0);
+    expect(row.createdAt).toBeInstanceOf(Date);
+    expect(result).toMatchObject({
+      eventRef: values.eventRef,
+      origin: 'integration',
+      workspaceId: values.workspaceId,
+      source: 'github',
+      event: 'push',
+      outcome: 'received',
+      matchedCount: 0,
+    });
   });
 
   test('rejects a duplicate event_ref', async () => {

--- a/libs/api/triggers/src/db/schema/received-events.test.ts
+++ b/libs/api/triggers/src/db/schema/received-events.test.ts
@@ -1,0 +1,108 @@
+import {db} from '../db.js';
+import {
+  type TriggerReceivedEventDb,
+  type TriggerReceivedEventInsertDb,
+  toTriggerReceivedEvent,
+  triggersReceivedEvents,
+} from './received-events.js';
+
+describe('toTriggerReceivedEvent', () => {
+  test('maps a fully populated row to the domain entity', () => {
+    const row: TriggerReceivedEventDb = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      eventRef: 'evt-1',
+      origin: 'integration',
+      workspaceId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      source: 'github',
+      event: 'push',
+      deliveryId: 'delivery-1',
+      connectionId: '019e98ab-b90f-7265-b13c-8b441c991382',
+      outcome: 'routed',
+      matchedCount: 3,
+      payload: {ref: 'refs/heads/main'},
+      receivedAt: new Date('2026-06-09T10:00:00.000Z'),
+      processedAt: new Date('2026-06-09T10:00:01.000Z'),
+      createdAt: new Date('2026-06-09T10:00:02.000Z'),
+    };
+
+    const result = toTriggerReceivedEvent(row);
+
+    expect(result).toEqual({
+      id: row.id,
+      eventRef: 'evt-1',
+      origin: 'integration',
+      workspaceId: row.workspaceId,
+      source: 'github',
+      event: 'push',
+      deliveryId: 'delivery-1',
+      connectionId: row.connectionId,
+      outcome: 'routed',
+      matchedCount: 3,
+      payload: {ref: 'refs/heads/main'},
+      receivedAt: row.receivedAt,
+      processedAt: row.processedAt,
+      createdAt: row.createdAt,
+    });
+  });
+
+  test('passes through null delivery, connection, payload, and processed_at', () => {
+    const row: TriggerReceivedEventDb = {
+      id: '019e98ab-6656-7ca1-b9ad-1ca4442c479d',
+      eventRef: 'evt-2',
+      origin: 'manual',
+      workspaceId: '019e98ab-b90f-7265-b13c-8b441c991381',
+      source: 'manual',
+      event: 'fire',
+      deliveryId: null,
+      connectionId: null,
+      outcome: 'received',
+      matchedCount: 0,
+      payload: null,
+      receivedAt: new Date('2026-06-09T10:00:00.000Z'),
+      processedAt: null,
+      createdAt: new Date('2026-06-09T10:00:02.000Z'),
+    };
+
+    const result = toTriggerReceivedEvent(row);
+
+    expect(result.deliveryId).toBeNull();
+    expect(result.connectionId).toBeNull();
+    expect(result.payload).toBeNull();
+    expect(result.processedAt).toBeNull();
+  });
+});
+
+describe('triggers_received_events schema', () => {
+  test('applies outcome, matched_count, and created_at defaults on insert', async () => {
+    const values: TriggerReceivedEventInsertDb = {
+      eventRef: crypto.randomUUID(),
+      origin: 'integration',
+      workspaceId: crypto.randomUUID(),
+      source: 'github',
+      event: 'push',
+      receivedAt: new Date(),
+    };
+
+    const [row] = await db().insert(triggersReceivedEvents).values(values).returning();
+
+    expect(row?.outcome).toBe('received');
+    expect(row?.matchedCount).toBe(0);
+    expect(row?.createdAt).toBeInstanceOf(Date);
+  });
+
+  test('rejects a duplicate event_ref', async () => {
+    const values: TriggerReceivedEventInsertDb = {
+      eventRef: crypto.randomUUID(),
+      origin: 'integration',
+      workspaceId: crypto.randomUUID(),
+      source: 'github',
+      event: 'push',
+      receivedAt: new Date(),
+    };
+    await db().insert(triggersReceivedEvents).values(values);
+
+    const duplicate = db().insert(triggersReceivedEvents).values(values);
+
+    await expect(duplicate).rejects.toThrow();
+  });
+});

--- a/libs/api/triggers/src/db/schema/received-events.ts
+++ b/libs/api/triggers/src/db/schema/received-events.ts
@@ -11,6 +11,9 @@ export const triggersReceivedEvents = pgTable(
   'received_events',
   {
     id: uuidv7PrimaryKey(),
+    // Globally-unique idempotency key (the outbox event id), not the provider
+    // delivery id: delivery ids are only unique per provider and would collide
+    // across workspaces under the global event_ref unique index below.
     eventRef: text('event_ref').notNull(),
     origin: text('origin', {enum: triggerEventOrigins}).notNull(),
     workspaceId: uuid('workspace_id').notNull(),

--- a/libs/api/triggers/src/db/schema/received-events.ts
+++ b/libs/api/triggers/src/db/schema/received-events.ts
@@ -1,0 +1,58 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, integer, jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {
+  type TriggerReceivedEvent,
+  triggerEventOrigins,
+  triggerEventOutcomes,
+} from '#core/entities/received-event.js';
+import {pgTable} from './common.js';
+
+export const triggersReceivedEvents = pgTable(
+  'received_events',
+  {
+    id: uuidv7PrimaryKey(),
+    eventRef: text('event_ref').notNull(),
+    origin: text('origin', {enum: triggerEventOrigins}).notNull(),
+    workspaceId: uuid('workspace_id').notNull(),
+    source: text('source').notNull(),
+    event: text('event').notNull(),
+    deliveryId: text('delivery_id'),
+    connectionId: uuid('connection_id'),
+    outcome: text('outcome', {enum: triggerEventOutcomes}).notNull().default('received'),
+    matchedCount: integer('matched_count').notNull().default(0),
+    payload: jsonb('payload').$type<Record<string, unknown>>(),
+    receivedAt: timestamp('received_at', {withTimezone: true}).notNull(),
+    processedAt: timestamp('processed_at', {withTimezone: true}),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('triggers_received_events_event_ref_unique').on(table.eventRef),
+    index('triggers_received_events_workspace_received_idx').on(
+      table.workspaceId,
+      table.receivedAt.desc(),
+    ),
+    index('triggers_received_events_prune_idx').on(table.createdAt),
+  ],
+);
+
+export type TriggerReceivedEventDb = typeof triggersReceivedEvents.$inferSelect;
+export type TriggerReceivedEventInsertDb = typeof triggersReceivedEvents.$inferInsert;
+
+export function toTriggerReceivedEvent(row: TriggerReceivedEventDb): TriggerReceivedEvent {
+  return {
+    id: row.id,
+    eventRef: row.eventRef,
+    origin: row.origin,
+    workspaceId: row.workspaceId,
+    source: row.source,
+    event: row.event,
+    deliveryId: row.deliveryId,
+    connectionId: row.connectionId,
+    outcome: row.outcome,
+    matchedCount: row.matchedCount,
+    payload: row.payload,
+    receivedAt: row.receivedAt,
+    processedAt: row.processedAt,
+    createdAt: row.createdAt,
+  };
+}

--- a/libs/api/triggers/test/globalSetup.ts
+++ b/libs/api/triggers/test/globalSetup.ts
@@ -10,6 +10,8 @@ export async function setup() {
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_triggers');
   await db().execute(sql`TRUNCATE triggers_subscriptions CASCADE`);
   await db().execute(sql`TRUNCATE triggers_outbox CASCADE`);
+  await db().execute(sql`TRUNCATE triggers_received_events CASCADE`);
+  await db().execute(sql`TRUNCATE triggers_decisions CASCADE`);
 
   closeDb();
   await closePostgresClient();


### PR DESCRIPTION
Adds the two append-only tables that back the trigger event history, owned by the triggers module: `triggers_received_events` (one row per processed event) and `triggers_decisions` (zero-to-many per event, one per subscription evaluated). DB layer only - Drizzle schema, inferred types, and row->domain mappers; no write or read path is wired yet (those land in ENG-547/548).

This is the first slice of the Trigger event history project (spec §6): a queryable, append-only log of every event the trigger module processes and which runs it produced, so operators can answer "I pushed, why did nothing run?" without reading server logs.

Notes for review:

- Enum columns (`origin`/`outcome`/`decision`) use Drizzle `text({enum})`, not `pgEnum` - the spec reserves future decision values, and a text enum evolves with a no-op migration. The enum is TS-enforced only (no DB CHECK), matching the `attempt_streams` convention; ENG-547/548 validate at the boundary.
- `received_at` is NOT NULL with no DB default: it is the source's delivery time (distinct from `created_at`), so the write path must supply it - a forgetful caller fails loud rather than silently storing insert-time.
- The decisions `unique(received_event_id, subscription_id)` already serves `received_event_id` lookups as a prefix, so there is no standalone index on that column.
- Tables are reachable within the package via `#db/schema/*`; they are intentionally not added to the package root exports until ENG-547/548 consume them.

Migration: since nothing is deployed, the two tables are folded into the existing `0000_initial` baseline (regenerated) rather than stacked as a new migration. Heads-up: any environment that already applied the old `0000_initial` must reset the triggers tables + `drizzle.__drizzle_migrations_triggers` (or recreate the DB) - CI runs on a fresh DB, so it is unaffected.

Covered by mapper unit tests (populated + all-null) plus Postgres round-trip tests asserting the column defaults, both unique constraints, and the FK cascade.

Closes ENG-546

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add append-only trigger event history tables and DB schema in the triggers module. DB layer only; no read/write path yet. Aligns `workflow_definition_id` naming and hardens tests to meet ENG-546.

- **New Features**
  - Added `triggers_received_events` (one per event) and `triggers_decisions` (per subscription) with unique indexes and FK cascade.
  - Drizzle schema, inferred types, and row→domain mappers under `#db/schema/*` (not exported at the package root yet).
  - `received_events.event_ref` is the globally-unique outbox event id; enum-like fields are text with TS-enforced values; `received_at` is required with no DB default.
  - Renamed decisions column to `workflow_definition_id` to match `triggers_subscriptions`; tests now round-trip rows through mappers and assert defaults/uniques/cascade.

- **Migration**
  - Folded into `0000_initial` for `@shipfox/api-triggers` (pre-deploy rename included).
  - Fresh DBs: no action.
  - If the prior baseline was applied, reset the triggers tables and `drizzle.__drizzle_migrations_triggers` (or recreate the DB).

<sup>Written for commit 129e1317af14733a0986c362a37244bd3f5fdaa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

