### PR TITLE
[api/triggers] Record trigger events and decisions on the write path

### DIFF
--- a/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
@@ -1,5 +1,3 @@
-import type {IntegrationEventReceivedEvent} from '@shipfox/api-integration-core-dto';
-import type {DomainEvent} from '@shipfox/node-outbox';
 import {triggerSubscriptionFactory} from '#test/index.js';
 
 const runWorkflow = vi.fn();
@@ -18,10 +16,10 @@ vi.mock('#db/event-history.js', () => ({
   upsertErroredDecision: vi.fn(),
 }));
 
-// Import after mocks so the subscriber sees the spies.
-const {onIntegrationEventReceived} = await import('./on-integration-event-received.js');
+// Import after mocks so the code under test sees the spies.
+const {dispatchIntegrationEvent} = await import('./dispatch-integration-event.js');
 
-describe('onIntegrationEventReceived resilience to history-write failure', () => {
+describe('dispatchIntegrationEvent resilience to history-write failure', () => {
   beforeEach(() => {
     runWorkflow.mockReset();
     insertReceivedEvent.mockReset();
@@ -37,23 +35,19 @@ describe('onIntegrationEventReceived resilience to history-write failure', () =>
       event: 'push',
       config: {},
     });
-    const envelope: IntegrationEventReceivedEvent = {
-      source: 'github',
-      event: 'push',
-      workspaceId,
-      connectionId: crypto.randomUUID(),
-      deliveryId: crypto.randomUUID(),
-      receivedAt: new Date().toISOString(),
-      payload: {ref: 'main'},
-    };
-    const event: DomainEvent<IntegrationEventReceivedEvent> = {
-      id: crypto.randomUUID(),
-      type: 'integrations.event.received',
-      createdAt: new Date(),
-      payload: envelope,
-    };
 
-    await expect(onIntegrationEventReceived(envelope, event)).resolves.toBeUndefined();
+    await expect(
+      dispatchIntegrationEvent({
+        eventRef: crypto.randomUUID(),
+        workspaceId,
+        source: 'github',
+        event: 'push',
+        connectionId: crypto.randomUUID(),
+        deliveryId: crypto.randomUUID(),
+        receivedAt: new Date(),
+        payload: {ref: 'main'},
+      }),
+    ).resolves.toBeUndefined();
 
     expect(runWorkflow).toHaveBeenCalledTimes(1);
   });

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -1,0 +1,344 @@
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {triggersDecisions} from '#db/schema/decisions.js';
+import {triggersReceivedEvents} from '#db/schema/received-events.js';
+import {triggerSubscriptionFactory} from '#test/index.js';
+
+const runWorkflow = vi.fn();
+
+vi.mock('@shipfox/api-workflows', () => ({
+  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+}));
+
+// Import after mocks so the core dispatcher sees the spy.
+const {dispatchIntegrationEvent} = await import('./dispatch-integration-event.js');
+
+interface DispatchOverrides {
+  eventRef?: string;
+  workspaceId?: string;
+  source?: string;
+  event?: string;
+  deliveryId?: string;
+  connectionId?: string;
+  payload?: unknown;
+  receivedAt?: Date;
+}
+
+function dispatch(overrides: DispatchOverrides = {}): Promise<void> {
+  return dispatchIntegrationEvent({
+    eventRef: overrides.eventRef ?? crypto.randomUUID(),
+    source: overrides.source ?? 'github',
+    event: overrides.event ?? 'push',
+    workspaceId: overrides.workspaceId ?? crypto.randomUUID(),
+    connectionId: overrides.connectionId ?? crypto.randomUUID(),
+    deliveryId: overrides.deliveryId ?? crypto.randomUUID(),
+    receivedAt: overrides.receivedAt ?? new Date(),
+    payload: overrides.payload ?? {ref: 'main', headCommitSha: 'abc123'},
+  });
+}
+
+async function receivedEvent(eventRef: string) {
+  const [row] = await db()
+    .select()
+    .from(triggersReceivedEvents)
+    .where(eq(triggersReceivedEvents.eventRef, eventRef));
+  return row;
+}
+
+function decisionsForEvent(receivedEventId: string) {
+  return db()
+    .select()
+    .from(triggersDecisions)
+    .where(eq(triggersDecisions.receivedEventId, receivedEventId));
+}
+
+describe('dispatchIntegrationEvent', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+  });
+
+  test('fires the workflow for each matching workspace subscription, regardless of project', async () => {
+    const workspaceId = crypto.randomUUID();
+    const subA = await triggerSubscriptionFactory.create({
+      workspaceId,
+      projectId: crypto.randomUUID(),
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const subB = await triggerSubscriptionFactory.create({
+      workspaceId,
+      projectId: crypto.randomUUID(),
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+
+    await dispatch({workspaceId});
+
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
+    const firedProjects = runWorkflow.mock.calls.map(([params]) => params.projectId);
+    expect(firedProjects).toEqual(expect.arrayContaining([subA.projectId, subB.projectId]));
+  });
+
+  test('passes the source, event, deliveryId and raw payload through as the trigger payload', async () => {
+    const workspaceId = crypto.randomUUID();
+    const deliveryId = crypto.randomUUID();
+    const payload = {ref: 'refs/heads/feature', headCommitSha: 'deadbeef'};
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+
+    await dispatch({workspaceId, deliveryId, payload});
+
+    expect(runWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerPayload: {source: 'github', event: 'push', deliveryId, data: payload},
+      }),
+    );
+  });
+
+  test('dispatches an arbitrary non-github source without any source-specific handling', async () => {
+    const workspaceId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'sentry',
+      event: 'alert_triggered',
+      config: {},
+    });
+
+    await dispatch({workspaceId, source: 'sentry', event: 'alert_triggered'});
+
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    expect(runWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        triggerPayload: expect.objectContaining({source: 'sentry', event: 'alert_triggered'}),
+      }),
+    );
+  });
+
+  test('passes triggerIdempotencyKey = subscription.id:eventRef to runWorkflow', async () => {
+    const workspaceId = crypto.randomUUID();
+    const subscription = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const eventRef = crypto.randomUUID();
+
+    await dispatch({workspaceId, eventRef});
+
+    expect(runWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({triggerIdempotencyKey: `${subscription.id}:${eventRef}`}),
+    );
+  });
+
+  test('forwards subscription.config.with as inputs to runWorkflow', async () => {
+    const workspaceId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {with: {env: 'staging'}},
+    });
+
+    await dispatch({workspaceId});
+
+    expect(runWorkflow).toHaveBeenCalledWith(expect.objectContaining({inputs: {env: 'staging'}}));
+  });
+
+  test('does not fire when no subscription matches the workspace, source and event', async () => {
+    const workspaceId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+
+    await dispatch({workspaceId, event: 'pull_request'});
+
+    expect(runWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe('dispatchIntegrationEvent trigger history', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+  });
+
+  test('records a discarded event when no subscription matches', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+
+    await dispatch({workspaceId, event: 'pull_request', eventRef});
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.origin).toBe('integration');
+    expect(event.outcome).toBe('discarded');
+    expect(event.matchedCount).toBe(0);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    expect(await decisionsForEvent(event.id)).toHaveLength(0);
+  });
+
+  test('records a routed event with a triggered decision per matched subscription', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const subA = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const subB = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const runs: {id: string; name: string}[] = [];
+    runWorkflow.mockImplementation(() => {
+      const run = {id: crypto.randomUUID(), name: 'Build and test'};
+      runs.push(run);
+      return run;
+    });
+
+    await dispatch({workspaceId, eventRef});
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('routed');
+    expect(event.matchedCount).toBe(2);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(2);
+    expect(decisions.every((d) => d.decision === 'triggered')).toBe(true);
+    expect(decisions.map((d) => d.subscriptionId).sort()).toEqual([subA.id, subB.id].sort());
+    expect(decisions.map((d) => d.runId).sort()).toEqual(runs.map((r) => r.id).sort());
+    expect(decisions.every((d) => d.runName === 'Build and test')).toBe(true);
+  });
+
+  test('records a failed event, stops the loop at the first throw, and re-throws', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(new Error('runWorkflow boom'));
+
+    await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('runWorkflow boom');
+
+    // Every match would throw, so one call proves the loop stops at the first failure.
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.matchedCount).toBe(2);
+    expect(event.processedAt).toBeNull();
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toBe('errored');
+    expect(decisions[0]?.reason).toContain('runWorkflow boom');
+  });
+
+  test('replaying the same event does not duplicate rows and reuses the idempotency key', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const subscription = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'Build and test'});
+
+    await dispatch({workspaceId, eventRef});
+    await dispatch({workspaceId, eventRef});
+
+    const events = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, eventRef));
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    if (!event) throw new Error('received event not found');
+    expect(await decisionsForEvent(event.id)).toHaveLength(1);
+    // `runWorkflow` is mocked here; run-row dedup depends on stable keys at its boundary.
+    const keys = runWorkflow.mock.calls.map(([params]) => params.triggerIdempotencyKey);
+    expect(keys).toEqual([`${subscription.id}:${eventRef}`, `${subscription.id}:${eventRef}`]);
+  });
+
+  test('records a triggered and an errored decision for a mixed-outcome fan-out', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+    runWorkflow.mockResolvedValueOnce(run).mockRejectedValueOnce(new Error('second boom'));
+
+    await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('second boom');
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.matchedCount).toBe(2);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(2);
+    const triggered = decisions.find((d) => d.decision === 'triggered');
+    const errored = decisions.find((d) => d.decision === 'errored');
+    expect(triggered?.runId).toBe(run.id);
+    expect(errored?.reason).toContain('second boom');
+  });
+
+  test('converges a failed event to routed when a later replay succeeds', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const subscription = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+    runWorkflow.mockRejectedValueOnce(new Error('transient boom')).mockResolvedValue(run);
+
+    await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('transient boom');
+    await dispatch({workspaceId, eventRef});
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('routed');
+    expect(event.matchedCount).toBe(1);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.subscriptionId).toBe(subscription.id);
+    expect(decisions[0]?.decision).toBe('triggered');
+    expect(decisions[0]?.runId).toBe(run.id);
+    expect(decisions[0]?.reason).toBeNull();
+  });
+});

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -1,0 +1,74 @@
+import {runWorkflow} from '@shipfox/api-workflows';
+import {findMatchingSubscriptions} from '#db/subscriptions.js';
+import {readConfigInputs} from './config.js';
+import {beginTriggerHistory, toReason} from './record-trigger-history.js';
+
+export interface DispatchIntegrationEventParams {
+  eventRef: string;
+  workspaceId: string;
+  source: string;
+  event: string;
+  deliveryId: string;
+  connectionId: string;
+  payload: unknown;
+  receivedAt: Date;
+}
+
+// Source-agnostic dispatcher: any inbound integration event fans out to every
+// workspace subscription registered for its (source, event), passing the raw
+// payload through untouched. The module knows nothing about github, gitlab, etc.
+// History is best-effort, but `runWorkflow` errors still re-throw so the outbox retries.
+// A transient failure converges to `routed` on replay; a permanent one (e.g. a deleted
+// definition) re-throws every retry, so the event stays `failed`. The recorded outcome
+// tracks reality; it is not a stuck state to recover from here.
+export async function dispatchIntegrationEvent(
+  params: DispatchIntegrationEventParams,
+): Promise<void> {
+  const history = await beginTriggerHistory({
+    eventRef: params.eventRef,
+    origin: 'integration',
+    workspaceId: params.workspaceId,
+    source: params.source,
+    event: params.event,
+    deliveryId: params.deliveryId,
+    connectionId: params.connectionId,
+    payload: (params.payload ?? null) as Record<string, unknown> | null,
+    receivedAt: params.receivedAt,
+  });
+
+  const subscriptions = await findMatchingSubscriptions({
+    workspaceId: params.workspaceId,
+    source: params.source,
+    event: params.event,
+  });
+
+  if (subscriptions.length === 0) {
+    await history.discarded();
+    return;
+  }
+
+  for (const subscription of subscriptions) {
+    try {
+      const run = await runWorkflow({
+        workspaceId: subscription.workspaceId,
+        projectId: subscription.projectId,
+        definitionId: subscription.workflowDefinitionId,
+        triggerPayload: {
+          source: params.source,
+          event: params.event,
+          deliveryId: params.deliveryId,
+          data: params.payload,
+        },
+        inputs: readConfigInputs(subscription),
+        triggerIdempotencyKey: `${subscription.id}:${params.eventRef}`,
+      });
+      await history.triggered(subscription, run);
+    } catch (error) {
+      await history.errored(subscription, toReason(error));
+      await history.failed(subscriptions.length);
+      throw error;
+    }
+  }
+
+  await history.routed(subscriptions.length);
+}

--- a/libs/api/triggers/src/core/fire-manual.test.ts
+++ b/libs/api/triggers/src/core/fire-manual.test.ts
@@ -1,0 +1,115 @@
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {triggersDecisions} from '#db/schema/decisions.js';
+import {triggersReceivedEvents} from '#db/schema/received-events.js';
+import {triggerSubscriptionFactory} from '#test/index.js';
+import {TriggerSubscriptionNotManualError} from './errors.js';
+
+const runWorkflow = vi.fn();
+
+vi.mock('@shipfox/api-workflows', () => ({
+  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+}));
+
+// Import after mocks so the function under test sees the spy.
+const {fireManualSubscription} = await import('./fire-manual.js');
+
+function eventsForWorkspace(workspaceId: string) {
+  return db()
+    .select()
+    .from(triggersReceivedEvents)
+    .where(eq(triggersReceivedEvents.workspaceId, workspaceId));
+}
+
+function decisionsForEvent(receivedEventId: string) {
+  return db()
+    .select()
+    .from(triggersDecisions)
+    .where(eq(triggersDecisions.receivedEventId, receivedEventId));
+}
+
+describe('fireManualSubscription (trigger history)', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+  });
+
+  test('records a routed manual event and a triggered decision on success', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'manual',
+      event: 'fire',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Manual run'};
+    runWorkflow.mockResolvedValue(run);
+
+    const result = await fireManualSubscription({
+      subscriptionId: subscription.id,
+      callerWorkspaceId: subscription.workspaceId,
+      userId: crypto.randomUUID(),
+    });
+
+    expect(result).toEqual(run);
+    const [event] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, run.id));
+    if (!event) throw new Error('received event not found');
+    expect(event.origin).toBe('manual');
+    expect(event.outcome).toBe('routed');
+    expect(event.matchedCount).toBe(1);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toBe('triggered');
+    expect(decisions[0]?.runId).toBe(run.id);
+    expect(decisions[0]?.runName).toBe('Manual run');
+  });
+
+  test('records a failed manual event with an errored decision and re-throws when runWorkflow throws', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'manual',
+      event: 'fire',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(new Error('manual boom'));
+
+    await expect(
+      fireManualSubscription({
+        subscriptionId: subscription.id,
+        callerWorkspaceId: subscription.workspaceId,
+        userId: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow('manual boom');
+
+    const events = await eventsForWorkspace(subscription.workspaceId);
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    if (!event) throw new Error('received event not found');
+    expect(event.origin).toBe('manual');
+    expect(event.outcome).toBe('failed');
+    expect(event.matchedCount).toBe(1);
+    expect(event.processedAt).toBeNull();
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toBe('errored');
+    expect(decisions[0]?.reason).toContain('manual boom');
+  });
+
+  test('does not record a received event when the subscription is not a manual trigger', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+
+    await expect(
+      fireManualSubscription({
+        subscriptionId: subscription.id,
+        callerWorkspaceId: subscription.workspaceId,
+        userId: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow(TriggerSubscriptionNotManualError);
+
+    expect(await eventsForWorkspace(subscription.workspaceId)).toHaveLength(0);
+    expect(runWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/triggers/src/core/fire-manual.ts
+++ b/libs/api/triggers/src/core/fire-manual.ts
@@ -1,3 +1,4 @@
+import {randomUUID} from 'node:crypto';
 import {runWorkflow, type WorkflowRun} from '@shipfox/api-workflows';
 import {getTriggerSubscriptionById} from '#db/subscriptions.js';
 import {readConfigInputs} from './config.js';
@@ -6,6 +7,7 @@ import {
   TriggerSubscriptionNotManualError,
   TriggerWorkspaceMismatchError,
 } from './errors.js';
+import {beginTriggerHistory, toReason} from './record-trigger-history.js';
 
 export interface FireManualSubscriptionParams {
   subscriptionId: string;
@@ -31,16 +33,42 @@ export async function fireManualSubscription(
     );
   }
 
-  return await runWorkflow({
+  // Manual fires have no upstream event id. Use the run id after success; failed
+  // attempts need a synthesized ref because there is no run to key on.
+  const historyBase = {
+    origin: 'manual' as const,
     workspaceId: subscription.workspaceId,
-    projectId: subscription.projectId,
-    definitionId: subscription.workflowDefinitionId,
-    triggerPayload: {
-      source: 'manual',
-      event: 'fire',
-      subscriptionId: subscription.id,
-      userId: params.userId,
-    },
-    inputs: params.inputs ?? readConfigInputs(subscription),
-  });
+    source: subscription.source,
+    event: subscription.event,
+    deliveryId: null,
+    connectionId: null,
+    payload: null,
+    receivedAt: new Date(),
+  };
+
+  let run: WorkflowRun;
+  try {
+    run = await runWorkflow({
+      workspaceId: subscription.workspaceId,
+      projectId: subscription.projectId,
+      definitionId: subscription.workflowDefinitionId,
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: subscription.id,
+        userId: params.userId,
+      },
+      inputs: params.inputs ?? readConfigInputs(subscription),
+    });
+  } catch (error) {
+    const failure = await beginTriggerHistory({...historyBase, eventRef: randomUUID()});
+    await failure.errored(subscription, toReason(error));
+    await failure.failed(1);
+    throw error;
+  }
+
+  const history = await beginTriggerHistory({...historyBase, eventRef: run.id});
+  await history.triggered(subscription, run);
+  await history.routed(1);
+  return run;
 }

--- a/libs/api/triggers/src/core/index.ts
+++ b/libs/api/triggers/src/core/index.ts
@@ -1,4 +1,8 @@
 export {readConfigInputs} from './config.js';
+export {
+  type DispatchIntegrationEventParams,
+  dispatchIntegrationEvent,
+} from './dispatch-integration-event.js';
 export type {TriggerSubscription} from './entities/subscription.js';
 export {
   ManualTriggerNotFoundError,

--- a/libs/api/triggers/src/core/record-trigger-history.test.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.test.ts
@@ -100,6 +100,11 @@ describe('a per-write failure after a successful insert is swallowed', () => {
       recorder.triggered(subscription, {id: crypto.randomUUID(), name: 'r'}),
     ).resolves.toBeUndefined();
     await expect(recorder.routed(1)).resolves.toBeUndefined();
+
+    // Prove the post-insert writes were actually attempted (not skipped by the
+    // missing-id no-op), so the assertions exercise the swallow path they claim to.
+    expect(upsertTriggeredDecision).toHaveBeenCalledTimes(1);
+    expect(markReceivedEventRouted).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/libs/api/triggers/src/core/record-trigger-history.test.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.test.ts
@@ -1,0 +1,124 @@
+import {triggerSubscriptionFactory} from '#test/index.js';
+
+const runWorkflow = vi.fn();
+const insertReceivedEvent = vi.fn();
+const markReceivedEventRouted = vi.fn();
+const upsertTriggeredDecision = vi.fn();
+
+vi.mock('@shipfox/api-workflows', () => ({
+  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+}));
+
+vi.mock('#db/event-history.js', () => ({
+  insertReceivedEvent: (...args: unknown[]) => insertReceivedEvent(...args),
+  markReceivedEventDiscarded: vi.fn(),
+  markReceivedEventRouted: (...args: unknown[]) => markReceivedEventRouted(...args),
+  markReceivedEventFailed: vi.fn(),
+  upsertTriggeredDecision: (...args: unknown[]) => upsertTriggeredDecision(...args),
+  upsertErroredDecision: vi.fn(),
+}));
+
+// Import after mocks so the code under test sees the spies.
+const {beginTriggerHistory, toReason} = await import('./record-trigger-history.js');
+const {fireManualSubscription} = await import('./fire-manual.js');
+
+describe('trigger history is best-effort and never blocks triggering', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+    insertReceivedEvent.mockReset();
+    insertReceivedEvent.mockRejectedValue(new Error('history db down'));
+  });
+
+  test('beginTriggerHistory resolves and its methods never throw when the insert fails', async () => {
+    const recorder = await beginTriggerHistory({
+      eventRef: crypto.randomUUID(),
+      origin: 'integration',
+      workspaceId: crypto.randomUUID(),
+      source: 'github',
+      event: 'push',
+      deliveryId: null,
+      connectionId: null,
+      payload: null,
+      receivedAt: new Date(),
+    });
+    const subscription = triggerSubscriptionFactory.build();
+
+    await expect(
+      recorder.triggered(subscription, {id: crypto.randomUUID(), name: 'r'}),
+    ).resolves.toBeUndefined();
+    await expect(recorder.errored(subscription, 'boom')).resolves.toBeUndefined();
+    await expect(recorder.discarded()).resolves.toBeUndefined();
+    await expect(recorder.routed(1)).resolves.toBeUndefined();
+    await expect(recorder.failed(1)).resolves.toBeUndefined();
+  });
+
+  test('fireManualSubscription still returns the run when history recording fails', async () => {
+    const run = {id: crypto.randomUUID(), name: 'Manual run'};
+    runWorkflow.mockResolvedValue(run);
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'manual',
+      event: 'fire',
+      config: {},
+    });
+
+    const result = await fireManualSubscription({
+      subscriptionId: subscription.id,
+      callerWorkspaceId: subscription.workspaceId,
+      userId: crypto.randomUUID(),
+    });
+
+    expect(result).toEqual(run);
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('a per-write failure after a successful insert is swallowed', () => {
+  beforeEach(() => {
+    insertReceivedEvent.mockReset();
+    markReceivedEventRouted.mockReset();
+    upsertTriggeredDecision.mockReset();
+    insertReceivedEvent.mockResolvedValue(crypto.randomUUID());
+    markReceivedEventRouted.mockRejectedValue(new Error('route write failed'));
+    upsertTriggeredDecision.mockRejectedValue(new Error('decision write failed'));
+  });
+
+  test('recorder methods resolve when the insert succeeds but a later write throws', async () => {
+    const recorder = await beginTriggerHistory({
+      eventRef: crypto.randomUUID(),
+      origin: 'integration',
+      workspaceId: crypto.randomUUID(),
+      source: 'github',
+      event: 'push',
+      deliveryId: null,
+      connectionId: null,
+      payload: null,
+      receivedAt: new Date(),
+    });
+    const subscription = triggerSubscriptionFactory.build();
+
+    await expect(
+      recorder.triggered(subscription, {id: crypto.randomUUID(), name: 'r'}),
+    ).resolves.toBeUndefined();
+    await expect(recorder.routed(1)).resolves.toBeUndefined();
+  });
+});
+
+describe('toReason', () => {
+  test('caps an over-long message at the maximum reason length', () => {
+    const reason = toReason(new Error('x'.repeat(5000)));
+
+    expect(reason).toHaveLength(2000);
+  });
+
+  test('stringifies a non-Error throwable', () => {
+    const reason = toReason('plain string failure');
+
+    expect(reason).toBe('plain string failure');
+  });
+
+  test('passes a short Error message through verbatim', () => {
+    const reason = toReason(new Error('definition deleted'));
+
+    expect(reason).toBe('definition deleted');
+  });
+});

--- a/libs/api/triggers/src/core/record-trigger-history.test.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.test.ts
@@ -121,6 +121,16 @@ describe('toReason', () => {
     expect(reason).toBe('plain string failure');
   });
 
+  test('falls back when a non-Error throwable cannot be stringified', () => {
+    const reason = toReason({
+      toString() {
+        throw new Error('string conversion failed');
+      },
+    });
+
+    expect(reason).toBe('[unprintable thrown value]');
+  });
+
   test('passes a short Error message through verbatim', () => {
     const reason = toReason(new Error('definition deleted'));
 

--- a/libs/api/triggers/src/core/record-trigger-history.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.ts
@@ -15,7 +15,12 @@ const MAX_REASON_LENGTH = 2000;
 // A bounded, deterministic reason string safe to persist: error messages can be
 // long or carry untrusted data, so cap the length and never serialize the object.
 export function toReason(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
+  let message: string;
+  try {
+    message = error instanceof Error ? error.message : String(error);
+  } catch {
+    message = '[unprintable thrown value]';
+  }
   return message.slice(0, MAX_REASON_LENGTH);
 }
 

--- a/libs/api/triggers/src/core/record-trigger-history.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.ts
@@ -1,0 +1,101 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import type {TriggerEventOrigin} from '#core/entities/received-event.js';
+import type {TriggerSubscription} from '#core/entities/subscription.js';
+import {
+  insertReceivedEvent,
+  markReceivedEventDiscarded,
+  markReceivedEventFailed,
+  markReceivedEventRouted,
+  upsertErroredDecision,
+  upsertTriggeredDecision,
+} from '#db/event-history.js';
+
+const MAX_REASON_LENGTH = 2000;
+
+// A bounded, deterministic reason string safe to persist: error messages can be
+// long or carry untrusted data, so cap the length and never serialize the object.
+export function toReason(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.slice(0, MAX_REASON_LENGTH);
+}
+
+export interface TriggerRun {
+  id: string;
+  name: string;
+}
+
+export interface TriggerHistoryRecorder {
+  triggered(subscription: TriggerSubscription, run: TriggerRun): Promise<void>;
+  errored(subscription: TriggerSubscription, reason: string): Promise<void>;
+  discarded(): Promise<void>;
+  routed(matchedCount: number): Promise<void>;
+  failed(matchedCount: number): Promise<void>;
+}
+
+export interface BeginTriggerHistoryParams {
+  eventRef: string;
+  origin: TriggerEventOrigin;
+  workspaceId: string;
+  source: string;
+  event: string;
+  deliveryId: string | null;
+  connectionId: string | null;
+  payload: Record<string, unknown> | null;
+  receivedAt: Date;
+}
+
+// History writes are best-effort and log stable ids only, never payloads or tokens.
+// If the parent insert fails there is no row to attach to, so later calls no-op.
+export async function beginTriggerHistory(
+  params: BeginTriggerHistoryParams,
+): Promise<TriggerHistoryRecorder> {
+  const receivedEventId = await safe(params.eventRef, 'insert-received-event', () =>
+    insertReceivedEvent(params),
+  );
+
+  const record = async (
+    label: string,
+    write: (receivedEventId: string) => Promise<unknown>,
+    subscriptionId?: string,
+  ): Promise<void> => {
+    if (receivedEventId === undefined) return;
+    await safe(params.eventRef, label, () => write(receivedEventId), subscriptionId);
+  };
+
+  return {
+    triggered: (subscription, run) =>
+      record(
+        'triggered-decision',
+        (id) => upsertTriggeredDecision({receivedEventId: id, subscription, run}),
+        subscription.id,
+      ),
+    errored: (subscription, reason) =>
+      record(
+        'errored-decision',
+        (id) => upsertErroredDecision({receivedEventId: id, subscription, reason}),
+        subscription.id,
+      ),
+    discarded: () => record('discard-event', (id) => markReceivedEventDiscarded(id)),
+    routed: (matchedCount) =>
+      record('route-event', (id) => markReceivedEventRouted(id, matchedCount)),
+    failed: (matchedCount) =>
+      record('fail-event', (id) => markReceivedEventFailed(id, matchedCount)),
+  };
+}
+
+async function safe<T>(
+  eventRef: string,
+  label: string,
+  fn: () => Promise<T>,
+  subscriptionId?: string,
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (error) {
+    logger().warn(
+      {err: error, label, eventRef, ...(subscriptionId ? {subscriptionId} : {})},
+      'trigger history write failed; ignored (best-effort)',
+    );
+    return undefined;
+  }
+}

--- a/libs/api/triggers/src/db/event-history.test.ts
+++ b/libs/api/triggers/src/db/event-history.test.ts
@@ -1,0 +1,189 @@
+import {eq} from 'drizzle-orm';
+import type {TriggerSubscription} from '#core/entities/subscription.js';
+import {db} from './db.js';
+import {
+  type InsertReceivedEventParams,
+  insertReceivedEvent,
+  markReceivedEventDiscarded,
+  markReceivedEventFailed,
+  markReceivedEventRouted,
+  upsertErroredDecision,
+  upsertTriggeredDecision,
+} from './event-history.js';
+import {triggersDecisions} from './schema/decisions.js';
+import {triggersReceivedEvents} from './schema/received-events.js';
+
+function buildEventParams(
+  overrides: Partial<InsertReceivedEventParams> = {},
+): InsertReceivedEventParams {
+  return {
+    eventRef: crypto.randomUUID(),
+    origin: 'integration',
+    workspaceId: crypto.randomUUID(),
+    source: 'github',
+    event: 'push',
+    deliveryId: null,
+    connectionId: null,
+    payload: null,
+    receivedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function buildSubscription(overrides: Partial<TriggerSubscription> = {}): TriggerSubscription {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    workflowDefinitionId: crypto.randomUUID(),
+    name: 'trigger',
+    source: 'github',
+    event: 'push',
+    config: {},
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function decisionsFor(receivedEventId: string) {
+  return db()
+    .select()
+    .from(triggersDecisions)
+    .where(eq(triggersDecisions.receivedEventId, receivedEventId));
+}
+
+describe('insertReceivedEvent', () => {
+  it('inserts a received event and returns its id', async () => {
+    const params = buildEventParams();
+
+    const id = await insertReceivedEvent(params);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.eventRef).toBe(params.eventRef);
+    expect(row?.outcome).toBe('received');
+    expect(row?.matchedCount).toBe(0);
+  });
+
+  it('returns the existing id on event_ref conflict (replay)', async () => {
+    const params = buildEventParams();
+
+    const first = await insertReceivedEvent(params);
+    const second = await insertReceivedEvent(params);
+
+    expect(second).toBe(first);
+    const rows = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, params.eventRef));
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('received-event outcome transitions', () => {
+  it('marks an event routed with matched_count and processed_at', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+
+    await markReceivedEventRouted(id, 3);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('routed');
+    expect(row?.matchedCount).toBe(3);
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('marks an event discarded with matched_count 0', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+
+    await markReceivedEventDiscarded(id);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('discarded');
+    expect(row?.matchedCount).toBe(0);
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('marks an event failed without setting processed_at (transient, retried)', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+
+    await markReceivedEventFailed(id, 2);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('failed');
+    expect(row?.matchedCount).toBe(2);
+    expect(row?.processedAt).toBeNull();
+  });
+
+  it('does not downgrade a routed event to failed (terminal success wins under a stale failed write)', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+    await markReceivedEventRouted(id, 2);
+
+    await markReceivedEventFailed(id, 2);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('routed');
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('decision upserts', () => {
+  it('is idempotent on (received_event_id, subscription_id)', async () => {
+    const receivedEventId = await insertReceivedEvent(buildEventParams());
+    const subscription = buildSubscription();
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+
+    await upsertTriggeredDecision({receivedEventId, subscription, run});
+    await upsertTriggeredDecision({receivedEventId, subscription, run});
+
+    const rows = await decisionsFor(receivedEventId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.decision).toBe('triggered');
+    expect(rows[0]?.runId).toBe(run.id);
+    expect(rows[0]?.runName).toBe(run.name);
+  });
+
+  it('flips an errored decision to triggered on a successful retry', async () => {
+    const receivedEventId = await insertReceivedEvent(buildEventParams());
+    const subscription = buildSubscription();
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+
+    await upsertErroredDecision({receivedEventId, subscription, reason: 'boom'});
+    await upsertTriggeredDecision({receivedEventId, subscription, run});
+
+    const rows = await decisionsFor(receivedEventId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.decision).toBe('triggered');
+    expect(rows[0]?.runId).toBe(run.id);
+    expect(rows[0]?.reason).toBeNull();
+  });
+
+  it('never downgrades an existing triggered decision to errored', async () => {
+    const receivedEventId = await insertReceivedEvent(buildEventParams());
+    const subscription = buildSubscription();
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+
+    await upsertTriggeredDecision({receivedEventId, subscription, run});
+    await upsertErroredDecision({receivedEventId, subscription, reason: 'definition deleted'});
+
+    const rows = await decisionsFor(receivedEventId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.decision).toBe('triggered');
+    expect(rows[0]?.runId).toBe(run.id);
+    expect(rows[0]?.reason).toBeNull();
+  });
+});

--- a/libs/api/triggers/src/db/event-history.test.ts
+++ b/libs/api/triggers/src/db/event-history.test.ts
@@ -112,6 +112,20 @@ describe('received-event outcome transitions', () => {
     expect(row?.processedAt).toBeInstanceOf(Date);
   });
 
+  it('does not downgrade a routed event to discarded', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+    await markReceivedEventRouted(id, 1);
+
+    await markReceivedEventDiscarded(id);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('routed');
+    expect(row?.matchedCount).toBe(1);
+  });
+
   it('marks an event failed without setting processed_at (transient, retried)', async () => {
     const id = await insertReceivedEvent(buildEventParams());
 

--- a/libs/api/triggers/src/db/event-history.ts
+++ b/libs/api/triggers/src/db/event-history.ts
@@ -51,7 +51,7 @@ export async function markReceivedEventDiscarded(id: string): Promise<void> {
   await db()
     .update(triggersReceivedEvents)
     .set({outcome: 'discarded', matchedCount: 0, processedAt: new Date()})
-    .where(eq(triggersReceivedEvents.id, id));
+    .where(and(eq(triggersReceivedEvents.id, id), ne(triggersReceivedEvents.outcome, 'routed')));
 }
 
 export async function markReceivedEventRouted(id: string, matchedCount: number): Promise<void> {

--- a/libs/api/triggers/src/db/event-history.ts
+++ b/libs/api/triggers/src/db/event-history.ts
@@ -1,0 +1,128 @@
+import {and, eq, ne, notInArray} from 'drizzle-orm';
+import type {TriggerEventOrigin} from '#core/entities/received-event.js';
+import type {TriggerSubscription} from '#core/entities/subscription.js';
+import {db} from './db.js';
+import {triggersDecisions} from './schema/decisions.js';
+import {triggersReceivedEvents} from './schema/received-events.js';
+
+export interface InsertReceivedEventParams {
+  eventRef: string;
+  origin: TriggerEventOrigin;
+  workspaceId: string;
+  source: string;
+  event: string;
+  deliveryId: string | null;
+  connectionId: string | null;
+  payload: Record<string, unknown> | null;
+  receivedAt: Date;
+}
+
+// `event_ref` is unique and delivery is at-least-once, so the same event can
+// arrive twice; either path returns the row id used to attach decisions.
+export async function insertReceivedEvent(params: InsertReceivedEventParams): Promise<string> {
+  const [inserted] = await db()
+    .insert(triggersReceivedEvents)
+    .values({
+      eventRef: params.eventRef,
+      origin: params.origin,
+      workspaceId: params.workspaceId,
+      source: params.source,
+      event: params.event,
+      deliveryId: params.deliveryId,
+      connectionId: params.connectionId,
+      payload: params.payload,
+      receivedAt: params.receivedAt,
+    })
+    .onConflictDoNothing({target: triggersReceivedEvents.eventRef})
+    .returning({id: triggersReceivedEvents.id});
+  if (inserted) return inserted.id;
+
+  const [existing] = await db()
+    .select({id: triggersReceivedEvents.id})
+    .from(triggersReceivedEvents)
+    .where(eq(triggersReceivedEvents.eventRef, params.eventRef));
+  if (!existing) {
+    throw new Error(`received_events row missing after conflict for event_ref ${params.eventRef}`);
+  }
+  return existing.id;
+}
+
+export async function markReceivedEventDiscarded(id: string): Promise<void> {
+  await db()
+    .update(triggersReceivedEvents)
+    .set({outcome: 'discarded', matchedCount: 0, processedAt: new Date()})
+    .where(eq(triggersReceivedEvents.id, id));
+}
+
+export async function markReceivedEventRouted(id: string, matchedCount: number): Promise<void> {
+  await db()
+    .update(triggersReceivedEvents)
+    .set({outcome: 'routed', matchedCount, processedAt: new Date()})
+    .where(eq(triggersReceivedEvents.id, id));
+}
+
+// No processedAt: `failed` is transient. Under at-least-once dispatch, a late
+// failure must not clobber a sibling invocation's terminal outcome.
+export async function markReceivedEventFailed(id: string, matchedCount: number): Promise<void> {
+  await db()
+    .update(triggersReceivedEvents)
+    .set({outcome: 'failed', matchedCount})
+    .where(
+      and(
+        eq(triggersReceivedEvents.id, id),
+        notInArray(triggersReceivedEvents.outcome, ['routed', 'discarded']),
+      ),
+    );
+}
+
+export interface UpsertTriggeredDecisionParams {
+  receivedEventId: string;
+  subscription: TriggerSubscription;
+  run: {id: string; name: string};
+}
+
+export async function upsertTriggeredDecision(
+  params: UpsertTriggeredDecisionParams,
+): Promise<void> {
+  await db()
+    .insert(triggersDecisions)
+    .values({
+      receivedEventId: params.receivedEventId,
+      subscriptionId: params.subscription.id,
+      workflowDefinitionId: params.subscription.workflowDefinitionId,
+      projectId: params.subscription.projectId,
+      decision: 'triggered',
+      runId: params.run.id,
+      runName: params.run.name,
+      reason: null,
+    })
+    .onConflictDoUpdate({
+      target: [triggersDecisions.receivedEventId, triggersDecisions.subscriptionId],
+      set: {decision: 'triggered', runId: params.run.id, runName: params.run.name, reason: null},
+    });
+}
+
+export interface UpsertErroredDecisionParams {
+  receivedEventId: string;
+  subscription: TriggerSubscription;
+  reason: string;
+}
+
+// A created run is ground truth. A later retry failure must not erase it.
+export async function upsertErroredDecision(params: UpsertErroredDecisionParams): Promise<void> {
+  await db()
+    .insert(triggersDecisions)
+    .values({
+      receivedEventId: params.receivedEventId,
+      subscriptionId: params.subscription.id,
+      workflowDefinitionId: params.subscription.workflowDefinitionId,
+      projectId: params.subscription.projectId,
+      decision: 'errored',
+      reason: params.reason,
+    })
+    .onConflictDoUpdate({
+      target: [triggersDecisions.receivedEventId, triggersDecisions.subscriptionId],
+      set: {decision: 'errored', reason: params.reason, runId: null, runName: null},
+      setWhere: ne(triggersDecisions.decision, 'triggered'),
+    });
+}

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.history-failure.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.history-failure.test.ts
@@ -1,0 +1,60 @@
+import type {IntegrationEventReceivedEvent} from '@shipfox/api-integration-core-dto';
+import type {DomainEvent} from '@shipfox/node-outbox';
+import {triggerSubscriptionFactory} from '#test/index.js';
+
+const runWorkflow = vi.fn();
+const insertReceivedEvent = vi.fn();
+
+vi.mock('@shipfox/api-workflows', () => ({
+  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+}));
+
+vi.mock('#db/event-history.js', () => ({
+  insertReceivedEvent: (...args: unknown[]) => insertReceivedEvent(...args),
+  markReceivedEventDiscarded: vi.fn(),
+  markReceivedEventRouted: vi.fn(),
+  markReceivedEventFailed: vi.fn(),
+  upsertTriggeredDecision: vi.fn(),
+  upsertErroredDecision: vi.fn(),
+}));
+
+// Import after mocks so the subscriber sees the spies.
+const {onIntegrationEventReceived} = await import('./on-integration-event-received.js');
+
+describe('onIntegrationEventReceived resilience to history-write failure', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+    insertReceivedEvent.mockReset();
+    insertReceivedEvent.mockRejectedValue(new Error('history db down'));
+  });
+
+  test('still fires runWorkflow and does not throw when history recording fails', async () => {
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'Build'});
+    const workspaceId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const envelope: IntegrationEventReceivedEvent = {
+      source: 'github',
+      event: 'push',
+      workspaceId,
+      connectionId: crypto.randomUUID(),
+      deliveryId: crypto.randomUUID(),
+      receivedAt: new Date().toISOString(),
+      payload: {ref: 'main'},
+    };
+    const event: DomainEvent<IntegrationEventReceivedEvent> = {
+      id: crypto.randomUUID(),
+      type: 'integrations.event.received',
+      createdAt: new Date(),
+      payload: envelope,
+    };
+
+    await expect(onIntegrationEventReceived(envelope, event)).resolves.toBeUndefined();
+
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
@@ -1,5 +1,9 @@
 import type {IntegrationEventReceivedEvent} from '@shipfox/api-integration-core-dto';
 import type {DomainEvent} from '@shipfox/node-outbox';
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {triggersDecisions} from '#db/schema/decisions.js';
+import {triggersReceivedEvents} from '#db/schema/received-events.js';
 import {triggerSubscriptionFactory} from '#test/index.js';
 
 const runWorkflow = vi.fn();
@@ -157,5 +161,197 @@ describe('onIntegrationEventReceived (triggers)', () => {
     await dispatch({workspaceId, event: 'pull_request'});
 
     expect(runWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe('onIntegrationEventReceived trigger history', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+  });
+
+  async function receivedEvent(eventRef: string) {
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, eventRef));
+    return row;
+  }
+
+  function decisionsForEvent(receivedEventId: string) {
+    return db()
+      .select()
+      .from(triggersDecisions)
+      .where(eq(triggersDecisions.receivedEventId, receivedEventId));
+  }
+
+  test('records a discarded event when no subscription matches', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventId = crypto.randomUUID();
+
+    await dispatch({workspaceId, event: 'pull_request'}, eventId);
+
+    const event = await receivedEvent(eventId);
+    if (!event) throw new Error('received event not found');
+    expect(event.origin).toBe('integration');
+    expect(event.outcome).toBe('discarded');
+    expect(event.matchedCount).toBe(0);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    expect(await decisionsForEvent(event.id)).toHaveLength(0);
+  });
+
+  test('records a routed event with a triggered decision per matched subscription', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventId = crypto.randomUUID();
+    const subA = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const subB = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const runs: {id: string; name: string}[] = [];
+    runWorkflow.mockImplementation(() => {
+      const run = {id: crypto.randomUUID(), name: 'Build and test'};
+      runs.push(run);
+      return run;
+    });
+
+    await dispatch({workspaceId}, eventId);
+
+    const event = await receivedEvent(eventId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('routed');
+    expect(event.matchedCount).toBe(2);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(2);
+    expect(decisions.every((d) => d.decision === 'triggered')).toBe(true);
+    expect(decisions.map((d) => d.subscriptionId).sort()).toEqual([subA.id, subB.id].sort());
+    expect(decisions.map((d) => d.runId).sort()).toEqual(runs.map((r) => r.id).sort());
+    expect(decisions.every((d) => d.runName === 'Build and test')).toBe(true);
+  });
+
+  test('records a failed event, stops the loop at the first throw, and re-throws', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(new Error('runWorkflow boom'));
+
+    await expect(dispatch({workspaceId}, eventId)).rejects.toThrow('runWorkflow boom');
+
+    // Every match would throw, so one call proves the loop stops at the first failure.
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    const event = await receivedEvent(eventId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.matchedCount).toBe(2);
+    expect(event.processedAt).toBeNull();
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toBe('errored');
+    expect(decisions[0]?.reason).toContain('runWorkflow boom');
+  });
+
+  test('replaying the same event does not duplicate rows and reuses the idempotency key', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventId = crypto.randomUUID();
+    const subscription = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'Build and test'});
+
+    await dispatch({workspaceId}, eventId);
+    await dispatch({workspaceId}, eventId);
+
+    const events = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, eventId));
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    if (!event) throw new Error('received event not found');
+    expect(await decisionsForEvent(event.id)).toHaveLength(1);
+    // `runWorkflow` is mocked here; run-row dedup depends on stable keys at its boundary.
+    const keys = runWorkflow.mock.calls.map(([params]) => params.triggerIdempotencyKey);
+    expect(keys).toEqual([`${subscription.id}:${eventId}`, `${subscription.id}:${eventId}`]);
+  });
+
+  test('records a triggered and an errored decision for a mixed-outcome fan-out', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventId = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+    runWorkflow.mockResolvedValueOnce(run).mockRejectedValueOnce(new Error('second boom'));
+
+    await expect(dispatch({workspaceId}, eventId)).rejects.toThrow('second boom');
+
+    const event = await receivedEvent(eventId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.matchedCount).toBe(2);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(2);
+    const triggered = decisions.find((d) => d.decision === 'triggered');
+    const errored = decisions.find((d) => d.decision === 'errored');
+    expect(triggered?.runId).toBe(run.id);
+    expect(errored?.reason).toContain('second boom');
+  });
+
+  test('converges a failed event to routed when a later replay succeeds', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventId = crypto.randomUUID();
+    const subscription = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+    runWorkflow.mockRejectedValueOnce(new Error('transient boom')).mockResolvedValue(run);
+
+    await expect(dispatch({workspaceId}, eventId)).rejects.toThrow('transient boom');
+    await dispatch({workspaceId}, eventId);
+
+    const event = await receivedEvent(eventId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('routed');
+    expect(event.matchedCount).toBe(1);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.subscriptionId).toBe(subscription.id);
+    expect(decisions[0]?.decision).toBe('triggered');
+    expect(decisions[0]?.runId).toBe(run.id);
+    expect(decisions[0]?.reason).toBeNull();
   });
 });

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
@@ -1,357 +1,49 @@
 import type {IntegrationEventReceivedEvent} from '@shipfox/api-integration-core-dto';
 import type {DomainEvent} from '@shipfox/node-outbox';
-import {eq} from 'drizzle-orm';
-import {db} from '#db/db.js';
-import {triggersDecisions} from '#db/schema/decisions.js';
-import {triggersReceivedEvents} from '#db/schema/received-events.js';
-import {triggerSubscriptionFactory} from '#test/index.js';
 
-const runWorkflow = vi.fn();
+const dispatchIntegrationEvent = vi.fn();
 
-vi.mock('@shipfox/api-workflows', () => ({
-  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+vi.mock('#core/dispatch-integration-event.js', () => ({
+  dispatchIntegrationEvent: (...args: unknown[]) => dispatchIntegrationEvent(...args),
 }));
 
-// Import after mocks so the subscriber sees the spies.
+// Import after mocks so the subscriber sees the spy.
 const {onIntegrationEventReceived} = await import('./on-integration-event-received.js');
 
-function buildEnvelope(
-  overrides: Partial<IntegrationEventReceivedEvent> = {},
-): IntegrationEventReceivedEvent {
-  return {
-    source: 'github',
-    event: 'push',
-    workspaceId: crypto.randomUUID(),
-    connectionId: crypto.randomUUID(),
-    deliveryId: crypto.randomUUID(),
-    receivedAt: new Date().toISOString(),
-    payload: {ref: 'main', headCommitSha: 'abc123'},
-    ...overrides,
-  };
-}
-
-function buildEvent(
-  payload: IntegrationEventReceivedEvent,
-  id = crypto.randomUUID(),
-): DomainEvent<IntegrationEventReceivedEvent> {
-  return {
-    id,
-    type: 'integrations.event.received',
-    createdAt: new Date(),
-    payload,
-  };
-}
-
-function dispatch(
-  overrides: Partial<IntegrationEventReceivedEvent> = {},
-  id = crypto.randomUUID(),
-): Promise<void> {
-  const envelope = buildEnvelope(overrides);
-  return onIntegrationEventReceived(envelope, buildEvent(envelope, id));
-}
-
-describe('onIntegrationEventReceived (triggers)', () => {
+describe('onIntegrationEventReceived', () => {
   beforeEach(() => {
-    runWorkflow.mockReset();
+    dispatchIntegrationEvent.mockReset();
   });
 
-  test('fires the workflow for each matching workspace subscription, regardless of project', async () => {
-    const workspaceId = crypto.randomUUID();
-    const subA = await triggerSubscriptionFactory.create({
-      workspaceId,
-      projectId: crypto.randomUUID(),
+  test('passes the integration envelope to the core dispatcher', async () => {
+    const receivedAt = '2026-06-21T03:20:00.000Z';
+    const envelope: IntegrationEventReceivedEvent = {
       source: 'github',
       event: 'push',
-      config: {},
+      workspaceId: crypto.randomUUID(),
+      connectionId: crypto.randomUUID(),
+      deliveryId: crypto.randomUUID(),
+      receivedAt,
+      payload: {ref: 'main', headCommitSha: 'abc123'},
+    };
+    const event: DomainEvent<IntegrationEventReceivedEvent> = {
+      id: crypto.randomUUID(),
+      type: 'integrations.event.received',
+      createdAt: new Date(),
+      payload: envelope,
+    };
+
+    await onIntegrationEventReceived(envelope, event);
+
+    expect(dispatchIntegrationEvent).toHaveBeenCalledWith({
+      eventRef: event.id,
+      workspaceId: envelope.workspaceId,
+      source: envelope.source,
+      event: envelope.event,
+      deliveryId: envelope.deliveryId,
+      connectionId: envelope.connectionId,
+      payload: envelope.payload,
+      receivedAt: new Date(receivedAt),
     });
-    const subB = await triggerSubscriptionFactory.create({
-      workspaceId,
-      projectId: crypto.randomUUID(),
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-
-    await dispatch({workspaceId});
-
-    expect(runWorkflow).toHaveBeenCalledTimes(2);
-    const firedProjects = runWorkflow.mock.calls.map(([params]) => params.projectId);
-    expect(firedProjects).toEqual(expect.arrayContaining([subA.projectId, subB.projectId]));
-  });
-
-  test('passes the source, event, deliveryId and raw payload through as the trigger payload', async () => {
-    const workspaceId = crypto.randomUUID();
-    const deliveryId = crypto.randomUUID();
-    const payload = {ref: 'refs/heads/feature', headCommitSha: 'deadbeef'};
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-
-    await dispatch({workspaceId, deliveryId, payload});
-
-    expect(runWorkflow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        triggerPayload: {source: 'github', event: 'push', deliveryId, data: payload},
-      }),
-    );
-  });
-
-  test('dispatches an arbitrary non-github source without any source-specific handling', async () => {
-    const workspaceId = crypto.randomUUID();
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'sentry',
-      event: 'alert_triggered',
-      config: {},
-    });
-
-    await dispatch({workspaceId, source: 'sentry', event: 'alert_triggered'});
-
-    expect(runWorkflow).toHaveBeenCalledTimes(1);
-    expect(runWorkflow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        triggerPayload: expect.objectContaining({source: 'sentry', event: 'alert_triggered'}),
-      }),
-    );
-  });
-
-  test('passes triggerIdempotencyKey = subscription.id:event.id to runWorkflow', async () => {
-    const workspaceId = crypto.randomUUID();
-    const subscription = await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    const eventId = crypto.randomUUID();
-
-    await dispatch({workspaceId}, eventId);
-
-    expect(runWorkflow).toHaveBeenCalledWith(
-      expect.objectContaining({triggerIdempotencyKey: `${subscription.id}:${eventId}`}),
-    );
-  });
-
-  test('forwards subscription.config.with as inputs to runWorkflow', async () => {
-    const workspaceId = crypto.randomUUID();
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {with: {env: 'staging'}},
-    });
-
-    await dispatch({workspaceId});
-
-    expect(runWorkflow).toHaveBeenCalledWith(expect.objectContaining({inputs: {env: 'staging'}}));
-  });
-
-  test('does not fire when no subscription matches the workspace, source and event', async () => {
-    const workspaceId = crypto.randomUUID();
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-
-    await dispatch({workspaceId, event: 'pull_request'});
-
-    expect(runWorkflow).not.toHaveBeenCalled();
-  });
-});
-
-describe('onIntegrationEventReceived trigger history', () => {
-  beforeEach(() => {
-    runWorkflow.mockReset();
-  });
-
-  async function receivedEvent(eventRef: string) {
-    const [row] = await db()
-      .select()
-      .from(triggersReceivedEvents)
-      .where(eq(triggersReceivedEvents.eventRef, eventRef));
-    return row;
-  }
-
-  function decisionsForEvent(receivedEventId: string) {
-    return db()
-      .select()
-      .from(triggersDecisions)
-      .where(eq(triggersDecisions.receivedEventId, receivedEventId));
-  }
-
-  test('records a discarded event when no subscription matches', async () => {
-    const workspaceId = crypto.randomUUID();
-    const eventId = crypto.randomUUID();
-
-    await dispatch({workspaceId, event: 'pull_request'}, eventId);
-
-    const event = await receivedEvent(eventId);
-    if (!event) throw new Error('received event not found');
-    expect(event.origin).toBe('integration');
-    expect(event.outcome).toBe('discarded');
-    expect(event.matchedCount).toBe(0);
-    expect(event.processedAt).toBeInstanceOf(Date);
-    expect(await decisionsForEvent(event.id)).toHaveLength(0);
-  });
-
-  test('records a routed event with a triggered decision per matched subscription', async () => {
-    const workspaceId = crypto.randomUUID();
-    const eventId = crypto.randomUUID();
-    const subA = await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    const subB = await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    const runs: {id: string; name: string}[] = [];
-    runWorkflow.mockImplementation(() => {
-      const run = {id: crypto.randomUUID(), name: 'Build and test'};
-      runs.push(run);
-      return run;
-    });
-
-    await dispatch({workspaceId}, eventId);
-
-    const event = await receivedEvent(eventId);
-    if (!event) throw new Error('received event not found');
-    expect(event.outcome).toBe('routed');
-    expect(event.matchedCount).toBe(2);
-    expect(event.processedAt).toBeInstanceOf(Date);
-    const decisions = await decisionsForEvent(event.id);
-    expect(decisions).toHaveLength(2);
-    expect(decisions.every((d) => d.decision === 'triggered')).toBe(true);
-    expect(decisions.map((d) => d.subscriptionId).sort()).toEqual([subA.id, subB.id].sort());
-    expect(decisions.map((d) => d.runId).sort()).toEqual(runs.map((r) => r.id).sort());
-    expect(decisions.every((d) => d.runName === 'Build and test')).toBe(true);
-  });
-
-  test('records a failed event, stops the loop at the first throw, and re-throws', async () => {
-    const workspaceId = crypto.randomUUID();
-    const eventId = crypto.randomUUID();
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    runWorkflow.mockRejectedValue(new Error('runWorkflow boom'));
-
-    await expect(dispatch({workspaceId}, eventId)).rejects.toThrow('runWorkflow boom');
-
-    // Every match would throw, so one call proves the loop stops at the first failure.
-    expect(runWorkflow).toHaveBeenCalledTimes(1);
-    const event = await receivedEvent(eventId);
-    if (!event) throw new Error('received event not found');
-    expect(event.outcome).toBe('failed');
-    expect(event.matchedCount).toBe(2);
-    expect(event.processedAt).toBeNull();
-    const decisions = await decisionsForEvent(event.id);
-    expect(decisions).toHaveLength(1);
-    expect(decisions[0]?.decision).toBe('errored');
-    expect(decisions[0]?.reason).toContain('runWorkflow boom');
-  });
-
-  test('replaying the same event does not duplicate rows and reuses the idempotency key', async () => {
-    const workspaceId = crypto.randomUUID();
-    const eventId = crypto.randomUUID();
-    const subscription = await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'Build and test'});
-
-    await dispatch({workspaceId}, eventId);
-    await dispatch({workspaceId}, eventId);
-
-    const events = await db()
-      .select()
-      .from(triggersReceivedEvents)
-      .where(eq(triggersReceivedEvents.eventRef, eventId));
-    expect(events).toHaveLength(1);
-    const event = events[0];
-    if (!event) throw new Error('received event not found');
-    expect(await decisionsForEvent(event.id)).toHaveLength(1);
-    // `runWorkflow` is mocked here; run-row dedup depends on stable keys at its boundary.
-    const keys = runWorkflow.mock.calls.map(([params]) => params.triggerIdempotencyKey);
-    expect(keys).toEqual([`${subscription.id}:${eventId}`, `${subscription.id}:${eventId}`]);
-  });
-
-  test('records a triggered and an errored decision for a mixed-outcome fan-out', async () => {
-    const workspaceId = crypto.randomUUID();
-    const eventId = crypto.randomUUID();
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    const run = {id: crypto.randomUUID(), name: 'Build and test'};
-    runWorkflow.mockResolvedValueOnce(run).mockRejectedValueOnce(new Error('second boom'));
-
-    await expect(dispatch({workspaceId}, eventId)).rejects.toThrow('second boom');
-
-    const event = await receivedEvent(eventId);
-    if (!event) throw new Error('received event not found');
-    expect(event.outcome).toBe('failed');
-    expect(event.matchedCount).toBe(2);
-    const decisions = await decisionsForEvent(event.id);
-    expect(decisions).toHaveLength(2);
-    const triggered = decisions.find((d) => d.decision === 'triggered');
-    const errored = decisions.find((d) => d.decision === 'errored');
-    expect(triggered?.runId).toBe(run.id);
-    expect(errored?.reason).toContain('second boom');
-  });
-
-  test('converges a failed event to routed when a later replay succeeds', async () => {
-    const workspaceId = crypto.randomUUID();
-    const eventId = crypto.randomUUID();
-    const subscription = await triggerSubscriptionFactory.create({
-      workspaceId,
-      source: 'github',
-      event: 'push',
-      config: {},
-    });
-    const run = {id: crypto.randomUUID(), name: 'Build and test'};
-    runWorkflow.mockRejectedValueOnce(new Error('transient boom')).mockResolvedValue(run);
-
-    await expect(dispatch({workspaceId}, eventId)).rejects.toThrow('transient boom');
-    await dispatch({workspaceId}, eventId);
-
-    const event = await receivedEvent(eventId);
-    if (!event) throw new Error('received event not found');
-    expect(event.outcome).toBe('routed');
-    expect(event.matchedCount).toBe(1);
-    expect(event.processedAt).toBeInstanceOf(Date);
-    const decisions = await decisionsForEvent(event.id);
-    expect(decisions).toHaveLength(1);
-    expect(decisions[0]?.subscriptionId).toBe(subscription.id);
-    expect(decisions[0]?.decision).toBe('triggered');
-    expect(decisions[0]?.runId).toBe(run.id);
-    expect(decisions[0]?.reason).toBeNull();
   });
 });

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
@@ -1,66 +1,19 @@
 import type {IntegrationEventReceivedEvent} from '@shipfox/api-integration-core-dto';
-import {runWorkflow} from '@shipfox/api-workflows';
 import type {DomainEvent} from '@shipfox/node-outbox';
-import {readConfigInputs} from '#core/config.js';
-import {beginTriggerHistory, toReason} from '#core/record-trigger-history.js';
-import {findMatchingSubscriptions} from '#db/subscriptions.js';
+import {dispatchIntegrationEvent} from '#core/dispatch-integration-event.js';
 
-// Source-agnostic dispatcher: any inbound integration event fans out to every
-// workspace subscription registered for its (source, event), passing the raw
-// payload through untouched. The module knows nothing about github, gitlab, etc.
-// History is best-effort, but `runWorkflow` errors still re-throw so the outbox retries.
-// A transient failure converges to `routed` on replay; a permanent one (e.g. a deleted
-// definition) re-throws every retry, so the event stays `failed`. The recorded outcome
-// tracks reality; it is not a stuck state to recover from here.
 export async function onIntegrationEventReceived(
   envelope: IntegrationEventReceivedEvent,
   event: DomainEvent<IntegrationEventReceivedEvent>,
 ): Promise<void> {
-  const history = await beginTriggerHistory({
+  await dispatchIntegrationEvent({
     eventRef: event.id,
-    origin: 'integration',
     workspaceId: envelope.workspaceId,
     source: envelope.source,
     event: envelope.event,
     deliveryId: envelope.deliveryId,
     connectionId: envelope.connectionId,
-    payload: (envelope.payload ?? null) as Record<string, unknown> | null,
+    payload: envelope.payload,
     receivedAt: new Date(envelope.receivedAt),
   });
-
-  const subscriptions = await findMatchingSubscriptions({
-    workspaceId: envelope.workspaceId,
-    source: envelope.source,
-    event: envelope.event,
-  });
-
-  if (subscriptions.length === 0) {
-    await history.discarded();
-    return;
-  }
-
-  for (const subscription of subscriptions) {
-    try {
-      const run = await runWorkflow({
-        workspaceId: subscription.workspaceId,
-        projectId: subscription.projectId,
-        definitionId: subscription.workflowDefinitionId,
-        triggerPayload: {
-          source: envelope.source,
-          event: envelope.event,
-          deliveryId: envelope.deliveryId,
-          data: envelope.payload,
-        },
-        inputs: readConfigInputs(subscription),
-        triggerIdempotencyKey: `${subscription.id}:${event.id}`,
-      });
-      await history.triggered(subscription, run);
-    } catch (error) {
-      await history.errored(subscription, toReason(error));
-      await history.failed(subscriptions.length);
-      throw error;
-    }
-  }
-
-  await history.routed(subscriptions.length);
 }

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
@@ -10,8 +10,8 @@ import {findMatchingSubscriptions} from '#db/subscriptions.js';
 // payload through untouched. The module knows nothing about github, gitlab, etc.
 // History is best-effort, but `runWorkflow` errors still re-throw so the outbox retries.
 // A transient failure converges to `routed` on replay; a permanent one (e.g. a deleted
-// definition) re-throws every retry, so the event stays `failed` — the recorded outcome
-// tracking reality, not a stuck state to recover from here.
+// definition) re-throws every retry, so the event stays `failed`. The recorded outcome
+// tracks reality; it is not a stuck state to recover from here.
 export async function onIntegrationEventReceived(
   envelope: IntegrationEventReceivedEvent,
   event: DomainEvent<IntegrationEventReceivedEvent>,

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
@@ -2,34 +2,65 @@ import type {IntegrationEventReceivedEvent} from '@shipfox/api-integration-core-
 import {runWorkflow} from '@shipfox/api-workflows';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {readConfigInputs} from '#core/config.js';
+import {beginTriggerHistory, toReason} from '#core/record-trigger-history.js';
 import {findMatchingSubscriptions} from '#db/subscriptions.js';
 
 // Source-agnostic dispatcher: any inbound integration event fans out to every
 // workspace subscription registered for its (source, event), passing the raw
 // payload through untouched. The module knows nothing about github, gitlab, etc.
+// History is best-effort, but `runWorkflow` errors still re-throw so the outbox retries.
+// A transient failure converges to `routed` on replay; a permanent one (e.g. a deleted
+// definition) re-throws every retry, so the event stays `failed` — the recorded outcome
+// tracking reality, not a stuck state to recover from here.
 export async function onIntegrationEventReceived(
   envelope: IntegrationEventReceivedEvent,
   event: DomainEvent<IntegrationEventReceivedEvent>,
 ): Promise<void> {
+  const history = await beginTriggerHistory({
+    eventRef: event.id,
+    origin: 'integration',
+    workspaceId: envelope.workspaceId,
+    source: envelope.source,
+    event: envelope.event,
+    deliveryId: envelope.deliveryId,
+    connectionId: envelope.connectionId,
+    payload: (envelope.payload ?? null) as Record<string, unknown> | null,
+    receivedAt: new Date(envelope.receivedAt),
+  });
+
   const subscriptions = await findMatchingSubscriptions({
     workspaceId: envelope.workspaceId,
     source: envelope.source,
     event: envelope.event,
   });
 
-  for (const subscription of subscriptions) {
-    await runWorkflow({
-      workspaceId: subscription.workspaceId,
-      projectId: subscription.projectId,
-      definitionId: subscription.workflowDefinitionId,
-      triggerPayload: {
-        source: envelope.source,
-        event: envelope.event,
-        deliveryId: envelope.deliveryId,
-        data: envelope.payload,
-      },
-      inputs: readConfigInputs(subscription),
-      triggerIdempotencyKey: `${subscription.id}:${event.id}`,
-    });
+  if (subscriptions.length === 0) {
+    await history.discarded();
+    return;
   }
+
+  for (const subscription of subscriptions) {
+    try {
+      const run = await runWorkflow({
+        workspaceId: subscription.workspaceId,
+        projectId: subscription.projectId,
+        definitionId: subscription.workflowDefinitionId,
+        triggerPayload: {
+          source: envelope.source,
+          event: envelope.event,
+          deliveryId: envelope.deliveryId,
+          data: envelope.payload,
+        },
+        inputs: readConfigInputs(subscription),
+        triggerIdempotencyKey: `${subscription.id}:${event.id}`,
+      });
+      await history.triggered(subscription, run);
+    } catch (error) {
+      await history.errored(subscription, toReason(error));
+      await history.failed(subscriptions.length);
+      throw error;
+    }
+  }
+
+  await history.routed(subscriptions.length);
 }


### PR DESCRIPTION
Wires best-effort history recording into the trigger module's two write-path entry points — the integration outbox subscriber and manual fire — so every processed event and its per-subscription routing decisions are persisted to the two tables added in #264.

## Why

The trigger module was a stateless dispatcher that persisted nothing, so the cases operators most need to debug left no trace: an event that matched no subscription ("I pushed, why did nothing run?"), a handler that errored partway, and "this push matched 3 subscriptions — which runs came out, did any fail to start?". This is the write half of the trigger event history (ENG-546 / #264 added the schema; ENG-548+ add the read API and UI).

## Reliability invariant (the careful part)

Recording must never reduce job reliability:

- Every history write goes through a `safe()` wrapper that swallows and logs (ids + error only, never the payload or a token), so a triggers-DB outage cannot block a run.
- `runWorkflow`'s own error still re-throws exactly as before, so the outbox leaves the event undispatched and retries the whole handler; the recorded outcome converges to `routed` on replay.
- A created run's `triggered` decision is never downgraded to `errored` (a retry can re-throw if a definition was deleted between attempts), and a terminal `routed`/`discarded` event is never clobbered by a late `failed` write.

## Design notes for review

- Persistence lives in `db/event-history.ts`; the best-effort orchestration is a small recorder factory (`beginTriggerHistory`) in `core/record-trigger-history.ts`, shared by both entry points.
- Manual fire has no upstream event id, so `event_ref` is the created `run_id` on success and a synthesized uuid on failure. The `try` wraps only `runWorkflow` so a recorder bug cannot turn a created run into a reported failure.
- Idempotency: the received-event upsert keys on `event_ref`; the decision upsert keys on `(received_event_id, subscription_id)`, matching the existing `triggerIdempotencyKey` grain.

## Out of scope (tracked separately)

Retention/prune cron (ENG-549), read API + DTOs (ENG-548), client (ENG-550+). The eng review surfaced a pre-existing dispatch hole — a permanently-broken subscription starves its siblings, now visible via the history — tracked as ENG-557.

Closes ENG-547

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record trigger events and per-subscription decisions on the write path for integration dispatch and manual fires. Improves debuggability with best-effort persistence and stronger replay safety without reducing run reliability (ENG-547).

- New Features
  - Added `db/event-history` and `beginTriggerHistory` to persist received events and decisions; writes are best-effort and log ids only.
  - Moved integration dispatch into core: `dispatchIntegrationEvent` finds subscriptions, fans out runs with idempotency per `(subscription,eventRef)`, and records discarded/routed/failed outcomes and decisions; the subscriber now only adapts the envelope and delegates; dispatch tests moved to core.
  - Manual fire records routed/failed outcomes and decisions; uses the run id as `event_ref` on success or a UUID on failure; only wraps `runWorkflow` so recorder bugs cannot affect runs.
  - Reliability: never block runs; never downgrade `triggered` to `errored`; never downgrade `routed` via stale writes; replays converge `failed` to `routed`; failure reasons capped at 2000 chars and tolerate unstringifiable values.
  - Tests at the core boundary cover best-effort writes are attempted and swallowed, discard/routed transitions, fan-out with mixed outcomes, and idempotent replays; subscriber tests focus on envelope adaptation.

<sup>Written for commit 7dd4e462b7d5f71c49b38b0ff08e8a5f8f888601. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

