### PR TITLE
[api/auth] Fix optional chain lint warnings

### DIFF
--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -328,7 +328,7 @@ export async function refreshAccessToken(params: {
   }
 
   const user = await findUserById({id: current.userId});
-  if (!user || user.status !== 'active') {
+  if (user?.status !== 'active') {
     await revokeRefreshTokenByHash({hashedToken: currentHashedToken});
     throw new TokenInvalidError('Refresh token is invalid or expired');
   }
@@ -385,7 +385,7 @@ export async function confirmEmailVerification(params: {
   }
 
   const user = await markEmailVerified({userId: consumed.userId});
-  if (!user || user.status !== 'active') {
+  if (user?.status !== 'active') {
     throw new TokenInvalidError('Verification token is invalid or expired');
   }
 
@@ -415,7 +415,7 @@ export async function resendEmailVerification(params: {
 
 export async function requestPasswordReset(params: {email: string}): Promise<void> {
   const user = await findUserByEmail({email: params.email});
-  if (!user || user.status !== 'active') {
+  if (user?.status !== 'active') {
     return;
   }
 
@@ -452,7 +452,7 @@ export async function confirmPasswordReset(params: {
 
   const hashedPassword = await hashPassword({password: params.newPassword});
   const user = await updateUserPassword({userId: consumed.userId, hashedPassword});
-  if (!user || user.status !== 'active') {
+  if (user?.status !== 'active') {
     throw new TokenInvalidError('Reset token is invalid or expired');
   }
 


### PR DESCRIPTION
Use optional chaining for inactive-user checks in the auth core flows.

Biome reports these boolean expressions under complexity/useOptionalChain. This keeps the existing behavior while removing the warnings from scoped and full checks.

No changeset is included because this is a pure lint cleanup with no API or behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch user status checks to optional chaining in auth flows (`user?.status !== 'active'`) to clear Biome `complexity/useOptionalChain` warnings. No API or behavior changes.

<sup>Written for commit 01e4d31dc8ba2da61204c3cf176cc5933cfae738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

