### PR TITLE
[api/integration] Skip source pushes for inactive connections

### DIFF
--- a/.changeset/eng-555-skip-inactive-connection-pushes.md
+++ b/.changeset/eng-555-skip-inactive-connection-pushes.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-github": patch
+"@shipfox/api-integration-gitea": patch
+---
+
+Skip publishing source pushes for non-active integration connections. Both the GitHub and Gitea push webhook handlers now treat a connection whose `lifecycleStatus` is not `active` (disabled/error) like an unknown one: the delivery is recorded for dedup but no source-push event is published, so a disabled connection no longer triggers workflow runs.

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -171,6 +171,21 @@ describe('publishSourcePush', () => {
     expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(1);
     expect(await outboxFor(params.deliveryId)).toHaveLength(2);
   });
+
+  it('does not publish when the delivery was already recorded (record-only first)', async () => {
+    const params = buildSourcePushParams();
+    await recordDeliveryOnly({
+      tx: db(),
+      provider: params.provider,
+      deliveryId: params.deliveryId,
+    });
+
+    const result = await db().transaction((tx) => publishSourcePush({tx, ...params}));
+
+    expect(result.published).toBe(false);
+    expect(await deliveriesFor(params.provider, params.deliveryId)).toHaveLength(1);
+    expect(await outboxFor(params.deliveryId)).toHaveLength(0);
+  });
 });
 
 describe('publishSourceCommitPushed', () => {

--- a/libs/api/integration/gitea/src/core/webhook.test.ts
+++ b/libs/api/integration/gitea/src/core/webhook.test.ts
@@ -294,6 +294,42 @@ describe('handleGiteaWebhook', () => {
     });
   });
 
+  it.each([
+    'disabled',
+    'error',
+  ] as const)('records the delivery only when the connection is %s', async (lifecycleStatus) => {
+    const connection = fakeConnection({lifecycleStatus});
+    await seedConnection('shipfox', connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const rawBody = JSON.stringify(
+      giteaPushPayload({
+        owner: 'shipfox',
+        repo: 'api',
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: 'inactive',
+      }),
+    );
+
+    const result = await handleGiteaWebhook({
+      tx: db(),
+      deliveryId,
+      event: 'push',
+      rawBody,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('inactive-connection');
+    expect(handlers.getIntegrationConnectionById).toHaveBeenCalledTimes(1);
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+    expect(handlers.recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({
+      provider: 'gitea',
+      deliveryId,
+    });
+  });
+
   it('rejects malformed JSON', async () => {
     const handlers = deps();
 

--- a/libs/api/integration/gitea/src/core/webhook.ts
+++ b/libs/api/integration/gitea/src/core/webhook.ts
@@ -51,7 +51,12 @@ export interface HandleGiteaPushParams {
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
 }
 
-export type HandleGiteaPushOutcome = 'published' | 'duplicate' | 'deleted' | 'unknown-org';
+export type HandleGiteaPushOutcome =
+  | 'published'
+  | 'duplicate'
+  | 'deleted'
+  | 'unknown-org'
+  | 'inactive-connection';
 export type HandleGiteaWebhookOutcome = HandleGiteaPushOutcome | 'recorded-only';
 
 function isBranchDeletion(after: string): boolean {
@@ -118,6 +123,28 @@ export async function handleGiteaPush(
       deliveryId: params.deliveryId,
     });
     return {outcome: 'unknown-org'};
+  }
+
+  if (connection.lifecycleStatus !== 'active') {
+    const logContext = {
+      deliveryId: params.deliveryId,
+      org: owner,
+      connectionId: connection.id,
+      workspaceId: connection.workspaceId,
+      lifecycleStatus: connection.lifecycleStatus,
+    };
+    // `disabled` is an expected steady state; only `error` is anomalous.
+    if (connection.lifecycleStatus === 'error') {
+      logger().warn(logContext, 'gitea webhook: connection in error state, dropping');
+    } else {
+      logger().info(logContext, 'gitea webhook: connection disabled, dropping');
+    }
+    await params.recordDeliveryOnly({
+      tx: params.tx,
+      provider: giteaProviderKind,
+      deliveryId: params.deliveryId,
+    });
+    return {outcome: 'inactive-connection'};
   }
 
   const ref = stripRefsHeads(params.payload.ref);

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -29,6 +29,7 @@ export type HandleGithubPushOutcome =
   | 'duplicate'
   | 'deleted'
   | 'unknown-installation'
+  | 'inactive-connection'
   | 'no-installation-id';
 
 function isBranchDeletion(after: string): boolean {
@@ -80,6 +81,28 @@ export async function handleGithubPush(
       deliveryId: params.deliveryId,
     });
     return {outcome: 'unknown-installation'};
+  }
+
+  if (connection.lifecycleStatus !== 'active') {
+    const logContext = {
+      deliveryId: params.deliveryId,
+      installationId,
+      connectionId: connection.id,
+      workspaceId: connection.workspaceId,
+      lifecycleStatus: connection.lifecycleStatus,
+    };
+    // `disabled` is an expected steady state; only `error` is anomalous.
+    if (connection.lifecycleStatus === 'error') {
+      logger().warn(logContext, 'github webhook: connection in error state, dropping');
+    } else {
+      logger().info(logContext, 'github webhook: connection disabled, dropping');
+    }
+    await params.recordDeliveryOnly({
+      tx: params.tx,
+      provider: GITHUB_SOURCE,
+      deliveryId: params.deliveryId,
+    });
+    return {outcome: 'inactive-connection'};
   }
 
   const ref = stripRefsHeads(params.payload.ref);

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -274,6 +274,40 @@ describe('GitHub webhook route', () => {
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
+  it.each([
+    'disabled',
+    'error',
+  ] as const)('records the delivery only when the connection is %s', async (lifecycleStatus) => {
+    const installationId = 7782;
+    const connection = fakeConnection({lifecycleStatus});
+    const {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById} =
+      await createTestApp({connection});
+    await seedInstallation(installationId, connection.id);
+    const deliveryId = randomUUID();
+    const body = JSON.stringify(
+      githubPushPayload({
+        installationId,
+        repositoryId: 302,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: 'inactive',
+      }),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/github',
+      headers: signedHeaders(body, 'push', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(getIntegrationConnectionById).toHaveBeenCalledTimes(1);
+    expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+    expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
+  });
+
   it('ignores pushes whose payload has no installation id', async () => {
     const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();


### PR DESCRIPTION
Both the GitHub and Gitea push webhook handlers published a source-push as soon as a connection row existed, regardless of its `lifecycleStatus`. A connection that has been disabled (or in an error state) would still fan out `INTEGRATION_EVENT_RECEIVED` (triggers) and `INTEGRATION_SOURCE_COMMIT_PUSHED` (projects), starting workflow runs.

This guards both handlers: a non-active connection is now treated like an unknown one — the delivery is recorded for dedup, but nothing is published, so a disabled connection no longer triggers runs.

## Notes for review
- **Per-handler guard, not centralized.** The check is a domain policy and the connection (with `lifecycleStatus`) is already in hand after the existing `if (!connection)` block. Pushing it into `publishSourcePush` was rejected: that db-layer function takes only `connectionId`, has no lifecycle status, and would need a `recordDeliveryOnly` fallback plus a new return shape. The guard mirrors the precedent at `core/src/core/source-control-service.ts`.
- **Fail-closed** on `!== 'active'`: only an explicitly active connection may start runs. Today only `disabled` is ever assigned in source (sentry uninstall); `error` exists in the enum but no code path sets it yet, so the two non-active states are behaviorally equivalent here.
- **Log level:** `disabled` is an expected steady state (a still-installed app keeps sending pushes), so it logs at `info`; `warn` is reserved for the anomalous `error` state. Both include `workspaceId`.
- **Dedup-suppression is intentional and now tested.** Routing inactive connections through `recordDeliveryOnly` writes the same dedup row `publishSourcePush` checks, so a later publish of that exact delivery id is suppressed. A new core test in `webhook-deliveries.test.ts` proves it (record-only then publish same id → `published: false`, no outbox) — a gap the existing suite didn't cover.

Both providers keep their existing happy-path tests (active connection still publishes), which double as the regression guard for the new branch. New `it.each(['disabled', 'error'])` tests cover both non-active states on each handler.

Closes ENG-555

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops publishing source pushes for non-active GitHub and Gitea connections. Disabled or error connections now only record the delivery for dedup and don’t trigger runs (ENG-555).

- **Bug Fixes**
  - Added per-handler guard to treat `lifecycleStatus !== 'active'` as inactive: record via `recordDeliveryOnly`, publish nothing, return `inactive-connection`.
  - Logging: disabled at info, error at warn; includes `workspaceId`.
  - Tests: core dedup suppression (record-only then publish → suppressed) and provider tests for disabled/error; active path unchanged.

<sup>Written for commit 819854c899f9f9107fc7b2a623ad5e5e9d15f2f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

