### PR TITLE
Validate outbox event payloads at the drain boundary

### DIFF
--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -129,4 +129,47 @@ describe('drainAndDispatch', () => {
 
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
   });
+
+  it('isolates a poison row: dispatches valid siblings in the same drain, leaves the invalid one undispatched', async () => {
+    const error = {issues: [{path: ['jobId'], code: 'invalid_type', message: 'expected string'}]};
+    const validJob: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'workflows.job.terminated',
+      createdAt: new Date(),
+      payload: {jobId: 'job-1', runId: 'run-1', status: 'succeeded'},
+    };
+    const poison: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'workflows.job.terminated',
+      createdAt: new Date(),
+      payload: {jobId: 123},
+    };
+    const validPush: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'integrations.source_control.commit_pushed',
+      createdAt: new Date(),
+      payload: {deliveryId: 'delivery-1'},
+    };
+    const handler = vi.fn().mockResolvedValue(undefined);
+    mocks.drainAll.mockResolvedValueOnce([
+      {id: validJob.id, source: 'workflows', event: validJob},
+      {id: poison.id, source: 'workflows', event: poison},
+      {id: validPush.id, source: 'integrations', event: validPush},
+    ]);
+    mocks.getEventSchema
+      .mockReturnValueOnce({safeParse: () => ({success: true, data: validJob.payload})})
+      .mockReturnValueOnce({safeParse: () => ({success: false, error})})
+      .mockReturnValueOnce({safeParse: () => ({success: true, data: validPush.payload})});
+    mocks.getSubscribers.mockReturnValue([handler]);
+
+    await drainAndDispatch();
+
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [validJob.id]);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', [validPush.id]);
+    expect(mocks.markDispatched).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(mocks.captureException).toHaveBeenCalledWith(error, {
+      extra: {eventType: poison.type, eventId: poison.id, issues: error.issues},
+    });
+  });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -4,6 +4,7 @@ import {drainAndDispatch} from './drain-and-dispatch.js';
 const mocks = vi.hoisted(() => ({
   captureException: vi.fn(),
   drainAll: vi.fn(),
+  getEventSchema: vi.fn(),
   getSubscribers: vi.fn(),
   markDispatched: vi.fn(),
   errorLog: vi.fn(),
@@ -15,6 +16,7 @@ vi.mock('@shipfox/node-error-monitoring', () => ({
 
 vi.mock('@shipfox/node-module', () => ({
   drainAll: mocks.drainAll,
+  getEventSchema: mocks.getEventSchema,
   getSubscribers: mocks.getSubscribers,
   markDispatched: mocks.markDispatched,
 }));
@@ -29,6 +31,7 @@ describe('drainAndDispatch', () => {
   beforeEach(() => {
     mocks.captureException.mockReset();
     mocks.drainAll.mockReset();
+    mocks.getEventSchema.mockReset();
     mocks.getSubscribers.mockReset();
     mocks.markDispatched.mockReset();
     mocks.errorLog.mockReset();
@@ -67,5 +70,63 @@ describe('drainAndDispatch', () => {
       },
     });
     expect(mocks.markDispatched).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed payload at the drain: skips handlers and leaves the row undispatched', async () => {
+    const error = {issues: [{path: ['jobId'], code: 'invalid_type', message: 'expected string'}]};
+    const event: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'workflows.job.terminated',
+      createdAt: new Date(),
+      payload: {jobId: 123},
+    };
+    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'workflows', event}]);
+    mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: false, error})});
+
+    await drainAndDispatch();
+
+    expect(mocks.getSubscribers).not.toHaveBeenCalled();
+    expect(mocks.markDispatched).not.toHaveBeenCalled();
+    expect(mocks.captureException).toHaveBeenCalledWith(error, {
+      extra: {eventType: event.type, eventId: event.id, issues: error.issues},
+    });
+  });
+
+  it('passes the parsed payload to handlers when validation succeeds', async () => {
+    const parsed = {jobId: 'job-1', runId: 'run-1', status: 'succeeded'};
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const event: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'workflows.job.terminated',
+      createdAt: new Date(),
+      payload: {...parsed, extra: 'raw'},
+    };
+    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'workflows', event}]);
+    mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: true, data: parsed})});
+    mocks.getSubscribers.mockReturnValueOnce([handler]);
+
+    await drainAndDispatch();
+
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({type: event.type, payload: parsed}),
+    );
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+  });
+
+  it('validates and dispatches a valid event that has no subscribers', async () => {
+    const parsed = {runId: 'run-1', projectId: 'proj-1', status: 'failed'};
+    const event: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'workflows.workflow_run.terminated',
+      createdAt: new Date(),
+      payload: parsed,
+    };
+    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'workflows', event}]);
+    mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: true, data: parsed})});
+    mocks.getSubscribers.mockReturnValueOnce([]);
+
+    await drainAndDispatch();
+
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -1,5 +1,11 @@
 import {captureException} from '@shipfox/node-error-monitoring';
-import {drainAll, getSubscribers, markDispatched} from '@shipfox/node-module';
+import {
+  type DrainedEvent,
+  drainAll,
+  getEventSchema,
+  getSubscribers,
+  markDispatched,
+} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 
 export async function drainAndDispatch(): Promise<void> {
@@ -9,17 +15,20 @@ export async function drainAndDispatch(): Promise<void> {
   const dispatched = new Map<string, string[]>();
 
   for (const row of rows) {
-    const handlers = getSubscribers(row.event.type);
+    const event = validatePayload(row);
+    if (!event) continue;
+
+    const handlers = getSubscribers(event.type);
     let allSucceeded = true;
 
     for (const handler of handlers) {
       try {
-        await handler(row.event);
+        await handler(event);
       } catch (error) {
         const errorContext = {
-          eventType: row.event.type,
+          eventType: event.type,
           eventId: row.id,
-          eventPayload: row.event.payload,
+          eventPayload: event.payload,
         };
         logger().error({err: error, ...errorContext}, 'Handler failed for outbox event');
         captureException(error, {extra: errorContext});
@@ -37,4 +46,22 @@ export async function drainAndDispatch(): Promise<void> {
   for (const [source, ids] of dispatched) {
     await markDispatched(source, ids);
   }
+}
+
+/**
+ * Invalid rows stay undispatched so they can be retried after the publisher or
+ * schema is fixed. Log Zod issue paths instead of raw payloads because deterministic
+ * failures recur on every drain.
+ */
+function validatePayload(row: DrainedEvent): DrainedEvent['event'] | null {
+  const schema = getEventSchema(row.event.type);
+  if (!schema) return row.event;
+
+  const result = schema.safeParse(row.event.payload);
+  if (result.success) return {...row.event, payload: result.data};
+
+  const errorContext = {eventType: row.event.type, eventId: row.id, issues: result.error.issues};
+  logger().error({err: result.error, ...errorContext}, 'Invalid outbox payload at drain');
+  captureException(result.error, {extra: errorContext});
+  return null;
 }

--- a/libs/api/integration/core-dto/src/events.test.ts
+++ b/libs/api/integration/core-dto/src/events.test.ts
@@ -1,0 +1,49 @@
+import {integrationSourceCommitPushedSchema} from './events.js';
+
+const validCommitPushed = {
+  provider: 'github',
+  workspaceId: 'ws-1',
+  connectionId: 'conn-1',
+  deliveryId: 'delivery-1',
+  receivedAt: '2026-06-21T00:00:00.000Z',
+  push: {
+    externalRepositoryId: 'acme/repo',
+    ref: 'refs/heads/main',
+    headCommitSha: 'abc123',
+    defaultBranch: 'main',
+    isDefaultBranch: true,
+  },
+};
+
+describe('integrationSourceCommitPushedSchema', () => {
+  it('parses a valid commit-pushed payload unchanged', () => {
+    const result = integrationSourceCommitPushedSchema.parse(validCommitPushed);
+
+    expect(result).toEqual(validCommitPushed);
+  });
+
+  it('rejects a payload missing a top-level field', () => {
+    const {provider: _provider, ...withoutProvider} = validCommitPushed;
+
+    const parse = () => integrationSourceCommitPushedSchema.parse(withoutProvider);
+
+    expect(parse).toThrow();
+  });
+
+  it('rejects a payload missing a nested push field', () => {
+    const {headCommitSha: _headCommitSha, ...pushWithoutSha} = validCommitPushed.push;
+    const input = {...validCommitPushed, push: pushWithoutSha};
+
+    const parse = () => integrationSourceCommitPushedSchema.parse(input);
+
+    expect(parse).toThrow();
+  });
+
+  it('strips unknown keys (tolerant of forward-compatible producer additions)', () => {
+    const input = {...validCommitPushed, addedLater: 'ignored'};
+
+    const result = integrationSourceCommitPushedSchema.parse(input);
+
+    expect(result).toEqual(validCommitPushed);
+  });
+});

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -78,4 +78,4 @@ export interface IntegrationsEventMap {
 
 export const integrationsEventSchemas = {
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: integrationSourceCommitPushedSchema,
-};
+} satisfies Partial<Record<keyof IntegrationsEventMap, z.ZodType>>;

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod';
+
 export const INTEGRATION_EVENT_RECEIVED = 'integrations.event.received' as const;
 
 export interface IntegrationEventReceivedEvent {
@@ -13,13 +15,14 @@ export interface IntegrationEventReceivedEvent {
 // A source-control push, normalized by the producing provider. Carried both as the
 // generic `INTEGRATION_EVENT_RECEIVED` envelope payload (consumed opaquely by triggers)
 // and nested inside `INTEGRATION_SOURCE_COMMIT_PUSHED` (consumed by domain modules).
-export interface SourcePushPayload {
-  externalRepositoryId: string;
-  ref: string;
-  headCommitSha: string;
-  defaultBranch: string;
-  isDefaultBranch: boolean;
-}
+export const sourcePushSchema = z.object({
+  externalRepositoryId: z.string(),
+  ref: z.string(),
+  headCommitSha: z.string(),
+  defaultBranch: z.string(),
+  isDefaultBranch: z.boolean(),
+});
+export type SourcePushPayload = z.infer<typeof sourcePushSchema>;
 
 export const INTEGRATION_SOURCE_COMMIT_PUSHED =
   'integrations.source_control.commit_pushed' as const;
@@ -27,14 +30,17 @@ export const INTEGRATION_SOURCE_COMMIT_PUSHED =
 // Typed, provider-agnostic source-control event. The producing provider owns the
 // translation from its raw webhook into this shape, so domain consumers never decode
 // provider payloads. `isDefaultBranch` is a fact; the branch policy lives in the consumer.
-export interface IntegrationSourceCommitPushedEvent {
-  provider: string;
-  workspaceId: string;
-  connectionId: string;
-  deliveryId: string;
-  receivedAt: string;
-  push: SourcePushPayload;
-}
+export const integrationSourceCommitPushedSchema = z.object({
+  provider: z.string(),
+  workspaceId: z.string(),
+  connectionId: z.string(),
+  deliveryId: z.string(),
+  receivedAt: z.string(),
+  push: sourcePushSchema,
+});
+export type IntegrationSourceCommitPushedEvent = z.infer<
+  typeof integrationSourceCommitPushedSchema
+>;
 
 export interface SentryIssuePayload {
   action: SentryIssueAction;
@@ -69,3 +75,7 @@ export interface IntegrationsEventMap {
   [INTEGRATION_EVENT_RECEIVED]: IntegrationEventReceivedEvent;
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: IntegrationSourceCommitPushedEvent;
 }
+
+export const integrationsEventSchemas = {
+  [INTEGRATION_SOURCE_COMMIT_PUSHED]: integrationSourceCommitPushedSchema,
+};

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -1,5 +1,6 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {integrationsEventSchemas} from '@shipfox/api-integration-core-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {IntegrationProvider} from '#core/entities/provider.js';
@@ -136,7 +137,9 @@ export async function createIntegrationsContext(
       ...parts.flatMap((part) => (part.database ? [part.database] : [])),
     ],
     routes: createIntegrationRoutes(registry, sourceControl),
-    publishers: [{name: 'integrations', table: integrationsOutbox, db}],
+    publishers: [
+      {name: 'integrations', table: integrationsOutbox, db, eventSchemas: integrationsEventSchemas},
+    ],
     workers: [
       {
         taskQueue: INTEGRATIONS_MAINTENANCE_TASK_QUEUE,

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -1,0 +1,61 @@
+import {workflowsJobTerminatedSchema, workflowsWorkflowRunTerminatedSchema} from './events.js';
+
+const validJobTerminated = {
+  jobId: 'job-1',
+  runId: 'run-1',
+  status: 'succeeded',
+};
+
+const validRunTerminated = {
+  runId: 'run-1',
+  projectId: 'proj-1',
+  status: 'failed',
+};
+
+describe('workflowsJobTerminatedSchema', () => {
+  it('parses a valid job-terminated payload unchanged', () => {
+    const result = workflowsJobTerminatedSchema.parse(validJobTerminated);
+
+    expect(result).toEqual(validJobTerminated);
+  });
+
+  it('rejects a payload missing a required field', () => {
+    const {runId: _runId, ...withoutRunId} = validJobTerminated;
+
+    const parse = () => workflowsJobTerminatedSchema.parse(withoutRunId);
+
+    expect(parse).toThrow();
+  });
+
+  it('rejects a status outside the terminal set', () => {
+    const input = {...validJobTerminated, status: 'running'};
+
+    const parse = () => workflowsJobTerminatedSchema.parse(input);
+
+    expect(parse).toThrow();
+  });
+
+  it('strips unknown keys (tolerant of forward-compatible producer additions)', () => {
+    const input = {...validJobTerminated, addedLater: 'ignored'};
+
+    const result = workflowsJobTerminatedSchema.parse(input);
+
+    expect(result).toEqual(validJobTerminated);
+  });
+});
+
+describe('workflowsWorkflowRunTerminatedSchema', () => {
+  it('parses a valid run-terminated payload unchanged', () => {
+    const result = workflowsWorkflowRunTerminatedSchema.parse(validRunTerminated);
+
+    expect(result).toEqual(validRunTerminated);
+  });
+
+  it('rejects a payload missing a required field', () => {
+    const {projectId: _projectId, ...withoutProjectId} = validRunTerminated;
+
+    const parse = () => workflowsWorkflowRunTerminatedSchema.parse(withoutProjectId);
+
+    expect(parse).toThrow();
+  });
+});

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -58,4 +58,20 @@ describe('workflowsWorkflowRunTerminatedSchema', () => {
 
     expect(parse).toThrow();
   });
+
+  it('rejects a status outside the terminal set', () => {
+    const input = {...validRunTerminated, status: 'running'};
+
+    const parse = () => workflowsWorkflowRunTerminatedSchema.parse(input);
+
+    expect(parse).toThrow();
+  });
+
+  it('strips unknown keys (tolerant of forward-compatible producer additions)', () => {
+    const input = {...validRunTerminated, addedLater: 'ignored'};
+
+    const result = workflowsWorkflowRunTerminatedSchema.parse(input);
+
+    expect(result).toEqual(validRunTerminated);
+  });
 });

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -77,4 +77,4 @@ export interface WorkflowsEventMap {
 export const workflowsEventSchemas = {
   [WORKFLOWS_WORKFLOW_RUN_TERMINATED]: workflowsWorkflowRunTerminatedSchema,
   [WORKFLOWS_JOB_TERMINATED]: workflowsJobTerminatedSchema,
-};
+} satisfies Partial<Record<keyof WorkflowsEventMap, z.ZodType>>;

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod';
+
 export const WORKFLOWS_WORKFLOW_RUN_CREATED = 'workflows.workflow_run.created' as const;
 // Terminal fact for a workflow run, written in the same transaction as the status flip.
 export const WORKFLOWS_WORKFLOW_RUN_TERMINATED = 'workflows.workflow_run.terminated' as const;
@@ -23,22 +25,30 @@ export interface WorkflowsWorkflowRunCreatedEvent {
   definitionId: string;
 }
 
-export interface WorkflowsWorkflowRunTerminatedEvent {
-  runId: string;
-  projectId: string;
-  status: 'succeeded' | 'failed' | 'cancelled';
-}
+// Keep outbox terminal statuses narrower than runStatusSchema, which also
+// carries pending/running.
+export const terminalStatusSchema = z.enum(['succeeded', 'failed', 'cancelled']);
+
+export const workflowsWorkflowRunTerminatedSchema = z.object({
+  runId: z.string(),
+  projectId: z.string(),
+  status: terminalStatusSchema,
+});
+export type WorkflowsWorkflowRunTerminatedEvent = z.infer<
+  typeof workflowsWorkflowRunTerminatedSchema
+>;
 
 export interface WorkflowsJobTimedOutEvent {
   jobId: string;
   runId: string;
 }
 
-export interface WorkflowsJobTerminatedEvent {
-  jobId: string;
-  runId: string;
-  status: 'succeeded' | 'failed' | 'cancelled';
-}
+export const workflowsJobTerminatedSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+  status: terminalStatusSchema,
+});
+export type WorkflowsJobTerminatedEvent = z.infer<typeof workflowsJobTerminatedSchema>;
 
 export interface WorkflowsJobStepsSettledEvent {
   jobId: string;
@@ -63,3 +73,8 @@ export interface WorkflowsEventMap {
   [WORKFLOWS_JOB_STEPS_SETTLED]: WorkflowsJobStepsSettledEvent;
   [WORKFLOWS_STEP_RESTART_ENQUEUED]: WorkflowsStepRestartEnqueuedEvent;
 }
+
+export const workflowsEventSchemas = {
+  [WORKFLOWS_WORKFLOW_RUN_TERMINATED]: workflowsWorkflowRunTerminatedSchema,
+  [WORKFLOWS_JOB_TERMINATED]: workflowsJobTerminatedSchema,
+};

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -39,6 +39,7 @@ export {
   stepErrorReasonSchema,
 } from '#schemas/index.js';
 export {
+  terminalStatusSchema,
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
@@ -52,4 +53,7 @@ export {
   type WorkflowsStepRestartEnqueuedEvent,
   type WorkflowsWorkflowRunCreatedEvent,
   type WorkflowsWorkflowRunTerminatedEvent,
+  workflowsEventSchemas,
+  workflowsJobTerminatedSchema,
+  workflowsWorkflowRunTerminatedSchema,
 } from './events.js';

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -39,7 +39,6 @@ export {
   stepErrorReasonSchema,
 } from '#schemas/index.js';
 export {
-  terminalStatusSchema,
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
@@ -54,6 +53,4 @@ export {
   type WorkflowsWorkflowRunCreatedEvent,
   type WorkflowsWorkflowRunTerminatedEvent,
   workflowsEventSchemas,
-  workflowsJobTerminatedSchema,
-  workflowsWorkflowRunTerminatedSchema,
 } from './events.js';

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -5,6 +5,7 @@ import {
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
   type WorkflowsEventMap,
+  workflowsEventSchemas,
 } from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
@@ -31,7 +32,9 @@ export const workflowsModule: ShipfoxModule = {
   name: 'workflows',
   database: {db, migrationsPath},
   routes,
-  publishers: [{name: 'workflows', table: workflowsOutbox, db}],
+  publishers: [
+    {name: 'workflows', table: workflowsOutbox, db, eventSchemas: workflowsEventSchemas},
+  ],
   subscribers: [
     subscriber(WORKFLOWS_WORKFLOW_RUN_CREATED, onWorkflowRunCreated),
     subscriber(WORKFLOWS_JOB_STEPS_SETTLED, onJobStepsSettled),

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -42,7 +42,8 @@
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",
-    "drizzle-orm": "^0.45.2"
+    "drizzle-orm": "^0.45.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -6,6 +6,7 @@ export {initializeModules, startModuleWorkers} from './initialize.js';
 export type {DrainedEvent} from './publisher-registry.js';
 export {
   drainAll,
+  getEventSchema,
   markDispatched,
   registerPublisher,
   resetPublishers,

--- a/libs/shared/node/module/src/publisher-registry.test.ts
+++ b/libs/shared/node/module/src/publisher-registry.test.ts
@@ -1,0 +1,51 @@
+import {createOutboxTable} from '@shipfox/node-outbox';
+import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+import {z} from 'zod';
+import {getEventSchema, registerPublisher, resetPublishers} from './publisher-registry.js';
+
+const table = createOutboxTable(pgTableCreator((name) => name));
+const db = (() => undefined) as unknown as () => NodePgDatabase<Record<string, unknown>>;
+const fooSchema = z.object({id: z.string()});
+
+describe('getEventSchema', () => {
+  beforeEach(() => {
+    resetPublishers();
+  });
+
+  afterEach(() => {
+    resetPublishers();
+  });
+
+  it('returns the schema a publisher registered for an event type', () => {
+    registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
+
+    const schema = getEventSchema('foo.created');
+
+    expect(schema).toBe(fooSchema);
+  });
+
+  it('returns undefined for an event type with no registered schema', () => {
+    registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
+
+    const schema = getEventSchema('foo.unknown');
+
+    expect(schema).toBeUndefined();
+  });
+
+  it('returns undefined for a publisher that registered no schemas', () => {
+    registerPublisher({name: 'bar', table, db});
+
+    const schema = getEventSchema('bar.created');
+
+    expect(schema).toBeUndefined();
+  });
+
+  it('forgets registered schemas after resetPublishers', () => {
+    registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
+
+    resetPublishers();
+
+    expect(getEventSchema('foo.created')).toBeUndefined();
+  });
+});

--- a/libs/shared/node/module/src/publisher-registry.test.ts
+++ b/libs/shared/node/module/src/publisher-registry.test.ts
@@ -7,6 +7,7 @@ import {getEventSchema, registerPublisher, resetPublishers} from './publisher-re
 const table = createOutboxTable(pgTableCreator((name) => name));
 const db = (() => undefined) as unknown as () => NodePgDatabase<Record<string, unknown>>;
 const fooSchema = z.object({id: z.string()});
+const CONFLICTING_SCHEMA = /Conflicting outbox event schema/;
 
 describe('getEventSchema', () => {
   beforeEach(() => {
@@ -47,5 +48,24 @@ describe('getEventSchema', () => {
     resetPublishers();
 
     expect(getEventSchema('foo.created')).toBeUndefined();
+  });
+
+  it('throws when two publishers register a different schema for the same event type', () => {
+    const otherSchema = z.object({id: z.string()});
+    registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
+
+    const register = () =>
+      registerPublisher({name: 'bar', table, db, eventSchemas: {'foo.created': otherSchema}});
+
+    expect(register).toThrow(CONFLICTING_SCHEMA);
+  });
+
+  it('allows re-registering the identical schema for an event type', () => {
+    registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
+
+    const register = () =>
+      registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
+
+    expect(register).not.toThrow();
   });
 });

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -1,11 +1,13 @@
 import type {DomainEvent, OutboxTable} from '@shipfox/node-outbox';
 import {asc, inArray, isNull, sql} from 'drizzle-orm';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import type {ZodType} from 'zod';
 
 interface PublisherSource {
   name: string;
   table: OutboxTable;
   db: () => NodePgDatabase<Record<string, unknown>>;
+  eventSchemas?: Record<string, ZodType>;
 }
 
 export interface DrainedEvent {
@@ -20,6 +22,18 @@ const BATCH_SIZE = 100;
 
 export function registerPublisher(config: PublisherSource): void {
   _sources.push(config);
+}
+
+/**
+ * Event types are namespaced per module, so the registry treats the first schema
+ * match as the event owner instead of resolving collisions.
+ */
+export function getEventSchema(type: string): ZodType | undefined {
+  for (const source of _sources) {
+    const schema = source.eventSchemas?.[type];
+    if (schema) return schema;
+  }
+  return undefined;
 }
 
 export async function drainAll(): Promise<DrainedEvent[]> {

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -17,23 +17,29 @@ export interface DrainedEvent {
 }
 
 const _sources: PublisherSource[] = [];
+const _schemasByType = new Map<string, ZodType>();
 
 const BATCH_SIZE = 100;
 
 export function registerPublisher(config: PublisherSource): void {
   _sources.push(config);
+
+  for (const [type, schema] of Object.entries(config.eventSchemas ?? {})) {
+    const existing = _schemasByType.get(type);
+    // Each event type is namespaced to one owning module, so two publishers claiming the
+    // same type is a misconfiguration. Fail loudly at startup rather than silently keeping
+    // one and masking the drift. A module re-registering its own schema is a no-op.
+    if (existing && existing !== schema) {
+      throw new Error(
+        `Conflicting outbox event schema for "${type}": registered by more than one publisher. Each event type must have exactly one owning publisher.`,
+      );
+    }
+    _schemasByType.set(type, schema);
+  }
 }
 
-/**
- * Event types are namespaced per module, so the registry treats the first schema
- * match as the event owner instead of resolving collisions.
- */
 export function getEventSchema(type: string): ZodType | undefined {
-  for (const source of _sources) {
-    const schema = source.eventSchemas?.[type];
-    if (schema) return schema;
-  }
-  return undefined;
+  return _schemasByType.get(type);
 }
 
 export async function drainAll(): Promise<DrainedEvent[]> {
@@ -80,4 +86,5 @@ export async function markDispatched(source: string, ids: string[]): Promise<voi
 
 export function resetPublishers(): void {
   _sources.length = 0;
+  _schemasByType.clear();
 }

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -1,6 +1,7 @@
 import type {AuthMethod, RouteExport} from '@shipfox/node-fastify';
 import type {OutboxTable} from '@shipfox/node-outbox';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
+import type {ZodType} from 'zod';
 import type {ModuleSubscriber} from './subscriber.js';
 
 export interface ModuleDatabase {
@@ -21,6 +22,13 @@ export interface ModulePublisher {
   name: string;
   table: OutboxTable;
   db: () => NodePgDatabase<Record<string, unknown>>;
+  /**
+   * Optional schemas for events this publisher writes. Omitted entries preserve
+   * the historical unchecked payload path; new entries should live in the
+   * producing module's `*-dto` package so payload types and validation share one
+   * contract.
+   */
+  eventSchemas?: Record<string, ZodType>;
 }
 
 export interface WorkflowStart {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3190,6 +3190,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Outbox payloads arrive as `unknown` from a JSONB column and were cast unchecked (`e.payload as TMap[K]`) before reaching handlers, so a malformed, schema-drifted, or legacy row could hand a handler a payload TypeScript believed was complete and fail silently inside it.

Each producing module now registers a Zod schema per event type on its existing publisher (`eventSchemas` on `ModulePublisher`), and the dispatcher validates every drained payload at the boundary before dispatch: on success the parsed payload replaces `event.payload` (so both handler arguments are validated); on failure the row is logged (issue paths only, not the raw payload) and reported to Sentry, then left undispatched instead of dispatched as if valid. Validation covers the whole event stream, including events with no subscriber yet (e.g. `workflows.workflow_run.terminated`).

## Design notes

- **Drain-level, not consumer-level.** Validating only when a handler consumes an event would leave unsubscribed events unchecked. Schemas hang off the existing publisher registration, so there is no new central registry and no new import edge: `@shipfox/node-module` imports no feature/dto package, and schemas flow in as data at init exactly like Drizzle tables and handlers already do.
- **Schemas live in the `*-dto` packages** next to the event maps, with payload types derived via `z.infer` so schema and type cannot drift (matches the existing dto convention). `z.object` strips unknown keys by default, so the stream tolerates forward-compatible producer additions across rolling deploys while handlers see only declared fields.
- **Failure behavior.** A validation failure is deterministically permanent, so it re-drains and re-alerts every cycle — accepted for now (identical to existing handler-error behavior; no real poison rows pre-deployment). Unified poison-row handling (bounded retry / dead-letter) and sanitizing the raw payload the existing handler-error path sends to Sentry are tracked separately in ENG-559.

## Notes for reviewers

- No changeset: every touched package (`@shipfox/node-module`, both `*-dto` packages, the producer modules, the dispatcher) is `private: true` and not published to npm.
- Candidate events covered: `integrations.source_control.commit_pushed`, `workflows.job.terminated`, `workflows.workflow_run.terminated`.

Closes ENG-517

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate outbox event payloads at the drain boundary using publisher-registered `zod` schemas so handlers only receive trusted data; malformed rows are logged to Sentry and left undispatched, closing ENG-517.

- **New Features**
  - Validate drained payloads via publisher `eventSchemas`; pass parsed payloads to handlers.
  - On failure, log issue paths to Sentry and skip dispatch so rows can be retried; poison rows are isolated so valid siblings still dispatch.
  - Validate all events (including ones without subscribers); unknown keys are stripped for forward compatibility.
  - Added schemas for `workflows.job.terminated`, `workflows.workflow_run.terminated`, and `integrations.source_control.commit_pushed` in `@shipfox/api-workflows-dto` and `@shipfox/api-integration-core-dto`, registered on publishers; schema maps use `satisfies Partial<Record<keyof EventMap, z.ZodType>>` to catch key drift.
  - Detect conflicting schemas at registration and throw to prevent misconfiguration; dispatcher uses `getEventSchema` for lookups.

- **Dependencies**
  - Added `zod` to `@shipfox/node-module`.

<sup>Written for commit 0b9904d6baaa9565d1ce55f6fd745b4f7bc100d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

