### PR TITLE
[react-ui] Add design-sync state for the design system

### DIFF
--- a/libs/shared/react/ui/.design-sync/NOTES.md
+++ b/libs/shared/react/ui/.design-sync/NOTES.md
@@ -1,0 +1,45 @@
+# design-sync notes — @shipfox/react-ui
+
+Storybook-shape sync. Bundle global: `window.ShipfoxReactUi`. 31 components, 89 stories.
+
+## Build / config learnings
+
+- [GENERAL] **dist `.d.ts` are emitted separately from the JS build.** The package `build`
+  script is `shipfox-swc --copy-files && build:css` — it emits `.js` + `styles.css` but
+  NOT `.d.ts`. Type declarations come from `type:emit` (`shipfox-tsc-emit`). On first sync
+  the committed dist had stale `.d.ts` (missing empty-state + load-error-state entirely),
+  so the converter's `exportedNames` (ts-morph over `dist/index.d.ts`) dropped EmptyState +
+  LoadErrorState as "not public exports". Fix: run `turbo run type:emit --filter=@shipfox/react-ui`
+  before the converter so dist `.d.ts` matches the JS. Re-run it whenever components are
+  added/removed. (`buildCmd` runs `build` only — type:emit is a manual prerequisite.)
+- **titleMap**: story titles `Components/Loader` and `Components/Toast` use component
+  vars `ShipfoxLoader` and `Toaster`. Mapped via `cfg.titleMap`. EmptyState/LoadErrorState
+  match by name once their `.d.ts` exist (see above).
+- **Theme / provider**: `.storybook/preview.tsx` wraps stories in `ThemeProvider`
+  (`#components/theme`) which adds a `.light`/`.dark` class to `<html>`. Tokens default to
+  light at `:root` in styles.css (there is NO `.light` block — only `.dark` overrides), so
+  **previews render correctly in light with NO provider**. `cfg.provider` is intentionally
+  left UNSET. The converter prints `! preview decorator bundle failed: Could not resolve
+  "tailwindcss"` (the decorator imports `../index.css` which `@import "tailwindcss"`, which
+  esbuild can't resolve) — this warning is HARMLESS for previews because the bundle CSS
+  ships separately and light needs no wrapper. Document ThemeProvider for dark mode in the
+  conventions header, not as a preview provider.
+- **cardMode overrides** (presentation-only, grades carry): portal/overlay components
+  DropdownMenu/Sheet/Tooltip → `single` (escape); 16 wide components → `column`. See config.
+  Select/Command/Popover/Toast render fine in grid cells (closed trigger) — not flagged.
+
+## Environment
+
+- [GENERAL] **Spawned subagents (Agent tool) cannot run Bash in this session** — every
+  `node` invocation is denied for them. The §4c parallel fan-out therefore can't be
+  delegated; the orchestrator must run the captures (`compare.mjs`) and grading itself,
+  serially. Captures over the whole roster in one scoped `compare.mjs --components <all>`
+  run are fine (one browser launch). If a future session grants Bash to agents, fan-out
+  works as the skill intends.
+
+## Re-sync risks
+
+- The dist `.d.ts` staleness above WILL recur if `type:emit` isn't run before the converter
+  and a component was added/removed. Always `type:emit` first.
+- `[FONT_REMOTE] "Inter"` — styles.css `@import`s Inter from a remote font host; validate
+  assumes it serves at runtime. Verify the font actually renders (not a fallback) during compare.

--- a/libs/shared/react/ui/.design-sync/config.json
+++ b/libs/shared/react/ui/.design-sync/config.json
@@ -1,0 +1,34 @@
+{
+  "projectId": "12990931-d5cb-4a33-8632-b13be6d6871f",
+  "pkg": "@shipfox/react-ui",
+  "shape": "storybook",
+  "storybookConfigDir": ".storybook",
+  "storybookStatic": ".design-sync/sb-reference",
+  "buildCmd": "turbo run build --filter=@shipfox/react-ui...",
+  "readmeHeader": ".design-sync/conventions.md",
+  "titleMap": {
+    "Loader": "ShipfoxLoader",
+    "Toast": "Toaster"
+  },
+  "overrides": {
+    "DropdownMenu": { "cardMode": "single", "primaryStory": "Default" },
+    "Sheet": { "cardMode": "single", "primaryStory": "Default" },
+    "Tooltip": { "cardMode": "single", "primaryStory": "Default" },
+    "IconButton": { "cardMode": "column" },
+    "Alert": { "cardMode": "column" },
+    "Badge": { "cardMode": "column" },
+    "Button": { "cardMode": "column" },
+    "Card": { "cardMode": "column" },
+    "Combobox": { "cardMode": "column" },
+    "EmptyState": { "cardMode": "column" },
+    "FormField": { "cardMode": "column" },
+    "Input": { "cardMode": "column" },
+    "LoadErrorState": { "cardMode": "column" },
+    "Modal": { "cardMode": "column" },
+    "RadioGroup": { "cardMode": "column" },
+    "ShipfoxLoader": { "cardMode": "column" },
+    "Skeleton": { "cardMode": "column" },
+    "Table": { "cardMode": "column" },
+    "Tabs": { "cardMode": "column" }
+  }
+}

--- a/libs/shared/react/ui/.design-sync/conventions.md
+++ b/libs/shared/react/ui/.design-sync/conventions.md
@@ -1,0 +1,58 @@
+## Building with @shipfox/react-ui
+
+This is Shipfox's real component library (Radix + Tailwind v4, React 19). Compose screens
+from `window.ShipfoxReactUi.*`; style your own layout glue with the design tokens below.
+
+### Setup
+
+`styles.css` carries everything (tokens, fonts, and component styles via `_ds_bundle.css`) —
+load it once and components are styled out of the box. No provider is required for the default
+(light) theme: the tokens resolve at `:root`.
+
+Dark mode is opt-in. The library toggles a `.dark` class on `<html>` via `ThemeProvider`
+(a bundle export). Wrap your tree in it only when you want dark or a theme switch:
+
+```jsx
+const { ThemeProvider, Button } = window.ShipfoxReactUi;
+<ThemeProvider defaultTheme="dark"> … </ThemeProvider>   // omit for light
+```
+
+### Styling idiom — props first, then tokens
+
+1. **Component appearance comes from props, never from restyling.** Components take
+   `variant`, `size`, `tone`, `iconLeft`/`iconRight`, `isLoading`, etc. — read each
+   component's `<Name>.prompt.md` for its exact API. Example: `<Button variant="danger"
+   size="sm" iconLeft="google">`. The brand orange is the *interactive/focus* accent
+   (`--foreground-highlight-interactive`), not a primary fill — the default primary Button is
+   inverted neutral (dark). Use orange for links and focus, not for CTAs.
+
+2. **For your own layout/styling, use the design tokens** — they are the reliable surface.
+   `_ds_bundle.css` is a *static* Tailwind build: only utility classes the components already
+   use are compiled (so `flex`, `flex-col`, `gap-16`, `text-foreground-neutral-subtle` exist,
+   but an arbitrary class like `bg-background-accent-blue-soft` is NOT emitted and renders
+   nothing). When in doubt, reference the CSS variables directly via `style`, which always
+   resolve:
+
+   ```jsx
+   <div style={{ display: 'flex', gap: 16,
+     color: 'var(--foreground-neutral-subtle)',
+     background: 'var(--background-components-base)',
+     border: '1px solid var(--border-neutral-base)' }} />
+   ```
+
+   Token families (names verbatim in `_ds_bundle.css`):
+   - `--foreground-*` — text/icon color: `neutral-{base,subtle,muted,disabled,on-color}`,
+     `contrast-*`, `highlight-interactive` (orange), `highlight-error`.
+   - `--background-*` — surfaces: `components-{base,hover,pressed}`, `field-*`, `neutral-*`,
+     `subtle-*`, `accent-{blue,purple,success,warning,error,neutral}-{soft,base,strong}`,
+     `button-{inverted,neutral,danger,success,transparent}-*`, `modal-overlay`.
+   - `--border-*` — `neutral-{base,strong,transparent}`, `contrast-*`, `highlights-*`.
+   - `--ring-*`, `--shadow-*` — focus rings and elevation. `--font-sans`, `--font-mono`.
+   - **Spacing base is 1px**: Tailwind spacing maps directly to pixels (`gap-16` = 16px,
+     `p-4` = 4px), so token-driven numbers are literal pixels.
+
+### Where the truth lives
+
+- `styles.css` → its `@import` closure (`_ds_bundle.css`, tokens, fonts) is the full token list.
+- `components/<group>/<Name>/<Name>.prompt.md` — per-component API, variants, and example JSX.
+  Read it before composing a component.

--- a/libs/shared/react/ui/.gitignore
+++ b/libs/shared/react/ui/.gitignore
@@ -1,2 +1,8 @@
 storybook-static/
 screenshots/
+.design-sync/sb-reference/
+.design-sync/learnings/
+.design-sync/.cache/
+.design-sync/node_modules
+.ds-sync/
+ds-bundle/


### PR DESCRIPTION
Adds the durable design-sync configuration that converts `@shipfox/react-ui` into the claude.ai/design format, so the design agent there builds with our real compiled components and future re-syncs run mostly deterministically.

The first sync of all 31 components is already uploaded to the Claude Design project (`@shipfox/react-ui`); this PR commits the repo-side state that drives it.

## What's here

- **`.design-sync/config.json`** — converter knobs: the built `dist` entry, `titleMap` (story titles `Loader`/`Toast` map to the `ShipfoxLoader`/`Toaster` exports), `cardMode` overrides (portal/overlay components render single-story, wide components render one-per-row), and the `readmeHeader` wiring.
- **`.design-sync/conventions.md`** — the design-agent usage header prepended to the generated README: setup (`window.ShipfoxReactUi`, `styles.css`, `ThemeProvider` for dark mode), the token vocabulary (`--background-*`, `--foreground-*`, `--border-*`, `--font-sans/mono`), and the styling idiom (props first; the compiled CSS is a static Tailwind build, so the reliable surface is component props + `var(--token)`).
- **`.design-sync/NOTES.md`** — build learnings and re-sync risks. Most important: the package `build` script emits JS but not `.d.ts`, so `type:emit` must run before the converter or newer components get dropped as non-exports.
- **`.gitignore`** — excludes the transient converter artifacts (`sb-reference`, `.cache`, `learnings`, `ds-bundle`, `.ds-sync`).

## Notes for review

- These are tooling/config files with no published-package impact, so no changeset is included.
- All 31 components were visually verified against the repo's own Storybook render (every story graded a match); the verification state lives with the uploaded anchor, not in git.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable design-sync for `@shipfox/react-ui` to export Storybook to the Claude Design project and support deterministic re-syncs. Includes the initial state for all 31 components with no changes to the published package.

- **New Features**
  - `.design-sync/config.json` with build command, `titleMap` (`Loader` → `ShipfoxLoader`, `Toast` → `Toaster`), and card layout overrides.
  - `.design-sync/conventions.md` used as the README header (setup, tokens, styling guidance).
  - `.design-sync/NOTES.md` with build learnings and re-sync risks.
  - `.gitignore` updated to exclude converter artifacts.

- **Migration**
  - Before running the converter or re-syncing: emit types so `dist/index.d.ts` matches JS — `turbo run type:emit --filter=@shipfox/react-ui`.

<sup>Written for commit 07619a6974a97ca41a0d4b80e0fd5ee155d414e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

