### PR TITLE
Forward agent step session entries into the logs module

### DIFF
--- a/.changeset/eng-497-runner-session-logs.md
+++ b/.changeset/eng-497-runner-session-logs.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-logs-dto": patch
+"@shipfox/api-logs": patch
+"@shipfox/runner-logs": patch
+"@shipfox/runner-agent": patch
+"@shipfox/runner-orchestration": patch
+---
+
+Forward agent step session entries into the logs module as opaque `agent_session` records: the runner tails the pi session file and forwards each verbatim entry over a shared log-stream sink, and the write path stores them with a configurable per-line size cap sized for inline base64 content.

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -54,3 +54,4 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_LOG_FLUSH_BYTES` | `262144` | Backlog size that triggers an early log upload before the interval elapses, so bursts do not wait for the timer. |
 | `SHIPFOX_LOG_SPOOL_MAX_BYTES` | `67108864` | Max not-yet-acknowledged log bytes kept on disk per step attempt. Beyond this, output is dropped and a gap marker is recorded. |
 | `SHIPFOX_LOG_DRAIN_TIMEOUT_MS` | `5000` | How long the runner waits at job end for in-flight log uploads before deleting the workspace. |
+| `SHIPFOX_AGENT_SESSION_FLUSH_BYTES` | `4194304` | Upload window and per-entry drop threshold for agent-session logs. Entries over this encoded-record size are dropped with a gap marker instead of forwarded. |

--- a/libs/api/logs-dto/src/schemas/record.test.ts
+++ b/libs/api/logs-dto/src/schemas/record.test.ts
@@ -23,6 +23,15 @@ const recordsByType: Array<{record: LogRecord; appendable: boolean}> = [
   {record: {v: 1, ts, type: 'group_end', group_id: 'g1'}, appendable: true},
   {record: {v: 1, ts, type: 'end', total_bytes: 1048576}, appendable: true},
   {record: {v: 1, ts, type: 'gap', dropped_bytes: 4096}, appendable: true},
+  {
+    record: {
+      v: 1,
+      ts,
+      type: 'agent_session',
+      data: '{"type":"message","id":"a","parentId":null,"timestamp":"t"}',
+    },
+    appendable: true,
+  },
   {record: {v: 1, ts, type: 'capped'}, appendable: false},
   {record: {v: 1, ts, type: 'runner_lost'}, appendable: false},
 ];
@@ -78,6 +87,20 @@ describe('logRecordSchema (read union)', () => {
     expect(() =>
       logRecordSchema.parse({v: 1, ts, type: 'output', stream: 'stdout', data: ''}),
     ).toThrow();
+  });
+
+  it('accepts an agent_session record whose data far exceeds the output byte cap', () => {
+    const data = 'x'.repeat(MAX_RECORD_DATA_BYTES * 4);
+
+    const parsed = logRecordSchema.parse({v: 1, ts, type: 'agent_session', data});
+
+    expect(Buffer.byteLength((parsed as {data: string}).data, 'utf8')).toBe(
+      MAX_RECORD_DATA_BYTES * 4,
+    );
+  });
+
+  it('rejects an empty agent_session record', () => {
+    expect(() => logRecordSchema.parse({v: 1, ts, type: 'agent_session', data: ''})).toThrow();
   });
 
   it('accepts a null parent_group_id at the top level', () => {

--- a/libs/api/logs-dto/src/schemas/record.ts
+++ b/libs/api/logs-dto/src/schemas/record.ts
@@ -17,6 +17,10 @@ import {z} from 'zod';
  * `type`. The ingest (appendable) and read unions are distinct types: the server-only
  * `capped` / `runner_lost` tombstones are members of the read union only, so a forged
  * tombstone cannot pass append validation.
+ *
+ * The `agent_session` record carries one verbatim agent session entry line in `data`,
+ * forwarded opaquely by the runner. Its per-line size is bounded by the server's
+ * configurable `LOG_MAX_SESSION_LINE_BYTES` in the write path, not by this schema.
  */
 
 /** Largest decoded `data` payload per record. Longer lines are split by the runner. */
@@ -81,6 +85,16 @@ const logGap = z.object({
   dropped_bytes: z.number().int().nonnegative(),
 });
 
+// One verbatim agent session entry line, forwarded opaquely by the runner. `data` is
+// intentionally uncapped here: the per-line byte limit is the server's configurable
+// LOG_MAX_SESSION_LINE_BYTES (a Zod schema cannot read runtime config, and a static cap
+// would collide with the body-limit invariant), enforced in the append write path.
+const logAgentSession = z.object({
+  ...envelope,
+  type: z.literal('agent_session'),
+  data: z.string().min(1, {message: 'agent_session data must not be empty'}),
+});
+
 // Server-only tombstones: NOT members of the appendable union.
 const logCapped = z.object({...envelope, type: z.literal('capped')});
 const logRunnerLost = z.object({...envelope, type: z.literal('runner_lost')});
@@ -92,6 +106,7 @@ export const appendableLogRecordSchema = z.discriminatedUnion('type', [
   logGroupEnd,
   logEnd,
   logGap,
+  logAgentSession,
 ]);
 
 /** Full read union: appendable records plus the server-only tombstones. */
@@ -101,6 +116,7 @@ export const logRecordSchema = z.discriminatedUnion('type', [
   logGroupEnd,
   logEnd,
   logGap,
+  logAgentSession,
   logCapped,
   logRunnerLost,
 ]);

--- a/libs/api/logs/README.md
+++ b/libs/api/logs/README.md
@@ -45,11 +45,12 @@ One JSON object per line. The shared envelope is `{v, ts}`. The pipe rides on `s
 output; control records are flat by `type`:
 
 ```ts
-{v: 1, ts, type: 'output',      stream: 'stdout' | 'stderr', data}     // <= 16 KiB data
-{v: 1, ts, type: 'group_start', group_id, parent_group_id, name}      // name <= 1 KiB
-{v: 1, ts, type: 'group_end',   group_id}
-{v: 1, ts, type: 'end',         total_bytes}
-{v: 1, ts, type: 'gap',         dropped_bytes}
+{v: 1, ts, type: 'output',        stream: 'stdout' | 'stderr', data}   // <= 16 KiB data
+{v: 1, ts, type: 'group_start',   group_id, parent_group_id, name}     // name <= 1 KiB
+{v: 1, ts, type: 'group_end',     group_id}
+{v: 1, ts, type: 'end',           total_bytes}
+{v: 1, ts, type: 'gap',           dropped_bytes}
+{v: 1, ts, type: 'agent_session', data}                               // one verbatim entry, <= LOG_MAX_SESSION_LINE_BYTES
 {v: 1, ts, type: 'capped'}        // server-only
 {v: 1, ts, type: 'runner_lost'}   // server-only
 ```
@@ -89,13 +90,17 @@ leaks.
 - **Cold (compacted, `object_key` set)** — a presigned GET URL (`LOG_READ_URL_TTL_SECONDS`) so the
   browser fetches the object directly and API egress is bypassed.
 
-## Agent-session capture (future)
+## Agent-session capture
 
-Agent-session capture is a separate, not-yet-built feature. When it lands, an agent step's session
-events ride this **same** stream as ordinary records, distinguished by their own record `type`(s);
-a reader filters by `type` and re-joins those records to reconstruct the session. There is no
-separate stream and no stream `kind` — one stream per `(job, step, attempt)`, read without knowing
-any kind.
+An agent step forwards each agent session entry as one `agent_session` record on this **same**
+stream, distinguished by its `type`; a reader filters by `type` and `JSON.parse`s each record's
+`data` (one verbatim session entry line) to reconstruct the session. There is no separate stream
+and no stream `kind` — one stream per `(job, step, attempt)`, read without knowing any kind.
+
+The runner forwards entries opaquely and never splits one across records, so a record always
+carries a whole entry. Per-entry size is bounded by `LOG_MAX_SESSION_LINE_BYTES` (a larger line is
+rejected with 400, and the runner drops it with a `gap`); the request body limit
+(`LOG_APPEND_BODY_LIMIT_BYTES`) must hold a full line plus framing, enforced by a startup invariant.
 
 ## Budget and terminal state
 

--- a/libs/api/logs/src/config.test.ts
+++ b/libs/api/logs/src/config.test.ts
@@ -71,3 +71,28 @@ describe('LOG_STREAM_REAP_AFTER_SECONDS validation', () => {
     expect(config.LOG_STREAM_REAP_AFTER_SECONDS).toBe(600);
   });
 });
+
+describe('LOG_MAX_SESSION_LINE_BYTES validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('fails startup when the session line cap exceeds the append body limit', async () => {
+    vi.stubEnv('LOG_APPEND_BODY_LIMIT_BYTES', '1024');
+    vi.stubEnv('LOG_MAX_SESSION_LINE_BYTES', '2048');
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('LOG_APPEND_BODY_LIMIT_BYTES');
+  });
+
+  it('accepts a session line cap equal to the append body limit', async () => {
+    vi.stubEnv('LOG_APPEND_BODY_LIMIT_BYTES', '2048');
+    vi.stubEnv('LOG_MAX_SESSION_LINE_BYTES', '2048');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.LOG_MAX_SESSION_LINE_BYTES).toBe(2048);
+  });
+});

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -32,8 +32,8 @@ export const config = createConfig({
     default: true,
   }),
   LOG_BUDGET_BASE_BYTES: num({
-    desc: 'Base of the per-job log accrual budget, in stored bytes (raw NDJSON the server keeps, framing included). A job may always store this much before the time-based rate is added. Defaults to 5 MiB.',
-    default: 5_242_880,
+    desc: 'Base of the per-job log accrual budget, in stored bytes (raw NDJSON the server keeps, framing included). A job may always store this much before the time-based rate is added. Sized to hold a few inline agent_session entries (such as base64 images) before the shared per-job cap trips. Defaults to 32 MiB.',
+    default: 33_554_432,
   }),
   LOG_BUDGET_RATE_BYTES_PER_MINUTE: num({
     desc: 'Stored bytes added to the per-job log budget for each minute since the first log append. Defaults to 1 MiB per minute.',
@@ -52,8 +52,12 @@ export const config = createConfig({
     default: 7200,
   }),
   LOG_APPEND_BODY_LIMIT_BYTES: num({
-    desc: 'Maximum size of a single log append request body, in bytes. The runner flushes at most a few hundred KB per request and each record caps at 16 KiB, so 1 MiB is generous headroom. This also bounds how far a job can overshoot its log budget: the one append that crosses the budget is stored in full before the job is capped. Defaults to 1 MiB.',
-    default: 1_048_576,
+    desc: 'Maximum size of a single log append request body, in bytes. Output records cap at 16 KiB each, but one agent_session record carries a whole session entry (which can inline base64 images), so the body must hold a full LOG_MAX_SESSION_LINE_BYTES line plus framing. This also bounds how far a job can overshoot its log budget: the one append that crosses the budget is stored in full before the job is capped. Defaults to 8 MiB.',
+    default: 8_388_608,
+  }),
+  LOG_MAX_SESSION_LINE_BYTES: num({
+    desc: 'Maximum size of one agent_session log line (a verbatim agent session entry), in bytes. A larger line is rejected with 400, and the runner drops it with a gap marker instead of sending it. Sized generously for entries that inline large content such as base64 images. Must be at most LOG_APPEND_BODY_LIMIT_BYTES, since a line that cannot fit in one request body could never be accepted. Defaults to 4 MiB.',
+    default: 4_194_304,
   }),
   LOG_READ_URL_TTL_SECONDS: num({
     desc: 'Lifetime, in seconds, of a presigned GET URL handed out for a compacted (cold) log read. The browser must finish fetching the object before it expires; raise it for slow links or large logs. Must be between 1 and 604800 (7 days, the longest a presigned URL can live). Defaults to 3600 (one hour).',
@@ -83,6 +87,15 @@ if (
 if (config.LOG_READ_INLINE_MAX_BYTES < 1) {
   throw new Error(
     `LOG_READ_INLINE_MAX_BYTES must be at least 1; got ${config.LOG_READ_INLINE_MAX_BYTES}`,
+  );
+}
+
+// A whole agent_session line is one record in one body. If the body limit is below the
+// line cap, a legitimate large session line could never fit in one request body — Fastify
+// would 413 it before the per-line validator runs. Fail fast at startup instead.
+if (config.LOG_APPEND_BODY_LIMIT_BYTES < config.LOG_MAX_SESSION_LINE_BYTES) {
+  throw new Error(
+    `LOG_APPEND_BODY_LIMIT_BYTES (${config.LOG_APPEND_BODY_LIMIT_BYTES}) must be >= LOG_MAX_SESSION_LINE_BYTES (${config.LOG_MAX_SESSION_LINE_BYTES}).`,
   );
 }
 

--- a/libs/api/logs/src/core/append-logs.test.ts
+++ b/libs/api/logs/src/core/append-logs.test.ts
@@ -8,6 +8,7 @@ import {
   outputLine,
   outputOfBytes,
   recordLine,
+  sessionLine,
 } from '#test/fixtures/ndjson.js';
 import {findAccounting, findStream, listChunks, listStreamClosedEvents} from '#test/queries.js';
 
@@ -99,6 +100,36 @@ describe('appendLogs', () => {
     });
   });
 
+  describe('agent_session', () => {
+    it('stores a session line verbatim as one runner chunk and leaves the stream open', async () => {
+      const ctx = newCtx();
+      // Small enough to stay under the tiny test budget (100 bytes) so capped stays false.
+      const body = ndjsonBody(sessionLine('{"type":"x"}'));
+
+      const result = await appendLogs({...ctx, attempt: 1, offset: 0, body});
+
+      expect(result).toEqual({committedLength: body.length, capped: false});
+      const stream = await findStream({...ctx, attempt: 1});
+      expect(stream?.state).toBe('open');
+      const chunks = await listChunks(stream?.id as string);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.origin).toBe('runner');
+      expect(chunks[0]?.data).toEqual(body);
+    });
+
+    it('rejects a session line over LOG_MAX_SESSION_LINE_BYTES before any stream is created', async () => {
+      const ctx = newCtx();
+      const body = ndjsonBody(sessionLine('x'.repeat(600)));
+
+      const error = await appendLogs({...ctx, attempt: 1, offset: 0, body}).catch(
+        (e: unknown) => e,
+      );
+
+      expect(error).toBeInstanceOf(MalformedLogChunkError);
+      expect(await findStream({...ctx, attempt: 1})).toBeNull();
+    });
+  });
+
   describe('budget accounting', () => {
     it('charges the raw stored bytes, envelope and control records included', async () => {
       const ctx = newCtx();
@@ -148,7 +179,8 @@ describe('appendLogs', () => {
 
       expect(result).toEqual({committedLength: first.length + straggler.length, capped: true});
       const stream = await findStream({...ctx, attempt: 1});
-      expect(await listChunks(stream?.id as string)).toHaveLength(2); // runner + tombstone, no straggler
+      const chunks = await listChunks(stream?.id as string);
+      expect(chunks.map((c) => c.origin)).toEqual(['runner', 'control']);
     });
 
     it('does not cap when stored bytes land exactly on the budget', async () => {
@@ -375,7 +407,8 @@ describe('appendLogs', () => {
 
     it('rejects an invalid NDJSON record', async () => {
       const ctx = newCtx();
-      const body = ndjsonBody(recordLine({type: 'output', stream: 'stdout'})); // missing data
+      const recordWithoutData = recordLine({type: 'output', stream: 'stdout'});
+      const body = ndjsonBody(recordWithoutData);
 
       const error = await appendLogs({...ctx, attempt: 1, offset: 0, body}).catch(
         (e: unknown) => e,

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -1,4 +1,4 @@
-import type {Buffer} from 'node:buffer';
+import {Buffer} from 'node:buffer';
 import {parseAppendableLogRecordLine, parseLogRecordLine} from '@shipfox/api-logs-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
@@ -70,6 +70,17 @@ function parseAppendBody(body: Buffer): ParsedBody {
     }
     if (record.type === 'end') {
       declaredTotalBytes = record.total_bytes;
+    }
+    // An agent_session line is one whole entry in one record; bound its size here (the DTO
+    // schema leaves `data` uncapped because it cannot read this runtime config). An over-cap
+    // line is rejected so a single entry can never blow the request body or the spool window.
+    if (
+      record.type === 'agent_session' &&
+      Buffer.byteLength(line, 'utf8') > config.LOG_MAX_SESSION_LINE_BYTES
+    ) {
+      throw new MalformedLogChunkError(
+        `agent_session line exceeds ${config.LOG_MAX_SESSION_LINE_BYTES} bytes`,
+      );
     }
   }
 

--- a/libs/api/logs/test/env.ts
+++ b/libs/api/logs/test/env.ts
@@ -15,6 +15,10 @@ process.env.LOG_BUDGET_RATE_BYTES_PER_MINUTE = '60';
 // Modest body limit (64 KiB) so the route 413 test uses a small payload.
 process.env.LOG_APPEND_BODY_LIMIT_BYTES = '65536';
 
+// Small agent_session line cap so the over-cap test uses a tiny payload. Must stay
+// <= LOG_APPEND_BODY_LIMIT_BYTES for the startup invariant.
+process.env.LOG_MAX_SESSION_LINE_BYTES = '512';
+
 // Tiny inline read page so the read-path drain/has_more test pages with small fixtures.
 process.env.LOG_READ_INLINE_MAX_BYTES = '256';
 

--- a/libs/api/logs/test/fixtures/ndjson.ts
+++ b/libs/api/logs/test/fixtures/ndjson.ts
@@ -12,6 +12,10 @@ export function endLine(totalBytes: number): string {
   return recordLine({type: 'end', total_bytes: totalBytes});
 }
 
+export function sessionLine(data: string): string {
+  return recordLine({type: 'agent_session', data});
+}
+
 export function groupStartLine(
   groupId: string,
   name: string,

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@earendil-works/pi-coding-agent": "0.79.3",
     "@shipfox/api-workflows-dto": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/runner-execution": "workspace:*"
   },
   "devDependencies": {

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -40,6 +40,9 @@ function invocation(overrides: Partial<AgentInvocation> = {}): AgentInvocation {
 }
 
 describe('runAgent', () => {
+  // Tracked so the temp dir is removed in afterEach even if an assertion throws first.
+  let sessionDir: string | undefined;
+
   beforeEach(() => {
     createAgentSessionMock.mockReset();
     findMock.mockReset();
@@ -54,6 +57,11 @@ describe('runAgent', () => {
     createAgentSessionMock.mockResolvedValue({
       session: {prompt: promptMock, abort: abortMock, messages: []},
     });
+  });
+
+  afterEach(() => {
+    if (sessionDir) rmSync(sessionDir, {recursive: true, force: true});
+    sessionDir = undefined;
   });
 
   it('resolves the configured model under the requested provider and runs the prompt', async () => {
@@ -71,8 +79,8 @@ describe('runAgent', () => {
   });
 
   it('forwards each persisted session entry to onSessionEntry in order', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'shipfox-run-agent-'));
-    const sessionFile = join(dir, 'session.jsonl');
+    sessionDir = mkdtempSync(join(tmpdir(), 'shipfox-run-agent-'));
+    const sessionFile = join(sessionDir, 'session.jsonl');
     // pi persists entries to the session file during the turn; the final read on completion
     // forwards everything written before the prompt resolved.
     promptMock.mockImplementation(() => {
@@ -87,7 +95,6 @@ describe('runAgent', () => {
     await runAgent(invocation({onSessionEntry: (line) => entries.push(line)}));
 
     expect(entries).toEqual(['{"type":"session"}', '{"type":"message","id":"a"}']);
-    rmSync(dir, {recursive: true, force: true});
   });
 
   it('skips forwarding when the session is not persisted (no session file)', async () => {

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -18,8 +18,12 @@ vi.mock('@earendil-works/pi-coding-agent', () => ({
       hasConfiguredAuth: hasConfiguredAuthMock,
     }),
   },
+  SessionManager: {create: () => ({})},
 }));
 
+import {appendFileSync, mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {AgentConfigError} from '#core/errors.js';
 import {type AgentInvocation, runAgent} from '#core/run-agent.js';
 
@@ -64,6 +68,34 @@ describe('runAgent', () => {
     );
     expect(promptMock).toHaveBeenCalledWith('Fix it.');
     expect(result).toEqual({});
+  });
+
+  it('forwards each persisted session entry to onSessionEntry in order', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shipfox-run-agent-'));
+    const sessionFile = join(dir, 'session.jsonl');
+    // pi persists entries to the session file during the turn; the final read on completion
+    // forwards everything written before the prompt resolved.
+    promptMock.mockImplementation(() => {
+      appendFileSync(sessionFile, '{"type":"session"}\n{"type":"message","id":"a"}\n');
+      return Promise.resolve();
+    });
+    createAgentSessionMock.mockResolvedValue({
+      session: {prompt: promptMock, abort: abortMock, messages: [], sessionFile},
+    });
+    const entries: string[] = [];
+
+    await runAgent(invocation({onSessionEntry: (line) => entries.push(line)}));
+
+    expect(entries).toEqual(['{"type":"session"}', '{"type":"message","id":"a"}']);
+    rmSync(dir, {recursive: true, force: true});
+  });
+
+  it('skips forwarding when the session is not persisted (no session file)', async () => {
+    const entries: string[] = [];
+
+    await runAgent(invocation({onSessionEntry: (line) => entries.push(line)}));
+
+    expect(entries).toEqual([]);
   });
 
   it('throws an AgentConfigError naming the provider when it is unknown', async () => {
@@ -120,9 +152,7 @@ describe('runAgent', () => {
 
   it('aborts the pi session when the signal fires', async () => {
     const ac = new AbortController();
-    let resolvePrompt: () => void = () => {
-      // replaced by the mock implementation below
-    };
+    let resolvePrompt: () => void = () => undefined;
     promptMock.mockImplementation(
       () =>
         new Promise<void>((resolve) => {
@@ -141,9 +171,7 @@ describe('runAgent', () => {
 
   it('aborts the session and skips the prompt when the signal fires during session creation', async () => {
     const ac = new AbortController();
-    let resolveCreate: (value: {session: unknown}) => void = () => {
-      // replaced by the mock implementation below
-    };
+    let resolveCreate: (value: {session: unknown}) => void = () => undefined;
     createAgentSessionMock.mockImplementation(
       () =>
         new Promise((resolve) => {

--- a/libs/runner/agent/src/core/run-agent.ts
+++ b/libs/runner/agent/src/core/run-agent.ts
@@ -83,6 +83,12 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
 
   signal.addEventListener('abort', abortSession, {once: true});
   const forwarder = startForwarding(session.sessionFile, onSessionEntry);
+  // pi may not settle session.prompt() promptly on abort (step.ts races the call), so the
+  // finally below can be delayed indefinitely. Stop the forwarder on abort too, or its poll
+  // timer leaks past workspace teardown. stop() is idempotent, so the finally re-calling it is
+  // safe, and the early stop still does its final drain.
+  const stopForwarder = () => forwarder?.stop();
+  signal.addEventListener('abort', stopForwarder, {once: true});
   try {
     await session.prompt(prompt);
     return {};
@@ -91,6 +97,7 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
     // stream, so all session records precede its end marker.
     forwarder?.stop();
     signal.removeEventListener('abort', abortSession);
+    signal.removeEventListener('abort', stopForwarder);
   }
 }
 

--- a/libs/runner/agent/src/core/run-agent.ts
+++ b/libs/runner/agent/src/core/run-agent.ts
@@ -1,10 +1,13 @@
+import {join} from 'node:path';
 import {
   AuthStorage,
   type CreateAgentSessionOptions,
   createAgentSession,
   ModelRegistry,
+  SessionManager,
 } from '@earendil-works/pi-coding-agent';
 import {AgentConfigError} from '#core/errors.js';
+import {type SessionForwarder, startSessionForwarder} from '#core/session-forwarder.js';
 
 type PiThinkingLevel = NonNullable<CreateAgentSessionOptions['thinkingLevel']>;
 
@@ -18,6 +21,12 @@ export interface AgentInvocation {
   readonly thinking: string;
   readonly prompt: string;
   readonly signal: AbortSignal;
+  /**
+   * Forwards each verbatim pi session entry line as it is persisted, in order. Best-effort
+   * observability: when absent (or the session is not persisted), forwarding is skipped and
+   * the step is unaffected.
+   */
+  readonly onSessionEntry?: (line: string) => void;
 }
 
 /**
@@ -29,7 +38,7 @@ export interface AgentInvocation {
  * observability and never sent to the API, so it is optional.
  */
 export async function runAgent(invocation: AgentInvocation): Promise<{summary?: string}> {
-  const {cwd, model: modelId, provider, thinking, prompt, signal} = invocation;
+  const {cwd, model: modelId, provider, thinking, prompt, signal, onSessionEntry} = invocation;
 
   // A listener added to an already-aborted signal never fires, so an abort that lands
   // before this point (or during the awaits below) would leave pi running and burning
@@ -56,6 +65,9 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
     thinkingLevel: thinking as PiThinkingLevel,
     authStorage,
     modelRegistry,
+    // Keep the session JSONL inside the job workspace so it forwards from a deterministic path
+    // and is cleaned up with the workspace; pi's default lives under ~/.pi, outside it.
+    sessionManager: SessionManager.create(cwd, join(cwd, 'logs', 'agent-sessions')),
   });
 
   // session.abort() returns a promise; a rejected abort must not become an unhandled
@@ -70,12 +82,24 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
   }
 
   signal.addEventListener('abort', abortSession, {once: true});
+  const forwarder = startForwarding(session.sessionFile, onSessionEntry);
   try {
     await session.prompt(prompt);
     return {};
   } finally {
+    // A final synchronous read forwards every entry written before the caller closes the log
+    // stream, so all session records precede its end marker.
+    forwarder?.stop();
     signal.removeEventListener('abort', abortSession);
   }
+}
+
+function startForwarding(
+  sessionFile: string | undefined,
+  onSessionEntry: ((line: string) => void) | undefined,
+): SessionForwarder | undefined {
+  if (onSessionEntry === undefined || sessionFile === undefined) return undefined;
+  return startSessionForwarder({filePath: sessionFile, onEntry: onSessionEntry});
 }
 
 type ResolvedModel = NonNullable<ReturnType<ModelRegistry['find']>>;

--- a/libs/runner/agent/src/core/session-forwarder.test.ts
+++ b/libs/runner/agent/src/core/session-forwarder.test.ts
@@ -99,6 +99,24 @@ describe('startSessionForwarder', () => {
     forwarder.stop();
   });
 
+  it('re-reads from the start when the file is truncated to a shorter length', async () => {
+    const lines: string[] = [];
+    writeFileSync(file, '{"first":1}\n'); // 12 bytes
+    const forwarder = startSessionForwarder({
+      filePath: file,
+      onEntry: (l) => lines.push(l),
+      intervalMs: 5,
+    });
+    await vi.waitFor(() => expect(lines).toEqual(['{"first":1}']));
+
+    // Replace with strictly shorter content: the offset (12) now points past the new end,
+    // so the tailer must reset and forward the new file instead of silently skipping it.
+    writeFileSync(file, '{"b":2}\n'); // 8 bytes
+    await vi.waitFor(() => expect(lines).toEqual(['{"first":1}', '{"b":2}']));
+
+    forwarder.stop();
+  });
+
   it('does a final read on stop so trailing entries are forwarded', () => {
     const lines: string[] = [];
     const intervalTooLongForTest = 1_000_000;

--- a/libs/runner/agent/src/core/session-forwarder.test.ts
+++ b/libs/runner/agent/src/core/session-forwarder.test.ts
@@ -1,0 +1,113 @@
+import {appendFileSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {startSessionForwarder} from '#core/session-forwarder.js';
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('startSessionForwarder', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'shipfox-session-forwarder-'));
+    file = join(dir, 'session.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, {recursive: true, force: true});
+  });
+
+  it('emits nothing for a file that never appears and stops quietly', () => {
+    const lines: string[] = [];
+    const forwarder = startSessionForwarder({filePath: file, onEntry: (l) => lines.push(l)});
+
+    expect(() => forwarder.stop()).not.toThrow();
+    expect(lines).toEqual([]);
+  });
+
+  it('emits a deferred bulk first write as N ordered lines', () => {
+    const lines: string[] = [];
+    const forwarder = startSessionForwarder({filePath: file, onEntry: (l) => lines.push(l)});
+
+    // pi defers the first write, then writes the header plus buffered entries at once.
+    writeFileSync(file, '{"type":"session"}\n{"type":"message","id":"a"}\n{"type":"label"}\n');
+    forwarder.stop();
+
+    expect(lines).toEqual([
+      '{"type":"session"}',
+      '{"type":"message","id":"a"}',
+      '{"type":"label"}',
+    ]);
+  });
+
+  it('forwards entries incrementally and in order as they are appended', async () => {
+    const lines: string[] = [];
+    writeFileSync(file, '');
+    const forwarder = startSessionForwarder({
+      filePath: file,
+      onEntry: (l) => lines.push(l),
+      intervalMs: 5,
+    });
+
+    appendFileSync(file, '{"a":1}\n');
+    await vi.waitFor(() => expect(lines).toEqual(['{"a":1}']));
+    appendFileSync(file, '{"b":2}\n');
+    await vi.waitFor(() => expect(lines).toEqual(['{"a":1}', '{"b":2}']));
+
+    forwarder.stop();
+  });
+
+  it('holds a partial line until its newline arrives', async () => {
+    const lines: string[] = [];
+    const lineWithoutTrailingNewline = '{"partial":1}';
+    const forwarder = startSessionForwarder({
+      filePath: file,
+      onEntry: (l) => lines.push(l),
+      intervalMs: 5,
+    });
+
+    appendFileSync(file, lineWithoutTrailingNewline);
+    await delay(30);
+    expect(lines).toEqual([]);
+
+    appendFileSync(file, '\n');
+    await vi.waitFor(() => expect(lines).toEqual(['{"partial":1}']));
+
+    forwarder.stop();
+  });
+
+  it('does a final read on stop so trailing entries are forwarded', () => {
+    const lines: string[] = [];
+    const intervalTooLongForTest = 1_000_000;
+    const forwarder = startSessionForwarder({
+      filePath: file,
+      onEntry: (l) => lines.push(l),
+      intervalMs: intervalTooLongForTest,
+    });
+
+    writeFileSync(file, '{"x":1}\n{"y":2}\n');
+    forwarder.stop();
+
+    expect(lines).toEqual(['{"x":1}', '{"y":2}']);
+  });
+
+  it('stops quietly when the file is deleted mid-tail', async () => {
+    const lines: string[] = [];
+    writeFileSync(file, '{"a":1}\n');
+    const forwarder = startSessionForwarder({
+      filePath: file,
+      onEntry: (l) => lines.push(l),
+      intervalMs: 5,
+    });
+
+    await vi.waitFor(() => expect(lines).toEqual(['{"a":1}']));
+    rmSync(file);
+    await delay(20);
+
+    expect(() => forwarder.stop()).not.toThrow();
+    expect(lines).toEqual(['{"a":1}']);
+  });
+});

--- a/libs/runner/agent/src/core/session-forwarder.test.ts
+++ b/libs/runner/agent/src/core/session-forwarder.test.ts
@@ -79,6 +79,26 @@ describe('startSessionForwarder', () => {
     forwarder.stop();
   });
 
+  it('reassembles a multi-byte character split across two reads', async () => {
+    const lines: string[] = [];
+    const entry = '{"emoji":"😀 héllo"}';
+    const bytes = Buffer.from(`${entry}\n`, 'utf8');
+    const splitInsideCodepoint = Buffer.byteLength('{"emoji":"', 'utf8') + 1;
+    writeFileSync(file, '');
+    const forwarder = startSessionForwarder({
+      filePath: file,
+      onEntry: (l) => lines.push(l),
+      intervalMs: 5,
+    });
+
+    appendFileSync(file, bytes.subarray(0, splitInsideCodepoint));
+    await delay(20);
+    appendFileSync(file, bytes.subarray(splitInsideCodepoint));
+
+    await vi.waitFor(() => expect(lines).toEqual([entry]));
+    forwarder.stop();
+  });
+
   it('does a final read on stop so trailing entries are forwarded', () => {
     const lines: string[] = [];
     const intervalTooLongForTest = 1_000_000;

--- a/libs/runner/agent/src/core/session-forwarder.ts
+++ b/libs/runner/agent/src/core/session-forwarder.ts
@@ -4,6 +4,10 @@ import {logger} from '@shipfox/node-opentelemetry';
 
 const DEFAULT_POLL_INTERVAL_MS = 250;
 
+// A 0x0a byte only ever terminates an entry: it never appears inside a multi-byte UTF-8
+// sequence, so the bytes up to a newline are always a whole entry that decodes cleanly.
+const NEWLINE = 0x0a;
+
 export interface SessionForwarderOptions {
   filePath: string;
   onEntry: (line: string) => void;
@@ -19,9 +23,10 @@ export interface SessionForwarder {
  *
  * pi persists each session entry synchronously (appendFileSync) and may defer the first write
  * until the first assistant message, then bulk-write several lines at once — a byte-offset
- * reader handles both, where a line-index reader would not. pi runs in-process and always
- * terminates an entry with `\n`, so a read of `offset..EOF` ends on a line boundary and never
- * tears a multi-byte character; a partial-line buffer guards the contract anyway.
+ * reader handles both, where a line-index reader would not. A poll can observe a partial write
+ * (a large entry spans several write() syscalls), so the carry buffer holds raw bytes, not a
+ * decoded string: bytes are split on the newline and only whole lines are decoded, so a read
+ * that ends mid-codepoint never turns the split character into U+FFFD.
  *
  * Capture is best-effort: a missing file (not yet written, or removed on workspace cleanup)
  * or a read error stops forwarding quietly without ever throwing into the caller.
@@ -29,7 +34,7 @@ export interface SessionForwarder {
 export function startSessionForwarder(options: SessionForwarderOptions): SessionForwarder {
   const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   let offset = 0;
-  let pending = '';
+  let pending = Buffer.alloc(0);
   let stopped = false;
 
   function drainNewBytes(): void {
@@ -53,17 +58,19 @@ export function startSessionForwarder(options: SessionForwarderOptions): Session
       const buffer = Buffer.allocUnsafe(length);
       const read = readSync(fd, buffer, 0, length, offset);
       offset += read;
-      pending += buffer.subarray(0, read).toString('utf8');
+      // Concat copies the read bytes, so carrying a partial trailing line into the next poll
+      // (and decoding only whole lines below) keeps a mid-codepoint split intact.
+      pending = Buffer.concat([pending, buffer.subarray(0, read)]);
     } finally {
       closeSync(fd);
     }
 
-    let newline = pending.indexOf('\n');
+    let newline = pending.indexOf(NEWLINE);
     while (newline !== -1) {
-      const line = pending.slice(0, newline);
-      pending = pending.slice(newline + 1);
+      const line = pending.subarray(0, newline).toString('utf8');
+      pending = pending.subarray(newline + 1);
       if (line.length > 0) options.onEntry(line);
-      newline = pending.indexOf('\n');
+      newline = pending.indexOf(NEWLINE);
     }
   }
 

--- a/libs/runner/agent/src/core/session-forwarder.ts
+++ b/libs/runner/agent/src/core/session-forwarder.ts
@@ -45,6 +45,13 @@ export function startSessionForwarder(options: SessionForwarderOptions): Session
       // File not present yet (pi defers the first write) or removed on cleanup.
       return;
     }
+    // A file shorter than the byte offset was truncated or replaced (e.g. log rotation): the
+    // offset now points past the end, so reset and re-read the new content from the start
+    // instead of silently skipping it. pi only ever appends, so this is a defensive guard.
+    if (size < offset) {
+      offset = 0;
+      pending = Buffer.alloc(0);
+    }
     if (size <= offset) return;
 
     let fd: number;
@@ -80,7 +87,7 @@ export function startSessionForwarder(options: SessionForwarderOptions): Session
       drainNewBytes();
     } catch (err) {
       // Never let a tail read crash the runner; capture is best-effort.
-      logger().warn({err: String(err), filePath: options.filePath}, 'Agent session tail failed');
+      logger().warn({err, filePath: options.filePath}, 'Agent session tail failed');
     }
   }
 
@@ -98,7 +105,7 @@ export function startSessionForwarder(options: SessionForwarderOptions): Session
       try {
         drainNewBytes();
       } catch (err) {
-        logger().warn({err: String(err), filePath: options.filePath}, 'Agent session tail failed');
+        logger().warn({err, filePath: options.filePath}, 'Agent session tail failed');
       }
     },
   };

--- a/libs/runner/agent/src/core/session-forwarder.ts
+++ b/libs/runner/agent/src/core/session-forwarder.ts
@@ -1,0 +1,98 @@
+import {Buffer} from 'node:buffer';
+import {closeSync, openSync, readSync, statSync} from 'node:fs';
+import {logger} from '@shipfox/node-opentelemetry';
+
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+export interface SessionForwarderOptions {
+  filePath: string;
+  onEntry: (line: string) => void;
+  intervalMs?: number;
+}
+
+export interface SessionForwarder {
+  stop(): void;
+}
+
+/**
+ * Tails a growing append-only JSONL file by byte offset and forwards each complete line.
+ *
+ * pi persists each session entry synchronously (appendFileSync) and may defer the first write
+ * until the first assistant message, then bulk-write several lines at once — a byte-offset
+ * reader handles both, where a line-index reader would not. pi runs in-process and always
+ * terminates an entry with `\n`, so a read of `offset..EOF` ends on a line boundary and never
+ * tears a multi-byte character; a partial-line buffer guards the contract anyway.
+ *
+ * Capture is best-effort: a missing file (not yet written, or removed on workspace cleanup)
+ * or a read error stops forwarding quietly without ever throwing into the caller.
+ */
+export function startSessionForwarder(options: SessionForwarderOptions): SessionForwarder {
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  let offset = 0;
+  let pending = '';
+  let stopped = false;
+
+  function drainNewBytes(): void {
+    let size: number;
+    try {
+      size = statSync(options.filePath).size;
+    } catch {
+      // File not present yet (pi defers the first write) or removed on cleanup.
+      return;
+    }
+    if (size <= offset) return;
+
+    let fd: number;
+    try {
+      fd = openSync(options.filePath, 'r');
+    } catch {
+      return;
+    }
+    try {
+      const length = size - offset;
+      const buffer = Buffer.allocUnsafe(length);
+      const read = readSync(fd, buffer, 0, length, offset);
+      offset += read;
+      pending += buffer.subarray(0, read).toString('utf8');
+    } finally {
+      closeSync(fd);
+    }
+
+    let newline = pending.indexOf('\n');
+    while (newline !== -1) {
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      if (line.length > 0) options.onEntry(line);
+      newline = pending.indexOf('\n');
+    }
+  }
+
+  function poll(): void {
+    if (stopped) return;
+    try {
+      drainNewBytes();
+    } catch (err) {
+      // Never let a tail read crash the runner; capture is best-effort.
+      logger().warn({err: String(err), filePath: options.filePath}, 'Agent session tail failed');
+    }
+  }
+
+  const timer = setInterval(poll, intervalMs);
+  // A pending poll must not keep the runner process alive on its own.
+  timer.unref();
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+      // Final synchronous read so every entry written before stop is forwarded ahead of the
+      // caller closing the log stream.
+      try {
+        drainNewBytes();
+      } catch (err) {
+        logger().warn({err: String(err), filePath: options.filePath}, 'Agent session tail failed');
+      }
+    },
+  };
+}

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -11,7 +11,7 @@ const DEFAULT_PROVIDER = 'anthropic';
 
 export function executeAgentStep(
   step: StepDto,
-  options: {signal?: AbortSignal; cwd?: string} = {},
+  options: {signal?: AbortSignal; cwd?: string; onSessionEntry?: (line: string) => void} = {},
 ): Promise<StepResult> {
   if (step.type !== 'agent') {
     return Promise.resolve(agentFailure(`Unsupported step type: ${step.type}`));
@@ -31,6 +31,7 @@ export function executeAgentStep(
     thinking: typeof thinking === 'string' ? thinking : DEFAULT_THINKING,
     provider: typeof provider === 'string' && provider !== '' ? provider : DEFAULT_PROVIDER,
     signal: options.signal,
+    onSessionEntry: options.onSessionEntry,
   });
 }
 
@@ -41,13 +42,22 @@ async function runAgentStep(params: {
   thinking: string;
   provider: string;
   signal: AbortSignal | undefined;
+  onSessionEntry: ((line: string) => void) | undefined;
 }): Promise<StepResult> {
-  const {cwd, model, prompt, thinking, provider} = params;
+  const {cwd, model, prompt, thinking, provider, onSessionEntry} = params;
   const signal = params.signal ?? new AbortController().signal;
 
   try {
     const {summary} = await raceAbort(
-      runAgent({cwd, model, provider, thinking, prompt, signal}),
+      runAgent({
+        cwd,
+        model,
+        provider,
+        thinking,
+        prompt,
+        signal,
+        ...(onSessionEntry ? {onSessionEntry} : {}),
+      }),
       signal,
     );
     return {success: true, output: summary ?? '', error: null, exit_code: 0};

--- a/libs/runner/logs/src/config.test.ts
+++ b/libs/runner/logs/src/config.test.ts
@@ -6,7 +6,7 @@ describe('SHIPFOX_AGENT_SESSION_FLUSH_BYTES validation', () => {
 
   it.each([
     '65535',
-    '16777217',
+    '4194305',
   ])('fails startup when SHIPFOX_AGENT_SESSION_FLUSH_BYTES is %s', async (value) => {
     vi.stubEnv('SHIPFOX_AGENT_SESSION_FLUSH_BYTES', value);
     vi.resetModules();
@@ -16,7 +16,7 @@ describe('SHIPFOX_AGENT_SESSION_FLUSH_BYTES validation', () => {
 
   it.each([
     '65536',
-    '16777216',
+    '4194304',
   ])('accepts boundary value %s for SHIPFOX_AGENT_SESSION_FLUSH_BYTES', async (value) => {
     vi.stubEnv('SHIPFOX_AGENT_SESSION_FLUSH_BYTES', value);
     vi.resetModules();

--- a/libs/runner/logs/src/config.test.ts
+++ b/libs/runner/logs/src/config.test.ts
@@ -1,0 +1,28 @@
+describe('SHIPFOX_AGENT_SESSION_FLUSH_BYTES validation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each([
+    '65535',
+    '16777217',
+  ])('fails startup when SHIPFOX_AGENT_SESSION_FLUSH_BYTES is %s', async (value) => {
+    vi.stubEnv('SHIPFOX_AGENT_SESSION_FLUSH_BYTES', value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow('SHIPFOX_AGENT_SESSION_FLUSH_BYTES');
+  });
+
+  it.each([
+    '65536',
+    '16777216',
+  ])('accepts boundary value %s for SHIPFOX_AGENT_SESSION_FLUSH_BYTES', async (value) => {
+    vi.stubEnv('SHIPFOX_AGENT_SESSION_FLUSH_BYTES', value);
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.SHIPFOX_AGENT_SESSION_FLUSH_BYTES).toBe(Number(value));
+  });
+});

--- a/libs/runner/logs/src/config.ts
+++ b/libs/runner/logs/src/config.ts
@@ -16,11 +16,15 @@ const MIN_FLUSH_BYTES = MAX_RECORD_DATA_BYTES * 6 + 1024;
 const MAX_FLUSH_BYTES = 1024 * 1024;
 
 // The agent-session stream forwards one whole entry per record, so its flush window doubles
-// as the read window and the runner's per-entry drop threshold. It is sized far above the
-// output window (entries can inline base64 images) and must stay <= the server's
-// LOG_APPEND_BODY_LIMIT_BYTES. Bounded here so a misconfig fails fast at startup.
+// as the read window and the runner's per-entry drop threshold: a record larger than it is
+// dropped with a gap, never sent. The ceiling matches the server's DEFAULT
+// LOG_MAX_SESSION_LINE_BYTES (4 MiB). A window above the server's per-line cap would let an
+// entry sized between the two slip past the runner's drop and be rejected 400 by the server,
+// which stops the upload for the whole attempt (terminal) instead of dropping just that entry.
+// The runner cannot read the server config, so the documented default is the safe ceiling.
+// Bounded here so a misconfig fails fast at startup.
 const MIN_AGENT_SESSION_FLUSH_BYTES = 64 * 1024;
-const MAX_AGENT_SESSION_FLUSH_BYTES = 16 * 1024 * 1024;
+const MAX_AGENT_SESSION_FLUSH_BYTES = 4 * 1024 * 1024;
 
 export const config = createConfig({
   SHIPFOX_LOG_FLUSH_INTERVAL_MS: num({

--- a/libs/runner/logs/src/config.ts
+++ b/libs/runner/logs/src/config.ts
@@ -15,6 +15,13 @@ const MIN_FLUSH_BYTES = MAX_RECORD_DATA_BYTES * 6 + 1024;
 // must lower SHIPFOX_LOG_FLUSH_BYTES below it too.
 const MAX_FLUSH_BYTES = 1024 * 1024;
 
+// The agent-session stream forwards one whole entry per record, so its flush window doubles
+// as the read window and the runner's per-entry drop threshold. It is sized far above the
+// output window (entries can inline base64 images) and must stay <= the server's
+// LOG_APPEND_BODY_LIMIT_BYTES. Bounded here so a misconfig fails fast at startup.
+const MIN_AGENT_SESSION_FLUSH_BYTES = 64 * 1024;
+const MAX_AGENT_SESSION_FLUSH_BYTES = 16 * 1024 * 1024;
+
 export const config = createConfig({
   SHIPFOX_LOG_FLUSH_INTERVAL_MS: num({
     desc: 'How often the runner uploads buffered step logs, in milliseconds. This bounds how much recent output is lost if the runner machine dies mid-step.',
@@ -32,6 +39,10 @@ export const config = createConfig({
     desc: 'How long, in milliseconds, the runner waits at the end of a job for in-flight log uploads to finish before deleting the workspace. Bounds shutdown when the API is slow or unreachable.',
     default: 5000,
   }),
+  SHIPFOX_AGENT_SESSION_FLUSH_BYTES: num({
+    desc: `Upload window and per-entry drop threshold for agent-session logs, in bytes. One agent session entry rides one record; an entry whose encoded record exceeds this is dropped with a gap marker instead of forwarded. Must be between ${MIN_AGENT_SESSION_FLUSH_BYTES} and ${MAX_AGENT_SESSION_FLUSH_BYTES}, and no larger than the server's LOG_APPEND_BODY_LIMIT_BYTES (a body over that limit 413s and stops capture for the attempt). Defaults to 4 MiB.`,
+    default: 4_194_304,
+  }),
 });
 
 // envalid's num has no range support, so enforce the flush-window bounds here: an out-of-range
@@ -43,5 +54,14 @@ if (
 ) {
   throw new Error(
     `SHIPFOX_LOG_FLUSH_BYTES must be between ${MIN_FLUSH_BYTES} and ${MAX_FLUSH_BYTES} bytes; got ${config.SHIPFOX_LOG_FLUSH_BYTES}.`,
+  );
+}
+
+if (
+  config.SHIPFOX_AGENT_SESSION_FLUSH_BYTES < MIN_AGENT_SESSION_FLUSH_BYTES ||
+  config.SHIPFOX_AGENT_SESSION_FLUSH_BYTES > MAX_AGENT_SESSION_FLUSH_BYTES
+) {
+  throw new Error(
+    `SHIPFOX_AGENT_SESSION_FLUSH_BYTES must be between ${MIN_AGENT_SESSION_FLUSH_BYTES} and ${MAX_AGENT_SESSION_FLUSH_BYTES} bytes; got ${config.SHIPFOX_AGENT_SESSION_FLUSH_BYTES}.`,
   );
 }

--- a/libs/runner/logs/src/config.ts
+++ b/libs/runner/logs/src/config.ts
@@ -40,7 +40,7 @@ export const config = createConfig({
     default: 5000,
   }),
   SHIPFOX_AGENT_SESSION_FLUSH_BYTES: num({
-    desc: `Upload window and per-entry drop threshold for agent-session logs, in bytes. One agent session entry rides one record; an entry whose encoded record exceeds this is dropped with a gap marker instead of forwarded. Must be between ${MIN_AGENT_SESSION_FLUSH_BYTES} and ${MAX_AGENT_SESSION_FLUSH_BYTES}, and no larger than the server's LOG_APPEND_BODY_LIMIT_BYTES (a body over that limit 413s and stops capture for the attempt). Defaults to 4 MiB.`,
+    desc: `Upload window and per-entry drop threshold for agent-session logs, in bytes. One agent session entry rides one record; an entry whose encoded record exceeds this is dropped with a gap marker instead of forwarded. Must be between ${MIN_AGENT_SESSION_FLUSH_BYTES} and ${MAX_AGENT_SESSION_FLUSH_BYTES}, and no larger than the server's LOG_MAX_SESSION_LINE_BYTES (the binding ceiling: a kept entry above it is rejected with 400, which ends capture for the attempt; the server keeps that cap at or below its LOG_APPEND_BODY_LIMIT_BYTES). Defaults to 4 MiB.`,
     default: 4_194_304,
   }),
 });

--- a/libs/runner/logs/src/core/framing.test.ts
+++ b/libs/runner/logs/src/core/framing.test.ts
@@ -43,6 +43,15 @@ describe('StreamFramer.frameAgentSession', () => {
     expect(records).toHaveLength(1);
     expect(records[0]).toMatchObject({type: 'agent_session', data: line});
   });
+
+  it('frames nothing for an empty line (data would fail the DTO non-empty constraint)', () => {
+    const framer = new StreamFramer(() => 1);
+
+    const framed = framer.frameAgentSession('');
+
+    expect(framed.bytes.length).toBe(0);
+    expect(framed.payloadBytes).toBe(0);
+  });
 });
 
 describe('StreamFramer.frameOutputText', () => {

--- a/libs/runner/logs/src/core/framing.test.ts
+++ b/libs/runner/logs/src/core/framing.test.ts
@@ -22,6 +22,29 @@ function outputData(records: LogRecord[]): string {
     .join('');
 }
 
+describe('StreamFramer.frameAgentSession', () => {
+  it('frames one verbatim entry line into a single agent_session record', () => {
+    const framer = new StreamFramer(() => 1000);
+    const line = '{"type":"message","id":"a","parentId":null}';
+
+    const framed = framer.frameAgentSession(line);
+    const [record] = parseRecords(framed.bytes);
+
+    expect(record).toEqual({v: 1, ts: 1000, type: 'agent_session', data: line});
+    expect(framed.payloadBytes).toBe(Buffer.byteLength(line, 'utf8'));
+  });
+
+  it('does not split a line larger than the output data cap (one entry, one record)', () => {
+    const framer = new StreamFramer(() => 1);
+    const line = 'x'.repeat(MAX_RECORD_DATA_BYTES * 3);
+
+    const records = parseRecords(framer.frameAgentSession(line).bytes);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({type: 'agent_session', data: line});
+  });
+});
+
 describe('StreamFramer.frameOutputText', () => {
   it('frames text into a single output record with its stream pipe and stamped ts', () => {
     const framer = new StreamFramer(() => 1000);

--- a/libs/runner/logs/src/core/framing.ts
+++ b/libs/runner/logs/src/core/framing.ts
@@ -147,8 +147,10 @@ export class StreamFramer {
 
   // One verbatim agent session entry per record — never split (splitting would break the
   // entry's JSON). The caller drops an over-cap line before this runs. payloadBytes counts
-  // the entry's bytes toward the stream's end total, like output `data`.
+  // the entry's bytes toward the stream's end total, like output `data`. An empty line frames
+  // nothing (the DTO requires `data` non-empty), so it is never emitted as a record.
   frameAgentSession(line: string): FramedOutput {
+    if (line.length === 0) return EMPTY_FRAME;
     return {
       bytes: encodeRecord(agentSessionRecord({ts: this.now(), data: line})),
       payloadBytes: Buffer.byteLength(line, 'utf8'),

--- a/libs/runner/logs/src/core/framing.ts
+++ b/libs/runner/logs/src/core/framing.ts
@@ -5,7 +5,6 @@ import {
   MAX_RECORD_NAME_BYTES,
 } from '@shipfox/api-logs-dto';
 
-/** A pipe origin for captured output. */
 export type OutputSource = 'stdout' | 'stderr';
 
 export const PIPES: readonly OutputSource[] = ['stdout', 'stderr'];
@@ -44,6 +43,10 @@ function gapRecord(args: {ts: number; droppedBytes: number}): AppendableLogRecor
 
 function endRecord(args: {ts: number; totalBytes: number}): AppendableLogRecord {
   return {v: 1, ts: args.ts, type: 'end', total_bytes: args.totalBytes};
+}
+
+function agentSessionRecord(args: {ts: number; data: string}): AppendableLogRecord {
+  return {v: 1, ts: args.ts, type: 'agent_session', data: args.data};
 }
 
 export interface FramedOutput {
@@ -140,5 +143,15 @@ export class StreamFramer {
 
   frameEnd(totalBytes: number): Buffer {
     return encodeRecord(endRecord({ts: this.now(), totalBytes}));
+  }
+
+  // One verbatim agent session entry per record — never split (splitting would break the
+  // entry's JSON). The caller drops an over-cap line before this runs. payloadBytes counts
+  // the entry's bytes toward the stream's end total, like output `data`.
+  frameAgentSession(line: string): FramedOutput {
+    return {
+      bytes: encodeRecord(agentSessionRecord({ts: this.now(), data: line})),
+      payloadBytes: Buffer.byteLength(line, 'utf8'),
+    };
   }
 }

--- a/libs/runner/logs/src/core/lifecycle.ts
+++ b/libs/runner/logs/src/core/lifecycle.ts
@@ -1,0 +1,18 @@
+/**
+ * The close/drain/dispose lifecycle shared by every per-attempt log stream (process output
+ * and agent-session forwarding). The orchestration settles a stream through this contract
+ * without knowing which producer it carries.
+ */
+export interface LogStreamLifecycle {
+  /**
+   * Records the trailing end marker and resolves with the final raw stream length. Does NOT
+   * wait for upload — the report is never blocked on log drain.
+   */
+  close(): Promise<{streamLength: number}>;
+  /**
+   * Waits (bounded) for the uploader to ship everything spooled so far.
+   * `timeoutMs` defaults to `SHIPFOX_LOG_DRAIN_TIMEOUT_MS`.
+   */
+  drain(opts?: {signal?: AbortSignal; timeoutMs?: number}): Promise<void>;
+  dispose(): void;
+}

--- a/libs/runner/logs/src/core/record-sink.test.ts
+++ b/libs/runner/logs/src/core/record-sink.test.ts
@@ -1,0 +1,135 @@
+import {Buffer} from 'node:buffer';
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {type LogRecord, logRecordSchema} from '@shipfox/api-logs-dto';
+import type {LogAppendFn} from '@shipfox/runner-protocol';
+import type {FramedOutput} from '#core/framing.js';
+import {createRecordSink} from '#core/record-sink.js';
+
+const STEP_ID = '00000000-0000-0000-0000-000000000abc';
+
+function casServer() {
+  let committed = 0;
+  const append: LogAppendFn = ({offset, body}) => {
+    if (offset > committed)
+      return Promise.resolve({status: 'conflict', committedLength: committed});
+    if (offset === committed) committed += body.length;
+    return Promise.resolve({status: 'committed', committedLength: committed, capped: false});
+  };
+  return {append, committed: () => committed};
+}
+
+// Never resolves, so the server-acked offset stays at 0 (simulates an outage).
+const hangingAppend: LogAppendFn = ({signal}) =>
+  new Promise((_resolve, reject) => {
+    signal?.addEventListener('abort', () => reject(new Error('aborted')), {once: true});
+  });
+
+function framedOutput(data: string): FramedOutput {
+  const record = {v: 1, ts: 1, type: 'output', stream: 'stdout', data};
+  return {
+    bytes: Buffer.from(`${JSON.stringify(record)}\n`, 'utf8'),
+    payloadBytes: Buffer.byteLength(data, 'utf8'),
+  };
+}
+
+describe('createRecordSink', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'shipfox-record-sink-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  async function readRecords(attempt: number): Promise<LogRecord[]> {
+    const text = await readFile(join(dir, 'logs', `${STEP_ID}-${attempt}.ndjson`), 'utf8');
+    return text
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => logRecordSchema.parse(JSON.parse(line)));
+  }
+
+  function open(attempt: number, overrides: Partial<Parameters<typeof createRecordSink>[0]> = {}) {
+    return createRecordSink({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt,
+      append: casServer().append,
+      flushIntervalMs: 5,
+      now: () => 1,
+      ...overrides,
+    });
+  }
+
+  it('spools records, ends with the summed payload total, and commits to the server', async () => {
+    const server = casServer();
+    const sink = open(1, {append: server.append});
+
+    sink.spool(framedOutput('hello\n'));
+    sink.spool(framedOutput('world\n'));
+    const {streamLength} = sink.closeWithEnd();
+    await sink.drain({timeoutMs: 1000});
+    sink.dispose();
+
+    const records = await readRecords(1);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'output', stream: 'stdout', data: 'hello\n'},
+      {v: 1, ts: 1, type: 'output', stream: 'stdout', data: 'world\n'},
+      {v: 1, ts: 1, type: 'end', total_bytes: 12},
+    ]);
+    expect(server.committed()).toBe(streamLength);
+  });
+
+  it('drops records past the unacked-backlog cap and records a single gap', async () => {
+    const sink = open(2, {append: hangingAppend, spoolMaxBytes: 150});
+
+    const accepted = framedOutput('a'.repeat(40));
+    const droppedA = framedOutput('b'.repeat(40));
+    const droppedB = framedOutput('c'.repeat(40));
+
+    sink.spool(accepted);
+    sink.spool(droppedA);
+    sink.spool(droppedB);
+    sink.closeWithEnd();
+    sink.dispose();
+
+    const records = await readRecords(2);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'output', stream: 'stdout', data: 'a'.repeat(40)},
+      {v: 1, ts: 1, type: 'gap', dropped_bytes: 80},
+      {v: 1, ts: 1, type: 'end', total_bytes: 40},
+    ]);
+  });
+
+  it('abandons capture after fail(): later spools are no-ops and close writes no end record', async () => {
+    const sink = open(3);
+
+    sink.spool(framedOutput('before\n'));
+    sink.fail(new Error('disk full'));
+    sink.spool(framedOutput('after\n'));
+    const {streamLength} = sink.closeWithEnd();
+    sink.dispose();
+
+    expect(sink.isFailed()).toBe(true);
+    expect(streamLength).toBe(framedOutput('before\n').bytes.length);
+    const records = await readRecords(3);
+    expect(records).toEqual([{v: 1, ts: 1, type: 'output', stream: 'stdout', data: 'before\n'}]);
+  });
+
+  it('is idempotent on close: a second closeWithEnd writes no second end record', async () => {
+    const sink = open(4);
+
+    sink.spool(framedOutput('x\n'));
+    const first = sink.closeWithEnd();
+    const second = sink.closeWithEnd();
+    sink.dispose();
+
+    expect(second.streamLength).toBe(first.streamLength);
+    const records = await readRecords(4);
+    expect(records.filter((r) => r.type === 'end')).toHaveLength(1);
+  });
+});

--- a/libs/runner/logs/src/core/record-sink.ts
+++ b/libs/runner/logs/src/core/record-sink.ts
@@ -1,0 +1,180 @@
+import type {Buffer} from 'node:buffer';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {LogAppendFn} from '@shipfox/runner-protocol';
+import {AttemptSpool} from '#api/spool.js';
+import {LogUploader} from '#api/uploader.js';
+import {config} from '#config.js';
+import {type FramedOutput, StreamFramer} from '#core/framing.js';
+
+export interface RecordSinkOptions {
+  logsDir: string;
+  stepId: string;
+  attempt: number;
+  append: LogAppendFn;
+  flushBytes?: number;
+  spoolMaxBytes?: number;
+  flushIntervalMs?: number;
+  now?: () => number;
+}
+
+/**
+ * Per step-attempt transport substrate shared by every record producer (process output and
+ * agent-session forwarding):
+ *
+ *   spool(framed) ─▶ [backlog cap?] ─▶ spool ─▶ uploader ─▶ /logs
+ *                       │ over cap
+ *                       └▶ drop + remember dropped bytes ─▶ gap marker
+ *
+ * It owns the spool, the offset-CAS uploader, the unacked-backlog cap (drops past it and
+ * remembers the dropped bytes for the next `gap`), the trailing `end` record, and the
+ * fail-stream guard. It does NOT decode, mask, or frame: a producer frames its own records
+ * and hands the bytes here. The backlog cap bounds UNACKED bytes (spool length minus the
+ * server-acked offset), not total output, so a healthy long stream never drops.
+ */
+export interface RecordSink {
+  spool(framed: FramedOutput): void;
+  /** Spools a framed record bypassing the backlog cap (small, bounded close-time tails). */
+  spoolFinal(framed: FramedOutput): void;
+  dropPayload(payloadBytes: number): void;
+  notify(): void;
+  /**
+   * Flushes a pending gap and writes the `end` marker (unless the server capped or the
+   * stream failed), then notifies the uploader. Idempotent. Returns the raw stream length
+   * without waiting for upload.
+   */
+  closeWithEnd(): {streamLength: number};
+  drain(opts?: {signal?: AbortSignal; timeoutMs?: number}): Promise<void>;
+  dispose(): void;
+  fail(err: unknown): void;
+  isCapped(): boolean;
+  isStopped(): boolean;
+  isFailed(): boolean;
+  isClosed(): boolean;
+  readonly streamLength: number;
+}
+
+export function createRecordSink(options: RecordSinkOptions): RecordSink {
+  const now = options.now ?? Date.now;
+  const flushBytes = options.flushBytes ?? config.SHIPFOX_LOG_FLUSH_BYTES;
+  const spoolMaxBytes = options.spoolMaxBytes ?? config.SHIPFOX_LOG_SPOOL_MAX_BYTES;
+  const intervalMs = options.flushIntervalMs ?? config.SHIPFOX_LOG_FLUSH_INTERVAL_MS;
+
+  const framer = new StreamFramer(now);
+  const spool = AttemptSpool.open(options.logsDir, options.stepId, options.attempt);
+  const uploader = new LogUploader(spool, options.append, {intervalMs, flushBytes});
+
+  let streamLength = 0;
+  let payloadTotal = 0;
+  let droppedPayload = 0;
+  let dropping = false;
+  let closed = false;
+  let failed = false;
+
+  function spoolBytes(bytes: Buffer): void {
+    spool.append(bytes);
+    streamLength += bytes.length;
+  }
+
+  // A synchronous spool write (writeSync/openSync/mkdirSync) can throw on a real fs
+  // failure (ENOSPC, EMFILE, EACCES, logs dir removed mid-step). Abandon log capture for
+  // this step instead of letting the throw escape into a pipe/tail handler and kill the
+  // runner: the report still goes out, and the server closes the stream via timeout.
+  function fail(err: unknown): void {
+    if (failed) return;
+    failed = true;
+    logger().error(
+      {err: String(err), stepId: options.stepId, attempt: options.attempt},
+      'Log spool write failed; abandoning log capture for this step',
+    );
+    uploader.stop();
+  }
+
+  function flushPendingGap(): void {
+    if (!dropping) return;
+    spoolBytes(framer.frameGap(droppedPayload));
+    droppedPayload = 0;
+    dropping = false;
+  }
+
+  uploader.start();
+
+  return {
+    get streamLength() {
+      return streamLength;
+    },
+    isCapped: () => uploader.isCapped(),
+    isStopped: () => uploader.isStopped(),
+    isFailed: () => failed,
+    isClosed: () => closed,
+    fail,
+    notify: () => uploader.notify(),
+
+    spool(framed) {
+      if (framed.bytes.length === 0 || failed || closed) return;
+      const projectedBacklog = streamLength + framed.bytes.length - uploader.ackedOffset;
+      if (projectedBacklog > spoolMaxBytes) {
+        droppedPayload += framed.payloadBytes;
+        dropping = true;
+        return;
+      }
+      try {
+        flushPendingGap();
+        spoolBytes(framed.bytes);
+      } catch (err) {
+        fail(err);
+        return;
+      }
+      payloadTotal += framed.payloadBytes;
+    },
+
+    dropPayload(payloadBytes) {
+      if (failed || closed || payloadBytes <= 0) return;
+      droppedPayload += payloadBytes;
+      dropping = true;
+    },
+
+    spoolFinal(framed) {
+      if (framed.bytes.length === 0 || failed) return;
+      try {
+        flushPendingGap();
+        spoolBytes(framed.bytes);
+      } catch (err) {
+        fail(err);
+        return;
+      }
+      payloadTotal += framed.payloadBytes;
+    },
+
+    closeWithEnd() {
+      if (closed) return {streamLength};
+      closed = true;
+      if (failed) return {streamLength};
+
+      try {
+        flushPendingGap();
+        // On a server cap the stream is already closed by the cap tombstone, so the runner
+        // does not append its own end marker.
+        if (!uploader.isCapped()) {
+          spoolBytes(framer.frameEnd(payloadTotal));
+        }
+      } catch (err) {
+        fail(err);
+        return {streamLength};
+      }
+      uploader.notify();
+      return {streamLength};
+    },
+
+    async drain(opts = {}) {
+      await uploader.drain({
+        timeoutMs: opts.timeoutMs ?? config.SHIPFOX_LOG_DRAIN_TIMEOUT_MS,
+        ...(opts.signal ? {signal: opts.signal} : {}),
+      });
+    },
+
+    dispose() {
+      uploader.stop();
+      spool.close();
+    },
+  };
+}

--- a/libs/runner/logs/src/core/record-sink.ts
+++ b/libs/runner/logs/src/core/record-sink.ts
@@ -83,7 +83,7 @@ export function createRecordSink(options: RecordSinkOptions): RecordSink {
     if (failed) return;
     failed = true;
     logger().error(
-      {err: String(err), stepId: options.stepId, attempt: options.attempt},
+      {err, stepId: options.stepId, attempt: options.attempt},
       'Log spool write failed; abandoning log capture for this step',
     );
     uploader.stop();

--- a/libs/runner/logs/src/core/secrets.ts
+++ b/libs/runner/logs/src/core/secrets.ts
@@ -1,0 +1,15 @@
+import {secretWireForms} from '@shipfox/redact';
+
+/**
+ * One deduped, longest-first variant set for registered-secret masking. Each secret fans out
+ * to all its wire forms (base64/base64url/url/hex); longest-first so a secret that is a prefix
+ * of another is masked whole. Shared by the streaming output transform and the agent-session
+ * stream so the two masking paths can never drift.
+ */
+export function buildSecretVariants(secrets: string[]): string[] {
+  const variants = new Set<string>();
+  for (const secret of secrets) {
+    for (const form of secretWireForms(secret)) variants.add(form);
+  }
+  return [...variants].sort((a, b) => b.length - a.length);
+}

--- a/libs/runner/logs/src/core/session-log-stream.test.ts
+++ b/libs/runner/logs/src/core/session-log-stream.test.ts
@@ -1,0 +1,120 @@
+import {mkdtemp, readFile, rm} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {type LogRecord, logRecordSchema} from '@shipfox/api-logs-dto';
+import type {LogAppendFn} from '@shipfox/runner-protocol';
+import {createSessionLogStream} from '#core/session-log-stream.js';
+
+const STEP_ID = '00000000-0000-0000-0000-000000000abc';
+
+function casServer() {
+  let committed = 0;
+  const append: LogAppendFn = ({offset, body}) => {
+    if (offset > committed)
+      return Promise.resolve({status: 'conflict', committedLength: committed});
+    if (offset === committed) committed += body.length;
+    return Promise.resolve({status: 'committed', committedLength: committed, capped: false});
+  };
+  return {append, committed: () => committed};
+}
+
+describe('createSessionLogStream', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'shipfox-session-stream-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, {recursive: true, force: true});
+  });
+
+  async function readRecords(attempt: number): Promise<LogRecord[]> {
+    const text = await readFile(join(dir, 'logs', `${STEP_ID}-${attempt}.ndjson`), 'utf8');
+    return text
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => logRecordSchema.parse(JSON.parse(line)));
+  }
+
+  function open(
+    attempt: number,
+    overrides: Partial<Parameters<typeof createSessionLogStream>[0]> = {},
+  ) {
+    return createSessionLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt,
+      append: casServer().append,
+      flushIntervalMs: 5,
+      now: () => 1,
+      ...overrides,
+    });
+  }
+
+  it('forwards each entry as an agent_session record in order, then an end, and commits', async () => {
+    const server = casServer();
+    const stream = open(1, {append: server.append});
+
+    stream.writeEntry('{"type":"session","id":"s"}');
+    stream.writeEntry('{"type":"message","id":"a"}');
+    const {streamLength} = await stream.close();
+    await stream.drain({timeoutMs: 1000});
+    stream.dispose();
+
+    const records = await readRecords(1);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'agent_session', data: '{"type":"session","id":"s"}'},
+      {v: 1, ts: 1, type: 'agent_session', data: '{"type":"message","id":"a"}'},
+      {v: 1, ts: 1, type: 'end', total_bytes: 54},
+    ]);
+    expect(server.committed()).toBe(streamLength);
+  });
+
+  it('drops an entry whose record exceeds the flush window and records a single gap', async () => {
+    const stream = open(2, {flushBytes: 200});
+
+    const acceptedBeforeGap = '{"type":"a"}';
+    const oversizedEntry = 'y'.repeat(300);
+    const acceptedAfterGap = '{"type":"b"}';
+
+    stream.writeEntry(acceptedBeforeGap);
+    stream.writeEntry(oversizedEntry);
+    stream.writeEntry(acceptedAfterGap);
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(2);
+    expect(records).toEqual([
+      {v: 1, ts: 1, type: 'agent_session', data: acceptedBeforeGap},
+      {v: 1, ts: 1, type: 'gap', dropped_bytes: 300},
+      {v: 1, ts: 1, type: 'agent_session', data: acceptedAfterGap},
+      {v: 1, ts: 1, type: 'end', total_bytes: 24},
+    ]);
+  });
+
+  it('masks registered secrets in the entry before it reaches the spool', async () => {
+    const stream = open(3, {secrets: ['SUPERSECRET']});
+
+    stream.writeEntry('{"text":"token=SUPERSECRET done"}');
+    await stream.close();
+    stream.dispose();
+
+    const [record] = await readRecords(3);
+    expect(record).toMatchObject({type: 'agent_session'});
+    const data = record?.type === 'agent_session' ? record.data : '';
+    expect(data).not.toContain('SUPERSECRET');
+    expect(data).toContain('***');
+  });
+
+  it('ignores an empty entry', async () => {
+    const stream = open(4);
+
+    stream.writeEntry('');
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(4);
+    expect(records).toEqual([{v: 1, ts: 1, type: 'end', total_bytes: 0}]);
+  });
+});

--- a/libs/runner/logs/src/core/session-log-stream.ts
+++ b/libs/runner/logs/src/core/session-log-stream.ts
@@ -1,9 +1,10 @@
-import {redactSecrets, secretWireForms} from '@shipfox/redact';
+import {redactSecrets} from '@shipfox/redact';
 import type {LogAppendFn} from '@shipfox/runner-protocol';
 import {config} from '#config.js';
 import {type FramedOutput, StreamFramer} from '#core/framing.js';
 import type {LogStreamLifecycle} from '#core/lifecycle.js';
 import {createRecordSink} from '#core/record-sink.js';
+import {buildSecretVariants} from '#core/secrets.js';
 
 export interface SessionLogStreamOptions {
   logsDir: string;
@@ -92,14 +93,4 @@ export function createSessionLogStream(options: SessionLogStreamOptions): Sessio
       sink.dispose();
     },
   };
-}
-
-// One deduped, longest-first variant set (registered-secret masking), built exactly like
-// LogTransformer's. Longest-first so a secret that is a prefix of another is masked whole.
-function buildSecretVariants(secrets: string[]): string[] {
-  const variants = new Set<string>();
-  for (const secret of secrets) {
-    for (const form of secretWireForms(secret)) variants.add(form);
-  }
-  return [...variants].sort((a, b) => b.length - a.length);
 }

--- a/libs/runner/logs/src/core/session-log-stream.ts
+++ b/libs/runner/logs/src/core/session-log-stream.ts
@@ -1,0 +1,105 @@
+import {redactSecrets, secretWireForms} from '@shipfox/redact';
+import type {LogAppendFn} from '@shipfox/runner-protocol';
+import {config} from '#config.js';
+import {type FramedOutput, StreamFramer} from '#core/framing.js';
+import type {LogStreamLifecycle} from '#core/lifecycle.js';
+import {createRecordSink} from '#core/record-sink.js';
+
+export interface SessionLogStreamOptions {
+  logsDir: string;
+  stepId: string;
+  attempt: number;
+  append: LogAppendFn;
+  /**
+   * Secrets masked out of each entry before it reaches the spool, each replaced (with all its
+   * base64/base64url/url/hex forms) by `***`. Empty disables masking.
+   */
+  secrets?: string[];
+  /**
+   * Upload window and per-entry drop threshold. An entry whose encoded record exceeds it is
+   * dropped with a gap. Defaults to `SHIPFOX_AGENT_SESSION_FLUSH_BYTES`.
+   */
+  flushBytes?: number;
+  spoolMaxBytes?: number;
+  flushIntervalMs?: number;
+  now?: () => number;
+}
+
+export interface SessionLogStream extends LogStreamLifecycle {
+  writeEntry(line: string): void;
+}
+
+/**
+ * Forwards verbatim agent session entries onto the step attempt's log stream as opaque
+ * `agent_session` records over the shared `RecordSink`. One entry rides one record (never
+ * split — that would break the entry's JSON); masking applies whole-line, so no streaming
+ * lookbehind is needed. An over-window entry is dropped with a gap rather than forwarded.
+ */
+export function createSessionLogStream(options: SessionLogStreamOptions): SessionLogStream {
+  const now = options.now ?? Date.now;
+  const flushBytes = options.flushBytes ?? config.SHIPFOX_AGENT_SESSION_FLUSH_BYTES;
+  const framer = new StreamFramer(now);
+  const variants = buildSecretVariants(options.secrets ?? []);
+
+  const sink = createRecordSink({
+    logsDir: options.logsDir,
+    stepId: options.stepId,
+    attempt: options.attempt,
+    append: options.append,
+    now,
+    flushBytes,
+    ...(options.spoolMaxBytes !== undefined ? {spoolMaxBytes: options.spoolMaxBytes} : {}),
+    ...(options.flushIntervalMs !== undefined ? {flushIntervalMs: options.flushIntervalMs} : {}),
+  });
+
+  return {
+    writeEntry(line) {
+      if (line.length === 0) return;
+      if (sink.isClosed() || sink.isFailed() || sink.isCapped() || sink.isStopped()) return;
+
+      let framed: FramedOutput;
+      try {
+        const masked = variants.length > 0 ? redactSecrets(line, variants) : line;
+        framed = framer.frameAgentSession(masked);
+      } catch (err) {
+        // Masking/framing is pure, but guard the boundary so a surprise never escapes into
+        // the tailer callback and crashes the runner.
+        sink.fail(err);
+        return;
+      }
+
+      // One entry rides one record and is never split. A record larger than the flush window
+      // could not be read back whole or accepted by the server, so drop it and account a gap
+      // of the entry's bytes instead.
+      if (framed.bytes.length > flushBytes) {
+        sink.dropPayload(framed.payloadBytes);
+        return;
+      }
+
+      sink.spool(framed);
+      sink.notify();
+    },
+
+    close() {
+      return Promise.resolve(sink.closeWithEnd());
+    },
+
+    async drain(opts = {}) {
+      await sink.drain(opts);
+    },
+
+    dispose() {
+      sink.dispose();
+    },
+  };
+}
+
+// One deduped, longest-first variant set (registered-secret masking), built exactly like
+// LogTransformer's. Longest-first so a secret that is a prefix of another is masked whole.
+function buildSecretVariants(secrets: string[]): string[] {
+  const variants = new Set<string>();
+  for (const secret of secrets) {
+    for (const form of secretWireForms(secret)) variants.add(form);
+  }
+  return [...variants].sort((a, b) => b.length - a.length);
+}

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -1,10 +1,8 @@
 import {Buffer} from 'node:buffer';
-import {logger} from '@shipfox/node-opentelemetry';
 import type {LogAppendFn} from '@shipfox/runner-protocol';
-import {AttemptSpool} from '#api/spool.js';
-import {LogUploader} from '#api/uploader.js';
-import {config} from '#config.js';
 import {type FramedOutput, type OutputSource, StreamFramer} from '#core/framing.js';
+import type {LogStreamLifecycle} from '#core/lifecycle.js';
+import {createRecordSink} from '#core/record-sink.js';
 import {LogTransformer, type TransformEvent} from '#core/transform.js';
 
 const EMPTY_FRAMED: FramedOutput = {bytes: Buffer.alloc(0), payloadBytes: 0};
@@ -28,81 +26,32 @@ export interface StepLogStreamOptions {
   now?: () => number;
 }
 
-export interface StepLogStream {
+export interface StepLogStream extends LogStreamLifecycle {
   /** Frames and spools a captured output chunk. Safe to call from a pipe handler. */
   write(chunk: Buffer, source: OutputSource): void;
-  /**
-   * Flushes decoders, records a trailing gap and the end marker, and resolves
-   * with the final raw stream length. Does NOT wait for upload — the report is
-   * never blocked on log drain.
-   */
-  close(): Promise<{streamLength: number}>;
-  /**
-   * Waits (bounded) for the uploader to ship everything spooled so far.
-   * `timeoutMs` defaults to `SHIPFOX_LOG_DRAIN_TIMEOUT_MS`.
-   */
-  drain(opts?: {signal?: AbortSignal; timeoutMs?: number}): Promise<void>;
-  /** Stops the uploader and closes spool file descriptors. */
-  dispose(): void;
 }
 
 /**
- * Per step-attempt log pipeline:
- *
- *   write(chunk) ─▶ transform ─▶ [backlog cap?] ─▶ spool ─▶ uploader ─▶ /logs
- *                  (mask + markers)   │ over cap
- *                                     └▶ drop + remember dropped bytes ─▶ gap marker
- *
- * The transform decodes, masks secrets before any byte touches disk, and turns
- * `::group::`/`::endgroup::` lines into control records. The backlog cap bounds UNACKED
- * bytes (spool length minus the server-acked offset), not total output, so a healthy long
- * stream never drops. Output and group records pass through the cap (a step controls both);
- * runner-originated gap/end records bypass it so truncation is always visible.
+ * Per step-attempt process-output pipeline. The transform decodes, masks secrets before any
+ * byte touches disk, and turns `::group::`/`::endgroup::` lines into control records; the
+ * framing turns events into NDJSON; the shared `RecordSink` applies the backlog cap, spools,
+ * uploads, and writes the trailing gap/end. Output and group records pass through the cap (a
+ * step controls both); runner-originated gap/end records bypass it so truncation is visible.
  */
 export function createStepLogStream(options: StepLogStreamOptions): StepLogStream {
   const now = options.now ?? Date.now;
-  const flushBytes = options.flushBytes ?? config.SHIPFOX_LOG_FLUSH_BYTES;
-  const spoolMaxBytes = options.spoolMaxBytes ?? config.SHIPFOX_LOG_SPOOL_MAX_BYTES;
-  const intervalMs = options.flushIntervalMs ?? config.SHIPFOX_LOG_FLUSH_INTERVAL_MS;
-
   const framer = new StreamFramer(now);
   const transformer = new LogTransformer(options.secrets ?? []);
-  const spool = AttemptSpool.open(options.logsDir, options.stepId, options.attempt);
-  const uploader = new LogUploader(spool, options.append, {intervalMs, flushBytes});
-
-  let streamLength = 0;
-  let payloadTotal = 0;
-  let droppedPayload = 0;
-  let dropping = false;
-  let closed = false;
-  let failed = false;
-
-  function spoolBytes(bytes: Buffer): void {
-    spool.append(bytes);
-    streamLength += bytes.length;
-  }
-
-  // A synchronous spool write (writeSync/openSync/mkdirSync) can throw on a real fs
-  // failure (ENOSPC, EMFILE, EACCES, logs dir removed mid-step). That throw originates
-  // inside the child process's stdout/stderr 'data' handler, where it would escape as
-  // an uncaughtException and kill the whole runner. Abandon log capture for this step
-  // instead: the report still goes out, and the server closes the stream via timeout.
-  function failStream(err: unknown): void {
-    if (failed) return;
-    failed = true;
-    logger().error(
-      {err: String(err), stepId: options.stepId, attempt: options.attempt},
-      'Log spool write failed; abandoning log capture for this step',
-    );
-    uploader.stop();
-  }
-
-  function flushPendingGap(): void {
-    if (!dropping) return;
-    spoolBytes(framer.frameGap(droppedPayload));
-    droppedPayload = 0;
-    dropping = false;
-  }
+  const sink = createRecordSink({
+    logsDir: options.logsDir,
+    stepId: options.stepId,
+    attempt: options.attempt,
+    append: options.append,
+    now,
+    ...(options.flushBytes !== undefined ? {flushBytes: options.flushBytes} : {}),
+    ...(options.spoolMaxBytes !== undefined ? {spoolMaxBytes: options.spoolMaxBytes} : {}),
+    ...(options.flushIntervalMs !== undefined ? {flushIntervalMs: options.flushIntervalMs} : {}),
+  });
 
   // ── Group nesting ───────────────────────────────────────────────────────────
   // Single sequential consumer across both pipes. Each `::group::` gets a monotonic
@@ -149,28 +98,11 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
     return {bytes: framer.frameGroupEnd(groupId), payloadBytes: 0};
   }
 
-  // Applies the backlog cap to one framed record and spools it, or drops it and remembers the
-  // dropped payload for the next gap marker.
-  function spoolFramed(framed: FramedOutput): void {
-    if (framed.bytes.length === 0) return;
-    const projectedBacklog = streamLength + framed.bytes.length - uploader.ackedOffset;
-    if (projectedBacklog > spoolMaxBytes) {
-      droppedPayload += framed.payloadBytes;
-      dropping = true;
-      return;
-    }
-    flushPendingGap();
-    spoolBytes(framed.bytes);
-    payloadTotal += framed.payloadBytes;
-  }
-
-  uploader.start();
-
   return {
     write(chunk, source) {
       // Once the server caps the budget the runner stops emitting; the cap
       // tombstone is server-side, so no gap is recorded here.
-      if (closed || failed || uploader.isCapped() || uploader.isStopped()) return;
+      if (sink.isClosed() || sink.isFailed() || sink.isCapped() || sink.isStopped()) return;
 
       let events: TransformEvent[];
       try {
@@ -178,60 +110,38 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       } catch (err) {
         // Decoding/masking is pure, but guard the boundary so a surprise never escapes
         // into the child-output handler and crashes the runner.
-        failStream(err);
+        sink.fail(err);
         return;
       }
 
       try {
-        for (const event of events) spoolFramed(frameEvent(event));
+        for (const event of events) sink.spool(frameEvent(event));
       } catch (err) {
-        failStream(err);
+        sink.fail(err);
         return;
       }
-      uploader.notify();
+      sink.notify();
     },
 
     close() {
-      if (closed) return Promise.resolve({streamLength});
-      closed = true;
-      if (failed) return Promise.resolve({streamLength});
+      if (sink.isClosed()) return Promise.resolve({streamLength: sink.streamLength});
 
       try {
         // Flush held partial lines and decoder tails; these final bytes bypass the backlog cap
         // (they are small and bounded) so the stream always ends cleanly.
-        for (const event of transformer.flush()) {
-          const framed = frameEvent(event);
-          if (framed.bytes.length === 0) continue;
-          flushPendingGap();
-          spoolBytes(framed.bytes);
-          payloadTotal += framed.payloadBytes;
-        }
-        flushPendingGap();
-
-        // On a server cap the stream is already closed by the cap tombstone, so the
-        // runner does not append its own end marker.
-        if (!uploader.isCapped()) {
-          spoolBytes(framer.frameEnd(payloadTotal));
-        }
+        for (const event of transformer.flush()) sink.spoolFinal(frameEvent(event));
       } catch (err) {
-        failStream(err);
-        return Promise.resolve({streamLength});
+        sink.fail(err);
       }
-
-      uploader.notify();
-      return Promise.resolve({streamLength});
+      return Promise.resolve(sink.closeWithEnd());
     },
 
     async drain(opts = {}) {
-      await uploader.drain({
-        timeoutMs: opts.timeoutMs ?? config.SHIPFOX_LOG_DRAIN_TIMEOUT_MS,
-        ...(opts.signal ? {signal: opts.signal} : {}),
-      });
+      await sink.drain(opts);
     },
 
     dispose() {
-      uploader.stop();
-      spool.close();
+      sink.dispose();
     },
   };
 }

--- a/libs/runner/logs/src/core/transform.ts
+++ b/libs/runner/logs/src/core/transform.ts
@@ -1,7 +1,8 @@
 import {TextDecoder} from 'node:util';
-import {redactSecrets, secretWireForms} from '@shipfox/redact';
+import {redactSecrets} from '@shipfox/redact';
 import {type OutputSource, PIPES} from '#core/framing.js';
 import {couldBeMarker, parseMarker} from '#core/markers.js';
+import {buildSecretVariants} from '#core/secrets.js';
 
 /** What the transform hands the framer: masked output text, or a swallowed group marker. */
 export type TransformEvent =
@@ -39,14 +40,10 @@ export class LogTransformer {
   private readonly sources: Record<OutputSource, SourceState>;
 
   constructor(secrets: string[]) {
-    // One deduped, longest-first variant set shared across pipes (secrets are global). The
-    // per-pipe decoder and line buffer are independent: stdout and stderr are separate byte
-    // streams that must never complete each other's partial sequences or split secrets.
-    const variantSet = new Set<string>();
-    for (const secret of secrets) {
-      for (const form of secretWireForms(secret)) variantSet.add(form);
-    }
-    this.variants = [...variantSet].sort((a, b) => b.length - a.length);
+    // The variant set is shared across pipes (secrets are global), but the per-pipe decoder and
+    // line buffer are independent: stdout and stderr are separate byte streams that must never
+    // complete each other's partial sequences or split secrets.
+    this.variants = buildSecretVariants(secrets);
     this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
     this.sources = {
       stdout: {decoder: newDecoder(), buffer: ''},

--- a/libs/runner/logs/src/index.ts
+++ b/libs/runner/logs/src/index.ts
@@ -1,4 +1,10 @@
 export type {OutputSource} from '#core/framing.js';
+export type {LogStreamLifecycle} from '#core/lifecycle.js';
+export {
+  createSessionLogStream,
+  type SessionLogStream,
+  type SessionLogStreamOptions,
+} from '#core/session-log-stream.js';
 export {
   createStepLogStream,
   type StepLogStream,

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -480,6 +480,30 @@ describe('runJobSteps', () => {
     expect(sessionStream.dispose).toHaveBeenCalled();
   });
 
+  it('runs and reports an agent step when opening the session stream fails (capture abandoned)', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    // Opening the session spool throws (e.g. a broken logs dir): capture must be abandoned, not
+    // fatal to the step, and the agent runs without a session sink (no onSessionEntry).
+    createSessionLogStreamMock.mockImplementationOnce(() => {
+      throw new Error('logs dir is a file');
+    });
+    executeAgentStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+
+    expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {signal: ac.signal, cwd: '/work'});
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({stepId: agent.id, status: 'succeeded'}),
+    );
+  });
+
   it('does not report the agent step when the signal aborts mid-run', async () => {
     const setup = buildSetupStep();
     const agent = buildAgentStep();

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -7,6 +7,7 @@ const appendStepLogsMock = vi.fn();
 const executeRunStepMock = vi.fn();
 const executeSetupStepMock = vi.fn();
 const createStepLogStreamMock = vi.fn();
+const createSessionLogStreamMock = vi.fn();
 const executeAgentStepMock = vi.fn();
 
 vi.mock('@shipfox/runner-protocol', () => ({
@@ -23,6 +24,7 @@ vi.mock('@shipfox/runner-execution', () => ({
 
 vi.mock('@shipfox/runner-logs', () => ({
   createStepLogStream: (...args: unknown[]) => createStepLogStreamMock(...args),
+  createSessionLogStream: (...args: unknown[]) => createSessionLogStreamMock(...args),
 }));
 
 vi.mock('@shipfox/runner-agent', () => ({
@@ -41,6 +43,7 @@ let events: string[];
 
 interface FakeStream {
   write: ReturnType<typeof vi.fn>;
+  writeEntry: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   drain: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
@@ -49,6 +52,7 @@ interface FakeStream {
 function makeFakeStream(label: string): FakeStream {
   return {
     write: vi.fn(),
+    writeEntry: vi.fn(),
     close: vi.fn(() => {
       events.push(`close:${label}`);
       return Promise.resolve({streamLength: STREAM_LENGTH});
@@ -71,12 +75,17 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockReset();
     executeSetupStepMock.mockReset();
     createStepLogStreamMock.mockReset();
+    createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
     events = [];
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
     // Setup succeeds by default; tests that exercise setup failure override it.
     executeSetupStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     createStepLogStreamMock.mockImplementation((opts: {stepId: string}) => {
+      events.push(`create:${opts.stepId}`);
+      return makeFakeStream(opts.stepId);
+    });
+    createSessionLogStreamMock.mockImplementation((opts: {stepId: string}) => {
       events.push(`create:${opts.stepId}`);
       return makeFakeStream(opts.stepId);
     });
@@ -134,9 +143,7 @@ describe('runJobSteps', () => {
       secrets: [],
       append: expect.any(Function),
     });
-    // No stream for the synthetic setup step.
     expect(createStepLogStreamMock).toHaveBeenCalledTimes(1);
-    // Drained and disposed once the loop finishes.
     expect(events).toContain(`drain:${run.id}`);
     expect(events).toContain(`dispose:${run.id}`);
   });
@@ -182,7 +189,6 @@ describe('runJobSteps', () => {
 
     await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
-    // The step still runs and is reported succeeded; the stream failure does not fail the step.
     expect(executeRunStepMock).toHaveBeenCalled();
     expect(reportStepMock).toHaveBeenCalledWith(
       leaseClient,
@@ -204,7 +210,6 @@ describe('runJobSteps', () => {
 
     await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
-    // The first stream is drained and disposed before the second is created.
     expect(events.indexOf(`dispose:${run1.id}`)).toBeLessThan(events.indexOf(`create:${run2.id}`));
     expect(events).toContain(`dispose:${run2.id}`);
   });
@@ -421,9 +426,12 @@ describe('runJobSteps', () => {
 
     await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
-    expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {signal: ac.signal, cwd: '/work'});
+    expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {
+      signal: ac.signal,
+      cwd: '/work',
+      onSessionEntry: expect.any(Function),
+    });
     expect(executeRunStepMock).not.toHaveBeenCalled();
-    // No log stream is opened for agent steps, so the report carries no stream length.
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: agent.id,
       attempt: 1,
@@ -432,6 +440,44 @@ describe('runJobSteps', () => {
       exitCode: 0,
       signal: ac.signal,
     });
+  });
+
+  it('opens a session stream for an agent step, forwards entries, and settles it', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    const sessionStream = makeFakeStream(agent.id);
+    createSessionLogStreamMock.mockReturnValue(sessionStream);
+    executeAgentStepMock.mockImplementation(
+      (_step: StepDto, opts: {onSessionEntry?: (line: string) => void}) => {
+        opts.onSessionEntry?.('{"type":"message","id":"a"}');
+        return Promise.resolve({success: true, output: '', error: null, exit_code: 0});
+      },
+    );
+    const ac = new AbortController();
+
+    await runJobSteps({
+      jobId: JOB_ID,
+      leaseClient,
+      secrets: ['s3cr3t'],
+      signal: ac.signal,
+      cwd: '/work',
+    });
+
+    expect(createSessionLogStreamMock).toHaveBeenCalledWith({
+      logsDir: '/work/logs',
+      stepId: agent.id,
+      attempt: 1,
+      secrets: ['s3cr3t'],
+      append: expect.any(Function),
+    });
+    expect(sessionStream.writeEntry).toHaveBeenCalledWith('{"type":"message","id":"a"}');
+    expect(sessionStream.close).toHaveBeenCalled();
+    expect(sessionStream.drain).toHaveBeenCalled();
+    expect(sessionStream.dispose).toHaveBeenCalled();
   });
 
   it('does not report the agent step when the signal aborts mid-run', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -3,8 +3,20 @@ import type {NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {executeAgentStep} from '@shipfox/runner-agent';
 import {executeRunStep, executeSetupStep, type StepResult} from '@shipfox/runner-execution';
-import {createStepLogStream, type StepLogStream} from '@shipfox/runner-logs';
-import {appendStepLogs, HTTPError, reportStep, requestNextStep} from '@shipfox/runner-protocol';
+import {
+  createSessionLogStream,
+  createStepLogStream,
+  type LogStreamLifecycle,
+  type SessionLogStream,
+  type StepLogStream,
+} from '@shipfox/runner-logs';
+import {
+  appendStepLogs,
+  HTTPError,
+  type LogAppendFn,
+  reportStep,
+  requestNextStep,
+} from '@shipfox/runner-protocol';
 import type {KyInstance} from 'ky';
 
 // Reporting a step before pulling the next one is the safety invariant: a lost report is
@@ -29,9 +41,10 @@ export async function runJobSteps(params: {
   // against an unprepared cwd. The guard and its rollout rationale live in `executeStep`.
   let workspacePrepared = false;
 
-  // The most recent run step's stream, kept until the next iteration settles it (or the
-  // finally does at job end). The step loop is sequential, so at most one tail drains.
-  let activeStream: StepLogStream | undefined;
+  // The most recent step's stream (run output or agent session), kept until the next
+  // iteration settles it (or the finally does at job end). The step loop is sequential, so
+  // at most one tail drains.
+  let activeStream: LogStreamLifecycle | undefined;
 
   try {
     while (!signal.aborted) {
@@ -129,8 +142,7 @@ export async function pullNextStep(params: {
 
 export interface StepExecution {
   result: StepResult;
-  /** The run step's log stream, when one was opened; settle it after reporting. */
-  stream?: StepLogStream | undefined;
+  stream?: LogStreamLifecycle | undefined;
   /** True when a setup step succeeded, unlocking the run steps that follow it. */
   preparedWorkspace: boolean;
 }
@@ -153,7 +165,7 @@ export async function executeStep(params: {
   const {step, attempt, cwd, leaseClient, secrets, signal, workspacePrepared, jobId, stepLabel} =
     params;
 
-  let stream: StepLogStream | undefined;
+  let stream: LogStreamLifecycle | undefined;
   try {
     if (step.type === 'setup') {
       const result = await executeSetupStep({cwd, leaseClient, signal});
@@ -175,29 +187,57 @@ export async function executeStep(params: {
       };
     }
 
-    // Agent steps run the embedded pi harness; they capture their own summary and do not
-    // stream output through the log pipeline (run steps below do).
+    // Both step kinds capture to the same per-attempt stream contract (one stream per
+    // job/step/attempt). The append port is bound to the lease client, step, and attempt.
+    const append: LogAppendFn = ({offset, body, signal: appendSignal}) =>
+      appendStepLogs(leaseClient, {
+        stepId: step.id,
+        attempt,
+        offset,
+        body,
+        ...(appendSignal ? {signal: appendSignal} : {}),
+      });
+
+    // Agent steps run the embedded pi harness and forward every session entry into the log
+    // pipeline as opaque `agent_session` records. Capture is best-effort: if the spool cannot
+    // be opened, run the agent without it rather than failing the step.
     if (step.type === 'agent') {
-      const result = await executeAgentStep(step, {signal, cwd});
-      return {result, preparedWorkspace: false};
+      let sessionStream: SessionLogStream | undefined;
+      try {
+        sessionStream = createSessionLogStream({
+          logsDir: join(cwd, 'logs'),
+          stepId: step.id,
+          attempt,
+          secrets,
+          append,
+        });
+      } catch (error) {
+        logger().error(
+          {err: error, jobId, stepId: step.id, attempt},
+          'Failed to open agent session capture; running the step without it',
+        );
+      }
+      stream = sessionStream;
+      const result = await executeAgentStep(step, {
+        signal,
+        cwd,
+        ...(sessionStream
+          ? {onSessionEntry: (line: string) => sessionStream?.writeEntry(line)}
+          : {}),
+      });
+      return {result, stream, preparedWorkspace: false};
     }
 
     // Log capture is best-effort: if the spool cannot be opened (e.g. a broken logs dir),
     // abandon capture and run the step without a stream rather than failing the step itself.
+    let stepStream: StepLogStream | undefined;
     try {
-      stream = createStepLogStream({
+      stepStream = createStepLogStream({
         logsDir: join(cwd, 'logs'),
         stepId: step.id,
         attempt,
         secrets,
-        append: ({offset, body, signal: appendSignal}) =>
-          appendStepLogs(leaseClient, {
-            stepId: step.id,
-            attempt,
-            offset,
-            body,
-            ...(appendSignal ? {signal: appendSignal} : {}),
-          }),
+        append,
       });
     } catch (error) {
       logger().error(
@@ -205,11 +245,12 @@ export async function executeStep(params: {
         'Failed to open log capture; running the step without it',
       );
     }
+    stream = stepStream;
 
     const result = await executeRunStep(step, {
       signal,
       cwd,
-      onOutput: (chunk, source) => stream?.write(chunk, source),
+      onOutput: (chunk, source) => stepStream?.write(chunk, source),
     });
     return {result, stream, preparedWorkspace: false};
   } catch (error) {
@@ -236,7 +277,7 @@ export async function reportStepResult(params: {
   step: StepDto;
   attempt: number;
   result: StepResult;
-  stream: StepLogStream | undefined;
+  stream: LogStreamLifecycle | undefined;
   jobId: string;
   stepLabel: string;
   signal: AbortSignal;
@@ -272,7 +313,7 @@ export async function reportStepResult(params: {
 // Closes (idempotent), drains (bounded; an abort cuts it short), and disposes a stream.
 // A no-op when there is no stream, so callers can settle unconditionally.
 export async function settleStream(params: {
-  stream: StepLogStream | undefined;
+  stream: LogStreamLifecycle | undefined;
   signal: AbortSignal;
 }): Promise<void> {
   const {stream, signal} = params;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2814,6 +2814,9 @@ importers:
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../api/workflows-dto
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
       '@shipfox/runner-execution':
         specifier: workspace:*
         version: link:../execution


### PR DESCRIPTION
Forwards every pi agent-session entry into the existing logs pipeline as an opaque `agent_session` record, riding the same `(job, step, attempt)` stream as process output, so a failed or long-running agent step becomes inspectable. The runner is a pure forwarder: it tails the pi session JSONL file by byte offset and hands each verbatim line to a session log stream that masks, frames, and spools it. The logs module stores entries verbatim; the client (ENG-502) parses them.

Agent steps previously left no durable trail beyond a runner-local summary.

Notes for review:

- The transport substrate (spool, offset-CAS upload, backlog cap, gap/end, fail guard) is extracted from the output stream into a shared `RecordSink`; `step-log-stream` is refactored onto it with no behavior change, and its existing 20-test suite is the regression guard.
- Per-entry size is enforced at several mutually-consistent points: runner `SHIPFOX_AGENT_SESSION_FLUSH_BYTES` (4 MiB drop threshold) <= server `LOG_MAX_SESSION_LINE_BYTES` (4 MiB, 400 over-cap) <= `LOG_APPEND_BODY_LIMIT_BYTES` (8 MiB, restored from 1 MiB, with a startup invariant) <= `LOG_BUDGET_BASE_BYTES` (32 MiB). Sized for entries that inline base64 images.
- Whole-entry records (one `agent_session` record per entry, never split) so the client just `JSON.parse`s each record's `data`.
- Capture is best-effort and non-blocking: an oversized entry drops with a gap, a failed spool abandons capture, a missing session file skips forwarding, and none change the step outcome.

Coverage is unit-per-package (real-Postgres for `api-logs`) plus a manual end-to-end check; an automated runner-to-api round-trip is a possible follow-up.

Refs ENG-497

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwards agent step session entries into the logs pipeline as opaque `agent_session` records so agent runs are inspectable. Tailing is UTF-8 safe, abort-safe, ignores empty lines, masks secrets, and enforces per-entry and budget limits.

- **New Features**
  - Agent steps open a session stream; each JSONL entry becomes one `agent_session` record on the same `(job, step, attempt)` stream as process output; orchestration settles it via a shared lifecycle.
  - Runner tails the pi session file by byte offset with UTF-8–safe reassembly, holds partial lines until newline, resets the offset on truncation/replacement, does a final read on stop, and stops promptly on abort; missing/deleted files skip quietly.
  - `@shipfox/api-logs` accepts `agent_session` with a per-entry cap (`LOG_MAX_SESSION_LINE_BYTES`) enforced in the write path (400 on over-cap); startup invariant requires `LOG_APPEND_BODY_LIMIT_BYTES` ≥ the cap; docs updated. Addresses ENG-497.

- **Refactors**
  - Extracted a shared `RecordSink` (spool, offset-CAS upload, backlog cap, gap/end, fail guard) and moved `step-log-stream` onto it; added `LogStreamLifecycle` and `createSessionLogStream` (drops over-window entries with a gap, masks secrets, ignores empty lines).
  - Config tuned for large entries: server defaults `LOG_BUDGET_BASE_BYTES` 32 MiB, `LOG_APPEND_BODY_LIMIT_BYTES` 8 MiB, `LOG_MAX_SESSION_LINE_BYTES` 4 MiB; runner `SHIPFOX_AGENT_SESSION_FLUSH_BYTES` default 4 MiB and bounded [64 KiB, 4 MiB] to align with server caps; README updated.
  - Improved diagnostics and tests: log original error objects on spool/tail failures; fix a temp-dir leak in tests; add forwarder tests (UTF-8 splits, truncation reset, final drain). Added `@shipfox/node-opentelemetry` to `@shipfox/runner-agent`.

<sup>Written for commit 64387ef049299a31612968f7084b890d1be81290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

