### PR TITLE
[react-ui] Add log viewer UI primitives to the design system

### DIFF
--- a/.changeset/lively-otters-tail.md
+++ b/.changeset/lively-otters-tail.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds log viewer UI primitives (LogRows, LogRow, LogHeader, LogContent) for composing CI and agent log records.

--- a/libs/shared/react/ui/src/components/index.ts
+++ b/libs/shared/react/ui/src/components/index.ts
@@ -17,6 +17,7 @@ export * from './kbd/index.js';
 export * from './label/index.js';
 export * from './load-error-state/index.js';
 export * from './loader/index.js';
+export * from './log/index.js';
 export * from './logo/index.js';
 export * from './modal/index.js';
 export * from './popover/index.js';

--- a/libs/shared/react/ui/src/components/log/ansi.test.ts
+++ b/libs/shared/react/ui/src/components/log/ansi.test.ts
@@ -81,6 +81,15 @@ describe('parseAnsi', () => {
     expect(result[0]?.className).toBe('italic underline');
   });
 
+  test('an unsupported extended color clears the previous color instead of leaking it', () => {
+    const result = parseAnsi(`${ESC}[31mred${ESC}[38;5;200mreset`);
+
+    expect(result.map((span) => [span.text, span.className])).toEqual([
+      ['red', 'text-red-400'],
+      ['reset', ''],
+    ]);
+  });
+
   test('leaves a non-SGR escape sequence untouched as text', () => {
     const result = parseAnsi(`${ESC}[2Kdone`);
 

--- a/libs/shared/react/ui/src/components/log/ansi.test.ts
+++ b/libs/shared/react/ui/src/components/log/ansi.test.ts
@@ -1,0 +1,89 @@
+import {parseAnsi} from './ansi.js';
+
+const ESC = String.fromCharCode(27);
+
+describe('parseAnsi', () => {
+  test('returns a single unstyled span for plain text', () => {
+    const result = parseAnsi('hello world');
+
+    expect(result).toEqual([{text: 'hello world', className: '', start: 0}]);
+  });
+
+  test('maps a foreground color to a palette class', () => {
+    const result = parseAnsi(`${ESC}[31mred${ESC}[0m`);
+
+    expect(result).toEqual([{text: 'red', className: 'text-red-400', start: 5}]);
+  });
+
+  test('maps a background color to a palette class', () => {
+    const result = parseAnsi(`${ESC}[42mok`);
+
+    expect(result).toEqual([{text: 'ok', className: 'bg-green-500', start: 5}]);
+  });
+
+  test('combines a color with a bold attribute', () => {
+    const result = parseAnsi(`${ESC}[1;32mok`);
+
+    expect(result).toEqual([{text: 'ok', className: 'text-green-400 font-bold', start: 7}]);
+  });
+
+  test('reset clears all styling for the following text', () => {
+    const result = parseAnsi(`${ESC}[31mA${ESC}[0mB`);
+
+    expect(result).toEqual([
+      {text: 'A', className: 'text-red-400', start: 5},
+      {text: 'B', className: '', start: 10},
+    ]);
+  });
+
+  test('an empty parameter list is shorthand for reset', () => {
+    const result = parseAnsi(`${ESC}[31mA${ESC}[mB`);
+
+    expect(result.map((span) => [span.text, span.className])).toEqual([
+      ['A', 'text-red-400'],
+      ['B', ''],
+    ]);
+  });
+
+  test('default-foreground (39) clears the color but keeps other attributes', () => {
+    const result = parseAnsi(`${ESC}[1;31mA${ESC}[39mB`);
+
+    expect(result.map((span) => [span.text, span.className])).toEqual([
+      ['A', 'text-red-400 font-bold'],
+      ['B', 'font-bold'],
+    ]);
+  });
+
+  test('22 clears bold and dim without touching color', () => {
+    const result = parseAnsi(`${ESC}[1;2;34mA${ESC}[22mB`);
+
+    expect(result.map((span) => [span.text, span.className])).toEqual([
+      ['A', 'text-blue-400 font-bold opacity-60'],
+      ['B', 'text-blue-400'],
+    ]);
+  });
+
+  test('consumes 256-color operands without leaking them as text', () => {
+    const result = parseAnsi(`${ESC}[38;5;200mX`);
+
+    expect(result).toEqual([{text: 'X', className: '', start: 11}]);
+  });
+
+  test('consumes truecolor operands without leaking them as text', () => {
+    const result = parseAnsi(`${ESC}[38;2;255;0;0mX`);
+
+    expect(result).toEqual([{text: 'X', className: '', start: 15}]);
+  });
+
+  test('renders italic and underline together', () => {
+    const result = parseAnsi(`${ESC}[3;4mX`);
+
+    expect(result[0]?.className).toBe('italic underline');
+  });
+
+  test('leaves a non-SGR escape sequence untouched as text', () => {
+    const result = parseAnsi(`${ESC}[2Kdone`);
+
+    expect(result).toEqual([{text: `${ESC}[2Kdone`, className: '', start: 0}]);
+  });
+});

--- a/libs/shared/react/ui/src/components/log/ansi.ts
+++ b/libs/shared/react/ui/src/components/log/ansi.ts
@@ -8,12 +8,11 @@
  * leaked into the rendered text. Extended color codes (`38;5;n`, `38;2;r;g;b`)
  * are parsed and skipped rather than mis-rendered.
  *
- * The parser is intentionally pure (no React) so it can be unit-tested in a
- * node environment; `LogContent` maps the returned spans to elements.
+ * The parser is intentionally pure (no React) so `LogContent` can decide how
+ * returned spans become elements.
  */
 
 export interface AnsiSpan {
-  /** The run of text that shares one style. */
   text: string;
   /** Space-joined utility classes for the run; '' when unstyled. */
   className: string;

--- a/libs/shared/react/ui/src/components/log/ansi.ts
+++ b/libs/shared/react/ui/src/components/log/ansi.ts
@@ -1,0 +1,167 @@
+/**
+ * Minimal ANSI SGR (`ESC[…m`) parser for terminal output.
+ *
+ * It turns a raw output string into an ordered list of styled spans, mapping
+ * the standard 16 foreground/background colors and the bold / dim / italic /
+ * underline attributes onto the design-system palette so colors stay theme
+ * consistent. Non-color escapes and unknown SGR codes are consumed, never
+ * leaked into the rendered text. Extended color codes (`38;5;n`, `38;2;r;g;b`)
+ * are parsed and skipped rather than mis-rendered.
+ *
+ * The parser is intentionally pure (no React) so it can be unit-tested in a
+ * node environment; `LogContent` maps the returned spans to elements.
+ */
+
+export interface AnsiSpan {
+  /** The run of text that shares one style. */
+  text: string;
+  /** Space-joined utility classes for the run; '' when unstyled. */
+  className: string;
+  /** Character offset of the run in the source string; a stable React key. */
+  start: number;
+}
+
+interface AnsiStyle {
+  fg?: string | undefined;
+  bg?: string | undefined;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+}
+
+const FOREGROUND: Record<number, string> = {
+  30: 'text-neutral-500',
+  31: 'text-red-400',
+  32: 'text-green-400',
+  33: 'text-orange-400',
+  34: 'text-blue-400',
+  35: 'text-purple-400',
+  36: 'text-blue-300',
+  37: 'text-neutral-200',
+  90: 'text-neutral-400',
+  91: 'text-red-300',
+  92: 'text-green-300',
+  93: 'text-orange-300',
+  94: 'text-blue-300',
+  95: 'text-purple-300',
+  96: 'text-blue-200',
+  97: 'text-neutral-0',
+};
+
+const BACKGROUND: Record<number, string> = {
+  40: 'bg-neutral-500',
+  41: 'bg-red-500',
+  42: 'bg-green-500',
+  43: 'bg-orange-500',
+  44: 'bg-blue-500',
+  45: 'bg-purple-500',
+  46: 'bg-blue-400',
+  47: 'bg-neutral-200',
+  100: 'bg-neutral-400',
+  101: 'bg-red-400',
+  102: 'bg-green-400',
+  103: 'bg-orange-400',
+  104: 'bg-blue-400',
+  105: 'bg-purple-400',
+  106: 'bg-blue-300',
+  107: 'bg-neutral-0',
+};
+
+const ESC = 0x1b;
+
+export function parseAnsi(input: string): AnsiSpan[] {
+  const spans: AnsiSpan[] = [];
+  let style: AnsiStyle = {};
+  let textStart = 0;
+  let i = 0;
+
+  const flush = (end: number) => {
+    if (end > textStart) {
+      spans.push({
+        text: input.slice(textStart, end),
+        className: styleToClassName(style),
+        start: textStart,
+      });
+    }
+  };
+
+  while (i < input.length) {
+    if (input.charCodeAt(i) === ESC && input[i + 1] === '[') {
+      const close = sgrTerminator(input, i + 2);
+      if (close !== -1) {
+        flush(i);
+        style = applyCodes(style, input.slice(i + 2, close));
+        i = close + 1;
+        textStart = i;
+        continue;
+      }
+    }
+    i++;
+  }
+
+  flush(input.length);
+  return spans;
+}
+
+/**
+ * Returns the index of the `m` that closes an SGR sequence whose parameter
+ * bytes start at `from`, or -1 when the run is not a well-formed SGR escape
+ * (so the leading ESC is treated as ordinary text).
+ */
+function sgrTerminator(input: string, from: number): number {
+  let i = from;
+  while (i < input.length) {
+    const code = input.charCodeAt(i);
+    if (code === 0x6d) return i; // 'm'
+    // Parameter bytes are digits (0x30-0x39) and ';' (0x3b).
+    if (code !== 0x3b && (code < 0x30 || code > 0x39)) return -1;
+    i++;
+  }
+  return -1;
+}
+
+function applyCodes(style: AnsiStyle, raw: string): AnsiStyle {
+  // An empty parameter list (`ESC[m`) is shorthand for reset.
+  const codes = raw === '' ? [0] : raw.split(';').map((value) => Number.parseInt(value, 10));
+  let next: AnsiStyle = {...style};
+
+  for (let i = 0; i < codes.length; i++) {
+    const code = codes[i];
+    if (code === undefined) continue;
+    if (code === 0) next = {};
+    else if (code === 1) next.bold = true;
+    else if (code === 2) next.dim = true;
+    else if (code === 3) next.italic = true;
+    else if (code === 4) next.underline = true;
+    else if (code === 22) {
+      next.bold = false;
+      next.dim = false;
+    } else if (code === 23) next.italic = false;
+    else if (code === 24) next.underline = false;
+    else if (code === 39) next.fg = undefined;
+    else if (code === 49) next.bg = undefined;
+    else if (FOREGROUND[code]) next.fg = FOREGROUND[code];
+    else if (BACKGROUND[code]) next.bg = BACKGROUND[code];
+    else if (code === 38 || code === 48) {
+      // Extended color: drop the unsupported color but consume its operands so
+      // the trailing numbers never render as literal text.
+      const mode = codes[i + 1];
+      if (mode === 5) i += 2;
+      else if (mode === 2) i += 4;
+    }
+  }
+
+  return next;
+}
+
+function styleToClassName(style: AnsiStyle): string {
+  const classes: string[] = [];
+  if (style.fg) classes.push(style.fg);
+  if (style.bg) classes.push(style.bg);
+  if (style.bold) classes.push('font-bold');
+  if (style.dim) classes.push('opacity-60');
+  if (style.italic) classes.push('italic');
+  if (style.underline) classes.push('underline');
+  return classes.join(' ');
+}

--- a/libs/shared/react/ui/src/components/log/ansi.ts
+++ b/libs/shared/react/ui/src/components/log/ansi.ts
@@ -143,8 +143,11 @@ function applyCodes(style: AnsiStyle, raw: string): AnsiStyle {
     else if (FOREGROUND[code]) next.fg = FOREGROUND[code];
     else if (BACKGROUND[code]) next.bg = BACKGROUND[code];
     else if (code === 38 || code === 48) {
-      // Extended color: drop the unsupported color but consume its operands so
+      // Extended color: 256/truecolor is unsupported, so clear the channel it
+      // sets rather than leak the previous color, and consume its operands so
       // the trailing numbers never render as literal text.
+      if (code === 38) next.fg = undefined;
+      else next.bg = undefined;
       const mode = codes[i + 1];
       if (mode === 5) i += 2;
       else if (mode === 2) i += 4;

--- a/libs/shared/react/ui/src/components/log/format-timestamp.test.ts
+++ b/libs/shared/react/ui/src/components/log/format-timestamp.test.ts
@@ -13,7 +13,7 @@ describe('formatLogTimestamp', () => {
   test('formats a sub-minute relative offset with millisecond precision', () => {
     const date = new Date('2026-06-22T14:32:00.412Z');
 
-    const result = formatLogTimestamp(date, {mode: 'rel', origin});
+    const result = formatLogTimestamp(date, {mode: 'rel', timestampOrigin: origin});
 
     expect(result).toBe('+0.412');
   });
@@ -21,7 +21,7 @@ describe('formatLogTimestamp', () => {
   test('formats a multi-minute relative offset as m:ss.mmm', () => {
     const date = new Date('2026-06-22T14:33:05.300Z');
 
-    const result = formatLogTimestamp(date, {mode: 'rel', origin});
+    const result = formatLogTimestamp(date, {mode: 'rel', timestampOrigin: origin});
 
     expect(result).toBe('+1:05.300');
   });
@@ -29,7 +29,7 @@ describe('formatLogTimestamp', () => {
   test('signs a negative relative offset', () => {
     const date = new Date('2026-06-22T14:31:59.500Z');
 
-    const result = formatLogTimestamp(date, {mode: 'rel', origin});
+    const result = formatLogTimestamp(date, {mode: 'rel', timestampOrigin: origin});
 
     expect(result).toBe('-0.500');
   });

--- a/libs/shared/react/ui/src/components/log/format-timestamp.test.ts
+++ b/libs/shared/react/ui/src/components/log/format-timestamp.test.ts
@@ -1,0 +1,52 @@
+import {formatLogTimestamp} from './format-timestamp.js';
+
+const origin = new Date('2026-06-22T14:32:00.000Z');
+const CLOCK_PATTERN = /^\d{2}:\d{2}:\d{2}$/;
+
+describe('formatLogTimestamp', () => {
+  test('returns an empty string when the mode is off', () => {
+    const result = formatLogTimestamp(new Date('2026-06-22T14:32:09Z'), {mode: 'off'});
+
+    expect(result).toBe('');
+  });
+
+  test('formats a sub-minute relative offset with millisecond precision', () => {
+    const date = new Date('2026-06-22T14:32:00.412Z');
+
+    const result = formatLogTimestamp(date, {mode: 'rel', origin});
+
+    expect(result).toBe('+0.412');
+  });
+
+  test('formats a multi-minute relative offset as m:ss.mmm', () => {
+    const date = new Date('2026-06-22T14:33:05.300Z');
+
+    const result = formatLogTimestamp(date, {mode: 'rel', origin});
+
+    expect(result).toBe('+1:05.300');
+  });
+
+  test('signs a negative relative offset', () => {
+    const date = new Date('2026-06-22T14:31:59.500Z');
+
+    const result = formatLogTimestamp(date, {mode: 'rel', origin});
+
+    expect(result).toBe('-0.500');
+  });
+
+  test('falls back to the absolute clock when relative mode has no origin', () => {
+    const date = new Date('2026-06-22T14:32:09Z');
+
+    const result = formatLogTimestamp(date, {mode: 'rel'});
+
+    expect(result).toMatch(CLOCK_PATTERN);
+  });
+
+  test('formats absolute mode as a 24-hour clock time', () => {
+    const date = new Date('2026-06-22T14:32:09Z');
+
+    const result = formatLogTimestamp(date, {mode: 'abs'});
+
+    expect(result).toMatch(CLOCK_PATTERN);
+  });
+});

--- a/libs/shared/react/ui/src/components/log/format-timestamp.test.ts
+++ b/libs/shared/react/ui/src/components/log/format-timestamp.test.ts
@@ -1,4 +1,4 @@
-import {formatLogTimestamp} from './format-timestamp.js';
+import {formatLogTimestamp, toggleTimestampUnit} from './format-timestamp.js';
 
 const origin = new Date('2026-06-22T14:32:00.000Z');
 const CLOCK_PATTERN = /^\d{2}:\d{2}:\d{2}$/;
@@ -48,5 +48,19 @@ describe('formatLogTimestamp', () => {
     const result = formatLogTimestamp(date, {mode: 'abs'});
 
     expect(result).toMatch(CLOCK_PATTERN);
+  });
+});
+
+describe('toggleTimestampUnit', () => {
+  test('flips relative to absolute', () => {
+    expect(toggleTimestampUnit('rel')).toBe('abs');
+  });
+
+  test('flips absolute to relative', () => {
+    expect(toggleTimestampUnit('abs')).toBe('rel');
+  });
+
+  test('leaves off unchanged', () => {
+    expect(toggleTimestampUnit('off')).toBe('off');
   });
 });

--- a/libs/shared/react/ui/src/components/log/format-timestamp.ts
+++ b/libs/shared/react/ui/src/components/log/format-timestamp.ts
@@ -1,0 +1,41 @@
+/** Time-column mode shared across a `LogRows` list. */
+export type LogTimestampMode = 'off' | 'rel' | 'abs';
+
+const absoluteFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hourCycle: 'h23',
+});
+
+/**
+ * Formats a row's time for the gutter column.
+ *
+ * `abs` renders the wall-clock `HH:MM:SS`. `rel` renders a signed offset from
+ * `origin` (`+0.412`, `+1:05.300`); without an `origin` there is no baseline to
+ * subtract, so it falls back to the absolute clock rather than render blank.
+ * `off` returns '' because the column is hidden upstream.
+ */
+export function formatLogTimestamp(
+  date: Date,
+  {mode, origin}: {mode: LogTimestampMode; origin?: Date | undefined},
+): string {
+  if (mode === 'off') return '';
+  if (mode === 'rel' && origin) return formatOffset(date.getTime() - origin.getTime());
+  return absoluteFormatter.format(date);
+}
+
+function formatOffset(deltaMs: number): string {
+  const sign = deltaMs < 0 ? '-' : '+';
+  const totalSeconds = Math.abs(deltaMs) / 1000;
+
+  if (totalSeconds < 60) return `${sign}${totalSeconds.toFixed(3)}`;
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = (totalSeconds % 60).toFixed(3).padStart(6, '0');
+  if (minutes < 60) return `${sign}${minutes}:${seconds}`;
+
+  const hours = Math.floor(minutes / 60);
+  const mins = String(minutes % 60).padStart(2, '0');
+  return `${sign}${hours}:${mins}:${seconds}`;
+}

--- a/libs/shared/react/ui/src/components/log/format-timestamp.ts
+++ b/libs/shared/react/ui/src/components/log/format-timestamp.ts
@@ -26,6 +26,13 @@ export function formatLogTimestamp(
   return absoluteFormatter.format(date);
 }
 
+/** Flips the visible timestamp unit (relative ↔ absolute); leaves `off` unchanged. */
+export function toggleTimestampUnit(mode: LogTimestampMode): LogTimestampMode {
+  if (mode === 'rel') return 'abs';
+  if (mode === 'abs') return 'rel';
+  return mode;
+}
+
 function formatOffset(deltaMs: number): string {
   const sign = deltaMs < 0 ? '-' : '+';
   const totalSeconds = Math.abs(deltaMs) / 1000;

--- a/libs/shared/react/ui/src/components/log/format-timestamp.ts
+++ b/libs/shared/react/ui/src/components/log/format-timestamp.ts
@@ -1,4 +1,3 @@
-/** Time-column mode shared across a `LogRows` list. */
 export type LogTimestampMode = 'off' | 'rel' | 'abs';
 
 const absoluteFormatter = new Intl.DateTimeFormat(undefined, {
@@ -12,16 +11,18 @@ const absoluteFormatter = new Intl.DateTimeFormat(undefined, {
  * Formats a row's time for the gutter column.
  *
  * `abs` renders the wall-clock `HH:MM:SS`. `rel` renders a signed offset from
- * `origin` (`+0.412`, `+1:05.300`); without an `origin` there is no baseline to
+ * `timestampOrigin` (`+0.412`, `+1:05.300`); without one there is no baseline to
  * subtract, so it falls back to the absolute clock rather than render blank.
  * `off` returns '' because the column is hidden upstream.
  */
 export function formatLogTimestamp(
   date: Date,
-  {mode, origin}: {mode: LogTimestampMode; origin?: Date | undefined},
+  {mode, timestampOrigin}: {mode: LogTimestampMode; timestampOrigin?: Date | undefined},
 ): string {
   if (mode === 'off') return '';
-  if (mode === 'rel' && origin) return formatOffset(date.getTime() - origin.getTime());
+  if (mode === 'rel' && timestampOrigin) {
+    return formatOffset(date.getTime() - timestampOrigin.getTime());
+  }
   return absoluteFormatter.format(date);
 }
 

--- a/libs/shared/react/ui/src/components/log/index.ts
+++ b/libs/shared/react/ui/src/components/log/index.ts
@@ -1,5 +1,9 @@
 export {type AnsiSpan, parseAnsi} from './ansi.js';
-export {formatLogTimestamp, type LogTimestampMode} from './format-timestamp.js';
+export {
+  formatLogTimestamp,
+  type LogTimestampMode,
+  toggleTimestampUnit,
+} from './format-timestamp.js';
 export {LogContent, type LogContentProps} from './log-content.js';
 export {
   type LogRowContextValue,

--- a/libs/shared/react/ui/src/components/log/index.ts
+++ b/libs/shared/react/ui/src/components/log/index.ts
@@ -10,3 +10,5 @@ export {
 export {LogHeader, type LogHeaderProps} from './log-header.js';
 export {LogRow, type LogRowProps, type LogRowTone} from './log-row.js';
 export {LogRows, type LogRowsProps} from './log-rows.js';
+export {type UseLogWrapResult, useLogWrap} from './use-log-wrap.js';
+export type {LogLineId} from './wrap-state.js';

--- a/libs/shared/react/ui/src/components/log/index.ts
+++ b/libs/shared/react/ui/src/components/log/index.ts
@@ -1,0 +1,12 @@
+export {type AnsiSpan, parseAnsi} from './ansi.js';
+export {formatLogTimestamp, type LogTimestampMode} from './format-timestamp.js';
+export {LogContent, type LogContentProps} from './log-content.js';
+export {
+  type LogRowContextValue,
+  type LogRowsContextValue,
+  useLogRowContext,
+  useLogRowsContext,
+} from './log-context.js';
+export {LogHeader, type LogHeaderProps} from './log-header.js';
+export {LogRow, type LogRowProps, type LogRowTone} from './log-row.js';
+export {LogRows, type LogRowsProps} from './log-rows.js';

--- a/libs/shared/react/ui/src/components/log/index.ts
+++ b/libs/shared/react/ui/src/components/log/index.ts
@@ -14,5 +14,6 @@ export {
 export {LogHeader, type LogHeaderProps} from './log-header.js';
 export {LogRow, type LogRowProps, type LogRowTone} from './log-row.js';
 export {LogRows, type LogRowsProps} from './log-rows.js';
+export {LogWrapToggle, type LogWrapToggleProps} from './log-wrap-toggle.js';
 export {type UseLogWrapResult, useLogWrap} from './use-log-wrap.js';
 export type {LogLineId} from './wrap-state.js';

--- a/libs/shared/react/ui/src/components/log/log-content.tsx
+++ b/libs/shared/react/ui/src/components/log/log-content.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import {cva, type VariantProps} from 'class-variance-authority';
+import type {ComponentProps, ReactNode} from 'react';
+import {cn} from '#utils/cn.js';
+import {parseAnsi} from './ansi.js';
+import {useLogRowContext, useLogRowsContext} from './log-context.js';
+
+const logContentVariants = cva('block leading-20', {
+  variants: {
+    variant: {
+      text: 'font-display whitespace-normal break-words',
+      code: 'font-code',
+    },
+  },
+  defaultVariants: {variant: 'text'},
+});
+
+export interface LogContentProps
+  extends Omit<ComponentProps<'span'>, 'children'>,
+    VariantProps<typeof logContentVariants> {
+  /** Body content; a string for text / code, or any element. */
+  children?: ReactNode;
+  /** Parse SGR escape codes from a string child (code variant). */
+  ansi?: boolean;
+  /** Override soft-wrap for this content. */
+  wrap?: boolean;
+}
+
+/**
+ * The body. `variant` selects typography: `text` for prose, `code` for
+ * monospace output with whitespace preserved (and optional ANSI parsing). It
+ * also takes arbitrary children, so anything custom drops straight in.
+ */
+export function LogContent({
+  className,
+  children,
+  variant = 'text',
+  ansi = false,
+  wrap,
+  ...props
+}: LogContentProps) {
+  const rowsContext = useLogRowsContext();
+  const rowContext = useLogRowContext();
+  const resolvedWrap = wrap ?? rowContext?.wrap ?? rowsContext.wrap;
+
+  const whitespace =
+    variant === 'code' ? (resolvedWrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre') : '';
+
+  const body =
+    ansi && typeof children === 'string'
+      ? parseAnsi(children).map((span) => (
+          <span key={span.start} className={span.className || undefined}>
+            {span.text}
+          </span>
+        ))
+      : children;
+
+  return (
+    <span
+      data-slot="log-content"
+      className={cn(logContentVariants({variant}), whitespace, className)}
+      {...props}
+    >
+      {body}
+    </span>
+  );
+}

--- a/libs/shared/react/ui/src/components/log/log-content.tsx
+++ b/libs/shared/react/ui/src/components/log/log-content.tsx
@@ -19,18 +19,18 @@ const logContentVariants = cva('block leading-20', {
 export interface LogContentProps
   extends Omit<ComponentProps<'span'>, 'children'>,
     VariantProps<typeof logContentVariants> {
-  /** Body content; a string for text / code, or any element. */
   children?: ReactNode;
-  /** Parse SGR escape codes from a string child (code variant). */
+  /** Only string children are parsed; custom elements pass through unchanged. */
   ansi?: boolean;
   /** Override soft-wrap for this content. */
   wrap?: boolean;
 }
 
 /**
- * The body. `variant` selects typography: `text` for prose, `code` for
- * monospace output with whitespace preserved (and optional ANSI parsing). It
- * also takes arbitrary children, so anything custom drops straight in.
+ * Body content for prose or terminal-style output. The code variant preserves
+ * whitespace and can parse ANSI SGR escapes when `ansi` is enabled. When the
+ * code variant soft-wraps, continuation lines get a hanging indent so a wrapped
+ * line reads as one logical line rather than a blank-gutter marker row.
  */
 export function LogContent({
   className,
@@ -44,8 +44,14 @@ export function LogContent({
   const rowContext = useLogRowContext();
   const resolvedWrap = wrap ?? rowContext?.wrap ?? rowsContext.wrap;
 
-  const whitespace =
-    variant === 'code' ? (resolvedWrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre') : '';
+  // The hanging indent only affects lines after the first, so a line that does
+  // not wrap is untouched — the inset appears exactly when wrapping happens.
+  const codeStyling =
+    variant === 'code'
+      ? resolvedWrap
+        ? 'whitespace-pre-wrap break-words pl-[2ch] [text-indent:-2ch]'
+        : 'whitespace-pre'
+      : '';
 
   const body =
     ansi && typeof children === 'string'
@@ -59,7 +65,7 @@ export function LogContent({
   return (
     <span
       data-slot="log-content"
-      className={cn(logContentVariants({variant}), whitespace, className)}
+      className={cn(logContentVariants({variant}), codeStyling, className)}
       {...props}
     >
       {body}

--- a/libs/shared/react/ui/src/components/log/log-content.tsx
+++ b/libs/shared/react/ui/src/components/log/log-content.tsx
@@ -28,9 +28,14 @@ export interface LogContentProps
 
 /**
  * Body content for prose or terminal-style output. The code variant preserves
- * whitespace and can parse ANSI SGR escapes when `ansi` is enabled. When the
- * code variant soft-wraps, continuation lines get a hanging indent so a wrapped
- * line reads as one logical line rather than a blank-gutter marker row.
+ * whitespace and can parse ANSI SGR escapes when `ansi` is enabled.
+ *
+ * When the code variant soft-wraps, continuation lines get a hanging indent so
+ * a wrapped line reads as one logical line rather than a blank-gutter marker
+ * row. When it does not wrap, the line scrolls horizontally and a right-edge
+ * fade marks any line that runs past the edge, so a truncated line is never
+ * silently clipped. Both cues are pure CSS and self-revealing: a line that
+ * fits, or does not wrap, is left untouched.
  */
 export function LogContent({
   className,
@@ -44,13 +49,11 @@ export function LogContent({
   const rowContext = useLogRowContext();
   const resolvedWrap = wrap ?? rowContext?.wrap ?? rowsContext.wrap;
 
-  // The hanging indent only affects lines after the first, so a line that does
-  // not wrap is untouched — the inset appears exactly when wrapping happens.
   const codeStyling =
     variant === 'code'
       ? resolvedWrap
         ? 'whitespace-pre-wrap break-words pl-[2ch] [text-indent:-2ch]'
-        : 'whitespace-pre'
+        : 'w-full overflow-x-auto scrollbar whitespace-pre [mask-image:linear-gradient(to_right,#000_calc(100%_-_1.5rem),transparent)]'
       : '';
 
   const body =

--- a/libs/shared/react/ui/src/components/log/log-context.tsx
+++ b/libs/shared/react/ui/src/components/log/log-context.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import {createContext, useContext} from 'react';
+import type {LogTimestampMode} from './format-timestamp.js';
+
+/**
+ * Defaults the container provides to every row: time-column mode, soft-wrap,
+ * the line-number gutter, and the baseline for relative timestamps. A `LogRow`
+ * used outside a `LogRows` reads these fallbacks.
+ */
+export interface LogRowsContextValue {
+  timestamps: LogTimestampMode;
+  wrap: boolean;
+  showLineNumbers: boolean;
+  origin?: Date | undefined;
+}
+
+export const defaultLogRowsContext: LogRowsContextValue = {
+  timestamps: 'off',
+  wrap: false,
+  showLineNumbers: true,
+};
+
+const LogRowsContext = createContext<LogRowsContextValue>(defaultLogRowsContext);
+
+export const LogRowsContextProvider = LogRowsContext.Provider;
+
+export function useLogRowsContext(): LogRowsContextValue {
+  return useContext(LogRowsContext);
+}
+
+/**
+ * What a `LogRow` publishes to its own body so a nested `LogContent` inherits
+ * the row's resolved wrap before falling back to the container default.
+ */
+export interface LogRowContextValue {
+  wrap: boolean;
+}
+
+const LogRowContext = createContext<LogRowContextValue | null>(null);
+
+export const LogRowContextProvider = LogRowContext.Provider;
+
+export function useLogRowContext(): LogRowContextValue | null {
+  return useContext(LogRowContext);
+}

--- a/libs/shared/react/ui/src/components/log/log-context.tsx
+++ b/libs/shared/react/ui/src/components/log/log-context.tsx
@@ -13,6 +13,8 @@ export interface LogRowsContextValue {
   wrap: boolean;
   showLineNumbers: boolean;
   timestampOrigin?: Date | undefined;
+  /** When set, the timestamp column renders as a button that calls this. */
+  onTimestampsClick?: (() => void) | undefined;
 }
 
 export const defaultLogRowsContext: LogRowsContextValue = {

--- a/libs/shared/react/ui/src/components/log/log-context.tsx
+++ b/libs/shared/react/ui/src/components/log/log-context.tsx
@@ -12,7 +12,7 @@ export interface LogRowsContextValue {
   timestamps: LogTimestampMode;
   wrap: boolean;
   showLineNumbers: boolean;
-  origin?: Date | undefined;
+  timestampOrigin?: Date | undefined;
 }
 
 export const defaultLogRowsContext: LogRowsContextValue = {

--- a/libs/shared/react/ui/src/components/log/log-header.tsx
+++ b/libs/shared/react/ui/src/components/log/log-header.tsx
@@ -1,0 +1,29 @@
+import type {ComponentProps, ReactNode} from 'react';
+import {cn} from '#utils/cn.js';
+
+export interface LogHeaderProps extends ComponentProps<'div'> {
+  /** Right-aligned slot — usage, model name, duration. */
+  end?: ReactNode;
+}
+
+/**
+ * An optional header line inside a row's body: a left cluster (badge, glyph,
+ * label) and a right-aligned `end` slot. Pure flex layout — you decide what
+ * goes in. Omit it for plain output lines.
+ */
+export function LogHeader({className, children, end, ...props}: LogHeaderProps) {
+  return (
+    <div
+      data-slot="log-header"
+      className={cn('flex items-center gap-8 leading-20', className)}
+      {...props}
+    >
+      <div className="flex min-w-0 items-center gap-6">{children}</div>
+      {end != null && (
+        <div className="ml-auto flex items-center gap-8 text-foreground-neutral-muted tabular-nums">
+          {end}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/libs/shared/react/ui/src/components/log/log-header.tsx
+++ b/libs/shared/react/ui/src/components/log/log-header.tsx
@@ -2,14 +2,12 @@ import type {ComponentProps, ReactNode} from 'react';
 import {cn} from '#utils/cn.js';
 
 export interface LogHeaderProps extends ComponentProps<'div'> {
-  /** Right-aligned slot — usage, model name, duration. */
+  /** Right-aligned metadata slot, such as usage, model name, or duration. */
   end?: ReactNode;
 }
 
 /**
- * An optional header line inside a row's body: a left cluster (badge, glyph,
- * label) and a right-aligned `end` slot. Pure flex layout — you decide what
- * goes in. Omit it for plain output lines.
+ * Optional header line inside a row body. Omit it for plain output lines.
  */
 export function LogHeader({className, children, end, ...props}: LogHeaderProps) {
   return (

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -12,9 +12,11 @@ const logRowTone = cva('', {
       default: '',
       error: 'bg-red-50 dark:bg-red-500/10 shadow-[inset_2px_0_0_var(--color-red-500)]',
       warning: 'bg-orange-50 dark:bg-orange-500/10 shadow-[inset_2px_0_0_var(--color-orange-500)]',
+      success: 'bg-green-50 dark:bg-green-500/10 shadow-[inset_2px_0_0_var(--color-green-500)]',
       info: 'bg-blue-50 dark:bg-blue-500/10 shadow-[inset_2px_0_0_var(--color-blue-500)]',
-      accent:
-        'bg-primary-50 dark:bg-primary-500/10 shadow-[inset_2px_0_0_var(--color-primary-400)]',
+      // Reserve brand orange for the `selected` affordance; the agent/highlight
+      // tone reads violet, matching the agent mock and staying clear of warning.
+      accent: 'bg-purple-50 dark:bg-purple-500/10 shadow-[inset_2px_0_0_var(--color-purple-500)]',
     },
   },
   defaultVariants: {tone: 'default'},

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -93,14 +93,25 @@ export function LogRow({
             {lineNumber ?? ''}
           </span>
         )}
-        {showTime && (
-          <span
-            data-slot="log-row-time"
-            className="w-80 flex-none select-none px-4 text-foreground-neutral-muted tabular-nums"
-          >
-            {timeText}
-          </span>
-        )}
+        {showTime &&
+          (context.onTimestampsClick ? (
+            <button
+              type="button"
+              data-slot="log-row-time"
+              onClick={context.onTimestampsClick}
+              aria-label="Switch timestamp format"
+              className="w-80 flex-none cursor-pointer select-none px-4 text-left text-foreground-neutral-muted tabular-nums transition-colors hover:text-foreground-neutral-base"
+            >
+              {timeText}
+            </button>
+          ) : (
+            <span
+              data-slot="log-row-time"
+              className="w-80 flex-none select-none px-4 text-foreground-neutral-muted tabular-nums"
+            >
+              {timeText}
+            </span>
+          ))}
         <div
           data-slot="log-row-body"
           className="min-w-0 flex-1 overflow-hidden pr-12"

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -67,12 +67,16 @@ export function LogRow({
       <div
         data-slot="log-row"
         data-selected={selected || undefined}
+        data-wrap={resolvedWrap}
         aria-current={selected || undefined}
         className={cn(
-          'flex items-start',
+          'group/log-row flex items-start transition-colors',
+          'hover:bg-neutral-500/[0.06]',
           logRowTone({tone}),
+          // Selected keeps its pressed tint while hovered so the cursor row
+          // stays distinct from a plain hover.
           selected &&
-            'bg-background-neutral-pressed shadow-[inset_2px_0_0_var(--color-primary-400)]',
+            'bg-background-neutral-pressed shadow-[inset_2px_0_0_var(--color-primary-400)] hover:bg-background-neutral-pressed',
           className,
         )}
         {...props}

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -29,20 +29,17 @@ export interface LogRowProps extends ComponentProps<'div'> {
   lineNumber?: number | null;
   /** Row time; the container's mode formats it. `null` renders a blank cell. */
   timestamp?: Date | null;
-  /** Left accent bar + background tint. */
   tone?: LogRowTone;
-  /** Left padding of the body in px — pass `depth * step` for nested content. */
+  /** Left padding of the body in pixels. */
   indent?: number;
-  /** Cursor / active row for keyboard traversal. */
   selected?: boolean;
   /** Override the container's soft-wrap for this row. */
   wrap?: boolean;
 }
 
 /**
- * The structure for a single row: a line-number gutter, an optional timestamp
- * column, and a body that holds an optional `LogHeader` and a `LogContent`. It
- * owns tone, indent and wrap — pure layout that never inspects its children.
+ * Primitive row renderer. It owns the gutter, timestamp, tone, indent, and wrap
+ * context, but does not inspect or reshape its children.
  */
 export function LogRow({
   className,
@@ -99,7 +96,7 @@ export function LogRow({
         )}
         <div
           data-slot="log-row-body"
-          className={cn('min-w-0 flex-1 pr-12', resolvedWrap ? '' : 'overflow-x-auto scrollbar')}
+          className="min-w-0 flex-1 overflow-hidden pr-12"
           style={{paddingLeft: indent || 12}}
         >
           {children}

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import {cva, type VariantProps} from 'class-variance-authority';
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+import {formatLogTimestamp} from './format-timestamp.js';
+import {LogRowContextProvider, useLogRowsContext} from './log-context.js';
+
+const logRowTone = cva('', {
+  variants: {
+    tone: {
+      default: '',
+      error: 'bg-red-50 dark:bg-red-500/10 shadow-[inset_2px_0_0_var(--color-red-500)]',
+      warning: 'bg-orange-50 dark:bg-orange-500/10 shadow-[inset_2px_0_0_var(--color-orange-500)]',
+      info: 'bg-blue-50 dark:bg-blue-500/10 shadow-[inset_2px_0_0_var(--color-blue-500)]',
+      accent:
+        'bg-primary-50 dark:bg-primary-500/10 shadow-[inset_2px_0_0_var(--color-primary-400)]',
+    },
+  },
+  defaultVariants: {tone: 'default'},
+});
+
+export type LogRowTone = NonNullable<VariantProps<typeof logRowTone>['tone']>;
+
+export interface LogRowProps extends ComponentProps<'div'> {
+  /** Gutter number; `null` renders a blank cell (used by markers). */
+  lineNumber?: number | null;
+  /** Row time; the container's mode formats it. `null` renders a blank cell. */
+  timestamp?: Date | null;
+  /** Left accent bar + background tint. */
+  tone?: LogRowTone;
+  /** Left padding of the body in px — pass `depth * step` for nested content. */
+  indent?: number;
+  /** Cursor / active row for keyboard traversal. */
+  selected?: boolean;
+  /** Override the container's soft-wrap for this row. */
+  wrap?: boolean;
+}
+
+/**
+ * The structure for a single row: a line-number gutter, an optional timestamp
+ * column, and a body that holds an optional `LogHeader` and a `LogContent`. It
+ * owns tone, indent and wrap — pure layout that never inspects its children.
+ */
+export function LogRow({
+  className,
+  children,
+  lineNumber = null,
+  timestamp = null,
+  tone = 'default',
+  indent = 0,
+  selected = false,
+  wrap,
+  ...props
+}: LogRowProps) {
+  const context = useLogRowsContext();
+  const resolvedWrap = wrap ?? context.wrap;
+  const showTime = context.timestamps !== 'off';
+  const timeText = timestamp
+    ? formatLogTimestamp(timestamp, {mode: context.timestamps, origin: context.origin})
+    : '';
+
+  return (
+    <LogRowContextProvider value={{wrap: resolvedWrap}}>
+      <div
+        data-slot="log-row"
+        data-selected={selected || undefined}
+        aria-current={selected || undefined}
+        className={cn(
+          'flex items-start',
+          logRowTone({tone}),
+          selected &&
+            'bg-background-neutral-pressed shadow-[inset_2px_0_0_var(--color-primary-400)]',
+          className,
+        )}
+        {...props}
+      >
+        {context.showLineNumbers && (
+          <span
+            data-slot="log-row-gutter"
+            aria-hidden="true"
+            className={cn(
+              'w-44 flex-none select-none px-12 text-right tabular-nums',
+              selected ? 'text-foreground-neutral-base' : 'text-foreground-neutral-subtle',
+            )}
+          >
+            {lineNumber ?? ''}
+          </span>
+        )}
+        {showTime && (
+          <span
+            data-slot="log-row-time"
+            className="w-80 flex-none select-none px-4 text-foreground-neutral-muted tabular-nums"
+          >
+            {timeText}
+          </span>
+        )}
+        <div
+          data-slot="log-row-body"
+          className={cn('min-w-0 flex-1 pr-12', resolvedWrap ? '' : 'overflow-x-auto scrollbar')}
+          style={{paddingLeft: indent || 12}}
+        >
+          {children}
+        </div>
+      </div>
+    </LogRowContextProvider>
+  );
+}

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -30,7 +30,7 @@ export interface LogRowProps extends ComponentProps<'div'> {
   /** Row time; the container's mode formats it. `null` renders a blank cell. */
   timestamp?: Date | null;
   tone?: LogRowTone;
-  /** Extra left padding (px) added on top of the body's base inset for nesting — pass `depth * step`. */
+  /** Extra left padding in pixels, added on top of the body's base inset. */
   indent?: number;
   selected?: boolean;
   /** Override the container's soft-wrap for this row. */

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -56,7 +56,10 @@ export function LogRow({
   const resolvedWrap = wrap ?? context.wrap;
   const showTime = context.timestamps !== 'off';
   const timeText = timestamp
-    ? formatLogTimestamp(timestamp, {mode: context.timestamps, origin: context.origin})
+    ? formatLogTimestamp(timestamp, {
+        mode: context.timestamps,
+        timestampOrigin: context.timestampOrigin,
+      })
     : '';
 
   return (

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -105,7 +105,7 @@ export function LogRow({
                 if (window.getSelection()?.isCollapsed === false) return;
                 onTimestampsClick();
               }}
-              className="w-80 flex-none cursor-pointer px-4 text-foreground-neutral-muted tabular-nums"
+              className="w-80 flex-none cursor-pointer px-4 text-foreground-neutral-muted tabular-nums transition-colors hover:text-foreground-neutral-base"
             >
               {timeText}
             </span>

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -30,7 +30,7 @@ export interface LogRowProps extends ComponentProps<'div'> {
   /** Row time; the container's mode formats it. `null` renders a blank cell. */
   timestamp?: Date | null;
   tone?: LogRowTone;
-  /** Left padding of the body in pixels. */
+  /** Extra left padding (px) added on top of the body's base inset for nesting — pass `depth * step`. */
   indent?: number;
   selected?: boolean;
   /** Override the container's soft-wrap for this row. */
@@ -97,7 +97,7 @@ export function LogRow({
         <div
           data-slot="log-row-body"
           className="min-w-0 flex-1 overflow-hidden pr-12"
-          style={{paddingLeft: indent || 12}}
+          style={{paddingLeft: 12 + indent}}
         >
           {children}
         </div>

--- a/libs/shared/react/ui/src/components/log/log-row.tsx
+++ b/libs/shared/react/ui/src/components/log/log-row.tsx
@@ -53,6 +53,7 @@ export function LogRow({
   ...props
 }: LogRowProps) {
   const context = useLogRowsContext();
+  const onTimestampsClick = context.onTimestampsClick;
   const resolvedWrap = wrap ?? context.wrap;
   const showTime = context.timestamps !== 'off';
   const timeText = timestamp
@@ -94,20 +95,24 @@ export function LogRow({
           </span>
         )}
         {showTime &&
-          (context.onTimestampsClick ? (
-            <button
-              type="button"
+          (onTimestampsClick ? (
+            // biome-ignore lint/a11y/noStaticElementInteractions: kept a span (not a button) so the timestamp stays part of a multi-line text selection; switching format is a pointer convenience.
+            // biome-ignore lint/a11y/useKeyWithClickEvents: the accessible way to switch timestamp format is a toolbar control, not this inline cell.
+            <span
               data-slot="log-row-time"
-              onClick={context.onTimestampsClick}
-              aria-label="Switch timestamp format"
-              className="w-80 flex-none cursor-pointer select-none px-4 text-left text-foreground-neutral-muted tabular-nums transition-colors hover:text-foreground-neutral-base"
+              onClick={() => {
+                // Ignore the click that ends a drag-selection so timestamps stay copyable.
+                if (window.getSelection()?.isCollapsed === false) return;
+                onTimestampsClick();
+              }}
+              className="w-80 flex-none cursor-pointer px-4 text-foreground-neutral-muted tabular-nums"
             >
               {timeText}
-            </button>
+            </span>
           ) : (
             <span
               data-slot="log-row-time"
-              className="w-80 flex-none select-none px-4 text-foreground-neutral-muted tabular-nums"
+              className="w-80 flex-none px-4 text-foreground-neutral-muted tabular-nums"
             >
               {timeText}
             </span>

--- a/libs/shared/react/ui/src/components/log/log-rows.tsx
+++ b/libs/shared/react/ui/src/components/log/log-rows.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+import type {LogTimestampMode} from './format-timestamp.js';
+import {LogRowsContextProvider} from './log-context.js';
+
+export interface LogRowsProps extends ComponentProps<'div'> {
+  /** Time-column mode shared by every row. */
+  timestamps?: LogTimestampMode;
+  /** Default soft-wrap applied to rows that do not override it. */
+  wrap?: boolean;
+  /** Show the line-number gutter across the list. */
+  showLineNumbers?: boolean;
+  /** Baseline that relative timestamps are measured from. */
+  origin?: Date;
+}
+
+/**
+ * The scroll surface that wraps the rows. It owns nothing about what a row
+ * contains; it only provides the shared defaults every `LogRow` reads
+ * (timestamp mode, wrap, line numbers) and the code-surface chrome.
+ */
+export function LogRows({
+  className,
+  children,
+  timestamps = 'off',
+  wrap = false,
+  showLineNumbers = true,
+  origin,
+  ...props
+}: LogRowsProps) {
+  return (
+    <LogRowsContextProvider value={{timestamps, wrap, showLineNumbers, origin}}>
+      <div
+        data-slot="log-rows"
+        role="log"
+        aria-live="polite"
+        className={cn(
+          'overflow-y-auto rounded-12 border border-border-contrast-bottom shadow-button-neutral',
+          'bg-background-neutral-base dark:bg-background-contrast-subtle',
+          'py-8 font-code text-xs leading-20 text-foreground-neutral-base',
+          'scrollbar',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </LogRowsContextProvider>
+  );
+}

--- a/libs/shared/react/ui/src/components/log/log-rows.tsx
+++ b/libs/shared/react/ui/src/components/log/log-rows.tsx
@@ -6,15 +6,12 @@ import type {LogTimestampMode} from './format-timestamp.js';
 import {LogRowsContextProvider} from './log-context.js';
 
 export interface LogRowsProps extends ComponentProps<'div'> {
-  /** Time-column mode shared by every row. */
   timestamps?: LogTimestampMode;
-  /** Default soft-wrap applied to rows that do not override it. */
   wrap?: boolean;
-  /** Show the line-number gutter across the list. */
   showLineNumbers?: boolean;
-  /** Baseline that relative timestamps are measured from. */
+  /** Baseline for relative timestamps; without one, relative mode falls back to absolute time. */
   timestampOrigin?: Date;
-  /** When set, the timestamp column becomes a button that calls this (e.g. to switch rel/abs for all rows). */
+  /** Adds a pointer shortcut to each timestamp cell, commonly used to switch rel/abs for all rows. */
   onTimestampsClick?: () => void;
 }
 

--- a/libs/shared/react/ui/src/components/log/log-rows.tsx
+++ b/libs/shared/react/ui/src/components/log/log-rows.tsx
@@ -14,6 +14,8 @@ export interface LogRowsProps extends ComponentProps<'div'> {
   showLineNumbers?: boolean;
   /** Baseline that relative timestamps are measured from. */
   timestampOrigin?: Date;
+  /** When set, the timestamp column becomes a button that calls this (e.g. to switch rel/abs for all rows). */
+  onTimestampsClick?: () => void;
 }
 
 /**
@@ -28,10 +30,13 @@ export function LogRows({
   wrap = false,
   showLineNumbers = true,
   timestampOrigin,
+  onTimestampsClick,
   ...props
 }: LogRowsProps) {
   return (
-    <LogRowsContextProvider value={{timestamps, wrap, showLineNumbers, timestampOrigin}}>
+    <LogRowsContextProvider
+      value={{timestamps, wrap, showLineNumbers, timestampOrigin, onTimestampsClick}}
+    >
       <div
         data-slot="log-rows"
         role="log"

--- a/libs/shared/react/ui/src/components/log/log-rows.tsx
+++ b/libs/shared/react/ui/src/components/log/log-rows.tsx
@@ -13,7 +13,7 @@ export interface LogRowsProps extends ComponentProps<'div'> {
   /** Show the line-number gutter across the list. */
   showLineNumbers?: boolean;
   /** Baseline that relative timestamps are measured from. */
-  origin?: Date;
+  timestampOrigin?: Date;
 }
 
 /**
@@ -27,11 +27,11 @@ export function LogRows({
   timestamps = 'off',
   wrap = false,
   showLineNumbers = true,
-  origin,
+  timestampOrigin,
   ...props
 }: LogRowsProps) {
   return (
-    <LogRowsContextProvider value={{timestamps, wrap, showLineNumbers, origin}}>
+    <LogRowsContextProvider value={{timestamps, wrap, showLineNumbers, timestampOrigin}}>
       <div
         data-slot="log-rows"
         role="log"

--- a/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
+++ b/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
@@ -5,17 +5,15 @@ import {cn} from '#utils/cn.js';
 import {Icon} from '../icon/index.js';
 
 export interface LogWrapToggleProps extends Omit<ComponentProps<'button'>, 'aria-pressed'> {
-  /** Whether the line is currently wrapped — drives the chevron and the label. */
+  /** Current row wrap state; drives `aria-pressed`, the label, and the chevron. */
   wrapped: boolean;
   /** Whether this line overrides the container's wrap, pinning the control on. */
   overridden?: boolean;
 }
 
 /**
- * A per-line wrap affordance: a chevron button that reveals on row hover (it
- * reads the `group/log-row` set by `LogRow`) and stays pinned when the line
- * overrides the container's wrap. Compose it into a `LogRow` body and wire
- * `onClick` to your wrap store — it holds no wrap state of its own.
+ * Per-line wrap affordance. It reads the `group/log-row` set by `LogRow`, stays
+ * pinned for overridden lines, and holds no wrap state of its own.
  */
 export function LogWrapToggle({
   className,

--- a/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
+++ b/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
@@ -23,7 +23,6 @@ export function LogWrapToggle({
 }: LogWrapToggleProps) {
   return (
     <button
-      type="button"
       data-slot="log-wrap-toggle"
       aria-pressed={wrapped}
       aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
@@ -36,6 +35,7 @@ export function LogWrapToggle({
         className,
       )}
       {...props}
+      type="button"
     >
       <Icon
         name="chevronRight"

--- a/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
+++ b/libs/shared/react/ui/src/components/log/log-wrap-toggle.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+import {Icon} from '../icon/index.js';
+
+export interface LogWrapToggleProps extends Omit<ComponentProps<'button'>, 'aria-pressed'> {
+  /** Whether the line is currently wrapped — drives the chevron and the label. */
+  wrapped: boolean;
+  /** Whether this line overrides the container's wrap, pinning the control on. */
+  overridden?: boolean;
+}
+
+/**
+ * A per-line wrap affordance: a chevron button that reveals on row hover (it
+ * reads the `group/log-row` set by `LogRow`) and stays pinned when the line
+ * overrides the container's wrap. Compose it into a `LogRow` body and wire
+ * `onClick` to your wrap store — it holds no wrap state of its own.
+ */
+export function LogWrapToggle({
+  className,
+  wrapped,
+  overridden = false,
+  ...props
+}: LogWrapToggleProps) {
+  return (
+    <button
+      type="button"
+      data-slot="log-wrap-toggle"
+      aria-pressed={wrapped}
+      aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
+      className={cn(
+        'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition',
+        'opacity-0 group-hover/log-row:opacity-100 focus-visible:opacity-100',
+        overridden
+          ? 'text-foreground-highlight-interactive opacity-100'
+          : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',
+        className,
+      )}
+      {...props}
+    >
+      <Icon
+        name="chevronRight"
+        className={cn('size-16 transition-transform', wrapped && 'rotate-90')}
+      />
+    </button>
+  );
+}

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,0 +1,334 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Badge} from '#components/badge/index.js';
+import {Code} from '#components/typography/index.js';
+import {LogContent} from './log-content.js';
+import {LogHeader} from './log-header.js';
+import {LogRow} from './log-row.js';
+import {LogRows} from './log-rows.js';
+
+const meta = {
+  title: 'Components/Log',
+  component: LogRows,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    timestamps: {control: 'inline-radio', options: ['off', 'rel', 'abs']},
+    wrap: {control: 'boolean'},
+    showLineNumbers: {control: 'boolean'},
+  },
+  args: {
+    timestamps: 'off',
+    wrap: false,
+    showLineNumbers: true,
+  },
+} satisfies Meta<typeof LogRows>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const origin = new Date('2026-06-22T14:32:00.000Z');
+const at = (offsetSeconds: number) => new Date(origin.getTime() + offsetSeconds * 1000);
+
+const ansiBuild = `${String.fromCharCode(27)}[32m✓${String.fromCharCode(27)}[0m built ${String.fromCharCode(27)}[34m1284${String.fromCharCode(27)}[0m modules · ${String.fromCharCode(27)}[1;31m1 error${String.fromCharCode(27)}[0m`;
+
+const YouChip = () => (
+  <span className="rounded-4 bg-primary-400 px-6 text-[10px] font-bold uppercase tracking-wide text-white">
+    You
+  </span>
+);
+
+const Glyph = ({className, children}: {className: string; children: string}) => (
+  <span className={className}>{children}</span>
+);
+
+/** A controllable surface — flip the args to explore timestamps, wrap, gutter. */
+export const Default: Story = {
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogRows {...args} origin={origin} className="max-h-72">
+        <LogRow lineNumber={34} timestamp={at(9)}>
+          <LogContent variant="code">transforming (1284) src/index.tsx</LogContent>
+        </LogRow>
+        <LogRow lineNumber={35} timestamp={at(9.4)}>
+          <LogContent variant="code">
+            <Glyph className="font-bold text-green-500 dark:text-green-400">{'✓ '}</Glyph>
+            1284 modules transformed
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={36} timestamp={at(9.7)} selected>
+          <LogContent variant="code">dist/assets/index-a3f9b1c2.js</LogContent>
+        </LogRow>
+        <LogRow lineNumber={37} timestamp={at(10)}>
+          <LogContent variant="code" className="text-foreground-neutral-muted">
+            built in 412ms
+          </LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/** Output line — was `OutputLogRow`, now just markup. */
+export const OutputLine: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows timestamps="abs" origin={origin}>
+        <LogRow lineNumber={42} timestamp={at(9)}>
+          <LogContent variant="code" ansi>
+            {ansiBuild}
+          </LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/** Agent turn — was `AgentSessionLogRow`. A header band over a prose body. */
+export const AgentTurn: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows timestamps="abs" origin={origin}>
+        <LogRow tone="accent" lineNumber={57} timestamp={at(11)}>
+          <LogHeader end={<>claude-sonnet-4-5 · $0.084 · 2.1s</>}>
+            <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
+            <Badge variant="feature">Assistant</Badge>
+          </LogHeader>
+          <LogContent>Fixed the off-by-one in withRetry().</LogContent>
+        </LogRow>
+        <LogRow tone="accent" lineNumber={58} timestamp={at(12)}>
+          <LogHeader>
+            <YouChip />
+          </LogHeader>
+          <LogContent>Now make sure the 503 retry test passes.</LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/**
+ * Timeline marker — was `TimelineMarkerLogRow`. The library ships no marker;
+ * the app composes one from a toned row with a blank gutter.
+ */
+export const TimelineMarker: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogRow lineNumber={88}>
+          <LogContent variant="code">writing dist/assets/index-a3f9b1c2.js</LogContent>
+        </LogRow>
+        <LogRow tone="warning">
+          <LogContent>
+            <span className="inline-flex w-full items-center gap-8 text-orange-600 dark:text-orange-300">
+              {'⚠'} <b>18,432 bytes dropped</b>
+              <span className="h-px flex-1 border-t border-dashed border-current opacity-40" />
+            </span>
+          </LogContent>
+        </LogRow>
+        <LogRow tone="error">
+          <LogContent>
+            <span className="inline-flex items-center gap-8 font-bold text-red-600 dark:text-red-400">
+              {'■'} Runner lost
+              <span className="font-normal opacity-80">— log incomplete</span>
+            </span>
+          </LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/** The five tones — a left accent bar plus a background tint. */
+export const Tones: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        {(['default', 'info', 'accent', 'warning', 'error'] as const).map((tone, index) => (
+          <LogRow key={tone} lineNumber={index + 1} tone={tone}>
+            <LogContent variant="code">tone="{tone}"</LogContent>
+          </LogRow>
+        ))}
+      </LogRows>
+    </div>
+  ),
+};
+
+/** Timestamp column modes, provided by the container to every row. */
+export const Timestamps: Story = {
+  render: () => (
+    <div className="grid max-w-5xl gap-16 md:grid-cols-3">
+      {(['off', 'rel', 'abs'] as const).map((mode) => (
+        <div key={mode} className="flex flex-col gap-8">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            timestamps="{mode}"
+          </Code>
+          <LogRows timestamps={mode} origin={origin}>
+            <LogRow lineNumber={17} timestamp={at(0.412)}>
+              <LogContent variant="code">resolving dependencies</LogContent>
+            </LogRow>
+            <LogRow lineNumber={18} timestamp={at(0.53)}>
+              <LogContent variant="code">linking 318 packages</LogContent>
+            </LogRow>
+            <LogRow lineNumber={19} timestamp={at(65.3)}>
+              <LogContent variant="code">done</LogContent>
+            </LogRow>
+          </LogRows>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Soft-wrap versus the default horizontal scroll under a sticky gutter. */
+export const Wrap: Story = {
+  render: () => {
+    const long =
+      'ERROR  TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)';
+    return (
+      <div className="flex max-w-3xl flex-col gap-16">
+        <div className="flex flex-col gap-8">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            wrap=false (scroll)
+          </Code>
+          <LogRows wrap={false}>
+            <LogRow lineNumber={120} tone="error">
+              <LogContent variant="code">{long}</LogContent>
+            </LogRow>
+          </LogRows>
+        </div>
+        <div className="flex flex-col gap-8">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            wrap=true
+          </Code>
+          <LogRows wrap>
+            <LogRow lineNumber={120} tone="error">
+              <LogContent variant="code">{long}</LogContent>
+            </LogRow>
+          </LogRows>
+        </div>
+      </div>
+    );
+  },
+};
+
+/** ANSI SGR escapes parsed into themed spans by `LogContent variant="code" ansi`. */
+export const AnsiOutput: Story = {
+  render: () => {
+    const e = String.fromCharCode(27);
+    const lines = [
+      `${e}[32m✓${e}[0m ${e}[1mbuild${e}[0m succeeded in ${e}[34m412ms${e}[0m`,
+      `${e}[33mWARN${e}[0m ${e}[2mdeprecated${e}[0m glob@7 · ${e}[4mupgrade to glob@10${e}[0m`,
+      `${e}[1;31mFAIL${e}[0m client.test.ts ${e}[31m> retries on 503${e}[0m`,
+    ];
+    return (
+      <div className="max-w-3xl">
+        <LogRows>
+          {lines.map((line, index) => (
+            <LogRow key={line} lineNumber={index + 1}>
+              <LogContent variant="code" ansi>
+                {line}
+              </LogContent>
+            </LogRow>
+          ))}
+        </LogRows>
+      </div>
+    );
+  },
+};
+
+/** A full interleaved stream: CI output and agent records share one renderer. */
+export const Interleaved: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows timestamps="abs" origin={origin} className="max-h-96">
+        <LogRow lineNumber={41} timestamp={at(8.12)}>
+          <LogContent variant="code">
+            <Glyph className="text-green-500 dark:text-green-400">{'$ '}</Glyph>pnpm vitest run
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={42} timestamp={at(9.0)} tone="accent">
+          <LogHeader end={<>$0.084 · 2.1s</>}>
+            <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
+            <Badge variant="feature">Assistant</Badge>
+          </LogHeader>
+          <LogContent>Re-running the failing shard.</LogContent>
+        </LogRow>
+        <LogRow lineNumber={43} timestamp={at(9.22)}>
+          <LogContent variant="code">
+            <Glyph className="text-blue-500 dark:text-blue-400">{'⚙ '}</Glyph>
+            <span className="font-bold text-blue-600 dark:text-blue-400">read_file</span>
+            <span className="text-foreground-neutral-muted"> src/api/client.ts</span>
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={44} timestamp={at(9.54)}>
+          <LogContent variant="code" className="text-foreground-neutral-muted">
+            <Glyph className="font-bold text-green-500 dark:text-green-400">{'✓ '}</Glyph>
+            read_file · 64 lines
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={45} timestamp={at(10.12)} tone="error">
+          <LogContent variant="code">
+            <span className="font-bold text-red-600 dark:text-red-400">FAIL </span>
+            client.test.ts &gt; retries on 503
+          </LogContent>
+        </LogRow>
+        <LogRow tone="warning">
+          <LogContent>
+            <span className="inline-flex w-full items-center gap-8 text-orange-600 dark:text-orange-300">
+              {'⚠'} <b>End of log · 1.5 KB</b>
+              <span className="h-px flex-1 border-t border-dashed border-current opacity-40" />
+            </span>
+          </LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/** The two body slots in isolation: `LogHeader` and `LogContent` variants. */
+export const Slots: Story = {
+  render: () => (
+    <div className="flex max-w-3xl flex-col gap-16">
+      <div className="flex flex-col gap-8">
+        <Code variant="label" className="text-foreground-neutral-subtle">
+          LogHeader
+        </Code>
+        <LogRows>
+          <LogRow lineNumber={1}>
+            <LogHeader end={<>claude-sonnet-4-5 · $0.084</>}>
+              <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
+              <Badge variant="feature">Assistant</Badge>
+            </LogHeader>
+          </LogRow>
+          <LogRow lineNumber={2}>
+            <LogHeader end={<>64 lines</>}>
+              <Glyph className="text-blue-500 dark:text-blue-400">{'⚙'}</Glyph>
+              <span className="font-bold text-blue-600 dark:text-blue-400">read_file</span>
+            </LogHeader>
+          </LogRow>
+        </LogRows>
+      </div>
+      <div className="flex flex-col gap-8">
+        <Code variant="label" className="text-foreground-neutral-subtle">
+          LogContent
+        </Code>
+        <LogRows>
+          <LogRow lineNumber={1}>
+            <LogContent variant="text">Prose body — wraps like normal text.</LogContent>
+          </LogRow>
+          <LogRow lineNumber={2}>
+            <LogContent variant="code">mono · whitespace preserved</LogContent>
+          </LogRow>
+          <LogRow lineNumber={3}>
+            <LogContent variant="code" ansi>
+              {`${String.fromCharCode(27)}[32m✓${String.fromCharCode(27)}[0m code + ansi`}
+            </LogContent>
+          </LogRow>
+        </LogRows>
+      </div>
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {type ReactNode, useRef, useState} from 'react';
-import {useArgs} from 'storybook/preview-api';
+import type {ReactNode} from 'react';
+import {useArgs, useRef, useState} from 'storybook/preview-api';
 import {Badge} from '#components/badge/index.js';
 import {Icon} from '#components/icon/index.js';
 import {Code} from '#components/typography/index.js';
@@ -358,10 +358,9 @@ export const Interactive: Story = {
                     aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
                     onClick={() => toggleLine(line.id)}
                     className={cn(
-                      'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition-opacity',
-                      'opacity-60 group-hover/log-row:opacity-100 focus-visible:opacity-100',
+                      'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition-colors',
                       overridden
-                        ? 'text-foreground-highlight-interactive opacity-100'
+                        ? 'text-foreground-highlight-interactive'
                         : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',
                     )}
                   >

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -53,11 +53,15 @@ const Section = ({label, children}: {label: string; children: ReactNode}) => (
   </div>
 );
 
-/** Interactive surface — flip the args to explore timestamps, wrap, and the gutter. */
+/**
+ * Controls-driven surface — flip the args to explore timestamps, wrap, and the
+ * gutter. The click- and hook-driven behaviors (switch timestamps, per-line
+ * wrap) live in the `Interactive` story, since they own state the args cannot.
+ */
 export const Playground: Story = {
   render: (args) => (
     <div className="max-w-3xl">
-      <LogRows {...args} timestampOrigin={origin} className="max-h-72">
+      <LogRows {...args} timestampOrigin={origin} className="max-h-360">
         <LogRow lineNumber={34} timestamp={at(9)}>
           <LogContent variant="code">transforming (1284) src/index.tsx</LogContent>
         </LogRow>

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,11 +1,14 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import type {ReactNode} from 'react';
 import {Badge} from '#components/badge/index.js';
+import {Button} from '#components/button/index.js';
 import {Code} from '#components/typography/index.js';
+import {cn} from '#utils/cn.js';
 import {LogContent} from './log-content.js';
 import {LogHeader} from './log-header.js';
-import {LogRow} from './log-row.js';
+import {LogRow, type LogRowTone} from './log-row.js';
 import {LogRows} from './log-rows.js';
+import {useLogWrap} from './use-log-wrap.js';
 
 const meta = {
   title: 'Components/Log',
@@ -238,6 +241,106 @@ export const Wrapping: Story = {
       </div>
     );
   },
+};
+
+/**
+ * Interactive wrapping with `useLogWrap`. The toolbar toggle sets the global
+ * default; a per-line action (revealed on row hover) overrides one line — to
+ * read a long error in full, say. Flipping the global toggle clears every
+ * override, so the global control always wins, and the state is keyed by line
+ * id so an override survives a row leaving and re-entering a virtualized window.
+ */
+export const WrapControls: Story = {
+  render: () => {
+    const lines: {id: number; text: string; tone?: LogRowTone}[] = [
+      {id: 1, text: 'pnpm vitest run --reporter=verbose --coverage'},
+      {
+        id: 2,
+        tone: 'error',
+        text: 'ERROR  TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)',
+      },
+      {id: 3, text: 'compiled 1284 modules in 1.2s'},
+      {
+        id: 4,
+        tone: 'warning',
+        text: 'WARN  deprecated glob@7 — upgrade to glob@10 to avoid the slow recursive walk on large repositories',
+      },
+      {id: 5, text: 'done in 412ms'},
+    ];
+    const wrap = useLogWrap(false);
+
+    return (
+      <div className="flex max-w-2xl flex-col gap-8">
+        <div className="flex items-center gap-12">
+          <Button
+            size="xs"
+            variant={wrap.globalWrap ? 'secondary' : 'transparentMuted'}
+            aria-pressed={wrap.globalWrap}
+            onClick={wrap.toggleGlobal}
+          >
+            Wrap: {wrap.globalWrap ? 'on' : 'off'}
+          </Button>
+          <Code variant="label" className="text-foreground-neutral-muted">
+            {wrap.overriddenCount} overridden — toggling global resets them
+          </Code>
+        </div>
+        <LogRows wrap={wrap.globalWrap}>
+          {lines.map((line) => {
+            const wrapped = wrap.rowWrap(line.id) ?? wrap.globalWrap;
+            const overridden = wrap.isOverridden(line.id);
+            return (
+              <LogRow
+                key={line.id}
+                lineNumber={line.id}
+                tone={line.tone}
+                wrap={wrap.rowWrap(line.id)}
+              >
+                <div className="flex items-start gap-8">
+                  <span className="min-w-0 flex-1">
+                    <LogContent variant="code">{line.text}</LogContent>
+                  </span>
+                  <button
+                    type="button"
+                    aria-pressed={wrapped}
+                    onClick={() => wrap.toggleLine(line.id)}
+                    className={cn(
+                      'flex-none rounded-4 px-6 text-xs transition-opacity',
+                      'opacity-70 group-hover/log-row:opacity-100 focus-visible:opacity-100',
+                      overridden
+                        ? 'text-foreground-highlight-interactive opacity-100'
+                        : 'text-foreground-neutral-muted',
+                    )}
+                  >
+                    {wrapped ? 'collapse' : 'expand'}
+                  </button>
+                </div>
+              </LogRow>
+            );
+          })}
+        </LogRows>
+      </div>
+    );
+  },
+};
+
+/** Rows carry a hover state so the pointer's target line is always clear. */
+export const Hover: Story = {
+  parameters: {pseudo: {hover: ['.story-hovered']}},
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogRow lineNumber={1}>
+          <LogContent variant="code">a resting row</LogContent>
+        </LogRow>
+        <LogRow lineNumber={2} className="story-hovered">
+          <LogContent variant="code">hovered — the row tints to mark the pointer target</LogContent>
+        </LogRow>
+        <LogRow lineNumber={3} className="story-hovered" selected>
+          <LogContent variant="code">selected + hovered — the cursor row stays distinct</LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
 };
 
 /**

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -34,12 +34,6 @@ const at = (offsetSeconds: number) => new Date(origin.getTime() + offsetSeconds 
 
 const ansiBuild = `${String.fromCharCode(27)}[32m✓${String.fromCharCode(27)}[0m built ${String.fromCharCode(27)}[34m1284${String.fromCharCode(27)}[0m modules · ${String.fromCharCode(27)}[1;31m1 error${String.fromCharCode(27)}[0m`;
 
-const YouChip = () => (
-  <span className="rounded-4 bg-primary-400 px-6 text-[10px] font-bold uppercase tracking-wide text-white">
-    You
-  </span>
-);
-
 const Glyph = ({className, children}: {className: string; children: string}) => (
   <span className={className}>{children}</span>
 );
@@ -88,18 +82,19 @@ export const AgentTurn: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows timestamps="abs" origin={origin}>
-        <LogRow tone="accent" lineNumber={57} timestamp={at(11)}>
+        <LogRow tone="info" lineNumber={57} timestamp={at(11)}>
+          <LogHeader>
+            <Glyph className="text-blue-500 dark:text-blue-400">{'❯'}</Glyph>
+            <Badge variant="info">You</Badge>
+          </LogHeader>
+          <LogContent>Make sure the 503 retry test passes.</LogContent>
+        </LogRow>
+        <LogRow tone="accent" lineNumber={58} timestamp={at(13)}>
           <LogHeader end={<>claude-sonnet-4-5 · $0.084 · 2.1s</>}>
             <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
             <Badge variant="feature">Assistant</Badge>
           </LogHeader>
           <LogContent>Fixed the off-by-one in withRetry().</LogContent>
-        </LogRow>
-        <LogRow tone="accent" lineNumber={58} timestamp={at(12)}>
-          <LogHeader>
-            <YouChip />
-          </LogHeader>
-          <LogContent>Now make sure the 503 retry test passes.</LogContent>
         </LogRow>
       </LogRows>
     </div>

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
+import type {ReactNode} from 'react';
 import {Badge} from '#components/badge/index.js';
 import {Code} from '#components/typography/index.js';
 import {LogContent} from './log-content.js';
@@ -31,14 +32,23 @@ type Story = StoryObj<typeof meta>;
 
 const origin = new Date('2026-06-22T14:32:00.000Z');
 const at = (offsetSeconds: number) => new Date(origin.getTime() + offsetSeconds * 1000);
-
-const ansiBuild = `${String.fromCharCode(27)}[32m✓${String.fromCharCode(27)}[0m built ${String.fromCharCode(27)}[34m1284${String.fromCharCode(27)}[0m modules · ${String.fromCharCode(27)}[1;31m1 error${String.fromCharCode(27)}[0m`;
+const ESC = String.fromCharCode(27);
 
 const Glyph = ({className, children}: {className: string; children: string}) => (
   <span className={className}>{children}</span>
 );
 
-export const Default: Story = {
+const Section = ({label, children}: {label: string; children: ReactNode}) => (
+  <div className="flex flex-col gap-8">
+    <Code variant="label" className="text-foreground-neutral-subtle">
+      {label}
+    </Code>
+    {children}
+  </div>
+);
+
+/** Interactive surface — flip the args to explore timestamps, wrap, and the gutter. */
+export const Playground: Story = {
   render: (args) => (
     <div className="max-w-3xl">
       <LogRows {...args} origin={origin} className="max-h-72">
@@ -64,71 +74,69 @@ export const Default: Story = {
   ),
 };
 
-export const OutputLine: Story = {
+/**
+ * The gutter. `lineNumber` numbers a row; `null` leaves a blank cell so a marker
+ * still aligns. `showLineNumbers={false}` drops the column entirely.
+ */
+export const LineNumbers: Story = {
   render: () => (
-    <div className="max-w-3xl">
-      <LogRows timestamps="abs" origin={origin}>
-        <LogRow lineNumber={42} timestamp={at(9)}>
-          <LogContent variant="code" ansi>
-            {ansiBuild}
-          </LogContent>
-        </LogRow>
-      </LogRows>
+    <div className="flex max-w-3xl flex-col gap-16">
+      <Section label="showLineNumbers (default) · lineNumber={null} leaves a blank cell">
+        <LogRows>
+          <LogRow lineNumber={1}>
+            <LogContent variant="code">resolving dependencies</LogContent>
+          </LogRow>
+          <LogRow lineNumber={2}>
+            <LogContent variant="code">linking 318 packages</LogContent>
+          </LogRow>
+          <LogRow lineNumber={null}>
+            <LogContent variant="code" className="text-foreground-neutral-muted">
+              lineNumber=null — a marker row keeps the gutter blank
+            </LogContent>
+          </LogRow>
+          <LogRow lineNumber={3}>
+            <LogContent variant="code">done</LogContent>
+          </LogRow>
+        </LogRows>
+      </Section>
+      <Section label="showLineNumbers={false}">
+        <LogRows showLineNumbers={false}>
+          <LogRow lineNumber={1}>
+            <LogContent variant="code">no gutter column</LogContent>
+          </LogRow>
+          <LogRow lineNumber={2}>
+            <LogContent variant="code">content starts at the left edge</LogContent>
+          </LogRow>
+        </LogRows>
+      </Section>
     </div>
   ),
 };
 
-export const AgentTurn: Story = {
+/** The container's `timestamps` mode formats every row's `timestamp` Date. */
+export const Timestamps: Story = {
   render: () => (
-    <div className="max-w-3xl">
-      <LogRows timestamps="abs" origin={origin}>
-        <LogRow tone="info" lineNumber={57} timestamp={at(11)}>
-          <LogHeader>
-            <Glyph className="text-blue-500 dark:text-blue-400">{'❯'}</Glyph>
-            <Badge variant="info">You</Badge>
-          </LogHeader>
-          <LogContent>Make sure the 503 retry test passes.</LogContent>
-        </LogRow>
-        <LogRow tone="accent" lineNumber={58} timestamp={at(13)}>
-          <LogHeader end={<>claude-sonnet-4-5 · $0.084 · 2.1s</>}>
-            <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
-            <Badge variant="feature">Assistant</Badge>
-          </LogHeader>
-          <LogContent>Fixed the off-by-one in withRetry().</LogContent>
-        </LogRow>
-      </LogRows>
+    <div className="grid max-w-5xl gap-16 md:grid-cols-3">
+      {(['off', 'rel', 'abs'] as const).map((mode) => (
+        <Section key={mode} label={`timestamps="${mode}"`}>
+          <LogRows timestamps={mode} origin={origin}>
+            <LogRow lineNumber={17} timestamp={at(0.412)}>
+              <LogContent variant="code">resolving dependencies</LogContent>
+            </LogRow>
+            <LogRow lineNumber={18} timestamp={at(0.53)}>
+              <LogContent variant="code">linking 318 packages</LogContent>
+            </LogRow>
+            <LogRow lineNumber={19} timestamp={at(65.3)}>
+              <LogContent variant="code">done</LogContent>
+            </LogRow>
+          </LogRows>
+        </Section>
+      ))}
     </div>
   ),
 };
 
-export const TimelineMarker: Story = {
-  render: () => (
-    <div className="max-w-3xl">
-      <LogRows>
-        <LogRow lineNumber={88}>
-          <LogContent variant="code">writing dist/assets/index-a3f9b1c2.js</LogContent>
-        </LogRow>
-        <LogRow tone="warning">
-          <LogContent>
-            <span className="inline-flex w-full items-center gap-8 text-orange-600 dark:text-orange-300">
-              {'⚠'} <b>18,432 bytes dropped</b>
-              <span className="h-px flex-1 border-t border-dashed border-current opacity-40" />
-            </span>
-          </LogContent>
-        </LogRow>
-        <LogRow tone="error">
-          <LogContent>
-            <span className="inline-flex items-center gap-8 font-bold text-red-600 dark:text-red-400">
-              {'■'} Runner lost
-              <span className="font-normal opacity-80">— log incomplete</span>
-            </span>
-          </LogContent>
-        </LogRow>
-      </LogRows>
-    </div>
-  ),
-};
-
+/** Each `tone` is a distinct hue — a left accent bar plus a background tint. */
 export const Tones: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -145,41 +153,69 @@ export const Tones: Story = {
   ),
 };
 
-export const Timestamps: Story = {
+/**
+ * `selected` marks the cursor row for keyboard traversal. Its brand-orange bar
+ * is the one orange in the system, so it always wins over a row's `tone`.
+ */
+export const Selected: Story = {
   render: () => (
-    <div className="grid max-w-5xl gap-16 md:grid-cols-3">
-      {(['off', 'rel', 'abs'] as const).map((mode) => (
-        <div key={mode} className="flex flex-col gap-8">
-          <Code variant="label" className="text-foreground-neutral-subtle">
-            timestamps="{mode}"
-          </Code>
-          <LogRows timestamps={mode} origin={origin}>
-            <LogRow lineNumber={17} timestamp={at(0.412)}>
-              <LogContent variant="code">resolving dependencies</LogContent>
-            </LogRow>
-            <LogRow lineNumber={18} timestamp={at(0.53)}>
-              <LogContent variant="code">linking 318 packages</LogContent>
-            </LogRow>
-            <LogRow lineNumber={19} timestamp={at(65.3)}>
-              <LogContent variant="code">done</LogContent>
-            </LogRow>
-          </LogRows>
-        </div>
-      ))}
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogRow lineNumber={11}>
+          <LogContent variant="code">a normal row</LogContent>
+        </LogRow>
+        <LogRow lineNumber={12} selected>
+          <LogContent variant="code">selected — the cursor row (j / k)</LogContent>
+        </LogRow>
+        <LogRow lineNumber={13}>
+          <LogContent variant="code">another normal row</LogContent>
+        </LogRow>
+        <LogRow lineNumber={14} tone="error" selected>
+          <LogContent variant="code">selected keeps the orange bar over a tone tint</LogContent>
+        </LogRow>
+      </LogRows>
     </div>
   ),
 };
 
-export const Wrap: Story = {
+/** `indent` adds left padding for nested content — pass `depth * step`. */
+export const Indent: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogRow lineNumber={1} indent={0}>
+          <LogContent variant="code">depth 0 — build</LogContent>
+        </LogRow>
+        <LogRow lineNumber={2} indent={16}>
+          <LogContent variant="code">depth 1 — typecheck</LogContent>
+        </LogRow>
+        <LogRow lineNumber={3} indent={32}>
+          <LogContent variant="code">depth 2 — transform module</LogContent>
+        </LogRow>
+        <LogRow lineNumber={4} indent={48}>
+          <LogContent variant="code">depth 3 — emit chunk</LogContent>
+        </LogRow>
+        <LogRow lineNumber={5} indent={16}>
+          <LogContent variant="code">depth 1 — bundle</LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/**
+ * `wrap` chooses between soft-wrap and horizontal scroll. Both states make a
+ * long line legible without hiding it: wrapped continuations hang-indent under
+ * the first line; a non-wrapping line scrolls and fades at the truncated edge.
+ * A line that fits is untouched either way.
+ */
+export const Wrapping: Story = {
   render: () => {
     const long =
       'ERROR  TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)';
     return (
-      <div className="flex max-w-3xl flex-col gap-16">
-        <div className="flex max-w-md flex-col gap-8">
-          <Code variant="label" className="text-foreground-neutral-subtle">
-            wrap=false — the line scrolls; a right fade marks the truncation
-          </Code>
+      <div className="flex max-w-md flex-col gap-16">
+        <Section label="wrap=false — the line scrolls; a right fade marks the truncation">
           <LogRows wrap={false}>
             <LogRow lineNumber={120} tone="error">
               <LogContent variant="code">{long}</LogContent>
@@ -188,11 +224,8 @@ export const Wrap: Story = {
               <LogContent variant="code">resuming after the failure</LogContent>
             </LogRow>
           </LogRows>
-        </div>
-        <div className="flex max-w-md flex-col gap-8">
-          <Code variant="label" className="text-foreground-neutral-subtle">
-            wrap=true — continuation lines hang-indent under the first
-          </Code>
+        </Section>
+        <Section label="wrap=true — continuation lines hang-indent under the first">
           <LogRows wrap>
             <LogRow lineNumber={120} tone="error">
               <LogContent variant="code">{long}</LogContent>
@@ -201,19 +234,62 @@ export const Wrap: Story = {
               <LogContent variant="code">resuming after the failure</LogContent>
             </LogRow>
           </LogRows>
-        </div>
+        </Section>
       </div>
     );
   },
 };
 
-export const AnsiOutput: Story = {
+/**
+ * `LogContent` selects body typography. `text` is prose in the display font;
+ * `code` is monospace with whitespace preserved. Either accepts arbitrary
+ * children, and the code variant can parse ANSI from a string.
+ */
+export const Content: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogRow lineNumber={1}>
+          <LogContent variant="text">
+            variant="text" — prose in the display font that wraps like normal copy.
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={2}>
+          <LogContent variant="code">variant="code" — monospace output</LogContent>
+        </LogRow>
+        <LogRow lineNumber={3}>
+          <LogContent variant="code">{'  whitespace   and\ttabs   are preserved'}</LogContent>
+        </LogRow>
+        <LogRow lineNumber={4}>
+          <LogContent variant="code" ansi>
+            {`${ESC}[32m✓${ESC}[0m code + ansi — escapes become themed spans`}
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={5}>
+          <LogContent>
+            <span className="inline-flex items-center gap-6">
+              arbitrary children — <Badge variant="neutral">any node</Badge>
+            </span>
+          </LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/**
+ * `LogContent variant="code" ansi` parses SGR escapes into themed spans:
+ * the 16 colors, their bright variants, bold / dim / italic / underline, and
+ * backgrounds. Reset and default codes clear styling; unknown codes are dropped.
+ */
+export const Ansi: Story = {
   render: () => {
-    const e = String.fromCharCode(27);
     const lines = [
-      `${e}[32m✓${e}[0m ${e}[1mbuild${e}[0m succeeded in ${e}[34m412ms${e}[0m`,
-      `${e}[33mWARN${e}[0m ${e}[2mdeprecated${e}[0m glob@7 · ${e}[4mupgrade to glob@10${e}[0m`,
-      `${e}[1;31mFAIL${e}[0m client.test.ts ${e}[31m> retries on 503${e}[0m`,
+      `${ESC}[31mred${ESC}[0m ${ESC}[32mgreen${ESC}[0m ${ESC}[33myellow${ESC}[0m ${ESC}[34mblue${ESC}[0m ${ESC}[35mmagenta${ESC}[0m ${ESC}[36mcyan${ESC}[0m`,
+      `${ESC}[91mbright red${ESC}[0m ${ESC}[92mbright green${ESC}[0m ${ESC}[96mbright cyan${ESC}[0m`,
+      `${ESC}[1mbold${ESC}[0m ${ESC}[2mdim${ESC}[0m ${ESC}[3mitalic${ESC}[0m ${ESC}[4munderline${ESC}[0m`,
+      `${ESC}[42;30m black on green ${ESC}[0m then ${ESC}[1;31mbold red${ESC}[39m default again${ESC}[0m`,
+      `${ESC}[32m✓${ESC}[0m built ${ESC}[34m1284${ESC}[0m modules · ${ESC}[1;31m1 error${ESC}[0m`,
     ];
     return (
       <div className="max-w-3xl">
@@ -231,7 +307,50 @@ export const AnsiOutput: Story = {
   },
 };
 
-export const Interleaved: Story = {
+/**
+ * `LogHeader` is an optional band inside a row body: a left cluster plus an
+ * optional right-aligned `end` slot. It is pure layout — supply the glyphs,
+ * badges, and meta yourself.
+ */
+export const Header: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogRow lineNumber={1}>
+          <LogHeader>
+            <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
+            <Badge variant="feature">Assistant</Badge>
+          </LogHeader>
+        </LogRow>
+        <LogRow lineNumber={2}>
+          <LogHeader end={<>claude-sonnet-4-5 · $0.084 · 2.1s</>}>
+            <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
+            <Badge variant="feature">Assistant</Badge>
+          </LogHeader>
+        </LogRow>
+        <LogRow lineNumber={3}>
+          <LogHeader end={<>64 lines</>}>
+            <Glyph className="text-blue-500 dark:text-blue-400">{'⚙'}</Glyph>
+            <span className="font-bold text-blue-600 dark:text-blue-400">read_file</span>
+          </LogHeader>
+        </LogRow>
+        <LogRow lineNumber={4}>
+          <LogHeader end={<>exit 0</>}>
+            <Badge variant="success">bash</Badge>
+          </LogHeader>
+          <LogContent variant="code">$ pnpm build</LogContent>
+        </LogRow>
+      </LogRows>
+    </div>
+  ),
+};
+
+/**
+ * Composition is the API. The library ships no record components — output
+ * lines, agent turns, tool results, and timeline markers are all assembled from
+ * the four primitives, interleaved in one stream.
+ */
+export const Composition: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows timestamps="abs" origin={origin} className="max-h-96">
@@ -247,14 +366,14 @@ export const Interleaved: Story = {
           </LogHeader>
           <LogContent>Re-running the failing shard.</LogContent>
         </LogRow>
-        <LogRow lineNumber={43} timestamp={at(9.22)}>
+        <LogRow lineNumber={43} timestamp={at(9.22)} indent={16}>
           <LogContent variant="code">
             <Glyph className="text-blue-500 dark:text-blue-400">{'⚙ '}</Glyph>
             <span className="font-bold text-blue-600 dark:text-blue-400">read_file</span>
             <span className="text-foreground-neutral-muted"> src/api/client.ts</span>
           </LogContent>
         </LogRow>
-        <LogRow lineNumber={44} timestamp={at(9.54)}>
+        <LogRow lineNumber={44} timestamp={at(9.54)} indent={16}>
           <LogContent variant="code" className="text-foreground-neutral-muted">
             <Glyph className="font-bold text-green-500 dark:text-green-400">{'✓ '}</Glyph>
             read_file · 64 lines
@@ -275,50 +394,6 @@ export const Interleaved: Story = {
           </LogContent>
         </LogRow>
       </LogRows>
-    </div>
-  ),
-};
-
-export const Slots: Story = {
-  render: () => (
-    <div className="flex max-w-3xl flex-col gap-16">
-      <div className="flex flex-col gap-8">
-        <Code variant="label" className="text-foreground-neutral-subtle">
-          LogHeader
-        </Code>
-        <LogRows>
-          <LogRow lineNumber={1}>
-            <LogHeader end={<>claude-sonnet-4-5 · $0.084</>}>
-              <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
-              <Badge variant="feature">Assistant</Badge>
-            </LogHeader>
-          </LogRow>
-          <LogRow lineNumber={2}>
-            <LogHeader end={<>64 lines</>}>
-              <Glyph className="text-blue-500 dark:text-blue-400">{'⚙'}</Glyph>
-              <span className="font-bold text-blue-600 dark:text-blue-400">read_file</span>
-            </LogHeader>
-          </LogRow>
-        </LogRows>
-      </div>
-      <div className="flex flex-col gap-8">
-        <Code variant="label" className="text-foreground-neutral-subtle">
-          LogContent
-        </Code>
-        <LogRows>
-          <LogRow lineNumber={1}>
-            <LogContent variant="text">Prose body — wraps like normal text.</LogContent>
-          </LogRow>
-          <LogRow lineNumber={2}>
-            <LogContent variant="code">mono · whitespace preserved</LogContent>
-          </LogRow>
-          <LogRow lineNumber={3}>
-            <LogContent variant="code" ansi>
-              {`${String.fromCharCode(27)}[32m✓${String.fromCharCode(27)}[0m code + ansi`}
-            </LogContent>
-          </LogRow>
-        </LogRows>
-      </div>
     </div>
   ),
 };

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -358,9 +358,10 @@ export const Interactive: Story = {
                     aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
                     onClick={() => toggleLine(line.id)}
                     className={cn(
-                      'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition-colors',
+                      'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition',
+                      'opacity-0 group-hover/log-row:opacity-100 focus-visible:opacity-100',
                       overridden
-                        ? 'text-foreground-highlight-interactive'
+                        ? 'text-foreground-highlight-interactive opacity-100'
                         : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',
                     )}
                   >

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -181,13 +181,16 @@ export const Wrap: Story = {
       'ERROR  TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)';
     return (
       <div className="flex max-w-3xl flex-col gap-16">
-        <div className="flex flex-col gap-8">
+        <div className="flex max-w-md flex-col gap-8">
           <Code variant="label" className="text-foreground-neutral-subtle">
-            wrap=false (scroll)
+            wrap=false — the line scrolls; a right fade marks the truncation
           </Code>
           <LogRows wrap={false}>
             <LogRow lineNumber={120} tone="error">
               <LogContent variant="code">{long}</LogContent>
+            </LogRow>
+            <LogRow lineNumber={121}>
+              <LogContent variant="code">resuming after the failure</LogContent>
             </LogRow>
           </LogRows>
         </div>

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -141,16 +141,18 @@ export const TimelineMarker: Story = {
   ),
 };
 
-/** The five tones — a left accent bar plus a background tint. */
+/** Each tone is a distinct hue — a left accent bar plus a background tint. */
 export const Tones: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows>
-        {(['default', 'info', 'accent', 'warning', 'error'] as const).map((tone, index) => (
-          <LogRow key={tone} lineNumber={index + 1} tone={tone}>
-            <LogContent variant="code">tone="{tone}"</LogContent>
-          </LogRow>
-        ))}
+        {(['default', 'info', 'accent', 'success', 'warning', 'error'] as const).map(
+          (tone, index) => (
+            <LogRow key={tone} lineNumber={index + 1} tone={tone}>
+              <LogContent variant="code">tone="{tone}"</LogContent>
+            </LogRow>
+          ),
+        )}
       </LogRows>
     </div>
   ),

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -142,7 +142,6 @@ export const LineNumbers: Story = {
   ),
 };
 
-/** The container's `timestamps` mode formats every row's `timestamp` Date. */
 export const Timestamps: Story = {
   render: () => (
     <div className="grid max-w-5xl gap-16 md:grid-cols-3">
@@ -165,7 +164,6 @@ export const Timestamps: Story = {
   ),
 };
 
-/** Each `tone` is a distinct hue — a left accent bar plus a background tint. */
 export const Tones: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -207,7 +205,6 @@ export const Selected: Story = {
   ),
 };
 
-/** `indent` adds left padding for nested content — pass `depth * step`. */
 export const Indent: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -366,7 +363,6 @@ export const Interactive: Story = {
   },
 };
 
-/** Rows carry a hover state so the pointer's target line is always clear. */
 export const Hover: Story = {
   parameters: {pseudo: {hover: ['.story-hovered']}},
   render: () => (

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,16 +1,13 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {type ReactNode, useState} from 'react';
+import {type ReactNode, useRef, useState} from 'react';
 import {Badge} from '#components/badge/index.js';
-import {Button} from '#components/button/index.js';
 import {Icon} from '#components/icon/index.js';
 import {Code} from '#components/typography/index.js';
 import {cn} from '#utils/cn.js';
-import {type LogTimestampMode, toggleTimestampUnit} from './format-timestamp.js';
 import {LogContent} from './log-content.js';
 import {LogHeader} from './log-header.js';
 import {LogRow, type LogRowTone} from './log-row.js';
 import {LogRows} from './log-rows.js';
-import {useLogWrap} from './use-log-wrap.js';
 
 const meta = {
   title: 'Components/Log',
@@ -272,17 +269,17 @@ export const Wrapping: Story = {
 };
 
 /**
- * Tying the controls together with `useLogWrap` and a clickable timestamp.
+ * Controls linked to the component: the Storybook Controls panel drives the
+ * globals (`timestamps`, `wrap`, `showLineNumbers`) straight through `{...args}`.
  *
- * Click any timestamp to switch rel/abs for every row. Per-line wrap stays off
- * the text so copy/paste is untouched: the explicit toggle is the hover button
- * (and a future keyboard shortcut), with Alt/Option-click on the line as a
- * power gesture — plain clicks and drag-selection are left alone. The global
- * Wrap toggle clears every per-line override, and overrides are keyed by line
- * id, so they survive a row leaving and re-entering a virtualized window.
+ * Per-line wrap is layered on top and stays off the text so copy/paste is
+ * untouched: the chevron is the explicit toggle, with Alt/Option-click on the
+ * line as a power gesture. Toggling the global `wrap` control clears every
+ * per-line override, so the global always wins.
  */
 export const Interactive: Story = {
-  render: () => {
+  args: {timestamps: 'rel'},
+  render: (args) => {
     const lines: {id: number; ts: number; text: string; tone?: LogRowTone}[] = [
       {id: 1, ts: 0.12, text: 'pnpm vitest run --reporter=verbose --coverage'},
       {
@@ -300,48 +297,50 @@ export const Interactive: Story = {
       },
       {id: 5, ts: 2.95, text: 'done in 412ms'},
     ];
-    const [timestamps, setTimestamps] = useState<LogTimestampMode>('rel');
-    const wrap = useLogWrap(false);
+    const [exceptions, setExceptions] = useState<ReadonlySet<number>>(() => new Set());
+
+    // Toggling the global `wrap` control clears the per-line overrides so the
+    // global wins. Adjusted during render — React's reset-on-prop-change pattern.
+    const lastWrap = useRef(args.wrap);
+    if (lastWrap.current !== args.wrap) {
+      lastWrap.current = args.wrap;
+      if (exceptions.size > 0) setExceptions(new Set());
+    }
+
+    const toggleLine = (id: number) =>
+      setExceptions((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
 
     return (
       <div className="flex max-w-2xl flex-col gap-8">
-        <div className="flex items-center gap-12">
-          <Button
-            size="xs"
-            variant={wrap.globalWrap ? 'secondary' : 'transparentMuted'}
-            aria-pressed={wrap.globalWrap}
-            onClick={wrap.toggleGlobal}
-          >
-            Wrap: {wrap.globalWrap ? 'on' : 'off'}
-          </Button>
-          <Code variant="label" className="text-foreground-neutral-muted">
-            click a timestamp to switch rel/abs · ⌥-click or the hover button to wrap a line
-          </Code>
-        </div>
-        <LogRows
-          timestamps={timestamps}
-          timestampOrigin={origin}
-          wrap={wrap.globalWrap}
-          onTimestampsClick={() => setTimestamps(toggleTimestampUnit)}
-        >
+        <Code variant="label" className="text-foreground-neutral-muted">
+          Globals come from the Controls panel · the chevron (or ⌥-click) wraps one line ·{' '}
+          {exceptions.size} overridden
+        </Code>
+        <LogRows {...args} timestampOrigin={origin}>
           {lines.map((line) => {
-            const wrapped = wrap.rowWrap(line.id) ?? wrap.globalWrap;
-            const overridden = wrap.isOverridden(line.id);
+            const overridden = exceptions.has(line.id);
+            const rowWrap = overridden ? !args.wrap : undefined;
+            const wrapped = rowWrap ?? args.wrap;
             return (
               <LogRow
                 key={line.id}
                 lineNumber={line.id}
                 timestamp={at(line.ts)}
                 tone={line.tone}
-                wrap={wrap.rowWrap(line.id)}
+                wrap={rowWrap}
               >
                 <div className="flex items-start gap-8">
-                  {/* biome-ignore lint/a11y/noStaticElementInteractions: Alt-click is a pointer-only shortcut; the hover button is the accessible toggle and plain clicks/selection are deliberately untouched so copy still works. */}
-                  {/* biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard path is the hover button (and a future cursor shortcut), not the text. */}
+                  {/* biome-ignore lint/a11y/noStaticElementInteractions: Alt-click is a pointer-only shortcut; the chevron is the accessible toggle and plain clicks/selection are deliberately untouched so copy still works. */}
+                  {/* biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard path is the chevron button, not the text. */}
                   <span
                     className="min-w-0 flex-1"
                     onClick={(event) => {
-                      if (event.altKey) wrap.toggleLine(line.id);
+                      if (event.altKey) toggleLine(line.id);
                     }}
                   >
                     <LogContent variant="code">{line.text}</LogContent>
@@ -350,10 +349,10 @@ export const Interactive: Story = {
                     type="button"
                     aria-pressed={wrapped}
                     aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
-                    onClick={() => wrap.toggleLine(line.id)}
+                    onClick={() => toggleLine(line.id)}
                     className={cn(
                       'flex-none rounded-4 p-2 transition-opacity',
-                      'opacity-0 group-hover/log-row:opacity-100 focus-visible:opacity-100',
+                      'opacity-60 group-hover/log-row:opacity-100 focus-visible:opacity-100',
                       overridden
                         ? 'text-foreground-highlight-interactive opacity-100'
                         : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -44,7 +44,6 @@ const Glyph = ({className, children}: {className: string; children: string}) => 
   <span className={className}>{children}</span>
 );
 
-/** A controllable surface — flip the args to explore timestamps, wrap, gutter. */
 export const Default: Story = {
   render: (args) => (
     <div className="max-w-3xl">
@@ -71,7 +70,6 @@ export const Default: Story = {
   ),
 };
 
-/** Output line — was `OutputLogRow`, now just markup. */
 export const OutputLine: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -86,7 +84,6 @@ export const OutputLine: Story = {
   ),
 };
 
-/** Agent turn — was `AgentSessionLogRow`. A header band over a prose body. */
 export const AgentTurn: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -109,10 +106,6 @@ export const AgentTurn: Story = {
   ),
 };
 
-/**
- * Timeline marker — was `TimelineMarkerLogRow`. The library ships no marker;
- * the app composes one from a toned row with a blank gutter.
- */
 export const TimelineMarker: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -141,7 +134,6 @@ export const TimelineMarker: Story = {
   ),
 };
 
-/** Each tone is a distinct hue — a left accent bar plus a background tint. */
 export const Tones: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -158,7 +150,6 @@ export const Tones: Story = {
   ),
 };
 
-/** Timestamp column modes, provided by the container to every row. */
 export const Timestamps: Story = {
   render: () => (
     <div className="grid max-w-5xl gap-16 md:grid-cols-3">
@@ -184,7 +175,6 @@ export const Timestamps: Story = {
   ),
 };
 
-/** Soft-wrap versus the default horizontal scroll under a sticky gutter. */
 export const Wrap: Story = {
   render: () => {
     const long =
@@ -201,13 +191,16 @@ export const Wrap: Story = {
             </LogRow>
           </LogRows>
         </div>
-        <div className="flex flex-col gap-8">
+        <div className="flex max-w-md flex-col gap-8">
           <Code variant="label" className="text-foreground-neutral-subtle">
-            wrap=true
+            wrap=true — continuation lines hang-indent under the first
           </Code>
           <LogRows wrap>
             <LogRow lineNumber={120} tone="error">
               <LogContent variant="code">{long}</LogContent>
+            </LogRow>
+            <LogRow lineNumber={121}>
+              <LogContent variant="code">resuming after the failure</LogContent>
             </LogRow>
           </LogRows>
         </div>
@@ -216,7 +209,6 @@ export const Wrap: Story = {
   },
 };
 
-/** ANSI SGR escapes parsed into themed spans by `LogContent variant="code" ansi`. */
 export const AnsiOutput: Story = {
   render: () => {
     const e = String.fromCharCode(27);
@@ -241,7 +233,6 @@ export const AnsiOutput: Story = {
   },
 };
 
-/** A full interleaved stream: CI output and agent records share one renderer. */
 export const Interleaved: Story = {
   render: () => (
     <div className="max-w-3xl">
@@ -290,7 +281,6 @@ export const Interleaved: Story = {
   ),
 };
 
-/** The two body slots in isolation: `LogHeader` and `LogContent` variants. */
 export const Slots: Story = {
   render: () => (
     <div className="flex max-w-3xl flex-col gap-16">

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,9 +1,11 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {type ReactNode, useRef, useState} from 'react';
+import {useArgs} from 'storybook/preview-api';
 import {Badge} from '#components/badge/index.js';
 import {Icon} from '#components/icon/index.js';
 import {Code} from '#components/typography/index.js';
 import {cn} from '#utils/cn.js';
+import {toggleTimestampUnit} from './format-timestamp.js';
 import {LogContent} from './log-content.js';
 import {LogHeader} from './log-header.js';
 import {LogRow, type LogRowTone} from './log-row.js';
@@ -297,6 +299,7 @@ export const Interactive: Story = {
       },
       {id: 5, ts: 2.95, text: 'done in 412ms'},
     ];
+    const [, updateArgs] = useArgs();
     const [exceptions, setExceptions] = useState<ReadonlySet<number>>(() => new Set());
 
     // Toggling the global `wrap` control clears the per-line overrides so the
@@ -321,7 +324,11 @@ export const Interactive: Story = {
           Globals come from the Controls panel · the chevron (or ⌥-click) wraps one line ·{' '}
           {exceptions.size} overridden
         </Code>
-        <LogRows {...args} timestampOrigin={origin}>
+        <LogRows
+          {...args}
+          timestampOrigin={origin}
+          onTimestampsClick={() => updateArgs({timestamps: toggleTimestampUnit(args.timestamps)})}
+        >
           {lines.map((line) => {
             const overridden = exceptions.has(line.id);
             const rowWrap = overridden ? !args.wrap : undefined;
@@ -351,7 +358,7 @@ export const Interactive: Story = {
                     aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
                     onClick={() => toggleLine(line.id)}
                     className={cn(
-                      'flex-none rounded-4 p-2 transition-opacity',
+                      'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition-opacity',
                       'opacity-60 group-hover/log-row:opacity-100 focus-visible:opacity-100',
                       overridden
                         ? 'text-foreground-highlight-interactive opacity-100'
@@ -360,7 +367,7 @@ export const Interactive: Story = {
                   >
                     <Icon
                       name="chevronRight"
-                      className={cn('size-12 transition-transform', wrapped && 'rotate-90')}
+                      className={cn('size-16 transition-transform', wrapped && 'rotate-90')}
                     />
                   </button>
                 </div>

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -2,14 +2,13 @@ import type {Meta, StoryObj} from '@storybook/react';
 import type {ReactNode} from 'react';
 import {useArgs, useRef, useState} from 'storybook/preview-api';
 import {Badge} from '#components/badge/index.js';
-import {Icon} from '#components/icon/index.js';
 import {Code} from '#components/typography/index.js';
-import {cn} from '#utils/cn.js';
 import {toggleTimestampUnit} from './format-timestamp.js';
 import {LogContent} from './log-content.js';
 import {LogHeader} from './log-header.js';
 import {LogRow, type LogRowTone} from './log-row.js';
 import {LogRows} from './log-rows.js';
+import {LogWrapToggle} from './log-wrap-toggle.js';
 
 const meta = {
   title: 'Components/Log',
@@ -352,24 +351,11 @@ export const Interactive: Story = {
                   >
                     <LogContent variant="code">{line.text}</LogContent>
                   </span>
-                  <button
-                    type="button"
-                    aria-pressed={wrapped}
-                    aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
+                  <LogWrapToggle
+                    wrapped={wrapped}
+                    overridden={overridden}
                     onClick={() => toggleLine(line.id)}
-                    className={cn(
-                      'flex h-20 w-20 flex-none items-center justify-center rounded-4 transition',
-                      'opacity-0 group-hover/log-row:opacity-100 focus-visible:opacity-100',
-                      overridden
-                        ? 'text-foreground-highlight-interactive opacity-100'
-                        : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',
-                    )}
-                  >
-                    <Icon
-                      name="chevronRight"
-                      className={cn('size-16 transition-transform', wrapped && 'rotate-90')}
-                    />
-                  </button>
+                  />
                 </div>
               </LogRow>
             );

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -2,6 +2,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {type ReactNode, useState} from 'react';
 import {Badge} from '#components/badge/index.js';
 import {Button} from '#components/button/index.js';
+import {Icon} from '#components/icon/index.js';
 import {Code} from '#components/typography/index.js';
 import {cn} from '#utils/cn.js';
 import {type LogTimestampMode, toggleTimestampUnit} from './format-timestamp.js';
@@ -37,6 +38,7 @@ type Story = StoryObj<typeof meta>;
 const origin = new Date('2026-06-22T14:32:00.000Z');
 const at = (offsetSeconds: number) => new Date(origin.getTime() + offsetSeconds * 1000);
 const ESC = String.fromCharCode(27);
+const ansiBuild = `${ESC}[32m✓${ESC}[0m built ${ESC}[34m1284${ESC}[0m modules · ${ESC}[1;31m1 error${ESC}[0m`;
 
 const Glyph = ({className, children}: {className: string; children: string}) => (
   <span className={className}>{children}</span>
@@ -60,15 +62,36 @@ export const Playground: Story = {
           <LogContent variant="code">transforming (1284) src/index.tsx</LogContent>
         </LogRow>
         <LogRow lineNumber={35} timestamp={at(9.4)}>
+          <LogContent variant="code" ansi>
+            {ansiBuild}
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={36} timestamp={at(9.7)} tone="warning">
+          <LogContent variant="code">WARN deprecated glob@7 — upgrade to glob@10</LogContent>
+        </LogRow>
+        <LogRow lineNumber={37} timestamp={at(9.9)} tone="error">
+          <LogContent variant="code">
+            ERROR TypeError: Cannot read properties of undefined (reading "id") at withRetry
+            (src/api/retry.ts:42:18)
+          </LogContent>
+        </LogRow>
+        <LogRow lineNumber={38} timestamp={at(10.1)} tone="accent">
+          <LogHeader end={<>$0.084 · 2.1s</>}>
+            <Glyph className="text-purple-500 dark:text-purple-400">{'✦'}</Glyph>
+            <Badge variant="feature">Assistant</Badge>
+          </LogHeader>
+          <LogContent>Patched the off-by-one in withRetry().</LogContent>
+        </LogRow>
+        <LogRow lineNumber={39} timestamp={at(10.3)} selected>
+          <LogContent variant="code">dist/assets/index-a3f9b1c2.js</LogContent>
+        </LogRow>
+        <LogRow lineNumber={40} timestamp={at(10.5)} indent={16}>
           <LogContent variant="code">
             <Glyph className="font-bold text-green-500 dark:text-green-400">{'✓ '}</Glyph>
             1284 modules transformed
           </LogContent>
         </LogRow>
-        <LogRow lineNumber={36} timestamp={at(9.7)} selected>
-          <LogContent variant="code">dist/assets/index-a3f9b1c2.js</LogContent>
-        </LogRow>
-        <LogRow lineNumber={37} timestamp={at(10)}>
+        <LogRow lineNumber={41} timestamp={at(10.7)}>
           <LogContent variant="code" className="text-foreground-neutral-muted">
             built in 412ms
           </LogContent>
@@ -322,17 +345,20 @@ export const Interactive: Story = {
                   <button
                     type="button"
                     aria-pressed={wrapped}
-                    aria-label={wrapped ? 'Collapse line' : 'Expand line'}
+                    aria-label={wrapped ? 'Collapse line' : 'Wrap line'}
                     onClick={() => wrap.toggleLine(line.id)}
                     className={cn(
-                      'flex-none rounded-4 px-6 text-xs transition-opacity',
-                      'opacity-70 group-hover/log-row:opacity-100 focus-visible:opacity-100',
+                      'flex-none rounded-4 p-2 transition-opacity',
+                      'opacity-0 group-hover/log-row:opacity-100 focus-visible:opacity-100',
                       overridden
                         ? 'text-foreground-highlight-interactive opacity-100'
-                        : 'text-foreground-neutral-muted',
+                        : 'text-foreground-neutral-muted hover:text-foreground-neutral-base',
                     )}
                   >
-                    {wrapped ? 'collapse' : 'expand'}
+                    <Icon
+                      name="chevronRight"
+                      className={cn('size-12 transition-transform', wrapped && 'rotate-90')}
+                    />
                   </button>
                 </div>
               </LogRow>

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -1,9 +1,10 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import type {ReactNode} from 'react';
+import {type ReactNode, useState} from 'react';
 import {Badge} from '#components/badge/index.js';
 import {Button} from '#components/button/index.js';
 import {Code} from '#components/typography/index.js';
 import {cn} from '#utils/cn.js';
+import {type LogTimestampMode, toggleTimestampUnit} from './format-timestamp.js';
 import {LogContent} from './log-content.js';
 import {LogHeader} from './log-header.js';
 import {LogRow, type LogRowTone} from './log-row.js';
@@ -244,29 +245,35 @@ export const Wrapping: Story = {
 };
 
 /**
- * Interactive wrapping with `useLogWrap`. The toolbar toggle sets the global
- * default; a per-line action (revealed on row hover) overrides one line — to
- * read a long error in full, say. Flipping the global toggle clears every
- * override, so the global control always wins, and the state is keyed by line
- * id so an override survives a row leaving and re-entering a virtualized window.
+ * Tying the controls together with `useLogWrap` and a clickable timestamp.
+ *
+ * Click any timestamp to switch rel/abs for every row. Per-line wrap stays off
+ * the text so copy/paste is untouched: the explicit toggle is the hover button
+ * (and a future keyboard shortcut), with Alt/Option-click on the line as a
+ * power gesture — plain clicks and drag-selection are left alone. The global
+ * Wrap toggle clears every per-line override, and overrides are keyed by line
+ * id, so they survive a row leaving and re-entering a virtualized window.
  */
-export const WrapControls: Story = {
+export const Interactive: Story = {
   render: () => {
-    const lines: {id: number; text: string; tone?: LogRowTone}[] = [
-      {id: 1, text: 'pnpm vitest run --reporter=verbose --coverage'},
+    const lines: {id: number; ts: number; text: string; tone?: LogRowTone}[] = [
+      {id: 1, ts: 0.12, text: 'pnpm vitest run --reporter=verbose --coverage'},
       {
         id: 2,
+        ts: 1.04,
         tone: 'error',
         text: 'ERROR  TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)',
       },
-      {id: 3, text: 'compiled 1284 modules in 1.2s'},
+      {id: 3, ts: 1.22, text: 'compiled 1284 modules in 1.2s'},
       {
         id: 4,
+        ts: 2.31,
         tone: 'warning',
         text: 'WARN  deprecated glob@7 — upgrade to glob@10 to avoid the slow recursive walk on large repositories',
       },
-      {id: 5, text: 'done in 412ms'},
+      {id: 5, ts: 2.95, text: 'done in 412ms'},
     ];
+    const [timestamps, setTimestamps] = useState<LogTimestampMode>('rel');
     const wrap = useLogWrap(false);
 
     return (
@@ -281,10 +288,15 @@ export const WrapControls: Story = {
             Wrap: {wrap.globalWrap ? 'on' : 'off'}
           </Button>
           <Code variant="label" className="text-foreground-neutral-muted">
-            {wrap.overriddenCount} overridden — toggling global resets them
+            click a timestamp to switch rel/abs · ⌥-click or the hover button to wrap a line
           </Code>
         </div>
-        <LogRows wrap={wrap.globalWrap}>
+        <LogRows
+          timestamps={timestamps}
+          timestampOrigin={origin}
+          wrap={wrap.globalWrap}
+          onTimestampsClick={() => setTimestamps(toggleTimestampUnit)}
+        >
           {lines.map((line) => {
             const wrapped = wrap.rowWrap(line.id) ?? wrap.globalWrap;
             const overridden = wrap.isOverridden(line.id);
@@ -292,16 +304,25 @@ export const WrapControls: Story = {
               <LogRow
                 key={line.id}
                 lineNumber={line.id}
+                timestamp={at(line.ts)}
                 tone={line.tone}
                 wrap={wrap.rowWrap(line.id)}
               >
                 <div className="flex items-start gap-8">
-                  <span className="min-w-0 flex-1">
+                  {/* biome-ignore lint/a11y/noStaticElementInteractions: Alt-click is a pointer-only shortcut; the hover button is the accessible toggle and plain clicks/selection are deliberately untouched so copy still works. */}
+                  {/* biome-ignore lint/a11y/useKeyWithClickEvents: the keyboard path is the hover button (and a future cursor shortcut), not the text. */}
+                  <span
+                    className="min-w-0 flex-1"
+                    onClick={(event) => {
+                      if (event.altKey) wrap.toggleLine(line.id);
+                    }}
+                  >
                     <LogContent variant="code">{line.text}</LogContent>
                   </span>
                   <button
                     type="button"
                     aria-pressed={wrapped}
+                    aria-label={wrapped ? 'Collapse line' : 'Expand line'}
                     onClick={() => wrap.toggleLine(line.id)}
                     className={cn(
                       'flex-none rounded-4 px-6 text-xs transition-opacity',

--- a/libs/shared/react/ui/src/components/log/log.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log.stories.tsx
@@ -51,7 +51,7 @@ const Section = ({label, children}: {label: string; children: ReactNode}) => (
 export const Playground: Story = {
   render: (args) => (
     <div className="max-w-3xl">
-      <LogRows {...args} origin={origin} className="max-h-72">
+      <LogRows {...args} timestampOrigin={origin} className="max-h-72">
         <LogRow lineNumber={34} timestamp={at(9)}>
           <LogContent variant="code">transforming (1284) src/index.tsx</LogContent>
         </LogRow>
@@ -119,7 +119,7 @@ export const Timestamps: Story = {
     <div className="grid max-w-5xl gap-16 md:grid-cols-3">
       {(['off', 'rel', 'abs'] as const).map((mode) => (
         <Section key={mode} label={`timestamps="${mode}"`}>
-          <LogRows timestamps={mode} origin={origin}>
+          <LogRows timestamps={mode} timestampOrigin={origin}>
             <LogRow lineNumber={17} timestamp={at(0.412)}>
               <LogContent variant="code">resolving dependencies</LogContent>
             </LogRow>
@@ -353,7 +353,7 @@ export const Header: Story = {
 export const Composition: Story = {
   render: () => (
     <div className="max-w-3xl">
-      <LogRows timestamps="abs" origin={origin} className="max-h-96">
+      <LogRows timestamps="abs" timestampOrigin={origin} className="max-h-96">
         <LogRow lineNumber={41} timestamp={at(8.12)}>
           <LogContent variant="code">
             <Glyph className="text-green-500 dark:text-green-400">{'$ '}</Glyph>pnpm vitest run

--- a/libs/shared/react/ui/src/components/log/use-log-wrap.ts
+++ b/libs/shared/react/ui/src/components/log/use-log-wrap.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import {useCallback, useMemo, useState} from 'react';
+import {
+  createWrapState,
+  type LogLineId,
+  resolveRowWrap,
+  setGlobalWrap,
+  toggleGlobalWrap,
+  toggleLineWrap,
+  type WrapState,
+} from './wrap-state.js';
+
+export interface UseLogWrapResult {
+  /** Wrap default for the list; pass to `LogRows.wrap`. */
+  globalWrap: boolean;
+  /** How many lines currently differ from the global default. */
+  overriddenCount: number;
+  /** The `wrap` value for a row — `undefined` inherits the global default. */
+  rowWrap: (id: LogLineId) => boolean | undefined;
+  /** Whether a line currently overrides the global default. */
+  isOverridden: (id: LogLineId) => boolean;
+  /** Toggle one line's wrap against the global default. */
+  toggleLine: (id: LogLineId) => void;
+  /** Flip the global default, clearing every per-line override. */
+  toggleGlobal: () => void;
+  /** Set the global default; a real change clears the overrides. */
+  setGlobal: (wrap: boolean) => void;
+}
+
+/**
+ * Owns interactive wrap state for a log surface: one global default plus the
+ * lines that deliberately differ from it. A global change clears the per-line
+ * overrides, so the global control always wins. State is keyed by line id, so a
+ * per-line choice survives the row scrolling out of and back into a virtualized
+ * window. Keep the four primitives stateless and drive them from this hook.
+ */
+export function useLogWrap(defaultWrap = false): UseLogWrapResult {
+  const [state, setState] = useState<WrapState>(() => createWrapState(defaultWrap));
+
+  const rowWrap = useCallback((id: LogLineId) => resolveRowWrap(state, id), [state]);
+  const isOverridden = useCallback((id: LogLineId) => state.exceptions.has(id), [state]);
+  const toggleLine = useCallback((id: LogLineId) => setState((s) => toggleLineWrap(s, id)), []);
+  const toggleGlobal = useCallback(() => setState(toggleGlobalWrap), []);
+  const setGlobal = useCallback((wrap: boolean) => setState((s) => setGlobalWrap(s, wrap)), []);
+
+  return useMemo(
+    () => ({
+      globalWrap: state.globalWrap,
+      overriddenCount: state.exceptions.size,
+      rowWrap,
+      isOverridden,
+      toggleLine,
+      toggleGlobal,
+      setGlobal,
+    }),
+    [state, rowWrap, isOverridden, toggleLine, toggleGlobal, setGlobal],
+  );
+}

--- a/libs/shared/react/ui/src/components/log/use-log-wrap.ts
+++ b/libs/shared/react/ui/src/components/log/use-log-wrap.ts
@@ -12,7 +12,6 @@ import {
 } from './wrap-state.js';
 
 export interface UseLogWrapResult {
-  /** Wrap default for the list; pass to `LogRows.wrap`. */
   globalWrap: boolean;
   /** How many lines currently differ from the global default. */
   overriddenCount: number;
@@ -20,7 +19,6 @@ export interface UseLogWrapResult {
   rowWrap: (id: LogLineId) => boolean | undefined;
   /** Whether a line currently overrides the global default. */
   isOverridden: (id: LogLineId) => boolean;
-  /** Toggle one line's wrap against the global default. */
   toggleLine: (id: LogLineId) => void;
   /** Flip the global default, clearing every per-line override. */
   toggleGlobal: () => void;
@@ -33,7 +31,7 @@ export interface UseLogWrapResult {
  * lines that deliberately differ from it. A global change clears the per-line
  * overrides, so the global control always wins. State is keyed by line id, so a
  * per-line choice survives the row scrolling out of and back into a virtualized
- * window. Keep the four primitives stateless and drive them from this hook.
+ * window.
  */
 export function useLogWrap(defaultWrap = false): UseLogWrapResult {
   const [state, setState] = useState<WrapState>(() => createWrapState(defaultWrap));

--- a/libs/shared/react/ui/src/components/log/wrap-state.test.ts
+++ b/libs/shared/react/ui/src/components/log/wrap-state.test.ts
@@ -1,0 +1,69 @@
+import {
+  createWrapState,
+  resolveRowWrap,
+  setGlobalWrap,
+  toggleGlobalWrap,
+  toggleLineWrap,
+} from './wrap-state.js';
+
+describe('wrap-state', () => {
+  test('a fresh state carries the given global default and no overrides', () => {
+    const state = createWrapState(true);
+
+    expect(state.globalWrap).toBe(true);
+    expect(state.exceptions.size).toBe(0);
+  });
+
+  test('a row with no override inherits the global default', () => {
+    const state = createWrapState(false);
+
+    expect(resolveRowWrap(state, 'a')).toBeUndefined();
+  });
+
+  test('an overridden row resolves to the opposite of the global default', () => {
+    const state = toggleLineWrap(createWrapState(false), 'a');
+
+    expect(resolveRowWrap(state, 'a')).toBe(true);
+  });
+
+  test('toggling an overridden row again clears its override', () => {
+    const cleared = toggleLineWrap(toggleLineWrap(createWrapState(false), 'a'), 'a');
+
+    expect(cleared.exceptions.has('a')).toBe(false);
+    expect(resolveRowWrap(cleared, 'a')).toBeUndefined();
+  });
+
+  test('toggling the global default clears every override', () => {
+    const overridden = toggleLineWrap(toggleLineWrap(createWrapState(false), 'a'), 'b');
+
+    const toggled = toggleGlobalWrap(overridden);
+
+    expect(toggled.globalWrap).toBe(true);
+    expect(toggled.exceptions.size).toBe(0);
+  });
+
+  test('setting a changed global value clears overrides', () => {
+    const overridden = toggleLineWrap(createWrapState(false), 'a');
+
+    const result = setGlobalWrap(overridden, true);
+
+    expect(result.globalWrap).toBe(true);
+    expect(result.exceptions.size).toBe(0);
+  });
+
+  test('setting the current global value is a no-op that keeps overrides', () => {
+    const overridden = toggleLineWrap(createWrapState(false), 'a');
+
+    const result = setGlobalWrap(overridden, false);
+
+    expect(result).toBe(overridden);
+  });
+
+  test('transitions do not mutate the previous state', () => {
+    const state = createWrapState(false);
+
+    toggleLineWrap(state, 'a');
+
+    expect(state.exceptions.size).toBe(0);
+  });
+});

--- a/libs/shared/react/ui/src/components/log/wrap-state.ts
+++ b/libs/shared/react/ui/src/components/log/wrap-state.ts
@@ -1,14 +1,13 @@
 /**
  * Pure state for interactive line wrapping: one global default plus the set of
- * lines that deliberately differ from it. Kept free of React so the transitions
- * can be unit-tested and, if a consumer prefers, driven from their own reducer
- * or persisted to a URL. `useLogWrap` is the ergonomic React wrapper.
+ * lines that deliberately differ from it. Kept free of React so consumers can
+ * drive it from their own reducer or persist it outside component state.
+ * `useLogWrap` is the ergonomic React wrapper.
  */
 
 export type LogLineId = string | number;
 
 export interface WrapState {
-  /** Wrap default applied to every line that has no override. */
   readonly globalWrap: boolean;
   /** Lines whose wrap deliberately differs from the global default. */
   readonly exceptions: ReadonlySet<LogLineId>;
@@ -27,7 +26,6 @@ export function resolveRowWrap(state: WrapState, id: LogLineId): boolean | undef
   return state.exceptions.has(id) ? !state.globalWrap : undefined;
 }
 
-/** Flip one line's override against the global default (or clear it). */
 export function toggleLineWrap(state: WrapState, id: LogLineId): WrapState {
   const exceptions = new Set(state.exceptions);
   if (exceptions.has(id)) exceptions.delete(id);
@@ -44,7 +42,6 @@ export function setGlobalWrap(state: WrapState, globalWrap: boolean): WrapState 
   return {globalWrap, exceptions: new Set()};
 }
 
-/** Flip the global default, clearing every per-line override so it wins. */
 export function toggleGlobalWrap(state: WrapState): WrapState {
   return {globalWrap: !state.globalWrap, exceptions: new Set()};
 }

--- a/libs/shared/react/ui/src/components/log/wrap-state.ts
+++ b/libs/shared/react/ui/src/components/log/wrap-state.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure state for interactive line wrapping: one global default plus the set of
+ * lines that deliberately differ from it. Kept free of React so the transitions
+ * can be unit-tested and, if a consumer prefers, driven from their own reducer
+ * or persisted to a URL. `useLogWrap` is the ergonomic React wrapper.
+ */
+
+export type LogLineId = string | number;
+
+export interface WrapState {
+  /** Wrap default applied to every line that has no override. */
+  readonly globalWrap: boolean;
+  /** Lines whose wrap deliberately differs from the global default. */
+  readonly exceptions: ReadonlySet<LogLineId>;
+}
+
+export function createWrapState(globalWrap = false): WrapState {
+  return {globalWrap, exceptions: new Set()};
+}
+
+/**
+ * The `wrap` value to hand a `LogRow`: `undefined` lets the row inherit the
+ * container default, while an overridden line resolves to the opposite of the
+ * global value (expand one line when all are collapsed, or vice versa).
+ */
+export function resolveRowWrap(state: WrapState, id: LogLineId): boolean | undefined {
+  return state.exceptions.has(id) ? !state.globalWrap : undefined;
+}
+
+/** Flip one line's override against the global default (or clear it). */
+export function toggleLineWrap(state: WrapState, id: LogLineId): WrapState {
+  const exceptions = new Set(state.exceptions);
+  if (exceptions.has(id)) exceptions.delete(id);
+  else exceptions.add(id);
+  return {...state, exceptions};
+}
+
+/**
+ * Set the global default. A real change clears every per-line override so the
+ * global control always wins; setting the current value is a no-op.
+ */
+export function setGlobalWrap(state: WrapState, globalWrap: boolean): WrapState {
+  if (globalWrap === state.globalWrap) return state;
+  return {globalWrap, exceptions: new Set()};
+}
+
+/** Flip the global default, clearing every per-line override so it wins. */
+export function toggleGlobalWrap(state: WrapState): WrapState {
+  return {globalWrap: !state.globalWrap, exceptions: new Set()};
+}


### PR DESCRIPTION
Introduces four semantic-free primitives in `@shipfox/react-ui` that the client will compose to render the log records served by `@shipfox/api-logs`: `LogRows` (scroll surface plus the shared row context — timestamp mode, wrap, line numbers), `LogRow` (the gutter / time / body grid that owns tone, indent and selection), and the `LogHeader` and `LogContent` body slots.

The deliberate choice here is that the library carries no domain meaning. Output lines, agent turns and timeline markers are not components — they are compositions the application assembles from these four. That keeps the design system free of log semantics and lets new record types (agent sessions, markers) interleave in the same renderer without new primitives.

Visuals follow the existing `code-block` component (`text-xs`/`leading-20`, theme-adaptive contrast surfaces, code-style line numbers) rather than inventing a separate log aesthetic. `LogContent` includes an ANSI SGR parser mapped onto the design palette, and timestamps render absolute or relative to a container origin.

### Review notes
- This is the design-system pass only: the primitives are intentionally abstract and do not yet wire to the `api-logs` read endpoint. Virtualization, follow/tail and the toolbar/status-bar organisms are out of scope (inventoried in the companion design files for follow-up).
- Stories cover every primitive plus the composition recipes (output line, agent turn, timeline marker, interleaved stream) and feed Argos visual regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds semantic-free log viewer primitives to `@shipfox/react-ui` for composing logs from `@shipfox/api-logs`. Includes ANSI-aware code styling, a clickable timestamp column, distinct tones (incl. green `success` and violet `accent`), per-line wrap via `LogWrapToggle`, hang-indented wraps, and a right-edge fade for long lines.

- **New Features**
  - Components: `LogRows`, `LogRow`, `LogHeader`, `LogContent`, `LogWrapToggle`. Context: `timestamps`, `wrap`, `showLineNumbers`, `timestampOrigin`, `onTimestampsClick`. Rows support `tone`, `indent`, `selected`, per-row `wrap`, and expose resolved wrap via `data-wrap`. Tones use distinct hues; brand orange is reserved for selection.
  - Output & time: `parseAnsi` maps SGR colors/styles to the palette. `LogContent` code variant hang-indents when wrapped; otherwise it scrolls and shows a right-edge fade. `formatLogTimestamp` supports `off`, `rel`, `abs`; `toggleTimestampUnit` flips rel/abs. The timestamp column is clickable and brightens on hover while staying selectable.
  - Wrapping: `useLogWrap` over pure `wrap-state` (global default plus per-line exceptions that reset on global change; state keyed by `LogLineId`). Toggle per-line wrap with `LogWrapToggle` or Option/Alt-click; the chevron hides by default, reveals on row hover/focus, pins when overridden, and rotates when wrapped.
  - Stories & tests: Capability-focused stories (Playground, Interactive with Controls via `useArgs`, Composition) and unit tests for ANSI parsing (incl. extended-color operands), timestamp formatting, and wrap-state transitions.

- **Bug Fixes**
  - `parseAnsi` now clears fg/bg when an unsupported extended color (`38;5;n`, `38;2;r;g;b`) is seen, preventing previous colors from leaking.
  - `LogWrapToggle` enforces `type="button"` after prop spread so consumers cannot override it.

<sup>Written for commit 58fa87bd705c01e06385ca50bf1f417d1519f51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

