### PR TITLE
Stop a broken trigger subscription from starving its siblings

### DIFF
--- a/.changeset/eng-557-poison-subscription-isolation.md
+++ b/.changeset/eng-557-poison-subscription-isolation.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-triggers": patch
+"@shipfox/api-triggers-dto": patch
+"@shipfox/api-workflows": patch
+---
+
+Stop a permanently-broken trigger subscription from starving its siblings or wedging the outbox. Integration dispatch now attempts every matched subscription and classifies each `runWorkflow` failure: a permanent error (deleted definition or project mismatch) is recorded and skipped, while a transient one re-throws so the outbox replays the event and converges. The event reaches a terminal outcome once no transient error remains (`routed` when any run was created, otherwise the new `errored` outcome), with a guarded write that never records `errored` over an event that already produced a run. The manual-fire path records the same terminal outcome, and `@shipfox/api-workflows` exports an `isPermanentRunWorkflowError` classifier. The trigger-events read API (`triggerEventOutcomeSchema`) accepts the new `errored` outcome for serialization and filtering.

--- a/libs/api/triggers-dto/src/schemas/trigger-events.ts
+++ b/libs/api/triggers-dto/src/schemas/trigger-events.ts
@@ -3,7 +3,13 @@ import {z} from 'zod';
 export const triggerEventOriginSchema = z.enum(['integration', 'manual']);
 export type TriggerEventOriginDto = z.infer<typeof triggerEventOriginSchema>;
 
-export const triggerEventOutcomeSchema = z.enum(['received', 'routed', 'discarded', 'failed']);
+export const triggerEventOutcomeSchema = z.enum([
+  'received',
+  'routed',
+  'discarded',
+  'failed',
+  'errored',
+]);
 export type TriggerEventOutcomeDto = z.infer<typeof triggerEventOutcomeSchema>;
 
 export const triggerDecisionOutcomeSchema = z.enum(['triggered', 'errored']);

--- a/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
@@ -5,6 +5,7 @@ const insertReceivedEvent = vi.fn();
 
 vi.mock('@shipfox/api-workflows', () => ({
   runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+  isPermanentRunWorkflowError: () => false,
 }));
 
 vi.mock('#db/event-history.js', () => ({
@@ -12,6 +13,7 @@ vi.mock('#db/event-history.js', () => ({
   markReceivedEventDiscarded: vi.fn(),
   markReceivedEventRouted: vi.fn(),
   markReceivedEventFailed: vi.fn(),
+  markReceivedEventErrored: vi.fn(),
   upsertTriggeredDecision: vi.fn(),
   upsertErroredDecision: vi.fn(),
 }));

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -6,9 +6,33 @@ import {triggerSubscriptionFactory} from '#test/index.js';
 
 const runWorkflow = vi.fn();
 
-vi.mock('@shipfox/api-workflows', () => ({
-  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
-}));
+// Mock the package root but keep real-enough permanent-error classes + the classifier, so the
+// dispatcher's permanent/transient branching is exercised without loading the workflows module graph.
+vi.mock('@shipfox/api-workflows', () => {
+  class DefinitionNotFoundError extends Error {
+    constructor(definitionId: string) {
+      super(`Definition not found: ${definitionId}`);
+      this.name = 'DefinitionNotFoundError';
+    }
+  }
+  class ProjectMismatchError extends Error {
+    constructor(definitionProjectId: string, requestProjectId: string) {
+      super(
+        `Definition belongs to project ${definitionProjectId}, but request targets project ${requestProjectId}`,
+      );
+      this.name = 'ProjectMismatchError';
+    }
+  }
+  return {
+    runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+    DefinitionNotFoundError,
+    ProjectMismatchError,
+    isPermanentRunWorkflowError: (error: unknown) =>
+      error instanceof DefinitionNotFoundError || error instanceof ProjectMismatchError,
+  };
+});
+
+import {DefinitionNotFoundError, ProjectMismatchError} from '@shipfox/api-workflows';
 
 // Import after mocks so the core dispatcher sees the spy.
 const {dispatchIntegrationEvent} = await import('./dispatch-integration-event.js');
@@ -223,7 +247,7 @@ describe('dispatchIntegrationEvent trigger history', () => {
     expect(decisions.every((d) => d.runName === 'Build and test')).toBe(true);
   });
 
-  test('records a failed event, stops the loop at the first throw, and re-throws', async () => {
+  test('continues the fan-out past a transient error, records a failed event, and re-throws', async () => {
     const workspaceId = crypto.randomUUID();
     const eventRef = crypto.randomUUID();
     await triggerSubscriptionFactory.create({
@@ -242,17 +266,205 @@ describe('dispatchIntegrationEvent trigger history', () => {
 
     await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('runWorkflow boom');
 
-    // Every match would throw, so one call proves the loop stops at the first failure.
-    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
     const event = await receivedEvent(eventRef);
     if (!event) throw new Error('received event not found');
     expect(event.outcome).toBe('failed');
     expect(event.matchedCount).toBe(2);
     expect(event.processedAt).toBeNull();
     const decisions = await decisionsForEvent(event.id);
-    expect(decisions).toHaveLength(1);
-    expect(decisions[0]?.decision).toBe('errored');
-    expect(decisions[0]?.reason).toContain('runWorkflow boom');
+    expect(decisions).toHaveLength(2);
+    expect(decisions.every((d) => d.decision === 'errored')).toBe(true);
+    expect(decisions.every((d) => d.reason?.includes('runWorkflow boom'))).toBe(true);
+  });
+
+  test('re-throws the first transient error, not a later one', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    let attempt = 0;
+    runWorkflow.mockImplementation(() => {
+      attempt += 1;
+      throw new Error(attempt === 1 ? 'first transient' : 'second transient');
+    });
+
+    await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('first transient');
+
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
+  });
+
+  test('treats a thrown undefined as a transient failure and re-throws it', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(undefined);
+
+    await expect(dispatch({workspaceId, eventRef})).rejects.toBeUndefined();
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.processedAt).toBeNull();
+  });
+
+  test('runs every sibling and routes when one subscription is permanently broken', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const poison = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const healthy = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+    runWorkflow.mockImplementation(({projectId}: {projectId: string}) => {
+      if (projectId === poison.projectId) throw new DefinitionNotFoundError('def-gone');
+      return run;
+    });
+
+    await dispatch({workspaceId, eventRef});
+
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('routed');
+    expect(event.matchedCount).toBe(2);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    const errored = decisions.find((d) => d.subscriptionId === poison.id);
+    const triggered = decisions.find((d) => d.subscriptionId === healthy.id);
+    expect(errored?.decision).toBe('errored');
+    expect(errored?.reason).toContain('Definition not found');
+    expect(triggered?.decision).toBe('triggered');
+    expect(triggered?.runId).toBe(run.id);
+  });
+
+  test('marks the event errored when every subscription errors permanently', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockImplementation(() => {
+      throw new ProjectMismatchError('proj-a', 'proj-b');
+    });
+
+    await dispatch({workspaceId, eventRef});
+
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    expect(event.matchedCount).toBe(2);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(2);
+    expect(decisions.every((d) => d.decision === 'errored')).toBe(true);
+  });
+
+  test('records failed (not errored) when a permanent and a transient error mix in one attempt', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const permanent = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    runWorkflow.mockImplementation(({projectId}: {projectId: string}) => {
+      if (projectId === permanent.projectId) throw new DefinitionNotFoundError('def-gone');
+      throw new Error('transient boom');
+    });
+
+    await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('transient boom');
+
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.processedAt).toBeNull();
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(2);
+    expect(decisions.every((d) => d.decision === 'errored')).toBe(true);
+  });
+
+  test('promotes to routed across replay when a prior run survives a later definition deletion', async () => {
+    const workspaceId = crypto.randomUUID();
+    const eventRef = crypto.randomUUID();
+    const ranThenDeleted = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const transient = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'github',
+      event: 'push',
+      config: {},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Build and test'};
+
+    runWorkflow.mockImplementation(({projectId}: {projectId: string}) => {
+      if (projectId === ranThenDeleted.projectId) return run;
+      throw new Error('transient boom');
+    });
+    await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('transient boom');
+
+    // A later permanent failure must not downgrade a run recorded during a prior
+    // transiently failed attempt.
+    runWorkflow.mockImplementation(() => {
+      throw new DefinitionNotFoundError('def-gone');
+    });
+    await dispatch({workspaceId, eventRef});
+
+    const event = await receivedEvent(eventRef);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('routed');
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    const survived = decisions.find((d) => d.subscriptionId === ranThenDeleted.id);
+    const stillBroken = decisions.find((d) => d.subscriptionId === transient.id);
+    expect(survived?.decision).toBe('triggered');
+    expect(survived?.runId).toBe(run.id);
+    expect(stillBroken?.decision).toBe('errored');
   });
 
   test('replaying the same event does not duplicate rows and reuses the idempotency key', async () => {
@@ -302,6 +514,7 @@ describe('dispatchIntegrationEvent trigger history', () => {
 
     await expect(dispatch({workspaceId, eventRef})).rejects.toThrow('second boom');
 
+    expect(runWorkflow).toHaveBeenCalledTimes(2);
     const event = await receivedEvent(eventRef);
     if (!event) throw new Error('received event not found');
     expect(event.outcome).toBe('failed');

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -1,4 +1,4 @@
-import {runWorkflow} from '@shipfox/api-workflows';
+import {isPermanentRunWorkflowError, runWorkflow} from '@shipfox/api-workflows';
 import {findMatchingSubscriptions} from '#db/subscriptions.js';
 import {readConfigInputs} from './config.js';
 import {beginTriggerHistory, toReason} from './record-trigger-history.js';
@@ -17,10 +17,14 @@ export interface DispatchIntegrationEventParams {
 // Source-agnostic dispatcher: any inbound integration event fans out to every
 // workspace subscription registered for its (source, event), passing the raw
 // payload through untouched. The module knows nothing about github, gitlab, etc.
-// History is best-effort, but `runWorkflow` errors still re-throw so the outbox retries.
-// A transient failure converges to `routed` on replay; a permanent one (e.g. a deleted
-// definition) re-throws every retry, so the event stays `failed`. The recorded outcome
-// tracks reality; it is not a stuck state to recover from here.
+//
+// Continue-on-error: every matched subscription is attempted so one broken subscription
+// cannot starve its siblings. A permanent failure (deleted definition, project mismatch)
+// is recorded and skipped; a transient one is recorded and re-thrown so the outbox replays
+// the whole event and converges (succeeded siblings dedup on the idempotency key). The event
+// reaches a terminal outcome only when no transient error remains: `routed` if any run was
+// created, otherwise `errored`. History is best-effort; the thrown transient error, not the
+// recorded outcome, is what drives the retry.
 export async function dispatchIntegrationEvent(
   params: DispatchIntegrationEventParams,
 ): Promise<void> {
@@ -47,6 +51,10 @@ export async function dispatchIntegrationEvent(
     return;
   }
 
+  let triggeredCount = 0;
+  let sawTransientError = false;
+  let firstTransientError: unknown;
+
   for (const subscription of subscriptions) {
     try {
       const run = await runWorkflow({
@@ -63,12 +71,27 @@ export async function dispatchIntegrationEvent(
         triggerIdempotencyKey: `${subscription.id}:${params.eventRef}`,
       });
       await history.triggered(subscription, run);
+      triggeredCount += 1;
     } catch (error) {
       await history.errored(subscription, toReason(error));
-      await history.failed(subscriptions.length);
-      throw error;
+      // Track presence with a flag, not `firstTransientError === undefined`: a thrown
+      // value of `undefined` is still a transient failure and must drive the replay.
+      if (!isPermanentRunWorkflowError(error) && !sawTransientError) {
+        sawTransientError = true;
+        firstTransientError = error;
+      }
     }
   }
 
-  await history.routed(subscriptions.length);
+  if (sawTransientError) {
+    await history.failed(subscriptions.length);
+    throw firstTransientError;
+  }
+
+  if (triggeredCount > 0) {
+    await history.routed(subscriptions.length);
+    return;
+  }
+
+  await history.allErrored(subscriptions.length);
 }

--- a/libs/api/triggers/src/core/entities/received-event.ts
+++ b/libs/api/triggers/src/core/entities/received-event.ts
@@ -1,7 +1,13 @@
 export const triggerEventOrigins = ['integration', 'manual'] as const;
 export type TriggerEventOrigin = (typeof triggerEventOrigins)[number];
 
-export const triggerEventOutcomes = ['received', 'routed', 'discarded', 'failed'] as const;
+export const triggerEventOutcomes = [
+  'received',
+  'routed',
+  'discarded',
+  'failed',
+  'errored',
+] as const;
 export type TriggerEventOutcome = (typeof triggerEventOutcomes)[number];
 
 export interface TriggerReceivedEvent {

--- a/libs/api/triggers/src/core/fire-manual.test.ts
+++ b/libs/api/triggers/src/core/fire-manual.test.ts
@@ -7,9 +7,23 @@ import {TriggerSubscriptionNotManualError} from './errors.js';
 
 const runWorkflow = vi.fn();
 
-vi.mock('@shipfox/api-workflows', () => ({
-  runWorkflow: (...args: unknown[]) => runWorkflow(...args),
-}));
+// Keep real-enough permanent-error classes + the classifier so the manual path's
+// permanent/transient branching is exercised without loading the workflows module graph.
+vi.mock('@shipfox/api-workflows', () => {
+  class DefinitionNotFoundError extends Error {
+    constructor(definitionId: string) {
+      super(`Definition not found: ${definitionId}`);
+      this.name = 'DefinitionNotFoundError';
+    }
+  }
+  return {
+    runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+    DefinitionNotFoundError,
+    isPermanentRunWorkflowError: (error: unknown) => error instanceof DefinitionNotFoundError,
+  };
+});
+
+import {DefinitionNotFoundError} from '@shipfox/api-workflows';
 
 // Import after mocks so the function under test sees the spy.
 const {fireManualSubscription} = await import('./fire-manual.js');
@@ -92,6 +106,34 @@ describe('fireManualSubscription (trigger history)', () => {
     expect(decisions).toHaveLength(1);
     expect(decisions[0]?.decision).toBe('errored');
     expect(decisions[0]?.reason).toContain('manual boom');
+  });
+
+  test('records an errored (terminal) manual event when runWorkflow fails permanently', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'manual',
+      event: 'fire',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(new DefinitionNotFoundError('def-gone'));
+
+    await expect(
+      fireManualSubscription({
+        subscriptionId: subscription.id,
+        callerWorkspaceId: subscription.workspaceId,
+        userId: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow('Definition not found');
+
+    const events = await eventsForWorkspace(subscription.workspaceId);
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    expect(event.matchedCount).toBe(1);
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions[0]?.decision).toBe('errored');
+    expect(decisions[0]?.reason).toContain('Definition not found');
   });
 
   test('does not record a received event when the subscription is not a manual trigger', async () => {

--- a/libs/api/triggers/src/core/fire-manual.ts
+++ b/libs/api/triggers/src/core/fire-manual.ts
@@ -1,5 +1,5 @@
 import {randomUUID} from 'node:crypto';
-import {runWorkflow, type WorkflowRun} from '@shipfox/api-workflows';
+import {isPermanentRunWorkflowError, runWorkflow, type WorkflowRun} from '@shipfox/api-workflows';
 import {getTriggerSubscriptionById} from '#db/subscriptions.js';
 import {readConfigInputs} from './config.js';
 import {
@@ -63,7 +63,13 @@ export async function fireManualSubscription(
   } catch (error) {
     const failure = await beginTriggerHistory({...historyBase, eventRef: randomUUID()});
     await failure.errored(subscription, toReason(error));
-    await failure.failed(1);
+    // Manual fires do not replay, so permanent workflow errors can close history
+    // immediately while preserving the thrown error for callers.
+    if (isPermanentRunWorkflowError(error)) {
+      await failure.allErrored(1);
+    } else {
+      await failure.failed(1);
+    }
     throw error;
   }
 

--- a/libs/api/triggers/src/core/record-trigger-history.test.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.test.ts
@@ -7,6 +7,7 @@ const upsertTriggeredDecision = vi.fn();
 
 vi.mock('@shipfox/api-workflows', () => ({
   runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+  isPermanentRunWorkflowError: () => false,
 }));
 
 vi.mock('#db/event-history.js', () => ({
@@ -14,6 +15,7 @@ vi.mock('#db/event-history.js', () => ({
   markReceivedEventDiscarded: vi.fn(),
   markReceivedEventRouted: (...args: unknown[]) => markReceivedEventRouted(...args),
   markReceivedEventFailed: vi.fn(),
+  markReceivedEventErrored: vi.fn(),
   upsertTriggeredDecision: (...args: unknown[]) => upsertTriggeredDecision(...args),
   upsertErroredDecision: vi.fn(),
 }));
@@ -50,6 +52,7 @@ describe('trigger history is best-effort and never blocks triggering', () => {
     await expect(recorder.discarded()).resolves.toBeUndefined();
     await expect(recorder.routed(1)).resolves.toBeUndefined();
     await expect(recorder.failed(1)).resolves.toBeUndefined();
+    await expect(recorder.allErrored(1)).resolves.toBeUndefined();
   });
 
   test('fireManualSubscription still returns the run when history recording fails', async () => {

--- a/libs/api/triggers/src/core/record-trigger-history.ts
+++ b/libs/api/triggers/src/core/record-trigger-history.ts
@@ -4,6 +4,7 @@ import type {TriggerSubscription} from '#core/entities/subscription.js';
 import {
   insertReceivedEvent,
   markReceivedEventDiscarded,
+  markReceivedEventErrored,
   markReceivedEventFailed,
   markReceivedEventRouted,
   upsertErroredDecision,
@@ -35,6 +36,7 @@ export interface TriggerHistoryRecorder {
   discarded(): Promise<void>;
   routed(matchedCount: number): Promise<void>;
   failed(matchedCount: number): Promise<void>;
+  allErrored(matchedCount: number): Promise<void>;
 }
 
 export interface BeginTriggerHistoryParams {
@@ -85,6 +87,8 @@ export async function beginTriggerHistory(
       record('route-event', (id) => markReceivedEventRouted(id, matchedCount)),
     failed: (matchedCount) =>
       record('fail-event', (id) => markReceivedEventFailed(id, matchedCount)),
+    allErrored: (matchedCount) =>
+      record('all-errored-event', (id) => markReceivedEventErrored(id, matchedCount)),
   };
 }
 

--- a/libs/api/triggers/src/db/event-history.test.ts
+++ b/libs/api/triggers/src/db/event-history.test.ts
@@ -5,6 +5,7 @@ import {
   type InsertReceivedEventParams,
   insertReceivedEvent,
   markReceivedEventDiscarded,
+  markReceivedEventErrored,
   markReceivedEventFailed,
   markReceivedEventRouted,
   upsertErroredDecision,
@@ -151,6 +152,81 @@ describe('received-event outcome transitions', () => {
       .from(triggersReceivedEvents)
       .where(eq(triggersReceivedEvents.id, id));
     expect(row?.outcome).toBe('routed');
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('marks an event errored with processed_at when no run was created', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+
+    await markReceivedEventErrored(id, 2);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('errored');
+    expect(row?.matchedCount).toBe(2);
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('promotes to routed instead of errored when a triggered decision exists (cross-attempt run)', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+    await upsertTriggeredDecision({
+      receivedEventId: id,
+      subscription: buildSubscription(),
+      run: {id: crypto.randomUUID(), name: 'Build and test'},
+    });
+
+    await markReceivedEventErrored(id, 2);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('routed');
+    expect(row?.matchedCount).toBe(2);
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('does not downgrade a routed event to errored', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+    await markReceivedEventRouted(id, 1);
+
+    await markReceivedEventErrored(id, 1);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('routed');
+  });
+
+  it('does not downgrade an errored event to failed (a late transient write loses)', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+    await markReceivedEventErrored(id, 1);
+
+    await markReceivedEventFailed(id, 1);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('errored');
+    expect(row?.processedAt).toBeInstanceOf(Date);
+  });
+
+  it('promotes a transient failed event to errored on the all-permanent replay', async () => {
+    const id = await insertReceivedEvent(buildEventParams());
+    await markReceivedEventFailed(id, 2);
+
+    await markReceivedEventErrored(id, 2);
+
+    const [row] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.id, id));
+    expect(row?.outcome).toBe('errored');
+    expect(row?.matchedCount).toBe(2);
     expect(row?.processedAt).toBeInstanceOf(Date);
   });
 });

--- a/libs/api/triggers/src/db/event-history.ts
+++ b/libs/api/triggers/src/db/event-history.ts
@@ -1,4 +1,4 @@
-import {and, eq, ne, notInArray} from 'drizzle-orm';
+import {and, eq, ne, notInArray, sql} from 'drizzle-orm';
 import type {TriggerEventOrigin} from '#core/entities/received-event.js';
 import type {TriggerSubscription} from '#core/entities/subscription.js';
 import {db} from './db.js';
@@ -51,7 +51,12 @@ export async function markReceivedEventDiscarded(id: string): Promise<void> {
   await db()
     .update(triggersReceivedEvents)
     .set({outcome: 'discarded', matchedCount: 0, processedAt: new Date()})
-    .where(and(eq(triggersReceivedEvents.id, id), ne(triggersReceivedEvents.outcome, 'routed')));
+    .where(
+      and(
+        eq(triggersReceivedEvents.id, id),
+        notInArray(triggersReceivedEvents.outcome, ['routed', 'errored']),
+      ),
+    );
 }
 
 export async function markReceivedEventRouted(id: string, matchedCount: number): Promise<void> {
@@ -67,6 +72,32 @@ export async function markReceivedEventFailed(id: string, matchedCount: number):
   await db()
     .update(triggersReceivedEvents)
     .set({outcome: 'failed', matchedCount})
+    .where(
+      and(
+        eq(triggersReceivedEvents.id, id),
+        notInArray(triggersReceivedEvents.outcome, ['routed', 'discarded', 'errored']),
+      ),
+    );
+}
+
+// Terminal outcome for a fan-out that produced no new run this pass. The CASE is a
+// cross-attempt safety net: under at-least-once delivery a prior attempt may already have
+// created a run (its decision row is `triggered`, which is never downgraded), so promote the
+// event to `routed` rather than falsely record `errored`. Guarded so it never downgrades a
+// terminal success.
+export async function markReceivedEventErrored(id: string, matchedCount: number): Promise<void> {
+  await db()
+    .update(triggersReceivedEvents)
+    .set({
+      outcome: sql`CASE WHEN EXISTS (
+        SELECT 1
+        FROM ${triggersDecisions}
+        WHERE ${triggersDecisions.receivedEventId} = ${triggersReceivedEvents.id}
+          AND ${triggersDecisions.decision} = 'triggered'
+      ) THEN 'routed' ELSE 'errored' END`,
+      matchedCount,
+      processedAt: new Date(),
+    })
     .where(
       and(
         eq(triggersReceivedEvents.id, id),

--- a/libs/api/triggers/src/presentation/routes/list-trigger-events.test.ts
+++ b/libs/api/triggers/src/presentation/routes/list-trigger-events.test.ts
@@ -115,6 +115,18 @@ describe('GET /trigger-events', () => {
     expect(eventIds(res)).toEqual([discarded.id]);
   });
 
+  test('filters and serializes the errored outcome', async () => {
+    const errored = await receivedEventFactory.create({workspaceId, outcome: 'errored'});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/trigger-events?workspace_id=${workspaceId}&outcome=errored`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(eventIds(res)).toEqual([errored.id]);
+  });
+
   test('treats a blank outcome as no filter', async () => {
     const {routed, discarded, failed} = await seedOutcomes(workspaceId);
 

--- a/libs/api/workflows/src/core/errors.test.ts
+++ b/libs/api/workflows/src/core/errors.test.ts
@@ -1,0 +1,31 @@
+import {
+  DefinitionNotFoundError,
+  isPermanentRunWorkflowError,
+  ProjectMismatchError,
+} from './errors.js';
+
+describe('isPermanentRunWorkflowError', () => {
+  test('is true for a deleted definition', () => {
+    const result = isPermanentRunWorkflowError(new DefinitionNotFoundError('def-1'));
+
+    expect(result).toBe(true);
+  });
+
+  test('is true for a project mismatch', () => {
+    const result = isPermanentRunWorkflowError(new ProjectMismatchError('proj-a', 'proj-b'));
+
+    expect(result).toBe(true);
+  });
+
+  test('is false for a plain error treated as transient', () => {
+    const result = isPermanentRunWorkflowError(new Error('database unavailable'));
+
+    expect(result).toBe(false);
+  });
+
+  test('is false for a non-error thrown value', () => {
+    const result = isPermanentRunWorkflowError('boom');
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -16,6 +16,16 @@ export class ProjectMismatchError extends Error {
   }
 }
 
+/**
+ * True when a `runWorkflow` failure can never succeed on retry: the definition is gone or
+ * the subscription points at the wrong project. Callers (e.g. the trigger dispatcher) use this
+ * to skip a permanently-broken target instead of retrying it forever. Every other failure is
+ * treated as transient so at-least-once delivery can converge.
+ */
+export function isPermanentRunWorkflowError(error: unknown): boolean {
+  return error instanceof DefinitionNotFoundError || error instanceof ProjectMismatchError;
+}
+
 export class JobNotFoundError extends Error {
   constructor(jobId: string) {
     super(`Job not found or has no steps: ${jobId}`);

--- a/libs/api/workflows/src/core/index.ts
+++ b/libs/api/workflows/src/core/index.ts
@@ -9,6 +9,7 @@ export type {Step, StepStatus} from './entities/step.js';
 export type {TriggerPayload, WorkflowRun, WorkflowRunStatus} from './entities/workflow-run.js';
 export {
   DefinitionNotFoundError,
+  isPermanentRunWorkflowError,
   JobNotFoundError,
   ProjectMismatchError,
   StepNotFoundError,

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -18,7 +18,12 @@ import {
 import {createOrchestrationActivities, WORKFLOWS_TASK_QUEUE} from '#temporal/index.js';
 
 export type {Job, RunWorkflowParams, Step, TriggerPayload, WorkflowRun} from '#core/index.js';
-export {DefinitionNotFoundError, ProjectMismatchError, runWorkflow} from '#core/index.js';
+export {
+  DefinitionNotFoundError,
+  isPermanentRunWorkflowError,
+  ProjectMismatchError,
+  runWorkflow,
+} from '#core/index.js';
 export {setSourceControl} from '#core/source-control.js';
 export {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 export {routes} from '#presentation/index.js';


### PR DESCRIPTION
Integration dispatch previously stopped fanning out at the first `runWorkflow` error and re-threw, so one permanently-broken subscription (deleted definition, project mismatch) starved every sibling registered for the same `(source, event)` and could wedge the outbox forever: each replay threw again before reaching the healthy siblings.

Dispatch now attempts every matched subscription and classifies each failure via the new `isPermanentRunWorkflowError` classifier:

- A **permanent** error (`DefinitionNotFoundError`, `ProjectMismatchError`) is recorded as an `errored` decision and skipped.
- A **transient** error is recorded and the first one is re-thrown after the loop, so the outbox replays the whole event and converges. Succeeded siblings dedup on the trigger idempotency key (`subscriptionId:eventRef`), so replay creates no duplicate runs.

The event reaches a terminal outcome only when no transient error remains: `routed` if any run was created this pass, otherwise the new `errored` outcome. `markReceivedEventErrored` uses a guarded `CASE` that promotes to `routed` when a `triggered` decision already exists (a cross-attempt run under at-least-once delivery), and the outcome guards never downgrade a terminal `routed`/`discarded`/`errored`. The manual-fire path records the same terminal `errored` for permanent errors.

## Worth a careful look

- **`event-history.ts` outcome guards** — the asymmetry is deliberate: `markReceivedEventErrored` allows `failed → errored` (its WHERE excludes only `routed`/`discarded`), while `markReceivedEventFailed` excludes `errored` so a late transient can't downgrade a terminal `errored`. There are now DB tests pinning both.
- **The cross-attempt `CASE`** in `markReceivedEventErrored` keys on the persisted `triggered` decision row; this is the safety net that avoids recording `errored` over an event that already produced a run.

No migration is required: `received_events.outcome` is a plain `text` column (no pg enum / CHECK), and the new value has no DTO or client consumer.

Closes ENG-557

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a permanently broken trigger subscription from blocking its siblings and wedging the outbox. Addresses ENG-557 by fanning out to all matches, classifying `runWorkflow` errors, replaying only on transients, and marking a terminal `errored` outcome when no run is created.

- **Bug Fixes**
  - Continue fan-out on errors; record a decision per subscription to avoid starvation.
  - Classify `runWorkflow` failures via `isPermanentRunWorkflowError`: permanent (deleted definition, project mismatch) are recorded as `errored` and skipped; transient are recorded and the first is re-thrown after the loop to trigger replay.
  - New terminal event outcome `errored`; guarded DB writes promote to `routed` if a `triggered` decision exists and never downgrade `routed`/`discarded`/`errored`. Manual-fire records `errored` for permanent failures.
  - Replays dedup by trigger idempotency key, so successful runs aren’t duplicated.

- **Dependencies**
  - `@shipfox/api-workflows` exports `isPermanentRunWorkflowError`.
  - `@shipfox/api-triggers-dto` accepts `errored` in `triggerEventOutcomeSchema` (list API filters/serializes). No migration needed; `received_events.outcome` is a text column.

<sup>Written for commit 1f55c13cd602b154e14664c9bfef1a4000bc6890. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

