### PR TITLE
[tools/vite] Use Vite's native tsconfig paths resolution

### DIFF
--- a/.changeset/swift-otters-resolve.md
+++ b/.changeset/swift-otters-resolve.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/vite": patch
+---
+
+Replaces the `vite-tsconfig-paths` plugin with Vite's native `resolve.tsconfigPaths` option, dropping the dependency.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3828,9 +3828,6 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
-      vite-tsconfig-paths:
-        specifier: ^6.0.0
-        version: 6.1.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))
     devDependencies:
       '@shipfox/swc':
         specifier: workspace:*
@@ -8946,9 +8943,6 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   google-auth-library@10.7.0:
     resolution: {integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==}
     engines: {node: '>=18'}
@@ -10566,17 +10560,6 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
@@ -10730,11 +10713,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -16312,8 +16290,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globrex@0.1.2: {}
-
   google-auth-library@10.7.0:
     dependencies:
       base64-js: 1.5.1
@@ -17900,8 +17876,6 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  tsconfck@3.1.6: {}
-
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -18058,16 +18032,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vite-tsconfig-paths@6.1.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:

--- a/tools/vite/README.md
+++ b/tools/vite/README.md
@@ -4,7 +4,7 @@ Vite defaults and CLI wrappers for Shipfox frontend packages. It adds TypeScript
 
 ## What it does
 
-- **`defineConfig(config?)`**: Wraps Vite `defineConfig` and adds `vite-tsconfig-paths`.
+- **`defineConfig(config?)`**: Wraps Vite `defineConfig` and enables Vite's native `resolve.tsconfigPaths`.
 - **`loadEnv`**: Re-export from Vite.
 - **`vite-dev`**: Runs the project-local Vite dev server.
 - **`vite-build`**: Runs `vite build --outDir dist`.

--- a/tools/vite/README.md
+++ b/tools/vite/README.md
@@ -4,7 +4,7 @@ Vite defaults and CLI wrappers for Shipfox frontend packages. It adds TypeScript
 
 ## What it does
 
-- **`defineConfig(config?)`**: Wraps Vite `defineConfig` and enables Vite's native `resolve.tsconfigPaths`.
+- **`defineConfig(config?)`**: Wraps Vite `defineConfig` with Shipfox defaults.
 - **`loadEnv`**: Re-export from Vite.
 - **`vite-dev`**: Runs the project-local Vite dev server.
 - **`vite-build`**: Runs `vite build --outDir dist`.

--- a/tools/vite/package.json
+++ b/tools/vite/package.json
@@ -29,8 +29,7 @@
   },
   "dependencies": {
     "@shipfox/tool-utils": "workspace:*",
-    "vite": "^8.0.3",
-    "vite-tsconfig-paths": "^6.0.0"
+    "vite": "^8.0.3"
   },
   "devDependencies": {
     "@shipfox/swc": "workspace:*",

--- a/tools/vite/src/index.ts
+++ b/tools/vite/src/index.ts
@@ -5,7 +5,6 @@ import {
   type UserConfigFnObject,
   defineConfig as viteDefinedConfig,
 } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export type {ConfigEnv, UserConfig, UserConfigExport, UserConfigFnObject} from 'vite';
 export {loadEnv} from 'vite';
@@ -13,7 +12,7 @@ export {loadEnv} from 'vite';
 export function defineConfig(configOrFn?: UserConfig | UserConfigFnObject): UserConfigExport {
   const mergeConfig = (config?: UserConfig) => ({
     ...config,
-    plugins: [tsconfigPaths(), ...(config?.plugins || [])],
+    resolve: {tsconfigPaths: true, ...config?.resolve},
   });
   const config =
     typeof configOrFn === 'function'


### PR DESCRIPTION
Swaps the `vite-tsconfig-paths` plugin for Vite 8's native `resolve.tsconfigPaths` option in `@shipfox/vite`'s `defineConfig`, and drops the dependency.

Vite 8 resolves tsconfig paths natively and prints a startup warning whenever the `vite-tsconfig-paths` plugin is detected, suggesting the native option instead. That warning shows up across every app build and Vitest run, since they all flow through `@shipfox/vite`'s `defineConfig`.

This repo defines no `compilerOptions.paths`/`baseUrl` in any tsconfig. The `#core/...`, `#test/*`, `#*` imports used throughout are Node.js subpath imports (package.json `imports` field), which Vite/Vitest resolve natively and independently of this plugin. So the plugin had nothing to resolve here, and the change is behavior-equivalent while silencing the warning.

The native `resolve.tsconfigPaths` is marked `@experimental` in Vite 8, but the practical risk is nil: with no tsconfig paths defined, the option is dormant and only activates if someone later adds `compilerOptions.paths`.

Verified: the client production build (real Vite 8 build through `@shipfox/vite`), Node-lib Vitest with heavy `#*` imports (`@shipfox/api-auth`), and jsdom/React Vitest (`@shipfox/client-auth`) all pass, and the warning no longer appears. Full build/test/check/type/type:emit pass on affected packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `@shipfox/vite` to Vite 8’s native tsconfig path resolution via `resolve.tsconfigPaths`, removing `vite-tsconfig-paths`. This silences Vite/Vitest startup warnings with no behavior changes (no tsconfig paths; `#` subpath imports are Node-resolved).

- **Refactors**
  - Enable `resolve.tsconfigPaths` in `defineConfig`, drop `vite-tsconfig-paths`, and clarify the README to reflect Shipfox defaults.

<sup>Written for commit 74f44d4cdccb79a8add7c2af22c2a99e4e31a2bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

