### PR TITLE
[react-ui] Silence Popper act warning in dropdown submenu story

### DIFF
--- a/libs/shared/react/ui/.storybook/preview.tsx
+++ b/libs/shared/react/ui/.storybook/preview.tsx
@@ -8,6 +8,7 @@ const ignoredRadixActWarningComponents = new Set([
   'FocusScope',
   'Menu',
   'MenuSub',
+  'Popper',
   'PopperContent',
   'Presence',
 ]);
@@ -29,7 +30,7 @@ function installRadixActWarningFilter() {
   }
 
   globalState.__shipfoxRadixActWarningFilterInstalled = true;
-  // biome-ignore lint/suspicious/noConsole: Storybook browser tests patch console.error to suppress known Radix internals only.
+  // biome-ignore lint/suspicious/noConsole: Storybook browser tests must keep actionable console errors while filtering known Radix act warnings.
   const originalError = console.error;
 
   console.error = (...args) => {


### PR DESCRIPTION
The `OrganizationSubmenuOpen` Storybook story force-opens a nested `DropdownMenuSub`, which mounts a second Radix Popper root (`@radix-ui/react-popper`). That Popper's anchor position updates asynchronously after mount (via floating-ui's `ResizeObserver`/rAF `autoUpdate`), so the update lands outside React's `act()` scope and CI logs:

> An update to Popper inside a test was not wrapped in act(...)

This is benign test noise, not a real bug. I confirmed the warning only comes from the nested-submenu story (the plain menu and other force-open stories emit zero), and that it fires at unpredictable times racing the `act` boundary.

`.storybook/preview.tsx` already filters exactly these unavoidable Radix-internal `act` warnings against an explicit component allowlist (`Menu`, `MenuSub`, `PopperContent`, `Presence`, ...). The popper *root* component name (`Popper`) was missing while its sibling (`PopperContent`) was already listed. This adds `Popper` to the allowlist.

I also tried wrapping the story helper's settle delay in `act()`, but the warning count was flaky (2 -> 4 -> 6) because the floating-ui updates race the `act` boundary, so that made it worse. The allowlist is the established, reliable mechanism here.

No changeset: the change is limited to `.storybook` dev/test tooling and is not part of the published package, so there is no npm-consumer impact.

Verification: `Organization Submenu Open` now emits 0 Popper warnings across repeated runs; the full `@shipfox/react-ui` suite passes (110 tests) with no `act` warnings; `turbo build/test/check --filter '...[origin/main]'` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences flaky `act()` warnings in the `Organization Submenu Open` Storybook story by adding Radix `Popper` to the `.storybook` warning allowlist. This removes CI noise from `@radix-ui/react-popper` auto-updates without changing runtime behavior or the published `@shipfox/react-ui` package.

<sup>Written for commit 9e7b562e36e5dc906e6f940351baaca824ff11f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

