### PR TITLE
Clean up low-value comments

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# Production image for @shipfox/api.
-#
 # "Build outside Docker, ingest dist": `shipfox-docker --setup-context` prunes
 # the workspace and overlays the turbo-cached dist/. The build stage installs
 # the pruned workspace and runs `pnpm deploy` to extract @shipfox/api's
@@ -9,10 +7,6 @@
 # ships only that, so the dev-only tools/* workspace packages (biome, vitest,
 # the swc/playwright toolchains) never reach the image. Docker never compiles
 # TypeScript.
-#
-# Build context is this package directory; the build tool writes the pruned
-# workspace under out/ (out/json = manifests + lockfile, out/full = full source
-# with each package's prebuilt dist/ overlaid).
 
 ARG NODE_VERSION=24.16.0
 ARG PNPM_VERSION=11.6.0
@@ -25,9 +19,6 @@ ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 WORKDIR /app
 
-# Build stage: install the pruned workspace, then deploy only @shipfox/api's
-# production closure into /prod. Workspace dependencies are copied in as real
-# directories (with their prebuilt dist/), and dev-only packages are dropped.
 FROM base AS build
 # Manifests + lockfile first (out/full carries the source but not the lockfile).
 COPY out/json/ ./
@@ -48,7 +39,7 @@ COPY --from=build /prod ./
 
 USER shipfox
 
-# OCI metadata. The build/promotion workflows pass revision/created as build args.
+# The build/promotion workflows pass revision/created as build args.
 ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
 ARG IMAGE_REVISION
 ARG IMAGE_CREATED

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -1,14 +1,10 @@
 # syntax=docker/dockerfile:1
 
-# Production image for @shipfox/client: nginx serving the prebuilt Vite SPA.
-#
 # Unlike the api/runner images there is no prune and no node_modules: the client
 # is a static artifact built outside Docker by `turbo build` (dist/). Docker only
 # assembles. The API endpoint is NOT baked at build time; an entrypoint script
 # rewrites /config.js from environment at container start, so one image serves
 # any self-hosted deployment without a rebuild.
-#
-# Build context is this package directory; the build serves dist/ over nginx.
 
 ARG NGINX_VERSION=1.29
 
@@ -27,7 +23,7 @@ RUN chmod +x /docker-entrypoint.d/*.sh
 # copy last.
 COPY dist/ /usr/share/nginx/html/
 
-# OCI metadata. The build/promotion workflows pass revision/created as build args.
+# The build/promotion workflows pass revision/created as build args.
 ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
 ARG IMAGE_REVISION
 ARG IMAGE_CREATED

--- a/apps/client/src/config.ts
+++ b/apps/client/src/config.ts
@@ -11,8 +11,7 @@ import {
 import {z} from 'zod';
 
 // Each feature module owns the config fragment it needs; the composition root
-// merges them into the one schema validated at boot. Add a key by editing its
-// module's fragment, not here.
+// merges them into the one schema validated at boot.
 const appConfigShape = {
   ...apiConfigShape,
   environment: z
@@ -30,8 +29,6 @@ export function loadAppConfig(): ConfigResult<AppConfig> {
   });
 }
 
-/** Reads the validated config outside React (boot wiring, monitoring init). */
 export const getAppConfig = (): AppConfig => getLoadedConfig<AppConfig>();
 
-/** Reads the validated config inside React components. */
 export const useAppConfig = (): AppConfig => useConfig<AppConfig>();

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -1,7 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# Production image for @shipfox/runner.
-#
 # "Build outside Docker, ingest dist": `shipfox-docker --setup-context` prunes
 # the workspace and overlays the turbo-cached dist/. The build stage installs
 # the pruned workspace and runs `pnpm deploy` to extract @shipfox/runner's
@@ -9,17 +7,10 @@
 # ships only that, so the dev-only tools/* workspace packages (biome, vitest,
 # the swc/playwright toolchains) never reach the image. Docker never compiles
 # TypeScript.
-#
-# Build context is this package directory; the build tool writes the pruned
-# workspace under out/ (out/json = manifests + lockfile, out/full = full source
-# with each package's prebuilt dist/ overlaid).
 
 ARG NODE_VERSION=24.16.0
 ARG PNPM_VERSION=11.6.0
 
-# Build stage: install the pruned workspace, then deploy only @shipfox/runner's
-# production closure into /prod. Workspace dependencies are copied in as real
-# directories (with their prebuilt dist/), and dev-only packages are dropped.
 # The official node image (Debian/glibc) carries corepack and a clean pnpm store.
 # The runner's prod closure is JS + wasm plus pi's lazily-loaded optional clipboard
 # native addon (glibc prebuilds, never loaded on the headless runner path), so /prod
@@ -123,7 +114,7 @@ COPY --from=build /prod ./
 
 USER shipfox
 
-# OCI metadata. The build/promotion workflows pass revision/created as build args.
+# The build/promotion workflows pass revision/created as build args.
 ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
 ARG IMAGE_REVISION
 ARG IMAGE_CREATED

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -4,8 +4,7 @@ import {expect, test} from './test.js';
 
 const ADDED_DATE_RE = /^Added /u;
 
-// The settings catalogue's Available grid is the surface PR #179 shipped, but
-// the e2e API may only enable Debug. Stub the providers list so the multi-tile
+// The e2e API may only enable Debug. Stub the providers list so the multi-tile
 // grid renders deterministically and the screenshot guards the GitHub/Sentry
 // tiles regardless of provider config. Typed against the real response DTO so a
 // contract change fails `turbo type` — e2e packages depend on *-dto packages
@@ -81,8 +80,7 @@ test('settings catalogue shows a connected provider after Debug connect', async 
   await expect(installed.getByText('Connected')).toBeVisible();
 
   // `Added <date>` is server-generated, so it would drift the Argos baseline
-  // every day. Pin it to a fixed string before the snapshot (repo convention:
-  // see e2e/client/runners/tests/runner-token-flows.e2e.ts), keeping the row
+  // every day. Pin it to a fixed string before the snapshot, keeping the row
   // anchored to the real Debug connection otherwise.
   await installed.getByText(ADDED_DATE_RE).evaluate((element) => {
     element.textContent = 'Added Jan 15, 2026';

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -98,7 +98,6 @@ test('persists the active workspace across reload and via /', async ({page, auth
 
   await page.goto('/');
   await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
-  // Sanity: never landed on wsA.
   expect(page.url()).not.toMatch(workspaceUrlRe(wsA.id));
 });
 
@@ -153,7 +152,6 @@ test('creates a second workspace from the switcher mid-session', async ({
   expect(newWid).toBeTruthy();
   expect(newWid).not.toBe(wsA.id);
 
-  // Switcher now lists both workspaces.
   await page.getByLabel('Switch workspace').click();
   await expect(page.getByRole('option', {name: workspaceAName})).toBeVisible();
   await expect(page.getByRole('option', {name: workspaceBName})).toBeVisible();
@@ -235,10 +233,8 @@ test('routes a returning user with workspaces straight to /workspaces/$wid', asy
   const wsA = await workspaces.create({userId: user.user.id, name: 'Alpha Workspace'});
   await auth.loginAs(page, user);
 
-  // Record every URL the page transits through. The PR #23 regression was a
-  // brief flash of /setup/workspaces/new while auth-refresh resolved
-  // memberships; asserting only the final URL would let that flash slip
-  // past Playwright auto-wait.
+  // Record every URL the page transits through. Asserting only the final URL
+  // would let a brief flash through onboarding slip past Playwright auto-wait.
   const urlsSeen: string[] = [];
   page.on('framenavigated', (frame) => {
     if (frame === page.mainFrame()) {

--- a/libs/api/auth/src/db/users.test.ts
+++ b/libs/api/auth/src/db/users.test.ts
@@ -69,7 +69,6 @@ describe('users db', () => {
     expect(verified?.emailVerifiedAt).toBeInstanceOf(Date);
   });
 
-  // Ensure the imported hashOpaqueToken is recognized by the linter as used.
   test('opaque token helpers remain available', () => {
     expect(typeof hashOpaqueToken).toBe('function');
   });

--- a/libs/api/auth/src/presentation/auth/jwt-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/jwt-auth.test.ts
@@ -130,7 +130,6 @@ describe('jwt-auth', () => {
     expect(res.json().client.email).toBe(email);
   });
 
-  // Keep helper imports referenced
   test('helpers remain available', () => {
     expect(typeof findUserById).toBe('function');
   });

--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -67,8 +67,8 @@ console.log(model.jobs[0]?.steps[0]?.command.value);
 The model does not own project ids, commit shas, refs, dates, database rows, or
 file paths. Those fields belong to `WorkflowDefinition`.
 
-Trigger filters stay as source strings in this module for now. A later change
-will type-check them when event schemas define the expression context.
+Trigger filters stay as source strings in this module until event schemas define
+the expression context needed to type-check them.
 
 Run-step gate expressions are different. They have a small local result context,
 so this module can parse and type-check `success_if` now. The accepted model

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -547,17 +547,15 @@ describe('definition queries', () => {
     });
 
     test('rolls back the outbox event when the transaction fails', async () => {
-      try {
-        await db().transaction(async (tx) => {
-          await tx.insert(definitionsOutbox).values({
-            eventType: DEFINITION_RESOLVED,
-            payload: {definitionId: 'test', projectId, configPath: 'test'},
-          });
-          throw new Error('Simulated failure');
+      const transaction = db().transaction(async (tx) => {
+        await tx.insert(definitionsOutbox).values({
+          eventType: DEFINITION_RESOLVED,
+          payload: {definitionId: 'test', projectId, configPath: 'test'},
         });
-      } catch {
-        // expected
-      }
+        throw new Error('Simulated failure');
+      });
+
+      await expect(transaction).rejects.toThrow('Simulated failure');
 
       const outboxRows = await listOutboxRowsForProject(projectId);
 

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -4,12 +4,8 @@ import {githubProviderModule} from '#providers/github.js';
 import {sentryProviderModule} from '#providers/sentry.js';
 import type {IntegrationModuleParts} from '#providers/types.js';
 
-/**
- * Every integration the core module can compose. To add a provider, add its
- * file under `#providers/` and append it here — nothing else in this package
- * needs to change. Order is significant: databases are migrated in this order,
- * so list a provider before any that depend on its tables.
- */
+// Order is significant: databases are migrated in this order, so list a provider
+// before any that depend on its tables.
 const providerModules = [
   debugProviderModule,
   githubProviderModule,

--- a/libs/api/integration/core/src/providers/sentry.ts
+++ b/libs/api/integration/core/src/providers/sentry.ts
@@ -50,7 +50,6 @@ async function loadSentryModuleParts(): Promise<IntegrationModuleParts> {
         {tx},
       );
 
-      // Promotes the verified-unclaimed row to claimed by setting connection_id.
       await upsertSentryInstallation(
         {
           connectionId: connection.id,

--- a/libs/api/integration/sentry/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/webhooks.test.ts
@@ -689,7 +689,6 @@ describe('Sentry webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    // No re-exchange and the stored hash is untouched (no clobber).
     expect(sentry.exchangeAuthorizationCode).not.toHaveBeenCalled();
     expect((await readInstallation(installationUuid))?.codeHash).toBe('pre-existing');
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);

--- a/libs/api/logs/src/db/schema/attempt-streams.ts
+++ b/libs/api/logs/src/db/schema/attempt-streams.ts
@@ -84,7 +84,6 @@ export const attemptStreams = pgTable(
 export type AttemptStreamDb = typeof attemptStreams.$inferSelect;
 export type AttemptStreamInsertDb = typeof attemptStreams.$inferInsert;
 
-/** Maps a persisted row to the `AttemptStream` domain entity. */
 export function toAttemptStream(row: AttemptStreamDb): AttemptStream {
   return {
     id: row.id,

--- a/libs/api/logs/src/db/schema/job-accounting.ts
+++ b/libs/api/logs/src/db/schema/job-accounting.ts
@@ -27,7 +27,6 @@ export const jobAccounting = pgTable('job_accounting', {
 export type JobAccountingDb = typeof jobAccounting.$inferSelect;
 export type JobAccountingInsertDb = typeof jobAccounting.$inferInsert;
 
-/** Maps a persisted row to the `JobAccounting` domain entity. */
 export function toJobAccounting(row: JobAccountingDb): JobAccounting {
   return {
     jobId: row.jobId,

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
@@ -137,8 +137,6 @@ describe('onSourceCommitPushed', () => {
     expect(rows).toHaveLength(1);
   });
 
-  // The source/event filter is now the subscription itself (projects only receives the
-  // typed source event), so this registration replaces the old non-github/non-push tests.
   it('registers the projects module on INTEGRATION_SOURCE_COMMIT_PUSHED', () => {
     const module = createProjectsModule({sourceControl: {} as never});
 

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -12,10 +12,10 @@ export const WORKFLOWS_JOB_TERMINATED = 'workflows.job.terminated' as const;
 // before the job row is terminal; observe WORKFLOWS_JOB_TERMINATED for the outcome.
 export const WORKFLOWS_JOB_STEPS_SETTLED = 'workflows.job.steps_settled' as const;
 // Written in the same transaction as a durable gate restart (the failed attempt
-// + the rewind of the projection from `restart_from`), as a durable audit record
-// of the restart. The pull-based runner re-dispatches the rewound step on its
-// next pull, so this event is not required to advance execution. Audit-only for
-// now; any future consumer must be idempotent (the outbox is at-least-once).
+// + the rewind of the projection from `restart_from`). The pull-based runner
+// re-dispatches the rewound step on its next pull, so this audit event is not
+// required to advance execution. Consumers must be idempotent: the outbox is
+// at-least-once.
 export const WORKFLOWS_STEP_RESTART_ENQUEUED = 'workflows.step.restart_enqueued' as const;
 
 export interface WorkflowsWorkflowRunCreatedEvent {

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -17,8 +17,7 @@ export interface Step {
   version: number;
   // Execution-attempt identity for the current projection: which attempt the
   // status/output/error above reflect. Distinct from `version` (the optimistic
-  // row counter). Starts at 1; bumped only when a step is rewound by a durable
-  // restart (PR E).
+  // row counter). Starts at 1; bumped only when a step is rewound by a durable restart.
   currentAttempt: number;
   createdAt: Date;
   updatedAt: Date;

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -387,8 +387,8 @@ describe('step attempts', () => {
   test('reporting creates a missing running attempt before finalization', async () => {
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const stepId = steps[0]?.id as string;
-    // Migration boundary: a step may already be running before PR B's attempt
-    // rows exist. Reporting should backfill the attempt row and finalize it.
+    // A step may already be running before its attempt row exists. Reporting
+    // should backfill the attempt row and finalize it.
     await db().update(stepsTable).set({status: 'running'}).where(eq(stepsTable.id, stepId));
 
     const outcome = await recordStepResult({
@@ -510,7 +510,7 @@ describe('step attempts', () => {
     const stepId = steps[0]?.id as string;
     await nextStepForJob(jobId);
     await recordStepResult({jobId, stepId, status: 'succeeded', exitCode: 0});
-    // Simulate a later rewind bump on the now-terminal step.
+    // Simulate a rewind bump on the terminal step.
     await db().update(stepsTable).set({currentAttempt: 2}).where(eq(stepsTable.id, stepId));
 
     const outcome = await recordStepResult({
@@ -813,7 +813,7 @@ describe('durable gate restart', () => {
     await runStep(jobId, producer, 0);
     await runStep(jobId, build, 0); // build passes (its attempt 3)
 
-    // deploy now runs for the FIRST time with an inflated current_attempt of 3.
+    // deploy runs for the first time with an inflated current_attempt of 3.
     expect((await getStepsByJobId(jobId)).find((s) => s.id === deploy)?.currentAttempt).toBe(3);
     const deployFail = await runStep(jobId, deploy, 1);
 

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -58,10 +58,9 @@ export interface RecordStepResultParams {
   status: 'succeeded' | 'failed';
   error?: Record<string, unknown> | null;
   // Structured runner output for audit/history on the attempt row. The current
-  // step projection keeps status/error only until logs/output have a stable
-  // product contract.
+  // step projection keeps status/error only.
   output?: Record<string, unknown> | null;
-  // Process exit code reported by the runner (PR B persists it on the attempt).
+  // Process exit code reported by the runner.
   exitCode?: number | null;
   // The attempt the runner was dispatched. Omitted = "the step's current
   // attempt" (back-compat for callers that don't track attempts yet).

--- a/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/decide-step-transition.ts
@@ -56,8 +56,7 @@ export interface DecideStepTransitionInput {
 // a further restart is refused. Bounds runaway restart loops.
 export const DEFAULT_RESTART_ATTEMPT_CAP = 3;
 
-// The semantic outcome of a step report, independent of persistence. The restart
-// variants are typed now but only produced once durable restart lands (PR E).
+// The semantic outcome of a step report, independent of persistence.
 export type StepTransitionDecision =
   | {kind: 'complete-step'; stepId: string; attempt: number}
   // The step succeeds and is the last to finish; apply re-derives the job's

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -48,9 +48,9 @@ export function readStepGate(config: Record<string, unknown>): StepGate | undefi
 // could trigger a restart.
 //
 // NOTE: callers run this inside the FOR UPDATE transaction, so the eval holds the
-// job's step-row locks. The context is a single scalar (`exit_code`) today, so
-// this is cheap — but do not widen the context (or add CEL call sites) inside the
-// lock without an eval budget. `language` is assumed CEL (the only language the
+// job's step-row locks. The context is a single scalar (`exit_code`), so this is
+// cheap — but do not widen the context (or add CEL call sites) inside the lock
+// without an eval budget. `language` is assumed CEL (the only language the
 // materializer writes); the evaluator reads only `.source`.
 export function evaluateGate(gate: StepGate | undefined, result: StepResult): GateOutcome {
   if (!gate?.successIf) return {kind: 'no-gate'};
@@ -73,7 +73,7 @@ export function evaluateGate(gate: StepGate | undefined, result: StepResult): Ga
 
 // Build the audit payload recorded on the step attempt for a gate evaluation.
 // Includes the evaluated `exit_code` so the gate decision is reconstructable from
-// the attempt row alone (PR E / audit), independent of the column shape.
+// the attempt row alone, independent of the column shape.
 export function gateResultPayload(
   outcome: GateOutcome,
   exitCode: number | null | undefined,

--- a/libs/api/workflows/src/db/schema/step-attempts.ts
+++ b/libs/api/workflows/src/db/schema/step-attempts.ts
@@ -28,9 +28,9 @@ export const stepAttempts = pgTable(
     output: jsonb('output').$type<Record<string, unknown>>(),
     error: jsonb('error').$type<Record<string, unknown>>(),
     exitCode: integer('exit_code'),
-    // Gate evaluation payload for this attempt (populated in PR D).
+    // Gate evaluation payload for this attempt.
     gateResult: jsonb('gate_result').$type<Record<string, unknown>>(),
-    // Why this attempt triggered a restart (populated in PR E).
+    // Why this attempt triggered a restart.
     restartReason: text('restart_reason'),
     startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
     finishedAt: timestamp('finished_at', {withTimezone: true}),

--- a/libs/api/workflows/src/db/schema/steps.ts
+++ b/libs/api/workflows/src/db/schema/steps.ts
@@ -28,7 +28,7 @@ export const steps = pgTable(
     position: integer('position').notNull(),
     version: integer('version').notNull().default(1),
     // Execution-attempt identity (which attempt the projection reflects), NOT the
-    // optimistic `version` counter. Starts at 1; bumped only on rewind (PR E).
+    // optimistic `version` counter. Starts at 1; bumped only on rewind.
     currentAttempt: integer('current_attempt').notNull().default(1),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -161,17 +161,15 @@ describe('workflow run queries', () => {
     test('rolls back outbox event when transaction fails', async () => {
       const marker = crypto.randomUUID();
 
-      try {
-        await db().transaction(async (tx) => {
-          await tx.insert(workflowsOutbox).values({
-            eventType: WORKFLOWS_WORKFLOW_RUN_CREATED,
-            payload: {runId: marker, projectId, definitionId},
-          });
-          throw new Error('Simulated failure');
+      const transaction = db().transaction(async (tx) => {
+        await tx.insert(workflowsOutbox).values({
+          eventType: WORKFLOWS_WORKFLOW_RUN_CREATED,
+          payload: {runId: marker, projectId, definitionId},
         });
-      } catch {
-        // expected
-      }
+        throw new Error('Simulated failure');
+      });
+
+      await expect(transaction).rejects.toThrow('Simulated failure');
 
       const leaked = await db()
         .select()
@@ -923,8 +921,8 @@ describe('workflow run queries', () => {
       const runJobs = await getJobsByRunId(run.id);
       const job = runJobs[0];
 
-      // Defensive: simulate a hypothetical separate writer (no realistic path
-      // today) that bumped version + status without setting timed_out_at.
+      // Defensive: simulate a separate writer that bumped version + status
+      // without setting timed_out_at.
       await db()
         .update(jobs)
         .set({status: 'failed', version: 5})

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -28,8 +28,7 @@ export const nextStepRoute = defineRoute({
 
     if (next.kind === 'step') {
       // The runner echoes this back on report so a stale report from a superseded
-      // attempt is ignored. It is 1 until a durable restart (PR E) bumps the
-      // step's current attempt.
+      // attempt is ignored.
       return {kind: 'step' as const, step: toStepDto(next.step), attempt: next.step.currentAttempt};
     }
     return {kind: 'done' as const, status: next.status};

--- a/libs/client/app-shell/src/components/footer.test.tsx
+++ b/libs/client/app-shell/src/components/footer.test.tsx
@@ -4,7 +4,7 @@ import {Footer} from './footer.js';
 const OPERATIONAL_REGEX = /operational/i;
 
 describe('Footer', () => {
-  test('renders Docs and Support links; right side empty in v1', () => {
+  test('renders Docs and Support links without a status badge', () => {
     render(<Footer />);
 
     expect(screen.getByRole('link', {name: 'Docs'})).toHaveAttribute(
@@ -15,7 +15,6 @@ describe('Footer', () => {
       'href',
       'mailto:support@shipfox.io',
     );
-    // Status badge intentionally omitted in v1 (would lie about state).
     expect(screen.queryByText(OPERATIONAL_REGEX)).not.toBeInTheDocument();
   });
 });

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -79,9 +79,9 @@ export function IntegrationGallery({
   );
 
   const allConnections = connectionsQuery.data?.connections ?? [];
-  // Filter in memory (Eng review P1): the all-status `connections(wid,'all')`
-  // cache key must stay shared; passing capability into the hook would collide
-  // with the active-only `source_control` key used elsewhere.
+  // The all-status `connections(wid,'all')` cache key must stay shared; passing
+  // capability into the hook would collide with the active-only `source_control`
+  // key used elsewhere.
   const connections = capability
     ? allConnections.filter((connection) => connection.capabilities.includes(capability))
     : allConnections;

--- a/libs/client/invitations/src/complete-acceptance.ts
+++ b/libs/client/invitations/src/complete-acceptance.ts
@@ -16,8 +16,8 @@ export async function completeInvitationAcceptance(params: {
   refreshAuth: () => Promise<unknown>;
   navigate: (opts: NavigateOptions) => Promise<void> | void;
 }): Promise<void> {
-  // Codex F2: signAccessToken embeds memberships at issue time. Refresh first
-  // so the next render's AuthGuard sees the new workspace.
+  // Access tokens embed memberships at issue time. Refresh first so the next
+  // render's AuthGuard sees the new workspace.
   try {
     await params.refreshAuth();
   } catch {

--- a/libs/client/invitations/src/pages/invitation-accept-page.tsx
+++ b/libs/client/invitations/src/pages/invitation-accept-page.tsx
@@ -23,7 +23,6 @@ export function InvitationAcceptPage() {
   const accept = useAcceptInvitation();
   const hasKickedAccept = useRef(false);
 
-  // Missing token → toast + bounce home.
   useEffect(() => {
     if (!token) {
       toast.error('This invitation link is missing a token.');
@@ -169,7 +168,6 @@ export function InvitationAcceptPage() {
     );
   }
 
-  // data.status === 'pending'
   const inviterLine =
     data.invited_by_display != null
       ? `Invited by ${data.invited_by_display} to join as ${data.email}.`
@@ -196,7 +194,6 @@ export function InvitationAcceptPage() {
     );
   }
 
-  // Authenticated branch — check email match.
   const viewerEmail = auth.user?.email?.toLowerCase();
   const inviteeEmail = data.email.toLowerCase();
   if (viewerEmail !== inviteeEmail) {

--- a/libs/client/projects/src/components/project-switcher.tsx
+++ b/libs/client/projects/src/components/project-switcher.tsx
@@ -25,8 +25,7 @@ export function ProjectSwitcher({workspaceId, activeProjectId, onSelect}: Projec
   const projects = query.data?.pages.flatMap((page) => page.projects) ?? [];
 
   // Eagerly fetch additional pages once the popover opens; the switcher should
-  // show the full list, not just the first page. (Lazy-fetch + cursor pagination
-  // are deferred — see TODOS.md "Project switcher lazy-fetch + pagination".)
+  // show the full list, not just the first page.
   useEffect(() => {
     if (query.hasNextPage && !query.isFetchingNextPage) {
       query.fetchNextPage();

--- a/libs/client/projects/src/components/source-strip.tsx
+++ b/libs/client/projects/src/components/source-strip.tsx
@@ -16,15 +16,13 @@ import {
 /**
  * Slim provenance strip at the top of the Workflows page.
  *
- * Replaces the old "Source identity" sidebar Card. Shows enough for
- * an operator to recognize the GitOps loop at a glance: provider icon,
+ * Shows enough for an operator to recognize the GitOps loop at a glance: provider icon,
  * connection display name, repo id chip, sync status pill.
  *
  * We cannot cheaply resolve `external_repository_id` → `owner/repo`
  * (no by-id endpoint; `listRepositories` is paginated by connection).
- * Until the backend exposes `repository_full_name` on `ProjectDto.source`
- * (filed in TODOS as a follow-up), the strip surfaces the raw id as a
- * `<Code>` chip with a tooltip carrying the full string.
+ * The strip surfaces the raw id as a `<Code>` chip with a tooltip carrying the
+ * full string.
  */
 
 export function SourceStrip({
@@ -76,7 +74,6 @@ export function SourceStrip({
 
 function providerIconName(provider: string | undefined): IconName {
   if (provider === 'github') return 'github' as IconName;
-  // Future: gitlab, bitbucket. Until then, neutral fallback.
   return 'componentLine' as IconName;
 }
 

--- a/libs/client/projects/src/hooks/api/workflow-runs.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.ts
@@ -32,9 +32,7 @@ function normalizeFilters(filters: WorkflowRunFilters) {
  * Fire the manual trigger of a workflow definition.
  *
  * The server resolves the manual subscription by definition id (workflows
- * may declare at most one manual trigger). `inputs` are forwarded to the
- * run; the Run button passes none today, but the same call shape will
- * carry a user-supplied payload when the input dialog ships.
+ * may declare at most one manual trigger). `inputs` are forwarded to the run.
  */
 export async function fireManualWorkflow({
   definitionId,

--- a/libs/client/projects/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.test.tsx
@@ -24,7 +24,6 @@ describe('ProjectWorkflowsPage', () => {
     expect(await screen.findByText('Acme GitHub')).toBeInTheDocument();
     expect(screen.getAllByText('platform')[0]).toBeInTheDocument();
     expect(screen.getAllByText('succeeded')[0]).toBeInTheDocument();
-    // Legacy "Source identity" sidebar is gone.
     expect(screen.queryByRole('heading', {name: 'Source identity'})).not.toBeInTheDocument();
   });
 
@@ -86,8 +85,6 @@ describe('ProjectWorkflowsPage', () => {
       <ProjectWorkflowsPage projectId={PROJECT_ID} />,
     );
 
-    // The row carries the click handler now (no separate Details button).
-    // Find the row containing the workflow name and click it.
     const workflowName = (await screen.findAllByText('Deploy production'))[0];
     if (!workflowName) throw new Error('Workflow row was not rendered');
     fireEvent.click(workflowName);

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -37,8 +37,7 @@ describe('ProjectsHubPage', () => {
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
 
-    // Regression: the page-level "Projects" title is now an in-content H2 (the
-    // top nav owns identity); the old workspace-name/email subtitle is gone.
+    // The top nav owns workspace identity; the page title stays in-content.
     expect(await screen.findByRole('heading', {name: 'Projects'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: NEW_PROJECT_REGEX})).toHaveAttribute(
       'href',

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -94,10 +94,9 @@ function createTestRouter(path: string, element: ReactElement) {
         return element;
       }
 
-      // Production redirects the project-detail URL to the Runs tab, which now lives in
-      // @shipfox/client-workflows. The harness only needs to prove navigation landed there
-      // (e.g. create-project duplicate recovery), so it renders a minimal stand-in rather
-      // than depending on that package.
+      // Production redirects the project-detail URL to the Runs tab. The harness
+      // only needs to prove navigation landed there (e.g. create-project duplicate
+      // recovery), so it renders a minimal stand-in rather than depending on that package.
       return <h1>Runs</h1>;
     },
   });

--- a/libs/client/router/src/routes/setup/_layout.tsx
+++ b/libs/client/router/src/routes/setup/_layout.tsx
@@ -8,8 +8,6 @@ export const Route = createFileRoute('/setup/_layout')({
     if (!auth.isAuthenticated) {
       throw redirect({to: '/auth/login', search: {redirect: location.href}});
     }
-    // If the user has no workspaces and they're not already on the workspace
-    // creation page, send them there.
     if (auth.workspaces.length === 0 && !location.pathname.startsWith('/setup/workspaces/new')) {
       throw redirect({to: '/setup/workspaces/new'});
     }

--- a/libs/client/workspace-settings/src/pages/integrations-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/integrations-settings-page.test.tsx
@@ -48,8 +48,8 @@ function renderPage() {
 }
 
 const INTEGRATIONS_LINK_RE = /Integrations/;
-// The provider is named once (icon + account name); the meta line carries the
-// date only, so it no longer repeats "GitHub".
+// The provider is named once (icon + account name); the meta line carries only
+// the date.
 const ADDED_META_RE = /^Added /;
 
 describe('IntegrationsSettingsPage', () => {

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -7,8 +7,7 @@ import {executeRunStep, type OutputSink} from '#core/run-step.js';
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const ESRCH_REGEX = /ESRCH/;
 
-// Collects what the durable pipeline would receive, the way the runner now
-// captures step output (StepResult no longer carries it).
+// Collects what the durable pipeline receives from captured step output.
 function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
   const chunks: Buffer[] = [];
   const sources: string[] = [];

--- a/libs/runner/logs/src/core/transform.test.ts
+++ b/libs/runner/logs/src/core/transform.test.ts
@@ -13,7 +13,7 @@ function outputText(events: TransformEvent[]): string {
     .join('');
 }
 
-describe('LogTransformer decoding (relocated from StreamFramer)', () => {
+describe('LogTransformer decoding', () => {
   it('reassembles a multi-byte char split across two pushes on the same pipe', () => {
     const transformer = new LogTransformer([]);
     const euro = Buffer.from('€', 'utf8'); // 0xE2 0x82 0xAC

--- a/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
@@ -49,15 +49,12 @@ describe('startHeartbeatLoop', () => {
 
     const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 10_000});
 
-    // First tick fires
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
 
-    // Advancing time further does NOT start a second call while the first is in flight
     await vi.advanceTimersByTimeAsync(500);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
 
-    // Resolve the first call → next tick scheduled
     resolve?.({cancel: false});
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(2);
@@ -82,16 +79,13 @@ describe('startHeartbeatLoop', () => {
 
     const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 200});
 
-    // First tick fires; heartbeat hangs.
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
     expect(receivedSignal?.aborted).toBe(false);
 
-    // maxStaleMs elapses → in-flight call aborted, next tick scheduled.
     await vi.advanceTimersByTimeAsync(200);
     expect(receivedSignal?.aborted).toBe(true);
 
-    // Next tick fires after another intervalMs.
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(2);
 
@@ -111,7 +105,6 @@ describe('startHeartbeatLoop', () => {
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
     expect(ac.signal.aborted).toBe(true);
 
-    // No further ticks even after additional time.
     await vi.advanceTimersByTimeAsync(500);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
 

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -83,9 +83,9 @@ export async function runJob(
 
   try {
     const leaseClient = createLeaseClient(job.lease_token);
-    // The v1 log mask set is the runner's own credentials: the long-lived runner token and
+    // The log mask set is the runner's own credentials: the long-lived runner token and
     // this job's lease token. Both can reach a step's environment, so they are scrubbed from
-    // captured output before it touches the spool. The set grows as step-level secrets land.
+    // captured output before it touches the spool.
     const secrets = [runnerToken(), job.lease_token];
     await runJobSteps({jobId: job.job_id, leaseClient, secrets, signal: ac.signal, cwd});
     logger().info({jobId: job.job_id}, 'Job step loop finished');
@@ -98,7 +98,6 @@ export async function runJob(
   } finally {
     heartbeatLoop.stop();
     if (currentJobAbortController === ac) currentJobAbortController = undefined;
-    // Clean up the per-job workspace on every exit path.
     await cleanupWorkspace(cwd);
   }
 }

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -38,7 +38,7 @@ export async function runJobSteps(params: {
 
   // The setup step (position 0) prepares the workspace; every run step assumes it ran.
   // A run step pulled before a successful setup is failed cleanly rather than spawned
-  // against an unprepared cwd. The guard and its rollout rationale live in `executeStep`.
+  // against an unprepared cwd.
   let workspacePrepared = false;
 
   // The most recent step's stream (run output or agent session), kept until the next
@@ -175,8 +175,7 @@ export async function executeStep(params: {
     if (!workspacePrepared) {
       // Invariant violation (a run or agent step before setup prepared the cwd), not a
       // setup-phase failure, so no `reason`. step.type is not 'setup' so the server
-      // derives category 'user'. Only reachable for a setup-less in-flight job hitting a
-      // new runner during the rollout window.
+      // derives category 'user'.
       return {
         result: {
           success: false,

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -33,7 +33,6 @@ beforeEach(async () => {
   await git(['add', '.'], sourceRepo);
   await git(['commit', '-m', 'initial'], sourceRepo);
 
-  // The per-job directory the workspace manager prepares: present and empty.
   cwd = join(workdir, 'job-1');
   await mkdir(cwd, {recursive: true});
 });

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -54,7 +54,6 @@ export function resolveWorkspaceRoot(root: string | undefined): string {
   return resolved;
 }
 
-/** Resolves the workspace root from this package's own configuration. */
 export function resolveWorkspaceRootFromEnv(): string {
   return resolveWorkspaceRoot(config.SHIPFOX_RUNNER_WORKSPACE_ROOT);
 }

--- a/libs/shared/common/config/src/index.test.ts
+++ b/libs/shared/common/config/src/index.test.ts
@@ -13,7 +13,6 @@ describe('config', () => {
       TEST_STRING: str(),
     };
 
-    // Set test environment variable
     process.env.TEST_STRING = 'test-value';
 
     const config = createConfig(schema);
@@ -26,7 +25,6 @@ describe('config', () => {
       TEST_NUMBER: num(),
     };
 
-    // Set test environment variable
     process.env.TEST_NUMBER = '42';
 
     const config = createConfig(schema);
@@ -39,7 +37,6 @@ describe('config', () => {
       TEST_BOOL: bool(),
     };
 
-    // Set test environment variable
     process.env.TEST_BOOL = 'true';
 
     const config = createConfig(schema);

--- a/libs/shared/common/config/src/index.ts
+++ b/libs/shared/common/config/src/index.ts
@@ -12,7 +12,6 @@ export type {
 } from 'envalid';
 export {bool, cleanEnv, email, host, num, port, str, url} from 'envalid';
 
-// Helper function to create properly typed configs
 export function createConfig<T extends Record<string, unknown>>(
   schema: T,
   update?: Partial<NodeJS.ProcessEnv>,

--- a/libs/shared/node/opentelemetry/src/diag.ts
+++ b/libs/shared/node/opentelemetry/src/diag.ts
@@ -3,20 +3,11 @@ import {config} from '#config.js';
 
 const logLevels: Record<string, number> = {
   none: 0,
-  /** Identifies an error scenario */
   error: 30,
-  /** Identifies a warning scenario */
   warn: 50,
-  /** General informational log message */
   info: 60,
-  /** General debug log message */
   debug: 70,
-  /**
-   * Detailed trace level logging should only be used for development, should only be set
-   * in a development environment.
-   */
   verbose: 80,
-  /** Used to set the logging level to include all logging */
   all: 9999,
 };
 

--- a/libs/shared/node/opentelemetry/src/utils.ts
+++ b/libs/shared/node/opentelemetry/src/utils.ts
@@ -1,7 +1,6 @@
 import type {FastifyOtelInstrumentationOpts} from '@fastify/otel';
 import {isUuid} from '@shipfox/regex';
 
-// Pure integers (numeric IDs)
 const NUMERIC_SEGMENT = /^\d+$/;
 
 export const normalizeRoutePath = (path: string): string =>

--- a/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
@@ -76,7 +76,6 @@ export const Default: Story = {
   ),
 };
 
-// AvatarGroup Stories
 const avatarGroupMeta = {
   title: 'Components/AvatarGroup',
   component: AvatarGroup,

--- a/libs/shared/react/ui/src/hooks/useMediaQuery.ts
+++ b/libs/shared/react/ui/src/hooks/useMediaQuery.ts
@@ -2,6 +2,8 @@
 
 import {useEffect, useState} from 'react';
 
+const noop = () => undefined;
+
 class MediaQueryManager {
   private queries = new Map<string, MediaQueryList>();
   private listeners = new Map<string, Set<() => void>>();
@@ -21,9 +23,7 @@ class MediaQueryManager {
 
   subscribe(query: string, callback: () => void): () => void {
     if (typeof window === 'undefined') {
-      return () => {
-        // Cleanup function for SSR - no-op
-      };
+      return noop;
     }
 
     if (!this.queries.has(query)) {
@@ -35,9 +35,7 @@ class MediaQueryManager {
     const listeners = this.listeners.get(query);
 
     if (!mediaQuery || !listeners) {
-      return () => {
-        // Cleanup function - no-op if query wasn't found
-      };
+      return noop;
     }
 
     listeners.add(callback);

--- a/libs/shared/react/ui/src/hooks/useResolvedTheme.ts
+++ b/libs/shared/react/ui/src/hooks/useResolvedTheme.ts
@@ -3,15 +3,15 @@
 import {useSyncExternalStore} from 'react';
 import {useTheme} from './useTheme.js';
 
+const noop = () => undefined;
+
 export function useResolvedTheme(): 'light' | 'dark' {
   const {theme} = useTheme();
 
   const systemTheme = useSyncExternalStore<'light' | 'dark'>(
     (callback) => {
       if (typeof window === 'undefined' || theme !== 'system') {
-        return () => {
-          // No-op unsubscribe
-        };
+        return noop;
       }
       const mql = window.matchMedia('(prefers-color-scheme: dark)');
       mql.addEventListener('change', callback);
@@ -25,12 +25,11 @@ export function useResolvedTheme(): 'light' | 'dark' {
           ? 'dark'
           : 'light'
         : 'light',
-    (): 'light' | 'dark' => 'light', // Server snapshot
+    (): 'light' | 'dark' => 'light',
   );
 
   if (theme === 'system') {
     return systemTheme;
   }
-  // TypeScript should narrow theme to 'light' | 'dark' here
   return theme as 'light' | 'dark';
 }

--- a/tools/docker/src/docker.ts
+++ b/tools/docker/src/docker.ts
@@ -122,8 +122,8 @@ if (setupIndex !== -1) {
 const imageName = takeImageName();
 const registries = readRegistries();
 
-// An --image with no registry configured is the PR Dockerfile-validation path: build
-// one arch and --load it locally instead of pushing a multi-arch index.
+// An --image with no registry configured validates the Dockerfile locally: build
+// one arch and --load it instead of pushing a multi-arch index.
 const validateOnly = imageName !== undefined && registries.length === 0;
 
 const args: string[] = [];

--- a/tools/utils/README.md
+++ b/tools/utils/README.md
@@ -25,14 +25,11 @@ import {
   log,
 } from "@shipfox/tool-utils";
 
-// Resolve paths
 const projectRoot = getProjectRootPath(import.meta.url);
 const workspaceRoot = getWorkspaceRootPath();
 const swcBin = getProjectBinaryPath("swc", import.meta.url);
 
-// Build a safe shell command
 const cmd = buildShellCommand([swcBin, "-d", "dist", "src"]);
 
-// Log
 log.info("Build started");
 ```


### PR DESCRIPTION
Clean up comments that had drifted away from the AGENTS.md commenting guidelines.

This removes low-value narration, PR/ticket history, future-planning wording, and self-evident JSDoc across app, API, client, runner, shared, tool, and e2e modules while preserving comments that explain security, concurrency, idempotency, browser timing, and runtime constraints.

A few empty-catch tests now assert the expected rejection directly, so they no longer need placeholder comments.

No changeset is included because this is comment/documentation/test-intent cleanup with no package behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed low-value comments to align with AGENTS.md, reducing noise while keeping high-signal explanations. Tightened a few tests; no runtime or API changes.

- **Refactors**
  - Removed narration, history, future-planning, and self-evident JSDoc across app, API, client, runner, tools, and e2e.
  - Preserved comments on security, concurrency, idempotency, browser timing, and runtime constraints.
  - Simplified tests to assert expected rejections and clarified test names/notes without logic changes.
  - Minor cleanups: shorter Dockerfile headers, tightened README phrasing, and `noop` unsubscribe helpers in `useMediaQuery`/`useResolvedTheme`.

<sup>Written for commit f3caa41a46e745f6e1bdf5ce8ac5fac181445297. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

