### PR TITLE
[react-ui] Add Collapsible component

### DIFF
--- a/.changeset/react-ui-collapsible.md
+++ b/.changeset/react-ui-collapsible.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Add the `Collapsible` component (`Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`) built on `@radix-ui/react-collapsible`. It is a thin design-system wrapper carrying `data-slot` attributes, and its content animates its height open and closed with the shared `collapsible-down`/`collapsible-up` keyframes. Use it for "show more" rows, optional or advanced settings, and any section that should fold away until needed.

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-collapsible": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
@@ -1,0 +1,117 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {Button} from '#components/button/index.js';
+import {Card} from '#components/card/index.js';
+import {Icon} from '#components/icon/index.js';
+import {Text} from '#components/typography/index.js';
+import {Collapsible, CollapsibleContent, CollapsibleTrigger} from './collapsible.js';
+
+const meta = {
+  title: 'Components/Collapsible',
+  component: Collapsible,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Single panel that expands and collapses, built on `@radix-ui/react-collapsible`. Use it for "show more" rows, optional/advanced settings, and any place a section should fold away until needed. The three primitives — `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent` — compose with our `Button`, `Icon`, and surface components; the content animates its height with the shared `collapsible-down`/`collapsible-up` keyframes. For several independently toggled rows that behave as a group, reach for an Accordion instead.',
+      },
+    },
+  },
+} satisfies Meta<typeof Collapsible>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+function TriggerRow({children}: {children: React.ReactNode}) {
+  return (
+    <CollapsibleTrigger className="group flex w-full items-center justify-between gap-8 rounded-6 px-8 py-6 text-left text-foreground-neutral-base transition-colors hover:bg-background-button-transparent-hover focus-visible:shadow-button-neutral-focus">
+      <Text size="sm" bold>
+        {children}
+      </Text>
+      <Icon
+        name="chevronRight"
+        className="text-foreground-neutral-muted transition-transform group-data-[state=open]:rotate-90"
+      />
+    </CollapsibleTrigger>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <Collapsible className="flex w-[420px] flex-col gap-4">
+      <TriggerRow>Repository access</TriggerRow>
+      <CollapsibleContent>
+        <Text size="sm" className="px-8 py-6 text-foreground-neutral-muted">
+          Grant the runner read access to the repositories it needs to clone. You can change the
+          selection at any time from workspace settings.
+        </Text>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+export const Open: Story = {
+  render: () => (
+    <Collapsible defaultOpen className="flex w-[420px] flex-col gap-4">
+      <TriggerRow>Repository access</TriggerRow>
+      <CollapsibleContent>
+        <Text size="sm" className="px-8 py-6 text-foreground-neutral-muted">
+          Grant the runner read access to the repositories it needs to clone. You can change the
+          selection at any time from workspace settings.
+        </Text>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    function ControlledCollapsible() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div className="flex w-[420px] flex-col gap-10">
+          <Button
+            variant="secondary"
+            size="sm"
+            className="self-start"
+            iconRight={open ? 'subtractLine' : 'addLine'}
+            onClick={() => setOpen((value) => !value)}
+          >
+            {open ? 'Hide advanced settings' : 'Show advanced settings'}
+          </Button>
+
+          <Collapsible open={open} onOpenChange={setOpen}>
+            <CollapsibleContent>
+              <Card>
+                <Text size="sm" className="text-foreground-neutral-muted">
+                  Advanced settings let you override the default runner image, concurrency limits,
+                  and environment variables. Most workspaces never need to touch these.
+                </Text>
+              </Card>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      );
+    }
+
+    return <ControlledCollapsible />;
+  },
+};
+
+export const InCard: Story = {
+  render: () => (
+    <Card className="w-[420px] gap-8">
+      <Collapsible defaultOpen className="flex flex-col gap-4">
+        <TriggerRow>What counts as a build minute?</TriggerRow>
+        <CollapsibleContent>
+          <Text size="sm" className="px-8 py-6 text-foreground-neutral-muted">
+            A build minute is one wall-clock minute a runner spends executing your job, rounded up
+            to the nearest second and billed per runner.
+          </Text>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  ),
+};

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
@@ -6,6 +6,8 @@ import {Icon} from '#components/icon/index.js';
 import {Text} from '#components/typography/index.js';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from './collapsible.js';
 
+const isTestEnvironment = () => typeof navigator !== 'undefined' && navigator.webdriver === true;
+
 const meta = {
   title: 'Components/Collapsible',
   component: Collapsible,
@@ -14,7 +16,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Single panel that expands and collapses, built on `@radix-ui/react-collapsible`. Use it for "show more" rows, optional/advanced settings, and any place a section should fold away until needed. The three primitives — `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent` — compose with our `Button`, `Icon`, and surface components; the content animates its height with the shared `collapsible-down`/`collapsible-up` keyframes. For several independently toggled rows that behave as a group, reach for an Accordion instead.',
+          'Single panel that expands and collapses, built on `@radix-ui/react-collapsible`. Use it for "show more" rows, optional/advanced settings, and any place a section should fold away until needed. The three primitives — `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent` — compose with our `Button`, `Icon`, and surface components; the content animates its height with the shared `collapsible-down`/`collapsible-up` keyframes. For several independently toggled rows, compose multiple `Collapsible`s. `CollapsibleContent` stays `overflow-hidden` so the height animation can clip cleanly, so portal any nested overlay (popover, tooltip, dropdown menu) rather than rendering it inline, where it would be clipped.',
       },
     },
   },
@@ -69,7 +71,7 @@ export const Open: Story = {
 export const Controlled: Story = {
   render: () => {
     function ControlledCollapsible() {
-      const [open, setOpen] = useState(false);
+      const [open, setOpen] = useState(isTestEnvironment());
       return (
         <div className="flex w-[420px] flex-col gap-10">
           <Button

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+
+function Collapsible({...props}: ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+function CollapsibleTrigger({
+  className,
+  ...props
+}: ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      className={cn('outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+function CollapsibleContent({
+  className,
+  ...props
+}: ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      className={cn(
+        // Radix publishes the measured height on the element as a CSS variable;
+        // the tw-animate-css keyframes read it to animate between 0 and auto.
+        'overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {Collapsible, CollapsibleContent, CollapsibleTrigger};

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.tsx
@@ -15,7 +15,7 @@ function CollapsibleTrigger({
   return (
     <CollapsiblePrimitive.Trigger
       data-slot="collapsible-trigger"
-      className={cn('outline-none', className)}
+      className={cn('outline-none focus-visible:shadow-button-neutral-focus', className)}
       {...props}
     />
   );

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.tsx
@@ -11,9 +11,9 @@ function Collapsible({...props}: ComponentProps<typeof CollapsiblePrimitive.Root
 function CollapsibleTrigger({
   className,
   ...props
-}: ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+}: ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
   return (
-    <CollapsiblePrimitive.CollapsibleTrigger
+    <CollapsiblePrimitive.Trigger
       data-slot="collapsible-trigger"
       className={cn('outline-none', className)}
       {...props}
@@ -24,9 +24,9 @@ function CollapsibleTrigger({
 function CollapsibleContent({
   className,
   ...props
-}: ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+}: ComponentProps<typeof CollapsiblePrimitive.Content>) {
   return (
-    <CollapsiblePrimitive.CollapsibleContent
+    <CollapsiblePrimitive.Content
       data-slot="collapsible-content"
       className={cn(
         // Radix publishes the measured height on the element as a CSS variable;

--- a/libs/shared/react/ui/src/components/collapsible/index.ts
+++ b/libs/shared/react/ui/src/components/collapsible/index.ts
@@ -1,0 +1,1 @@
+export * from './collapsible.js';

--- a/libs/shared/react/ui/src/components/index.ts
+++ b/libs/shared/react/ui/src/components/index.ts
@@ -4,6 +4,7 @@ export * from './badge/index.js';
 export * from './button/index.js';
 export * from './card/index.js';
 export * from './code-block/index.js';
+export * from './collapsible/index.js';
 export * from './combobox/index.js';
 export * from './command/index.js';
 export * from './dot/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3518,6 +3518,9 @@ importers:
       '@radix-ui/react-avatar':
         specifier: ^1.1.10
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.14
+        version: 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6560,6 +6563,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collapsible@1.1.14':
+    resolution: {integrity: sha512-9bT+FvifX1FK2Mj6UEsTdyu0cN3JaA3KdfhaBao+ONrYFy/pyOy3TU1TNw7iOk1o+0hOEq67RojlUUmoFGwxyA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.9':
     resolution: {integrity: sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==}
     peerDependencies:
@@ -6792,6 +6808,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-radio-group@1.4.0':
     resolution: {integrity: sha512-eHdV5bLx9sH+tBnbDjkIBdvQEH/c6MEtQYhTbxkaDK9qsIFFLtmJYEQFVdwhnruWotLfQmIuWEL/J+L3utE8rQ==}
     peerDependencies:
@@ -6855,6 +6884,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.5':
     resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -13752,6 +13790,22 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-collapsible@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-collection@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
@@ -13982,6 +14036,15 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-radio-group@1.4.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -14072,6 +14135,13 @@ snapshots:
       '@types/react': 19.2.17
 
   '@radix-ui/react-slot@1.2.5(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7


### PR DESCRIPTION
Add a `Collapsible` component to the `@shipfox/react-ui` design system: `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent`, built on `@radix-ui/react-collapsible`.

It is modeled on shadcn's Radix collapsible but unified with how this design system already wraps Radix primitives (see `popover`, `radio-group`, `dropdown-menu`): `data-slot` attributes on each part, `cn`-merged classes, and `ComponentProps<typeof Primitive>` typing with no abstraction over the primitive. The content animates its height open and closed using the shared `collapsible-down`/`collapsible-up` keyframes already provided by `tw-animate-css`, so a section can fold away until needed (a "show more" row, optional or advanced settings).

The API is intentionally primitive-only, matching both shadcn's base and our existing thin wrappers. The Storybook stories show the recommended composition with our `Button`, `Card`, `Icon`, and typography, including the chevron-rotation pattern (`group-data-[state=open]:rotate-90`). Argos snapshots each story in light and dark via the existing preview config, and the open/card stories cover the expanded visual state.

DESIGN.md is intentionally left unchanged: its decisions log stopped recording individual component additions after the initial batches (recent `dot`/`code-block` adds have no entry), and this component introduces no new tokens or design deviations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Collapsible primitive (`Collapsible`, `CollapsibleTrigger`, `CollapsibleContent`) to `@shipfox/react-ui`, built on `@radix-ui/react-collapsible`. Lets you animate show/hide sections for “show more” rows and advanced settings.

- **New Features**
  - Thin wrapper aligned with DS patterns: `data-slot`, `cn` class merging, `ComponentProps` typing; animated height with shared `collapsible-down`/`collapsible-up` keyframes from `tw-animate-css`.
  - Storybook examples (default, open, controlled, in-card) using `Button`, `Card`, `Icon`; includes chevron rotation, seeds the Controlled story open under Argos, and notes `CollapsibleContent` stays overflow-hidden so nested overlays should be portaled.
  - Internal polish and accessibility: use Radix `Trigger`/`Content` aliases to match `popover`/`dropdown-menu`. Add a default `focus-visible` ring on `CollapsibleTrigger` that’s overridable via `cn` to meet WCAG 2.4.7.

- **Dependencies**
  - Add `@radix-ui/react-collapsible` to `@shipfox/react-ui`; export in index and include a changeset for a minor release.

<sup>Written for commit e794b296f1eeee4f0268c2c781e539a83245540c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

