### PR TITLE
Add source-keyed integration and trigger icon components

### DIFF
--- a/.changeset/eng-510-icon-prop-forwarding.md
+++ b/.changeset/eng-510-icon-prop-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Forward props on the `componentLine` and `componentFill` custom icons so `className`, `aria-*`, and sizing reach the rendered `<svg>` like every other icon. Previously these two glyphs dropped all props, so `<Icon name="componentLine">` (the neutral fallback `IntegrationIcon` and `TriggerSourceIcon` use for uncataloged sources) rendered at its intrinsic size with no accessible name regardless of what the caller passed.

--- a/.changeset/eng-510-integration-icon.md
+++ b/.changeset/eng-510-integration-icon.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/client-integrations": minor
+"@shipfox/client-triggers": minor
+---
+
+Add reusable, source-keyed icon building blocks so any surface can render an integration or trigger icon without re-implementing the catalog lookup and fallback.
+
+`@shipfox/client-integrations` exposes `getIntegrationIcon(source)` and `<IntegrationIcon source />`, resolving an integration source (a connection `provider`, a run `trigger_source`, or a trigger event `source`) against the central `PROVIDER_CATALOG` with a neutral `componentLine` fallback. The catalog stays the single place each integration declares its icon; the integration gallery now renders `<IntegrationIcon>` instead of an inline lookup (no behavior change).
+
+New `@shipfox/client-triggers` package adds `getTriggerSourceIcon(source)` and `<TriggerSourceIcon source />`, built on the integration resolver. It recognizes the system trigger sources `manual` (a person fired the run) and `cron` (a schedule), and delegates every other source to the integration catalog. This is the building block for showing an icon on run rows and trigger events; adopting it on those surfaces lands separately.

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.test.ts
@@ -137,6 +137,8 @@ describe('onSourceCommitPushed', () => {
     expect(rows).toHaveLength(1);
   });
 
+  // The source/event filter is the subscription itself, so this module should
+  // only receive the typed source-control event.
   it('registers the projects module on INTEGRATION_SOURCE_COMMIT_PUSHED', () => {
     const module = createProjectsModule({sourceControl: {} as never});
 

--- a/libs/api/workflows/src/core/entities/step.ts
+++ b/libs/api/workflows/src/core/entities/step.ts
@@ -17,7 +17,7 @@ export interface Step {
   version: number;
   // Execution-attempt identity for the current projection: which attempt the
   // status/output/error above reflect. Distinct from `version` (the optimistic
-  // row counter). Starts at 1; bumped only when a step is rewound by a durable restart.
+  // row counter). Starts at 1 and is bumped when a step is rewound.
   currentAttempt: number;
   createdAt: Date;
   updatedAt: Date;

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -486,7 +486,7 @@ describe('step attempts', () => {
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const stepId = steps[0]?.id as string;
     await nextStepForJob(jobId);
-    // Simulate a rewind having bumped the current attempt to 2.
+
     await db()
       .update(stepsTable)
       .set({currentAttempt: 2, status: 'running'})
@@ -510,7 +510,6 @@ describe('step attempts', () => {
     const stepId = steps[0]?.id as string;
     await nextStepForJob(jobId);
     await recordStepResult({jobId, stepId, status: 'succeeded', exitCode: 0});
-    // Simulate a rewind bump on the terminal step.
     await db().update(stepsTable).set({currentAttempt: 2}).where(eq(stepsTable.id, stepId));
 
     const outcome = await recordStepResult({
@@ -813,7 +812,6 @@ describe('durable gate restart', () => {
     await runStep(jobId, producer, 0);
     await runStep(jobId, build, 0); // build passes (its attempt 3)
 
-    // deploy runs for the first time with an inflated current_attempt of 3.
     expect((await getStepsByJobId(jobId)).find((s) => s.id === deploy)?.currentAttempt).toBe(3);
     const deployFail = await runStep(jobId, deploy, 1);
 

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -57,10 +57,9 @@ export interface RecordStepResultParams {
   stepId: string;
   status: 'succeeded' | 'failed';
   error?: Record<string, unknown> | null;
-  // Structured runner output for audit/history on the attempt row. The current
-  // step projection keeps status/error only.
+  // Structured runner output is audit/history on the attempt row; the current
+  // step projection keeps only status/error.
   output?: Record<string, unknown> | null;
-  // Process exit code reported by the runner.
   exitCode?: number | null;
   // The attempt the runner was dispatched. Omitted = "the step's current
   // attempt" (back-compat for callers that don't track attempts yet).

--- a/libs/api/workflows/src/db/schema/step-attempts.ts
+++ b/libs/api/workflows/src/db/schema/step-attempts.ts
@@ -28,9 +28,7 @@ export const stepAttempts = pgTable(
     output: jsonb('output').$type<Record<string, unknown>>(),
     error: jsonb('error').$type<Record<string, unknown>>(),
     exitCode: integer('exit_code'),
-    // Gate evaluation payload for this attempt.
     gateResult: jsonb('gate_result').$type<Record<string, unknown>>(),
-    // Why this attempt triggered a restart.
     restartReason: text('restart_reason'),
     startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
     finishedAt: timestamp('finished_at', {withTimezone: true}),

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -24,6 +24,7 @@ import {
   useIntegrationConnectionsQuery,
   useIntegrationProvidersQuery,
 } from '#hooks/api/integrations.js';
+import {IntegrationIcon} from '#integration-icon.js';
 import {PROVIDER_CATALOG} from '#provider-catalog.js';
 
 export interface IntegrationGalleryProps {
@@ -48,8 +49,6 @@ const lifecyclePills: Record<
   disabled: {variant: 'neutral', label: 'Disabled', iconLeft: 'errorWarningLine'},
   error: {variant: 'error', label: 'Error'},
 };
-
-const FALLBACK_ICON: IconName = 'componentLine';
 
 // Shared so the live grid and its loading skeleton can never drift to a
 // different column rule. Container-driven (auto-fill) columns work in both the
@@ -179,14 +178,13 @@ function InstalledRow({
   connection: IntegrationConnectionDto;
   providerLabel: string;
 }) {
-  const iconName = PROVIDER_CATALOG[connection.provider]?.iconName ?? FALLBACK_ICON;
   const pill = lifecyclePills[connection.lifecycle_status];
   const muted = connection.lifecycle_status === 'disabled';
 
   return (
     <li className="flex items-center gap-12 px-16 py-10 transition-colors hover:bg-background-components-hover">
-      <Icon
-        name={iconName}
+      <IntegrationIcon
+        source={connection.provider}
         className={cn(
           'size-24 shrink-0',
           muted ? 'text-foreground-neutral-disabled' : 'text-foreground-neutral-base',
@@ -262,7 +260,10 @@ function AvailableCard({
     >
       <Card className="h-full gap-8 p-16 transition-colors hover:bg-background-components-hover">
         <div className="flex min-w-0 items-center gap-12">
-          <Icon name={catalog.iconName} className="size-24 shrink-0 text-foreground-neutral-base" />
+          <IntegrationIcon
+            source={provider.provider}
+            className="size-24 shrink-0 text-foreground-neutral-base"
+          />
           <Text size="md" bold className="truncate">
             {provider.display_name}
           </Text>

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -185,6 +185,7 @@ function InstalledRow({
     <li className="flex items-center gap-12 px-16 py-10 transition-colors hover:bg-background-components-hover">
       <IntegrationIcon
         source={connection.provider}
+        aria-hidden
         className={cn(
           'size-24 shrink-0',
           muted ? 'text-foreground-neutral-disabled' : 'text-foreground-neutral-base',
@@ -262,6 +263,7 @@ function AvailableCard({
         <div className="flex min-w-0 items-center gap-12">
           <IntegrationIcon
             source={provider.provider}
+            aria-hidden
             className="size-24 shrink-0 text-foreground-neutral-base"
           />
           <Text size="md" bold className="truncate">

--- a/libs/client/integrations/src/index.ts
+++ b/libs/client/integrations/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/integration-gallery.js';
 export * from './components/redirect-install-page.js';
 export * from './components/repository-picker.js';
 export * from './hooks/api/integrations.js';
+export * from './integration-icon.js';
 export * from './pages/debug-install-page.js';
 export * from './pages/github-install-page.js';
 export * from './pages/integration-gallery-page.js';

--- a/libs/client/integrations/src/integration-icon.test.ts
+++ b/libs/client/integrations/src/integration-icon.test.ts
@@ -1,0 +1,17 @@
+import {FALLBACK_INTEGRATION_ICON, getIntegrationIcon} from './integration-icon.js';
+
+describe('getIntegrationIcon', () => {
+  it('resolves cataloged providers to the icon they declare', () => {
+    expect(getIntegrationIcon('github')).toBe('github');
+    expect(getIntegrationIcon('sentry')).toBe('sentry');
+  });
+
+  it('falls back for sources missing from the catalog', () => {
+    expect(getIntegrationIcon('gitlab')).toBe(FALLBACK_INTEGRATION_ICON);
+    expect(getIntegrationIcon('mystery')).toBe(FALLBACK_INTEGRATION_ICON);
+  });
+
+  it.each([['' as const], [null], [undefined]])('falls back for an empty source (%s)', (source) => {
+    expect(getIntegrationIcon(source)).toBe(FALLBACK_INTEGRATION_ICON);
+  });
+});

--- a/libs/client/integrations/src/integration-icon.test.tsx
+++ b/libs/client/integrations/src/integration-icon.test.tsx
@@ -1,33 +1,22 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import {render} from '@testing-library/react';
-import {
-  FALLBACK_INTEGRATION_ICON,
-  getIntegrationIcon,
-  IntegrationIcon,
-} from './integration-icon.js';
-
-describe('getIntegrationIcon', () => {
-  it('resolves cataloged providers to the icon they declare', () => {
-    expect(getIntegrationIcon('github')).toBe('github');
-    expect(getIntegrationIcon('sentry')).toBe('sentry');
-  });
-
-  it('falls back for sources missing from the catalog', () => {
-    expect(getIntegrationIcon('gitlab')).toBe(FALLBACK_INTEGRATION_ICON);
-    expect(getIntegrationIcon('mystery')).toBe(FALLBACK_INTEGRATION_ICON);
-  });
-
-  it.each([['' as const], [null], [undefined]])('falls back for an empty source (%s)', (source) => {
-    expect(getIntegrationIcon(source)).toBe(FALLBACK_INTEGRATION_ICON);
-  });
-});
+import {IntegrationIcon} from './integration-icon.js';
 
 describe('IntegrationIcon', () => {
-  it('renders an accessible icon for a cataloged source', () => {
-    const {getByLabelText} = render(<IntegrationIcon source="github" aria-label="GitHub" />);
+  it('exposes a labeled icon to assistive tech when it is the sole identifier', () => {
+    const {container} = render(<IntegrationIcon source="github" aria-label="GitHub" />);
 
-    expect(getByLabelText('GitHub')).toBeInTheDocument();
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'GitHub');
+    expect(svg).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('hides the icon from assistive tech when marked decorative', () => {
+    const {container} = render(<IntegrationIcon source="github" aria-hidden />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('forwards class names so callers control sizing and color', () => {
@@ -37,5 +26,15 @@ describe('IntegrationIcon', () => {
 
     const svg = container.querySelector('svg');
     expect(svg).toHaveClass('size-24', 'text-foreground-neutral-base');
+  });
+
+  it('forwards sizing and label to the neutral fallback glyph for an unknown source', () => {
+    const {container} = render(
+      <IntegrationIcon source="gitlab" aria-label="GitLab" className="size-24" />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'GitLab');
+    expect(svg).toHaveClass('size-24');
   });
 });

--- a/libs/client/integrations/src/integration-icon.test.tsx
+++ b/libs/client/integrations/src/integration-icon.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import {render} from '@testing-library/react';
+import {
+  FALLBACK_INTEGRATION_ICON,
+  getIntegrationIcon,
+  IntegrationIcon,
+} from './integration-icon.js';
+
+describe('getIntegrationIcon', () => {
+  it('resolves cataloged providers to the icon they declare', () => {
+    expect(getIntegrationIcon('github')).toBe('github');
+    expect(getIntegrationIcon('sentry')).toBe('sentry');
+  });
+
+  it('falls back for sources missing from the catalog', () => {
+    expect(getIntegrationIcon('gitlab')).toBe(FALLBACK_INTEGRATION_ICON);
+    expect(getIntegrationIcon('mystery')).toBe(FALLBACK_INTEGRATION_ICON);
+  });
+
+  it.each([['' as const], [null], [undefined]])('falls back for an empty source (%s)', (source) => {
+    expect(getIntegrationIcon(source)).toBe(FALLBACK_INTEGRATION_ICON);
+  });
+});
+
+describe('IntegrationIcon', () => {
+  it('renders an accessible icon for a cataloged source', () => {
+    const {getByLabelText} = render(<IntegrationIcon source="github" aria-label="GitHub" />);
+
+    expect(getByLabelText('GitHub')).toBeInTheDocument();
+  });
+
+  it('forwards class names so callers control sizing and color', () => {
+    const {container} = render(
+      <IntegrationIcon source="github" className="size-24 text-foreground-neutral-base" />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('size-24', 'text-foreground-neutral-base');
+  });
+});

--- a/libs/client/integrations/src/integration-icon.tsx
+++ b/libs/client/integrations/src/integration-icon.tsx
@@ -2,16 +2,11 @@ import {Icon, type IconName} from '@shipfox/react-ui';
 import type {ComponentProps} from 'react';
 import {PROVIDER_CATALOG} from '#provider-catalog.js';
 
-/** Shown for sources with no catalog entry (an unknown or not-yet-cataloged provider). */
 export const FALLBACK_INTEGRATION_ICON: IconName = 'componentLine';
 
 /**
- * Resolves an integration source to its icon, reading the central
- * {@link PROVIDER_CATALOG} so each integration declares its icon in one place. The
- * source is the same namespace everywhere it appears: a connection `provider`, a
- * run `trigger_source`, or a trigger event `source`. Unknown sources fall back to
- * a neutral component glyph. Single source of truth so call sites never
- * re-implement the lookup + fallback.
+ * Accepts the source strings used by connections and events; unknown values use
+ * the neutral fallback icon.
  */
 export function getIntegrationIcon(source: string | null | undefined): IconName {
   if (!source) return FALLBACK_INTEGRATION_ICON;
@@ -19,16 +14,12 @@ export function getIntegrationIcon(source: string | null | undefined): IconName 
 }
 
 export interface IntegrationIconProps extends Omit<ComponentProps<typeof Icon>, 'name'> {
-  /** Integration source: a connection provider, a run `trigger_source`, or a trigger event `source`. */
   source: string | null | undefined;
 }
 
 /**
- * Renders the catalog icon for an integration source with the shared fallback
- * baked in. A thin wrapper over {@link Icon}: size, color, and accessibility props
- * (such as `aria-label`) pass straight through. Mark it `aria-hidden` when an
- * adjacent text label already names the source; pass an `aria-label` when the icon
- * is the only thing identifying the source.
+ * Preserves the base icon props so callers can decide whether the glyph is
+ * decorative or labeled.
  */
 export function IntegrationIcon({source, ...props}: IntegrationIconProps) {
   return <Icon name={getIntegrationIcon(source)} {...props} />;

--- a/libs/client/integrations/src/integration-icon.tsx
+++ b/libs/client/integrations/src/integration-icon.tsx
@@ -1,0 +1,35 @@
+import {Icon, type IconName} from '@shipfox/react-ui';
+import type {ComponentProps} from 'react';
+import {PROVIDER_CATALOG} from '#provider-catalog.js';
+
+/** Shown for sources with no catalog entry (an unknown or not-yet-cataloged provider). */
+export const FALLBACK_INTEGRATION_ICON: IconName = 'componentLine';
+
+/**
+ * Resolves an integration source to its icon, reading the central
+ * {@link PROVIDER_CATALOG} so each integration declares its icon in one place. The
+ * source is the same namespace everywhere it appears: a connection `provider`, a
+ * run `trigger_source`, or a trigger event `source`. Unknown sources fall back to
+ * a neutral component glyph. Single source of truth so call sites never
+ * re-implement the lookup + fallback.
+ */
+export function getIntegrationIcon(source: string | null | undefined): IconName {
+  if (!source) return FALLBACK_INTEGRATION_ICON;
+  return PROVIDER_CATALOG[source]?.iconName ?? FALLBACK_INTEGRATION_ICON;
+}
+
+export interface IntegrationIconProps extends Omit<ComponentProps<typeof Icon>, 'name'> {
+  /** Integration source: a connection provider, a run `trigger_source`, or a trigger event `source`. */
+  source: string | null | undefined;
+}
+
+/**
+ * Renders the catalog icon for an integration source with the shared fallback
+ * baked in. A thin wrapper over {@link Icon}: size, color, and accessibility props
+ * (such as `aria-label`) pass straight through. Mark it `aria-hidden` when an
+ * adjacent text label already names the source; pass an `aria-label` when the icon
+ * is the only thing identifying the source.
+ */
+export function IntegrationIcon({source, ...props}: IntegrationIconProps) {
+  return <Icon name={getIntegrationIcon(source)} {...props} />;
+}

--- a/libs/client/projects/src/components/source-strip.tsx
+++ b/libs/client/projects/src/components/source-strip.tsx
@@ -14,17 +14,11 @@ import {
 } from '@shipfox/react-ui';
 
 /**
- * Slim provenance strip at the top of the Workflows page.
- *
- * Shows enough for an operator to recognize the GitOps loop at a glance: provider icon,
- * connection display name, repo id chip, sync status pill.
- *
  * We cannot cheaply resolve `external_repository_id` → `owner/repo`
  * (no by-id endpoint; `listRepositories` is paginated by connection).
  * The strip surfaces the raw id as a `<Code>` chip with a tooltip carrying the
  * full string.
  */
-
 export function SourceStrip({
   connectionId,
   externalRepositoryId,

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -94,9 +94,9 @@ function createTestRouter(path: string, element: ReactElement) {
         return element;
       }
 
-      // Production redirects the project-detail URL to the Runs tab. The harness
-      // only needs to prove navigation landed there (e.g. create-project duplicate
-      // recovery), so it renders a minimal stand-in rather than depending on that package.
+      // The harness only needs to prove project-detail navigation landed on the
+      // Runs surface, so it renders a minimal stand-in rather than depending on
+      // @shipfox/client-workflows.
       return <h1>Runs</h1>;
     },
   });

--- a/libs/client/triggers/package.json
+++ b/libs/client/triggers/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@shipfox/client-triggers",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/triggers"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/client-integrations": "workspace:*",
+    "@shipfox/react-ui": "workspace:*",
+    "@swc/helpers": "^0.5.17"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@types/react": "^19.1.11",
+    "@types/react-dom": "^19.1.7",
+    "jsdom": "^29.0.0",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  }
+}

--- a/libs/client/triggers/package.json
+++ b/libs/client/triggers/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
     "directory": "libs/client/triggers"
   },
   "private": true,

--- a/libs/client/triggers/src/components/trigger-source-icon.test.ts
+++ b/libs/client/triggers/src/components/trigger-source-icon.test.ts
@@ -1,0 +1,20 @@
+import {getTriggerSourceIcon} from './trigger-source-icon.js';
+
+describe('getTriggerSourceIcon', () => {
+  it('maps the system sources manual and cron to their own icons', () => {
+    expect(getTriggerSourceIcon('manual')).toBe('cursorLine');
+    expect(getTriggerSourceIcon('cron')).toBe('timeLine');
+  });
+
+  it('delegates integration sources to the integration catalog', () => {
+    expect(getTriggerSourceIcon('github')).toBe('github');
+    expect(getTriggerSourceIcon('sentry')).toBe('sentry');
+  });
+
+  it('falls back for unknown or empty sources', () => {
+    expect(getTriggerSourceIcon('gitlab')).toBe('componentLine');
+    expect(getTriggerSourceIcon('')).toBe('componentLine');
+    expect(getTriggerSourceIcon(null)).toBe('componentLine');
+    expect(getTriggerSourceIcon(undefined)).toBe('componentLine');
+  });
+});

--- a/libs/client/triggers/src/components/trigger-source-icon.test.tsx
+++ b/libs/client/triggers/src/components/trigger-source-icon.test.tsx
@@ -1,30 +1,20 @@
 import {render} from '@testing-library/react';
-import {getTriggerSourceIcon, TriggerSourceIcon} from './trigger-source-icon.js';
-
-describe('getTriggerSourceIcon', () => {
-  it('maps the system sources manual and cron to their own icons', () => {
-    expect(getTriggerSourceIcon('manual')).toBe('cursorLine');
-    expect(getTriggerSourceIcon('cron')).toBe('timeLine');
-  });
-
-  it('delegates integration sources to the integration catalog', () => {
-    expect(getTriggerSourceIcon('github')).toBe('github');
-    expect(getTriggerSourceIcon('sentry')).toBe('sentry');
-  });
-
-  it('falls back for unknown or empty sources', () => {
-    expect(getTriggerSourceIcon('gitlab')).toBe('componentLine');
-    expect(getTriggerSourceIcon('')).toBe('componentLine');
-    expect(getTriggerSourceIcon(null)).toBe('componentLine');
-    expect(getTriggerSourceIcon(undefined)).toBe('componentLine');
-  });
-});
+import {TriggerSourceIcon} from './trigger-source-icon.js';
 
 describe('TriggerSourceIcon', () => {
-  it('renders an accessible icon for a manual trigger', () => {
-    const {getByLabelText} = render(<TriggerSourceIcon source="manual" aria-label="Manual" />);
+  it('exposes a labeled icon to assistive tech when it is the sole identifier', () => {
+    const {container} = render(<TriggerSourceIcon source="manual" aria-label="Manual" />);
 
-    expect(getByLabelText('Manual')).toBeInTheDocument();
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-label', 'Manual');
+    expect(svg).not.toHaveAttribute('aria-hidden');
+  });
+
+  it('hides the icon from assistive tech when marked decorative', () => {
+    const {container} = render(<TriggerSourceIcon source="manual" aria-hidden />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('forwards class names so callers control sizing and color', () => {

--- a/libs/client/triggers/src/components/trigger-source-icon.test.tsx
+++ b/libs/client/triggers/src/components/trigger-source-icon.test.tsx
@@ -1,0 +1,38 @@
+import {render} from '@testing-library/react';
+import {getTriggerSourceIcon, TriggerSourceIcon} from './trigger-source-icon.js';
+
+describe('getTriggerSourceIcon', () => {
+  it('maps the system sources manual and cron to their own icons', () => {
+    expect(getTriggerSourceIcon('manual')).toBe('cursorLine');
+    expect(getTriggerSourceIcon('cron')).toBe('timeLine');
+  });
+
+  it('delegates integration sources to the integration catalog', () => {
+    expect(getTriggerSourceIcon('github')).toBe('github');
+    expect(getTriggerSourceIcon('sentry')).toBe('sentry');
+  });
+
+  it('falls back for unknown or empty sources', () => {
+    expect(getTriggerSourceIcon('gitlab')).toBe('componentLine');
+    expect(getTriggerSourceIcon('')).toBe('componentLine');
+    expect(getTriggerSourceIcon(null)).toBe('componentLine');
+    expect(getTriggerSourceIcon(undefined)).toBe('componentLine');
+  });
+});
+
+describe('TriggerSourceIcon', () => {
+  it('renders an accessible icon for a manual trigger', () => {
+    const {getByLabelText} = render(<TriggerSourceIcon source="manual" aria-label="Manual" />);
+
+    expect(getByLabelText('Manual')).toBeInTheDocument();
+  });
+
+  it('forwards class names so callers control sizing and color', () => {
+    const {container} = render(
+      <TriggerSourceIcon source="github" className="size-16 text-foreground-neutral-muted" />,
+    );
+
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('size-16', 'text-foreground-neutral-muted');
+  });
+});

--- a/libs/client/triggers/src/components/trigger-source-icon.tsx
+++ b/libs/client/triggers/src/components/trigger-source-icon.tsx
@@ -1,0 +1,41 @@
+import {getIntegrationIcon} from '@shipfox/client-integrations';
+import {Icon, type IconName} from '@shipfox/react-ui';
+import type {ComponentProps} from 'react';
+
+/**
+ * Icons for the trigger sources the integration catalog does not own. Integration
+ * sources (github, sentry, …) resolve through {@link getIntegrationIcon}; these are
+ * the system sources a run can carry instead — a person firing it (`manual`) or a
+ * schedule (`cron`).
+ */
+const SYSTEM_TRIGGER_SOURCE_ICONS: Record<string, IconName> = {
+  manual: 'cursorLine',
+  cron: 'timeLine',
+};
+
+/**
+ * Resolves a run `trigger_source` (or a trigger event `source`) to its icon.
+ * Recognizes the system sources `manual` and `cron`, and delegates every other
+ * source to the integration catalog, inheriting its neutral fallback for unknown
+ * providers.
+ */
+export function getTriggerSourceIcon(source: string | null | undefined): IconName {
+  const systemIcon = source ? SYSTEM_TRIGGER_SOURCE_ICONS[source] : undefined;
+  return systemIcon ?? getIntegrationIcon(source);
+}
+
+export interface TriggerSourceIconProps extends Omit<ComponentProps<typeof Icon>, 'name'> {
+  /** A run `trigger_source` or trigger event `source`: `manual`, `cron`, or an integration provider. */
+  source: string | null | undefined;
+}
+
+/**
+ * Renders the icon for what triggered a run: a person (`manual`), a schedule
+ * (`cron`), or the integration that delivered the event. A thin wrapper over
+ * {@link Icon} — size, color, and accessibility props pass straight through. Mark
+ * it `aria-hidden` when an adjacent label already names the source; pass an
+ * `aria-label` when the icon is the only thing identifying it.
+ */
+export function TriggerSourceIcon({source, ...props}: TriggerSourceIconProps) {
+  return <Icon name={getTriggerSourceIcon(source)} {...props} />;
+}

--- a/libs/client/triggers/src/components/trigger-source-icon.tsx
+++ b/libs/client/triggers/src/components/trigger-source-icon.tsx
@@ -2,12 +2,6 @@ import {getIntegrationIcon} from '@shipfox/client-integrations';
 import {Icon, type IconName} from '@shipfox/react-ui';
 import type {ComponentProps} from 'react';
 
-/**
- * Icons for the trigger sources the integration catalog does not own. Integration
- * sources (github, sentry, …) resolve through {@link getIntegrationIcon}; these are
- * the system sources a run can carry instead — a person firing it (`manual`) or a
- * schedule (`cron`).
- */
 const SYSTEM_TRIGGER_SOURCE_ICONS: Record<string, IconName> = {
   manual: 'cursorLine',
   cron: 'timeLine',

--- a/libs/client/triggers/src/components/trigger-source-icon.tsx
+++ b/libs/client/triggers/src/components/trigger-source-icon.tsx
@@ -8,10 +8,8 @@ const SYSTEM_TRIGGER_SOURCE_ICONS: Record<string, IconName> = {
 };
 
 /**
- * Resolves a run `trigger_source` (or a trigger event `source`) to its icon.
- * Recognizes the system sources `manual` and `cron`, and delegates every other
- * source to the integration catalog, inheriting its neutral fallback for unknown
- * providers.
+ * Gives first-class icons to system trigger sources; integration sources keep
+ * using the integration catalog and its fallback.
  */
 export function getTriggerSourceIcon(source: string | null | undefined): IconName {
   const systemIcon = source ? SYSTEM_TRIGGER_SOURCE_ICONS[source] : undefined;
@@ -19,16 +17,12 @@ export function getTriggerSourceIcon(source: string | null | undefined): IconNam
 }
 
 export interface TriggerSourceIconProps extends Omit<ComponentProps<typeof Icon>, 'name'> {
-  /** A run `trigger_source` or trigger event `source`: `manual`, `cron`, or an integration provider. */
   source: string | null | undefined;
 }
 
 /**
- * Renders the icon for what triggered a run: a person (`manual`), a schedule
- * (`cron`), or the integration that delivered the event. A thin wrapper over
- * {@link Icon} — size, color, and accessibility props pass straight through. Mark
- * it `aria-hidden` when an adjacent label already names the source; pass an
- * `aria-label` when the icon is the only thing identifying it.
+ * Preserves the base icon props so callers can decide whether the glyph is
+ * decorative or labeled.
  */
 export function TriggerSourceIcon({source, ...props}: TriggerSourceIconProps) {
   return <Icon name={getTriggerSourceIcon(source)} {...props} />;

--- a/libs/client/triggers/src/index.ts
+++ b/libs/client/triggers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './components/trigger-source-icon.js';

--- a/libs/client/triggers/test/setup.ts
+++ b/libs/client/triggers/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/libs/client/triggers/tsconfig.build.json
+++ b/libs/client/triggers/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/react",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/client/triggers/tsconfig.json
+++ b/libs/client/triggers/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/client/triggers/tsconfig.test.json
+++ b/libs/client/triggers/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/client/triggers/vitest.config.ts
+++ b/libs/client/triggers/vitest.config.ts
@@ -1,0 +1,28 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -7,7 +7,6 @@ import {executeRunStep, type OutputSink} from '#core/run-step.js';
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const ESRCH_REGEX = /ESRCH/;
 
-// Collects what the durable pipeline receives from captured step output.
 function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
   const chunks: Buffer[] = [];
   const sources: string[] = [];

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -83,8 +83,7 @@ export async function runJob(
 
   try {
     const leaseClient = createLeaseClient(job.lease_token);
-    // The log mask set is the runner's own credentials: the long-lived runner token and
-    // this job's lease token. Both can reach a step's environment, so they are scrubbed from
+    // Both runner credentials can reach a step's environment, so scrub them from
     // captured output before it touches the spool.
     const secrets = [runnerToken(), job.lease_token];
     await runJobSteps({jobId: job.job_id, leaseClient, secrets, signal: ac.signal, cwd});

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -36,8 +36,8 @@ export async function runJobSteps(params: {
 }): Promise<void> {
   const {jobId, leaseClient, secrets, signal, cwd} = params;
 
-  // The setup step (position 0) prepares the workspace; every run step assumes it ran.
-  // A run step pulled before a successful setup is failed cleanly rather than spawned
+  // The setup step prepares the workspace; every run step assumes it ran. A run
+  // step pulled before a successful setup is failed cleanly rather than spawned
   // against an unprepared cwd.
   let workspacePrepared = false;
 

--- a/libs/shared/react/ui/src/components/icon/custom/component-fill.tsx
+++ b/libs/shared/react/ui/src/components/icon/custom/component-fill.tsx
@@ -1,7 +1,7 @@
 import type {RemixiconComponentType} from '@remixicon/react';
 import type {ComponentProps} from 'react';
 
-export function ComponentFillIcon(_props: ComponentProps<RemixiconComponentType>) {
+export function ComponentFillIcon(props: ComponentProps<RemixiconComponentType>) {
   return (
     <svg
       width="25"
@@ -9,6 +9,7 @@ export function ComponentFillIcon(_props: ComponentProps<RemixiconComponentType>
       viewBox="0 0 25 24"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>Component Fill</title>
       <path d="M16.6277 17.1584L13.0159 20.7702C12.8791 20.9071 12.6989 20.9894 12.5151 20.999C12.3313 21.0087 12.1588 20.945 12.0357 20.8218L8.32124 17.1074L12.4489 12.9797L16.6277 17.1584ZM11.5203 12.0511L7.39263 16.1788L3.67817 12.4643C3.55503 12.3412 3.49129 12.1687 3.50096 11.9849C3.51064 11.8011 3.59294 11.6209 3.72976 11.4841L7.34155 7.87231L11.5203 12.0511ZM16.6788 6.89263L12.5521 11.0193L8.37334 6.84052L11.9841 3.22976C12.1209 3.09294 12.3011 3.01064 12.4849 3.00096C12.6687 2.99129 12.8412 3.05503 12.9643 3.17817L16.6788 6.89263ZM21.3218 11.5357C21.445 11.6588 21.5087 11.8313 21.499 12.0151C21.4894 12.1989 21.4071 12.3791 21.2702 12.5159L17.6595 16.1267L13.4807 11.9479L17.6074 7.82124L21.3218 11.5357Z" />

--- a/libs/shared/react/ui/src/components/icon/custom/component-line.tsx
+++ b/libs/shared/react/ui/src/components/icon/custom/component-line.tsx
@@ -1,7 +1,7 @@
 import type {RemixiconComponentType} from '@remixicon/react';
 import type {ComponentProps} from 'react';
 
-export function ComponentLineIcon(_props: ComponentProps<RemixiconComponentType>) {
+export function ComponentLineIcon(props: ComponentProps<RemixiconComponentType>) {
   return (
     <svg
       width="25"
@@ -9,6 +9,7 @@ export function ComponentLineIcon(_props: ComponentProps<RemixiconComponentType>
       viewBox="0 0 25 24"
       fill="currentColor"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <title>Component Line</title>
       <path d="M20.7217 12.1353C20.8449 12.2584 20.9086 12.4309 20.8989 12.6147C20.8893 12.7985 20.807 12.9787 20.6701 13.1155L12.4158 21.3698C12.279 21.5067 12.0988 21.589 11.915 21.5986C11.7312 21.6083 11.5587 21.5446 11.4356 21.4214L3.07807 13.0639C2.95493 12.9408 2.89119 12.7683 2.90086 12.5845C2.91054 12.4007 2.99284 12.2205 3.12966 12.0837L11.384 3.82937C11.5208 3.69255 11.701 3.61024 11.8848 3.60057C12.0686 3.59089 12.2411 3.65464 12.3642 3.77778L20.7217 12.1353ZM10.9197 12.6512L7.66955 9.40105L4.57417 12.4964L7.82432 15.7466L10.9197 12.6512ZM15.0985 16.83L11.8483 13.5798L8.75293 16.6752L12.0031 19.9253L15.0985 16.83ZM15.0469 8.52403L11.7967 5.27388L8.70134 8.36926L11.9515 11.6194L15.0469 8.52403ZM19.2256 12.7028L15.9755 9.45264L12.8801 12.548L16.1303 15.7982L19.2256 12.7028Z" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2569,6 +2569,55 @@ importers:
         specifier: ^19.1.1
         version: 19.2.7(react@19.2.7)
 
+  libs/client/triggers:
+    dependencies:
+      '@shipfox/client-integrations':
+        specifier: workspace:*
+        version: link:../integrations
+      '@shipfox/react-ui':
+        specifier: workspace:*
+        version: link:../../shared/react/ui
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.23
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.1.11
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.0.0
+        version: 29.1.1
+      react:
+        specifier: ^19.1.1
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.7(react@19.2.7)
+
   libs/client/ui:
     dependencies:
       '@shipfox/client-api':


### PR DESCRIPTION
Adds reusable, source-keyed icon building blocks so any surface can render an integration or trigger icon without re-implementing the catalog lookup and fallback.

## Why

Rendering an integration's icon meant re-implementing `PROVIDER_CATALOG[source]?.iconName ?? fallback` at each call site (the integration gallery did this twice). Trigger surfaces — workflow run rows via `trigger_source`, and trigger events via `source` — had no easy way to show an icon for what fired them.

## What

- **`@shipfox/client-integrations`** exposes `getIntegrationIcon(source)` and `<IntegrationIcon source />`, resolving an integration source (a connection `provider`, a run `trigger_source`, or a trigger event `source`) against the central `PROVIDER_CATALOG` with a neutral `componentLine` fallback. The gallery now renders `<IntegrationIcon>` instead of an inline lookup — no behavior change.
- **New `@shipfox/client-triggers` package** adds `getTriggerSourceIcon(source)` and `<TriggerSourceIcon source />`, built on the integration resolver. It recognizes the system trigger sources `manual` (a person fired the run) and `cron` (a schedule), and delegates every other source to the integration catalog.

## Design decisions

- **The catalog stays the single source of truth.** Each integration keeps declaring its own `iconName` in `PROVIDER_CATALOG`; the resolver reads from it rather than duplicating a source→icon map into a lower layer.
- **`client-triggers` mirrors the backend domain** (`api/triggers`, `triggers-dto`) rather than hosting the trigger wrapper in `client-workflows`. Client component packages track backend domain boundaries, not whichever surface consumes them first. It takes a workspace dep on `client-integrations` (acyclic).
- The trigger source taxonomy (`manual` event `fire`, `cron` event `tick`, opaque integration providers) comes from `TriggerPayload` in `api/workflows` core.

## Scope

This PR only ships the building blocks. Adopting the icon on specific surfaces (run rows, trigger events) and adding new providers to the catalog are out of scope and land separately.

Closes ENG-510

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds source-keyed icon components for integrations and triggers, and adopts them in the integration gallery. Improves accessibility by hiding decorative icons and forwarding props on fallback glyphs, addressing ENG-510; also fixes `@shipfox/client-triggers` package metadata.

- **New Features**
  - `@shipfox/client-integrations`: adds `getIntegrationIcon(source)` and `<IntegrationIcon source />` using `PROVIDER_CATALOG` with `componentLine` fallback; gallery now renders `<IntegrationIcon>` (no visual change).
  - `@shipfox/client-triggers`: new package with `getTriggerSourceIcon(source)` and `<TriggerSourceIcon source />`; maps `manual`→`cursorLine`, `cron`→`timeLine`, others delegate to integration icons.

- **Bug Fixes**
  - Gallery icons are now `aria-hidden` when decorative to avoid duplicate announcements.
  - `@shipfox/react-ui`: forward props on `componentLine` and `componentFill` so `className`, sizing, and `aria-*` reach the `<svg>`, fixing neutral fallback rendering.
  - Corrected `@shipfox/client-triggers` repository URL to point at the `shipfox` repo for accurate npm metadata.

<sup>Written for commit b81a194a6feb1f26178be6d0863bce5f05f0d832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

