### PR TITLE
Capture run, job, and step durations

### DIFF
--- a/.changeset/workflow-run-job-durations.md
+++ b/.changeset/workflow-run-job-durations.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-runners-dto": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-workflows-dto": patch
+"@shipfox/api-workflows": patch
+"@shipfox/client-projects": patch
+---
+
+Track queue/run/finish timing for workflow runs and jobs. Adds nullable `started_at`/`finished_at` to workflow runs and `queued_at`/`started_at`/`finished_at` to jobs, exposed on the run and job DTOs. The runners module emits two new authoritative-timestamp events (`runners.job.queued`, `runners.job.started`) in the same transaction as the enqueue/claim; workflows projects them onto the job row with a first-write-wins `coalesce`, so the at-least-once outbox can redeliver out of order safely. Run `started_at`/`finished_at` and job `finished_at` are stamped in-module at the status transitions. All columns are nullable and eventually consistent, so consumers must treat a missing endpoint as "not yet known" and clamp any duration math.

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -4,12 +4,11 @@ import {expect, test} from './test.js';
 
 const ADDED_DATE_RE = /^Added /u;
 
-// The e2e API may only enable Debug. Stub the providers list so the multi-tile
-// grid renders deterministically and the screenshot guards the GitHub/Sentry
-// tiles regardless of provider config. Typed against the real response DTO so a
-// contract change fails `turbo type` — e2e packages depend on *-dto packages
-// for types only (the runtime schema would load the package's dist, which
-// self-references src and is not loadable under the test runner).
+// The e2e API may only enable Debug, so stub the providers list to keep the
+// multi-tile grid deterministic. Typed against the real response DTO so a
+// contract change fails `turbo type`; e2e packages depend on *-dto packages
+// for types only because the runtime schema would load package dist, which
+// self-references src under the test runner.
 const CATALOGUE_PROVIDERS: ListIntegrationProvidersResponseDto = {
   providers: [
     {provider: 'github', display_name: 'GitHub', capabilities: ['source_control']},
@@ -40,8 +39,6 @@ test('settings catalogue lists available providers with an empty installed state
   });
   await auth.loginAs(page, user);
 
-  // Register the providers stub before navigating: the gallery fires its
-  // queries on mount.
   await stubProviders(page);
 
   await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
@@ -79,9 +76,9 @@ test('settings catalogue shows a connected provider after Debug connect', async 
   await expect(installed.getByText('Debug', {exact: true})).toBeVisible();
   await expect(installed.getByText('Connected')).toBeVisible();
 
-  // `Added <date>` is server-generated, so it would drift the Argos baseline
-  // every day. Pin it to a fixed string before the snapshot, keeping the row
-  // anchored to the real Debug connection otherwise.
+  // `Added <date>` is server-generated, so it would drift the Argos baseline.
+  // Pin only that text and keep the rest of the row anchored to the real Debug
+  // connection.
   await installed.getByText(ADDED_DATE_RE).evaluate((element) => {
     element.textContent = 'Added Jan 15, 2026';
   });

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -233,8 +233,9 @@ test('routes a returning user with workspaces straight to /workspaces/$wid', asy
   const wsA = await workspaces.create({userId: user.user.id, name: 'Alpha Workspace'});
   await auth.loginAs(page, user);
 
-  // Record every URL the page transits through. Asserting only the final URL
-  // would let a brief flash through onboarding slip past Playwright auto-wait.
+  // Capture transient redirects while auth refresh resolves memberships;
+  // asserting only the final URL would let a brief setup-page flash slip past
+  // Playwright auto-wait.
   const urlsSeen: string[] = [];
   page.on('framenavigated', (frame) => {
     if (frame === page.mainFrame()) {

--- a/libs/api/runners-dto/src/events.ts
+++ b/libs/api/runners-dto/src/events.ts
@@ -1,10 +1,33 @@
 export const RUNNER_JOB_LEASE_EXPIRED = 'runners.job.lease_expired' as const;
+export const RUNNER_JOB_QUEUED = 'runners.job.queued' as const;
+export const RUNNER_JOB_CLAIMED = 'runners.job.claimed' as const;
 
 export interface RunnerJobLeaseExpiredEvent {
   jobId: string;
   runId: string;
 }
 
+export interface RunnerJobQueuedEvent {
+  jobId: string;
+  runId: string;
+  /**
+   * ISO 8601 timestamp from `runners_pending_jobs.created_at`, not the outbox drain time.
+   */
+  queuedAt: string;
+}
+
+export interface RunnerJobClaimedEvent {
+  jobId: string;
+  runId: string;
+  /**
+   * ISO 8601 timestamp of the runner's claim (`runners_running_jobs.started_at`), not the
+   * outbox drain time.
+   */
+  claimedAt: string;
+}
+
 export interface RunnersEventMap {
   [RUNNER_JOB_LEASE_EXPIRED]: RunnerJobLeaseExpiredEvent;
+  [RUNNER_JOB_QUEUED]: RunnerJobQueuedEvent;
+  [RUNNER_JOB_CLAIMED]: RunnerJobClaimedEvent;
 }

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -15,7 +15,11 @@ export {
   runnerTokenDtoSchema,
 } from '#schemas/index.js';
 export {
+  RUNNER_JOB_CLAIMED,
   RUNNER_JOB_LEASE_EXPIRED,
+  RUNNER_JOB_QUEUED,
+  type RunnerJobClaimedEvent,
   type RunnerJobLeaseExpiredEvent,
+  type RunnerJobQueuedEvent,
   type RunnersEventMap,
 } from './events.js';

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -2,13 +2,13 @@ import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 export {closeDb, db, schema} from './db.js';
-export type {ClaimedJob, ScheduleJobParams} from './jobs.js';
+export type {ClaimedJob, EnqueueJobParams} from './jobs.js';
 export {
   claimPendingJob,
+  enqueueJob,
   expireStuckJobs,
   recordHeartbeat,
   releaseJob,
-  scheduleJob,
 } from './jobs.js';
 export type {CreateRunnerTokenParams} from './runner-tokens.js';
 export {

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -1,22 +1,26 @@
 import {verifyJobLeaseToken} from '@shipfox/api-auth';
-import {RUNNER_JOB_LEASE_EXPIRED} from '@shipfox/api-runners-dto';
+import {
+  RUNNER_JOB_CLAIMED,
+  RUNNER_JOB_LEASE_EXPIRED,
+  RUNNER_JOB_QUEUED,
+} from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
 import {claimJob, detectAndExpireStuckJobs} from '#core/jobs.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {db} from './db.js';
 import {
   claimPendingJob,
+  enqueueJob,
   expireStuckJobs,
   recordHeartbeat,
   releaseJob,
   requestJobCancellation,
-  scheduleJob,
 } from './jobs.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
 import {runningJobs} from './schema/running-jobs.js';
 
-describe('scheduleJob', () => {
+describe('enqueueJob', () => {
   beforeEach(async () => {
     await db().execute(
       sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_outbox CASCADE`,
@@ -29,7 +33,7 @@ describe('scheduleJob', () => {
     const workspaceId = crypto.randomUUID();
     const projectId = crypto.randomUUID();
 
-    await scheduleJob({workspaceId, jobId, runId, projectId});
+    await enqueueJob({workspaceId, jobId, runId, projectId});
 
     const rows = await db().select().from(pendingJobs);
     expect(rows).toHaveLength(1);
@@ -49,11 +53,47 @@ describe('scheduleJob', () => {
       jobId,
     };
 
-    await scheduleJob(params);
-    await expect(scheduleJob(params)).resolves.toBeUndefined();
+    await enqueueJob(params);
+    await expect(enqueueJob(params)).resolves.toBeUndefined();
 
     const rows = await db().select().from(pendingJobs);
     expect(rows).toHaveLength(1);
+  });
+
+  it('emits runners.job.queued carrying the pending row created_at', async () => {
+    const jobId = crypto.randomUUID();
+    const runId = crypto.randomUUID();
+
+    await enqueueJob({
+      workspaceId: crypto.randomUUID(),
+      jobId,
+      runId,
+      projectId: crypto.randomUUID(),
+    });
+
+    const [pending] = await db().select().from(pendingJobs);
+    const outbox = await db().select().from(runnersOutbox);
+    expect(outbox).toHaveLength(1);
+    expect(outbox[0]?.eventType).toBe(RUNNER_JOB_QUEUED);
+    const payload = outbox[0]?.payload as {jobId: string; runId: string; queuedAt: string};
+    expect(payload.jobId).toBe(jobId);
+    expect(payload.runId).toBe(runId);
+    expect(new Date(payload.queuedAt).getTime()).toBe(pending?.createdAt.getTime());
+  });
+
+  it('does not double-emit queued when the same jobId is re-enqueued (idempotency regression)', async () => {
+    const params = {
+      workspaceId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      jobId: crypto.randomUUID(),
+    };
+
+    await enqueueJob(params);
+    await enqueueJob(params);
+
+    expect(await db().select().from(pendingJobs)).toHaveLength(1);
+    expect(await db().select().from(runnersOutbox)).toHaveLength(1);
   });
 });
 
@@ -63,11 +103,61 @@ describe('claimPendingJob', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const runnerToken = await runnerTokenFactory.create({workspaceId});
     runnerTokenId = runnerToken.id;
+  });
+
+  it('emits runners.job.claimed carrying the claim instant on a real claim', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+
+    const [running] = await db()
+      .select()
+      .from(runningJobs)
+      .where(eq(runningJobs.jobId, claimed?.jobId as string));
+    const outbox = await db()
+      .select()
+      .from(runnersOutbox)
+      .where(eq(runnersOutbox.eventType, RUNNER_JOB_CLAIMED));
+    expect(outbox).toHaveLength(1);
+    const payload = outbox[0]?.payload as {jobId: string; runId: string; claimedAt: string};
+    expect(payload.jobId).toBe(created.jobId);
+    expect(payload.runId).toBe(created.runId);
+    expect(new Date(payload.claimedAt).getTime()).toBe(running?.startedAt.getTime());
+  });
+
+  it('emits no claimed event when there is nothing to claim', async () => {
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+
+    expect(claimed).toBeNull();
+    expect(
+      await db()
+        .select()
+        .from(runnersOutbox)
+        .where(eq(runnersOutbox.eventType, RUNNER_JOB_CLAIMED)),
+    ).toHaveLength(0);
+  });
+
+  it('emits no claimed event when dropping an orphan pending row', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+    await claimPendingJob({workspaceId, runnerTokenId});
+    await db().insert(pendingJobs).values({
+      workspaceId,
+      jobId: created.jobId,
+      runId: created.runId,
+      projectId: created.projectId,
+    });
+    // Clear the initial claim's events so this assertion only covers the orphan claim.
+    await db().delete(runnersOutbox);
+
+    const second = await claimPendingJob({workspaceId, runnerTokenId});
+
+    expect(second).toBeNull();
+    expect(await db().select().from(runnersOutbox)).toHaveLength(0);
   });
 
   it('returns the job ids when a job is available', async () => {
@@ -227,11 +317,12 @@ describe('releaseJob', () => {
   it('deletes the running row and writes no outbox event', async () => {
     await pendingJobFactory.create({workspaceId});
     const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const before = await db().select().from(runnersOutbox);
 
     await releaseJob({jobId: claimed?.jobId as string});
 
     expect(await db().select().from(runningJobs)).toHaveLength(0);
-    expect(await db().select().from(runnersOutbox)).toHaveLength(0);
+    expect(await db().select().from(runnersOutbox)).toHaveLength(before.length);
   });
 
   it('is a no-op when the job is absent (idempotent)', async () => {
@@ -426,6 +517,8 @@ describe('detectAndExpireStuckJobs', () => {
   async function outboxForJobs(jobIds: string[]) {
     const all = await db().select().from(runnersOutbox);
     return all.filter((row) => {
+      // The same job ids can also have queued and claimed events from setup.
+      if (row.eventType !== RUNNER_JOB_LEASE_EXPIRED) return false;
       const payload = row.payload as {jobId?: string};
       return payload.jobId !== undefined && jobIds.includes(payload.jobId);
     });

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -1,5 +1,10 @@
-import {RUNNER_JOB_LEASE_EXPIRED, type RunnersEventMap} from '@shipfox/api-runners-dto';
-import {writeOutboxEvents} from '@shipfox/node-outbox';
+import {
+  RUNNER_JOB_CLAIMED,
+  RUNNER_JOB_LEASE_EXPIRED,
+  RUNNER_JOB_QUEUED,
+  type RunnersEventMap,
+} from '@shipfox/api-runners-dto';
+import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
 import {and, asc, eq, inArray, lt, sql} from 'drizzle-orm';
 import {RunningJobNotFoundError} from '#core/errors.js';
 import {db} from './db.js';
@@ -7,7 +12,7 @@ import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
 import {runningJobs} from './schema/running-jobs.js';
 
-export interface ScheduleJobParams {
+export interface EnqueueJobParams {
   workspaceId: string;
   jobId: string;
   runId: string;
@@ -21,16 +26,33 @@ export interface ScheduleJobParams {
 // past the claim: once the job has moved to `runners_running_jobs`, a retry
 // can reinsert an orphan pending row, which a later `claimPendingJob` drops
 // via the running-job unique constraint (onConflictDoNothing) instead of failing.
-export async function scheduleJob(params: ScheduleJobParams): Promise<void> {
-  await db()
-    .insert(pendingJobs)
-    .values({
-      workspaceId: params.workspaceId,
-      jobId: params.jobId,
-      runId: params.runId,
-      projectId: params.projectId,
-    })
-    .onConflictDoNothing({target: pendingJobs.jobId});
+export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
+  await db().transaction(async (tx) => {
+    const [inserted] = await tx
+      .insert(pendingJobs)
+      .values({
+        workspaceId: params.workspaceId,
+        jobId: params.jobId,
+        runId: params.runId,
+        projectId: params.projectId,
+      })
+      .onConflictDoNothing({target: pendingJobs.jobId})
+      .returning({createdAt: pendingJobs.createdAt});
+
+    // A retry that hits the conflict inserts nothing: the first enqueue already
+    // emitted the queued event (durably, in the outbox), so re-emitting would
+    // only add a redundant row the subscriber coalesces away. Skip it.
+    if (!inserted) return;
+
+    await writeOutboxEvent<RunnersEventMap>(tx, runnersOutbox, {
+      type: RUNNER_JOB_QUEUED,
+      payload: {
+        jobId: params.jobId,
+        runId: params.runId,
+        queuedAt: inserted.createdAt.toISOString(),
+      },
+    });
+  });
 }
 
 export interface ClaimedJob {
@@ -74,9 +96,22 @@ export async function claimPendingJob(params: {
         runnerTokenId: params.runnerTokenId,
       })
       .onConflictDoNothing({target: runningJobs.jobId})
-      .returning({jobId: runningJobs.jobId});
+      .returning({claimedAt: runningJobs.startedAt});
 
-    if (inserted.length === 0) return null;
+    const claimed = inserted[0];
+    if (!claimed) return null;
+
+    // The running-row insert is the runner claiming the job. Emit in the same tx; the
+    // payload carries the row's own claim instant so a consumer records the true time,
+    // not the outbox drain time.
+    await writeOutboxEvent<RunnersEventMap>(tx, runnersOutbox, {
+      type: RUNNER_JOB_CLAIMED,
+      payload: {
+        jobId: row.jobId,
+        runId: row.runId,
+        claimedAt: claimed.claimedAt.toISOString(),
+      },
+    });
 
     return {
       jobId: row.jobId,

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -7,7 +7,7 @@ import {createRunnerTokenAuthMethod, onWorkflowsJobTimedOut, routes} from '#pres
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
 import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
-export {releaseJob, type ScheduleJobParams, scheduleJob} from '#db/index.js';
+export {type EnqueueJobParams, enqueueJob, releaseJob} from '#db/index.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');

--- a/libs/api/runners/test/factories/pending-job.ts
+++ b/libs/api/runners/test/factories/pending-job.ts
@@ -1,5 +1,5 @@
 import {Factory} from 'fishery';
-import {scheduleJob} from '#db/jobs.js';
+import {enqueueJob} from '#db/jobs.js';
 
 interface PendingJobAttrs {
   workspaceId: string;
@@ -15,7 +15,7 @@ export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) =>
   const projectId = crypto.randomUUID();
 
   onCreate(async (attrs) => {
-    await scheduleJob({
+    await enqueueJob({
       workspaceId: attrs.workspaceId,
       jobId: attrs.jobId,
       runId: attrs.runId,

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -11,11 +11,10 @@ export const WORKFLOWS_JOB_TERMINATED = 'workflows.job.terminated' as const;
 // on-job-steps-settled subscriber can raise the Temporal JOB_FINISHED_SIGNAL. Fires
 // before the job row is terminal; observe WORKFLOWS_JOB_TERMINATED for the outcome.
 export const WORKFLOWS_JOB_STEPS_SETTLED = 'workflows.job.steps_settled' as const;
-// Written in the same transaction as a durable gate restart (the failed attempt
-// + the rewind of the projection from `restart_from`). The pull-based runner
-// re-dispatches the rewound step on its next pull, so this audit event is not
-// required to advance execution. Consumers must be idempotent: the outbox is
-// at-least-once.
+// Written in the same transaction as a durable gate restart: the failed attempt
+// plus the rewind of the projection from `restart_from`. The pull-based runner
+// re-dispatches the rewound step on its next pull, so consumers must treat this
+// at-least-once outbox event as idempotent audit data.
 export const WORKFLOWS_STEP_RESTART_ENQUEUED = 'workflows.step.restart_enqueued' as const;
 
 export interface WorkflowsWorkflowRunCreatedEvent {

--- a/libs/api/workflows-dto/src/schemas/job.ts
+++ b/libs/api/workflows-dto/src/schemas/job.ts
@@ -9,6 +9,12 @@ export const jobDtoSchema = z.object({
   position: z.number(),
   created_at: z.string(),
   updated_at: z.string(),
+  // queued_at/started_at are eventually consistent: null until the runner queue/claim
+  // events project onto the job row. queue time = started_at - queued_at, run time =
+  // finished_at - started_at.
+  queued_at: z.string().nullable(),
+  started_at: z.string().nullable(),
+  finished_at: z.string().nullable(),
 });
 
 export type JobDto = z.infer<typeof jobDtoSchema>;

--- a/libs/api/workflows-dto/src/schemas/run.ts
+++ b/libs/api/workflows-dto/src/schemas/run.ts
@@ -64,6 +64,8 @@ export const runDtoSchema = z.object({
   inputs: z.record(z.string(), z.unknown()).nullable(),
   created_at: z.string(),
   updated_at: z.string(),
+  started_at: z.string().nullable(),
+  finished_at: z.string().nullable(),
 });
 
 export type RunDto = z.infer<typeof runDtoSchema>;

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -12,7 +12,10 @@ CREATE TABLE "workflows_jobs" (
 	"version" integer DEFAULT 1 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"timed_out_at" timestamp with time zone
+	"timed_out_at" timestamp with time zone,
+	"queued_at" timestamp with time zone,
+	"started_at" timestamp with time zone,
+	"finished_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "workflows_outbox" (
@@ -52,7 +55,9 @@ CREATE TABLE "workflows_workflow_runs" (
 	"trigger_idempotency_key" text,
 	"version" integer DEFAULT 1 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"started_at" timestamp with time zone,
+	"finished_at" timestamp with time zone
 );
 --> statement-breakpoint
 ALTER TABLE "workflows_jobs" ADD CONSTRAINT "workflows_jobs_run_id_workflows_workflow_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."workflows_workflow_runs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -79,6 +79,24 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
@@ -387,6 +405,18 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {

--- a/libs/api/workflows/drizzle/meta/0001_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0001_snapshot.json
@@ -79,6 +79,24 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
@@ -539,6 +557,18 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {

--- a/libs/api/workflows/src/core/entities/job.ts
+++ b/libs/api/workflows/src/core/entities/job.ts
@@ -20,6 +20,9 @@ export interface Job {
   createdAt: Date;
   updatedAt: Date;
   timedOutAt: Date | null;
+  queuedAt: Date | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
 }
 
 export type TerminalJobStatus = Extract<JobStatus, 'succeeded' | 'failed' | 'cancelled'>;

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -54,4 +54,6 @@ export interface WorkflowRun {
   version: number;
   createdAt: Date;
   updatedAt: Date;
+  startedAt: Date | null;
+  finishedAt: Date | null;
 }

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -49,9 +49,9 @@ export function readStepGate(config: Record<string, unknown>): StepGate | undefi
 //
 // NOTE: callers run this inside the FOR UPDATE transaction, so the eval holds the
 // job's step-row locks. The context is a single scalar (`exit_code`), so this is
-// cheap — but do not widen the context (or add CEL call sites) inside the lock
-// without an eval budget. `language` is assumed CEL (the only language the
-// materializer writes); the evaluator reads only `.source`.
+// cheap; do not widen the context or add CEL call sites inside the lock without
+// an eval budget. `language` is assumed CEL because the materializer writes only
+// that language, and the evaluator reads only `.source`.
 export function evaluateGate(gate: StepGate | undefined, result: StepResult): GateOutcome {
   if (!gate?.successIf) return {kind: 'no-gate'};
   const source = gate.successIf.source;

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -29,6 +29,8 @@ export {
   getWorkflowRunById,
   listWorkflowRuns,
   listWorkflowRunsByProject,
+  recordJobQueuedAt,
+  recordJobStartedAt,
   resolveJobAfterLeaseExpiry,
   updateJobStatus,
   updateWorkflowRunStatus,

--- a/libs/api/workflows/src/db/schema/jobs.ts
+++ b/libs/api/workflows/src/db/schema/jobs.ts
@@ -31,6 +31,12 @@ export const jobs = pgTable(
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
     timedOutAt: timestamp('timed_out_at', {withTimezone: true}),
+    // Lifecycle timing. queued_at/started_at are projected from the runners module
+    // (RUNNER_JOB_QUEUED/STARTED) and so lag the row until the outbox drains;
+    // finished_at is stamped in-module at the terminal transition.
+    queuedAt: timestamp('queued_at', {withTimezone: true}),
+    startedAt: timestamp('started_at', {withTimezone: true}),
+    finishedAt: timestamp('finished_at', {withTimezone: true}),
   },
   (table) => [index('workflows_jobs_run_id_idx').on(table.runId)],
 );
@@ -51,5 +57,8 @@ export function toJob(row: JobDb): Job {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     timedOutAt: row.timedOutAt,
+    queuedAt: row.queuedAt,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
   };
 }

--- a/libs/api/workflows/src/db/schema/steps.ts
+++ b/libs/api/workflows/src/db/schema/steps.ts
@@ -27,8 +27,8 @@ export const steps = pgTable(
     error: jsonb('error').$type<Record<string, unknown>>(),
     position: integer('position').notNull(),
     version: integer('version').notNull().default(1),
-    // Execution-attempt identity (which attempt the projection reflects), NOT the
-    // optimistic `version` counter. Starts at 1; bumped only on rewind.
+    // Execution-attempt identity, distinct from the optimistic `version` counter.
+    // Starts at 1 and is bumped only on durable rewind.
     currentAttempt: integer('current_attempt').notNull().default(1),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),

--- a/libs/api/workflows/src/db/schema/workflow-runs.ts
+++ b/libs/api/workflows/src/db/schema/workflow-runs.ts
@@ -38,6 +38,9 @@ export const workflowRuns = pgTable(
     version: integer('version').notNull().default(1),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+    // Execution window, stamped in-module at the run's status transitions.
+    startedAt: timestamp('started_at', {withTimezone: true}),
+    finishedAt: timestamp('finished_at', {withTimezone: true}),
   },
   (table) => [
     uniqueIndex('workflows_wr_trigger_idempotency_key_unique').on(table.triggerIdempotencyKey),
@@ -82,5 +85,7 @@ export function toWorkflowRun(row: WorkflowRunDb): WorkflowRun {
     version: row.version,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    startedAt: row.startedAt,
+    finishedAt: row.finishedAt,
   };
 }

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -758,6 +758,115 @@ describe('workflow run queries', () => {
     });
   });
 
+  describe('run and job lifecycle timing', () => {
+    test('run: stamps started_at on running and preserves it through the terminal transition', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+
+      const running = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'running',
+        expectedVersion: 1,
+      });
+
+      expect(running.startedAt).not.toBeNull();
+      expect(running.finishedAt).toBeNull();
+
+      const finished = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'succeeded',
+        expectedVersion: 2,
+      });
+
+      expect(finished.finishedAt).not.toBeNull();
+      expect(finished.startedAt?.getTime()).toBe(running.startedAt?.getTime());
+    });
+
+    test('run: cancelled straight from pending has no start but a finish', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+
+      const cancelled = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'cancelled',
+        expectedVersion: 1,
+      });
+
+      expect(cancelled.startedAt).toBeNull();
+      expect(cancelled.finishedAt).not.toBeNull();
+    });
+
+    test('job: stamps finished_at on a terminal transition', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const job = (await getJobsByRunId(run.id))[0];
+
+      const finished = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'succeeded',
+        expectedVersion: 1,
+      });
+
+      expect(finished.finishedAt).not.toBeNull();
+    });
+
+    test('job: leaves finished_at null on a non-terminal transition', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const job = (await getJobsByRunId(run.id))[0];
+
+      const running = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'running',
+        expectedVersion: 1,
+      });
+
+      expect(running.finishedAt).toBeNull();
+    });
+
+    test('job: failJobAsTimedOut stamps finished_at alongside timed_out_at', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const job = (await getJobsByRunId(run.id))[0];
+
+      const updated = await failJobAsTimedOut({
+        jobId: job?.id as string,
+        runId: run.id,
+        expectedVersion: 1,
+      });
+
+      expect(updated.finishedAt).not.toBeNull();
+      expect(updated.timedOutAt).not.toBeNull();
+    });
+
+    test('run: re-entering running keeps the first started_at (coalesce, not a fresh clock)', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const firstRunning = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'running',
+        expectedVersion: 1,
+      });
+
+      const secondRunning = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'running',
+        expectedVersion: 2,
+      });
+
+      expect(secondRunning.startedAt?.getTime()).toBe(firstRunning.startedAt?.getTime());
+    });
+
+    test('job: cancelled straight from pending has a finish but no start or queue time', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const job = (await getJobsByRunId(run.id))[0];
+
+      const cancelled = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'cancelled',
+        expectedVersion: 1,
+      });
+
+      expect(cancelled.finishedAt).not.toBeNull();
+      expect(cancelled.startedAt).toBeNull();
+      expect(cancelled.queuedAt).toBeNull();
+    });
+  });
+
   describe('job terminal event (WORKFLOWS_JOB_TERMINATED)', () => {
     async function seedPendingJob() {
       const run = await createTestRun({workspaceId, projectId, definitionId});
@@ -921,8 +1030,8 @@ describe('workflow run queries', () => {
       const runJobs = await getJobsByRunId(run.id);
       const job = runJobs[0];
 
-      // Defensive: simulate a separate writer that bumped version + status
-      // without setting timed_out_at.
+      // Simulate a separate writer that bumped version and status without
+      // setting timed_out_at.
       await db()
         .update(jobs)
         .set({status: 'failed', version: 5})
@@ -960,7 +1069,6 @@ describe('workflow run queries', () => {
       const jobId = runJobs[0]?.id ?? '';
       await bulkUpdateStepStatuses({jobId, status: 'succeeded'});
 
-      // 3 user steps + the synthetic setup step.
       const jobSteps = await getStepsByJobId(jobId);
       expect(jobSteps).toHaveLength(4);
       for (const step of jobSteps) {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -353,6 +353,14 @@ export async function updateWorkflowRunStatus(
         status: params.status,
         version: sql`${workflowRuns.version} + 1`,
         updatedAt: new Date(),
+        // Preserve the original start time if a retried transition re-enters `running`.
+        // Both endpoints use the DB clock (`now()`): the runner module shares this
+        // Postgres instance, so every timing column sits on one clock and a duration is
+        // never subtracted across hosts.
+        ...(params.status === 'running'
+          ? {startedAt: sql`coalesce(${workflowRuns.startedAt}, now())`}
+          : {}),
+        ...(isWorkflowRunTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
       })
       .where(
         and(eq(workflowRuns.id, params.runId), eq(workflowRuns.version, params.expectedVersion)),
@@ -411,6 +419,8 @@ async function updateJobStatusAtVersion(
       version: sql`${jobs.version} + 1`,
       updatedAt: new Date(),
       ...(params.markTimedOut ? {timedOutAt: new Date()} : {}),
+      // DB clock so finished_at shares the runner-sourced queued_at/started_at clock.
+      ...(isJobTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
     })
     .where(and(eq(jobs.id, params.jobId), eq(jobs.version, params.expectedVersion)))
     .returning();
@@ -459,6 +469,24 @@ export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Jo
       `Optimistic lock failure: job ${params.jobId} version ${params.expectedVersion}`,
     );
   });
+}
+
+// Project the runner-owned queue/claim moments onto the durable job row. `coalesce`
+// makes redelivery and out-of-order delivery first-write-wins, so the at-least-once
+// outbox can replay these freely. Eventually consistent by design: the column stays
+// null until the runner event drains.
+export async function recordJobQueuedAt(params: {jobId: string; queuedAt: Date}): Promise<void> {
+  await db()
+    .update(jobs)
+    .set({queuedAt: sql`coalesce(${jobs.queuedAt}, ${params.queuedAt})`})
+    .where(eq(jobs.id, params.jobId));
+}
+
+export async function recordJobStartedAt(params: {jobId: string; startedAt: Date}): Promise<void> {
+  await db()
+    .update(jobs)
+    .set({startedAt: sql`coalesce(${jobs.startedAt}, ${params.startedAt})`})
+    .where(eq(jobs.id, params.jobId));
 }
 
 export interface FailJobAsTimedOutParams {

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -1,6 +1,11 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {RUNNER_JOB_LEASE_EXPIRED, type RunnersEventMap} from '@shipfox/api-runners-dto';
+import {
+  RUNNER_JOB_CLAIMED,
+  RUNNER_JOB_LEASE_EXPIRED,
+  RUNNER_JOB_QUEUED,
+  type RunnersEventMap,
+} from '@shipfox/api-runners-dto';
 import {
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
@@ -11,7 +16,9 @@ import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
 import {
   onJobStepsSettled,
+  onRunnerJobClaimed,
   onRunnerJobLeaseExpired,
+  onRunnerJobQueued,
   onWorkflowRunCreated,
   routes,
 } from '#presentation/index.js';
@@ -44,6 +51,8 @@ export const workflowsModule: ShipfoxModule = {
     subscriber(WORKFLOWS_WORKFLOW_RUN_CREATED, onWorkflowRunCreated),
     subscriber(WORKFLOWS_JOB_STEPS_SETTLED, onJobStepsSettled),
     subscriber(RUNNER_JOB_LEASE_EXPIRED, onRunnerJobLeaseExpired),
+    subscriber(RUNNER_JOB_QUEUED, onRunnerJobQueued),
+    subscriber(RUNNER_JOB_CLAIMED, onRunnerJobClaimed),
   ],
   workers: [
     {

--- a/libs/api/workflows/src/presentation/dto/job.ts
+++ b/libs/api/workflows/src/presentation/dto/job.ts
@@ -11,5 +11,8 @@ export function toJobDto(job: Job): JobDto {
     position: job.position,
     created_at: job.createdAt.toISOString(),
     updated_at: job.updatedAt.toISOString(),
+    queued_at: job.queuedAt?.toISOString() ?? null,
+    started_at: job.startedAt?.toISOString() ?? null,
+    finished_at: job.finishedAt?.toISOString() ?? null,
   };
 }

--- a/libs/api/workflows/src/presentation/dto/workflow-run.ts
+++ b/libs/api/workflows/src/presentation/dto/workflow-run.ts
@@ -14,5 +14,7 @@ export function toRunDto(run: WorkflowRun): RunDto {
     inputs: run.inputs,
     created_at: run.createdAt.toISOString(),
     updated_at: run.updatedAt.toISOString(),
+    started_at: run.startedAt?.toISOString() ?? null,
+    finished_at: run.finishedAt?.toISOString() ?? null,
   };
 }

--- a/libs/api/workflows/src/presentation/index.ts
+++ b/libs/api/workflows/src/presentation/index.ts
@@ -1,6 +1,8 @@
 export {workflowRoutes as routes} from './routes/index.js';
 export {
   onJobStepsSettled,
+  onRunnerJobClaimed,
   onRunnerJobLeaseExpired,
+  onRunnerJobQueued,
   onWorkflowRunCreated,
 } from './subscribers/index.js';

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -104,6 +104,9 @@ describe('GET /api/workflows/runs/:id', () => {
     expect(body.jobs[0].steps[0].name).toBe('Set up job');
     expect(body.jobs[0].steps[1].name).toBe('Install');
     expect(body.jobs[0].steps[2].name).toBeNull();
+    // Timing fields flow through the read model (null on a fresh, unstamped run).
+    expect(body).toMatchObject({started_at: null, finished_at: null});
+    expect(body.jobs[0]).toMatchObject({queued_at: null, started_at: null, finished_at: null});
   });
 
   test('exposes per-step error and cancelled status after a failed per-step report', async () => {

--- a/libs/api/workflows/src/presentation/routes/list-runs.test.ts
+++ b/libs/api/workflows/src/presentation/routes/list-runs.test.ts
@@ -91,6 +91,8 @@ describe('GET /api/workflows/runs', () => {
     expect(body.runs[0].project_id).toBe(projectId);
     expect(body.runs[0].name).toBeDefined();
     expect(body.runs[0].trigger_source).toBe('manual');
+    // The runs list carries run-level timing (null until the run starts).
+    expect(body.runs[0]).toMatchObject({started_at: null, finished_at: null});
     expect(body.next_cursor).toBeNull();
     expect(body.filtered_total_count).toBe(2);
   });

--- a/libs/api/workflows/src/presentation/subscribers/index.ts
+++ b/libs/api/workflows/src/presentation/subscribers/index.ts
@@ -1,3 +1,5 @@
 export {onJobStepsSettled} from './on-job-steps-settled.js';
+export {onRunnerJobClaimed} from './on-runner-job-claimed.js';
 export {onRunnerJobLeaseExpired} from './on-runner-job-lease-expired.js';
+export {onRunnerJobQueued} from './on-runner-job-queued.js';
 export {onWorkflowRunCreated} from './on-workflow-run-created.js';

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.test.ts
@@ -1,0 +1,41 @@
+import {getJobsByRunId} from '#db/index.js';
+import {workflowRunFactory} from '#test/index.js';
+import {onRunnerJobClaimed} from './on-runner-job-claimed.js';
+
+describe('onRunnerJobClaimed', () => {
+  it('stamps started_at on the job from the claim event payload', async () => {
+    const run = await workflowRunFactory.create();
+    const job = (await getJobsByRunId(run.id))[0];
+    const claimedAt = new Date('2026-06-22T10:05:00.000Z');
+
+    await onRunnerJobClaimed({
+      jobId: job?.id as string,
+      runId: run.id,
+      claimedAt: claimedAt.toISOString(),
+    });
+
+    const after = (await getJobsByRunId(run.id))[0];
+    expect(after?.startedAt?.getTime()).toBe(claimedAt.getTime());
+  });
+
+  it('is idempotent: a redelivered event keeps the first started_at (coalesce)', async () => {
+    const run = await workflowRunFactory.create();
+    const job = (await getJobsByRunId(run.id))[0];
+    const first = new Date('2026-06-22T10:05:00.000Z');
+    const second = new Date('2026-06-22T10:06:00.000Z');
+
+    await onRunnerJobClaimed({
+      jobId: job?.id as string,
+      runId: run.id,
+      claimedAt: first.toISOString(),
+    });
+    await onRunnerJobClaimed({
+      jobId: job?.id as string,
+      runId: run.id,
+      claimedAt: second.toISOString(),
+    });
+
+    const after = (await getJobsByRunId(run.id))[0];
+    expect(after?.startedAt?.getTime()).toBe(first.getTime());
+  });
+});

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-claimed.ts
@@ -1,0 +1,15 @@
+import type {RunnerJobClaimedEvent} from '@shipfox/api-runners-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {recordJobStartedAt} from '#db/index.js';
+
+// Anticorruption layer: the runner reports a `claimed` fact in its own lease-broker
+// language; the run lifecycle treats the claim as the job's start, so we project it onto
+// `started_at`. Use the runner-owned claim timestamp, not subscriber time; the DB
+// projection is first-write-wins so outbox replay cannot move the run boundary.
+export async function onRunnerJobClaimed(payload: RunnerJobClaimedEvent): Promise<void> {
+  logger().debug(
+    {jobId: payload.jobId, runId: payload.runId},
+    'Recording job started_at from claim',
+  );
+  await recordJobStartedAt({jobId: payload.jobId, startedAt: new Date(payload.claimedAt)});
+}

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-queued.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-queued.test.ts
@@ -1,0 +1,41 @@
+import {getJobsByRunId} from '#db/index.js';
+import {workflowRunFactory} from '#test/index.js';
+import {onRunnerJobQueued} from './on-runner-job-queued.js';
+
+describe('onRunnerJobQueued', () => {
+  it('stamps queued_at on the job from the event payload', async () => {
+    const run = await workflowRunFactory.create();
+    const job = (await getJobsByRunId(run.id))[0];
+    const queuedAt = new Date('2026-06-22T10:00:00.000Z');
+
+    await onRunnerJobQueued({
+      jobId: job?.id as string,
+      runId: run.id,
+      queuedAt: queuedAt.toISOString(),
+    });
+
+    const after = (await getJobsByRunId(run.id))[0];
+    expect(after?.queuedAt?.getTime()).toBe(queuedAt.getTime());
+  });
+
+  it('is idempotent: a redelivered event keeps the first queued_at (coalesce)', async () => {
+    const run = await workflowRunFactory.create();
+    const job = (await getJobsByRunId(run.id))[0];
+    const first = new Date('2026-06-22T10:00:00.000Z');
+    const second = new Date('2026-06-22T11:00:00.000Z');
+
+    await onRunnerJobQueued({
+      jobId: job?.id as string,
+      runId: run.id,
+      queuedAt: first.toISOString(),
+    });
+    await onRunnerJobQueued({
+      jobId: job?.id as string,
+      runId: run.id,
+      queuedAt: second.toISOString(),
+    });
+
+    const after = (await getJobsByRunId(run.id))[0];
+    expect(after?.queuedAt?.getTime()).toBe(first.getTime());
+  });
+});

--- a/libs/api/workflows/src/presentation/subscribers/on-runner-job-queued.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-runner-job-queued.ts
@@ -1,0 +1,12 @@
+import type {RunnerJobQueuedEvent} from '@shipfox/api-runners-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {recordJobQueuedAt} from '#db/index.js';
+
+// Anticorruption layer for the runner's `queued` fact. Here the two contexts happen to
+// share the word, so this is an identity mapping (unlike claimed → started_at). Use the
+// runner-owned queue timestamp, not subscriber time; the DB projection is first-write-wins
+// so outbox replay cannot move the queue boundary.
+export async function onRunnerJobQueued(payload: RunnerJobQueuedEvent): Promise<void> {
+  logger().debug({jobId: payload.jobId, runId: payload.runId}, 'Recording job queued_at');
+  await recordJobQueuedAt({jobId: payload.jobId, queuedAt: new Date(payload.queuedAt)});
+}

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,4 +1,4 @@
-import {releaseJob, scheduleJob} from '@shipfox/api-runners';
+import {enqueueJob, releaseJob} from '@shipfox/api-runners';
 import {ApplicationFailure} from '@temporalio/common';
 import type {JobStatus} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus, RuntimeDagJob} from '#core/entities/runtime-dag.js';
@@ -142,7 +142,7 @@ export async function enqueueJobForRunner(params: {
   runId: string;
   projectId: string;
 }): Promise<void> {
-  await scheduleJob({
+  await enqueueJob({
     workspaceId: params.workspaceId,
     jobId: params.jobId,
     runId: params.runId,

--- a/libs/api/workflows/test/factories/job.ts
+++ b/libs/api/workflows/test/factories/job.ts
@@ -39,5 +39,8 @@ export const jobFactory = Factory.define<Job, JobTransientParams>(({transientPar
     createdAt: new Date(),
     updatedAt: new Date(),
     timedOutAt: null,
+    queuedAt: null,
+    startedAt: null,
+    finishedAt: null,
   };
 });

--- a/libs/api/workflows/test/factories/workflow-run.ts
+++ b/libs/api/workflows/test/factories/workflow-run.ts
@@ -40,5 +40,7 @@ export const workflowRunFactory = Factory.define<WorkflowRun>(({onCreate}) => {
     version: 1,
     createdAt: new Date(),
     updatedAt: new Date(),
+    startedAt: null,
+    finishedAt: null,
   };
 });

--- a/libs/client/app-shell/src/components/footer.test.tsx
+++ b/libs/client/app-shell/src/components/footer.test.tsx
@@ -15,6 +15,7 @@ describe('Footer', () => {
       'href',
       'mailto:support@shipfox.io',
     );
+    // A status badge would imply live status, but the footer only has static links.
     expect(screen.queryByText(OPERATIONAL_REGEX)).not.toBeInTheDocument();
   });
 });

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -78,9 +78,9 @@ export function IntegrationGallery({
   );
 
   const allConnections = connectionsQuery.data?.connections ?? [];
-  // The all-status `connections(wid,'all')` cache key must stay shared; passing
-  // capability into the hook would collide with the active-only `source_control`
-  // key used elsewhere.
+  // Filter in memory so the all-status cache key stays shared; passing capability
+  // into the hook would collide with the active-only `source_control` key used
+  // elsewhere.
   const connections = capability
     ? allConnections.filter((connection) => connection.capabilities.includes(capability))
     : allConnections;

--- a/libs/client/invitations/src/complete-acceptance.ts
+++ b/libs/client/invitations/src/complete-acceptance.ts
@@ -16,8 +16,8 @@ export async function completeInvitationAcceptance(params: {
   refreshAuth: () => Promise<unknown>;
   navigate: (opts: NavigateOptions) => Promise<void> | void;
 }): Promise<void> {
-  // Access tokens embed memberships at issue time. Refresh first so the next
-  // render's AuthGuard sees the new workspace.
+  // Access tokens embed memberships at issue time, so refresh before AuthGuard
+  // reads the accepted workspace.
   try {
     await params.refreshAuth();
   } catch {

--- a/libs/client/projects/src/hooks/api/workflow-runs.ts
+++ b/libs/client/projects/src/hooks/api/workflow-runs.ts
@@ -32,7 +32,8 @@ function normalizeFilters(filters: WorkflowRunFilters) {
  * Fire the manual trigger of a workflow definition.
  *
  * The server resolves the manual subscription by definition id (workflows
- * may declare at most one manual trigger). `inputs` are forwarded to the run.
+ * may declare at most one manual trigger). `inputs` are forwarded to the
+ * run when provided.
  */
 export async function fireManualWorkflow({
   definitionId,
@@ -106,6 +107,8 @@ function buildTempRun({
     inputs: null,
     created_at: createdAt,
     updated_at: createdAt,
+    started_at: null,
+    finished_at: null,
   };
 }
 

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -37,7 +37,8 @@ describe('ProjectsHubPage', () => {
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
 
-    // The top nav owns workspace identity; the page title stays in-content.
+    // The page-level "Projects" title belongs in content because the top nav owns
+    // workspace identity.
     expect(await screen.findByRole('heading', {name: 'Projects'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: NEW_PROJECT_REGEX})).toHaveAttribute(
       'href',

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-header.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-header.stories.tsx
@@ -17,6 +17,8 @@ function makeRun(overrides: Partial<RunResponseDto> = {}): RunResponseDto {
     inputs: null,
     created_at: new Date(Date.now() - 180_000).toISOString(),
     updated_at: new Date(Date.now() - 60_000).toISOString(),
+    started_at: null,
+    finished_at: null,
     ...overrides,
   };
 }

--- a/libs/client/workflows/src/components/workflow-runs-list/run-display.test.ts
+++ b/libs/client/workflows/src/components/workflow-runs-list/run-display.test.ts
@@ -14,6 +14,8 @@ function runDto(overrides: Partial<RunDto> = {}): RunDto {
     inputs: null,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
+    started_at: null,
+    finished_at: null,
     ...overrides,
   };
 }

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-view.test.tsx
@@ -105,5 +105,7 @@ function run(status: RunStatusDto, name: string, id = `run-${name}`): RunDto {
     inputs: null,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
+    started_at: null,
+    finished_at: null,
   };
 }

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list.stories.tsx
@@ -33,6 +33,8 @@ function makeRun(status: RunStatusDto, name: string, minutesAgo: number): RunDto
     inputs: null,
     created_at: new Date(Date.now() - minutesAgo * 120_000).toISOString(),
     updated_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
+    started_at: null,
+    finished_at: null,
   };
 }
 

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -83,6 +83,8 @@ function spawnAndCapture(scriptPath: string, options: RunStepOptions): Promise<S
       options.onOutput?.(chunk, 'stderr');
     });
 
+    let abortRequested = options.signal?.aborted === true;
+
     const killGroup = () => {
       if (child.pid !== undefined) {
         try {
@@ -99,7 +101,10 @@ function spawnAndCapture(scriptPath: string, options: RunStepOptions): Promise<S
       if (options.signal.aborted) {
         killGroup();
       } else {
-        onAbort = () => killGroup();
+        onAbort = () => {
+          abortRequested = true;
+          killGroup();
+        };
         options.signal.addEventListener('abort', onAbort, {once: true});
       }
     }
@@ -113,6 +118,22 @@ function spawnAndCapture(scriptPath: string, options: RunStepOptions): Promise<S
 
     child.on('close', (code, signal) => {
       cleanupAbortListener();
+      // Only report an abort kill when the child was actually terminated by a signal
+      // (code === null). If abort fired in the exit→close race but the process had
+      // already exited on its own, `code` is set — fall through to report its real
+      // outcome rather than masking a genuine success/failure as a kill.
+      if (abortRequested && code === null) {
+        resolve({
+          success: false,
+          error: {
+            message: `Killed by signal ${signal ?? 'SIGKILL'}`,
+            exit_code: null,
+            signal: signal ?? 'SIGKILL',
+          },
+          exit_code: null,
+        });
+        return;
+      }
       if (code === 0) {
         resolve({success: true, error: null, exit_code: 0});
         return;

--- a/tools/docker/src/docker.ts
+++ b/tools/docker/src/docker.ts
@@ -122,8 +122,8 @@ if (setupIndex !== -1) {
 const imageName = takeImageName();
 const registries = readRegistries();
 
-// An --image with no registry configured validates the Dockerfile locally: build
-// one arch and --load it instead of pushing a multi-arch index.
+// When --image is passed without registries, build one arch and --load it
+// locally instead of pushing a multi-arch index.
 const validateOnly = imageName !== undefined && registries.length === 0;
 
 const args: string[] = [];


### PR DESCRIPTION
Capture real start/end timing for runs and jobs so the workflow run page (ENG-509) can render durations.

Jobs now expose `queued_at`, `started_at`, and `finished_at`, separating queue time from run time. Because the queue-entry and claim moments are owned by the runners module, they flow back to the durable `workflows_jobs` row via two events (`runners.job.queued`, `runners.job.claimed`); the workflows subscribers project them onto the job row with a coalesce stamp. Job timing is intentionally **eventually consistent** — the column lands when the outbox drains, and the event payload carries the exact timestamp so the value is never approximate. `finished_at` is stamped in-module at the job's terminal transition.

Runs get `started_at`/`finished_at` columns stamped at their status transitions (a run has no runner queue, so no `queued_at`). Steps get nothing new: only step attempts are measured, and `step_attempts` already exposes its timing on the run-detail attempts array.

### Bounded-context vocabulary
Each context keeps its own ubiquitous language and the boundary is an anticorruption layer:
- The **runner** (a lease broker) speaks `enqueue`/`queued` and `claim`/`claimed`. Its events are facts in its own language.
- The **workflows** run-lifecycle speaks `queued`/`started`/`finished`. Its subscribers translate: `runners.job.claimed` → `started_at` (the runner claiming a job *is* the job starting). The `queued` mapping is identity because both contexts happen to share that word.

### Notes for reviewers
- The new columns are folded into the existing `0000_initial.sql` baseline rather than a new migration (pre-deploy; `drizzle-kit generate` reports no schema changes). Re-run the workflows/runners test DB reset if you have a stale local DB.
- `enqueueJob` (renamed from `scheduleJob`) became transactional to emit in the same tx as the pending insert; an enqueue-idempotency regression test guards against double-insert/double-emit.
- The runner events carry an ISO timestamp in their payload (a new shape for that event map).
- No changeset: all four packages are private/internal (ignored scopes).

Closes ENG-508