### PR TITLE
[react-ui] Stabilize code block visual snapshots

### DIFF
--- a/.changeset/steady-markers-wait.md
+++ b/.changeset/steady-markers-wait.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Stabilizes CodeBlock and CodeTabs visual snapshots by waiting for Shiki highlighting before Argos capture.

--- a/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
@@ -1,5 +1,6 @@
 import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
+import {waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
 import type {CodeBlockData} from './index.js';
 import {
@@ -94,11 +95,17 @@ export const Basic: Story = {
 };
 
 export const SyntaxHighlighting: Story = {
-  // Shiki loads and highlights asynchronously; wait for it so the snapshot
-  // captures the highlighted output rather than the plain fallback.
+  // Cold CI can snapshot the plain fallback before Shiki's dynamic import finishes.
   play: async (ctx) => {
     await document.fonts.ready;
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitFor(
+      () => {
+        if (!ctx.canvasElement.querySelector('.shiki-override')) {
+          throw new Error('Shiki highlighting has not rendered yet');
+        }
+      },
+      {timeout: 10_000},
+    );
     await argosScreenshot(ctx, 'CodeBlock SyntaxHighlighting');
   },
   render: () => <CodeBlockShowcase data={[sourceFile]} syntaxHighlighting />,

--- a/libs/shared/react/ui/src/components/code-block/code-tabs.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-tabs.stories.tsx
@@ -1,5 +1,6 @@
 import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
+import {waitFor} from '@testing-library/react';
 import {CodeTabs} from './index.js';
 
 const meta = {
@@ -60,11 +61,17 @@ export const SourceFiles: Story = {
     syntaxHighlighting: true,
     lineNumbers: true,
   },
-  // Shiki loads and highlights asynchronously; wait for it so the snapshot
-  // captures the highlighted output rather than the plain fallback.
+  // Cold CI can snapshot the plain fallback before Shiki's dynamic import finishes.
   play: async (ctx) => {
     await document.fonts.ready;
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await waitFor(
+      () => {
+        if (!ctx.canvasElement.querySelector('.shiki-override')) {
+          throw new Error('Shiki highlighting has not rendered yet');
+        }
+      },
+      {timeout: 10_000},
+    );
     await argosScreenshot(ctx, 'CodeTabs SourceFiles');
   },
 };


### PR DESCRIPTION
Stabilizes the CodeBlock and CodeTabs Storybook visual captures by waiting for Shiki's highlighted markup before taking Argos screenshots.

Cold CI runs could race Shiki's dynamic import and snapshot the plain fallback instead of the highlighted code output. Waiting on the rendered Shiki marker makes the snapshot condition match the state reviewers expect to compare.

A fixed timeout was simpler but still vulnerable to slow cold starts, so this uses Testing Library's polling wait around the actual DOM condition.

Includes a patch changeset for @shipfox/react-ui.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Storybook visual snapshots for CodeBlock and CodeTabs by waiting for Shiki highlighting before taking Argos screenshots. Prevents flaky captures on cold CI that showed unhighlighted code.

- **Bug Fixes**
  - Replace fixed delay with `waitFor` from `@testing-library/react` to poll for `.shiki-override` before calling `argosScreenshot` (10s timeout) in both stories.
  - Adds a patch changeset for `@shipfox/react-ui`.

<sup>Written for commit a3b642eed04230586960870bfc2d6b93a6e99dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

