### PR TITLE
[client-triggers] Add trigger events data layer

### DIFF
--- a/.changeset/eng-550-client-triggers-events-data-layer.md
+++ b/.changeset/eng-550-client-triggers-events-data-layer.md
@@ -1,0 +1,12 @@
+---
+"@shipfox/client-triggers": minor
+---
+
+Add the trigger events data layer to `@shipfox/client-triggers`: transport
+functions, colocated query keys, and React Query hooks for the workspace Events
+view. `useTriggerEventsInfiniteQuery(workspaceId, filters)` paginates the event
+history newest-first with cursor-based infinite scroll, and `useTriggerEventQuery(id)`
+loads a single event with its routing decisions. Filters (`source`, `event`,
+`outcome`, `from`, `to`) are normalized into a stable cache key so an out-of-order
+or duplicated `outcome` selection reuses the same cache entry. Consumes the
+`@shipfox/api-triggers-dto` contracts; no UI yet.

--- a/libs/client/triggers/package.json
+++ b/libs/client/triggers/package.json
@@ -36,9 +36,12 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-triggers-dto": "workspace:*",
+    "@shipfox/client-api": "workspace:*",
     "@shipfox/client-integrations": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
-    "@swc/helpers": "^0.5.17"
+    "@swc/helpers": "^0.5.17",
+    "@tanstack/react-query": "^5.101.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/libs/client/triggers/src/hooks/api/trigger-events.test.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-events.test.ts
@@ -1,0 +1,167 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {getTriggerEvent, listTriggerEvents, triggerEventsQueryKeys} from './trigger-events.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+function requestFrom(fetchImpl: ReturnType<typeof vi.fn>): Request {
+  return fetchImpl.mock.calls[0]?.[0] as Request;
+}
+
+describe('triggerEventsQueryKeys', () => {
+  test('list key nests under the workspace lists key', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+    const key = triggerEventsQueryKeys.list(workspaceId, {});
+
+    expect(key).toEqual([
+      'trigger-events',
+      'list',
+      workspaceId,
+      {source: null, event: null, outcome: null, from: null, to: null},
+    ]);
+    expect(key.slice(0, 3)).toEqual(triggerEventsQueryKeys.lists(workspaceId));
+  });
+
+  test('normalizes absent filter fields to null so empty variants share a key', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+    const empty = triggerEventsQueryKeys.list(workspaceId, {});
+    const allUndefined = triggerEventsQueryKeys.list(workspaceId, {
+      source: undefined,
+      event: undefined,
+      outcome: undefined,
+      from: undefined,
+      to: undefined,
+    });
+
+    expect(allUndefined).toEqual(empty);
+  });
+
+  test('treats an empty outcome array as no outcome filter', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+    const key = triggerEventsQueryKeys.list(workspaceId, {outcome: []});
+
+    expect(key[3]).toMatchObject({outcome: null});
+  });
+
+  test('sorts and de-duplicates outcome so filter order does not split the cache', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+    const a = triggerEventsQueryKeys.list(workspaceId, {outcome: ['routed', 'failed']});
+    const b = triggerEventsQueryKeys.list(workspaceId, {outcome: ['failed', 'routed', 'failed']});
+
+    expect(a).toEqual(b);
+    expect(a[3]).toMatchObject({outcome: ['failed', 'routed']});
+  });
+
+  test('keeps distinct filters on distinct keys', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+    const push = triggerEventsQueryKeys.list(workspaceId, {event: 'push'});
+    const pr = triggerEventsQueryKeys.list(workspaceId, {event: 'pull_request'});
+
+    expect(push).not.toEqual(pr);
+  });
+
+  test('detail key carries the event id', () => {
+    const id = '22222222-2222-4222-8222-222222222222';
+
+    expect(triggerEventsQueryKeys.detail(id)).toEqual(['trigger-events', 'detail', id]);
+  });
+});
+
+describe('listTriggerEvents', () => {
+  const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('sends workspace_id and the default limit with no filters', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({trigger_events: [], next_cursor: null}));
+    configureApiClient({fetchImpl});
+
+    await listTriggerEvents({workspaceId});
+
+    const url = new URL(requestFrom(fetchImpl).url);
+    expect(url.pathname).toBe('/trigger-events');
+    expect(url.searchParams.get('workspace_id')).toBe(workspaceId);
+    expect(url.searchParams.get('limit')).toBe('50');
+    expect(url.searchParams.has('cursor')).toBe(false);
+    expect(url.searchParams.has('outcome')).toBe(false);
+  });
+
+  test('serializes every filter, the cursor, and a custom limit', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({trigger_events: [], next_cursor: null}));
+    configureApiClient({fetchImpl});
+
+    await listTriggerEvents({
+      workspaceId,
+      limit: 25,
+      cursor: 'cursor-abc',
+      filters: {
+        source: 'github',
+        event: 'push',
+        outcome: ['routed', 'failed'],
+        from: '2026-06-01T00:00:00.000Z',
+        to: '2026-06-22T00:00:00.000Z',
+      },
+    });
+
+    const url = new URL(requestFrom(fetchImpl).url);
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('cursor')).toBe('cursor-abc');
+    expect(url.searchParams.get('source')).toBe('github');
+    expect(url.searchParams.get('event')).toBe('push');
+    expect(url.searchParams.get('from')).toBe('2026-06-01T00:00:00.000Z');
+    expect(url.searchParams.get('to')).toBe('2026-06-22T00:00:00.000Z');
+    expect(url.searchParams.get('outcome')).toBe('failed,routed');
+  });
+
+  test('omits the outcome param when the filter array is empty', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({trigger_events: [], next_cursor: null}));
+    configureApiClient({fetchImpl});
+
+    await listTriggerEvents({workspaceId, filters: {outcome: []}});
+
+    const url = new URL(requestFrom(fetchImpl).url);
+    expect(url.searchParams.has('outcome')).toBe(false);
+  });
+
+  test('returns the parsed list response', async () => {
+    const page = {
+      trigger_events: [],
+      next_cursor: 'next-page',
+    };
+    configureApiClient({fetchImpl: vi.fn(async () => jsonResponse(page))});
+
+    const result = await listTriggerEvents({workspaceId});
+
+    expect(result).toEqual(page);
+  });
+});
+
+describe('getTriggerEvent', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('requests the event detail by id', async () => {
+    const id = '22222222-2222-4222-8222-222222222222';
+    const fetchImpl = vi.fn(async () => jsonResponse({id, decisions: []}));
+    configureApiClient({fetchImpl});
+
+    await getTriggerEvent(id);
+
+    const url = new URL(requestFrom(fetchImpl).url);
+    expect(url.pathname).toBe(`/trigger-events/${id}`);
+    expect(requestFrom(fetchImpl).method).toBe('GET');
+  });
+});

--- a/libs/client/triggers/src/hooks/api/trigger-events.test.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-events.test.ts
@@ -135,6 +135,16 @@ describe('listTriggerEvents', () => {
     expect(url.searchParams.has('outcome')).toBe(false);
   });
 
+  test('sorts and de-duplicates the serialized outcome param', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({trigger_events: [], next_cursor: null}));
+    configureApiClient({fetchImpl});
+
+    await listTriggerEvents({workspaceId, filters: {outcome: ['routed', 'failed', 'routed']}});
+
+    const url = new URL(requestFrom(fetchImpl).url);
+    expect(url.searchParams.get('outcome')).toBe('failed,routed');
+  });
+
   test('returns the parsed list response', async () => {
     const page = {
       trigger_events: [],
@@ -158,7 +168,7 @@ describe('getTriggerEvent', () => {
     const fetchImpl = vi.fn(async () => jsonResponse({id, decisions: []}));
     configureApiClient({fetchImpl});
 
-    await getTriggerEvent(id);
+    await getTriggerEvent({id});
 
     const url = new URL(requestFrom(fetchImpl).url);
     expect(url.pathname).toBe(`/trigger-events/${id}`);

--- a/libs/client/triggers/src/hooks/api/trigger-events.test.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-events.test.ts
@@ -23,9 +23,21 @@ describe('triggerEventsQueryKeys', () => {
       'trigger-events',
       'list',
       workspaceId,
+      50,
       {source: null, event: null, outcome: null, from: null, to: null},
     ]);
     expect(key.slice(0, 3)).toEqual(triggerEventsQueryKeys.lists(workspaceId));
+  });
+
+  test('keeps distinct page limits on distinct keys', () => {
+    const workspaceId = '11111111-1111-4111-8111-111111111111';
+
+    const defaultLimit = triggerEventsQueryKeys.list(workspaceId, {});
+    const compactLimit = triggerEventsQueryKeys.list(workspaceId, {}, 25);
+
+    expect(defaultLimit).not.toEqual(compactLimit);
+    expect(defaultLimit[3]).toBe(50);
+    expect(compactLimit[3]).toBe(25);
   });
 
   test('normalizes absent filter fields to null so empty variants share a key', () => {
@@ -48,7 +60,7 @@ describe('triggerEventsQueryKeys', () => {
 
     const key = triggerEventsQueryKeys.list(workspaceId, {outcome: []});
 
-    expect(key[3]).toMatchObject({outcome: null});
+    expect(key[4]).toMatchObject({outcome: null});
   });
 
   test('sorts and de-duplicates outcome so filter order does not split the cache', () => {
@@ -58,7 +70,7 @@ describe('triggerEventsQueryKeys', () => {
     const b = triggerEventsQueryKeys.list(workspaceId, {outcome: ['failed', 'routed', 'failed']});
 
     expect(a).toEqual(b);
-    expect(a[3]).toMatchObject({outcome: ['failed', 'routed']});
+    expect(a[4]).toMatchObject({outcome: ['failed', 'routed']});
   });
 
   test('keeps distinct filters on distinct keys', () => {

--- a/libs/client/triggers/src/hooks/api/trigger-events.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-events.ts
@@ -29,9 +29,10 @@ function normalizeTriggerEventFiltersForQueryKey(filters: TriggerEventFilters) {
 export const triggerEventsQueryKeys = {
   all: ['trigger-events'] as const,
   lists: (workspaceId: string) => [...triggerEventsQueryKeys.all, 'list', workspaceId] as const,
-  list: (workspaceId: string, filters: TriggerEventFilters) =>
+  list: (workspaceId: string, filters: TriggerEventFilters, limit = 50) =>
     [
       ...triggerEventsQueryKeys.lists(workspaceId),
+      limit,
       normalizeTriggerEventFiltersForQueryKey(filters),
     ] as const,
   detail: (id: string) => [...triggerEventsQueryKeys.all, 'detail', id] as const,
@@ -79,7 +80,7 @@ export function useTriggerEventsInfiniteQuery(
 ) {
   return useInfiniteQuery({
     queryKey: workspaceId
-      ? triggerEventsQueryKeys.list(workspaceId, filters)
+      ? triggerEventsQueryKeys.list(workspaceId, filters, limit)
       : [...triggerEventsQueryKeys.all, 'list'],
     enabled: Boolean(workspaceId),
     initialPageParam: undefined as string | undefined,

--- a/libs/client/triggers/src/hooks/api/trigger-events.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-events.ts
@@ -1,0 +1,108 @@
+import type {
+  TriggerEventDetailResponseDto,
+  TriggerEventListResponseDto,
+  TriggerEventOutcomeDto,
+} from '@shipfox/api-triggers-dto';
+import {apiRequest} from '@shipfox/client-api';
+import {keepPreviousData, useInfiniteQuery, useQuery} from '@tanstack/react-query';
+
+export interface TriggerEventFilters {
+  source?: string | undefined;
+  event?: string | undefined;
+  outcome?: TriggerEventOutcomeDto[] | undefined;
+  from?: string | undefined;
+  to?: string | undefined;
+}
+
+/**
+ * Normalize filters into a stable, order-insensitive shape for the cache key.
+ *
+ * react-query keys one cache per filter combination by structural equality, so
+ * two filter objects that mean the same thing must serialize identically.
+ * `outcome` is sorted and de-duplicated (a set the caller can pass in any order)
+ * and every absent field collapses to `null` so `{}` and `{source: undefined}`
+ * share a cache entry.
+ */
+function normalizeFilters(filters: TriggerEventFilters) {
+  const outcome =
+    filters.outcome && filters.outcome.length > 0 ? [...new Set(filters.outcome)].sort() : null;
+  return {
+    source: filters.source ?? null,
+    event: filters.event ?? null,
+    outcome,
+    from: filters.from ?? null,
+    to: filters.to ?? null,
+  };
+}
+
+export const triggerEventsQueryKeys = {
+  all: ['trigger-events'] as const,
+  lists: (workspaceId: string) => [...triggerEventsQueryKeys.all, 'list', workspaceId] as const,
+  list: (workspaceId: string, filters: TriggerEventFilters) =>
+    [...triggerEventsQueryKeys.lists(workspaceId), normalizeFilters(filters)] as const,
+  detail: (id: string) => [...triggerEventsQueryKeys.all, 'detail', id] as const,
+};
+
+export async function listTriggerEvents({
+  workspaceId,
+  filters = {},
+  limit = 50,
+  cursor,
+  signal,
+}: {
+  workspaceId: string;
+  filters?: TriggerEventFilters;
+  limit?: number;
+  cursor?: string | undefined;
+  signal?: AbortSignal;
+}) {
+  const params = new URLSearchParams({workspace_id: workspaceId, limit: String(limit)});
+  if (cursor) params.set('cursor', cursor);
+  if (filters.source) params.set('source', filters.source);
+  if (filters.event) params.set('event', filters.event);
+  if (filters.from) params.set('from', filters.from);
+  if (filters.to) params.set('to', filters.to);
+  if (filters.outcome && filters.outcome.length > 0) {
+    params.set('outcome', [...new Set(filters.outcome)].sort().join(','));
+  }
+
+  return await apiRequest<TriggerEventListResponseDto>(`/trigger-events?${params.toString()}`, {
+    signal,
+  });
+}
+
+export async function getTriggerEvent(id: string) {
+  return await apiRequest<TriggerEventDetailResponseDto>(`/trigger-events/${id}`);
+}
+
+export function useTriggerEventsInfiniteQuery(
+  workspaceId: string | undefined,
+  filters: TriggerEventFilters = {},
+  limit = 50,
+) {
+  return useInfiniteQuery({
+    queryKey: workspaceId
+      ? triggerEventsQueryKeys.list(workspaceId, filters)
+      : [...triggerEventsQueryKeys.all, 'list'],
+    enabled: Boolean(workspaceId),
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({pageParam, signal}) =>
+      listTriggerEvents({
+        workspaceId: workspaceId ?? '',
+        filters,
+        limit,
+        cursor: pageParam,
+        signal,
+      }),
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useTriggerEventQuery(id: string | undefined) {
+  return useQuery({
+    queryKey: id ? triggerEventsQueryKeys.detail(id) : [...triggerEventsQueryKeys.all, 'detail'],
+    enabled: Boolean(id),
+    queryFn: () => getTriggerEvent(id ?? ''),
+  });
+}

--- a/libs/client/triggers/src/hooks/api/trigger-events.ts
+++ b/libs/client/triggers/src/hooks/api/trigger-events.ts
@@ -14,16 +14,7 @@ export interface TriggerEventFilters {
   to?: string | undefined;
 }
 
-/**
- * Normalize filters into a stable, order-insensitive shape for the cache key.
- *
- * react-query keys one cache per filter combination by structural equality, so
- * two filter objects that mean the same thing must serialize identically.
- * `outcome` is sorted and de-duplicated (a set the caller can pass in any order)
- * and every absent field collapses to `null` so `{}` and `{source: undefined}`
- * share a cache entry.
- */
-function normalizeFilters(filters: TriggerEventFilters) {
+function normalizeTriggerEventFiltersForQueryKey(filters: TriggerEventFilters) {
   const outcome =
     filters.outcome && filters.outcome.length > 0 ? [...new Set(filters.outcome)].sort() : null;
   return {
@@ -39,7 +30,10 @@ export const triggerEventsQueryKeys = {
   all: ['trigger-events'] as const,
   lists: (workspaceId: string) => [...triggerEventsQueryKeys.all, 'list', workspaceId] as const,
   list: (workspaceId: string, filters: TriggerEventFilters) =>
-    [...triggerEventsQueryKeys.lists(workspaceId), normalizeFilters(filters)] as const,
+    [
+      ...triggerEventsQueryKeys.lists(workspaceId),
+      normalizeTriggerEventFiltersForQueryKey(filters),
+    ] as const,
   detail: (id: string) => [...triggerEventsQueryKeys.all, 'detail', id] as const,
 };
 
@@ -71,8 +65,11 @@ export async function listTriggerEvents({
   });
 }
 
-export async function getTriggerEvent(id: string) {
-  return await apiRequest<TriggerEventDetailResponseDto>(`/trigger-events/${id}`);
+export async function getTriggerEvent({id, signal}: {id: string; signal?: AbortSignal}) {
+  return await apiRequest<TriggerEventDetailResponseDto>(
+    `/trigger-events/${encodeURIComponent(id)}`,
+    {signal},
+  );
 }
 
 export function useTriggerEventsInfiniteQuery(
@@ -103,6 +100,6 @@ export function useTriggerEventQuery(id: string | undefined) {
   return useQuery({
     queryKey: id ? triggerEventsQueryKeys.detail(id) : [...triggerEventsQueryKeys.all, 'detail'],
     enabled: Boolean(id),
-    queryFn: () => getTriggerEvent(id ?? ''),
+    queryFn: ({signal}) => getTriggerEvent({id: id ?? '', signal}),
   });
 }

--- a/libs/client/triggers/src/index.ts
+++ b/libs/client/triggers/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components/trigger-source-icon.js';
+export * from './hooks/api/trigger-events.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2571,6 +2571,12 @@ importers:
 
   libs/client/triggers:
     dependencies:
+      '@shipfox/api-triggers-dto':
+        specifier: workspace:*
+        version: link:../../api/triggers-dto
+      '@shipfox/client-api':
+        specifier: workspace:*
+        version: link:../api
       '@shipfox/client-integrations':
         specifier: workspace:*
         version: link:../integrations
@@ -2580,6 +2586,9 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Adds the data layer for the workspace Events view to the existing `@shipfox/client-triggers` package: transport functions, colocated query keys, and React Query hooks, consuming the `@shipfox/api-triggers-dto` contracts from ENG-548.

This is the transport/hooks layer only, no UI. It unblocks the Events page (ENG-551), which composes these hooks.

## What's here

- `useTriggerEventsInfiniteQuery(workspaceId, filters, limit)` — cursor-based infinite list of trigger events, newest first, modeled on the existing `useProjectsInfiniteQuery` / `useDefinitionsInfiniteQuery` shape (`keepPreviousData`, `getNextPageParam` off `next_cursor`, `enabled` gated on `workspaceId`).
- `useTriggerEventQuery(id)` — single event with its routing decisions.
- `listTriggerEvents` / `getTriggerEvent` — raw transport via `@shipfox/client-api`, snake_case query params.
- `triggerEventsQueryKeys` — colocated keys. The `list` key folds filters through `normalizeFilters`, which sorts + de-duplicates `outcome` and collapses absent fields to `null`, so an out-of-order or duplicated `outcome` selection reuses the same react-query cache entry instead of splitting it.

## Notes for review

- The issue references `useWorkflowRunsInfiniteQuery` as the model; that symbol doesn't actually exist in the codebase. The live infinite-query pattern is `useProjectsInfiniteQuery` in `@shipfox/client-projects`, which this follows.
- 11 Vitest node tests cover query-key shape, filter normalization (undefined to null, empty/duplicated/unordered `outcome`), param serialization, and detail transport.

Closes ENG-550

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the trigger events data layer to `@shipfox/client-triggers` with transport functions, colocated query keys, and React Query hooks for the workspace Events view. Satisfies ENG-550 and unblocks the Events page (ENG-551); consumes `@shipfox/api-triggers-dto`. No UI.

- **New Features**
  - `useTriggerEventsInfiniteQuery(workspaceId, filters, limit)` for a cursor-based, newest-first list.
  - `useTriggerEventQuery(id)` for a single event with routing decisions; detail requests are URL-encoded and abortable.
  - Stable query keys via filter normalization (`source`, `event`, `outcome`, `from`, `to`) and the `limit` value to avoid cache splits when page size changes.

- **Dependencies**
  - Add `@shipfox/api-triggers-dto`, `@shipfox/client-api`, and `@tanstack/react-query` to `@shipfox/client-triggers`.

<sup>Written for commit 6d515e214d8a8dbbf6539b891a209e784afc46be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

