### PR TITLE
[react-ui] Normalize barrel/internal imports to use .js extensions

### DIFF
--- a/libs/shared/react/ui/src/components/avatar/avatar-group.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar-group.tsx
@@ -11,7 +11,7 @@ import {
   useMemo,
 } from 'react';
 import {cn} from '#utils/cn.js';
-import {TooltipContent, TooltipProvider, TooltipTrigger} from '../tooltip/tooltip';
+import {TooltipContent, TooltipProvider, TooltipTrigger} from '../tooltip/tooltip.js';
 
 const avatarGroupVariants = cva('flex items-start', {
   variants: {

--- a/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
@@ -1,7 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {Code} from '../typography/index.js';
-import {Avatar} from './avatar';
-import {AvatarGroup, AvatarGroupTooltip} from './avatar-group';
+import {Avatar} from './avatar.js';
+import {AvatarGroup, AvatarGroupTooltip} from './avatar-group.js';
 
 // In Playwright (Argos CI) navigator.webdriver is true. DiceBear image fetches
 // are unreliable in CI — skip them so screenshots are deterministic.

--- a/libs/shared/react/ui/src/components/avatar/avatar.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.tsx
@@ -5,7 +5,7 @@ import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps, ReactNode} from 'react';
 import {getInitial, getPlaceholderImageUrl} from '#utils/avatar.js';
 import {cn} from '#utils/cn.js';
-import {Icon, type IconName} from '../icon/icon';
+import {Icon, type IconName} from '../icon/icon.js';
 
 export const avatarVariants = cva(
   'relative flex shrink-0 overflow-hidden bg-background-button-neutral-default text-foreground-neutral-base ring-1 ring-border-neutral-base-component ring-offset-1 ring-offset-background-neutral-base shadow-button-neutral',

--- a/libs/shared/react/ui/src/components/avatar/index.ts
+++ b/libs/shared/react/ui/src/components/avatar/index.ts
@@ -1,2 +1,2 @@
-export * from './avatar';
-export * from './avatar-group';
+export * from './avatar.js';
+export * from './avatar-group.js';

--- a/libs/shared/react/ui/src/components/combobox/combobox.stories.tsx
+++ b/libs/shared/react/ui/src/components/combobox/combobox.stories.tsx
@@ -1,7 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 import {Label} from '../label/index.js';
-import {Combobox, type ComboboxOption} from './combobox';
+import {Combobox, type ComboboxOption} from './combobox.js';
 
 const sampleItems: ComboboxOption[] = [
   {value: 'apache', label: 'apache'},

--- a/libs/shared/react/ui/src/components/combobox/combobox.tsx
+++ b/libs/shared/react/ui/src/components/combobox/combobox.tsx
@@ -11,9 +11,9 @@ import {
   CommandList,
   CommandTrigger,
   type CommandTriggerProps,
-} from '../command';
-import {Icon} from '../icon';
-import {Popover, PopoverContent, PopoverTrigger} from '../popover';
+} from '../command/index.js';
+import {Icon} from '../icon/index.js';
+import {Popover, PopoverContent, PopoverTrigger} from '../popover/index.js';
 import {ScrollArea} from '../scroll-area/index.js';
 
 export type ComboboxOption = {

--- a/libs/shared/react/ui/src/components/combobox/index.ts
+++ b/libs/shared/react/ui/src/components/combobox/index.ts
@@ -1,1 +1,1 @@
-export * from './combobox';
+export * from './combobox.js';

--- a/libs/shared/react/ui/src/components/command/command.stories.tsx
+++ b/libs/shared/react/ui/src/components/command/command.stories.tsx
@@ -1,7 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
-import {Icon} from '../icon';
-import {Popover, PopoverContent, PopoverTrigger} from '../popover';
+import {Icon} from '../icon/index.js';
+import {Popover, PopoverContent, PopoverTrigger} from '../popover/index.js';
 import {
   Command,
   CommandEmpty,
@@ -12,7 +12,7 @@ import {
   CommandSeparator,
   CommandShortcut,
   CommandTrigger,
-} from './command';
+} from './command.js';
 
 const meta = {
   title: 'Components/Command',

--- a/libs/shared/react/ui/src/components/command/command.tsx
+++ b/libs/shared/react/ui/src/components/command/command.tsx
@@ -4,8 +4,8 @@ import {cva, type VariantProps} from 'class-variance-authority';
 import {Command as CommandPrimitive} from 'cmdk';
 import {type ComponentProps, forwardRef, useCallback, useState} from 'react';
 import {cn} from '#utils/cn.js';
-import {Icon} from '../icon';
-import {Kbd} from '../kbd';
+import {Icon} from '../icon/index.js';
+import {Kbd} from '../kbd/index.js';
 
 const commandTriggerVariants = cva(
   [

--- a/libs/shared/react/ui/src/components/command/index.ts
+++ b/libs/shared/react/ui/src/components/command/index.ts
@@ -1,1 +1,1 @@
-export * from './command';
+export * from './command.js';

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -2,8 +2,8 @@ import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
 import {screen} from '@testing-library/react';
 import {useState} from 'react';
-import {Avatar} from '../avatar';
-import {Button} from '../button';
+import {Avatar} from '../avatar/index.js';
+import {Button} from '../button/index.js';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -18,7 +18,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from './dropdown-menu';
+} from './dropdown-menu.js';
 
 const isTestEnvironment = () => typeof navigator !== 'undefined' && navigator.webdriver === true;
 const hideTriggerInTests = () =>

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -4,7 +4,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import {cva, type VariantProps} from 'class-variance-authority';
 import type {ComponentProps} from 'react';
 import {cn} from '#utils/cn.js';
-import {Icon, type IconName} from '../icon';
+import {Icon, type IconName} from '../icon/index.js';
 
 function DropdownMenu({...props}: ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;

--- a/libs/shared/react/ui/src/components/dropdown-menu/index.ts
+++ b/libs/shared/react/ui/src/components/dropdown-menu/index.ts
@@ -1,1 +1,1 @@
-export * from './dropdown-menu';
+export * from './dropdown-menu.js';

--- a/libs/shared/react/ui/src/components/kbd/index.ts
+++ b/libs/shared/react/ui/src/components/kbd/index.ts
@@ -1,1 +1,1 @@
-export * from './kbd';
+export * from './kbd.js';

--- a/libs/shared/react/ui/src/components/kbd/kbd.stories.tsx
+++ b/libs/shared/react/ui/src/components/kbd/kbd.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {Kbd, KbdGroup} from './kbd';
+import {Kbd, KbdGroup} from './kbd.js';
 
 const meta = {
   title: 'Components/Kbd',

--- a/libs/shared/react/ui/src/components/popover/index.ts
+++ b/libs/shared/react/ui/src/components/popover/index.ts
@@ -1,1 +1,1 @@
-export * from './popover';
+export * from './popover.js';

--- a/libs/shared/react/ui/src/components/scroll-area/index.ts
+++ b/libs/shared/react/ui/src/components/scroll-area/index.ts
@@ -1,1 +1,1 @@
-export * from './scroll-area';
+export * from './scroll-area.js';

--- a/libs/shared/react/ui/src/components/sheet/index.ts
+++ b/libs/shared/react/ui/src/components/sheet/index.ts
@@ -1,1 +1,1 @@
-export * from './sheet';
+export * from './sheet.js';

--- a/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
@@ -15,7 +15,7 @@ import {
   SheetHeader,
   SheetTitle,
   SheetTrigger,
-} from './sheet';
+} from './sheet.js';
 
 const isTestEnvironment = () => typeof navigator !== 'undefined' && navigator.webdriver === true;
 

--- a/libs/shared/react/ui/src/components/tabs/index.ts
+++ b/libs/shared/react/ui/src/components/tabs/index.ts
@@ -1,1 +1,1 @@
-export * from './tabs';
+export * from './tabs.js';


### PR DESCRIPTION
Makes relative imports across `@shipfox/react-ui` consistently use the explicit `'.js'` extension.

Roughly half the package (modal, button, icon, input, label, collapsible, and the top-level `src/index.ts` / `src/components/index.ts` barrels) already imported sibling modules as `'./x.js'`, while sheet, avatar, combobox, command, dropdown-menu, kbd, popover, scroll-area, and tabs used bare `'./x'` in their barrels, internal cross-component imports, and stories. This normalizes the latter to the dominant convention.

### Why this matters

Extensionless specifiers are not a current bug: they type-check (react-ui extends `@shipfox/ts-config/react`, which sets `moduleResolution: bundler`) and resolve under every path the repo exercises, since consumers reach react-ui either through the `development` export condition pointing at TS source or through a Vite build, and bundlers resolve extensionless imports.

The gap is latent: SWC emits the specifier verbatim into `dist` (`dist/components/avatar/index.js` literally contains `export * from './avatar';`), so loading the built ESM through Node's native resolver would throw `ERR_MODULE_NOT_FOUND`. The top-level barrels already carry `.js` as a partial guard; this finishes the job so the whole package is portable and internally consistent.

No behavior or public API change. No changeset added since the published export surface is identical for npm consumers; happy to add a patch changeset if the release gate requires one.

Commits:
- Normalize Sheet barrel imports (the original scope of this branch)
- Normalize the remaining 8 components