### PR TITLE
[client-workflows] Stabilize the flaky workflow run view test under CI contention

### DIFF
--- a/libs/client/workflows/test/setup.ts
+++ b/libs/client/workflows/test/setup.ts
@@ -1,4 +1,11 @@
 import '@testing-library/jest-dom/vitest';
+import {configure} from '@testing-library/react';
+
+// The jsdom `dom` project shares a `vitest run` with the CPU-heavy `storybook (chromium)`
+// browser project, so a `findBy*`/`waitFor` can starve well past Testing Library's 1s
+// default while the browser tests saturate the host. Widen the ceiling: a resolved query
+// still returns immediately, so this only buys headroom for a contended cold start.
+configure({asyncUtilTimeout: 5000});
 
 class ResizeObserverStub {
   observe(): void {

--- a/libs/client/workflows/vitest.config.ts
+++ b/libs/client/workflows/vitest.config.ts
@@ -30,6 +30,9 @@ export default defineConfig(
             environment: 'jsdom',
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
+            // Keep the per-test budget above the widened `asyncUtilTimeout` (test/setup.ts) so a
+            // contended `findBy*` reports the real query failure instead of a Vitest timeout.
+            testTimeout: 15000,
           },
         },
         {


### PR DESCRIPTION
The `client-workflows` test job intermittently fails on `workflow-run-view.test.tsx > renders the jobs graph when a run loads` with `Unable to find role="region" and name "Jobs graph"`, the loading skeleton still on screen.

This is a timing failure under CI contention, not a logic bug. The package runs three Vitest projects in one `vitest run`: the lightweight `node` and `dom` (jsdom) projects alongside the CPU/memory-heavy `storybook (chromium)` browser project, all sharing the host. The failing assertion is the first `dom` test to mount the full tree (TanStack Router + React Query + a mocked `fetch`), so it pays a cold start. When the browser project saturates CPU, that cold start overran Testing Library's default 1s `findBy*` timeout (the failing run gave up at 1363ms). With the host idle the same query resolves in ~80ms, confirming contention rather than a stuck query.

Fix: give Testing Library's async queries headroom so they tolerate contention.

- `test/setup.ts`: `configure({asyncUtilTimeout: 5000})`, raising the `findBy*`/`waitFor` default from 1s to 5s for the `dom` project.
- `vitest.config.ts`: `testTimeout: 15000` on the `dom` project so a slow `findBy*` reports the real query failure instead of being cut short by Vitest's 5s per-test default.

A resolved query still returns immediately, so green runs are unaffected; this only buys headroom for a contended cold start.

No changeset: test infrastructure only, with no npm-consumer impact.

The same dom-vs-browser contention applies to other client packages that mix a jsdom project with a Storybook browser project (e.g. `client-auth`, `client-triggers`, `client-projects`). If those flake too, lifting the same `asyncUtilTimeout` into the shared `@shipfox/vitest` config would fix it once for all of them; this PR is scoped to the package that actually flaked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized a flaky `workflow-run-view.test.tsx` in `client-workflows` by giving async queries more headroom under CI contention. This reduces intermittent failures without changing runtime behavior.

- **Bug Fixes**
  - In `test/setup.ts`, set `@testing-library/react` `configure({ asyncUtilTimeout: 5000 })` for the `dom` project.
  - In `vitest.config.ts`, raised `testTimeout` to 15000 so slow `findBy*` calls fail on the real assertion, not Vitest’s default timeout.

<sup>Written for commit 60395f858f6229140eceb38d1c6cb9e1f7b256ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

