### PR TITLE
[client-logs] Add log record components for process and system logs

### DIFF
--- a/.changeset/client-logs-record-components.md
+++ b/.changeset/client-logs-record-components.md
@@ -1,0 +1,12 @@
+---
+"@shipfox/client-logs": minor
+"@shipfox/react-ui": minor
+"@shipfox/api-logs-dto": patch
+---
+
+Add `@shipfox/client-logs`: the record components for the step-log read stream, composing the `@shipfox/react-ui` log primitives. This covers every process and system record (`output`, `group_start`/`group_end`, `end`, `gap`, `capped`, `runner_lost`); `agent_session` is rendered by the agent-sessions surface.
+
+- `buildLogTree(records)` is a pure transform that reconstructs the group tree from the flat record list. `group_end` closes the matching `group_id` (so a `group_start` dropped under gap/backlog pressure does not mis-nest), record dispatch is an exhaustive switch, and each group node carries a precomputed `hasError` (a `runner_lost` in its subtree, a genuine failure; `stderr` is a channel, not an error) and subtree line count.
+- `OutputLogRow` renders stdout/stderr (stderr gets a subtle left channel rule, not a background tint), `LogGroup` is a collapsible disclosure with running/duration/incomplete affordances and an inset error bar, the system markers render as timeline rows, and `LogView` is the top-level dispatcher with an empty state. Reviewed in a package-local Storybook captured by Argos (`client-logs`).
+- `@shipfox/api-logs-dto` now measures UTF-8 byte length with `TextEncoder` instead of `node:buffer`, so this shared record contract is browser-safe for the client log viewer. Behavior is identical.
+- `@shipfox/react-ui` gains two shared formatters in `utils`: `formatBytes` (new) and `formatDuration` (an ms-span, sub-second sibling to the existing `humanDuration`), so `client-logs` and future packages share one implementation instead of re-rolling them.

--- a/libs/api/logs-dto/src/schemas/record.ts
+++ b/libs/api/logs-dto/src/schemas/record.ts
@@ -1,4 +1,3 @@
-import {Buffer} from 'node:buffer';
 import {z} from 'zod';
 
 /**
@@ -36,10 +35,15 @@ export const MAX_RECORD_NAME_BYTES = 1024;
  */
 export const MAX_RECORD_GROUP_ID_BYTES = 256;
 
+// UTF-8 byte length without node:buffer, so this shared DTO stays browser-safe (the
+// client log viewer imports these types too). Identical to Buffer.byteLength(x, 'utf8').
+const utf8Encoder = new TextEncoder();
+const utf8ByteLength = (value: string): number => utf8Encoder.encode(value).length;
+
 const groupId = z
   .string()
   .min(1, {message: 'group id must not be empty'})
-  .refine((value) => Buffer.byteLength(value, 'utf8') <= MAX_RECORD_GROUP_ID_BYTES, {
+  .refine((value) => utf8ByteLength(value) <= MAX_RECORD_GROUP_ID_BYTES, {
     message: `group id exceeds ${MAX_RECORD_GROUP_ID_BYTES} bytes`,
   });
 
@@ -56,7 +60,7 @@ const logOutput = z.object({
   data: z
     .string()
     .min(1, {message: 'output data must not be empty'})
-    .refine((value) => Buffer.byteLength(value, 'utf8') <= MAX_RECORD_DATA_BYTES, {
+    .refine((value) => utf8ByteLength(value) <= MAX_RECORD_DATA_BYTES, {
       message: `data exceeds ${MAX_RECORD_DATA_BYTES} payload bytes`,
     }),
 });
@@ -66,7 +70,7 @@ const logGroupStart = z.object({
   type: z.literal('group_start'),
   group_id: groupId,
   parent_group_id: groupId.nullable(),
-  name: z.string().refine((value) => Buffer.byteLength(value, 'utf8') <= MAX_RECORD_NAME_BYTES, {
+  name: z.string().refine((value) => utf8ByteLength(value) <= MAX_RECORD_NAME_BYTES, {
     message: `group name exceeds ${MAX_RECORD_NAME_BYTES} bytes`,
   }),
 });
@@ -124,7 +128,6 @@ export const logRecordSchema = z.discriminatedUnion('type', [
 export type AppendableLogRecord = z.infer<typeof appendableLogRecordSchema>;
 export type LogRecord = z.infer<typeof logRecordSchema>;
 
-/** Parses one NDJSON line against the full read union. Throws on invalid JSON or an unknown record. */
 export function parseLogRecordLine(line: string): LogRecord {
   return logRecordSchema.parse(JSON.parse(line));
 }

--- a/libs/client/logs/.gitignore
+++ b/libs/client/logs/.gitignore
@@ -1,0 +1,1 @@
+storybook-static/

--- a/libs/client/logs/.storybook/main.ts
+++ b/libs/client/logs/.storybook/main.ts
@@ -1,0 +1,23 @@
+import type {StorybookConfig} from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  framework: '@storybook/react-vite',
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  addons: ['storybook-addon-pseudo-states', '@storybook/addon-vitest'],
+  core: {
+    disableTelemetry: true,
+  },
+  viteFinal: async (config) => {
+    const [{default: react}, {default: tailwindcss}] = await Promise.all([
+      import('@vitejs/plugin-react'),
+      import('@tailwindcss/vite'),
+    ]);
+
+    config.plugins = config.plugins ?? [];
+    config.plugins.push(react(), tailwindcss());
+
+    return config;
+  },
+};
+
+export default config;

--- a/libs/client/logs/.storybook/preview.css
+++ b/libs/client/logs/.storybook/preview.css
@@ -1,0 +1,9 @@
+@import "@shipfox/react-ui/index.css";
+
+/* The `@import` pulls in the full design-system theme (tokens, preflight, base layer)
+   from react-ui. Tailwind v4 only emits utilities for classes it finds in scanned
+   source, and these stories render react-ui components whose classes live in react-ui's
+   own source. Scanning both trees keeps those components styled, the same way
+   apps/client/src/styles.css scans every package it renders. */
+@source "../src";
+@source "../../../shared/react/ui/src";

--- a/libs/client/logs/.storybook/preview.tsx
+++ b/libs/client/logs/.storybook/preview.tsx
@@ -1,0 +1,46 @@
+import './preview.css';
+import {ThemeProvider} from '@shipfox/react-ui';
+import type {Decorator, Preview} from '@storybook/react';
+
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-theme-${theme}`}>
+      <Story />
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    argos: {
+      modes: {
+        light: {theme: 'light'},
+        dark: {theme: 'dark'},
+      },
+      fitToContent: false,
+    },
+    options: {
+      storySort: {method: 'alphabetical'},
+    },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {value: 'light', icon: 'sun', title: 'Light'},
+          {value: 'dark', icon: 'moon', title: 'Dark'},
+          {value: 'system', icon: 'info', title: 'System'},
+        ],
+        showName: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/libs/client/logs/.swcrc
+++ b/libs/client/logs/.swcrc
@@ -1,0 +1,42 @@
+{
+  "jsc": {
+    "target": "es2023",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true,
+      "tsx": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true,
+      "react": {
+        "runtime": "automatic"
+      }
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true,
+    "experimental": {
+      "keepImportAttributes": true
+    }
+  },
+  "module": {
+    "type": "es6",
+    "strict": true,
+    "strictMode": true,
+    "noInterop": true,
+    "resolveFully": true
+  },
+  "sourceMaps": true,
+  "minify": false,
+  "exclude": [
+    "node_modules",
+    "jest.config.ts",
+    "^.*\\.spec\\.tsx?$",
+    "^.*\\.test\\.tsx?$",
+    "^.*\\.stories\\.tsx?$",
+    ".*/jest-setup\\.ts$",
+    "^.*\\.js$"
+  ]
+}

--- a/libs/client/logs/package.json
+++ b/libs/client/logs/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@shipfox/client-logs",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/platform.git",
+    "directory": "libs/client/logs"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "storybook": "storybook dev -p 6008",
+    "storybook:build": "storybook build -o storybook-static",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-logs-dto": "workspace:*",
+    "@shipfox/react-ui": "workspace:*",
+    "@swc/helpers": "^0.5.17"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@argos-ci/cli": "^5.0.0",
+    "@argos-ci/storybook": "^6.0.0",
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@storybook/addon-vitest": "^10.3.6",
+    "@storybook/react": "^10.0.0",
+    "@storybook/react-vite": "^10.0.0",
+    "@tailwindcss/vite": "^4.1.13",
+    "@types/react": "^19.1.11",
+    "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/browser-playwright": "^4.1.5",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "storybook": "^10.0.0",
+    "storybook-addon-pseudo-states": "^10.0.0",
+    "tailwindcss": "^4.1.13",
+    "vite": "^8.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/libs/client/logs/src/components/index.ts
+++ b/libs/client/logs/src/components/index.ts
@@ -1,0 +1,10 @@
+export {LogGroup, type LogGroupProps} from './log-group.js';
+export {LogView, type LogViewProps} from './log-view.js';
+export {OutputLogRow, type OutputLogRowProps} from './output-log-row.js';
+export {
+  CappedMarker,
+  EndMarker,
+  type EndMarkerProps,
+  GapMarker,
+  RunnerLostMarker,
+} from './system-markers.js';

--- a/libs/client/logs/src/components/log-group.stories.tsx
+++ b/libs/client/logs/src/components/log-group.stories.tsx
@@ -1,0 +1,204 @@
+import {LogRows} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {expect, userEvent, within} from 'storybook/test';
+import type {GroupLogNode, GroupStartLogRecord, OutputLogRecord} from '#core/log-tree.js';
+import {LogGroup} from './log-group.js';
+import {OutputLogRow} from './output-log-row.js';
+import {RunnerLostMarker} from './system-markers.js';
+
+const origin = new Date('2026-06-23T10:00:00.000Z').getTime();
+const at = (offsetSeconds: number) => origin + offsetSeconds * 1000;
+
+const groupStart = (groupId: string, name: string): GroupStartLogRecord => ({
+  v: 1,
+  ts: at(0),
+  type: 'group_start',
+  group_id: groupId,
+  parent_group_id: null,
+  name,
+});
+
+const out = (
+  data: string,
+  line: number,
+  stream: 'stdout' | 'stderr' = 'stdout',
+): OutputLogRecord => ({
+  v: 1,
+  ts: at(line),
+  type: 'output',
+  stream,
+  data,
+});
+
+const group = (over: Partial<GroupLogNode> & Pick<GroupLogNode, 'record'>): GroupLogNode => ({
+  kind: 'group',
+  seq: 0,
+  closed: false,
+  endTs: null,
+  hasError: false,
+  lineCount: 0,
+  children: [],
+  ...over,
+});
+
+const rows = (records: OutputLogRecord[]) =>
+  records.map((record) => (
+    <OutputLogRow key={record.ts + record.data} record={record} lineNumber={null} indent={1} />
+  ));
+
+const buildChildren = [
+  out('Compiling 1284 modules\n', 1),
+  out('Linking 318 packages\n', 2),
+  out('Done\n', 3),
+];
+
+const meta = {
+  title: 'Logs/LogGroup',
+  component: LogGroup,
+  parameters: {layout: 'padded'},
+  tags: ['autodocs'],
+} satisfies Meta<typeof LogGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BUILD_TRIGGER = /Build/;
+
+export const Collapsed: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogGroup
+          node={group({
+            record: groupStart('g1', 'Build'),
+            closed: true,
+            endTs: at(3),
+            lineCount: 3,
+          })}
+          depth={0}
+          terminated={false}
+        >
+          {rows(buildChildren)}
+        </LogGroup>
+      </LogRows>
+    </div>
+  ),
+};
+
+export const Open: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogGroup
+          node={group({
+            record: groupStart('g1', 'Build'),
+            closed: true,
+            endTs: at(3),
+            lineCount: 3,
+          })}
+          depth={0}
+          terminated={false}
+          defaultOpen
+        >
+          {rows(buildChildren)}
+        </LogGroup>
+      </LogRows>
+    </div>
+  ),
+};
+
+export const Running: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogGroup
+          node={group({record: groupStart('g1', 'Build'), lineCount: 2})}
+          depth={0}
+          terminated={false}
+          defaultOpen
+        >
+          {rows([out('Compiling...\n', 1), out('still going\n', 2)])}
+        </LogGroup>
+      </LogRows>
+    </div>
+  ),
+};
+
+export const Incomplete: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogGroup
+          node={group({record: groupStart('g1', 'Build'), lineCount: 1})}
+          depth={0}
+          terminated
+          defaultOpen
+        >
+          {rows([out('Compiling...\n', 1)])}
+        </LogGroup>
+      </LogRows>
+    </div>
+  ),
+};
+
+export const Truncated: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogGroup
+          node={group({
+            record: groupStart('g1', 'Build'),
+            closed: true,
+            endTs: null,
+            lineCount: 1,
+          })}
+          depth={0}
+          terminated={false}
+          defaultOpen
+        >
+          {rows([out('Compiling...\n', 1)])}
+        </LogGroup>
+      </LogRows>
+    </div>
+  ),
+};
+
+/**
+ * A genuine subtree failure (a `runner_lost`) draws an inset red bar on the header (a
+ * border, not a fill). stderr alone never triggers it — stderr is a channel, not an error.
+ */
+export const ErrorBar: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <LogGroup
+          node={group({
+            record: groupStart('g1', 'Build'),
+            closed: true,
+            endTs: null,
+            hasError: true,
+            lineCount: 1,
+          })}
+          depth={0}
+          terminated
+        >
+          <OutputLogRow record={out('connecting to runner...\n', 1)} lineNumber={null} indent={1} />
+          <RunnerLostMarker record={{v: 1, ts: at(2), type: 'runner_lost'}} />
+        </LogGroup>
+      </LogRows>
+    </div>
+  ),
+};
+
+export const Toggle: Story = {
+  ...Collapsed,
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    const user = userEvent.setup();
+    const trigger = canvas.getByRole('button', {name: BUILD_TRIGGER});
+
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await user.click(trigger);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  },
+};

--- a/libs/client/logs/src/components/log-group.tsx
+++ b/libs/client/logs/src/components/log-group.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {
+  cn,
+  formatDuration,
+  Icon,
+  LogDisclosure,
+  LogDisclosureContent,
+  LogDisclosureTrigger,
+} from '@shipfox/react-ui';
+import type {ReactNode} from 'react';
+import type {GroupLogNode} from '#core/log-tree.js';
+
+export interface LogGroupProps {
+  node: GroupLogNode;
+  depth: number;
+  terminated: boolean;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}
+
+export function LogGroup({node, depth, terminated, children, defaultOpen = false}: LogGroupProps) {
+  const lineLabel = `${node.lineCount} ${node.lineCount === 1 ? 'line' : 'lines'}`;
+
+  return (
+    <LogDisclosure indent={depth} defaultOpen={defaultOpen}>
+      <LogDisclosureTrigger
+        summary={lineLabel}
+        trailing={<GroupStatus node={node} terminated={terminated} />}
+        className={cn(node.hasError && 'shadow-[inset_2px_0_0_var(--color-red-500)]')}
+      >
+        {node.record.name}
+      </LogDisclosureTrigger>
+      <LogDisclosureContent rail={false}>{children}</LogDisclosureContent>
+    </LogDisclosure>
+  );
+}
+
+function GroupStatus({node, terminated}: {node: GroupLogNode; terminated: boolean}): ReactNode {
+  if (node.closed && node.endTs != null) {
+    return (
+      <span className="font-code tabular-nums">{formatDuration(node.endTs - node.record.ts)}</span>
+    );
+  }
+
+  // No clean end: either still open under a terminated stream (runner died mid-group), or
+  // closed only because an ancestor's group_end cascaded (its own end was dropped, so endTs
+  // is null). Either way show "incomplete" rather than a blank slot or a forever spinner.
+  if (node.closed || terminated) {
+    return <span className="text-foreground-neutral-muted">incomplete</span>;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-4 text-foreground-neutral-muted">
+      <Icon name="loader4Line" className="size-12 motion-safe:animate-spin" aria-hidden="true" />
+      running
+    </span>
+  );
+}

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -1,0 +1,134 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import type {Meta, StoryObj} from '@storybook/react';
+import {LogView} from './log-view.js';
+
+const ESC = String.fromCharCode(27);
+const origin = new Date('2026-06-23T10:00:00.000Z').getTime();
+const at = (offsetSeconds: number) => origin + offsetSeconds * 1000;
+
+const out = (data: string, offset: number, stream: 'stdout' | 'stderr' = 'stdout'): LogRecord => ({
+  v: 1,
+  ts: at(offset),
+  type: 'output',
+  stream,
+  data,
+});
+const groupStart = (
+  groupId: string,
+  name: string,
+  offset: number,
+  parentGroupId: string | null = null,
+): LogRecord => ({
+  v: 1,
+  ts: at(offset),
+  type: 'group_start',
+  group_id: groupId,
+  parent_group_id: parentGroupId,
+  name,
+});
+const groupEnd = (groupId: string, offset: number): LogRecord => ({
+  v: 1,
+  ts: at(offset),
+  type: 'group_end',
+  group_id: groupId,
+});
+
+const showcaseRecords: LogRecord[] = [
+  out('$ pnpm build && pnpm test\n', 0),
+  groupStart('g1', 'Install dependencies', 1),
+  out('Resolving packages...\n', 2),
+  out('Linking 318 packages\n', 3),
+  groupEnd('g1', 4),
+  groupStart('g2', 'Build', 5),
+  out(`${ESC}[32m✓${ESC}[0m built ${ESC}[34m1284${ESC}[0m modules\n`, 6),
+  out('warn: deprecated glob@7, upgrade to glob@10\n', 7, 'stderr'),
+  groupEnd('g2', 8),
+  groupStart('g3', 'Test', 9),
+  out('running 42 tests\n', 10),
+  out('FAIL client.test.ts > retries on 503\n', 11, 'stderr'),
+  groupEnd('g3', 12),
+  {v: 1, ts: at(13), type: 'gap', dropped_bytes: 2048},
+  {v: 1, ts: at(14), type: 'end', total_bytes: 15_360},
+];
+
+// A pipeline nested three levels deep: Deploy > Build > Compile, and Deploy >
+// Test > {unit, e2e}. The e2e leaf writes to stderr, so its error bubbles up to
+// Test and the top-level pipeline (visible as an inset bar when those groups are
+// collapsed); the Build branch stays clean. Closed inner groups carry a duration.
+const nestedRecords: LogRecord[] = [
+  groupStart('g1', 'Deploy pipeline', 0),
+  out('$ ./deploy.sh\n', 0.1),
+  groupStart('g2', 'Build', 1, 'g1'),
+  out('resolving workspace graph\n', 1.2),
+  groupStart('g3', 'Compile @app/web', 2, 'g2'),
+  out(`${ESC}[32m✓${ESC}[0m built ${ESC}[34m842${ESC}[0m modules\n`, 3),
+  groupEnd('g3', 4),
+  groupStart('g4', 'Compile @app/api', 4.2, 'g2'),
+  out('tsc --build\n', 5),
+  out('✓ 1.1k files emitted\n', 6),
+  groupEnd('g4', 7),
+  groupEnd('g2', 7.5),
+  groupStart('g5', 'Test', 8, 'g1'),
+  groupStart('g6', 'unit', 8.2, 'g5'),
+  out('running 128 tests\n', 9),
+  out('✓ 128 passed\n', 10),
+  groupEnd('g6', 11),
+  groupStart('g7', 'e2e', 11.2, 'g5'),
+  out('running 12 specs\n', 12),
+  out('FAIL checkout.spec.ts > applies coupon at checkout\n', 13, 'stderr'),
+  groupEnd('g7', 14),
+  groupEnd('g5', 14.5),
+  groupEnd('g1', 15),
+  {v: 1, ts: at(15.2), type: 'end', total_bytes: 9_216},
+];
+
+const meta = {
+  title: 'Logs/LogView',
+  component: LogView,
+  parameters: {layout: 'padded'},
+  tags: ['autodocs'],
+  argTypes: {
+    timestamps: {control: 'inline-radio', options: ['off', 'rel', 'abs']},
+    wrap: {control: 'boolean'},
+    showLineNumbers: {control: 'boolean'},
+  },
+  args: {
+    timestamps: 'off',
+    wrap: false,
+    showLineNumbers: true,
+  },
+} satisfies Meta<typeof LogView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Showcase: Story = {
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={showcaseRecords} />
+    </div>
+  ),
+};
+
+/**
+ * Groups nested three levels deep (Deploy > Build > Compile, Deploy > Test >
+ * unit/e2e). Each level indents; the failing `e2e` leaf bubbles its error up to
+ * `Test` and `Deploy pipeline`. Collapse any group to see its "N lines" summary,
+ * duration, and (for a branch with a failure) the inset error bar.
+ */
+export const NestedGroups: Story = {
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={nestedRecords} />
+    </div>
+  ),
+};
+
+export const Empty: Story = {
+  args: {showLineNumbers: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={[]} />
+    </div>
+  ),
+};

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import {LogContent, LogRow, LogRows, type LogTimestampMode} from '@shipfox/react-ui';
+import {type ReactNode, useMemo} from 'react';
+import {
+  assertNever,
+  buildLogTree,
+  type LogNode,
+  type LogTree,
+  type MarkerLogRecord,
+} from '#core/log-tree.js';
+import {LogGroup} from './log-group.js';
+import {OutputLogRow} from './output-log-row.js';
+import {CappedMarker, EndMarker, GapMarker, RunnerLostMarker} from './system-markers.js';
+
+export interface LogViewProps {
+  records: readonly LogRecord[];
+  timestamps?: LogTimestampMode;
+  wrap?: boolean;
+  showLineNumbers?: boolean;
+}
+
+export function LogView({
+  records,
+  timestamps = 'off',
+  wrap = false,
+  showLineNumbers = true,
+}: LogViewProps) {
+  const tree = useMemo(() => buildLogTree(records), [records]);
+  const isEmpty = tree.nodes.length === 0;
+
+  return (
+    <LogRows
+      timestamps={timestamps}
+      wrap={wrap}
+      showLineNumbers={showLineNumbers}
+      {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
+    >
+      {isEmpty ? (
+        <LogRow lineNumber={null}>
+          <LogContent variant="code" className="text-foreground-neutral-muted">
+            No output
+          </LogContent>
+        </LogRow>
+      ) : (
+        renderNodes(tree.nodes, 0, tree)
+      )}
+    </LogRows>
+  );
+}
+
+function renderNodes(nodes: readonly LogNode[], depth: number, tree: LogTree): ReactNode[] {
+  // `node.seq` is the stable, unique render key (see `LogNodeBase`): a concatenated
+  // multi-step/retry stream can repeat a `group_id` or a marker's `(type, ts)` at one
+  // level, which a key derived from those fields would collide on.
+  return nodes.map((node): ReactNode => {
+    switch (node.kind) {
+      case 'output':
+        return (
+          <OutputLogRow
+            key={node.seq}
+            record={node.record}
+            lineNumber={node.lineNumber}
+            indent={depth}
+          />
+        );
+      case 'group':
+        return (
+          <LogGroup
+            key={node.seq}
+            node={node}
+            depth={depth}
+            terminated={tree.terminated}
+            defaultOpen
+          >
+            {renderNodes(node.children, depth + 1, tree)}
+          </LogGroup>
+        );
+      case 'marker':
+        return <MarkerRow key={node.seq} record={node.record} tree={tree} />;
+      default:
+        return assertNever(node);
+    }
+  });
+}
+
+function MarkerRow({record, tree}: {record: MarkerLogRecord; tree: LogTree}): ReactNode {
+  switch (record.type) {
+    case 'end':
+      return (
+        <EndMarker
+          record={record}
+          lineCount={tree.lineCount}
+          durationMs={tree.originTs != null ? record.ts - tree.originTs : null}
+        />
+      );
+    case 'gap':
+      return <GapMarker record={record} />;
+    case 'capped':
+      return <CappedMarker record={record} />;
+    case 'runner_lost':
+      return <RunnerLostMarker record={record} />;
+    default:
+      return assertNever(record);
+  }
+}

--- a/libs/client/logs/src/components/output-log-row.stories.tsx
+++ b/libs/client/logs/src/components/output-log-row.stories.tsx
@@ -1,0 +1,76 @@
+import {LogRows} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import type {OutputLogRecord} from '#core/log-tree.js';
+import {OutputLogRow} from './output-log-row.js';
+
+const ESC = String.fromCharCode(27);
+const origin = new Date('2026-06-23T10:00:00.000Z').getTime();
+
+const record = (
+  data: string,
+  stream: 'stdout' | 'stderr' = 'stdout',
+  offsetSeconds = 0,
+): OutputLogRecord => ({
+  v: 1,
+  ts: origin + offsetSeconds * 1000,
+  type: 'output',
+  stream,
+  data,
+});
+
+const meta = {
+  title: 'Logs/OutputLogRow',
+  component: OutputLogRow,
+  parameters: {layout: 'padded'},
+  tags: ['autodocs'],
+} satisfies Meta<typeof OutputLogRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Streams: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <OutputLogRow
+          record={record('transforming (1284) src/index.tsx\n', 'stdout', 0)}
+          lineNumber={1}
+        />
+        <OutputLogRow
+          record={record(
+            `${ESC}[32m✓${ESC}[0m built ${ESC}[34m1284${ESC}[0m modules\n`,
+            'stdout',
+            1,
+          )}
+          lineNumber={2}
+        />
+        <OutputLogRow
+          record={record('warn: deprecated glob@7, upgrade to glob@10\n', 'stderr', 2)}
+          lineNumber={3}
+        />
+        <OutputLogRow
+          record={record('FAIL client.test.ts > retries on 503\n', 'stderr', 3)}
+          lineNumber={4}
+        />
+        <OutputLogRow record={record('done in 412ms\n', 'stdout', 4)} lineNumber={5} />
+      </LogRows>
+    </div>
+  ),
+};
+
+export const LongLine: Story = {
+  render: () => (
+    <div className="max-w-md">
+      <LogRows>
+        <OutputLogRow
+          record={record(
+            'ERROR TypeError: Cannot read properties of undefined (reading "id") at withRetry (src/api/retry.ts:42:18) at async runStep (src/runner/step.ts:118:7)\n',
+            'stderr',
+            0,
+          )}
+          lineNumber={120}
+        />
+      </LogRows>
+    </div>
+  ),
+};

--- a/libs/client/logs/src/components/output-log-row.tsx
+++ b/libs/client/logs/src/components/output-log-row.tsx
@@ -1,0 +1,34 @@
+import {cn, LogContent, LogRow} from '@shipfox/react-ui';
+import {type OutputLogRecord, stripTrailingNewline} from '#core/log-tree.js';
+
+export interface OutputLogRowProps {
+  record: OutputLogRecord;
+  lineNumber?: number | null;
+  indent?: number;
+  selected?: boolean;
+}
+
+export function OutputLogRow({
+  record,
+  lineNumber = null,
+  indent = 0,
+  selected = false,
+}: OutputLogRowProps) {
+  const isStderr = record.stream === 'stderr';
+  // Stderr uses a neutral channel rule; it is a stream, not a severity, so it never reads as an error.
+
+  return (
+    <LogRow
+      lineNumber={lineNumber}
+      timestamp={new Date(record.ts)}
+      indent={indent}
+      selected={selected}
+      data-stream={record.stream}
+      className={cn(isStderr && 'shadow-[inset_2px_0_0_var(--color-border-neutral-strong)]')}
+    >
+      <LogContent variant="code" ansi className={cn(isStderr && 'text-foreground-neutral-subtle')}>
+        {stripTrailingNewline(record.data)}
+      </LogContent>
+    </LogRow>
+  );
+}

--- a/libs/client/logs/src/components/system-markers.stories.tsx
+++ b/libs/client/logs/src/components/system-markers.stories.tsx
@@ -1,0 +1,32 @@
+import {LogRows} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {CappedMarker, EndMarker, GapMarker, RunnerLostMarker} from './system-markers.js';
+
+const ts = new Date('2026-06-23T10:00:00.000Z').getTime();
+
+const meta = {
+  title: 'Logs/SystemMarkers',
+  component: EndMarker,
+  parameters: {layout: 'padded'},
+  tags: ['autodocs'],
+} satisfies Meta<typeof EndMarker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const All: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <GapMarker record={{v: 1, ts, type: 'gap', dropped_bytes: 2048}} />
+        <CappedMarker record={{v: 1, ts, type: 'capped'}} />
+        <RunnerLostMarker record={{v: 1, ts, type: 'runner_lost'}} />
+        <EndMarker
+          record={{v: 1, ts, type: 'end', total_bytes: 15_360}}
+          lineCount={412}
+          durationMs={2100}
+        />
+      </LogRows>
+    </div>
+  ),
+};

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -1,0 +1,139 @@
+import {
+  cn,
+  formatBytes,
+  formatDuration,
+  Icon,
+  type IconName,
+  LogContent,
+  LogRow,
+} from '@shipfox/react-ui';
+import type {
+  CappedLogRecord,
+  EndLogRecord,
+  GapLogRecord,
+  RunnerLostLogRecord,
+} from '#core/log-tree.js';
+
+type MarkerTone = 'default' | 'warning' | 'error';
+
+const toneText: Record<MarkerTone, string> = {
+  default: 'text-foreground-neutral-muted',
+  warning: 'text-orange-600 dark:text-orange-400',
+  error: 'text-red-600 dark:text-red-400',
+};
+
+interface LogMarkerRowProps {
+  icon: IconName;
+  tone: MarkerTone;
+  timestamp?: Date | null;
+  /** Plain-language clause after the label: what it means / what to do. */
+  detail?: string;
+  /** Right-aligned `font-code` figures (bytes, line count, duration). */
+  meta?: string;
+  children: string;
+}
+
+/**
+ * Shared timeline-marker row: a non-numbered line with a leading icon, a bold label, an
+ * optional plain-language detail clause, a dashed divider, and optional right-aligned
+ * monospace figures. The detail explains the consequence to the operator (the label
+ * names the event, the icon/tone carry severity), so the copy reads helpfully rather
+ * than mechanically.
+ */
+function LogMarkerRow({icon, tone, timestamp = null, detail, meta, children}: LogMarkerRowProps) {
+  return (
+    <LogRow lineNumber={null} timestamp={timestamp} tone={tone}>
+      <LogContent className={cn('block', toneText[tone])}>
+        <span className="inline-flex w-full items-center gap-8">
+          <Icon name={icon} className="size-14 flex-none" aria-hidden="true" />
+          {/* Label, detail, and figures share one text cluster joined by a literal
+              " · ". Flex `gap` is visual only and would copy with no separator, so the
+              separators are real inline text. The dashed rule trails after the text
+              (an aria-hidden flex filler) and contributes nothing to a selection. */}
+          <span className="min-w-0">
+            <span className="font-medium">{children}</span>
+            {detail != null && (
+              <>
+                {' · '}
+                <span className="font-normal opacity-80">{detail}</span>
+              </>
+            )}
+            {meta != null && (
+              <>
+                {' · '}
+                <span className="font-code tabular-nums opacity-80">{meta}</span>
+              </>
+            )}
+          </span>
+          <span
+            aria-hidden="true"
+            className="h-px flex-1 border-t border-dashed border-current opacity-30"
+          />
+        </span>
+      </LogContent>
+    </LogRow>
+  );
+}
+
+export interface EndMarkerProps {
+  record: EndLogRecord;
+  lineCount: number;
+  durationMs?: number | null;
+}
+
+/** Clean end of the log: line count + output bytes (+ overall duration). `total_bytes` is payload bytes. */
+export function EndMarker({record, lineCount, durationMs = null}: EndMarkerProps) {
+  const meta = [
+    `${lineCount} ${lineCount === 1 ? 'line' : 'lines'}`,
+    formatBytes(record.total_bytes),
+    ...(durationMs != null ? [formatDuration(durationMs)] : []),
+  ].join(' · ');
+
+  return (
+    <LogMarkerRow icon="flagLine" tone="default" timestamp={new Date(record.ts)} meta={meta}>
+      End of log
+    </LogMarkerRow>
+  );
+}
+
+/** The runner's local backlog shed bytes before upload, so some output never arrived. A warning. */
+export function GapMarker({record}: {record: GapLogRecord}) {
+  return (
+    <LogMarkerRow
+      icon="errorWarningLine"
+      tone="warning"
+      timestamp={new Date(record.ts)}
+      detail={`the runner fell behind and dropped ${formatBytes(record.dropped_bytes)}`}
+    >
+      Output missing
+    </LogMarkerRow>
+  );
+}
+
+/** The job hit its shared log size limit; logging stopped but the step kept running. A warning. */
+export function CappedMarker({record}: {record: CappedLogRecord}) {
+  return (
+    <LogMarkerRow
+      icon="forbidLine"
+      tone="warning"
+      timestamp={new Date(record.ts)}
+      detail="later output isn't shown; the step kept running"
+    >
+      Log size limit reached
+    </LogMarkerRow>
+  );
+}
+
+/** The runner disappeared and the stream was force-closed. A terminal failure (status taxonomy §9). */
+export function RunnerLostMarker({record}: {record: RunnerLostLogRecord}) {
+  return (
+    <LogMarkerRow
+      icon="closeCircleLine"
+      tone="error"
+      timestamp={new Date(record.ts)}
+      detail="the log ends here and may be incomplete"
+    >
+      Runner disconnected
+    </LogMarkerRow>
+  );
+}

--- a/libs/client/logs/src/core/log-tree.test.ts
+++ b/libs/client/logs/src/core/log-tree.test.ts
@@ -1,0 +1,350 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import {buildLogTree, type GroupLogNode, type LogNode, stripTrailingNewline} from './log-tree.js';
+
+const out = (data: string, stream: 'stdout' | 'stderr' = 'stdout', ts = 0): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'output',
+  stream,
+  data,
+});
+const gstart = (
+  groupId: string,
+  name: string,
+  parentGroupId: string | null = null,
+  ts = 0,
+): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'group_start',
+  group_id: groupId,
+  parent_group_id: parentGroupId,
+  name,
+});
+const gend = (groupId: string, ts = 0): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'group_end',
+  group_id: groupId,
+});
+const end = (totalBytes = 0, ts = 0): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'end',
+  total_bytes: totalBytes,
+});
+const gap = (droppedBytes = 0, ts = 0): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'gap',
+  dropped_bytes: droppedBytes,
+});
+const capped = (ts = 0): LogRecord => ({v: 1, ts, type: 'capped'});
+const runnerLost = (ts = 0): LogRecord => ({v: 1, ts, type: 'runner_lost'});
+const agentSession = (data = 'entry', ts = 0): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'agent_session',
+  data,
+});
+
+const asGroup = (node: LogNode | undefined): GroupLogNode => {
+  if (node?.kind !== 'group') throw new Error(`expected a group node, got ${node?.kind}`);
+  return node;
+};
+
+describe('buildLogTree', () => {
+  test('numbers flat output lines and counts them', () => {
+    const records = [out('a'), out('b'), out('c')];
+
+    const tree = buildLogTree(records);
+
+    expect(tree.nodes.map((n) => (n.kind === 'output' ? n.lineNumber : null))).toEqual([1, 2, 3]);
+    expect(tree.lineCount).toBe(3);
+    expect(tree.terminated).toBe(false);
+  });
+
+  test('reads originTs from the first record and null when empty', () => {
+    const withRecords = buildLogTree([out('a', 'stdout', 42)]);
+    const empty = buildLogTree([]);
+
+    expect(withRecords.originTs).toBe(42);
+    expect(empty.originTs).toBeNull();
+    expect(empty.nodes).toEqual([]);
+    expect(empty.lineCount).toBe(0);
+  });
+
+  test('anchors originTs on the first render-relevant record, skipping a leading agent_session', () => {
+    const tree = buildLogTree([agentSession('entry', 5), out('a', 'stdout', 9)]);
+
+    expect(tree.originTs).toBe(9);
+  });
+
+  test('nests output inside a closed group', () => {
+    const records = [gstart('g1', 'Build'), out('compiling'), gend('g1', 9)];
+
+    const tree = buildLogTree(records);
+    const group = asGroup(tree.nodes[0]);
+
+    expect(tree.nodes).toHaveLength(1);
+    expect(group.record.name).toBe('Build');
+    expect(group.closed).toBe(true);
+    expect(group.endTs).toBe(9);
+    expect(group.children).toHaveLength(1);
+  });
+
+  test('builds a multi-level group tree', () => {
+    const records = [
+      gstart('g1', 'Build'),
+      gstart('g2', 'Compile', 'g1'),
+      out('cc'),
+      gend('g2'),
+      gend('g1'),
+    ];
+
+    const tree = buildLogTree(records);
+    const g1 = asGroup(tree.nodes[0]);
+    const g2 = asGroup(g1.children[0]);
+
+    expect(g1.record.group_id).toBe('g1');
+    expect(g2.record.group_id).toBe('g2');
+    expect(g2.children[0]?.kind).toBe('output');
+  });
+
+  test('precomputes the subtree output-line count per group', () => {
+    const records = [
+      gstart('g1', 'Build'),
+      out('a'),
+      gstart('g2', 'Compile', 'g1'),
+      out('b'),
+      out('c'),
+      gend('g2'),
+      gend('g1'),
+    ];
+
+    const g1 = asGroup(buildLogTree(records).nodes[0]);
+    const g2 = asGroup(g1.children[1]);
+
+    expect(g1.lineCount).toBe(3);
+    expect(g2.lineCount).toBe(2);
+  });
+
+  test('leaves a group open when its end never arrives', () => {
+    const records = [gstart('g1', 'Build'), out('still going')];
+
+    const tree = buildLogTree(records);
+    const group = asGroup(tree.nodes[0]);
+
+    expect(group.closed).toBe(false);
+    expect(group.endTs).toBeNull();
+  });
+
+  test('ignores an unbalanced group_end with no open group', () => {
+    const records = [out('a'), gend('ghost'), out('b')];
+
+    const tree = buildLogTree(records);
+
+    expect(tree.nodes.map((n) => n.kind)).toEqual(['output', 'output']);
+  });
+
+  test('closes the matching group_id when a group_start was dropped (C1)', () => {
+    const records = [gstart('g1', 'Build'), out('inside g1'), gend('g2'), gend('g1', 5)];
+
+    const tree = buildLogTree(records);
+    const g1 = asGroup(tree.nodes[0]);
+
+    expect(tree.nodes).toHaveLength(1);
+    expect(g1.closed).toBe(true);
+    expect(g1.endTs).toBe(5);
+    expect(g1.children.map((n) => n.kind)).toEqual(['output']);
+  });
+
+  test('orphaned inner groups close with their matched ancestor', () => {
+    const records = [gstart('g1', 'Build'), gstart('g2', 'Compile', 'g1'), out('x'), gend('g1', 7)];
+
+    const tree = buildLogTree(records);
+    const g1 = asGroup(tree.nodes[0]);
+    const g2 = asGroup(g1.children[0]);
+
+    expect(g1.closed).toBe(true);
+    expect(g1.endTs).toBe(7);
+    expect(g2.closed).toBe(true);
+    expect(g2.endTs).toBeNull();
+  });
+
+  test('a dropped root group_end does not nest or taint the next root group', () => {
+    // g1's group_end is dropped under backlog pressure (a gap stands in for it); g2 declares
+    // parent_group_id null, so it lands at root, not inside still-open g1. g1 is orphan-closed
+    // when g2 opens, so a runner_lost inside g2 must not bubble into the already-closed g1.
+    const records = [
+      gstart('g1', 'first'),
+      out('a'),
+      gap(64),
+      gstart('g2', 'second'),
+      runnerLost(),
+      gend('g2'),
+    ];
+
+    const tree = buildLogTree(records);
+    const g1 = asGroup(tree.nodes[0]);
+    const g2 = asGroup(tree.nodes[1]);
+
+    expect(tree.nodes).toHaveLength(2);
+    expect(g1.closed).toBe(true);
+    expect(g1.endTs).toBeNull();
+    expect(g1.lineCount).toBe(1);
+    expect(g1.hasError).toBe(false);
+    expect(g2.hasError).toBe(true);
+  });
+
+  test('a dropped inner group_end reparents the next sibling via parent_group_id', () => {
+    // g2's group_end is dropped; g3 declares parent g1, so it is a sibling of g2 under g1,
+    // not nested inside the still-open g2.
+    const records = [
+      gstart('g1', 'outer'),
+      gstart('g2', 'inner-a', 'g1'),
+      out('x'),
+      gstart('g3', 'inner-b', 'g1'),
+      out('y'),
+      gend('g3'),
+      gend('g1', 9),
+    ];
+
+    const tree = buildLogTree(records);
+    const g1 = asGroup(tree.nodes[0]);
+
+    expect(g1.children.map((n) => n.kind)).toEqual(['group', 'group']);
+    const g2 = asGroup(g1.children[0]);
+    const g3 = asGroup(g1.children[1]);
+    expect(g2.record.group_id).toBe('g2');
+    expect(g2.closed).toBe(true);
+    expect(g2.endTs).toBeNull();
+    expect(g3.record.group_id).toBe('g3');
+    expect(g3.closed).toBe(true);
+  });
+
+  test('places markers at the current nesting level', () => {
+    const records = [gstart('g1', 'Build'), gap(128), gend('g1'), end(2048)];
+
+    const tree = buildLogTree(records);
+    const g1 = asGroup(tree.nodes[0]);
+
+    expect(g1.children[0]?.kind).toBe('marker');
+    expect(tree.nodes[1]?.kind).toBe('marker');
+  });
+
+  test('assigns a unique seq across siblings that reuse a group_id or marker ts', () => {
+    // A concatenated multi-step/retry stream reuses g1 and can repeat a marker (type, ts);
+    // seq stays unique so the React keys in LogView never collide.
+    const records = [
+      gstart('g1', 'first'),
+      gend('g1'),
+      gstart('g1', 'second'),
+      gend('g1'),
+      gap(1, 5),
+      gap(2, 5),
+    ];
+
+    const seqs = buildLogTree(records).nodes.map((n) => n.seq);
+
+    expect(seqs).toEqual([0, 1, 2, 3]);
+  });
+
+  test('skips agent_session without consuming a line number', () => {
+    const records = [out('a'), agentSession('{"role":"assistant"}'), out('b')];
+
+    const tree = buildLogTree(records);
+
+    expect(tree.nodes).toHaveLength(2);
+    expect(tree.nodes.map((n) => (n.kind === 'output' ? n.lineNumber : null))).toEqual([1, 2]);
+  });
+
+  test.each([
+    ['end', [end()], true],
+    ['runner_lost', [runnerLost()], true],
+    ['capped', [capped()], false],
+    ['none', [out('a')], false],
+  ])('terminated is %s-driven', (_label, records, expected) => {
+    const tree = buildLogTree(records as LogRecord[]);
+
+    expect(tree.terminated).toBe(expected);
+  });
+
+  describe('hasError annotation', () => {
+    test('a runner_lost marker in a group sets hasError', () => {
+      const records = [gstart('g1', 'Run'), runnerLost(), gend('g1')];
+
+      const group = asGroup(buildLogTree(records).nodes[0]);
+
+      expect(group.hasError).toBe(true);
+    });
+
+    test('stderr does NOT set hasError (a channel, not a failure)', () => {
+      const records = [gstart('g1', 'Run'), out('boom', 'stderr'), gend('g1')];
+
+      const group = asGroup(buildLogTree(records).nodes[0]);
+
+      expect(group.hasError).toBe(false);
+    });
+
+    test('gap and capped are warnings, not errors', () => {
+      const records = [gstart('g1', 'Run'), gap(64), capped(), gend('g1')];
+
+      const group = asGroup(buildLogTree(records).nodes[0]);
+
+      expect(group.hasError).toBe(false);
+    });
+
+    test('a runner_lost bubbles up through nested ancestors', () => {
+      const records = [
+        gstart('g1', 'Build'),
+        gstart('g2', 'Compile', 'g1'),
+        runnerLost(),
+        gend('g2'),
+        gend('g1'),
+      ];
+
+      const g1 = asGroup(buildLogTree(records).nodes[0]);
+      const g2 = asGroup(g1.children[0]);
+
+      expect(g1.hasError).toBe(true);
+      expect(g2.hasError).toBe(true);
+    });
+
+    test('a closed sibling is not marked by a later runner_lost', () => {
+      const records = [
+        gstart('g1', 'first'),
+        out('ok'),
+        gend('g1'),
+        gstart('g2', 'second'),
+        runnerLost(),
+        gend('g2'),
+      ];
+
+      const tree = buildLogTree(records);
+      const g1 = asGroup(tree.nodes[0]);
+      const g2 = asGroup(tree.nodes[1]);
+
+      expect(g1.hasError).toBe(false);
+      expect(g2.hasError).toBe(true);
+    });
+  });
+});
+
+describe('stripTrailingNewline', () => {
+  test('removes a single trailing newline', () => {
+    expect(stripTrailingNewline('line\n')).toBe('line');
+  });
+
+  test('leaves a line without a trailing newline untouched', () => {
+    expect(stripTrailingNewline('line')).toBe('line');
+  });
+
+  test('removes only one of several trailing newlines', () => {
+    expect(stripTrailingNewline('line\n\n')).toBe('line\n');
+  });
+
+  test('strips a trailing CRLF, leaving no carriage return', () => {
+    expect(stripTrailingNewline('line\r\n')).toBe('line');
+  });
+});

--- a/libs/client/logs/src/core/log-tree.ts
+++ b/libs/client/logs/src/core/log-tree.ts
@@ -1,0 +1,196 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
+
+/**
+ * Pure render transform for the step-log read stream. The runner emits a flat,
+ * ordered NDJSON record list; `group_start`/`group_end` form a tree that the
+ * reader reconstructs here before rendering. No React, no state — one function
+ * over the record array.
+ *
+ *   records[] ──▶ buildLogTree ──▶ { nodes (forest), terminated, originTs, lineCount }
+ *
+ * Group closing matches `group_id` (not a blind top-of-stack pop) so a stream that
+ * drops a `group_start` under backlog/gap pressure but still delivers its
+ * `group_end` does not mis-nest everything after it.
+ */
+
+export type OutputLogRecord = Extract<LogRecord, {type: 'output'}>;
+export type GroupStartLogRecord = Extract<LogRecord, {type: 'group_start'}>;
+export type EndLogRecord = Extract<LogRecord, {type: 'end'}>;
+export type GapLogRecord = Extract<LogRecord, {type: 'gap'}>;
+export type CappedLogRecord = Extract<LogRecord, {type: 'capped'}>;
+export type RunnerLostLogRecord = Extract<LogRecord, {type: 'runner_lost'}>;
+export type MarkerLogRecord = EndLogRecord | GapLogRecord | CappedLogRecord | RunnerLostLogRecord;
+
+/**
+ * Stable, unique render key in creation order. A natural key is not enough: `group_id`
+ * and a marker's `(type, ts)` can both repeat among siblings once a consumer feeds a
+ * concatenated multi-step/retry stream (or two markers land in the same millisecond),
+ * and the append-only build order keeps `seq` stable across re-renders.
+ */
+export interface LogNodeBase {
+  seq: number;
+}
+
+export interface OutputLogNode extends LogNodeBase {
+  kind: 'output';
+  lineNumber: number;
+  record: OutputLogRecord;
+}
+
+export interface MarkerLogNode extends LogNodeBase {
+  kind: 'marker';
+  record: MarkerLogRecord;
+}
+
+export interface GroupLogNode extends LogNodeBase {
+  kind: 'group';
+  record: GroupStartLogRecord;
+  /** False when no matching `group_end` arrived (still streaming, or truncated). */
+  closed: boolean;
+  /** `group_end` timestamp when closed by its matching end, else null. */
+  endTs: number | null;
+  /** Precomputed: subtree contains a `runner_lost` (a genuine failure). `stderr` is a channel, not an error, so it never sets this. */
+  hasError: boolean;
+  /** Precomputed output-line count in the subtree, for the collapsed summary. */
+  lineCount: number;
+  children: LogNode[];
+}
+
+export type LogNode = OutputLogNode | MarkerLogNode | GroupLogNode;
+
+export interface LogTree {
+  nodes: LogNode[];
+  /** The stream is closed: the records contain an `end` or a `runner_lost`. */
+  terminated: boolean;
+  /** First record's timestamp; the baseline for relative timestamps. Null when empty. */
+  originTs: number | null;
+  /** Physical output lines (one per `output` record in v1); drives the end banner. */
+  lineCount: number;
+}
+
+const TRAILING_NEWLINE = /\r?\n$/;
+
+/** Strips a single trailing line ending (CRLF or LF) so a line-framed record renders without a blank continuation. */
+export function stripTrailingNewline(data: string): string {
+  return data.replace(TRAILING_NEWLINE, '');
+}
+
+export function assertNever(value: never): never {
+  throw new Error(`unexpected log record type: ${JSON.stringify(value)}`);
+}
+
+export function buildLogTree(records: readonly LogRecord[]): LogTree {
+  const nodes: LogNode[] = [];
+  const stack: GroupLogNode[] = [];
+  let seq = 0;
+  let lineNumber = 0;
+  let lineCount = 0;
+  let terminated = false;
+  // Anchor relative timestamps on the first render-relevant record, skipping a leading
+  // agent_session (rendered elsewhere) so the first visible row reads as the baseline.
+  let originTs: number | null = null;
+
+  const childrenOf = (): LogNode[] => stack[stack.length - 1]?.children ?? nodes;
+
+  // Bubble a failure signal (a runner_lost only) to every currently-open ancestor group
+  // in one pass, so `hasError` is read in O(1) at render time instead of re-walking subtrees.
+  const markOpenGroupsError = (): void => {
+    for (const frame of stack) frame.hasError = true;
+  };
+
+  for (const record of records) {
+    if (originTs === null && record.type !== 'agent_session') originTs = record.ts;
+    switch (record.type) {
+      case 'output': {
+        lineNumber += 1;
+        lineCount += 1;
+        for (const frame of stack) frame.lineCount += 1;
+        childrenOf().push({kind: 'output', seq: seq++, lineNumber, record});
+        break;
+      }
+      case 'group_start': {
+        // Reconcile the open stack to the declared parent before nesting. `parent_group_id`
+        // is the runner's stack top at emit time (null at the root), so any reader frame
+        // below that parent (or every open frame, when the parent is root) is a group whose
+        // own `group_end` was dropped under backlog pressure. Orphan-close those frames so a
+        // dropped end never mis-parents the groups that follow. A parent whose own start was
+        // dropped is not on the stack: it falls through to best-effort root placement.
+        const parentId = record.parent_group_id;
+        let parentIndex = -1;
+        if (parentId !== null) {
+          for (let i = stack.length - 1; i >= 0; i -= 1) {
+            if (stack[i]?.record.group_id === parentId) {
+              parentIndex = i;
+              break;
+            }
+          }
+        }
+        for (let i = stack.length - 1; i > parentIndex; i -= 1) {
+          const frame = stack[i];
+          if (frame) frame.closed = true;
+        }
+        stack.length = parentIndex + 1;
+
+        const group: GroupLogNode = {
+          kind: 'group',
+          seq: seq++,
+          record,
+          closed: false,
+          endTs: null,
+          hasError: false,
+          lineCount: 0,
+          children: [],
+        };
+        childrenOf().push(group);
+        stack.push(group);
+        break;
+      }
+      case 'group_end': {
+        // Close the matching open group_id; any inner frames orphaned by a dropped
+        // group_end close with it. An end with no matching open start is ignored.
+        let matchIndex = -1;
+        for (let i = stack.length - 1; i >= 0; i -= 1) {
+          if (stack[i]?.record.group_id === record.group_id) {
+            matchIndex = i;
+            break;
+          }
+        }
+        if (matchIndex !== -1) {
+          for (let i = stack.length - 1; i >= matchIndex; i -= 1) {
+            const frame = stack[i];
+            if (frame) frame.closed = true;
+          }
+          const matched = stack[matchIndex];
+          if (matched) matched.endTs = record.ts;
+          stack.length = matchIndex;
+        }
+        break;
+      }
+      case 'end':
+      case 'gap':
+      case 'capped': {
+        if (record.type === 'end') terminated = true;
+        childrenOf().push({kind: 'marker', seq: seq++, record});
+        break;
+      }
+      case 'runner_lost': {
+        terminated = true;
+        childrenOf().push({kind: 'marker', seq: seq++, record});
+        markOpenGroupsError();
+        break;
+      }
+      case 'agent_session':
+        // Rendered by the agent-session surface, not this package.
+        break;
+      default:
+        assertNever(record);
+    }
+  }
+
+  return {
+    nodes,
+    terminated,
+    originTs,
+    lineCount,
+  };
+}

--- a/libs/client/logs/src/env.d.ts
+++ b/libs/client/logs/src/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/libs/client/logs/src/index.ts
+++ b/libs/client/logs/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  buildLogTree,
+  type GroupLogNode,
+  type LogNode,
+  type LogTree,
+  type MarkerLogNode,
+  type OutputLogNode,
+} from '#core/log-tree.js';
+export * from './components/index.js';

--- a/libs/client/logs/tsconfig.build.json
+++ b/libs/client/logs/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/react",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts", "**/*.stories.tsx"]
+}

--- a/libs/client/logs/tsconfig.json
+++ b/libs/client/logs/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/client/logs/tsconfig.test.json
+++ b/libs/client/logs/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": ["**/*.stories.tsx"]
+}

--- a/libs/client/logs/vitest.config.ts
+++ b/libs/client/logs/vitest.config.ts
@@ -1,0 +1,58 @@
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {argosVitestPlugin} from '@argos-ci/storybook/vitest-plugin';
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig(
+  {
+    plugins: [react(), tailwindcss()],
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          plugins: [
+            storybookTest({configDir: path.join(dirname, '.storybook')}),
+            argosVitestPlugin({
+              uploadToArgos: !!process.env.CI,
+              ...(process.env.ARGOS_TOKEN ? {token: process.env.ARGOS_TOKEN} : {}),
+              buildName: 'client-logs',
+              argosCSS: `
+                *, *::before, *::after {
+                  animation-delay: 0s !important;
+                  animation-duration: 0s !important;
+                  transition-delay: 0s !important;
+                  transition-duration: 0s !important;
+                }
+              `,
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright(),
+              instances: [{browser: 'chromium'}],
+            },
+          },
+        },
+      ],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/libs/shared/react/ui/src/utils/duration.test.ts
+++ b/libs/shared/react/ui/src/utils/duration.test.ts
@@ -1,4 +1,4 @@
-import {humanDuration} from './duration.js';
+import {formatDuration, humanDuration} from './duration.js';
 
 describe('humanDuration', () => {
   test('returns seconds under a minute', () => {
@@ -78,5 +78,42 @@ describe('humanDuration', () => {
   test('returns empty string for unparseable input', () => {
     expect(humanDuration('not-a-date')).toBe('');
     expect(humanDuration('2026-05-13T00:00:00.000Z', 'nope')).toBe('');
+  });
+});
+
+describe('formatDuration', () => {
+  test.each([
+    [0, '0ms'],
+    [-10, '0ms'],
+    [412, '412ms'],
+    [2100, '2.1s'],
+    [59_000, '59s'],
+    [63_000, '1m 3s'],
+    [120_000, '2m'],
+    [3_600_000, '1h'],
+    [3_720_000, '1h 2m'],
+  ])('formats %i ms as %s', (ms, expected) => {
+    const result = formatDuration(ms);
+
+    expect(result).toBe(expected);
+  });
+
+  test.each([
+    [59_950, '1m'],
+    [59_999, '1m'],
+    [119_999, '2m'],
+    [3_599_999, '1h'],
+  ])('carries a rounded-up remainder instead of rendering 60 (%i → %s)', (ms, expected) => {
+    const result = formatDuration(ms);
+
+    expect(result).toBe(expected);
+  });
+
+  test('carries a sub-1000 fractional value up to 1s instead of 1000ms', () => {
+    expect(formatDuration(999.6)).toBe('1s');
+  });
+
+  test('collapses a non-finite value to 0ms', () => {
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('0ms');
   });
 });

--- a/libs/shared/react/ui/src/utils/duration.ts
+++ b/libs/shared/react/ui/src/utils/duration.ts
@@ -26,3 +26,40 @@ export function humanDuration(fromIso: string, toIso?: string): string {
 function pad2(n: number) {
   return n.toString().padStart(2, '0');
 }
+
+/**
+ * Formats a millisecond span as a short human string ("412ms", "2.1s", "1m 3s",
+ * "1h 2m"). Use this for a precise duration value (a step or log group's elapsed
+ * time); for wall-clock between two timestamps at second granularity use
+ * `humanDuration`. Negative or non-finite input collapses to "0ms".
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0ms';
+  if (ms < 1000) {
+    // A fractional value just under 1000 rounds up; carry it to "1s" rather than "1000ms".
+    const roundedMs = Math.round(ms);
+    return roundedMs < 1000 ? `${roundedMs}ms` : '1s';
+  }
+
+  // Below a minute, keep one decimal of seconds. Round there and carry to "1m" if
+  // it reaches 60.0 (e.g. 59_999ms) so we never render "60s".
+  if (ms < 60_000) {
+    const seconds = Math.round(ms / 100) / 10;
+    if (seconds < 60) return `${seconds}s`;
+    return '1m';
+  }
+
+  // Round to whole seconds once, up front, then split. Rounding the remainder in
+  // place could push it to 60 ("1m 60s", "59m 60s"); carrying through whole
+  // seconds keeps every tier in range.
+  const totalSeconds = Math.round(ms / 1000);
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    const seconds = totalSeconds - totalMinutes * 60;
+    return seconds > 0 ? `${totalMinutes}m ${seconds}s` : `${totalMinutes}m`;
+  }
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes - hours * 60;
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}

--- a/libs/shared/react/ui/src/utils/format-bytes.test.ts
+++ b/libs/shared/react/ui/src/utils/format-bytes.test.ts
@@ -1,0 +1,39 @@
+import {formatBytes} from './format-bytes.js';
+
+describe('formatBytes', () => {
+  test.each([
+    [0, '0 B'],
+    [-5, '0 B'],
+    [512, '512 B'],
+    [1023, '1023 B'],
+    [1024, '1 KB'],
+    [1536, '1.5 KB'],
+    [1024 * 1024, '1 MB'],
+    [1024 * 1024 * 1024, '1 GB'],
+  ])('formats %i bytes as %s', (bytes, expected) => {
+    const result = formatBytes(bytes);
+
+    expect(result).toBe(expected);
+  });
+
+  test('drops the decimal at or above 100 in a unit', () => {
+    const result = formatBytes(150 * 1024);
+
+    expect(result).toBe('150 KB');
+  });
+
+  test.each([
+    [1024 * 1024 - 1, '1 MB'],
+    [1024 * 1024 * 1024 - 1, '1 GB'],
+  ])('carries a rounded-up unit instead of rendering 1024 (%i → %s)', (bytes, expected) => {
+    const result = formatBytes(bytes);
+
+    expect(result).toBe(expected);
+  });
+
+  test('collapses a non-finite value to 0 B', () => {
+    const result = formatBytes(Number.NaN);
+
+    expect(result).toBe('0 B');
+  });
+});

--- a/libs/shared/react/ui/src/utils/format-bytes.ts
+++ b/libs/shared/react/ui/src/utils/format-bytes.ts
@@ -1,0 +1,28 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const;
+
+/**
+ * Formats a byte count as a short human string ("512 B", "1.2 KB", "3 MB"). Uses
+ * binary (1024) steps, one decimal below 100 in a unit and none above. Negative or
+ * non-finite input collapses to "0 B".
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+
+  if (unit === 0) return `${Math.round(value)} ${UNITS[unit]}`;
+
+  let rounded = value >= 100 ? Math.round(value) : Math.round(value * 10) / 10;
+  // Rounding can push the value to a full 1024 of its unit (1_048_575 → "1024 KB");
+  // carry into the next unit so we never render "1024 KB" next to "1 MB".
+  if (rounded >= 1024 && unit < UNITS.length - 1) {
+    rounded = 1;
+    unit += 1;
+  }
+  return `${rounded} ${UNITS[unit]}`;
+}

--- a/libs/shared/react/ui/src/utils/index.ts
+++ b/libs/shared/react/ui/src/utils/index.ts
@@ -3,5 +3,6 @@ export {copyTextToClipboard} from './clipboard.js';
 export {cn} from './cn.js';
 export {formatDate, formatTimestamp} from './datetime.js';
 export {debounce} from './debounce.js';
-export {humanDuration} from './duration.js';
+export {formatDuration, humanDuration} from './duration.js';
+export {formatBytes} from './format-bytes.js';
 export {formatRelative} from './relative-time.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2362,6 +2362,85 @@ importers:
         specifier: ^19.1.1
         version: 19.2.7(react@19.2.7)
 
+  libs/client/logs:
+    dependencies:
+      '@shipfox/api-logs-dto':
+        specifier: workspace:*
+        version: link:../../api/logs-dto
+      '@shipfox/react-ui':
+        specifier: workspace:*
+        version: link:../../shared/react/ui
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.23
+    devDependencies:
+      '@argos-ci/cli':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@argos-ci/storybook':
+        specifier: ^6.0.0
+        version: 6.0.7
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@storybook/addon-vitest':
+        specifier: ^10.3.6
+        version: 10.4.2(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8))(@vitest/runner@4.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.8)
+      '@storybook/react':
+        specifier: ^10.0.0
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.0.0
+        version: 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0))
+      '@tailwindcss/vite':
+        specifier: ^4.1.13
+        version: 4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.1.11
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      react:
+        specifier: ^19.1.1
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.7(react@19.2.7)
+      storybook:
+        specifier: ^10.0.0
+        version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook-addon-pseudo-states:
+        specifier: ^10.0.0
+        version: 10.4.2(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.3.0
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   libs/client/projects:
     dependencies:
       '@shipfox/api-definitions-dto':
@@ -12855,6 +12934,14 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+    optionalDependencies:
+      typescript: 6.0.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -14999,12 +15086,37 @@ snapshots:
       - react
       - react-dom
 
+  '@storybook/addon-vitest@10.4.2(@vitest/browser-playwright@4.1.8)(@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8))(@vitest/runner@4.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.8)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/runner': 4.1.8
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/browser-playwright@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@storybook/builder-vite@10.4.2(esbuild@0.28.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.0))':
     dependencies:
       '@storybook/csf-plugin': 10.4.2(esbuild@0.28.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))(webpack@5.107.2(esbuild@0.28.0))
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.2.0
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/builder-vite@10.4.2(esbuild@0.28.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0))':
+    dependencies:
+      '@storybook/csf-plugin': 10.4.2(esbuild@0.28.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0))
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      ts-dedent: 2.2.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -15017,6 +15129,15 @@ snapshots:
     optionalDependencies:
       esbuild: 0.28.0
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
+      webpack: 5.107.2(esbuild@0.28.0)
+
+  '@storybook/csf-plugin@10.4.2(esbuild@0.28.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0))':
+    dependencies:
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       webpack: 5.107.2(esbuild@0.28.0)
 
   '@storybook/global@5.0.0': {}
@@ -15050,6 +15171,30 @@ snapshots:
       storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tsconfig-paths: 4.2.0
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react-vite@10.4.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@rollup/pluginutils': 5.4.0
+      '@storybook/builder-vite': 10.4.2(esbuild@0.28.0)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.0))
+      '@storybook/react': 10.4.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.7
+      react-docgen: 8.0.3
+      react-dom: 19.2.7(react@19.2.7)
+      resolve: 1.22.12
+      storybook: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tsconfig-paths: 4.2.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -15228,6 +15373,13 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
+
+  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tanstack/devtools-event-client@0.4.3': {}
 
@@ -15650,6 +15802,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
 
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
   '@vitest/browser-playwright@4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)
@@ -15675,7 +15832,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))(vitest@4.1.8)':
     dependencies:
@@ -15710,7 +15866,6 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
-    optional: true
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -16118,7 +16273,7 @@ snapshots:
   binary-version-check@6.1.0:
     dependencies:
       binary-version: 7.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       semver-truncate: 3.0.0
 
   binary-version@7.1.0:
@@ -18639,7 +18794,7 @@ snapshots:
 
   semver-truncate@3.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   semver@6.3.1: {}
 
@@ -18796,7 +18951,7 @@ snapshots:
       oxc-parser: 0.127.0
       oxc-resolver: 11.20.0
       recast: 0.23.11
-      semver: 7.8.3
+      semver: 7.8.5
       use-sync-external-store: 1.6.0(react@19.2.7)
       ws: 8.21.0
     optionalDependencies:


### PR DESCRIPTION
Adds `@shipfox/client-logs`, the presentational record components for the step-log read stream. They compose the `@shipfox/react-ui` log primitives into renderers for every process and system record (`output`, `group_start`/`group_end`, `end`, `gap`, `capped`, `runner_lost`); `agent_session` is left to the agent-sessions surface.

The react-ui log viewer ships only structural primitives ("four primitives, zero semantics"); record renderers are meant to be composed by the consuming client. This package is the forward-looking home for the full step-log viewer (records now; read-path hook, step-detail page, and agent-session later), mirroring the `@shipfox/client-workflows` per-package Storybook + Argos recipe.

Scope is UI only, no state management. The read-path data wiring and the step-detail page are out of scope (separate issues).

### What's here
- `buildLogTree` reconstructs the group tree from the flat record list: `group_end` closes the matching `group_id` (robust to a `group_start` dropped under gap/backlog pressure), record dispatch is an exhaustive switch, and each group node carries a precomputed `hasError` and subtree line count.
- `OutputLogRow` (stdout/stderr; stderr distinguished by a subtle left rule, not a background tint), `LogGroup` (collapsible with running/duration/incomplete affordances and an inset error bar), the four system markers, and the `LogView` dispatcher with an empty state and copy-to-clipboard.
- A package-local Storybook with a story per record type and an interleaved showcase, captured by Argos (build `client-logs`).

### Needs a careful look
`libs/api/logs-dto/src/schemas/record.ts` now measures UTF-8 byte length with `TextEncoder` instead of `node:buffer`. The type-only import of `LogRecord` compiles the DTO source under the client's browser tsconfig, so the DTO must be browser-safe. Behavior is identical, the DTO's own tests are unchanged, and all dependent packages type-check clean.

Reviewed with /plan-ceo-review, /plan-design-review, and /plan-eng-review (plus two outside-voice passes) before implementation.

Part of the Runner log capture & streaming project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@shipfox/client-logs`, a UI package for rendering process and system step logs with `@shipfox/react-ui`. Makes `@shipfox/api-logs-dto` browser‑safe via `TextEncoder`, and adds `formatBytes`/`formatDuration` to `@shipfox/react-ui`.

- **New Features**
  - `LogView` renders logs with empty state, timestamp modes (`off`/`rel`/`abs`), optional wrap, line numbers, and a stable per‑node `seq`.
  - Record components: `OutputLogRow` (stderr gets a subtle left rule), `LogGroup` (collapsible with duration/running/incomplete and an inset error bar), and markers for `end`/`gap`/`capped`/`runner_lost` with clear copy and right‑aligned meta; excludes `agent_session`.
  - `buildLogTree(records)` reconstructs groups via `group_id`/`parent_group_id`, closes orphans when ends drop, places markers, numbers lines, computes `originTs`/`terminated`/per‑group line counts, and sets `hasError` only on `runner_lost`. Includes unit tests and Storybook + Argos.

- **Refactors**
  - `@shipfox/api-logs-dto`: use `TextEncoder` for UTF‑8 byte length so the DTO compiles in the browser; behavior unchanged.
  - `@shipfox/react-ui`: add `utils/format-bytes` and `utils/format-duration` with tests; re‑export from `utils/index`.

<sup>Written for commit 878c6160db84f4fb3c460f75eadb33fe43fbdc90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

