### PR TITLE
[node-drizzle] Extract shared keyset pagination helper

### DIFF
--- a/.changeset/shared-cursors-page.md
+++ b/.changeset/shared-cursors-page.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/node-drizzle": minor
+"@shipfox/api-triggers": patch
+"@shipfox/api-workflows": patch
+---
+
+Adds shared timestamp/id keyset pagination helpers and migrates workflow run and trigger event lists onto them.

--- a/libs/api/triggers/src/db/event-queries.ts
+++ b/libs/api/triggers/src/db/event-queries.ts
@@ -1,4 +1,5 @@
-import {and, asc, desc, eq, gte, inArray, lt, lte, or, type SQL} from 'drizzle-orm';
+import {paginateTimestampIdRows, timestampIdCursorWhere} from '@shipfox/node-drizzle';
+import {and, asc, desc, eq, gte, inArray, lte, type SQL} from 'drizzle-orm';
 import type {TriggerDecision} from '#core/entities/decision.js';
 import type {
   TriggerEventOutcome,
@@ -39,23 +40,14 @@ export interface ListTriggerEventsResult {
   nextCursor: TriggerEventCursor | null;
 }
 
-// Keyset on (received_at desc, id desc). The list index covers received_at; id breaks
-// the rare equal-timestamp tie so pages never overlap or skip a row.
-function cursorWhere(cursor: TriggerEventCursor | undefined): SQL | undefined {
-  if (!cursor) return undefined;
-  return or(
-    lt(triggersReceivedEvents.receivedAt, cursor.receivedAt),
-    and(
-      eq(triggersReceivedEvents.receivedAt, cursor.receivedAt),
-      lt(triggersReceivedEvents.id, cursor.id),
-    ),
-  );
-}
-
 function listConditions(params: ListTriggerEventsParams): SQL[] {
   const {workspaceId, cursor, filters} = params;
   const conditions: SQL[] = [eq(triggersReceivedEvents.workspaceId, workspaceId)];
-  const cursorCondition = cursorWhere(cursor);
+  const cursorCondition = timestampIdCursorWhere({
+    timestampColumn: triggersReceivedEvents.receivedAt,
+    idColumn: triggersReceivedEvents.id,
+    cursor: cursor ? {createdAt: cursor.receivedAt, id: cursor.id} : undefined,
+  });
   if (cursorCondition) conditions.push(cursorCondition);
   if (filters?.source) conditions.push(eq(triggersReceivedEvents.source, filters.source));
   if (filters?.event) conditions.push(eq(triggersReceivedEvents.event, filters.event));
@@ -76,13 +68,13 @@ export async function listTriggerEvents(
     .orderBy(desc(triggersReceivedEvents.receivedAt), desc(triggersReceivedEvents.id))
     .limit(params.limit + 1);
 
-  const hasMore = rows.length > params.limit;
-  const pageRows = hasMore ? rows.slice(0, params.limit) : rows;
-  const last = pageRows.at(-1);
+  const page = paginateTimestampIdRows({rows, limit: params.limit, timestampKey: 'receivedAt'});
 
   return {
-    events: pageRows.map(toTriggerReceivedEventSummary),
-    nextCursor: hasMore && last ? {receivedAt: last.receivedAt, id: last.id} : null,
+    events: page.pageRows.map(toTriggerReceivedEventSummary),
+    nextCursor: page.nextCursor
+      ? {receivedAt: page.nextCursor.createdAt, id: page.nextCursor.id}
+      : null,
   };
 }
 

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -8,8 +8,13 @@ import {
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMap,
 } from '@shipfox/api-workflows-dto';
+import {
+  paginateTimestampIdRows,
+  type TimestampIdCursor,
+  timestampIdCursorWhere,
+} from '@shipfox/node-drizzle';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
-import {and, asc, count, desc, eq, gte, inArray, lt, lte, or, type SQL, sql} from 'drizzle-orm';
+import {and, asc, count, desc, eq, gte, inArray, lte, type SQL, sql} from 'drizzle-orm';
 import {isJobTerminal, type Job, type JobStatus} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
@@ -140,10 +145,7 @@ export async function getWorkflowRunById(id: string): Promise<WorkflowRun | unde
   return toWorkflowRun(row);
 }
 
-export interface WorkflowRunCursor {
-  createdAt: Date;
-  id: string;
-}
+export type WorkflowRunCursor = TimestampIdCursor;
 
 export interface WorkflowRunFilters {
   status?: WorkflowRunStatus | undefined;
@@ -167,14 +169,6 @@ export interface ListWorkflowRunsResult {
   filteredTotalCount: number | null;
 }
 
-function cursorWhere(cursor: WorkflowRunCursor | undefined): SQL | undefined {
-  if (!cursor) return undefined;
-  return or(
-    lt(workflowRuns.createdAt, cursor.createdAt),
-    and(eq(workflowRuns.createdAt, cursor.createdAt), lt(workflowRuns.id, cursor.id)),
-  );
-}
-
 export function buildWorkflowRunListConditions(params: {
   projectId: string;
   filters?: WorkflowRunFilters | undefined;
@@ -183,7 +177,11 @@ export function buildWorkflowRunListConditions(params: {
 }): SQL[] {
   const filters = params.filters;
   const conditions: SQL[] = [eq(workflowRuns.projectId, params.projectId)];
-  const cursorCondition = cursorWhere(params.cursor);
+  const cursorCondition = timestampIdCursorWhere({
+    timestampColumn: workflowRuns.createdAt,
+    idColumn: workflowRuns.id,
+    cursor: params.cursor,
+  });
   if (cursorCondition) conditions.push(cursorCondition);
   if (filters?.status && params.omit !== 'status') {
     conditions.push(eq(workflowRuns.status, filters.status));
@@ -227,13 +225,11 @@ export async function listWorkflowRuns(
     totalCount = value;
   }
 
-  const hasMore = rows.length > params.limit;
-  const pageRows = hasMore ? rows.slice(0, params.limit) : rows;
-  const last = pageRows.at(-1);
+  const page = paginateTimestampIdRows({rows, limit: params.limit, timestampKey: 'createdAt'});
 
   return {
-    runs: pageRows.map(toWorkflowRun),
-    nextCursor: hasMore && last ? {createdAt: last.createdAt, id: last.id} : null,
+    runs: page.pageRows.map(toWorkflowRun),
+    nextCursor: page.nextCursor,
     filteredTotalCount: totalCount,
   };
 }

--- a/libs/shared/node/drizzle/src/cursor.ts
+++ b/libs/shared/node/drizzle/src/cursor.ts
@@ -1,6 +1,13 @@
+import {and, eq, lt, or, type SQL, type SQLWrapper} from 'drizzle-orm';
+
 export interface TimestampIdCursor {
   createdAt: Date;
   id: string;
+}
+
+export interface TimestampIdPage<TRow> {
+  pageRows: TRow[];
+  nextCursor: TimestampIdCursor | null;
 }
 
 export interface StringIdCursor {
@@ -20,6 +27,33 @@ export function decodeTimestampIdCursor(cursor: string | undefined): TimestampId
   const createdAt = new Date(createdAtRaw);
   if (Number.isNaN(createdAt.getTime())) return undefined;
   return {createdAt, id};
+}
+
+export function timestampIdCursorWhere(params: {
+  timestampColumn: SQLWrapper;
+  idColumn: SQLWrapper;
+  cursor: TimestampIdCursor | undefined;
+}): SQL | undefined {
+  const {timestampColumn, idColumn, cursor} = params;
+  if (!cursor) return undefined;
+  return or(
+    lt(timestampColumn, cursor.createdAt),
+    and(eq(timestampColumn, cursor.createdAt), lt(idColumn, cursor.id)),
+  );
+}
+
+export function paginateTimestampIdRows<
+  TTimestampKey extends string,
+  TRow extends {id: string} & Record<TTimestampKey, Date>,
+>(params: {rows: TRow[]; limit: number; timestampKey: TTimestampKey}): TimestampIdPage<TRow> {
+  const hasMore = params.rows.length > params.limit;
+  const pageRows = hasMore ? params.rows.slice(0, params.limit) : params.rows;
+  const last = pageRows.at(-1);
+
+  return {
+    pageRows,
+    nextCursor: hasMore && last ? {createdAt: last[params.timestampKey], id: last.id} : null,
+  };
 }
 
 export function encodeStringIdCursor(cursor: StringIdCursor): string {

--- a/libs/shared/node/drizzle/src/index.ts
+++ b/libs/shared/node/drizzle/src/index.ts
@@ -6,7 +6,10 @@ export {
   decodeTimestampIdCursor,
   encodeStringIdCursor,
   encodeTimestampIdCursor,
+  paginateTimestampIdRows,
   type StringIdCursor,
   type TimestampIdCursor,
+  type TimestampIdPage,
+  timestampIdCursorWhere,
 } from './cursor.js';
 export {uuidv7PrimaryKey} from './schema.js';


### PR DESCRIPTION
Extract the shared timestamp/id keyset pagination machinery into `@shipfox/node-drizzle`.

Workflow run listing and trigger event listing both carried the same `(timestamp desc, id desc)` cursor predicate and `limit + 1` page slicing. This moves that behavior next to the existing timestamp/id cursor codec so the two DB callers share one implementation without changing their external API behavior.

The helper stays scoped to timestamp/id pagination. Other cursor shapes, like string/name cursors, are left alone because they have different ordering semantics.

Closes ENG-562

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared timestamp/id keyset pagination into `@shipfox/node-drizzle` and migrated workflow runs and trigger events to use it, unifying cursor predicates and page slicing with no behavior change. Closes ENG-562.

- **Refactors**
  - Added `timestampIdCursorWhere`, `paginateTimestampIdRows`, and `TimestampIdCursor`/`TimestampIdPage` exports in `@shipfox/node-drizzle`.
  - Replaced local `cursorWhere` and manual limit+1 slicing in workflow run and trigger event queries with shared helpers.
  - Scope limited to timestamp/id `(timestamp desc, id desc)` pagination; other cursor types are unchanged.

<sup>Written for commit 7cff66e3685944b0c37608acfb8afbd6710beaa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

