### PR TITLE
[client-logs] Add Vercel config for Storybook preview deploys

### DIFF
--- a/libs/client/logs/vercel.json
+++ b/libs/client/logs/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo build && pnpm run storybook:build",
+  "devCommand": "pnpm run storybook",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
+}


### PR DESCRIPTION
Add a `vercel.json` to `@shipfox/client-logs` so its Storybook gets a dedicated Vercel preview deployment, the same way `@shipfox/client-workflows` already does.

The config mirrors the workflows package verbatim: `turbo build && pnpm run storybook:build` produces the static Storybook into `./storybook-static`, with `pnpm run storybook` as the dev command. Both scripts already exist in the package, so the config applies as-is.

This gives reviewers a hosted preview of the client-logs log record components on every PR, matching the workflows surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `vercel.json` to `@shipfox/client-logs` to enable a dedicated Vercel preview for its Storybook, mirroring `@shipfox/client-workflows`. Builds with `turbo` + `pnpm run storybook:build` to `./storybook-static`; dev uses `pnpm run storybook`.

<sup>Written for commit b5f11d57dc8aad7a49fc293a695ea6983a17df6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

