### PR TITLE
[client-workflows] Add trigger source icons to run rows

### DIFF
--- a/.changeset/steady-runs-align.md
+++ b/.changeset/steady-runs-align.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Adds trigger source icons to workflow run rows so trigger metadata aligns with the status column.

--- a/libs/client/workflows/package.json
+++ b/libs/client/workflows/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
+    "@shipfox/client-triggers": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
@@ -1,4 +1,5 @@
 import type {RunDto} from '@shipfox/api-workflows-dto';
+import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {Code, cn, RelativeTime} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
@@ -62,13 +63,24 @@ export function WorkflowRunRow({
         </Code>
       </div>
 
-      <div className="flex min-w-0 items-center gap-6 pl-21">
+      <div className="flex min-w-0 items-center gap-7">
         {triggerLabel ? (
-          <Code variant="label" className="min-w-0 flex-1 truncate text-foreground-neutral-subtle">
-            {triggerLabel}
-          </Code>
+          <>
+            <TriggerSourceIcon
+              source={run.trigger_source}
+              aria-hidden
+              className="size-14 shrink-0 text-foreground-neutral-muted"
+            />
+            <Code
+              variant="label"
+              className="min-w-0 flex-1 truncate text-foreground-neutral-subtle"
+            >
+              {triggerLabel}
+            </Code>
+          </>
         ) : (
-          <span className="min-w-0 flex-1 truncate text-foreground-neutral-muted">
+          <span className="flex min-w-0 flex-1 items-center gap-7 truncate text-foreground-neutral-muted">
+            <span aria-hidden="true" className="size-14 shrink-0" />
             <span className="sr-only">Run updated </span>
           </span>
         )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2699,6 +2699,9 @@ importers:
       '@shipfox/client-api':
         specifier: workspace:*
         version: link:../api
+      '@shipfox/client-triggers':
+        specifier: workspace:*
+        version: link:../triggers
       '@shipfox/client-ui':
         specifier: workspace:*
         version: link:../ui


### PR DESCRIPTION
Adds trigger source icons to workflow run history rows and keeps the second-line trigger metadata aligned with the status/name row.

The runs list already exposed trigger source and event text, but rows did not carry the same visual source affordance used elsewhere. Reusing `TriggerSourceIcon` makes system and integration-triggered runs easier to scan while preserving the existing text alignment.

Also adds the `@shipfox/client-triggers` workspace dependency and a patch changeset for `@shipfox/client-workflows`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trigger source icons to workflow run rows to improve scanability. Keeps the trigger metadata line aligned with the status/name column.

- **New Features**
  - Display `TriggerSourceIcon` next to the trigger label on each run.
  - Preserve alignment with a spacer icon when no trigger label is present.

- **Dependencies**
  - Add `@shipfox/client-triggers` as a workspace dependency.
  - Add a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 058e3dfaf0241d86aadfa73f785a506531f5ec5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

