### PR TITLE
Add bounded outbox dead-letter handling

### DIFF
--- a/libs/api/definitions/drizzle/0000_initial.sql
+++ b/libs/api/definitions/drizzle/0000_initial.sql
@@ -37,7 +37,12 @@ CREATE TABLE "definitions_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX "definitions_wd_project_id_config_path_unique" ON "definitions_workflow_definitions" USING btree ("project_id","config_path") WHERE "config_path" IS NOT NULL;
@@ -52,4 +57,4 @@ CREATE UNIQUE INDEX "definitions_sync_states_source_unique" ON "definitions_sync
 --> statement-breakpoint
 CREATE INDEX "definitions_sync_states_failed_idx" ON "definitions_sync_states" USING btree ("updated_at") WHERE "status" = 'failed';
 --> statement-breakpoint
-CREATE INDEX "definitions_outbox_pending_idx" ON "definitions_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;
+CREATE INDEX "definitions_outbox_pending_idx" ON "definitions_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;

--- a/libs/api/definitions/drizzle/meta/0000_snapshot.json
+++ b/libs/api/definitions/drizzle/meta/0000_snapshot.json
@@ -356,12 +356,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
         "definitions_outbox_pending_idx": {
           "name": "definitions_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -370,7 +408,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -3,6 +3,8 @@ import {
   type DrainedEvent,
   drainAll,
   markDispatched,
+  type OutboxDispatchFailure,
+  recordDispatchFailure,
   registerPublisher,
   resetPublishers,
 } from '@shipfox/node-module';
@@ -652,6 +654,136 @@ describe('definition queries', () => {
       const secondDrain = eventsForProject(await drainAll(), projectId);
 
       expect(secondDrain).toHaveLength(0);
+    });
+
+    test('drainAll skips rows scheduled for a future retry', async () => {
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'retry.yml',
+        name: 'Retry',
+        ...definitionFields(),
+      });
+      const events = eventsForProject(await drainAll(), projectId);
+      await db()
+        .update(definitionsOutbox)
+        .set({nextDispatchAt: sql`now() + interval '1 hour'`})
+        .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
+
+      const secondDrain = eventsForProject(await drainAll(), projectId);
+
+      expect(secondDrain).toHaveLength(0);
+    });
+
+    test('recordDispatchFailure increments attempts, stores sanitized error metadata, and delays retry', async () => {
+      const failure: OutboxDispatchFailure = {
+        kind: 'validation',
+        eventType: DEFINITION_RESOLVED,
+        eventId: crypto.randomUUID(),
+        issues: [{path: ['definitionId'], code: 'invalid_type', message: 'expected string'}],
+      };
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'failure.yml',
+        name: 'Failure',
+        ...definitionFields(),
+      });
+      const before = new Date();
+      const events = eventsForProject(await drainAll(), projectId);
+
+      await recordDispatchFailure('definitions', events[0]?.id as string, failure);
+
+      const after = new Date();
+      const rows = await listOutboxRowsForProject(projectId);
+      const secondDrain = eventsForProject(await drainAll(), projectId);
+      expect(rows[0]?.dispatchAttempts).toBe(1);
+      expect(rows[0]?.lastDispatchError).toEqual(failure);
+      expect(rows[0]?.lastDispatchFailedAt).toBeInstanceOf(Date);
+      expect(rows[0]?.nextDispatchAt.getTime()).toBeGreaterThanOrEqual(before.getTime() + 9_000);
+      expect(rows[0]?.nextDispatchAt.getTime()).toBeLessThanOrEqual(after.getTime() + 11_000);
+      expect(rows[0]?.deadLetteredAt).toBeNull();
+      expect(rows[0]?.dispatchedAt).toBeNull();
+      expect(secondDrain).toHaveLength(0);
+    });
+
+    test('recordDispatchFailure dead-letters on the fifth failed attempt and excludes the row from future drains', async () => {
+      const failure: OutboxDispatchFailure = {
+        kind: 'handler',
+        eventType: DEFINITION_RESOLVED,
+        eventId: crypto.randomUUID(),
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
+      };
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'poison.yml',
+        name: 'Poison',
+        ...definitionFields(),
+      });
+      const events = eventsForProject(await drainAll(), projectId);
+      await db()
+        .update(definitionsOutbox)
+        .set({dispatchAttempts: 4})
+        .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
+
+      await recordDispatchFailure('definitions', events[0]?.id as string, failure);
+
+      const rows = await listOutboxRowsForProject(projectId);
+      const secondDrain = eventsForProject(await drainAll(), projectId);
+      expect(rows[0]?.dispatchAttempts).toBe(5);
+      expect(rows[0]?.lastDispatchError).toEqual(failure);
+      expect(rows[0]?.deadLetteredAt).toBeInstanceOf(Date);
+      expect(rows[0]?.dispatchedAt).toBeNull();
+      expect(secondDrain).toHaveLength(0);
+    });
+
+    test('markDispatched leaves dead-lettered rows inspectable as undispatched', async () => {
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'dead.yml',
+        name: 'Dead',
+        ...definitionFields(),
+      });
+      const events = eventsForProject(await drainAll(), projectId);
+      await db()
+        .update(definitionsOutbox)
+        .set({deadLetteredAt: sql`now()`})
+        .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
+
+      await markDispatched('definitions', [events[0]?.id as string]);
+
+      const rows = await listOutboxRowsForProject(projectId);
+      expect(rows[0]?.dispatchedAt).toBeNull();
+      expect(rows[0]?.deadLetteredAt).toBeInstanceOf(Date);
+    });
+
+    test('recordDispatchFailure does not mutate already-dispatched rows', async () => {
+      const failure: OutboxDispatchFailure = {
+        kind: 'handler',
+        eventType: DEFINITION_RESOLVED,
+        eventId: crypto.randomUUID(),
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
+      };
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'dispatched.yml',
+        name: 'Dispatched',
+        ...definitionFields(),
+      });
+      const events = eventsForProject(await drainAll(), projectId);
+      await markDispatched('definitions', [events[0]?.id as string]);
+
+      await recordDispatchFailure('definitions', events[0]?.id as string, failure);
+
+      const rows = await listOutboxRowsForProject(projectId);
+      expect(rows[0]?.dispatchAttempts).toBe(0);
+      expect(rows[0]?.lastDispatchError).toBeNull();
+      expect(rows[0]?.dispatchedAt).toBeInstanceOf(Date);
     });
   });
 });

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -785,5 +785,86 @@ describe('definition queries', () => {
       expect(rows[0]?.lastDispatchError).toBeNull();
       expect(rows[0]?.dispatchedAt).toBeInstanceOf(Date);
     });
+
+    test.each([
+      {priorAttempts: 1, delaySeconds: 60},
+      {priorAttempts: 2, delaySeconds: 300},
+      {priorAttempts: 3, delaySeconds: 1800},
+    ])('recordDispatchFailure backs off retry by ~$delaySeconds s after $priorAttempts prior attempts', async ({
+      priorAttempts,
+      delaySeconds,
+    }) => {
+      const failure: OutboxDispatchFailure = {
+        kind: 'handler',
+        eventType: DEFINITION_RESOLVED,
+        eventId: crypto.randomUUID(),
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
+      };
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: `backoff-${priorAttempts}.yml`,
+        name: `Backoff ${priorAttempts}`,
+        ...definitionFields(),
+      });
+      const events = eventsForProject(await drainAll(), projectId);
+      await db()
+        .update(definitionsOutbox)
+        .set({dispatchAttempts: priorAttempts})
+        .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
+      const before = new Date();
+
+      await recordDispatchFailure('definitions', events[0]?.id as string, failure);
+
+      const after = new Date();
+      const rows = await listOutboxRowsForProject(projectId);
+      const delayMs = delaySeconds * 1_000;
+      expect(rows[0]?.dispatchAttempts).toBe(priorAttempts + 1);
+      expect(rows[0]?.deadLetteredAt).toBeNull();
+      expect(rows[0]?.nextDispatchAt.getTime()).toBeGreaterThanOrEqual(
+        before.getTime() + delayMs - 1_000,
+      );
+      expect(rows[0]?.nextDispatchAt.getTime()).toBeLessThanOrEqual(
+        after.getTime() + delayMs + 1_000,
+      );
+    });
+
+    test('redrains a failed row once its retry delay passes, then dispatches it', async () => {
+      const failure: OutboxDispatchFailure = {
+        kind: 'handler',
+        eventType: DEFINITION_RESOLVED,
+        eventId: crypto.randomUUID(),
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
+      };
+      await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'recover.yml',
+        name: 'Recover',
+        ...definitionFields(),
+      });
+      const events = eventsForProject(await drainAll(), projectId);
+      await recordDispatchFailure('definitions', events[0]?.id as string, failure);
+      await db()
+        .update(definitionsOutbox)
+        .set({nextDispatchAt: sql`now() - interval '1 second'`})
+        .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
+
+      const retryDrain = eventsForProject(await drainAll(), projectId);
+      await markDispatched(
+        'definitions',
+        retryDrain.map((event) => event.id),
+      );
+
+      const rows = await listOutboxRowsForProject(projectId);
+      const finalDrain = eventsForProject(await drainAll(), projectId);
+      expect(retryDrain).toHaveLength(1);
+      expect(retryDrain[0]?.id).toBe(events[0]?.id);
+      expect(rows[0]?.dispatchAttempts).toBe(1);
+      expect(rows[0]?.dispatchedAt).toBeInstanceOf(Date);
+      expect(finalDrain).toHaveLength(0);
+    });
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -211,4 +211,35 @@ describe('drainAndDispatch', () => {
       },
     });
   });
+
+  it('records a row failure and skips dispatch when one of several handlers fails', async () => {
+    const failure = new Error('second handler failed');
+    const rowId = crypto.randomUUID();
+    const parsed = {jobId: 'job-1', runId: 'run-1', status: 'succeeded'};
+    const event: DomainEvent = {
+      id: crypto.randomUUID(),
+      type: 'workflows.job.terminated',
+      createdAt: new Date(),
+      payload: parsed,
+    };
+    const succeedingHandler = vi.fn().mockResolvedValue(undefined);
+    const failingHandler = vi.fn().mockRejectedValueOnce(failure);
+    mocks.drainAll.mockResolvedValueOnce([{id: rowId, source: 'workflows', event}]);
+    mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: true, data: parsed})});
+    mocks.getSubscribers.mockReturnValueOnce([succeedingHandler, failingHandler]);
+
+    await drainAndDispatch();
+
+    expect(succeedingHandler).toHaveBeenCalledTimes(1);
+    expect(failingHandler).toHaveBeenCalledTimes(1);
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledTimes(1);
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', rowId, {
+      kind: 'handler',
+      eventType: event.type,
+      eventId: rowId,
+      errorName: 'Error',
+      errorMessage: 'second handler failed',
+    });
+    expect(mocks.markDispatched).not.toHaveBeenCalled();
+  });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getEventSchema: vi.fn(),
   getSubscribers: vi.fn(),
   markDispatched: vi.fn(),
+  recordDispatchFailure: vi.fn(),
   errorLog: vi.fn(),
 }));
 
@@ -19,6 +20,7 @@ vi.mock('@shipfox/node-module', () => ({
   getEventSchema: mocks.getEventSchema,
   getSubscribers: mocks.getSubscribers,
   markDispatched: mocks.markDispatched,
+  recordDispatchFailure: mocks.recordDispatchFailure,
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
@@ -34,11 +36,13 @@ describe('drainAndDispatch', () => {
     mocks.getEventSchema.mockReset();
     mocks.getSubscribers.mockReset();
     mocks.markDispatched.mockReset();
+    mocks.recordDispatchFailure.mockReset();
     mocks.errorLog.mockReset();
   });
 
-  it('logs payload context and captures failed subscriber exceptions', async () => {
+  it('logs sanitized context, captures failed subscriber exceptions, and records a row failure', async () => {
     const failure = new Error('subscriber failed');
+    const rowId = crypto.randomUUID();
     const event: DomainEvent = {
       id: crypto.randomUUID(),
       type: 'projects.project.source_bound',
@@ -48,7 +52,7 @@ describe('drainAndDispatch', () => {
         workspaceId: crypto.randomUUID(),
       },
     };
-    mocks.drainAll.mockResolvedValueOnce([{id: crypto.randomUUID(), source: 'projects', event}]);
+    mocks.drainAll.mockResolvedValueOnce([{id: rowId, source: 'projects', event}]);
     mocks.getSubscribers.mockReturnValueOnce([vi.fn().mockRejectedValueOnce(failure)]);
 
     await drainAndDispatch();
@@ -56,23 +60,34 @@ describe('drainAndDispatch', () => {
     expect(mocks.errorLog).toHaveBeenCalledWith(
       {
         err: failure,
+        kind: 'handler',
         eventType: event.type,
-        eventId: expect.any(String),
-        eventPayload: event.payload,
+        eventId: rowId,
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
       },
       'Handler failed for outbox event',
     );
     expect(mocks.captureException).toHaveBeenCalledWith(failure, {
       extra: {
+        kind: 'handler',
         eventType: event.type,
-        eventId: expect.any(String),
-        eventPayload: event.payload,
+        eventId: rowId,
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
       },
+    });
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('projects', rowId, {
+      kind: 'handler',
+      eventType: event.type,
+      eventId: rowId,
+      errorName: 'Error',
+      errorMessage: 'subscriber failed',
     });
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 
-  it('rejects a malformed payload at the drain: skips handlers and leaves the row undispatched', async () => {
+  it('rejects a malformed payload at the drain: skips handlers and records a row failure', async () => {
     const error = {issues: [{path: ['jobId'], code: 'invalid_type', message: 'expected string'}]};
     const event: DomainEvent = {
       id: crypto.randomUUID(),
@@ -87,8 +102,19 @@ describe('drainAndDispatch', () => {
 
     expect(mocks.getSubscribers).not.toHaveBeenCalled();
     expect(mocks.markDispatched).not.toHaveBeenCalled();
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', event.id, {
+      kind: 'validation',
+      eventType: event.type,
+      eventId: event.id,
+      issues: error.issues,
+    });
     expect(mocks.captureException).toHaveBeenCalledWith(error, {
-      extra: {eventType: event.type, eventId: event.id, issues: error.issues},
+      extra: {
+        kind: 'validation',
+        eventType: event.type,
+        eventId: event.id,
+        issues: error.issues,
+      },
     });
   });
 
@@ -111,6 +137,7 @@ describe('drainAndDispatch', () => {
       expect.objectContaining({type: event.type, payload: parsed}),
     );
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+    expect(mocks.recordDispatchFailure).not.toHaveBeenCalled();
   });
 
   it('validates and dispatches a valid event that has no subscribers', async () => {
@@ -128,9 +155,10 @@ describe('drainAndDispatch', () => {
     await drainAndDispatch();
 
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+    expect(mocks.recordDispatchFailure).not.toHaveBeenCalled();
   });
 
-  it('isolates a poison row: dispatches valid siblings in the same drain, leaves the invalid one undispatched', async () => {
+  it('isolates a poison row: dispatches valid siblings in the same drain and records the invalid one', async () => {
     const error = {issues: [{path: ['jobId'], code: 'invalid_type', message: 'expected string'}]};
     const validJob: DomainEvent = {
       id: crypto.randomUUID(),
@@ -168,8 +196,19 @@ describe('drainAndDispatch', () => {
     expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', [validPush.id]);
     expect(mocks.markDispatched).toHaveBeenCalledTimes(2);
     expect(handler).toHaveBeenCalledTimes(2);
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', poison.id, {
+      kind: 'validation',
+      eventType: poison.type,
+      eventId: poison.id,
+      issues: error.issues,
+    });
     expect(mocks.captureException).toHaveBeenCalledWith(error, {
-      extra: {eventType: poison.type, eventId: poison.id, issues: error.issues},
+      extra: {
+        kind: 'validation',
+        eventType: poison.type,
+        eventId: poison.id,
+        issues: error.issues,
+      },
     });
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -55,8 +55,8 @@ export async function drainAndDispatch(): Promise<void> {
 }
 
 /**
- * Invalid rows stay undispatched until they exhaust the bounded drain retry policy.
- * Log Zod issue paths instead of raw payloads because deterministic failures recur.
+ * Invalid rows stay undispatched until the bounded retry policy dead-letters them.
+ * Only log Zod issue paths so recurring validation failures do not repeatedly emit raw payloads.
  */
 function validatePayload(
   row: DrainedEvent,

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -5,6 +5,8 @@ import {
   getEventSchema,
   getSubscribers,
   markDispatched,
+  type OutboxDispatchFailure,
+  recordDispatchFailure,
 } from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 
@@ -15,23 +17,25 @@ export async function drainAndDispatch(): Promise<void> {
   const dispatched = new Map<string, string[]>();
 
   for (const row of rows) {
-    const event = validatePayload(row);
-    if (!event) continue;
+    const validation = validatePayload(row);
+    if (!validation.success) {
+      await recordDispatchFailure(row.source, row.id, validation.failure);
+      continue;
+    }
 
+    const event = validation.event;
     const handlers = getSubscribers(event.type);
     let allSucceeded = true;
+    let dispatchFailure: OutboxDispatchFailure | undefined;
 
     for (const handler of handlers) {
       try {
         await handler(event);
       } catch (error) {
-        const errorContext = {
-          eventType: event.type,
-          eventId: row.id,
-          eventPayload: event.payload,
-        };
+        const errorContext = failureFromHandler(row, error);
         logger().error({err: error, ...errorContext}, 'Handler failed for outbox event');
         captureException(error, {extra: errorContext});
+        dispatchFailure ??= errorContext;
         allSucceeded = false;
       }
     }
@@ -40,6 +44,8 @@ export async function drainAndDispatch(): Promise<void> {
       const ids = dispatched.get(row.source) ?? [];
       ids.push(row.id);
       dispatched.set(row.source, ids);
+    } else if (dispatchFailure) {
+      await recordDispatchFailure(row.source, row.id, dispatchFailure);
     }
   }
 
@@ -49,19 +55,41 @@ export async function drainAndDispatch(): Promise<void> {
 }
 
 /**
- * Invalid rows stay undispatched so they can be retried after the publisher or
- * schema is fixed. Log Zod issue paths instead of raw payloads because deterministic
- * failures recur on every drain.
+ * Invalid rows stay undispatched until they exhaust the bounded drain retry policy.
+ * Log Zod issue paths instead of raw payloads because deterministic failures recur.
  */
-function validatePayload(row: DrainedEvent): DrainedEvent['event'] | null {
+function validatePayload(
+  row: DrainedEvent,
+):
+  | {success: true; event: DrainedEvent['event']}
+  | {success: false; failure: OutboxDispatchFailure} {
   const schema = getEventSchema(row.event.type);
-  if (!schema) return row.event;
+  if (!schema) return {success: true, event: row.event};
 
   const result = schema.safeParse(row.event.payload);
-  if (result.success) return {...row.event, payload: result.data};
+  if (result.success) return {success: true, event: {...row.event, payload: result.data}};
 
-  const errorContext = {eventType: row.event.type, eventId: row.id, issues: result.error.issues};
+  const errorContext: OutboxDispatchFailure = {
+    kind: 'validation',
+    eventType: row.event.type,
+    eventId: row.id,
+    issues: result.error.issues.map((issue) => ({
+      path: issue.path.map((segment) => (typeof segment === 'number' ? segment : String(segment))),
+      code: issue.code,
+      message: issue.message,
+    })),
+  };
   logger().error({err: result.error, ...errorContext}, 'Invalid outbox payload at drain');
   captureException(result.error, {extra: errorContext});
-  return null;
+  return {success: false, failure: errorContext};
+}
+
+function failureFromHandler(row: DrainedEvent, error: unknown): OutboxDispatchFailure {
+  return {
+    kind: 'handler',
+    eventType: row.event.type,
+    eventId: row.id,
+    errorName: error instanceof Error ? error.name : 'NonErrorThrown',
+    errorMessage: error instanceof Error ? error.message : String(error),
+  };
 }

--- a/libs/api/integration/core/drizzle/0000_initial.sql
+++ b/libs/api/integration/core/drizzle/0000_initial.sql
@@ -14,7 +14,12 @@ CREATE TABLE "integrations_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "integrations_webhook_deliveries" (
@@ -26,5 +31,5 @@ CREATE TABLE "integrations_webhook_deliveries" (
 --> statement-breakpoint
 CREATE UNIQUE INDEX "integrations_connections_workspace_external_unique" ON "integrations_connections" USING btree ("workspace_id","provider","external_account_id");--> statement-breakpoint
 CREATE INDEX "integrations_connections_workspace_id_idx" ON "integrations_connections" USING btree ("workspace_id");--> statement-breakpoint
-CREATE INDEX "integrations_outbox_pending_idx" ON "integrations_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "integrations_outbox_pending_idx" ON "integrations_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "integrations_webhook_deliveries_received_at_idx" ON "integrations_webhook_deliveries" USING btree ("received_at");

--- a/libs/api/integration/core/drizzle/meta/0001_snapshot.json
+++ b/libs/api/integration/core/drizzle/meta/0001_snapshot.json
@@ -147,12 +147,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
-        "outbox_pending_idx": {
-          "name": "outbox_pending_idx",
+        "integrations_outbox_pending_idx": {
+          "name": "integrations_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -161,7 +199,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/logs/drizzle/0000_initial.sql
+++ b/libs/api/logs/drizzle/0000_initial.sql
@@ -43,7 +43,12 @@ CREATE TABLE "logs_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 ALTER TABLE "logs_chunks" ADD CONSTRAINT "logs_chunks_stream_id_logs_attempt_streams_id_fk" FOREIGN KEY ("stream_id") REFERENCES "public"."logs_attempt_streams"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -54,4 +59,4 @@ CREATE INDEX "logs_attempt_streams_open_age_idx" ON "logs_attempt_streams" USING
 CREATE INDEX "logs_attempt_streams_retention_idx" ON "logs_attempt_streams" USING btree ("closed_at") WHERE "state" = 'closed';--> statement-breakpoint
 CREATE INDEX "logs_attempt_streams_uncompacted_idx" ON "logs_attempt_streams" USING btree ("closed_at") WHERE "state" = 'closed' and "object_key" is null;--> statement-breakpoint
 CREATE INDEX "logs_chunks_stream_seq_idx" ON "logs_chunks" USING btree ("stream_id","seq");--> statement-breakpoint
-CREATE INDEX "logs_outbox_pending_idx" ON "logs_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;
+CREATE INDEX "logs_outbox_pending_idx" ON "logs_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;

--- a/libs/api/logs/drizzle/meta/0000_snapshot.json
+++ b/libs/api/logs/drizzle/meta/0000_snapshot.json
@@ -421,12 +421,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
         "logs_outbox_pending_idx": {
           "name": "logs_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -435,7 +473,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/projects/drizzle/0000_initial.sql
+++ b/libs/api/projects/drizzle/0000_initial.sql
@@ -13,7 +13,12 @@ CREATE TABLE "projects_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "projects_integration_event_dedup" (
@@ -25,5 +30,5 @@ CREATE TABLE "projects_integration_event_dedup" (
 --> statement-breakpoint
 CREATE UNIQUE INDEX "projects_source_unique" ON "projects_projects" USING btree ("source_connection_id","source_external_repository_id");--> statement-breakpoint
 CREATE INDEX "projects_workspace_created_id_idx" ON "projects_projects" USING btree ("workspace_id","created_at","id");--> statement-breakpoint
-CREATE INDEX "projects_outbox_pending_idx" ON "projects_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "projects_outbox_pending_idx" ON "projects_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "projects_integration_event_dedup_received_at_idx" ON "projects_integration_event_dedup" USING btree ("received_at");

--- a/libs/api/projects/drizzle/meta/0000_snapshot.json
+++ b/libs/api/projects/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,279 @@
+{
+  "id": "2686798f-1741-47d6-8d93-6554f138baa6",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.projects_integration_event_dedup": {
+      "name": "projects_integration_event_dedup",
+      "schema": "",
+      "columns": {
+        "integration_event_id": {
+          "name": "integration_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_integration_event_dedup_received_at_idx": {
+          "name": "projects_integration_event_dedup_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "projects_integration_event_dedup_integration_event_id_project_id_pk": {
+          "name": "projects_integration_event_dedup_integration_event_id_project_id_pk",
+          "columns": ["integration_event_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_outbox": {
+      "name": "projects_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_outbox_pending_idx": {
+          "name": "projects_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects_projects": {
+      "name": "projects_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_connection_id": {
+          "name": "source_connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_external_repository_id": {
+          "name": "source_external_repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_source_unique": {
+          "name": "projects_source_unique",
+          "columns": [
+            {
+              "expression": "source_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_external_repository_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_workspace_created_id_idx": {
+          "name": "projects_workspace_created_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -3,7 +3,12 @@ CREATE TABLE "runners_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "runners_pending_jobs" (
@@ -29,6 +34,6 @@ CREATE TABLE "runners_running_jobs" (
 	CONSTRAINT "runners_running_jobs_job_id_unique" UNIQUE("job_id")
 );
 --> statement-breakpoint
-CREATE INDEX "runners_outbox_pending_idx" ON "runners_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "runners_outbox_pending_idx" ON "runners_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "runners_pending_jobs_created_idx" ON "runners_pending_jobs" USING btree ("created_at");--> statement-breakpoint
 CREATE INDEX "runners_running_jobs_last_heartbeat_at_idx" ON "runners_running_jobs" USING btree ("last_heartbeat_at");

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -39,12 +39,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
         "runners_outbox_pending_idx": {
           "name": "runners_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -53,7 +91,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/triggers/drizzle/0000_initial.sql
+++ b/libs/api/triggers/drizzle/0000_initial.sql
@@ -16,7 +16,12 @@ CREATE TABLE "triggers_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "triggers_received_events" (
@@ -52,7 +57,7 @@ CREATE TABLE "triggers_subscriptions" (
 ALTER TABLE "triggers_decisions" ADD CONSTRAINT "triggers_decisions_received_event_id_triggers_received_events_id_fk" FOREIGN KEY ("received_event_id") REFERENCES "public"."triggers_received_events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_decisions_event_subscription_unique" ON "triggers_decisions" USING btree ("received_event_id","subscription_id");--> statement-breakpoint
 CREATE INDEX "triggers_decisions_run_idx" ON "triggers_decisions" USING btree ("run_id");--> statement-breakpoint
-CREATE INDEX "triggers_outbox_pending_idx" ON "triggers_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "triggers_outbox_pending_idx" ON "triggers_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_received_events_event_ref_unique" ON "triggers_received_events" USING btree ("event_ref");--> statement-breakpoint
 CREATE INDEX "triggers_received_events_workspace_received_idx" ON "triggers_received_events" USING btree ("workspace_id","received_at" DESC NULLS LAST);--> statement-breakpoint
 CREATE INDEX "triggers_received_events_prune_idx" ON "triggers_received_events" USING btree ("created_at");--> statement-breakpoint

--- a/libs/api/triggers/drizzle/meta/0000_snapshot.json
+++ b/libs/api/triggers/drizzle/meta/0000_snapshot.json
@@ -161,12 +161,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
         "triggers_outbox_pending_idx": {
           "name": "triggers_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -175,7 +213,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/triggers/src/db/schema/outbox.ts
+++ b/libs/api/triggers/src/db/schema/outbox.ts
@@ -1,18 +1,4 @@
-import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {sql} from 'drizzle-orm';
-import {index, jsonb, text, timestamp} from 'drizzle-orm/pg-core';
+import {createOutboxTable} from '@shipfox/node-outbox';
 import {pgTable} from './common.js';
 
-export const triggersOutbox = pgTable(
-  'outbox',
-  {
-    id: uuidv7PrimaryKey(),
-    eventType: text('event_type').notNull(),
-    payload: jsonb('payload').notNull(),
-    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
-    dispatchedAt: timestamp('dispatched_at', {withTimezone: true}),
-  },
-  (table) => [
-    index('triggers_outbox_pending_idx').on(table.createdAt).where(sql`"dispatched_at" IS NULL`),
-  ],
-);
+export const triggersOutbox = createOutboxTable(pgTable);

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -23,7 +23,12 @@ CREATE TABLE "workflows_outbox" (
 	"event_type" text NOT NULL,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"dispatched_at" timestamp with time zone
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
 CREATE TABLE "workflows_steps" (
@@ -63,7 +68,7 @@ CREATE TABLE "workflows_workflow_runs" (
 ALTER TABLE "workflows_jobs" ADD CONSTRAINT "workflows_jobs_run_id_workflows_workflow_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."workflows_workflow_runs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "workflows_steps" ADD CONSTRAINT "workflows_steps_job_id_workflows_jobs_id_fk" FOREIGN KEY ("job_id") REFERENCES "public"."workflows_jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "workflows_jobs_run_id_idx" ON "workflows_jobs" USING btree ("run_id");--> statement-breakpoint
-CREATE INDEX "workflows_outbox_pending_idx" ON "workflows_outbox" USING btree ("created_at") WHERE "dispatched_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "workflows_outbox_pending_idx" ON "workflows_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "workflows_steps_job_id_idx" ON "workflows_steps" USING btree ("job_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wr_trigger_idempotency_key_unique" ON "workflows_workflow_runs" USING btree ("trigger_idempotency_key");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","created_at","id");--> statement-breakpoint

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -168,12 +168,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
         "workflows_outbox_pending_idx": {
           "name": "workflows_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -182,7 +220,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/workflows/drizzle/meta/0001_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0001_snapshot.json
@@ -168,12 +168,50 @@
           "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
         }
       },
       "indexes": {
         "workflows_outbox_pending_idx": {
           "name": "workflows_outbox_pending_idx",
           "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
             {
               "expression": "created_at",
               "isExpression": false,
@@ -182,7 +220,7 @@
             }
           ],
           "isUnique": false,
-          "where": "\"dispatched_at\" IS NULL",
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/workflows/src/db/schema/outbox.ts
+++ b/libs/api/workflows/src/db/schema/outbox.ts
@@ -1,18 +1,4 @@
-import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {sql} from 'drizzle-orm';
-import {index, jsonb, text, timestamp} from 'drizzle-orm/pg-core';
+import {createOutboxTable} from '@shipfox/node-outbox';
 import {pgTable} from './common.js';
 
-export const workflowsOutbox = pgTable(
-  'outbox',
-  {
-    id: uuidv7PrimaryKey(),
-    eventType: text('event_type').notNull(),
-    payload: jsonb('payload').notNull(),
-    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
-    dispatchedAt: timestamp('dispatched_at', {withTimezone: true}),
-  },
-  (table) => [
-    index('workflows_outbox_pending_idx').on(table.createdAt).where(sql`"dispatched_at" IS NULL`),
-  ],
-);
+export const workflowsOutbox = createOutboxTable(pgTable);

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -3,11 +3,12 @@ export type {
   InitializeModulesOptions,
 } from './initialize.js';
 export {initializeModules, startModuleWorkers} from './initialize.js';
-export type {DrainedEvent} from './publisher-registry.js';
+export type {DrainedEvent, OutboxDispatchFailure} from './publisher-registry.js';
 export {
   drainAll,
   getEventSchema,
   markDispatched,
+  recordDispatchFailure,
   registerPublisher,
   resetPublishers,
 } from './publisher-registry.js';

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -1,5 +1,5 @@
 import type {DomainEvent, OutboxTable} from '@shipfox/node-outbox';
-import {asc, inArray, isNull, sql} from 'drizzle-orm';
+import {and, asc, eq, inArray, isNull, lte, sql} from 'drizzle-orm';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import type {ZodType} from 'zod';
 
@@ -16,10 +16,32 @@ export interface DrainedEvent {
   event: DomainEvent;
 }
 
+export interface OutboxDispatchIssue {
+  path: Array<string | number>;
+  code: string;
+  message: string;
+}
+
+export type OutboxDispatchFailure =
+  | {
+      kind: 'validation';
+      eventType: string;
+      eventId: string;
+      issues: OutboxDispatchIssue[];
+    }
+  | {
+      kind: 'handler';
+      eventType: string;
+      eventId: string;
+      errorName: string;
+      errorMessage: string;
+    };
+
 const _sources: PublisherSource[] = [];
 const _schemasByType = new Map<string, ZodType>();
 
 const BATCH_SIZE = 100;
+const MAX_DISPATCH_ATTEMPTS = 5;
 
 export function registerPublisher(config: PublisherSource): void {
   _sources.push(config);
@@ -50,8 +72,14 @@ export async function drainAll(): Promise<DrainedEvent[]> {
       .db()
       .select()
       .from(source.table)
-      .where(isNull(source.table.dispatchedAt))
-      .orderBy(asc(source.table.createdAt))
+      .where(
+        and(
+          isNull(source.table.dispatchedAt),
+          isNull(source.table.deadLetteredAt),
+          lte(source.table.nextDispatchAt, sql`now()`),
+        ),
+      )
+      .orderBy(asc(source.table.nextDispatchAt), asc(source.table.createdAt))
       .limit(BATCH_SIZE);
 
     for (const row of rows) {
@@ -81,10 +109,55 @@ export async function markDispatched(source: string, ids: string[]): Promise<voi
     .db()
     .update(config.table)
     .set({dispatchedAt: sql`now()`})
-    .where(inArray(config.table.id, ids));
+    .where(
+      and(
+        inArray(config.table.id, ids),
+        isNull(config.table.dispatchedAt),
+        isNull(config.table.deadLetteredAt),
+      ),
+    );
+}
+
+export async function recordDispatchFailure(
+  source: string,
+  id: string,
+  failure: OutboxDispatchFailure,
+): Promise<void> {
+  const config = _sources.find((s) => s.name === source);
+  if (!config) return;
+
+  await config
+    .db()
+    .update(config.table)
+    .set({
+      dispatchAttempts: sql`${config.table.dispatchAttempts} + 1`,
+      nextDispatchAt: nextDispatchAtSql(config.table),
+      lastDispatchError: failure,
+      lastDispatchFailedAt: sql`now()`,
+      deadLetteredAt: sql`CASE WHEN ${config.table.dispatchAttempts} >= ${
+        MAX_DISPATCH_ATTEMPTS - 1
+      } THEN now() ELSE ${config.table.deadLetteredAt} END`,
+    })
+    .where(
+      and(
+        eq(config.table.id, id),
+        isNull(config.table.dispatchedAt),
+        isNull(config.table.deadLetteredAt),
+      ),
+    );
 }
 
 export function resetPublishers(): void {
   _sources.length = 0;
   _schemasByType.clear();
+}
+
+function nextDispatchAtSql(table: OutboxTable) {
+  return sql`CASE
+    WHEN ${table.dispatchAttempts} = 0 THEN now() + interval '10 seconds'
+    WHEN ${table.dispatchAttempts} = 1 THEN now() + interval '1 minute'
+    WHEN ${table.dispatchAttempts} = 2 THEN now() + interval '5 minutes'
+    WHEN ${table.dispatchAttempts} = 3 THEN now() + interval '30 minutes'
+    ELSE now()
+  END`;
 }

--- a/libs/shared/node/outbox/README.md
+++ b/libs/shared/node/outbox/README.md
@@ -31,7 +31,13 @@ await db.transaction(async (tx) => {
 });
 ```
 
-The table includes a pending-event index on `created_at` for rows where `dispatched_at` is null.
+Each row also carries bounded-retry and dead-letter columns: `dispatch_attempts`,
+`next_dispatch_at`, `last_dispatch_error`, `last_dispatch_failed_at`, and
+`dead_lettered_at`. A dispatcher records failures, backs off `next_dispatch_at`,
+and dead-letters a row once it exhausts its attempts.
+
+The table includes a pending-event index on `(next_dispatch_at, created_at)` for
+rows where `dispatched_at` and `dead_lettered_at` are both null.
 
 ## Development
 

--- a/libs/shared/node/outbox/src/schema.ts
+++ b/libs/shared/node/outbox/src/schema.ts
@@ -1,6 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {getTableName, sql} from 'drizzle-orm';
-import {index, jsonb, type pgTableCreator, text, timestamp} from 'drizzle-orm/pg-core';
+import {index, integer, jsonb, type pgTableCreator, text, timestamp} from 'drizzle-orm/pg-core';
 
 export function createOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
   // The pgTableCreator prefixes table names but not index names, and inside the
@@ -16,9 +16,16 @@ export function createOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
       payload: jsonb('payload').notNull(),
       createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
       dispatchedAt: timestamp('dispatched_at', {withTimezone: true}),
+      dispatchAttempts: integer('dispatch_attempts').notNull().default(0),
+      nextDispatchAt: timestamp('next_dispatch_at', {withTimezone: true}).notNull().defaultNow(),
+      lastDispatchError: jsonb('last_dispatch_error'),
+      lastDispatchFailedAt: timestamp('last_dispatch_failed_at', {withTimezone: true}),
+      deadLetteredAt: timestamp('dead_lettered_at', {withTimezone: true}),
     },
     (table) => [
-      index(`${tableName}_pending_idx`).on(table.createdAt).where(sql`"dispatched_at" IS NULL`),
+      index(`${tableName}_pending_idx`)
+        .on(table.nextDispatchAt, table.createdAt)
+        .where(sql`"dispatched_at" IS NULL AND "dead_lettered_at" IS NULL`),
     ],
   );
 }

--- a/libs/shared/node/outbox/src/write.test.ts
+++ b/libs/shared/node/outbox/src/write.test.ts
@@ -9,6 +9,16 @@ interface TestEventMap {
   'thing.deleted': {id: string; reason: string};
 }
 
+describe('createOutboxTable', () => {
+  it('exposes dispatch retry and dead-letter columns', () => {
+    expect(outboxTable.dispatchAttempts.name).toBe('dispatch_attempts');
+    expect(outboxTable.nextDispatchAt.name).toBe('next_dispatch_at');
+    expect(outboxTable.lastDispatchError.name).toBe('last_dispatch_error');
+    expect(outboxTable.lastDispatchFailedAt.name).toBe('last_dispatch_failed_at');
+    expect(outboxTable.deadLetteredAt.name).toBe('dead_lettered_at');
+  });
+});
+
 function fakeTx() {
   const values = vi.fn().mockResolvedValue(undefined);
   const insert = vi.fn(() => ({values}));


### PR DESCRIPTION
Adds bounded retry and dead-letter handling to the shared outbox drain boundary.

A single poison row could previously be picked up on every drain and fail indefinitely. This introduces per-row retry metadata, delayed backoff, and dead-letter state across the module-owned outbox tables while keeping dead-letter rows inspectable with `dispatched_at` null.

The dispatcher now records sanitized validation and handler failure metadata through `@shipfox/node-module` and continues dispatching valid sibling rows. Success and failure state transitions are guarded against already-dispatched or dead-lettered rows, and `triggers`/`workflows` now use the shared `createOutboxTable` helper to avoid schema drift.

Initial migrations and snapshots are folded in place because the repo is pre-deploy. Remaining event-schema coverage is tracked separately in ENG-566.

Closes ENG-559

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded retry with backoff and dead-lettering to the outbox drain to stop poison rows from hot-looping and blocking newer events. Sanitized failure details are recorded; dead-lettered rows remain undispatched and inspectable. Implements ENG-559.

- New Features
  - Per-row retry state: new columns `dispatch_attempts`, `next_dispatch_at`, `last_dispatch_error`, `last_dispatch_failed_at`, `dead_lettered_at`; pending index is `(next_dispatch_at, created_at)` and excludes dead-lettered rows.
  - Backoff and cap: retries after 10s → 1m → 5m → 30m; dead-letters on the 5th failure.
  - Drain changes: `drainAll` only fetches rows with `next_dispatch_at <= now`, skips dead-lettered rows, and orders by `next_dispatch_at` then `created_at`.
  - Failure handling: new `recordDispatchFailure(source, id, failure)` in `@shipfox/node-module` stores sanitized validation/handler failures; `drain-and-dispatch` now calls it for both validation and handler errors and avoids logging raw payloads. Partial handler failures do not mark the row dispatched. Guarded transitions ensure `markDispatched`/failure updates no-op for already-dispatched or dead-lettered rows.

- Refactors
  - `createOutboxTable` in `@shipfox/node-outbox` now includes retry/dead-letter columns and the shared pending index; `triggers`/`workflows` switch to it. SQL schemas and snapshots updated (including the missing `projects` snapshot). Tests cover future-scheduled retries, backoff steps, fail→retry→dispatch recovery, dead-letter on 5th failure, and multi-handler partial failure. README documents the new columns and index.

<sup>Written for commit dc32f20d54f57a174dd34d465a61c0557fcf1eec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

