### PR TITLE
[client-logs] Add step log data layer

### DIFF
--- a/.changeset/steady-logs-read.md
+++ b/.changeset/steady-logs-read.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-logs": patch
+---
+
+Adds a React Query data layer for step logs that maps inline and presigned reads into one polling snapshot.

--- a/.changeset/steady-logs-read.md
+++ b/.changeset/steady-logs-read.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/client-logs": patch
+"@shipfox/client-logs": minor
 ---
 
 Adds a React Query data layer for step logs that maps inline and presigned reads into one polling snapshot.

--- a/libs/client/logs/package.json
+++ b/libs/client/logs/package.json
@@ -60,6 +60,7 @@
     "@storybook/react": "^10.0.0",
     "@storybook/react-vite": "^10.0.0",
     "@tailwindcss/vite": "^4.1.13",
+    "@testing-library/dom": "^10.0.0",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",

--- a/libs/client/logs/package.json
+++ b/libs/client/logs/package.json
@@ -39,8 +39,10 @@
   },
   "dependencies": {
     "@shipfox/api-logs-dto": "workspace:*",
+    "@shipfox/client-api": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
-    "@swc/helpers": "^0.5.17"
+    "@swc/helpers": "^0.5.17",
+    "@tanstack/react-query": "^5.101.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",
@@ -58,10 +60,12 @@
     "@storybook/react": "^10.0.0",
     "@storybook/react-vite": "^10.0.0",
     "@tailwindcss/vite": "^4.1.13",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/browser-playwright": "^4.1.5",
+    "jsdom": "^29.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "storybook": "^10.0.0",

--- a/libs/client/logs/src/core/log-read.test.ts
+++ b/libs/client/logs/src/core/log-read.test.ts
@@ -1,0 +1,196 @@
+import type {LogRecord, ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import {
+  mergeLogRead,
+  parseLogNdjson,
+  STEP_LOG_DRAIN_REFETCH_MS,
+  STEP_LOG_LIVE_REFETCH_MS,
+  type StepLogSnapshot,
+  stepLogRefetchInterval,
+} from './log-read.js';
+
+const output = (data: string, ts = 1): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'output',
+  stream: 'stdout',
+  data,
+});
+
+const line = (record: LogRecord): string => `${JSON.stringify(record)}\n`;
+
+const inline = (params: {
+  ndjson: string;
+  nextCursor?: number;
+  hasMore?: boolean;
+  state?: 'open' | 'closed';
+  truncated?: boolean;
+}): Extract<ReadLogsResponseDto, {mode: 'inline'}> => ({
+  mode: 'inline',
+  ndjson: params.ndjson,
+  next_cursor: params.nextCursor ?? 1,
+  has_more: params.hasMore ?? false,
+  state: params.state ?? 'open',
+  truncated: params.truncated ?? false,
+});
+
+const presigned = (
+  params: Partial<Extract<ReadLogsResponseDto, {mode: 'presigned'}>> = {},
+): Extract<ReadLogsResponseDto, {mode: 'presigned'}> => ({
+  mode: 'presigned',
+  url: params.url ?? 'https://storage.example.test/logs/object?sig=1',
+  expires_at: params.expires_at ?? '2026-06-23T10:00:00.000Z',
+  total_bytes: params.total_bytes ?? 128,
+  truncated: params.truncated ?? false,
+});
+
+describe('parseLogNdjson', () => {
+  test('returns an empty record list for an empty body', () => {
+    const records = parseLogNdjson('');
+
+    expect(records).toEqual([]);
+  });
+
+  test('parses multiple record lines', () => {
+    const first = output('first\n', 1);
+    const second = output('second\n', 2);
+
+    const records = parseLogNdjson(line(first) + line(second));
+
+    expect(records).toEqual([first, second]);
+  });
+
+  test('throws when a line is not a valid log record', () => {
+    const parse = () => parseLogNdjson('{"v":1,"ts":1,"type":"nope"}\n');
+
+    expect(parse).toThrow();
+  });
+});
+
+describe('mergeLogRead', () => {
+  test('appends inline records and advances the cursor', () => {
+    const previous: StepLogSnapshot = {
+      records: [output('old\n', 1)],
+      nextCursor: 3,
+      source: 'inline',
+      state: 'open',
+      complete: false,
+      hasMore: false,
+      truncated: false,
+      totalBytes: null,
+      expiresAt: null,
+    };
+    const response = inline({ndjson: line(output('new\n', 2)), nextCursor: 4, hasMore: true});
+
+    const snapshot = mergeLogRead(previous, {mode: 'inline', response});
+
+    expect(snapshot.records).toEqual([output('old\n', 1), output('new\n', 2)]);
+    expect(snapshot.nextCursor).toBe(4);
+    expect(snapshot.hasMore).toBe(true);
+    expect(snapshot.complete).toBe(false);
+  });
+
+  test('preserves records on an empty open inline page', () => {
+    const previous: StepLogSnapshot = {
+      records: [output('old\n', 1)],
+      nextCursor: 3,
+      source: 'inline',
+      state: 'open',
+      complete: false,
+      hasMore: false,
+      truncated: false,
+      totalBytes: null,
+      expiresAt: null,
+    };
+    const response = inline({ndjson: '', nextCursor: 3, state: 'open'});
+
+    const snapshot = mergeLogRead(previous, {mode: 'inline', response});
+
+    expect(snapshot.records).toEqual(previous.records);
+    expect(snapshot.nextCursor).toBe(3);
+    expect(snapshot.state).toBe('open');
+    expect(snapshot.complete).toBe(false);
+  });
+
+  test('marks a closed drained inline stream complete', () => {
+    const response = inline({ndjson: line(output('done\n')), state: 'closed', hasMore: false});
+
+    const snapshot = mergeLogRead(undefined, {mode: 'inline', response});
+
+    expect(snapshot.records).toEqual([output('done\n')]);
+    expect(snapshot.state).toBe('closed');
+    expect(snapshot.complete).toBe(true);
+    expect(snapshot.hasMore).toBe(false);
+  });
+
+  test('replaces partial inline records with the compacted object records', () => {
+    const previous: StepLogSnapshot = {
+      records: [output('partial\n', 1)],
+      nextCursor: 2,
+      source: 'inline',
+      state: 'closed',
+      complete: false,
+      hasMore: true,
+      truncated: false,
+      totalBytes: null,
+      expiresAt: null,
+    };
+    const response = presigned({
+      expires_at: '2026-06-23T10:00:00.000Z',
+      total_bytes: 256,
+      truncated: true,
+    });
+
+    const snapshot = mergeLogRead(previous, {
+      mode: 'presigned',
+      response,
+      ndjson: line(output('full\n', 2)),
+    });
+
+    expect(snapshot.records).toEqual([output('full\n', 2)]);
+    expect(snapshot.source).toBe('presigned');
+    expect(snapshot.state).toBe('compacted');
+    expect(snapshot.complete).toBe(true);
+    expect(snapshot.totalBytes).toBe(256);
+    expect(snapshot.expiresAt).toBe('2026-06-23T10:00:00.000Z');
+    expect(snapshot.truncated).toBe(true);
+  });
+});
+
+describe('stepLogRefetchInterval', () => {
+  const snapshot = (overrides: Partial<StepLogSnapshot>): StepLogSnapshot => ({
+    records: [],
+    nextCursor: 0,
+    source: 'inline',
+    state: 'open',
+    complete: false,
+    hasMore: false,
+    truncated: false,
+    totalBytes: null,
+    expiresAt: null,
+    ...overrides,
+  });
+
+  test('does not poll before the first snapshot', () => {
+    const interval = stepLogRefetchInterval(undefined);
+
+    expect(interval).toBe(false);
+  });
+
+  test('polls quickly while draining buffered inline pages', () => {
+    const interval = stepLogRefetchInterval(snapshot({hasMore: true}));
+
+    expect(interval).toBe(STEP_LOG_DRAIN_REFETCH_MS);
+  });
+
+  test('polls at live-tail cadence for an open drained stream', () => {
+    const interval = stepLogRefetchInterval(snapshot({state: 'open', hasMore: false}));
+
+    expect(interval).toBe(STEP_LOG_LIVE_REFETCH_MS);
+  });
+
+  test('stops polling once the stream is complete', () => {
+    const interval = stepLogRefetchInterval(snapshot({state: 'closed', complete: true}));
+
+    expect(interval).toBe(false);
+  });
+});

--- a/libs/client/logs/src/core/log-read.test.ts
+++ b/libs/client/logs/src/core/log-read.test.ts
@@ -64,6 +64,23 @@ describe('parseLogNdjson', () => {
 
     expect(parse).toThrow();
   });
+
+  test('splits records on CRLF line breaks', () => {
+    const first = output('first\n', 1);
+    const second = output('second\n', 2);
+
+    const records = parseLogNdjson(`${JSON.stringify(first)}\r\n${JSON.stringify(second)}\r\n`);
+
+    expect(records).toEqual([first, second]);
+  });
+
+  test('skips blank lines between records', () => {
+    const record = output('only\n', 1);
+
+    const records = parseLogNdjson(`\n${line(record)}\n`);
+
+    expect(records).toEqual([record]);
+  });
 });
 
 describe('mergeLogRead', () => {
@@ -190,6 +207,12 @@ describe('stepLogRefetchInterval', () => {
 
   test('stops polling once the stream is complete', () => {
     const interval = stepLogRefetchInterval(snapshot({state: 'closed', complete: true}));
+
+    expect(interval).toBe(false);
+  });
+
+  test('stops polling after a fetch errors out instead of re-polling the dead cursor', () => {
+    const interval = stepLogRefetchInterval(snapshot({hasMore: true}), true);
 
     expect(interval).toBe(false);
   });

--- a/libs/client/logs/src/core/log-read.ts
+++ b/libs/client/logs/src/core/log-read.ts
@@ -65,7 +65,15 @@ export function mergeLogRead(
   };
 }
 
-export function stepLogRefetchInterval(snapshot: StepLogSnapshot | undefined): number | false {
+export function stepLogRefetchInterval(
+  snapshot: StepLogSnapshot | undefined,
+  lastFetchErrored = false,
+): number | false {
+  // A persistent failure (deleted step, 5xx, an unparseable record line) never advances
+  // the cursor, so without this guard the interval re-polls the same dead cursor forever.
+  // Stop once a fetch errors out (React Query's own retry absorbs transient blips first);
+  // refetchOnWindowFocus/Reconnect (gated on !complete) resume it.
+  if (lastFetchErrored) return false;
   if (!snapshot || snapshot.complete) return false;
   return snapshot.hasMore ? STEP_LOG_DRAIN_REFETCH_MS : STEP_LOG_LIVE_REFETCH_MS;
 }

--- a/libs/client/logs/src/core/log-read.ts
+++ b/libs/client/logs/src/core/log-read.ts
@@ -1,0 +1,71 @@
+import {type LogRecord, parseLogRecordLine, type ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+
+export const STEP_LOG_DRAIN_REFETCH_MS = 250;
+export const STEP_LOG_LIVE_REFETCH_MS = 2_000;
+
+const NDJSON_LINE_BREAK = /\r?\n/;
+
+type InlineReadLogsResponse = Extract<ReadLogsResponseDto, {mode: 'inline'}>;
+type PresignedReadLogsResponse = Extract<ReadLogsResponseDto, {mode: 'presigned'}>;
+
+export interface StepLogSnapshot {
+  records: LogRecord[];
+  nextCursor: number;
+  source: 'inline' | 'presigned';
+  state: 'open' | 'closed' | 'compacted';
+  complete: boolean;
+  hasMore: boolean;
+  truncated: boolean;
+  totalBytes: number | null;
+  expiresAt: string | null;
+}
+
+export type ResolvedStepLogRead =
+  | {mode: 'inline'; response: InlineReadLogsResponse}
+  | {mode: 'presigned'; response: PresignedReadLogsResponse; ndjson: string};
+
+export function parseLogNdjson(ndjson: string): LogRecord[] {
+  return ndjson
+    .split(NDJSON_LINE_BREAK)
+    .filter((line) => line.length > 0)
+    .map(parseLogRecordLine);
+}
+
+export function mergeLogRead(
+  previous: StepLogSnapshot | undefined,
+  read: ResolvedStepLogRead,
+): StepLogSnapshot {
+  if (read.mode === 'presigned') {
+    return {
+      records: parseLogNdjson(read.ndjson),
+      nextCursor: 0,
+      source: 'presigned',
+      state: 'compacted',
+      complete: true,
+      hasMore: false,
+      truncated: read.response.truncated,
+      totalBytes: read.response.total_bytes,
+      expiresAt: read.response.expires_at,
+    };
+  }
+
+  const records = parseLogNdjson(read.response.ndjson);
+  const complete = read.response.state === 'closed' && !read.response.has_more;
+
+  return {
+    records: [...(previous?.records ?? []), ...records],
+    nextCursor: read.response.next_cursor,
+    source: 'inline',
+    state: read.response.state,
+    complete,
+    hasMore: read.response.has_more,
+    truncated: read.response.truncated,
+    totalBytes: null,
+    expiresAt: null,
+  };
+}
+
+export function stepLogRefetchInterval(snapshot: StepLogSnapshot | undefined): number | false {
+  if (!snapshot || snapshot.complete) return false;
+  return snapshot.hasMore ? STEP_LOG_DRAIN_REFETCH_MS : STEP_LOG_LIVE_REFETCH_MS;
+}

--- a/libs/client/logs/src/hooks/api/step-logs.test.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.test.ts
@@ -1,0 +1,66 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {readStepAttemptLogsPage, stepLogsQueryKeys} from './step-logs.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+function requestFrom(fetchImpl: ReturnType<typeof vi.fn>): Request {
+  return fetchImpl.mock.calls[0]?.[0] as Request;
+}
+
+describe('stepLogsQueryKeys', () => {
+  test('keys a log detail by step id and attempt', () => {
+    const key = stepLogsQueryKeys.detail('11111111-1111-4111-8111-111111111111', 2);
+
+    expect(key).toEqual(['step-logs', 'detail', '11111111-1111-4111-8111-111111111111', 2]);
+  });
+});
+
+describe('readStepAttemptLogsPage', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('requests a step attempt log page with the cursor', async () => {
+    const body = {
+      mode: 'inline',
+      ndjson: '',
+      next_cursor: 8,
+      has_more: false,
+      state: 'open',
+      truncated: false,
+    };
+    const fetchImpl = vi.fn(async () => jsonResponse(body));
+    configureApiClient({fetchImpl});
+
+    const result = await readStepAttemptLogsPage({
+      stepId: '11111111-1111-4111-8111-111111111111',
+      attempt: 2,
+      cursor: 7,
+    });
+
+    const url = new URL(requestFrom(fetchImpl).url);
+    expect(result).toEqual(body);
+    expect(url.pathname).toBe('/steps/11111111-1111-4111-8111-111111111111/attempts/2/logs');
+    expect(url.searchParams.get('cursor')).toBe('7');
+    expect(requestFrom(fetchImpl).method).toBe('GET');
+  });
+
+  test('bubbles API errors from the read endpoint', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({code: 'not-found'}, {status: 404}));
+    configureApiClient({fetchImpl});
+
+    const result = readStepAttemptLogsPage({
+      stepId: '11111111-1111-4111-8111-111111111111',
+      attempt: 1,
+      cursor: 0,
+    });
+
+    await expect(result).rejects.toMatchObject({code: 'not-found', status: 404});
+  });
+});

--- a/libs/client/logs/src/hooks/api/step-logs.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs.test.tsx
@@ -131,6 +131,24 @@ describe('useStepAttemptLogsQuery', () => {
     expect(result.current.data?.records).toMatchObject([{type: 'output', data: 'alpha\n'}]);
   });
 
+  test('stops polling after a persistent error instead of re-polling the dead cursor', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(inlineBody({ndjson: outputLine('alpha\n', 1), nextCursor: 5, hasMore: true})),
+      )
+      .mockResolvedValue(jsonResponse({code: 'server-error'}, {status: 500}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook();
+    await waitFor(() => expect(result.current.data?.records).toHaveLength(1));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const callsWhenErrored = fetchImpl.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(fetchImpl.mock.calls.length).toBe(callsWhenErrored);
+  });
+
   test('does not poll after a closed drained inline stream loads', async () => {
     const fetchImpl = vi.fn(async () =>
       jsonResponse(inlineBody({ndjson: outputLine('done\n', 1), nextCursor: 1, state: 'closed'})),

--- a/libs/client/logs/src/hooks/api/step-logs.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs.test.tsx
@@ -44,7 +44,12 @@ const presignedBody = () => ({
   truncated: false,
 });
 
-function renderStepLogsHook(stepId: string | undefined = STEP_ID, attempt: number | undefined = 1) {
+function renderStepLogsHook(
+  params: {stepId: string | undefined; attempt: number | undefined} = {
+    stepId: STEP_ID,
+    attempt: 1,
+  },
+) {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false}},
   });
@@ -52,7 +57,7 @@ function renderStepLogsHook(stepId: string | undefined = STEP_ID, attempt: numbe
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 
-  return renderHook(() => useStepAttemptLogsQuery(stepId, attempt), {wrapper});
+  return renderHook(() => useStepAttemptLogsQuery(params.stepId, params.attempt), {wrapper});
 }
 
 function requestsFrom(fetchImpl: ReturnType<typeof vi.fn>): Request[] {
@@ -70,7 +75,7 @@ describe('useStepAttemptLogsQuery', () => {
     const fetchImpl = vi.fn(async () => jsonResponse(inlineBody({ndjson: '', nextCursor: 0})));
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-    renderStepLogsHook(undefined, undefined);
+    renderStepLogsHook({stepId: undefined, attempt: undefined});
 
     expect(fetchImpl).not.toHaveBeenCalled();
   });

--- a/libs/client/logs/src/hooks/api/step-logs.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs.test.tsx
@@ -1,0 +1,146 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {cleanup, renderHook, waitFor} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {useStepAttemptLogsQuery} from './step-logs.js';
+
+const STEP_ID = '11111111-1111-4111-8111-111111111111';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+const outputLine = (data: string, ts = 1): string =>
+  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
+
+const inlineBody = ({
+  ndjson,
+  nextCursor,
+  hasMore = false,
+  state = 'open',
+}: {
+  ndjson: string;
+  nextCursor: number;
+  hasMore?: boolean;
+  state?: 'open' | 'closed';
+}) => ({
+  mode: 'inline',
+  ndjson,
+  next_cursor: nextCursor,
+  has_more: hasMore,
+  state,
+  truncated: false,
+});
+
+const presignedBody = () => ({
+  mode: 'presigned',
+  url: 'https://storage.example.test/logs/object?sig=1',
+  expires_at: '2026-06-23T10:00:00.000Z',
+  total_bytes: 128,
+  truncated: false,
+});
+
+function renderStepLogsHook(stepId: string | undefined = STEP_ID, attempt: number | undefined = 1) {
+  const queryClient = new QueryClient({
+    defaultOptions: {queries: {retry: false}},
+  });
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return renderHook(() => useStepAttemptLogsQuery(stepId, attempt), {wrapper});
+}
+
+function requestsFrom(fetchImpl: ReturnType<typeof vi.fn>): Request[] {
+  return fetchImpl.mock.calls.map((call) => call[0] as Request);
+}
+
+describe('useStepAttemptLogsQuery', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    configureApiClient({baseUrl: '', fetchImpl: undefined});
+  });
+
+  test('does not fetch until step id and attempt are available', () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(inlineBody({ndjson: '', nextCursor: 0})));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderStepLogsHook(undefined, undefined);
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test('uses the cached cursor on the next fetch and appends live records', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(inlineBody({ndjson: outputLine('alpha\n', 1), nextCursor: 5})),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(inlineBody({ndjson: outputLine('beta\n', 2), nextCursor: 6})),
+      );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook();
+    await waitFor(() => expect(result.current.data?.records).toHaveLength(1));
+    await result.current.refetch();
+
+    await waitFor(() => expect(result.current.data?.records).toHaveLength(2));
+    const urls = requestsFrom(fetchImpl).map((request) => new URL(request.url));
+    expect(urls.map((url) => url.searchParams.get('cursor'))).toEqual(['0', '5']);
+    expect(result.current.data?.records.map((record) => record.type)).toEqual(['output', 'output']);
+  });
+
+  test('fetches and parses compacted presigned logs into the same record state', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(presignedBody()));
+    const objectFetch = vi.fn(async () => new Response(outputLine('cold\n', 3), {status: 200}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    vi.stubGlobal('fetch', objectFetch);
+
+    const {result} = renderStepLogsHook();
+
+    await waitFor(() => expect(result.current.data?.source).toBe('presigned'));
+    expect(objectFetch).toHaveBeenCalledWith('https://storage.example.test/logs/object?sig=1', {
+      signal: expect.any(AbortSignal),
+    });
+    expect(result.current.data?.records).toMatchObject([{type: 'output', data: 'cold\n'}]);
+    expect(result.current.data?.state).toBe('compacted');
+    expect(result.current.data?.complete).toBe(true);
+    expect(result.current.data?.totalBytes).toBe(128);
+  });
+
+  test('keeps prior records visible when a refetch fails', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(inlineBody({ndjson: outputLine('alpha\n', 1), nextCursor: 5})),
+      )
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook();
+    await waitFor(() => expect(result.current.data?.records).toHaveLength(1));
+    const refetch = await result.current.refetch();
+
+    expect(refetch.error).toBeTruthy();
+    expect(result.current.data?.records).toMatchObject([{type: 'output', data: 'alpha\n'}]);
+  });
+
+  test('does not poll after a closed drained inline stream loads', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(inlineBody({ndjson: outputLine('done\n', 1), nextCursor: 1, state: 'closed'})),
+    );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook();
+    await waitFor(() => expect(result.current.data?.complete).toBe(true));
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -1,0 +1,80 @@
+import type {ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import {apiRequest} from '@shipfox/client-api';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
+import {mergeLogRead, type StepLogSnapshot, stepLogRefetchInterval} from '#core/log-read.js';
+
+export const stepLogsQueryKeys = {
+  all: ['step-logs'] as const,
+  detail: (stepId: string, attempt: number) =>
+    [...stepLogsQueryKeys.all, 'detail', stepId, attempt] as const,
+};
+
+interface ReadStepAttemptLogsPageParams {
+  stepId: string;
+  attempt: number;
+  cursor: number;
+  signal?: AbortSignal;
+}
+
+export async function readStepAttemptLogsPage({
+  stepId,
+  attempt,
+  cursor,
+  signal,
+}: ReadStepAttemptLogsPageParams): Promise<ReadLogsResponseDto> {
+  const params = new URLSearchParams({cursor: String(cursor)});
+  return await apiRequest<ReadLogsResponseDto>(
+    `/steps/${encodeURIComponent(stepId)}/attempts/${attempt}/logs?${params.toString()}`,
+    {signal},
+  );
+}
+
+class StepLogObjectFetchError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Could not load compacted logs (${status})`);
+    this.name = 'StepLogObjectFetchError';
+    this.status = status;
+  }
+}
+
+async function readPresignedLogObject(url: string, signal?: AbortSignal): Promise<string> {
+  const response = await fetch(url, signal ? {signal} : undefined);
+  if (!response.ok) throw new StepLogObjectFetchError(response.status);
+  return await response.text();
+}
+
+export function useStepAttemptLogsQuery(stepId: string | undefined, attempt: number | undefined) {
+  const queryClient = useQueryClient();
+  const enabled = Boolean(stepId && attempt && Number.isInteger(attempt) && attempt > 0);
+  const queryKey =
+    enabled && stepId && attempt
+      ? stepLogsQueryKeys.detail(stepId, attempt)
+      : [...stepLogsQueryKeys.all, 'detail'];
+
+  return useQuery({
+    queryKey,
+    enabled,
+    queryFn: async ({signal}) => {
+      const previous = queryClient.getQueryData<StepLogSnapshot>(queryKey);
+      const response = await readStepAttemptLogsPage({
+        stepId: stepId ?? '',
+        attempt: attempt ?? 0,
+        cursor: previous?.nextCursor ?? 0,
+        signal,
+      });
+
+      if (response.mode === 'presigned') {
+        const ndjson = await readPresignedLogObject(response.url, signal);
+        return mergeLogRead(previous, {mode: 'presigned', response, ndjson});
+      }
+
+      return mergeLogRead(previous, {mode: 'inline', response});
+    },
+    refetchInterval: (query) => stepLogRefetchInterval(query.state.data),
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: (query) => !query.state.data?.complete,
+    refetchOnReconnect: (query) => !query.state.data?.complete,
+  });
+}

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -72,8 +72,10 @@ export function useStepAttemptLogsQuery(stepId: string | undefined, attempt: num
 
       return mergeLogRead(previous, {mode: 'inline', response});
     },
-    refetchInterval: (query) => stepLogRefetchInterval(query.state.data),
+    refetchInterval: (query) =>
+      stepLogRefetchInterval(query.state.data, query.state.status === 'error'),
     refetchIntervalInBackground: false,
+    refetchOnMount: (query) => !query.state.data?.complete,
     refetchOnWindowFocus: (query) => !query.state.data?.complete,
     refetchOnReconnect: (query) => !query.state.data?.complete,
   });

--- a/libs/client/logs/src/index.ts
+++ b/libs/client/logs/src/index.ts
@@ -1,9 +1,4 @@
-export {
-  mergeLogRead,
-  parseLogNdjson,
-  type StepLogSnapshot,
-  stepLogRefetchInterval,
-} from '#core/log-read.js';
+export type {StepLogSnapshot} from '#core/log-read.js';
 export {
   buildLogTree,
   type GroupLogNode,

--- a/libs/client/logs/src/index.ts
+++ b/libs/client/logs/src/index.ts
@@ -1,4 +1,10 @@
 export {
+  mergeLogRead,
+  parseLogNdjson,
+  type StepLogSnapshot,
+  stepLogRefetchInterval,
+} from '#core/log-read.js';
+export {
   buildLogTree,
   type GroupLogNode,
   type LogNode,
@@ -7,3 +13,8 @@ export {
   type OutputLogNode,
 } from '#core/log-tree.js';
 export * from './components/index.js';
+export {
+  readStepAttemptLogsPage,
+  stepLogsQueryKeys,
+  useStepAttemptLogsQuery,
+} from './hooks/api/step-logs.js';

--- a/libs/client/logs/vitest.config.ts
+++ b/libs/client/logs/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig(
         },
         {
           extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+          },
+        },
+        {
+          extends: true,
           plugins: [
             storybookTest({configDir: path.join(dirname, '.storybook')}),
             argosVitestPlugin({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2367,12 +2367,18 @@ importers:
       '@shipfox/api-logs-dto':
         specifier: workspace:*
         version: link:../../api/logs-dto
+      '@shipfox/client-api':
+        specifier: workspace:*
+        version: link:../api
       '@shipfox/react-ui':
         specifier: workspace:*
         version: link:../../shared/react/ui
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
     devDependencies:
       '@argos-ci/cli':
         specifier: ^5.0.0
@@ -2407,6 +2413,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.1.11
         version: 19.2.17
@@ -2419,6 +2428,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.8(playwright@1.60.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      jsdom:
+        specifier: ^29.0.0
+        version: 29.1.1
       react:
         specifier: ^19.1.1
         version: 19.2.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2413,6 +2413,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.13
         version: 4.3.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@testing-library/dom':
+        specifier: ^10.0.0
+        version: 10.4.1
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
Add a reusable client-side read layer for step attempt logs.

The logs API already serves both live inline NDJSON pages and compacted presigned objects. This PR gives @shipfox/client-logs a single React Query hook and domain snapshot that hide that transport split from consumers, while preserving the existing presentation-only LogView.

The hook keeps one cache entry per {stepId, attempt}, follows next_cursor for inline pages, drains backlog faster than live tailing, stops once a stream is complete, stops interval polling after persistent fetch failures, and fetches compacted objects directly through their presigned URL. Parser, merge, transport, polling, and hook wiring are covered with node and jsdom tests.

Includes a patch changeset for @shipfox/client-logs.