### PR TITLE
Add outbox schemas for publisher events

### DIFF
--- a/.changeset/steady-outboxes-validate.md
+++ b/.changeset/steady-outboxes-validate.md
@@ -1,0 +1,15 @@
+---
+"@shipfox/api-definitions": patch
+"@shipfox/api-definitions-dto": patch
+"@shipfox/api-dispatcher": patch
+"@shipfox/api-integration-core-dto": patch
+"@shipfox/api-logs": patch
+"@shipfox/api-logs-dto": patch
+"@shipfox/api-projects": patch
+"@shipfox/api-projects-dto": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-runners-dto": patch
+"@shipfox/api-workflows-dto": patch
+---
+
+Adds drain-boundary Zod validation for current outbox publisher event payloads.

--- a/libs/api/definitions-dto/src/events.ts
+++ b/libs/api/definitions-dto/src/events.ts
@@ -1,22 +1,16 @@
 import {z} from 'zod';
+import {triggerDtoSchema} from '#schemas/trigger.js';
 
 export const DEFINITION_RESOLVED = 'definitions.definition.resolved' as const;
 export const DEFINITION_DELETED = 'definitions.definition.deleted' as const;
 export const DEFINITION_INVALID = 'definitions.definition.invalid' as const;
-
-const triggerEventSchema = z.object({
-  source: z.string(),
-  event: z.string(),
-  with: z.record(z.string(), z.unknown()).optional(),
-  filter: z.string().optional(),
-});
 
 export const definitionResolvedEventSchema = z.object({
   definitionId: z.string(),
   projectId: z.string(),
   workspaceId: z.string(),
   configPath: z.string().nullable(),
-  triggers: z.record(z.string(), triggerEventSchema),
+  triggers: z.record(z.string(), triggerDtoSchema),
 });
 export type DefinitionResolvedEvent = z.infer<typeof definitionResolvedEventSchema>;
 

--- a/libs/api/definitions-dto/src/events.ts
+++ b/libs/api/definitions-dto/src/events.ts
@@ -1,31 +1,47 @@
-import type {TriggerDto} from '#schemas/trigger.js';
+import {z} from 'zod';
 
 export const DEFINITION_RESOLVED = 'definitions.definition.resolved' as const;
 export const DEFINITION_DELETED = 'definitions.definition.deleted' as const;
 export const DEFINITION_INVALID = 'definitions.definition.invalid' as const;
 
-export interface DefinitionResolvedEvent {
-  definitionId: string;
-  projectId: string;
-  workspaceId: string;
-  configPath: string | null;
-  triggers: Record<string, TriggerDto>;
-}
+const triggerEventSchema = z.object({
+  source: z.string(),
+  event: z.string(),
+  with: z.record(z.string(), z.unknown()).optional(),
+  filter: z.string().optional(),
+});
 
-export interface DefinitionDeletedEvent {
-  definitionId: string;
-  projectId: string;
-  workspaceId: string;
-}
+export const definitionResolvedEventSchema = z.object({
+  definitionId: z.string(),
+  projectId: z.string(),
+  workspaceId: z.string(),
+  configPath: z.string().nullable(),
+  triggers: z.record(z.string(), triggerEventSchema),
+});
+export type DefinitionResolvedEvent = z.infer<typeof definitionResolvedEventSchema>;
 
-export interface DefinitionInvalidEvent {
-  projectId: string;
-  ref: string;
-  errors: string[];
-}
+export const definitionDeletedEventSchema = z.object({
+  definitionId: z.string(),
+  projectId: z.string(),
+  workspaceId: z.string(),
+});
+export type DefinitionDeletedEvent = z.infer<typeof definitionDeletedEventSchema>;
+
+export const definitionInvalidEventSchema = z.object({
+  projectId: z.string(),
+  ref: z.string(),
+  errors: z.array(z.string()),
+});
+export type DefinitionInvalidEvent = z.infer<typeof definitionInvalidEventSchema>;
 
 export interface DefinitionsEventMap {
   [DEFINITION_RESOLVED]: DefinitionResolvedEvent;
   [DEFINITION_DELETED]: DefinitionDeletedEvent;
   [DEFINITION_INVALID]: DefinitionInvalidEvent;
 }
+
+export const definitionsEventSchemas = {
+  [DEFINITION_RESOLVED]: definitionResolvedEventSchema,
+  [DEFINITION_DELETED]: definitionDeletedEventSchema,
+  [DEFINITION_INVALID]: definitionInvalidEventSchema,
+} satisfies Record<keyof DefinitionsEventMap, z.ZodType>;

--- a/libs/api/definitions-dto/src/events.ts
+++ b/libs/api/definitions-dto/src/events.ts
@@ -1,29 +1,31 @@
 import {z} from 'zod';
 import {triggerDtoSchema} from '#schemas/trigger.js';
 
+const nonEmptyStringSchema = z.string().nonempty();
+
 export const DEFINITION_RESOLVED = 'definitions.definition.resolved' as const;
 export const DEFINITION_DELETED = 'definitions.definition.deleted' as const;
 export const DEFINITION_INVALID = 'definitions.definition.invalid' as const;
 
 export const definitionResolvedEventSchema = z.object({
-  definitionId: z.string(),
-  projectId: z.string(),
-  workspaceId: z.string(),
+  definitionId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
   configPath: z.string().nullable(),
   triggers: z.record(z.string(), triggerDtoSchema),
 });
 export type DefinitionResolvedEvent = z.infer<typeof definitionResolvedEventSchema>;
 
 export const definitionDeletedEventSchema = z.object({
-  definitionId: z.string(),
-  projectId: z.string(),
-  workspaceId: z.string(),
+  definitionId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
 });
 export type DefinitionDeletedEvent = z.infer<typeof definitionDeletedEventSchema>;
 
 export const definitionInvalidEventSchema = z.object({
-  projectId: z.string(),
-  ref: z.string(),
+  projectId: nonEmptyStringSchema,
+  ref: nonEmptyStringSchema,
   errors: z.array(z.string()),
 });
 export type DefinitionInvalidEvent = z.infer<typeof definitionInvalidEventSchema>;

--- a/libs/api/definitions-dto/src/index.ts
+++ b/libs/api/definitions-dto/src/index.ts
@@ -21,4 +21,8 @@ export {
   type DefinitionInvalidEvent,
   type DefinitionResolvedEvent,
   type DefinitionsEventMap,
+  definitionDeletedEventSchema,
+  definitionInvalidEventSchema,
+  definitionResolvedEventSchema,
+  definitionsEventSchemas,
 } from './events.js';

--- a/libs/api/definitions-dto/src/schemas/trigger.ts
+++ b/libs/api/definitions-dto/src/schemas/trigger.ts
@@ -1,6 +1,9 @@
-export interface TriggerDto {
-  source: string;
-  event: string;
-  with?: Record<string, unknown>;
-  filter?: string;
-}
+import {z} from 'zod';
+
+export const triggerDtoSchema = z.object({
+  source: z.string(),
+  event: z.string(),
+  with: z.record(z.string(), z.unknown()).optional(),
+  filter: z.string().optional(),
+});
+export type TriggerDto = z.infer<typeof triggerDtoSchema>;

--- a/libs/api/definitions/src/index.ts
+++ b/libs/api/definitions/src/index.ts
@@ -1,6 +1,10 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {DEFINITION_RESOLVED, type DefinitionsEventMap} from '@shipfox/api-definitions-dto';
+import {
+  DEFINITION_RESOLVED,
+  type DefinitionsEventMap,
+  definitionsEventSchemas,
+} from '@shipfox/api-definitions-dto';
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
 import {
   PROJECT_SOURCE_BOUND,
@@ -42,7 +46,9 @@ export function createDefinitionsModule({
     name: 'definitions',
     database: {db, migrationsPath},
     routes,
-    publishers: [{name: 'definitions', table: definitionsOutbox, db}],
+    publishers: [
+      {name: 'definitions', table: definitionsOutbox, db, eventSchemas: definitionsEventSchemas},
+    ],
     subscribers: [
       subscriber(DEFINITION_RESOLVED, (_payload, event) => {
         logger().info({event}, 'Definition resolved');

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -1,3 +1,4 @@
+import {DEFINITION_RESOLVED, definitionsEventSchemas} from '@shipfox/api-definitions-dto';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {drainAndDispatch} from './drain-and-dispatch.js';
 
@@ -87,35 +88,51 @@ describe('drainAndDispatch', () => {
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 
-  it('rejects a malformed payload at the drain: skips handlers and records a row failure', async () => {
-    const error = {issues: [{path: ['jobId'], code: 'invalid_type', message: 'expected string'}]};
+  it('rejects a malformed schema-covered payload without capturing raw payload data', async () => {
     const event: DomainEvent = {
       id: crypto.randomUUID(),
-      type: 'workflows.job.terminated',
+      type: DEFINITION_RESOLVED,
       createdAt: new Date(),
-      payload: {jobId: 123},
+      payload: {
+        projectId: crypto.randomUUID(),
+        workspaceId: crypto.randomUUID(),
+        configPath: null,
+        triggers: {},
+        secret: 'raw-secret',
+      },
     };
-    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'workflows', event}]);
-    mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: false, error})});
+    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'definitions', event}]);
+    mocks.getEventSchema.mockReturnValueOnce(definitionsEventSchemas[DEFINITION_RESOLVED]);
 
     await drainAndDispatch();
 
     expect(mocks.getSubscribers).not.toHaveBeenCalled();
     expect(mocks.markDispatched).not.toHaveBeenCalled();
-    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', event.id, {
-      kind: 'validation',
-      eventType: event.type,
-      eventId: event.id,
-      issues: error.issues,
-    });
-    expect(mocks.captureException).toHaveBeenCalledWith(error, {
-      extra: {
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
+      'definitions',
+      event.id,
+      expect.objectContaining({
         kind: 'validation',
         eventType: event.type,
         eventId: event.id,
-        issues: error.issues,
-      },
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: ['definitionId'],
+            code: expect.any(String),
+            message: expect.any(String),
+          }),
+        ]),
+      }),
+    );
+    const captureOptions = mocks.captureException.mock.calls[0]?.[1];
+    expect(captureOptions).toEqual({
+      extra: expect.objectContaining({
+        kind: 'validation',
+        eventType: event.type,
+        eventId: event.id,
+      }),
     });
+    expect(JSON.stringify(captureOptions)).not.toContain('raw-secret');
   });
 
   it('passes the parsed payload to handlers when validation succeeds', async () => {

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -108,22 +108,20 @@ describe('drainAndDispatch', () => {
 
     expect(mocks.getSubscribers).not.toHaveBeenCalled();
     expect(mocks.markDispatched).not.toHaveBeenCalled();
-    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
-      'definitions',
-      event.id,
-      expect.objectContaining({
-        kind: 'validation',
-        eventType: event.type,
-        eventId: event.id,
-        issues: expect.arrayContaining([
-          expect.objectContaining({
-            path: ['definitionId'],
-            code: expect.any(String),
-            message: expect.any(String),
-          }),
-        ]),
-      }),
-    );
+    const failureContext = mocks.recordDispatchFailure.mock.calls[0]?.[2];
+    expect(failureContext).toEqual({
+      kind: 'validation',
+      eventType: event.type,
+      eventId: event.id,
+      issues: expect.arrayContaining([
+        expect.objectContaining({
+          path: ['definitionId'],
+          code: expect.any(String),
+          message: expect.any(String),
+        }),
+      ]),
+    });
+    expect(JSON.stringify(failureContext)).not.toContain('raw-secret');
     const captureOptions = mocks.captureException.mock.calls[0]?.[1];
     expect(captureOptions).toEqual({
       extra: expect.objectContaining({

--- a/libs/api/integration/core-dto/src/events.test.ts
+++ b/libs/api/integration/core-dto/src/events.test.ts
@@ -1,4 +1,20 @@
-import {integrationSourceCommitPushedSchema} from './events.js';
+import {
+  INTEGRATION_EVENT_RECEIVED,
+  INTEGRATION_SOURCE_COMMIT_PUSHED,
+  integrationEventReceivedSchema,
+  integrationSourceCommitPushedSchema,
+  integrationsEventSchemas,
+} from './events.js';
+
+const validEventReceived = {
+  source: 'github',
+  event: 'push',
+  workspaceId: 'ws-1',
+  connectionId: 'conn-1',
+  deliveryId: 'delivery-1',
+  receivedAt: '2026-06-21T00:00:00.000Z',
+  payload: {opaque: true},
+};
 
 const validCommitPushed = {
   provider: 'github',
@@ -45,5 +61,39 @@ describe('integrationSourceCommitPushedSchema', () => {
     const result = integrationSourceCommitPushedSchema.parse(input);
 
     expect(result).toEqual(validCommitPushed);
+  });
+});
+
+describe('integrationEventReceivedSchema', () => {
+  it('parses a valid generic integration event envelope unchanged', () => {
+    const result = integrationEventReceivedSchema.parse(validEventReceived);
+
+    expect(result).toEqual(validEventReceived);
+  });
+
+  it('rejects a payload missing the opaque provider payload key', () => {
+    const {payload: _payload, ...withoutPayload} = validEventReceived;
+
+    const parse = () => integrationEventReceivedSchema.parse(withoutPayload);
+
+    expect(parse).toThrow();
+  });
+
+  it('strips unknown envelope keys', () => {
+    const input = {...validEventReceived, addedLater: 'ignored'};
+
+    const result = integrationEventReceivedSchema.parse(input);
+
+    expect(result).toEqual(validEventReceived);
+  });
+});
+
+describe('integrationsEventSchemas', () => {
+  it('registers every integration publisher event type', () => {
+    const registeredTypes = Object.keys(integrationsEventSchemas).sort();
+
+    expect(registeredTypes).toEqual(
+      [INTEGRATION_EVENT_RECEIVED, INTEGRATION_SOURCE_COMMIT_PUSHED].sort(),
+    );
   });
 });

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -2,15 +2,17 @@ import {z} from 'zod';
 
 export const INTEGRATION_EVENT_RECEIVED = 'integrations.event.received' as const;
 
+const nonEmptyStringSchema = z.string().nonempty();
+const isoDateTimeSchema = z.string().datetime();
 const requiredUnknownSchema = z.custom<unknown>((value) => value !== undefined);
 
 export const integrationEventReceivedSchema = z.object({
-  source: z.string(),
-  event: z.string(),
-  workspaceId: z.string(),
-  connectionId: z.string(),
-  deliveryId: z.string(),
-  receivedAt: z.string(),
+  source: nonEmptyStringSchema,
+  event: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  connectionId: nonEmptyStringSchema,
+  deliveryId: nonEmptyStringSchema,
+  receivedAt: isoDateTimeSchema,
   payload: requiredUnknownSchema,
 });
 export type IntegrationEventReceivedEvent = z.infer<typeof integrationEventReceivedSchema>;
@@ -19,10 +21,10 @@ export type IntegrationEventReceivedEvent = z.infer<typeof integrationEventRecei
 // generic `INTEGRATION_EVENT_RECEIVED` envelope payload (consumed opaquely by triggers)
 // and nested inside `INTEGRATION_SOURCE_COMMIT_PUSHED` (consumed by domain modules).
 export const sourcePushSchema = z.object({
-  externalRepositoryId: z.string(),
-  ref: z.string(),
-  headCommitSha: z.string(),
-  defaultBranch: z.string(),
+  externalRepositoryId: nonEmptyStringSchema,
+  ref: nonEmptyStringSchema,
+  headCommitSha: nonEmptyStringSchema,
+  defaultBranch: nonEmptyStringSchema,
   isDefaultBranch: z.boolean(),
 });
 export type SourcePushPayload = z.infer<typeof sourcePushSchema>;
@@ -34,11 +36,11 @@ export const INTEGRATION_SOURCE_COMMIT_PUSHED =
 // translation from its raw webhook into this shape, so domain consumers never decode
 // provider payloads. `isDefaultBranch` is a fact; the branch policy lives in the consumer.
 export const integrationSourceCommitPushedSchema = z.object({
-  provider: z.string(),
-  workspaceId: z.string(),
-  connectionId: z.string(),
-  deliveryId: z.string(),
-  receivedAt: z.string(),
+  provider: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  connectionId: nonEmptyStringSchema,
+  deliveryId: nonEmptyStringSchema,
+  receivedAt: isoDateTimeSchema,
   push: sourcePushSchema,
 });
 export type IntegrationSourceCommitPushedEvent = z.infer<

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -2,15 +2,18 @@ import {z} from 'zod';
 
 export const INTEGRATION_EVENT_RECEIVED = 'integrations.event.received' as const;
 
-export interface IntegrationEventReceivedEvent {
-  source: string;
-  event: string;
-  workspaceId: string;
-  connectionId: string;
-  deliveryId: string;
-  receivedAt: string;
-  payload: unknown;
-}
+const requiredUnknownSchema = z.custom<unknown>((value) => value !== undefined);
+
+export const integrationEventReceivedSchema = z.object({
+  source: z.string(),
+  event: z.string(),
+  workspaceId: z.string(),
+  connectionId: z.string(),
+  deliveryId: z.string(),
+  receivedAt: z.string(),
+  payload: requiredUnknownSchema,
+});
+export type IntegrationEventReceivedEvent = z.infer<typeof integrationEventReceivedSchema>;
 
 // A source-control push, normalized by the producing provider. Carried both as the
 // generic `INTEGRATION_EVENT_RECEIVED` envelope payload (consumed opaquely by triggers)
@@ -77,5 +80,6 @@ export interface IntegrationsEventMap {
 }
 
 export const integrationsEventSchemas = {
+  [INTEGRATION_EVENT_RECEIVED]: integrationEventReceivedSchema,
   [INTEGRATION_SOURCE_COMMIT_PUSHED]: integrationSourceCommitPushedSchema,
-} satisfies Partial<Record<keyof IntegrationsEventMap, z.ZodType>>;
+} satisfies Record<keyof IntegrationsEventMap, z.ZodType>;

--- a/libs/api/logs-dto/src/events.ts
+++ b/libs/api/logs-dto/src/events.ts
@@ -1,13 +1,15 @@
 import {z} from 'zod';
 
+const nonEmptyStringSchema = z.string().nonempty();
+
 export const LOG_STREAM_CLOSED = 'logs.stream.closed' as const;
 
 export const logStreamClosedEventSchema = z.object({
-  workspaceId: z.string(),
-  jobId: z.string(),
-  stepId: z.string(),
+  workspaceId: nonEmptyStringSchema,
+  jobId: nonEmptyStringSchema,
+  stepId: nonEmptyStringSchema,
   attempt: z.number(),
-  streamId: z.string(),
+  streamId: nonEmptyStringSchema,
 });
 export type LogStreamClosedEvent = z.infer<typeof logStreamClosedEventSchema>;
 

--- a/libs/api/logs-dto/src/events.ts
+++ b/libs/api/logs-dto/src/events.ts
@@ -1,13 +1,20 @@
+import {z} from 'zod';
+
 export const LOG_STREAM_CLOSED = 'logs.stream.closed' as const;
 
-export interface LogStreamClosedEvent {
-  workspaceId: string;
-  jobId: string;
-  stepId: string;
-  attempt: number;
-  streamId: string;
-}
+export const logStreamClosedEventSchema = z.object({
+  workspaceId: z.string(),
+  jobId: z.string(),
+  stepId: z.string(),
+  attempt: z.number(),
+  streamId: z.string(),
+});
+export type LogStreamClosedEvent = z.infer<typeof logStreamClosedEventSchema>;
 
 export interface LogsEventMap {
   [LOG_STREAM_CLOSED]: LogStreamClosedEvent;
 }
+
+export const logsEventSchemas = {
+  [LOG_STREAM_CLOSED]: logStreamClosedEventSchema,
+} satisfies Record<keyof LogsEventMap, z.ZodType>;

--- a/libs/api/logs-dto/src/index.ts
+++ b/libs/api/logs-dto/src/index.ts
@@ -22,4 +22,6 @@ export {
   LOG_STREAM_CLOSED,
   type LogStreamClosedEvent,
   type LogsEventMap,
+  logStreamClosedEventSchema,
+  logsEventSchemas,
 } from './events.js';

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -1,6 +1,6 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {LOG_STREAM_CLOSED, type LogsEventMap} from '@shipfox/api-logs-dto';
+import {LOG_STREAM_CLOSED, type LogsEventMap, logsEventSchemas} from '@shipfox/api-logs-dto';
 import {WORKFLOWS_JOB_TERMINATED, type WorkflowsEventMap} from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, logsOutbox, migrationsPath} from '#db/index.js';
@@ -23,7 +23,7 @@ export const logsModule: ShipfoxModule = {
   routes: logsRoutes,
   // `logs.stream.closed` is written by the close paths: the job-terminated subscriber
   // force-closes streams the runner never ended, and the closed event drives compaction.
-  publishers: [{name: 'logs', table: logsOutbox, db}],
+  publishers: [{name: 'logs', table: logsOutbox, db, eventSchemas: logsEventSchemas}],
   subscribers: [
     subscriber(WORKFLOWS_JOB_TERMINATED, onJobTerminated),
     subscriber(LOG_STREAM_CLOSED, onLogStreamClosed),

--- a/libs/api/projects-dto/src/events.ts
+++ b/libs/api/projects-dto/src/events.ts
@@ -1,36 +1,38 @@
 import {z} from 'zod';
 
+const nonEmptyStringSchema = z.string().nonempty();
+
 export const PROJECT_CREATED = 'projects.project.created' as const;
 export const PROJECT_SOURCE_BOUND = 'projects.project.source_bound' as const;
 export const PROJECT_SOURCE_COMMIT_OBSERVED = 'projects.project.source_commit_observed' as const;
 
 export const projectCreatedEventSchema = z.object({
-  actorId: z.string(),
-  workspaceId: z.string(),
-  projectId: z.string(),
-  sourceConnectionId: z.string(),
-  sourceExternalRepositoryId: z.string(),
+  actorId: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  sourceConnectionId: nonEmptyStringSchema,
+  sourceExternalRepositoryId: nonEmptyStringSchema,
 });
 export type ProjectCreatedEvent = z.infer<typeof projectCreatedEventSchema>;
 
 export const projectSourceBoundEventSchema = z.object({
-  actorId: z.string(),
-  workspaceId: z.string(),
-  projectId: z.string(),
-  sourceConnectionId: z.string(),
-  provider: z.string(),
-  externalRepositoryId: z.string(),
+  actorId: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  sourceConnectionId: nonEmptyStringSchema,
+  provider: nonEmptyStringSchema,
+  externalRepositoryId: nonEmptyStringSchema,
 });
 export type ProjectSourceBoundEvent = z.infer<typeof projectSourceBoundEventSchema>;
 
 export const projectSourceCommitObservedEventSchema = z.object({
-  workspaceId: z.string(),
-  projectId: z.string(),
-  sourceConnectionId: z.string(),
-  provider: z.string(),
-  externalRepositoryId: z.string(),
-  ref: z.string(),
-  headCommitSha: z.string(),
+  workspaceId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  sourceConnectionId: nonEmptyStringSchema,
+  provider: nonEmptyStringSchema,
+  externalRepositoryId: nonEmptyStringSchema,
+  ref: nonEmptyStringSchema,
+  headCommitSha: nonEmptyStringSchema,
 });
 export type ProjectSourceCommitObservedEvent = z.infer<
   typeof projectSourceCommitObservedEventSchema

--- a/libs/api/projects-dto/src/events.ts
+++ b/libs/api/projects-dto/src/events.ts
@@ -1,36 +1,49 @@
+import {z} from 'zod';
+
 export const PROJECT_CREATED = 'projects.project.created' as const;
 export const PROJECT_SOURCE_BOUND = 'projects.project.source_bound' as const;
 export const PROJECT_SOURCE_COMMIT_OBSERVED = 'projects.project.source_commit_observed' as const;
 
-export interface ProjectCreatedEvent {
-  actorId: string;
-  workspaceId: string;
-  projectId: string;
-  sourceConnectionId: string;
-  sourceExternalRepositoryId: string;
-}
+export const projectCreatedEventSchema = z.object({
+  actorId: z.string(),
+  workspaceId: z.string(),
+  projectId: z.string(),
+  sourceConnectionId: z.string(),
+  sourceExternalRepositoryId: z.string(),
+});
+export type ProjectCreatedEvent = z.infer<typeof projectCreatedEventSchema>;
 
-export interface ProjectSourceBoundEvent {
-  actorId: string;
-  workspaceId: string;
-  projectId: string;
-  sourceConnectionId: string;
-  provider: string;
-  externalRepositoryId: string;
-}
+export const projectSourceBoundEventSchema = z.object({
+  actorId: z.string(),
+  workspaceId: z.string(),
+  projectId: z.string(),
+  sourceConnectionId: z.string(),
+  provider: z.string(),
+  externalRepositoryId: z.string(),
+});
+export type ProjectSourceBoundEvent = z.infer<typeof projectSourceBoundEventSchema>;
 
-export interface ProjectSourceCommitObservedEvent {
-  workspaceId: string;
-  projectId: string;
-  sourceConnectionId: string;
-  provider: string;
-  externalRepositoryId: string;
-  ref: string;
-  headCommitSha: string;
-}
+export const projectSourceCommitObservedEventSchema = z.object({
+  workspaceId: z.string(),
+  projectId: z.string(),
+  sourceConnectionId: z.string(),
+  provider: z.string(),
+  externalRepositoryId: z.string(),
+  ref: z.string(),
+  headCommitSha: z.string(),
+});
+export type ProjectSourceCommitObservedEvent = z.infer<
+  typeof projectSourceCommitObservedEventSchema
+>;
 
 export interface ProjectsEventMap {
   [PROJECT_CREATED]: ProjectCreatedEvent;
   [PROJECT_SOURCE_BOUND]: ProjectSourceBoundEvent;
   [PROJECT_SOURCE_COMMIT_OBSERVED]: ProjectSourceCommitObservedEvent;
 }
+
+export const projectsEventSchemas = {
+  [PROJECT_CREATED]: projectCreatedEventSchema,
+  [PROJECT_SOURCE_BOUND]: projectSourceBoundEventSchema,
+  [PROJECT_SOURCE_COMMIT_OBSERVED]: projectSourceCommitObservedEventSchema,
+} satisfies Record<keyof ProjectsEventMap, z.ZodType>;

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -5,6 +5,7 @@ import {
   INTEGRATION_SOURCE_COMMIT_PUSHED,
   type IntegrationsEventMap,
 } from '@shipfox/api-integration-core-dto';
+import {projectsEventSchemas} from '@shipfox/api-projects-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, projectsOutbox} from '#db/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
@@ -46,7 +47,7 @@ export function createProjectsModule({sourceControl}: CreateProjectsModuleOption
     name: 'projects',
     database: {db, migrationsPath},
     routes: createProjectRoutes(sourceControl),
-    publishers: [{name: 'projects', table: projectsOutbox, db}],
+    publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
     subscribers: [subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed)],
     workers: [
       {

--- a/libs/api/runners-dto/src/events.ts
+++ b/libs/api/runners-dto/src/events.ts
@@ -1,33 +1,37 @@
+import {z} from 'zod';
+
 export const RUNNER_JOB_LEASE_EXPIRED = 'runners.job.lease_expired' as const;
 export const RUNNER_JOB_QUEUED = 'runners.job.queued' as const;
 export const RUNNER_JOB_CLAIMED = 'runners.job.claimed' as const;
 
-export interface RunnerJobLeaseExpiredEvent {
-  jobId: string;
-  runId: string;
-}
+export const runnerJobLeaseExpiredEventSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+});
+export type RunnerJobLeaseExpiredEvent = z.infer<typeof runnerJobLeaseExpiredEventSchema>;
 
-export interface RunnerJobQueuedEvent {
-  jobId: string;
-  runId: string;
-  /**
-   * ISO 8601 timestamp from `runners_pending_jobs.created_at`, not the outbox drain time.
-   */
-  queuedAt: string;
-}
+export const runnerJobQueuedEventSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+  queuedAt: z.string(),
+});
+export type RunnerJobQueuedEvent = z.infer<typeof runnerJobQueuedEventSchema>;
 
-export interface RunnerJobClaimedEvent {
-  jobId: string;
-  runId: string;
-  /**
-   * ISO 8601 timestamp of the runner's claim (`runners_running_jobs.started_at`), not the
-   * outbox drain time.
-   */
-  claimedAt: string;
-}
+export const runnerJobClaimedEventSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+  claimedAt: z.string(),
+});
+export type RunnerJobClaimedEvent = z.infer<typeof runnerJobClaimedEventSchema>;
 
 export interface RunnersEventMap {
   [RUNNER_JOB_LEASE_EXPIRED]: RunnerJobLeaseExpiredEvent;
   [RUNNER_JOB_QUEUED]: RunnerJobQueuedEvent;
   [RUNNER_JOB_CLAIMED]: RunnerJobClaimedEvent;
 }
+
+export const runnersEventSchemas = {
+  [RUNNER_JOB_LEASE_EXPIRED]: runnerJobLeaseExpiredEventSchema,
+  [RUNNER_JOB_QUEUED]: runnerJobQueuedEventSchema,
+  [RUNNER_JOB_CLAIMED]: runnerJobClaimedEventSchema,
+} satisfies Record<keyof RunnersEventMap, z.ZodType>;

--- a/libs/api/runners-dto/src/events.ts
+++ b/libs/api/runners-dto/src/events.ts
@@ -1,26 +1,29 @@
 import {z} from 'zod';
 
+const nonEmptyStringSchema = z.string().nonempty();
+const isoDateTimeSchema = z.string().datetime();
+
 export const RUNNER_JOB_LEASE_EXPIRED = 'runners.job.lease_expired' as const;
 export const RUNNER_JOB_QUEUED = 'runners.job.queued' as const;
 export const RUNNER_JOB_CLAIMED = 'runners.job.claimed' as const;
 
 export const runnerJobLeaseExpiredEventSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
 });
 export type RunnerJobLeaseExpiredEvent = z.infer<typeof runnerJobLeaseExpiredEventSchema>;
 
 export const runnerJobQueuedEventSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
-  queuedAt: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
+  queuedAt: isoDateTimeSchema,
 });
 export type RunnerJobQueuedEvent = z.infer<typeof runnerJobQueuedEventSchema>;
 
 export const runnerJobClaimedEventSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
-  claimedAt: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
+  claimedAt: isoDateTimeSchema,
 });
 export type RunnerJobClaimedEvent = z.infer<typeof runnerJobClaimedEventSchema>;
 

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -22,4 +22,8 @@ export {
   type RunnerJobLeaseExpiredEvent,
   type RunnerJobQueuedEvent,
   type RunnersEventMap,
+  runnerJobClaimedEventSchema,
+  runnerJobLeaseExpiredEventSchema,
+  runnerJobQueuedEventSchema,
+  runnersEventSchemas,
 } from './events.js';

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -1,5 +1,6 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {runnersEventSchemas} from '@shipfox/api-runners-dto';
 import {WORKFLOWS_JOB_TIMED_OUT, type WorkflowsEventMap} from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, runnersOutbox} from '#db/index.js';
@@ -19,7 +20,7 @@ export const runnersModule: ShipfoxModule = {
   database: {db, migrationsPath},
   auth: [createRunnerTokenAuthMethod()],
   routes,
-  publishers: [{name: 'runners', table: runnersOutbox, db}],
+  publishers: [{name: 'runners', table: runnersOutbox, db, eventSchemas: runnersEventSchemas}],
   subscribers: [subscriber(WORKFLOWS_JOB_TIMED_OUT, onWorkflowsJobTimedOut)],
   workers: [
     {

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -1,4 +1,25 @@
-import {workflowsJobTerminatedSchema, workflowsWorkflowRunTerminatedSchema} from './events.js';
+import {
+  WORKFLOWS_JOB_STEPS_SETTLED,
+  WORKFLOWS_JOB_TERMINATED,
+  WORKFLOWS_JOB_TIMED_OUT,
+  WORKFLOWS_STEP_RESTART_ENQUEUED,
+  WORKFLOWS_WORKFLOW_RUN_CREATED,
+  WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+  workflowsEventSchemas,
+  workflowsJobStepsSettledSchema,
+  workflowsJobTerminatedSchema,
+  workflowsJobTimedOutSchema,
+  workflowsStepRestartEnqueuedSchema,
+  workflowsWorkflowRunCreatedSchema,
+  workflowsWorkflowRunTerminatedSchema,
+} from './events.js';
+
+const validRunCreated = {
+  runId: 'run-1',
+  workspaceId: 'ws-1',
+  projectId: 'proj-1',
+  definitionId: 'def-1',
+};
 
 const validJobTerminated = {
   jobId: 'job-1',
@@ -10,6 +31,26 @@ const validRunTerminated = {
   runId: 'run-1',
   projectId: 'proj-1',
   status: 'failed',
+};
+
+const validJobTimedOut = {
+  jobId: 'job-1',
+  runId: 'run-1',
+};
+
+const validJobStepsSettled = {
+  jobId: 'job-1',
+  runId: 'run-1',
+  status: 'failed',
+};
+
+const validStepRestartEnqueued = {
+  jobId: 'job-1',
+  runId: 'run-1',
+  failedStepId: 'step-1',
+  failedStepAttempt: 2,
+  restartFromStepId: 'step-0',
+  reason: 'gate failed',
 };
 
 describe('workflowsJobTerminatedSchema', () => {
@@ -73,5 +114,60 @@ describe('workflowsWorkflowRunTerminatedSchema', () => {
     const result = workflowsWorkflowRunTerminatedSchema.parse(input);
 
     expect(result).toEqual(validRunTerminated);
+  });
+});
+
+describe.each([
+  [
+    'workflowsWorkflowRunCreatedSchema',
+    workflowsWorkflowRunCreatedSchema,
+    validRunCreated,
+    'runId',
+  ],
+  ['workflowsJobTimedOutSchema', workflowsJobTimedOutSchema, validJobTimedOut, 'jobId'],
+  [
+    'workflowsJobStepsSettledSchema',
+    workflowsJobStepsSettledSchema,
+    validJobStepsSettled,
+    'status',
+  ],
+  [
+    'workflowsStepRestartEnqueuedSchema',
+    workflowsStepRestartEnqueuedSchema,
+    validStepRestartEnqueued,
+    'failedStepAttempt',
+  ],
+] as const)('%s', (_name, schema, validPayload, requiredKey) => {
+  it('parses a valid payload unchanged', () => {
+    const result = schema.parse(validPayload);
+
+    expect(result).toEqual(validPayload);
+  });
+
+  it('rejects a payload missing a required field', () => {
+    const withoutRequiredKey = Object.fromEntries(
+      Object.entries(validPayload).filter(([key]) => key !== requiredKey),
+    );
+
+    const parse = () => schema.parse(withoutRequiredKey);
+
+    expect(parse).toThrow();
+  });
+});
+
+describe('workflowsEventSchemas', () => {
+  it('registers every workflows publisher event type', () => {
+    const registeredTypes = Object.keys(workflowsEventSchemas).sort();
+
+    expect(registeredTypes).toEqual(
+      [
+        WORKFLOWS_WORKFLOW_RUN_CREATED,
+        WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+        WORKFLOWS_JOB_TIMED_OUT,
+        WORKFLOWS_JOB_TERMINATED,
+        WORKFLOWS_JOB_STEPS_SETTLED,
+        WORKFLOWS_STEP_RESTART_ENQUEUED,
+      ].sort(),
+    );
   });
 });

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -1,5 +1,7 @@
 import {z} from 'zod';
 
+const nonEmptyStringSchema = z.string().nonempty();
+
 export const WORKFLOWS_WORKFLOW_RUN_CREATED = 'workflows.workflow_run.created' as const;
 // Terminal fact for a workflow run, written in the same transaction as the status flip.
 export const WORKFLOWS_WORKFLOW_RUN_TERMINATED = 'workflows.workflow_run.terminated' as const;
@@ -18,10 +20,10 @@ export const WORKFLOWS_JOB_STEPS_SETTLED = 'workflows.job.steps_settled' as cons
 export const WORKFLOWS_STEP_RESTART_ENQUEUED = 'workflows.step.restart_enqueued' as const;
 
 export const workflowsWorkflowRunCreatedSchema = z.object({
-  runId: z.string(),
-  workspaceId: z.string(),
-  projectId: z.string(),
-  definitionId: z.string(),
+  runId: nonEmptyStringSchema,
+  workspaceId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+  definitionId: nonEmptyStringSchema,
 });
 export type WorkflowsWorkflowRunCreatedEvent = z.infer<typeof workflowsWorkflowRunCreatedSchema>;
 
@@ -30,8 +32,8 @@ export type WorkflowsWorkflowRunCreatedEvent = z.infer<typeof workflowsWorkflowR
 export const terminalStatusSchema = z.enum(['succeeded', 'failed', 'cancelled']);
 
 export const workflowsWorkflowRunTerminatedSchema = z.object({
-  runId: z.string(),
-  projectId: z.string(),
+  runId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
   status: terminalStatusSchema,
 });
 export type WorkflowsWorkflowRunTerminatedEvent = z.infer<
@@ -39,14 +41,14 @@ export type WorkflowsWorkflowRunTerminatedEvent = z.infer<
 >;
 
 export const workflowsJobTimedOutSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
 });
 export type WorkflowsJobTimedOutEvent = z.infer<typeof workflowsJobTimedOutSchema>;
 
 export const workflowsJobTerminatedSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
   status: terminalStatusSchema,
 });
 export type WorkflowsJobTerminatedEvent = z.infer<typeof workflowsJobTerminatedSchema>;
@@ -54,18 +56,18 @@ export type WorkflowsJobTerminatedEvent = z.infer<typeof workflowsJobTerminatedS
 const settledStatusSchema = z.enum(['succeeded', 'failed']);
 
 export const workflowsJobStepsSettledSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
   status: settledStatusSchema,
 });
 export type WorkflowsJobStepsSettledEvent = z.infer<typeof workflowsJobStepsSettledSchema>;
 
 export const workflowsStepRestartEnqueuedSchema = z.object({
-  jobId: z.string(),
-  runId: z.string(),
-  failedStepId: z.string(),
+  jobId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
+  failedStepId: nonEmptyStringSchema,
   failedStepAttempt: z.number(),
-  restartFromStepId: z.string(),
+  restartFromStepId: nonEmptyStringSchema,
   reason: z.string(),
 });
 export type WorkflowsStepRestartEnqueuedEvent = z.infer<typeof workflowsStepRestartEnqueuedSchema>;

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -17,12 +17,13 @@ export const WORKFLOWS_JOB_STEPS_SETTLED = 'workflows.job.steps_settled' as cons
 // at-least-once outbox event as idempotent audit data.
 export const WORKFLOWS_STEP_RESTART_ENQUEUED = 'workflows.step.restart_enqueued' as const;
 
-export interface WorkflowsWorkflowRunCreatedEvent {
-  runId: string;
-  workspaceId: string;
-  projectId: string;
-  definitionId: string;
-}
+export const workflowsWorkflowRunCreatedSchema = z.object({
+  runId: z.string(),
+  workspaceId: z.string(),
+  projectId: z.string(),
+  definitionId: z.string(),
+});
+export type WorkflowsWorkflowRunCreatedEvent = z.infer<typeof workflowsWorkflowRunCreatedSchema>;
 
 // Keep outbox terminal statuses narrower than runStatusSchema, which also
 // carries pending/running.
@@ -37,10 +38,11 @@ export type WorkflowsWorkflowRunTerminatedEvent = z.infer<
   typeof workflowsWorkflowRunTerminatedSchema
 >;
 
-export interface WorkflowsJobTimedOutEvent {
-  jobId: string;
-  runId: string;
-}
+export const workflowsJobTimedOutSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+});
+export type WorkflowsJobTimedOutEvent = z.infer<typeof workflowsJobTimedOutSchema>;
 
 export const workflowsJobTerminatedSchema = z.object({
   jobId: z.string(),
@@ -49,20 +51,24 @@ export const workflowsJobTerminatedSchema = z.object({
 });
 export type WorkflowsJobTerminatedEvent = z.infer<typeof workflowsJobTerminatedSchema>;
 
-export interface WorkflowsJobStepsSettledEvent {
-  jobId: string;
-  runId: string;
-  status: 'succeeded' | 'failed';
-}
+const settledStatusSchema = z.enum(['succeeded', 'failed']);
 
-export interface WorkflowsStepRestartEnqueuedEvent {
-  jobId: string;
-  runId: string;
-  failedStepId: string;
-  failedStepAttempt: number;
-  restartFromStepId: string;
-  reason: string;
-}
+export const workflowsJobStepsSettledSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+  status: settledStatusSchema,
+});
+export type WorkflowsJobStepsSettledEvent = z.infer<typeof workflowsJobStepsSettledSchema>;
+
+export const workflowsStepRestartEnqueuedSchema = z.object({
+  jobId: z.string(),
+  runId: z.string(),
+  failedStepId: z.string(),
+  failedStepAttempt: z.number(),
+  restartFromStepId: z.string(),
+  reason: z.string(),
+});
+export type WorkflowsStepRestartEnqueuedEvent = z.infer<typeof workflowsStepRestartEnqueuedSchema>;
 
 export interface WorkflowsEventMap {
   [WORKFLOWS_WORKFLOW_RUN_CREATED]: WorkflowsWorkflowRunCreatedEvent;
@@ -74,6 +80,10 @@ export interface WorkflowsEventMap {
 }
 
 export const workflowsEventSchemas = {
+  [WORKFLOWS_WORKFLOW_RUN_CREATED]: workflowsWorkflowRunCreatedSchema,
   [WORKFLOWS_WORKFLOW_RUN_TERMINATED]: workflowsWorkflowRunTerminatedSchema,
+  [WORKFLOWS_JOB_TIMED_OUT]: workflowsJobTimedOutSchema,
   [WORKFLOWS_JOB_TERMINATED]: workflowsJobTerminatedSchema,
-} satisfies Partial<Record<keyof WorkflowsEventMap, z.ZodType>>;
+  [WORKFLOWS_JOB_STEPS_SETTLED]: workflowsJobStepsSettledSchema,
+  [WORKFLOWS_STEP_RESTART_ENQUEUED]: workflowsStepRestartEnqueuedSchema,
+} satisfies Record<keyof WorkflowsEventMap, z.ZodType>;

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -47,6 +47,7 @@ export {
   stepErrorReasonSchema,
 } from '#schemas/index.js';
 export {
+  terminalStatusSchema,
   WORKFLOWS_JOB_STEPS_SETTLED,
   WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
@@ -61,4 +62,10 @@ export {
   type WorkflowsWorkflowRunCreatedEvent,
   type WorkflowsWorkflowRunTerminatedEvent,
   workflowsEventSchemas,
+  workflowsJobStepsSettledSchema,
+  workflowsJobTerminatedSchema,
+  workflowsJobTimedOutSchema,
+  workflowsStepRestartEnqueuedSchema,
+  workflowsWorkflowRunCreatedSchema,
+  workflowsWorkflowRunTerminatedSchema,
 } from './events.js';


### PR DESCRIPTION
Add Zod schemas for all current outbox publisher event maps and register them with module publishers.

ENG-559 made drain-boundary validation apply only to event types with schemas. The remaining publisher maps could still pass raw JSONB payloads directly to subscribers, so malformed rows would bypass the bounded poison-row path.

This keeps provider-specific integration envelopes opaque while still requiring the envelope payload key. Definition trigger payloads reuse the exported TriggerDto schema so resolved definition events remain assignable under exact optional property types.

The triggers publisher remains without schemas because it currently has no outbox event map or writeOutboxEvent calls. A changeset is included for the touched libs packages.

Closes ENG-566