### PR TITLE
Add outbox row retention cleanup

### DIFF
--- a/.changeset/eng-430-outbox-retention.md
+++ b/.changeset/eng-430-outbox-retention.md
@@ -1,0 +1,14 @@
+---
+"@shipfox/api-definitions": patch
+"@shipfox/api-dispatcher": patch
+"@shipfox/api-integration-core": patch
+"@shipfox/api-logs": patch
+"@shipfox/api-projects": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-triggers": patch
+"@shipfox/api-workflows": patch
+"@shipfox/node-module": patch
+"@shipfox/node-outbox": patch
+---
+
+Adds daily dispatched outbox row retention with bounded cleanup batches and retention indexes on module outbox tables.

--- a/libs/api/definitions/drizzle/0000_initial.sql
+++ b/libs/api/definitions/drizzle/0000_initial.sql
@@ -58,3 +58,5 @@ CREATE UNIQUE INDEX "definitions_sync_states_source_unique" ON "definitions_sync
 CREATE INDEX "definitions_sync_states_failed_idx" ON "definitions_sync_states" USING btree ("updated_at") WHERE "status" = 'failed';
 --> statement-breakpoint
 CREATE INDEX "definitions_outbox_pending_idx" ON "definitions_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "definitions_outbox_dispatched_retention_idx" ON "definitions_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;

--- a/libs/api/definitions/drizzle/meta/0000_snapshot.json
+++ b/libs/api/definitions/drizzle/meta/0000_snapshot.json
@@ -412,6 +412,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "definitions_outbox_dispatched_retention_idx": {
+          "name": "definitions_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -4,6 +4,7 @@ import {
   drainAll,
   markDispatched,
   type OutboxDispatchFailure,
+  pruneDispatchedOutboxRows,
   recordDispatchFailure,
   registerPublisher,
   resetPublishers,
@@ -22,6 +23,8 @@ import {
 } from './definitions.js';
 import {workflowDefinitions} from './schema/definitions.js';
 import {definitionsOutbox} from './schema/outbox.js';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
 
 function definitionFields(name = 'Test Workflow'): WorkflowDefinitionPayload {
   const document = {
@@ -43,6 +46,25 @@ function eventsForProject(events: DrainedEvent[], projectId: string) {
     const payload = event.event.payload as {projectId?: unknown};
     return payload.projectId === projectId;
   });
+}
+
+async function insertOutboxRow(params: {
+  projectId: string;
+  marker: string;
+  dispatchedAt?: Date | null;
+  deadLetteredAt?: Date | null;
+}) {
+  const id = crypto.randomUUID();
+  await db()
+    .insert(definitionsOutbox)
+    .values({
+      id,
+      eventType: DEFINITION_RESOLVED,
+      payload: {projectId: params.projectId, marker: params.marker},
+      dispatchedAt: params.dispatchedAt ?? null,
+      deadLetteredAt: params.deadLetteredAt ?? null,
+    });
+  return id;
 }
 
 describe('definition queries', () => {
@@ -865,6 +887,86 @@ describe('definition queries', () => {
       expect(rows[0]?.dispatchAttempts).toBe(1);
       expect(rows[0]?.dispatchedAt).toBeInstanceOf(Date);
       expect(finalDrain).toHaveLength(0);
+    });
+
+    test('pruneDispatchedOutboxRows deletes only dispatched rows older than retention', async () => {
+      const oldDispatchedAt = new Date(Date.now() - 8 * MS_PER_DAY);
+      const recentDispatchedAt = new Date(Date.now() - 6 * MS_PER_DAY);
+      await insertOutboxRow({projectId, marker: 'old-dispatched', dispatchedAt: oldDispatchedAt});
+      await insertOutboxRow({
+        projectId,
+        marker: 'recent-dispatched',
+        dispatchedAt: recentDispatchedAt,
+      });
+      await insertOutboxRow({projectId, marker: 'old-pending'});
+      await insertOutboxRow({
+        projectId,
+        marker: 'dead-lettered',
+        deadLetteredAt: oldDispatchedAt,
+      });
+
+      const result = await pruneDispatchedOutboxRows({
+        retentionDays: 7,
+        batchSize: 10,
+        maxBatchesPerSource: 2,
+      });
+
+      const remaining = await listOutboxRowsForProject(projectId);
+      const markers = remaining.map((row) => (row.payload as {marker: string}).marker).sort();
+      expect(result).toEqual([{source: 'definitions', deleted: 1, capped: false}]);
+      expect(markers).toEqual(['dead-lettered', 'old-pending', 'recent-dispatched']);
+    });
+
+    test('pruneDispatchedOutboxRows continues across batches', async () => {
+      const oldDispatchedAt = new Date(Date.now() - 8 * MS_PER_DAY);
+      await insertOutboxRow({projectId, marker: 'old-1', dispatchedAt: oldDispatchedAt});
+      await insertOutboxRow({projectId, marker: 'old-2', dispatchedAt: oldDispatchedAt});
+      await insertOutboxRow({projectId, marker: 'old-3', dispatchedAt: oldDispatchedAt});
+
+      const result = await pruneDispatchedOutboxRows({
+        retentionDays: 7,
+        batchSize: 2,
+        maxBatchesPerSource: 2,
+      });
+
+      const remaining = await listOutboxRowsForProject(projectId);
+      expect(result).toEqual([{source: 'definitions', deleted: 3, capped: false}]);
+      expect(remaining).toHaveLength(0);
+    });
+
+    test('pruneDispatchedOutboxRows reports capped sources', async () => {
+      const oldDispatchedAt = new Date(Date.now() - 8 * MS_PER_DAY);
+      await insertOutboxRow({projectId, marker: 'old-1', dispatchedAt: oldDispatchedAt});
+      await insertOutboxRow({projectId, marker: 'old-2', dispatchedAt: oldDispatchedAt});
+      await insertOutboxRow({projectId, marker: 'old-3', dispatchedAt: oldDispatchedAt});
+
+      const result = await pruneDispatchedOutboxRows({
+        retentionDays: 7,
+        batchSize: 2,
+        maxBatchesPerSource: 1,
+      });
+
+      const remaining = await listOutboxRowsForProject(projectId);
+      expect(result).toEqual([{source: 'definitions', deleted: 2, capped: true}]);
+      expect(remaining).toHaveLength(1);
+    });
+
+    test('pruneDispatchedOutboxRows returns zero when no rows are eligible', async () => {
+      await insertOutboxRow({
+        projectId,
+        marker: 'recent-dispatched',
+        dispatchedAt: new Date(Date.now() - 6 * MS_PER_DAY),
+      });
+
+      const result = await pruneDispatchedOutboxRows({
+        retentionDays: 7,
+        batchSize: 10,
+        maxBatchesPerSource: 2,
+      });
+
+      const remaining = await listOutboxRowsForProject(projectId);
+      expect(result).toEqual([{source: 'definitions', deleted: 0, capped: false}]);
+      expect(remaining).toHaveLength(1);
     });
   });
 });

--- a/libs/api/dispatcher/src/core/constants.ts
+++ b/libs/api/dispatcher/src/core/constants.ts
@@ -1,2 +1,3 @@
 export const DISPATCHER_WORKFLOW_ID = 'outbox-dispatcher';
+export const OUTBOX_RETENTION_WORKFLOW_ID = 'outbox-retention';
 export const DISPATCHER_TASK_QUEUE = 'outbox-dispatcher';

--- a/libs/api/dispatcher/src/module.test.ts
+++ b/libs/api/dispatcher/src/module.test.ts
@@ -1,0 +1,17 @@
+import {DISPATCHER_WORKFLOW_ID, OUTBOX_RETENTION_WORKFLOW_ID} from '#core/constants.js';
+import {dispatcherModule} from './module.js';
+
+describe('dispatcherModule', () => {
+  it('registers dispatch and retention workflows on the dispatcher worker', () => {
+    const worker = dispatcherModule.workers?.[0];
+
+    expect(worker?.workflows).toEqual([
+      {name: 'outboxDispatcherWorkflow', id: DISPATCHER_WORKFLOW_ID},
+      {
+        name: 'outboxRetentionWorkflow',
+        id: OUTBOX_RETENTION_WORKFLOW_ID,
+        cronSchedule: '0 0 * * *',
+      },
+    ]);
+  });
+});

--- a/libs/api/dispatcher/src/module.ts
+++ b/libs/api/dispatcher/src/module.ts
@@ -1,7 +1,11 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {ShipfoxModule} from '@shipfox/node-module';
-import {DISPATCHER_TASK_QUEUE, DISPATCHER_WORKFLOW_ID} from '#core/constants.js';
+import {
+  DISPATCHER_TASK_QUEUE,
+  DISPATCHER_WORKFLOW_ID,
+  OUTBOX_RETENTION_WORKFLOW_ID,
+} from '#core/constants.js';
 import {createActivities} from '#temporal/index.js';
 
 // Temporal's webpack bundler requires a compiled .js file. Whether running from
@@ -16,7 +20,14 @@ export const dispatcherModule: ShipfoxModule = {
       taskQueue: DISPATCHER_TASK_QUEUE,
       workflowsPath,
       activities: createActivities,
-      workflows: [{name: 'outboxDispatcherWorkflow', id: DISPATCHER_WORKFLOW_ID}],
+      workflows: [
+        {name: 'outboxDispatcherWorkflow', id: DISPATCHER_WORKFLOW_ID},
+        {
+          name: 'outboxRetentionWorkflow',
+          id: OUTBOX_RETENTION_WORKFLOW_ID,
+          cronSchedule: '0 0 * * *',
+        },
+      ],
     },
   ],
 };

--- a/libs/api/dispatcher/src/temporal/activities/index.ts
+++ b/libs/api/dispatcher/src/temporal/activities/index.ts
@@ -1,7 +1,9 @@
 import {drainAndDispatch} from './drain-and-dispatch.js';
+import {pruneOutboxRetention} from './prune-outbox-retention.js';
 
 export function createActivities() {
   return {
     drainAndDispatch,
+    pruneOutboxRetention,
   };
 }

--- a/libs/api/dispatcher/src/temporal/activities/prune-outbox-retention.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/prune-outbox-retention.test.ts
@@ -1,0 +1,48 @@
+import {pruneOutboxRetention} from './prune-outbox-retention.js';
+
+const mocks = vi.hoisted(() => ({
+  pruneDispatchedOutboxRows: vi.fn(),
+  infoLog: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-module', () => ({
+  pruneDispatchedOutboxRows: mocks.pruneDispatchedOutboxRows,
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => ({
+    info: mocks.infoLog,
+  }),
+}));
+
+describe('pruneOutboxRetention', () => {
+  beforeEach(() => {
+    mocks.pruneDispatchedOutboxRows.mockReset();
+    mocks.infoLog.mockReset();
+  });
+
+  it('prunes dispatched outbox rows with the fixed retention policy', async () => {
+    const sources = [
+      {source: 'definitions', deleted: 2, capped: false},
+      {source: 'workflows', deleted: 5_000, capped: true},
+    ];
+    mocks.pruneDispatchedOutboxRows.mockResolvedValueOnce(sources);
+
+    await pruneOutboxRetention();
+
+    expect(mocks.pruneDispatchedOutboxRows).toHaveBeenCalledWith({
+      retentionDays: 7,
+      batchSize: 5_000,
+      maxBatchesPerSource: 200,
+    });
+    expect(mocks.infoLog).toHaveBeenCalledWith(
+      {
+        retentionDays: 7,
+        batchSize: 5_000,
+        maxBatchesPerSource: 200,
+        sources,
+      },
+      'Pruned dispatched outbox rows',
+    );
+  });
+});

--- a/libs/api/dispatcher/src/temporal/activities/prune-outbox-retention.ts
+++ b/libs/api/dispatcher/src/temporal/activities/prune-outbox-retention.ts
@@ -1,0 +1,24 @@
+import {pruneDispatchedOutboxRows} from '@shipfox/node-module';
+import {logger} from '@shipfox/node-opentelemetry';
+
+const OUTBOX_RETENTION_DAYS = 7;
+const OUTBOX_RETENTION_BATCH_SIZE = 5_000;
+const OUTBOX_RETENTION_MAX_BATCHES_PER_SOURCE = 200;
+
+export async function pruneOutboxRetention(): Promise<void> {
+  const results = await pruneDispatchedOutboxRows({
+    retentionDays: OUTBOX_RETENTION_DAYS,
+    batchSize: OUTBOX_RETENTION_BATCH_SIZE,
+    maxBatchesPerSource: OUTBOX_RETENTION_MAX_BATCHES_PER_SOURCE,
+  });
+
+  logger().info(
+    {
+      retentionDays: OUTBOX_RETENTION_DAYS,
+      batchSize: OUTBOX_RETENTION_BATCH_SIZE,
+      maxBatchesPerSource: OUTBOX_RETENTION_MAX_BATCHES_PER_SOURCE,
+      sources: results,
+    },
+    'Pruned dispatched outbox rows',
+  );
+}

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
@@ -6,7 +6,7 @@ const {drainAndDispatch} = proxyActivities<ReturnType<typeof createActivities>>(
 });
 
 const {pruneOutboxRetention} = proxyActivities<ReturnType<typeof createActivities>>({
-  startToCloseTimeout: '30s',
+  startToCloseTimeout: '5m',
 });
 
 export async function outboxDispatcherWorkflow(): Promise<void> {

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
@@ -5,8 +5,16 @@ const {drainAndDispatch} = proxyActivities<ReturnType<typeof createActivities>>(
   startToCloseTimeout: '30s',
 });
 
+const {pruneOutboxRetention} = proxyActivities<ReturnType<typeof createActivities>>({
+  startToCloseTimeout: '30s',
+});
+
 export async function outboxDispatcherWorkflow(): Promise<void> {
   await drainAndDispatch();
   await sleep('1s');
   await continueAsNew<typeof outboxDispatcherWorkflow>();
+}
+
+export async function outboxRetentionWorkflow(): Promise<void> {
+  await pruneOutboxRetention();
 }

--- a/libs/api/integration/core/drizzle/0000_initial.sql
+++ b/libs/api/integration/core/drizzle/0000_initial.sql
@@ -31,5 +31,7 @@ CREATE TABLE "integrations_webhook_deliveries" (
 --> statement-breakpoint
 CREATE UNIQUE INDEX "integrations_connections_workspace_external_unique" ON "integrations_connections" USING btree ("workspace_id","provider","external_account_id");--> statement-breakpoint
 CREATE INDEX "integrations_connections_workspace_id_idx" ON "integrations_connections" USING btree ("workspace_id");--> statement-breakpoint
-CREATE INDEX "integrations_outbox_pending_idx" ON "integrations_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "integrations_outbox_pending_idx" ON "integrations_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "integrations_outbox_dispatched_retention_idx" ON "integrations_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "integrations_webhook_deliveries_received_at_idx" ON "integrations_webhook_deliveries" USING btree ("received_at");

--- a/libs/api/integration/core/drizzle/meta/0001_snapshot.json
+++ b/libs/api/integration/core/drizzle/meta/0001_snapshot.json
@@ -203,6 +203,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "integrations_outbox_dispatched_retention_idx": {
+          "name": "integrations_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/logs/drizzle/0000_initial.sql
+++ b/libs/api/logs/drizzle/0000_initial.sql
@@ -60,3 +60,5 @@ CREATE INDEX "logs_attempt_streams_retention_idx" ON "logs_attempt_streams" USIN
 CREATE INDEX "logs_attempt_streams_uncompacted_idx" ON "logs_attempt_streams" USING btree ("closed_at") WHERE "state" = 'closed' and "object_key" is null;--> statement-breakpoint
 CREATE INDEX "logs_chunks_stream_seq_idx" ON "logs_chunks" USING btree ("stream_id","seq");--> statement-breakpoint
 CREATE INDEX "logs_outbox_pending_idx" ON "logs_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "logs_outbox_dispatched_retention_idx" ON "logs_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;

--- a/libs/api/logs/drizzle/meta/0000_snapshot.json
+++ b/libs/api/logs/drizzle/meta/0000_snapshot.json
@@ -477,6 +477,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "logs_outbox_dispatched_retention_idx": {
+          "name": "logs_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/projects/drizzle/0000_initial.sql
+++ b/libs/api/projects/drizzle/0000_initial.sql
@@ -30,5 +30,7 @@ CREATE TABLE "projects_integration_event_dedup" (
 --> statement-breakpoint
 CREATE UNIQUE INDEX "projects_source_unique" ON "projects_projects" USING btree ("source_connection_id","source_external_repository_id");--> statement-breakpoint
 CREATE INDEX "projects_workspace_created_id_idx" ON "projects_projects" USING btree ("workspace_id","created_at","id");--> statement-breakpoint
-CREATE INDEX "projects_outbox_pending_idx" ON "projects_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "projects_outbox_pending_idx" ON "projects_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "projects_outbox_dispatched_retention_idx" ON "projects_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "projects_integration_event_dedup_received_at_idx" ON "projects_integration_event_dedup" USING btree ("received_at");

--- a/libs/api/projects/drizzle/meta/0000_snapshot.json
+++ b/libs/api/projects/drizzle/meta/0000_snapshot.json
@@ -148,6 +148,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "projects_outbox_dispatched_retention_idx": {
+          "name": "projects_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -34,6 +34,8 @@ CREATE TABLE "runners_running_jobs" (
 	CONSTRAINT "runners_running_jobs_job_id_unique" UNIQUE("job_id")
 );
 --> statement-breakpoint
-CREATE INDEX "runners_outbox_pending_idx" ON "runners_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "runners_outbox_pending_idx" ON "runners_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "runners_outbox_dispatched_retention_idx" ON "runners_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "runners_pending_jobs_created_idx" ON "runners_pending_jobs" USING btree ("created_at");--> statement-breakpoint
 CREATE INDEX "runners_running_jobs_last_heartbeat_at_idx" ON "runners_running_jobs" USING btree ("last_heartbeat_at");

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -95,6 +95,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "runners_outbox_dispatched_retention_idx": {
+          "name": "runners_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/triggers/drizzle/0000_initial.sql
+++ b/libs/api/triggers/drizzle/0000_initial.sql
@@ -57,7 +57,9 @@ CREATE TABLE "triggers_subscriptions" (
 ALTER TABLE "triggers_decisions" ADD CONSTRAINT "triggers_decisions_received_event_id_triggers_received_events_id_fk" FOREIGN KEY ("received_event_id") REFERENCES "public"."triggers_received_events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_decisions_event_subscription_unique" ON "triggers_decisions" USING btree ("received_event_id","subscription_id");--> statement-breakpoint
 CREATE INDEX "triggers_decisions_run_idx" ON "triggers_decisions" USING btree ("run_id");--> statement-breakpoint
-CREATE INDEX "triggers_outbox_pending_idx" ON "triggers_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "triggers_outbox_pending_idx" ON "triggers_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "triggers_outbox_dispatched_retention_idx" ON "triggers_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_received_events_event_ref_unique" ON "triggers_received_events" USING btree ("event_ref");--> statement-breakpoint
 CREATE INDEX "triggers_received_events_workspace_received_idx" ON "triggers_received_events" USING btree ("workspace_id","received_at" DESC NULLS LAST);--> statement-breakpoint
 CREATE INDEX "triggers_received_events_prune_idx" ON "triggers_received_events" USING btree ("created_at");--> statement-breakpoint

--- a/libs/api/triggers/drizzle/meta/0000_snapshot.json
+++ b/libs/api/triggers/drizzle/meta/0000_snapshot.json
@@ -217,6 +217,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "triggers_outbox_dispatched_retention_idx": {
+          "name": "triggers_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -68,7 +68,9 @@ CREATE TABLE "workflows_workflow_runs" (
 ALTER TABLE "workflows_jobs" ADD CONSTRAINT "workflows_jobs_run_id_workflows_workflow_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."workflows_workflow_runs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "workflows_steps" ADD CONSTRAINT "workflows_steps_job_id_workflows_jobs_id_fk" FOREIGN KEY ("job_id") REFERENCES "public"."workflows_jobs"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "workflows_jobs_run_id_idx" ON "workflows_jobs" USING btree ("run_id");--> statement-breakpoint
-CREATE INDEX "workflows_outbox_pending_idx" ON "workflows_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "workflows_outbox_pending_idx" ON "workflows_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;
+--> statement-breakpoint
+CREATE INDEX "workflows_outbox_dispatched_retention_idx" ON "workflows_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "workflows_steps_job_id_idx" ON "workflows_steps" USING btree ("job_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wr_trigger_idempotency_key_unique" ON "workflows_workflow_runs" USING btree ("trigger_idempotency_key");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","created_at","id");--> statement-breakpoint

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -224,6 +224,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/workflows/drizzle/meta/0001_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0001_snapshot.json
@@ -224,6 +224,28 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "workflows_outbox_dispatched_retention_idx": {
+          "name": "workflows_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -3,11 +3,17 @@ export type {
   InitializeModulesOptions,
 } from './initialize.js';
 export {initializeModules, startModuleWorkers} from './initialize.js';
-export type {DrainedEvent, OutboxDispatchFailure} from './publisher-registry.js';
+export type {
+  DrainedEvent,
+  OutboxDispatchFailure,
+  PruneDispatchedOutboxRowsOptions,
+  PrunedOutboxSource,
+} from './publisher-registry.js';
 export {
   drainAll,
   getEventSchema,
   markDispatched,
+  pruneDispatchedOutboxRows,
   recordDispatchFailure,
   registerPublisher,
   resetPublishers,

--- a/libs/shared/node/module/src/publisher-registry.test.ts
+++ b/libs/shared/node/module/src/publisher-registry.test.ts
@@ -2,7 +2,12 @@ import {createOutboxTable} from '@shipfox/node-outbox';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {pgTableCreator} from 'drizzle-orm/pg-core';
 import {z} from 'zod';
-import {getEventSchema, registerPublisher, resetPublishers} from './publisher-registry.js';
+import {
+  getEventSchema,
+  pruneDispatchedOutboxRows,
+  registerPublisher,
+  resetPublishers,
+} from './publisher-registry.js';
 
 const table = createOutboxTable(pgTableCreator((name) => name));
 const db = (() => undefined) as unknown as () => NodePgDatabase<Record<string, unknown>>;
@@ -67,5 +72,36 @@ describe('getEventSchema', () => {
       registerPublisher({name: 'foo', table, db, eventSchemas: {'foo.created': fooSchema}});
 
     expect(register).not.toThrow();
+  });
+});
+
+describe('pruneDispatchedOutboxRows', () => {
+  beforeEach(() => {
+    resetPublishers();
+  });
+
+  afterEach(() => {
+    resetPublishers();
+  });
+
+  it.each([
+    ['retentionDays', {retentionDays: 0, batchSize: 5_000, maxBatchesPerSource: 200}],
+    ['batchSize', {retentionDays: 7, batchSize: 0, maxBatchesPerSource: 200}],
+    ['maxBatchesPerSource', {retentionDays: 7, batchSize: 5_000, maxBatchesPerSource: 0}],
+    ['retentionDays', {retentionDays: 7.5, batchSize: 5_000, maxBatchesPerSource: 200}],
+  ])('rejects a non-positive-integer %s before touching the database', async (name, options) => {
+    const prune = pruneDispatchedOutboxRows(options);
+
+    await expect(prune).rejects.toThrow(`${name} must be a positive integer`);
+  });
+
+  it('returns no results when no publishers are registered', async () => {
+    const results = await pruneDispatchedOutboxRows({
+      retentionDays: 7,
+      batchSize: 5_000,
+      maxBatchesPerSource: 200,
+    });
+
+    expect(results).toEqual([]);
   });
 });

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -1,5 +1,5 @@
 import type {DomainEvent, OutboxTable} from '@shipfox/node-outbox';
-import {and, asc, eq, inArray, isNull, lte, sql} from 'drizzle-orm';
+import {and, asc, eq, getTableName, inArray, isNull, lte, sql} from 'drizzle-orm';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import type {ZodType} from 'zod';
 
@@ -36,6 +36,18 @@ export type OutboxDispatchFailure =
       errorName: string;
       errorMessage: string;
     };
+
+export interface PruneDispatchedOutboxRowsOptions {
+  retentionDays: number;
+  batchSize: number;
+  maxBatchesPerSource: number;
+}
+
+export interface PrunedOutboxSource {
+  source: string;
+  deleted: number;
+  capped: boolean;
+}
 
 const _sources: PublisherSource[] = [];
 const _schemasByType = new Map<string, ZodType>();
@@ -147,9 +159,75 @@ export async function recordDispatchFailure(
     );
 }
 
+export async function pruneDispatchedOutboxRows(
+  options: PruneDispatchedOutboxRowsOptions,
+): Promise<PrunedOutboxSource[]> {
+  assertPositiveInteger(options.retentionDays, 'retentionDays');
+  assertPositiveInteger(options.batchSize, 'batchSize');
+  assertPositiveInteger(options.maxBatchesPerSource, 'maxBatchesPerSource');
+
+  const results: PrunedOutboxSource[] = [];
+
+  for (const source of _sources) {
+    let deleted = 0;
+    let capped = false;
+
+    for (let batch = 0; batch < options.maxBatchesPerSource; batch += 1) {
+      const batchDeleted = await deleteDispatchedBatch(source, options);
+      deleted += batchDeleted;
+
+      if (batchDeleted < options.batchSize) {
+        capped = false;
+        break;
+      }
+
+      capped = batch === options.maxBatchesPerSource - 1;
+    }
+
+    results.push({source: source.name, deleted, capped});
+  }
+
+  return results;
+}
+
 export function resetPublishers(): void {
   _sources.length = 0;
   _schemasByType.clear();
+}
+
+async function deleteDispatchedBatch(
+  source: PublisherSource,
+  options: PruneDispatchedOutboxRowsOptions,
+): Promise<number> {
+  const result = await source.db().execute<{deleted: number}>(
+    sql`
+      WITH deleted AS (
+        SELECT id
+        FROM ${sql.raw(quoteIdentifier(getTableName(source.table)))}
+        WHERE dispatched_at < now() - (${options.retentionDays} * interval '1 day')
+        ORDER BY dispatched_at, id
+        LIMIT ${options.batchSize}
+      ),
+      removed AS (
+        DELETE FROM ${sql.raw(quoteIdentifier(getTableName(source.table)))}
+        WHERE id IN (SELECT id FROM deleted)
+        RETURNING id
+      )
+      SELECT count(*)::int AS deleted FROM removed
+    `,
+  );
+
+  return result.rows[0]?.deleted ?? 0;
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
 }
 
 function nextDispatchAtSql(table: OutboxTable) {

--- a/libs/shared/node/outbox/src/schema.ts
+++ b/libs/shared/node/outbox/src/schema.ts
@@ -26,6 +26,9 @@ export function createOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
       index(`${tableName}_pending_idx`)
         .on(table.nextDispatchAt, table.createdAt)
         .where(sql`"dispatched_at" IS NULL AND "dead_lettered_at" IS NULL`),
+      index(`${tableName}_dispatched_retention_idx`)
+        .on(table.dispatchedAt, table.id)
+        .where(sql`"dispatched_at" IS NOT NULL`),
     ],
   );
 }

--- a/libs/shared/node/outbox/src/write.test.ts
+++ b/libs/shared/node/outbox/src/write.test.ts
@@ -1,4 +1,4 @@
-import {pgTableCreator} from 'drizzle-orm/pg-core';
+import {getTableConfig, pgTableCreator} from 'drizzle-orm/pg-core';
 import {createOutboxTable} from './schema.js';
 import {writeOutboxEvent, writeOutboxEvents} from './write.js';
 
@@ -16,6 +16,18 @@ describe('createOutboxTable', () => {
     expect(outboxTable.lastDispatchError.name).toBe('last_dispatch_error');
     expect(outboxTable.lastDispatchFailedAt.name).toBe('last_dispatch_failed_at');
     expect(outboxTable.deadLetteredAt.name).toBe('dead_lettered_at');
+  });
+
+  it('indexes dispatched rows for retention pruning', () => {
+    const retentionIndex = getTableConfig(outboxTable).indexes.find(
+      (index) => index.config.name === 'outbox_dispatched_retention_idx',
+    );
+
+    expect(retentionIndex).toBeDefined();
+    expect(
+      retentionIndex?.config.columns.map((column) => ('name' in column ? column.name : null)),
+    ).toEqual(['dispatched_at', 'id']);
+    expect(retentionIndex?.config.where).toBeDefined();
   });
 });
 


### PR DESCRIPTION
Add a daily dispatcher-owned cleanup path for dispatched outbox rows older than seven days.

Dispatched rows currently accumulate indefinitely in each module outbox table, which bloats tables at scale. This adds a shared batched pruning helper over registered publishers, wires it into a daily Temporal workflow on the dispatcher worker, and adds partial `dispatched_at` retention indexes to the folded pre-deploy outbox migrations.

The cleanup intentionally deletes rather than archives because ENG-430 does not require an audit trail. The worker uses bounded batches so the first production run can make progress without one large delete transaction.

Fixes ENG-430

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a daily cleanup that deletes dispatched outbox rows after 7 days using bounded batches, with new indexes for fast pruning. Increased the retention activity timeout to 5 minutes to clear large backlogs without retries; satisfies ENG-430.

- **New Features**
  - `@shipfox/api-dispatcher`: adds `outboxRetentionWorkflow` (cron "0 0 * * *", id `OUTBOX_RETENTION_WORKFLOW_ID`) and `pruneOutboxRetention` activity with a 5m `startToCloseTimeout`.
  - `@shipfox/node-module`: adds `pruneDispatchedOutboxRows({ retentionDays: 7, batchSize: 5_000, maxBatchesPerSource: 200 })` to delete per registered publisher and return per-source stats; validates positive integers for options.
  - `@shipfox/node-outbox` and `@shipfox/api-*` schemas: adds partial index `*_outbox_dispatched_retention_idx (dispatched_at, id) WHERE dispatched_at IS NOT NULL` to speed pruning.
  - Rows are hard-deleted; no archiving, per ENG-430.

<sup>Written for commit 6abe6b89453a7b6414a90d9d2fc45fc16299f170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

