### PR TITLE
Add metrics observability foundation and runners demo

### DIFF
--- a/.changeset/metrics-observability-foundation.md
+++ b/.changeset/metrics-observability-foundation.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/node-module": patch
+"@shipfox/api-runners": patch
+---
+
+Add the foundation for metrics observability. `@shipfox/node-module` gains an optional `metrics` hook on `ShipfoxModule` plus `registerModuleMetrics`, a declarative slot for modules to register service-level metrics (observable gauges) once at app startup, kept separate from `initializeModules` so unit tests never bind the metrics port. `@shipfox/api-runners` is instrumented as the worked example across both planes: instance counters for job enqueue, claim, and lease expiry recorded inline, and `runners_pending_jobs` / `runners_running_jobs` observable gauges over a new `getJobQueueDepth` query wired through the module hook.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,9 +429,18 @@ src/metrics/
 
 Instance instruments are created at the top of `instance.ts` and exported, then
 imported and recorded where the event occurs. Creating them at import time is
-safe: `instanceMetrics.getMeter` returns a no-op meter until an app starts
-instrumentation, so tests that merely import the module record nothing and bind
-nothing.
+safe for tests: `instanceMetrics.getMeter` returns a no-op meter until an app
+starts instrumentation, so a test that merely imports the module records nothing
+and binds nothing.
+
+That same lazy resolution is a production trap. The metrics API has no proxy
+meter (unlike traces, which back-fill), so an instrument created before the app
+registers the global meter provider stays a no-op forever and never exports. The
+app must therefore start instance instrumentation **before** the module graph
+loads — preload it via `--import`, not from inside `run()`. See
+`apps/api/src/instrumentation.ts` (wired into the Dockerfile CMD and the dev
+script). A new app that calls `startInstanceInstrumentation` in-process after
+importing its feature modules will silently emit nothing.
 
 Service gauges are different. Reaching `getServiceMetricsProvider()` binds the
 metrics port, so it must never run at import time — it would break any unit test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,6 +387,110 @@ validation/known errors to 4xx codes, and logs + reports unknown errors to
 Sentry as a 500 `server-error`. Anything that reaches it untyped becomes an
 opaque 500 — so translate errors you can describe before they get here.
 
+## Metrics & observability
+
+Metrics are emitted through OpenTelemetry and scraped by Prometheus. All the
+plumbing — the SDK, the Prometheus exporters, the meter providers — lives in
+`@shipfox/node-opentelemetry`; an app turns it on once at startup (the API does
+this in `apps/api/src/core/run.ts`) and feature packages only define and record
+instruments. Never add a metrics SDK or exporter to a feature package.
+
+The worked example is `libs/api/runners/src/metrics`. Copy its shape.
+
+### Two planes: instance vs service
+
+There are two separate meter providers on two ports, and the choice between
+them is about *what the number means*, not convenience.
+
+- **Instance metrics** (`instanceMetrics.getMeter(name)`, port 9464) are
+  counters and histograms recorded inline as an event happens — a job claimed,
+  a request served, a duration observed. Each pod exposes its own values and
+  Prometheus sums across pods. This is the default; reach for it first.
+- **Service metrics** (`getServiceMetricsProvider().getMeter(name)`, port 9474)
+  are observable gauges that read shared state — a queue depth, a backlog size,
+  a current count — through a callback that runs on each scrape. They live on a
+  separate provider because every pod reading the same database row would report
+  the same value, and Prometheus must not sum those copies. Use a service gauge
+  only for point-in-time state derived from shared storage.
+
+If you are counting things that happen, you want an instance counter. If you are
+reporting how many things currently exist, you want a service gauge.
+
+### Package layout
+
+Each feature package that emits metrics owns a `src/metrics/` folder:
+
+```text
+src/metrics/
+  instance.ts   Counters and histograms, created at module load, recorded inline.
+  service.ts    register<Module>ServiceMetrics(): observable gauges (omit if none).
+  index.ts      Re-exports the above.
+```
+
+Instance instruments are created at the top of `instance.ts` and exported, then
+imported and recorded where the event occurs. Creating them at import time is
+safe: `instanceMetrics.getMeter` returns a no-op meter until an app starts
+instrumentation, so tests that merely import the module record nothing and bind
+nothing.
+
+Service gauges are different. Reaching `getServiceMetricsProvider()` binds the
+metrics port, so it must never run at import time — it would break any unit test
+that imports the module. Fetch the meter, create the gauges, and attach their
+callbacks **inside** an exported `register<Module>ServiceMetrics()` function.
+Wire that function to the module via the `metrics` hook:
+
+```ts
+export const runnersModule: ShipfoxModule = {
+  name: 'runners',
+  // ...
+  metrics: registerRunnersServiceMetrics,
+};
+```
+
+`registerModuleMetrics` (called once from the app bootstrap, after
+`startServiceMetrics` and `initializeModules`) invokes every module's hook. A
+package with no shared-state gauge omits `metrics` entirely.
+
+### Naming
+
+Snake_case, prefixed with the module name: `runners_job_claimed`,
+`runners_pending_jobs`, `runners_claim_duration`. The prefix is the namespace —
+it keeps `workflows_*` and `runners_*` from colliding in one Prometheus tenant.
+
+Do not hand-append `_total` to counters or unit suffixes to histograms: the
+Prometheus exporter derives `_total`, `_milliseconds`, and friends from the
+instrument kind and its `unit`. Set `unit: 'ms'` and `advice.explicitBucketBoundaries`
+on histograms; the name stays unit-free.
+
+### Cardinality is the one rule that matters
+
+A metric label multiplies into one time series per distinct value. Labels must
+be **bounded and low-cardinality**: an outcome, a reason, a type, a conclusion,
+a provider, an OS — values you could list on one hand or one page.
+
+Never label a metric with an unbounded identifier: no `jobId`, `runId`,
+`workspaceId`, `organizationId`, `userId`, raw URL, or error message. One job ID
+in a label is one new time series per job forever; it melts Prometheus and the
+bill. When you need per-entity detail, that is what logs and traces are for —
+put the ID in a `logger()` field, not a metric label.
+
+Type the label set so the shape is enforced at every call site:
+
+```ts
+const jobClaimedCount = meter.createCounter<{outcome: 'claimed' | 'empty'}>(
+  'runners_job_claimed',
+  {description: 'Job-claim attempts by outcome'},
+);
+```
+
+### Where recording lives
+
+Metrics are observability, like logging, so they are allowed in `core` and `db`
+— record where the event is known most precisely, not only at the HTTP edge.
+Keep recording out of pure row-to-domain mappers and DTO converters. A service
+gauge's callback queries through the same `db/` functions the rest of the
+package uses; it does not reach for raw Drizzle.
+
 ## Unit Testing Strategy (Client Apps)
 
 The detailed client testing strategy lives in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before working on this project.
 
 ## Running tasks locally
 
-This project uses [mise](https://mise.jdx.dev/) to manage tool versions. `node`, `pnpm`, and `turbo` are all available in the shell — no `npx` needed.
+This project uses [mise](https://mise.jdx.dev/) to manage tool versions. `node`, `pnpm`, and `turbo` are all available in the shell: no `npx` needed.
 
 ```sh
 # Install dependencies
@@ -114,7 +114,7 @@ const form = useForm({
 >
 ```
 
-Do not add `@tanstack/zod-form-adapter` or write custom Zod adapters — the
+Do not add `@tanstack/zod-form-adapter` or write custom Zod adapters: the
 adapter package is legacy (pinned to form-core v0.x) and unnecessary on v1+.
 
 Render every labeled input through `FormField` from `@shipfox/react-ui`, using
@@ -133,7 +133,7 @@ Render every labeled input through `FormField` from `@shipfox/react-ui`, using
 ```
 
 Validation runs `onBlur` per field and `onSubmit` for the form. Show field
-errors only after the field has been blurred or after a submit attempt — see
+errors only after the field has been blurred or after a submit attempt. See
 the `fieldError(field)` helper at the bottom of each page form for the
 boilerplate.
 
@@ -142,7 +142,7 @@ function in `form-errors.ts`. It returns either
 `{kind: 'field', field, message}` (routed to
 `form.setFieldMeta(field, prev => ({...prev, errorMap: {...prev.errorMap, onServer: message}}))`)
 or `{kind: 'form', message}` (rendered in an `<Alert>` above the form).
-Use the `onServer` slot in `errorMap` — not `errors` directly — because
+Use the `onServer` slot in `errorMap` (not `errors` directly) because
 TanStack Form v1 derives `field.state.meta.errors` from `errorMap`, so a
 direct write to `errors` gets overwritten on the next derived read.
 TanStack Form auto-clears `errorMap.onServer` on the next field validation
@@ -150,8 +150,8 @@ TanStack Form auto-clears `errorMap.onServer` on the next field validation
 every `ApiError` code the feature handles, plus the unknown-error fallback.
 
 For draft persistence across navigation (auth flows), sync TanStack Form values
-into a Jotai atom on field blur and on form unmount only — never on every
-keystroke — and filter the atom shape explicitly so unrelated fields (e.g.
+into a Jotai atom on field blur and on form unmount only (never on every
+keystroke) and filter the atom shape explicitly so unrelated fields (e.g.
 signup's `name`) don't leak into a `{email, password}` draft.
 
 ### E2E setup
@@ -278,8 +278,8 @@ Speculation about future work ("today X, tomorrow Y") and tracked tasks belong i
 
 ## Auth & token security
 
-The auth module issues two stateless bearer tokens — a **user session token** and
-a **job lease token** — each signed with its own dedicated secret. The full
+The auth module issues two stateless bearer tokens, a **user session token** and
+a **job lease token**, each signed with its own dedicated secret. The full
 security model (trust boundaries, scope, threat model, and rotation) lives in
 `libs/api/auth/README.md#security-model`; read it before touching anything that
 mints, verifies, or carries either token.
@@ -292,17 +292,17 @@ near it, keep its authority narrow:
   not a replacement for the long-lived runner credential.
 - **Keep a single issuer; everyone else verifies only.** Scheduling mints leases;
   every other side does an in-process signature check with no callback. Treat the
-  runner and the agent workload it hosts as untrusted — they only present a token.
+  runner and the agent workload it hosts as untrusted; they only present a token.
 - **Keep the lifetime bounded** and never trade the short TTL for convenience.
 - **Server state is the final gate.** A valid token must never be sufficient to
-  advance work on its own — on the lease path, terminal step/progression state
+  advance work on its own; on the lease path, terminal step/progression state
   always wins (job finalization is enforced outside it), and cancellation rides on
   the heartbeat response.
 - **Never log a raw token.** There is no automatic redaction; tokens must not reach
   logs, traces, or error payloads. Secrets come from configuration, never code.
 
 If the no-revocation window proves too wide, bind the lease to live runner or job
-state — do not broaden what the token itself authorizes.
+state; do not broaden what the token itself authorizes.
 
 ## Error handling
 
@@ -316,7 +316,7 @@ external system  →  api/core: typed error  →  presentation: ClientError  →
 ```
 
 Never swallow or wrap an error unless you add meaning. If you can re-throw
-as-is, do. Do not catch errors just to log them — let unknowns reach the global
+as-is, do. Do not catch errors just to log them; let unknowns reach the global
 handler.
 
 ### Domain errors (`core` / `db`)
@@ -324,7 +324,7 @@ handler.
 Throw typed domain errors from domain and persistence code. Define them in
 `core/errors.ts` as plain `Error` subclasses with a human-readable message, a
 `name`, and any context as public readonly fields. They carry **no HTTP
-concerns** (no status, no client-facing code) — that keeps them reusable by
+concerns** (no status, no client-facing code), which keeps them reusable by
 workers, subscribers, and jobs, not just routes:
 
 ```ts
@@ -369,10 +369,10 @@ errorHandler: (error) => {
 structured client response. `code` is a stable kebab-case string (`not-found`,
 `last-member`, `project-already-exists`). `params`:
 
-- `status` — HTTP status, **defaults to 400**; set it for any other 4xx.
-- `details` — structured data **returned to the client** (snake_case keys).
-- `data` — context **logged only**, never sent to the client.
-- `cause` — pass the original error when wrapping, so it stays in the chain for
+- `status`: HTTP status, **defaults to 400**; set it for any other 4xx.
+- `details`: structured data **returned to the client** (snake_case keys).
+- `data`: context **logged only**, never sent to the client.
+- `cause`: pass the original error when wrapping, so it stays in the chain for
   logs and diagnostics. Sentry sees unknown errors that reach the global handler;
   handled cases must capture explicitly if they need Sentry reporting.
 
@@ -385,12 +385,12 @@ The shared handler in `@shipfox/node-fastify` is the last resort. It sends
 `ClientError` as `{code, details?}` with its status, maps Fastify
 validation/known errors to 4xx codes, and logs + reports unknown errors to
 Sentry as a 500 `server-error`. Anything that reaches it untyped becomes an
-opaque 500 — so translate errors you can describe before they get here.
+opaque 500, so translate errors you can describe before they get here.
 
 ## Metrics & observability
 
 Metrics are emitted through OpenTelemetry and scraped by Prometheus. All the
-plumbing — the SDK, the Prometheus exporters, the meter providers — lives in
+plumbing (the SDK, the Prometheus exporters, the meter providers) lives in
 `@shipfox/node-opentelemetry`; an app turns it on once at startup (the API does
 this in `apps/api/src/core/run.ts`) and feature packages only define and record
 instruments. Never add a metrics SDK or exporter to a feature package.
@@ -403,12 +403,12 @@ There are two separate meter providers on two ports, and the choice between
 them is about *what the number means*, not convenience.
 
 - **Instance metrics** (`instanceMetrics.getMeter(name)`, port 9464) are
-  counters and histograms recorded inline as an event happens — a job claimed,
+  counters and histograms recorded inline as an event happens: a job claimed,
   a request served, a duration observed. Each pod exposes its own values and
   Prometheus sums across pods. This is the default; reach for it first.
 - **Service metrics** (`getServiceMetricsProvider().getMeter(name)`, port 9474)
-  are observable gauges that read shared state — a queue depth, a backlog size,
-  a current count — through a callback that runs on each scrape. They live on a
+  are observable gauges that read shared state (a queue depth, a backlog size,
+  a current count) through a callback that runs on each scrape. They live on a
   separate provider because every pod reading the same database row would report
   the same value, and Prometheus must not sum those copies. Use a service gauge
   only for point-in-time state derived from shared storage.
@@ -437,13 +437,13 @@ That same lazy resolution is a production trap. The metrics API has no proxy
 meter (unlike traces, which back-fill), so an instrument created before the app
 registers the global meter provider stays a no-op forever and never exports. The
 app must therefore start instance instrumentation **before** the module graph
-loads — preload it via `--import`, not from inside `run()`. See
+loads: preload it via `--import`, not from inside `run()`. See
 `apps/api/src/instrumentation.ts` (wired into the Dockerfile CMD and the dev
 script). A new app that calls `startInstanceInstrumentation` in-process after
 importing its feature modules will silently emit nothing.
 
 Service gauges are different. Reaching `getServiceMetricsProvider()` binds the
-metrics port, so it must never run at import time — it would break any unit test
+metrics port, so it must never run at import time; it would break any unit test
 that imports the module. Fetch the meter, create the gauges, and attach their
 callbacks **inside** an exported `register<Module>ServiceMetrics()` function.
 Wire that function to the module via the `metrics` hook:
@@ -463,7 +463,7 @@ package with no shared-state gauge omits `metrics` entirely.
 ### Naming
 
 Snake_case, prefixed with the module name: `runners_job_claimed`,
-`runners_pending_jobs`, `runners_claim_duration`. The prefix is the namespace —
+`runners_pending_jobs`, `runners_claim_duration`. The prefix is the namespace;
 it keeps `workflows_*` and `runners_*` from colliding in one Prometheus tenant.
 
 Do not hand-append `_total` to counters or unit suffixes to histograms: the
@@ -475,12 +475,12 @@ on histograms; the name stays unit-free.
 
 A metric label multiplies into one time series per distinct value. Labels must
 be **bounded and low-cardinality**: an outcome, a reason, a type, a conclusion,
-a provider, an OS — values you could list on one hand or one page.
+a provider, an OS: values you could list on one hand or one page.
 
 Never label a metric with an unbounded identifier: no `jobId`, `runId`,
 `workspaceId`, `organizationId`, `userId`, raw URL, or error message. One job ID
 in a label is one new time series per job forever; it melts Prometheus and the
-bill. When you need per-entity detail, that is what logs and traces are for —
+bill. When you need per-entity detail, that is what logs and traces are for;
 put the ID in a `logger()` field, not a metric label.
 
 Type the label set so the shape is enforced at every call site:
@@ -494,8 +494,8 @@ const jobClaimedCount = meter.createCounter<{outcome: 'claimed' | 'empty'}>(
 
 ### Where recording lives
 
-Metrics are observability, like logging, so they are allowed in `core` and `db`
-— record where the event is known most precisely, not only at the HTTP edge.
+Metrics are observability, like logging, so they are allowed in `core` and `db`;
+record where the event is known most precisely, not only at the HTTP edge.
 Keep recording out of pure row-to-domain mappers and DTO converters. A service
 gauge's callback queries through the same `db/` functions the rest of the
 package uses; it does not reach for raw Drizzle.
@@ -543,13 +543,13 @@ const jobs = jobFactory.buildList(3);
 
 Use `build()` for pure unit tests on `core/` logic; use `create()` when the code under test queries the DB.
 
-### Test structure — Arrange / Act / Assert
+### Test structure: Arrange / Act / Assert
 
 Each test is written in three clearly separated phases, in order:
 
-1. **Arrange** — declare all data and preconditions needed for the test.
-2. **Act** — call the function or trigger the behaviour under test.
-3. **Assert** — verify the outcome.
+1. **Arrange**: declare all data and preconditions needed for the test.
+2. **Act**: call the function or trigger the behaviour under test.
+3. **Assert**: verify the outcome.
 
 Keep a blank line between each phase so the boundary is immediately visible:
 
@@ -567,7 +567,7 @@ it("marks the runner as terminated", async () => {
 Never interleave assertions with setup, fold the act into the arrange line, or inline the act inside an assertion. The act must always be assigned to a variable first:
 
 ```typescript
-// bad — act collapsed into assert (AAA violation)
+// bad: act collapsed into assert (AAA violation)
 expect(await terminateRunner(runner.id)).toBeDefined();
 
 // good
@@ -575,12 +575,12 @@ const result = await terminateRunner(runner.id);
 expect(result).toBeDefined();
 ```
 
-If a test needs assertions in multiple places it is likely testing more than one thing — split it.
+If a test needs assertions in multiple places it is likely testing more than one thing; split it.
 
 ### Test isolation
 
 - Each `describe` block generates a fresh `organizationId` (or other scope key) via `faker` in `beforeEach` so tests don't share data.
-- `vi.restoreAllMocks()` is called automatically in `afterEach` — no need to do it manually.
+- `vi.restoreAllMocks()` is called automatically in `afterEach`; no need to do it manually.
 - DB state is cleaned by truncating tables in `globalSetup`, not between individual tests, so avoid relying on an empty DB mid-suite.
 
 ### Mocking
@@ -633,9 +633,9 @@ describe.each(runnerEventTypeEnum.enumValues)('createRunnerEvent "%s"', (eventTy
 
 Argos catches UI drift on every PR via one named build per source module:
 
-- `react-ui` — `@shipfox/react-ui` stories captured in **light + dark** by `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin`. Capture is part of `turbo test` for `@shipfox/react-ui`. Adding a new story snapshots automatically in both themes.
-- `client-workflows` — `@shipfox/client-workflows` stories, captured the same way under `turbo test` for that package. Story-based capture isn't limited to `react-ui`: any client package with stories can register its own `argosVitestPlugin` build named after the package.
-- `client-<module>` (today: `client-auth`) — explicit `argosScreenshot(page, '<surface>/<state>')` calls in the matching `e2e/client/<module>/*` Playwright specs. Each E2E package sets its own `buildName` matching the package suffix so PR checks stay scoped per surface. Place the call **after** the assertions that prove the page reached the expected state — the helper waits for fonts and layout, not for content you have not asserted on.
+- `react-ui`: `@shipfox/react-ui` stories captured in **light + dark** by `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin`. Capture is part of `turbo test` for `@shipfox/react-ui`. Adding a new story snapshots automatically in both themes.
+- `client-workflows`: `@shipfox/client-workflows` stories, captured the same way under `turbo test` for that package. Story-based capture isn't limited to `react-ui`: any client package with stories can register its own `argosVitestPlugin` build named after the package.
+- `client-<module>` (today: `client-auth`): explicit `argosScreenshot(page, '<surface>/<state>')` calls in the matching `e2e/client/<module>/*` Playwright specs. Each E2E package sets its own `buildName` matching the package suffix so PR checks stay scoped per surface. Place the call **after** the assertions that prove the page reached the expected state; the helper waits for fonts and layout, not for content you have not asserted on.
 
 To cover a component state a single render cannot reach (error states, populated lists, etc.), add it as a new story rather than driving interactions in `play`. To cover a new page state, add an `argosScreenshot` call in the existing test that already drives there; do not write a screenshot-only spec.
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -50,9 +50,11 @@ LABEL org.opencontainers.image.title="@shipfox/api" \
       org.opencontainers.image.revision=$IMAGE_REVISION \
       org.opencontainers.image.created=$IMAGE_CREATED
 
-# --enable-source-maps maps stack traces back to TypeScript; --import preloads
-# Sentry (error-monitoring/init) before the app graph loads. OpenTelemetry is
-# started in-process by run(), so it needs no preload flag. The flags stay on the
-# entrypoint command (not NODE_OPTIONS) so they apply to the app only, not to any
-# other node process run inside the container.
-CMD ["node", "--enable-source-maps", "--import", "@shipfox/node-error-monitoring/init", "./dist/index.js"]
+# --enable-source-maps maps stack traces back to TypeScript. The two --import
+# flags preload OpenTelemetry then Sentry before the app graph loads.
+# instrumentation.js must run first: the metrics API has no proxy meter, so any
+# instrument created at import time binds to a no-op provider unless the SDK has
+# already registered the global meter provider. The flags stay on the entrypoint
+# command (not NODE_OPTIONS) so they apply to the app only, not to any other node
+# process run inside the container.
+CMD ["node", "--enable-source-maps", "--import", "./dist/instrumentation.js", "--import", "@shipfox/node-error-monitoring/init", "./dist/index.js"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "shipfox-swc",
-    "dev": "tsx watch --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts",
+    "dev": "tsx watch --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=.env --env-file-if-exists=.env.local --import ./src/instrumentation.ts src/index.ts",
     "image": "shipfox-docker --setup-context --image api",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -9,7 +9,7 @@ import {triggersModule} from '@shipfox/api-triggers';
 import {setSourceControl, workflowsModule} from '@shipfox/api-workflows';
 import {workspacesModule} from '@shipfox/api-workspaces';
 import {createApp, listen} from '@shipfox/node-fastify';
-import {initializeModules, startModuleWorkers} from '@shipfox/node-module';
+import {initializeModules, registerModuleMetrics, startModuleWorkers} from '@shipfox/node-module';
 import {
   logger,
   startInstanceInstrumentation,
@@ -35,20 +35,22 @@ export async function run(): Promise<void> {
   const projectsModule = createProjectsModule({sourceControl: integrations.sourceControl});
   const definitionsModule = createDefinitionsModule({sourceControl: integrations.sourceControl});
 
-  const {auth, routes, e2eRoutes, workers} = await initializeModules({
-    modules: [
-      authModule,
-      workspacesModule,
-      integrations.module,
-      projectsModule,
-      definitionsModule,
-      workflowsModule,
-      runnersModule,
-      logsModule,
-      triggersModule,
-      dispatcherModule,
-    ],
-  });
+  const modules = [
+    authModule,
+    workspacesModule,
+    integrations.module,
+    projectsModule,
+    definitionsModule,
+    workflowsModule,
+    runnersModule,
+    logsModule,
+    triggersModule,
+    dispatcherModule,
+  ];
+  const {auth, routes, e2eRoutes, workers} = await initializeModules({modules});
+  // Register service metrics after migrations so gauge callbacks can query the
+  // database; the provider was started above with startServiceMetrics.
+  registerModuleMetrics({modules});
   // Boot-time provider tasks (post-migration). No-op when no enabled provider contributes
   // one; failures are isolated and logged, never thrown, so they cannot gate boot.
   await integrations.runStartupTasks();

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -10,20 +10,16 @@ import {setSourceControl, workflowsModule} from '@shipfox/api-workflows';
 import {workspacesModule} from '@shipfox/api-workspaces';
 import {createApp, listen} from '@shipfox/node-fastify';
 import {initializeModules, registerModuleMetrics, startModuleWorkers} from '@shipfox/node-module';
-import {
-  logger,
-  startInstanceInstrumentation,
-  startServiceMetrics,
-} from '@shipfox/node-opentelemetry';
+import {logger, startServiceMetrics} from '@shipfox/node-opentelemetry';
 import {createPostgresClient} from '@shipfox/node-postgres';
 import {config} from '../config.js';
 import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
 
 export async function run(): Promise<void> {
-  await startInstanceInstrumentation({
-    serviceName: 'api',
-    instrumentations: {fastify: true, http: true, pg: true},
-  });
+  // Instance instrumentation is started in instrumentation.ts, preloaded via the
+  // entrypoint's --import flag so the metrics meter provider is registered before
+  // any feature module creates its instruments. Service metrics use a dedicated
+  // provider and their registration is order-safe, so they stay here.
   startServiceMetrics({serviceName: 'api'});
 
   createPostgresClient();

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -16,10 +16,6 @@ import {config} from '../config.js';
 import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
 
 export async function run(): Promise<void> {
-  // Instance instrumentation is started in instrumentation.ts, preloaded via the
-  // entrypoint's --import flag so the metrics meter provider is registered before
-  // any feature module creates its instruments. Service metrics use a dedicated
-  // provider and their registration is order-safe, so they stay here.
   startServiceMetrics({serviceName: 'api'});
 
   createPostgresClient();
@@ -44,8 +40,7 @@ export async function run(): Promise<void> {
     dispatcherModule,
   ];
   const {auth, routes, e2eRoutes, workers} = await initializeModules({modules});
-  // Register service metrics after migrations so gauge callbacks can query the
-  // database; the provider was started above with startServiceMetrics.
+  // Gauge callbacks query migrated tables, so register them after module initialization.
   registerModuleMetrics({modules});
   // Boot-time provider tasks (post-migration). No-op when no enabled provider contributes
   // one; failures are isolated and logged, never thrown, so they cannot gate boot.

--- a/apps/api/src/instrumentation.ts
+++ b/apps/api/src/instrumentation.ts
@@ -1,0 +1,11 @@
+import {startInstanceInstrumentation} from '@shipfox/node-opentelemetry';
+
+// Preloaded via the entrypoint's --import flag (Dockerfile CMD and the dev
+// script) so it runs before the app module graph. The metrics API has no proxy
+// meter, so any instrument created at import time binds to a no-op provider
+// unless the SDK has already registered the global meter provider. The await
+// guarantees that registration completes before index.ts loads.
+await startInstanceInstrumentation({
+  serviceName: 'api',
+  instrumentations: {fastify: true, http: true, pg: true},
+});

--- a/apps/api/src/instrumentation.ts
+++ b/apps/api/src/instrumentation.ts
@@ -1,10 +1,7 @@
 import {startInstanceInstrumentation} from '@shipfox/node-opentelemetry';
 
-// Preloaded via the entrypoint's --import flag (Dockerfile CMD and the dev
-// script) so it runs before the app module graph. The metrics API has no proxy
-// meter, so any instrument created at import time binds to a no-op provider
-// unless the SDK has already registered the global meter provider. The await
-// guarantees that registration completes before index.ts loads.
+// The metrics API has no proxy meter: instruments created before this preload
+// completes bind to a no-op provider for the process lifetime.
 await startInstanceInstrumentation({
   serviceName: 'api',
   instrumentations: {fastify: true, http: true, pg: true},

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -1,5 +1,6 @@
 import {issueJobLeaseToken} from '@shipfox/api-auth';
 import {claimPendingJob, expireStuckJobs} from '#db/jobs.js';
+import {jobClaimedCount} from '#metrics/instance.js';
 
 export interface ClaimJobResult {
   jobId: string;
@@ -12,7 +13,11 @@ export async function claimJob(params: {
   runnerTokenId: string;
 }): Promise<ClaimJobResult | null> {
   const claimed = await claimPendingJob(params);
-  if (!claimed) return null;
+  if (!claimed) {
+    jobClaimedCount.add(1, {outcome: 'empty'});
+    return null;
+  }
+  jobClaimedCount.add(1, {outcome: 'claimed'});
 
   const leaseToken = await issueJobLeaseToken({
     jobId: claimed.jobId,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -12,6 +12,7 @@ import {
   claimPendingJob,
   enqueueJob,
   expireStuckJobs,
+  getJobQueueDepth,
   recordHeartbeat,
   releaseJob,
   requestJobCancellation,
@@ -678,5 +679,35 @@ describe('detectAndExpireStuckJobs', () => {
       0,
     );
     expect(await claimPendingJob({workspaceId, runnerTokenId})).toBeNull();
+  });
+});
+
+describe('getJobQueueDepth', () => {
+  let workspaceId: string;
+  let runnerTokenId: string;
+
+  beforeEach(async () => {
+    await db().execute(
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+    );
+    workspaceId = crypto.randomUUID();
+    const runnerToken = await runnerTokenFactory.create({workspaceId});
+    runnerTokenId = runnerToken.id;
+  });
+
+  it('reports zero on an empty queue', async () => {
+    const depth = await getJobQueueDepth();
+
+    expect(depth).toEqual({pending: 0, running: 0});
+  });
+
+  it('counts pending and running jobs separately', async () => {
+    await pendingJobFactory.create({workspaceId});
+    await pendingJobFactory.create({workspaceId});
+    await claimPendingJob({workspaceId, runnerTokenId});
+
+    const depth = await getJobQueueDepth();
+
+    expect(depth).toEqual({pending: 1, running: 1});
   });
 });

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -5,8 +5,9 @@ import {
   type RunnersEventMap,
 } from '@shipfox/api-runners-dto';
 import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
-import {and, asc, eq, inArray, lt, sql} from 'drizzle-orm';
+import {and, asc, count, eq, inArray, lt, sql} from 'drizzle-orm';
 import {RunningJobNotFoundError} from '#core/errors.js';
+import {jobEnqueuedCount, jobLeaseExpiredCount} from '#metrics/instance.js';
 import {db} from './db.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
@@ -27,7 +28,7 @@ export interface EnqueueJobParams {
 // can reinsert an orphan pending row, which a later `claimPendingJob` drops
 // via the running-job unique constraint (onConflictDoNothing) instead of failing.
 export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
-  await db().transaction(async (tx) => {
+  const enqueued = await db().transaction(async (tx) => {
     const [inserted] = await tx
       .insert(pendingJobs)
       .values({
@@ -42,7 +43,7 @@ export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
     // A retry that hits the conflict inserts nothing: the first enqueue already
     // emitted the queued event (durably, in the outbox), so re-emitting would
     // only add a redundant row the subscriber coalesces away. Skip it.
-    if (!inserted) return;
+    if (!inserted) return false;
 
     await writeOutboxEvent<RunnersEventMap>(tx, runnersOutbox, {
       type: RUNNER_JOB_QUEUED,
@@ -52,7 +53,10 @@ export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
         queuedAt: inserted.createdAt.toISOString(),
       },
     });
+    return true;
   });
+
+  if (enqueued) jobEnqueuedCount.add(1);
 }
 
 export interface ClaimedJob {
@@ -157,7 +161,7 @@ export async function expireStuckJobs(params: {
   thresholdSeconds: number;
   limit?: number;
 }): Promise<Array<{jobId: string; runId: string}>> {
-  return await db().transaction(async (tx) => {
+  const reaped = await db().transaction(async (tx) => {
     const cutoff = sql`now() - (${params.thresholdSeconds} || ' seconds')::interval`;
 
     const staleIds = tx
@@ -168,31 +172,46 @@ export async function expireStuckJobs(params: {
       .limit(params.limit ?? 100)
       .for('update', {skipLocked: true});
 
-    const reaped = await tx
+    const deleted = await tx
       .delete(runningJobs)
       .where(and(inArray(runningJobs.id, staleIds), lt(runningJobs.lastHeartbeatAt, cutoff)))
       .returning({jobId: runningJobs.jobId, runId: runningJobs.runId});
 
-    if (reaped.length === 0) return [];
+    if (deleted.length === 0) return [];
 
     await tx.delete(pendingJobs).where(
       inArray(
         pendingJobs.jobId,
-        reaped.map((row) => row.jobId),
+        deleted.map((row) => row.jobId),
       ),
     );
 
     await writeOutboxEvents<RunnersEventMap>(
       tx,
       runnersOutbox,
-      reaped.map((row) => ({
+      deleted.map((row) => ({
         type: RUNNER_JOB_LEASE_EXPIRED,
         payload: {jobId: row.jobId, runId: row.runId},
       })),
     );
 
-    return reaped;
+    return deleted;
   });
+
+  if (reaped.length > 0) jobLeaseExpiredCount.add(reaped.length);
+
+  return reaped;
+}
+
+/**
+ * Point-in-time queue depth: how many jobs are pending versus running right now.
+ * Backs the `runners_pending_jobs` / `runners_running_jobs` service gauges, which
+ * read shared state rather than counting events, so this is a plain aggregate.
+ */
+export async function getJobQueueDepth(): Promise<{pending: number; running: number}> {
+  const [pending] = await db().select({value: count()}).from(pendingJobs);
+  const [running] = await db().select({value: count()}).from(runningJobs);
+  return {pending: pending?.value ?? 0, running: running?.value ?? 0};
 }
 
 export async function recordHeartbeat(params: {

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -203,11 +203,6 @@ export async function expireStuckJobs(params: {
   return reaped;
 }
 
-/**
- * Point-in-time queue depth: how many jobs are pending versus running right now.
- * Backs the `runners_pending_jobs` / `runners_running_jobs` service gauges, which
- * read shared state rather than counting events, so this is a plain aggregate.
- */
 export async function getJobQueueDepth(): Promise<{pending: number; running: number}> {
   const [pending] = await db().select({value: count()}).from(pendingJobs);
   const [running] = await db().select({value: count()}).from(runningJobs);

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -4,6 +4,7 @@ import {runnersEventSchemas} from '@shipfox/api-runners-dto';
 import {WORKFLOWS_JOB_TIMED_OUT, type WorkflowsEventMap} from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, runnersOutbox} from '#db/index.js';
+import {registerRunnersServiceMetrics} from '#metrics/index.js';
 import {createRunnerTokenAuthMethod, onWorkflowsJobTimedOut, routes} from '#presentation/index.js';
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
 import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
@@ -20,6 +21,7 @@ export const runnersModule: ShipfoxModule = {
   database: {db, migrationsPath},
   auth: [createRunnerTokenAuthMethod()],
   routes,
+  metrics: registerRunnersServiceMetrics,
   publishers: [{name: 'runners', table: runnersOutbox, db, eventSchemas: runnersEventSchemas}],
   subscribers: [subscriber(WORKFLOWS_JOB_TIMED_OUT, onWorkflowsJobTimedOut)],
   workers: [

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -1,0 +1,2 @@
+export {jobClaimedCount, jobEnqueuedCount, jobLeaseExpiredCount} from './instance.js';
+export {registerRunnersServiceMetrics} from './service.js';

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -1,0 +1,17 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('runners');
+
+export const jobEnqueuedCount = meter.createCounter<Record<string, never>>('runners_job_enqueued', {
+  description: 'Jobs added to the pending queue',
+});
+
+export const jobClaimedCount = meter.createCounter<{outcome: 'claimed' | 'empty'}>(
+  'runners_job_claimed',
+  {description: 'Job-claim attempts by outcome'},
+);
+
+export const jobLeaseExpiredCount = meter.createCounter<Record<string, never>>(
+  'runners_job_lease_expired',
+  {description: 'Job leases reaped after passing the heartbeat threshold'},
+);

--- a/libs/api/runners/src/metrics/service.ts
+++ b/libs/api/runners/src/metrics/service.ts
@@ -3,7 +3,7 @@ import {getJobQueueDepth} from '#db/jobs.js';
 
 /**
  * Registers the job-queue depth gauges. Wired to `runnersModule.metrics`, so it
- * runs once at app startup via `registerModuleMetrics` — never at import time,
+ * runs once at app startup via `registerModuleMetrics`, never at import time,
  * which would bind the metrics port and break unit tests that import this
  * module. The single batch callback reads both counts from one round trip on
  * each scrape.

--- a/libs/api/runners/src/metrics/service.ts
+++ b/libs/api/runners/src/metrics/service.ts
@@ -1,13 +1,6 @@
 import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
 import {getJobQueueDepth} from '#db/jobs.js';
 
-/**
- * Registers the job-queue depth gauges. Wired to `runnersModule.metrics`, so it
- * runs once at app startup via `registerModuleMetrics`, never at import time,
- * which would bind the metrics port and break unit tests that import this
- * module. The single batch callback reads both counts from one round trip on
- * each scrape.
- */
 export function registerRunnersServiceMetrics(): void {
   const meter = getServiceMetricsProvider().getMeter('runners');
 

--- a/libs/api/runners/src/metrics/service.ts
+++ b/libs/api/runners/src/metrics/service.ts
@@ -1,0 +1,29 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getJobQueueDepth} from '#db/jobs.js';
+
+/**
+ * Registers the job-queue depth gauges. Wired to `runnersModule.metrics`, so it
+ * runs once at app startup via `registerModuleMetrics` — never at import time,
+ * which would bind the metrics port and break unit tests that import this
+ * module. The single batch callback reads both counts from one round trip on
+ * each scrape.
+ */
+export function registerRunnersServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('runners');
+
+  const pendingJobs = meter.createObservableGauge('runners_pending_jobs', {
+    description: 'Jobs currently waiting in the queue to be claimed',
+  });
+  const runningJobs = meter.createObservableGauge('runners_running_jobs', {
+    description: 'Jobs currently claimed by a runner and in progress',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      const depth = await getJobQueueDepth();
+      observer.observe(pendingJobs, depth.pending);
+      observer.observe(runningJobs, depth.running);
+    },
+    [pendingJobs, runningJobs],
+  );
+}

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -1,10 +1,11 @@
 # Shipfox Module
 
-Module setup helpers for Shipfox API services. A module can list its database, auth methods, routes, outbox publishers, event handlers, and Temporal workers in one object.
+Module setup helpers for Shipfox API services. A module can list its database, auth methods, routes, outbox publishers, event handlers, service metrics, and Temporal workers in one object.
 
 ## What it does
 
 - **`initializeModules({modules})`**: Sets up modules in array order.
+- **`registerModuleMetrics({modules})`**: Registers service-level metrics for modules that declare a metrics hook.
 - **`startModuleWorkers({workers})`**: Creates Temporal workers and starts declared workflows.
 - **`ShipfoxModule`**: Module contract used by API packages.
 - **Publisher registry**: Adds outbox tables, drains pending events, and marks events as sent.
@@ -14,12 +15,14 @@ Module setup helpers for Shipfox API services. A module can list its database, a
 
 ```ts
 import {createApp, listen} from '@shipfox/node-fastify';
-import {initializeModules, startModuleWorkers} from '@shipfox/node-module';
+import {initializeModules, registerModuleMetrics, startModuleWorkers} from '@shipfox/node-module';
 import {authModule} from '@shipfox/api-auth';
 
+const modules = [authModule];
 const {auth, routes, workers} = await initializeModules({
-  modules: [authModule],
+  modules,
 });
+registerModuleMetrics({modules});
 
 await createApp({auth, routes});
 await listen();
@@ -27,7 +30,7 @@ await listen();
 startModuleWorkers({workers});
 ```
 
-`initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array.
+`initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array. Call `registerModuleMetrics` once after instrumentation has started and migrations have run, so observable gauges can query shared storage safely.
 
 ## Module Shape
 
@@ -49,6 +52,7 @@ export const exampleModule: ShipfoxModule = {
   database: {db, migrationsPath},
   auth: [authMethod],
   routes: [routes],
+  metrics: registerExampleServiceMetrics,
   publishers: [{name: 'example', table: outbox, db}],
   subscribers: [subscriber('example.created', handleExampleCreated)],
   workers: [{taskQueue: 'example', workflowsPath, activities, workflows: []}],

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -2,7 +2,7 @@ export type {
   InitializedModules,
   InitializeModulesOptions,
 } from './initialize.js';
-export {initializeModules, startModuleWorkers} from './initialize.js';
+export {initializeModules, registerModuleMetrics, startModuleWorkers} from './initialize.js';
 export type {
   DrainedEvent,
   OutboxDispatchFailure,
@@ -24,6 +24,7 @@ export type {ModuleSubscriber} from './subscriber.js';
 export {subscriberFactory} from './subscriber.js';
 export type {
   ModuleDatabase,
+  ModuleMetricsRegistration,
   ModulePublisher,
   ModuleWorker,
   ShipfoxModule,

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -1,0 +1,44 @@
+import {registerModuleMetrics} from './initialize.js';
+import type {ShipfoxModule} from './types.js';
+
+describe('registerModuleMetrics', () => {
+  it('invokes the metrics hook for each module that declares one', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const modules: ShipfoxModule[] = [
+      {name: 'first', metrics: first},
+      {name: 'second', metrics: second},
+    ];
+
+    registerModuleMetrics({modules});
+
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('skips modules that declare no metrics hook', () => {
+    const withMetrics = vi.fn();
+    const modules: ShipfoxModule[] = [{name: 'none'}, {name: 'has', metrics: withMetrics}];
+
+    registerModuleMetrics({modules});
+
+    expect(withMetrics).toHaveBeenCalledOnce();
+  });
+
+  it('isolates a throwing hook so later modules still register', () => {
+    const later = vi.fn();
+    const modules: ShipfoxModule[] = [
+      {
+        name: 'throwing',
+        metrics: () => {
+          throw new Error('registration failed');
+        },
+      },
+      {name: 'later', metrics: later},
+    ];
+
+    registerModuleMetrics({modules});
+
+    expect(later).toHaveBeenCalledOnce();
+  });
+});

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -92,6 +92,25 @@ function moduleMigrationTableName(moduleName: string, index: number): string {
 }
 
 /**
+ * Registers service-level metrics for every module that declares a `metrics`
+ * callback. Call this once at app startup, after `startServiceMetrics` so the
+ * provider exists, and after `initializeModules` so migrations have run before
+ * any gauge callback can query the database.
+ *
+ * Kept separate from `initializeModules` on purpose: reaching the service
+ * metrics provider binds the metrics port, so registration must only happen in
+ * a process that actually serves metrics, never as a side effect of the init
+ * path that unit tests exercise.
+ */
+export function registerModuleMetrics(options: {modules: ShipfoxModule[]}): void {
+  for (const mod of options.modules) {
+    if (!mod.metrics) continue;
+    logger().info({module: mod.name}, 'Registering module metrics');
+    mod.metrics();
+  }
+}
+
+/**
  * Creates Temporal workers for all module-declared workers and starts their workflows.
  * Call this after `initializeModules` so that all publishers/subscribers are registered.
  */

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -101,12 +101,20 @@ function moduleMigrationTableName(moduleName: string, index: number): string {
  * metrics provider binds the metrics port, so registration must only happen in
  * a process that actually serves metrics, never as a side effect of the init
  * path that unit tests exercise.
+ *
+ * Failures are isolated and logged, never thrown: metrics are observability, not
+ * critical path, so a module whose registration throws loses its metrics but
+ * cannot gate boot or stop later modules from registering theirs.
  */
 export function registerModuleMetrics(options: {modules: ShipfoxModule[]}): void {
   for (const mod of options.modules) {
     if (!mod.metrics) continue;
-    logger().info({module: mod.name}, 'Registering module metrics');
-    mod.metrics();
+    try {
+      logger().info({module: mod.name}, 'Registering module metrics');
+      mod.metrics();
+    } catch (error) {
+      logger().warn({err: error, module: mod.name}, 'Failed to register module metrics');
+    }
   }
 }
 

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -92,19 +92,10 @@ function moduleMigrationTableName(moduleName: string, index: number): string {
 }
 
 /**
- * Registers service-level metrics for every module that declares a `metrics`
- * callback. Call this once at app startup, after `startServiceMetrics` so the
- * provider exists, and after `initializeModules` so migrations have run before
- * any gauge callback can query the database.
- *
- * Kept separate from `initializeModules` on purpose: reaching the service
- * metrics provider binds the metrics port, so registration must only happen in
- * a process that actually serves metrics, never as a side effect of the init
- * path that unit tests exercise.
- *
- * Failures are isolated and logged, never thrown: metrics are observability, not
- * critical path, so a module whose registration throws loses its metrics but
- * cannot gate boot or stop later modules from registering theirs.
+ * Service metrics must register after the app starts the service metrics
+ * provider and initializes modules. Keeping this separate prevents tests that
+ * import modules from binding the metrics port, and isolates registration
+ * failures from the boot path.
  */
 export function registerModuleMetrics(options: {modules: ShipfoxModule[]}): void {
   for (const mod of options.modules) {

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -49,6 +49,18 @@ export interface ModuleWorker {
   workflows: WorkflowStart[];
 }
 
+/**
+ * Registers a module's service-level metrics (observable gauges over shared
+ * state). Invoked once at app startup by `registerModuleMetrics`, after
+ * `startServiceMetrics` has created the provider. The callback must fetch its
+ * own meter via `getServiceMetricsProvider().getMeter(name)` and attach the
+ * gauge callbacks; it must not run at import time, because reaching the
+ * provider binds the metrics port and would break unit tests that only import
+ * the module. Instance metrics (counters/histograms) need no registration —
+ * they are created lazily by `instanceMetrics.getMeter` and recorded inline.
+ */
+export type ModuleMetricsRegistration = () => void;
+
 export interface ShipfoxModule {
   name: string;
   database?: ModuleDatabase | ModuleDatabase[];
@@ -58,4 +70,5 @@ export interface ShipfoxModule {
   publishers?: ModulePublisher[];
   subscribers?: ModuleSubscriber[];
   workers?: ModuleWorker[];
+  metrics?: ModuleMetricsRegistration;
 }

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -56,8 +56,13 @@ export interface ModuleWorker {
  * own meter via `getServiceMetricsProvider().getMeter(name)` and attach the
  * gauge callbacks; it must not run at import time, because reaching the
  * provider binds the metrics port and would break unit tests that only import
- * the module. Instance metrics (counters/histograms) need no registration —
+ * the module. Instance metrics (counters/histograms) need no registration:
  * they are created lazily by `instanceMetrics.getMeter` and recorded inline.
+ *
+ * This should be side-effect-only wiring that does not normally throw. If it
+ * does, `registerModuleMetrics` isolates and logs the failure so one module
+ * cannot gate boot or block others, rather than relying on every callback to be
+ * infallible.
  */
 export type ModuleMetricsRegistration = () => void;
 

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -50,19 +50,9 @@ export interface ModuleWorker {
 }
 
 /**
- * Registers a module's service-level metrics (observable gauges over shared
- * state). Invoked once at app startup by `registerModuleMetrics`, after
- * `startServiceMetrics` has created the provider. The callback must fetch its
- * own meter via `getServiceMetricsProvider().getMeter(name)` and attach the
- * gauge callbacks; it must not run at import time, because reaching the
- * provider binds the metrics port and would break unit tests that only import
- * the module. Instance metrics (counters/histograms) need no registration:
- * they are created lazily by `instanceMetrics.getMeter` and recorded inline.
- *
- * This should be side-effect-only wiring that does not normally throw. If it
- * does, `registerModuleMetrics` isolates and logs the failure so one module
- * cannot gate boot or block others, rather than relying on every callback to be
- * infallible.
+ * Hook for observable gauges over shared service state. Implementations must
+ * fetch the service metrics provider inside the callback so ordinary module
+ * imports do not bind the metrics port.
  */
 export type ModuleMetricsRegistration = () => void;
 


### PR DESCRIPTION
Stand up the foundation for system-wide metrics observability, then instrument one API package end to end as the pattern everything else follows.

## Why

We want observability through metrics, but nothing emitted business metrics yet. The OpenTelemetry SDK and Prometheus exporters already existed in `@shipfox/node-opentelemetry` (wired into `apps/api`), so the real gaps were a declarative place for modules to contribute metrics, a worked example, and written conventions.

## What

- **Core tooling (`@shipfox/node-module`).** New optional `metrics` hook on `ShipfoxModule` plus `registerModuleMetrics`, invoked once at app startup after `startServiceMetrics` and `initializeModules`. It is deliberately kept out of `initializeModules`: reaching the service-metrics provider binds the metrics port, so registration must only run in a process that actually serves metrics, never in the init path unit tests exercise. Wired into `apps/api/src/core/run.ts`.
- **Demo (`@shipfox/api-runners`).** Exercises both metric planes. Instance counters (`runners_job_enqueued`, `runners_job_claimed{outcome}`, `runners_job_lease_expired`) recorded inline in `core`/`db`, and `runners_pending_jobs` / `runners_running_jobs` observable gauges over a new `getJobQueueDepth` query, registered through the module hook. Includes Vitest coverage for the new query.
- **Guidelines.** New "Metrics & observability" section in `AGENTS.md`: the two-plane model (per-pod instance counters vs service gauges over shared state) and how to choose, the per-package `src/metrics/` layout, naming, the cardinality rule, and test-safe service registration.

## Reviewer notes

- The instance-vs-service split is the load-bearing design decision; the rationale for the separate provider and port is in the AGENTS.md section.
- Both touched libs are private, so the changeset is `patch` for changelog tracking only.

## Follow-up

Created ENG-570 through ENG-582 to roll metrics out across the remaining API packages and to bootstrap instrumentation in the runner app (which has no metrics endpoint yet). This PR does not close them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a module-level metrics hook with `registerModuleMetrics`, instruments `@shipfox/api-runners` with instance counters and service gauges, and preloads OpenTelemetry so instance metrics export correctly.

- **New Features**
  - `@shipfox/node-module`
    - Add optional `metrics` hook and `registerModuleMetrics`; export `ModuleMetricsRegistration`.
  - `apps/api`
    - Preload OpenTelemetry via `src/instrumentation.ts` and `--import` (Dockerfile/dev); keep `startServiceMetrics` in `run.ts` and call `registerModuleMetrics` after `initializeModules`.
  - `@shipfox/api-runners`
    - Counters: `runners_job_enqueued`, `runners_job_claimed{outcome}`, `runners_job_lease_expired` recorded in code paths.
    - Service gauges: `runners_pending_jobs`, `runners_running_jobs` via `registerRunnersServiceMetrics`, backed by `getJobQueueDepth` (with tests).
  - Docs
    - Add “Metrics & observability” to `AGENTS.md` and document the OpenTelemetry preload; align comments with the guidelines.

- **Bug Fixes**
  - `@shipfox/node-module`
    - Wrap each module’s metrics hook in try/catch so a throwing registration can’t block startup; add tests and type/README docs.

<sup>Written for commit b79b07b98494df6cc3a3881887483a69206a8dc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

