### PR TITLE
[api-triggers] Fix Drizzle schema discovery

### DIFF
--- a/libs/api/triggers/drizzle.config.ts
+++ b/libs/api/triggers/drizzle.config.ts
@@ -1,7 +1,12 @@
 import {defineConfig} from 'drizzle-kit';
 
 export default defineConfig({
-  schema: './src/db/schema/*.ts',
+  schema: [
+    './src/db/schema/decisions.ts',
+    './src/db/schema/outbox.ts',
+    './src/db/schema/received-events.ts',
+    './src/db/schema/subscriptions.ts',
+  ],
   out: './drizzle',
   dialect: 'postgresql',
 });


### PR DESCRIPTION
[api-triggers] Fix Drizzle schema discovery

Drizzle Kit was loading every TypeScript file under `src/db/schema`, including colocated Vitest files. That made `drizzle-kit generate` execute `describe` outside the test runner and fail before it could compare the triggers schema.

This points the triggers Drizzle config at the table-owning schema files instead of the broad directory glob. Relocating the tests would also work, but an explicit schema list keeps the existing test layout and makes Drizzle's import surface unambiguous.

No changeset is included because `@shipfox/api-triggers` is private.

Closes ENG-569

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Drizzle schema discovery in `@shipfox/api-triggers` by loading only real schema modules. This stops `drizzle-kit generate` from importing test files and running Vitest globals, satisfying ENG-569.

- **Bug Fixes**
  - Set `schema` to explicit files: `decisions.ts`, `outbox.ts`, `received-events.ts`, `subscriptions.ts` instead of `./src/db/schema/*.ts`.
  - Result: `drizzle-kit generate` ignores colocated tests and runs cleanly (ENG-569).

<sup>Written for commit 67b2cad5f15d0e342e69d7c15e841ec2feef1816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

