### PR TITLE
[api/definitions] Fix Drizzle snapshot index metadata

### DIFF
--- a/libs/api/definitions/drizzle/meta/0000_snapshot.json
+++ b/libs/api/definitions/drizzle/meta/0000_snapshot.json
@@ -171,6 +171,34 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "definitions_wd_project_name_id_idx": {
+          "name": "definitions_wd_project_name_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},


### PR DESCRIPTION
Fix the definitions Drizzle snapshot so it includes the existing `definitions_wd_project_name_id_idx` partial index metadata.

The index already exists in the TypeScript schema and baseline SQL, but the snapshot omitted it. That made `drizzle-kit generate` emit a duplicate migration for an index that applied databases already have.

No changeset is included because `@shipfox/api-definitions` is private.

Validated with `mise exec -- pnpm exec drizzle-kit generate --config drizzle.config.ts`, `mise exec -- turbo build --filter '...[origin/main]'`, `mise exec -- turbo test --filter '...[origin/main]'`, and `mise exec -- turbo check --filter '...[origin/main]'`.

Closes ENG-567

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the `definitions_wd_project_name_id_idx` partial index in the definitions Drizzle snapshot to match the schema and baseline SQL. This prevents `drizzle-kit generate` from emitting a duplicate index migration (ENG-567).

- **Bug Fixes**
  - Added the missing index metadata to `libs/api/definitions/drizzle/meta/0000_snapshot.json`.
  - Verified: `drizzle-kit generate` reports no changes; build, tests, and type checks pass.

<sup>Written for commit 7d006cd4455d18d0a55227ce21006b88e588fedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

