### PR TITLE
[api-dispatcher] Instrument outbox metrics

### DIFF
--- a/libs/api/dispatcher/src/metrics/index.ts
+++ b/libs/api/dispatcher/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export {dispatchFailureCount, drainBatchSize, eventDispatchedCount} from './instance.js';

--- a/libs/api/dispatcher/src/metrics/instance.ts
+++ b/libs/api/dispatcher/src/metrics/instance.ts
@@ -1,0 +1,22 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('dispatcher');
+
+export const eventDispatchedCount = meter.createCounter<{outcome: 'succeeded' | 'failed'}>(
+  'dispatcher_event_dispatched',
+  {description: 'Outbox events handled by the dispatcher by outcome'},
+);
+
+export const dispatchFailureCount = meter.createCounter<{reason: 'validation' | 'handler'}>(
+  'dispatcher_dispatch_failure',
+  {description: 'Dispatcher failures by reason'},
+);
+
+export const drainBatchSize = meter.createHistogram<Record<string, never>>(
+  'dispatcher_drain_batch',
+  {
+    description: 'Outbox events returned by each dispatcher drain tick',
+    unit: '1',
+    advice: {explicitBucketBoundaries: [0, 1, 5, 10, 25, 50, 100]},
+  },
+);

--- a/libs/api/dispatcher/src/metrics/instance.ts
+++ b/libs/api/dispatcher/src/metrics/instance.ts
@@ -2,15 +2,17 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
 const meter = instanceMetrics.getMeter('dispatcher');
 
-export const eventDispatchedCount = meter.createCounter<{outcome: 'succeeded' | 'failed'}>(
-  'dispatcher_event_dispatched',
-  {description: 'Outbox events handled by the dispatcher by outcome'},
-);
+export const eventDispatchedCount = meter.createCounter<{
+  module: string;
+  outcome: 'succeeded' | 'failed';
+}>('dispatcher_event_dispatched', {
+  description: 'Outbox events handled by the dispatcher by source module and outcome',
+});
 
-export const dispatchFailureCount = meter.createCounter<{reason: 'validation' | 'handler'}>(
-  'dispatcher_dispatch_failure',
-  {description: 'Dispatcher failures by reason'},
-);
+export const dispatchFailureCount = meter.createCounter<{
+  module: string;
+  reason: 'validation' | 'handler';
+}>('dispatcher_dispatch_failure', {description: 'Dispatcher failures by source module and reason'});
 
 export const drainBatchSize = meter.createHistogram<Record<string, never>>(
   'dispatcher_drain_batch',

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -10,6 +10,9 @@ const mocks = vi.hoisted(() => ({
   markDispatched: vi.fn(),
   recordDispatchFailure: vi.fn(),
   errorLog: vi.fn(),
+  eventDispatchedAdd: vi.fn(),
+  dispatchFailureAdd: vi.fn(),
+  drainBatchRecord: vi.fn(),
 }));
 
 vi.mock('@shipfox/node-error-monitoring', () => ({
@@ -25,6 +28,19 @@ vi.mock('@shipfox/node-module', () => ({
 }));
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
+  instanceMetrics: {
+    getMeter: () => ({
+      createCounter: (name: string) => {
+        if (name === 'dispatcher_event_dispatched') return {add: mocks.eventDispatchedAdd};
+        if (name === 'dispatcher_dispatch_failure') return {add: mocks.dispatchFailureAdd};
+        throw new Error(`Unexpected counter: ${name}`);
+      },
+      createHistogram: (name: string) => {
+        if (name === 'dispatcher_drain_batch') return {record: mocks.drainBatchRecord};
+        throw new Error(`Unexpected histogram: ${name}`);
+      },
+    }),
+  },
   logger: () => ({
     error: mocks.errorLog,
   }),
@@ -39,6 +55,19 @@ describe('drainAndDispatch', () => {
     mocks.markDispatched.mockReset();
     mocks.recordDispatchFailure.mockReset();
     mocks.errorLog.mockReset();
+    mocks.eventDispatchedAdd.mockReset();
+    mocks.dispatchFailureAdd.mockReset();
+    mocks.drainBatchRecord.mockReset();
+  });
+
+  it('records an empty drain batch tick', async () => {
+    mocks.drainAll.mockResolvedValueOnce([]);
+
+    await drainAndDispatch();
+
+    expect(mocks.drainBatchRecord).toHaveBeenCalledWith(0);
+    expect(mocks.eventDispatchedAdd).not.toHaveBeenCalled();
+    expect(mocks.dispatchFailureAdd).not.toHaveBeenCalled();
   });
 
   it('logs sanitized context, captures failed subscriber exceptions, and records a row failure', async () => {
@@ -85,6 +114,8 @@ describe('drainAndDispatch', () => {
       errorName: 'Error',
       errorMessage: 'subscriber failed',
     });
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'handler'});
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 
@@ -131,6 +162,8 @@ describe('drainAndDispatch', () => {
       }),
     });
     expect(JSON.stringify(captureOptions)).not.toContain('raw-secret');
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'validation'});
   });
 
   it('passes the parsed payload to handlers when validation succeeds', async () => {
@@ -152,6 +185,7 @@ describe('drainAndDispatch', () => {
       expect.objectContaining({type: event.type, payload: parsed}),
     );
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'succeeded'});
     expect(mocks.recordDispatchFailure).not.toHaveBeenCalled();
   });
 
@@ -170,6 +204,7 @@ describe('drainAndDispatch', () => {
     await drainAndDispatch();
 
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'succeeded'});
     expect(mocks.recordDispatchFailure).not.toHaveBeenCalled();
   });
 
@@ -225,6 +260,11 @@ describe('drainAndDispatch', () => {
         issues: error.issues,
       },
     });
+    expect(mocks.drainBatchRecord).toHaveBeenCalledWith(3);
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'validation'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'succeeded'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledTimes(3);
   });
 
   it('records a row failure and skips dispatch when one of several handlers fails', async () => {
@@ -255,6 +295,8 @@ describe('drainAndDispatch', () => {
       errorName: 'Error',
       errorMessage: 'second handler failed',
     });
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'handler'});
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -114,8 +114,14 @@ describe('drainAndDispatch', () => {
       errorName: 'Error',
       errorMessage: 'subscriber failed',
     });
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
-    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'handler'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'projects',
+      outcome: 'failed',
+    });
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {
+      module: 'projects',
+      reason: 'handler',
+    });
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 
@@ -162,8 +168,14 @@ describe('drainAndDispatch', () => {
       }),
     });
     expect(JSON.stringify(captureOptions)).not.toContain('raw-secret');
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
-    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'validation'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'definitions',
+      outcome: 'failed',
+    });
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {
+      module: 'definitions',
+      reason: 'validation',
+    });
   });
 
   it('passes the parsed payload to handlers when validation succeeds', async () => {
@@ -185,7 +197,10 @@ describe('drainAndDispatch', () => {
       expect.objectContaining({type: event.type, payload: parsed}),
     );
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'succeeded'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      outcome: 'succeeded',
+    });
     expect(mocks.recordDispatchFailure).not.toHaveBeenCalled();
   });
 
@@ -204,7 +219,10 @@ describe('drainAndDispatch', () => {
     await drainAndDispatch();
 
     expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'succeeded'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      outcome: 'succeeded',
+    });
     expect(mocks.recordDispatchFailure).not.toHaveBeenCalled();
   });
 
@@ -261,9 +279,22 @@ describe('drainAndDispatch', () => {
       },
     });
     expect(mocks.drainBatchRecord).toHaveBeenCalledWith(3);
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
-    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'validation'});
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'succeeded'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      outcome: 'failed',
+    });
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      reason: 'validation',
+    });
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      outcome: 'succeeded',
+    });
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'integrations',
+      outcome: 'succeeded',
+    });
     expect(mocks.eventDispatchedAdd).toHaveBeenCalledTimes(3);
   });
 
@@ -295,8 +326,14 @@ describe('drainAndDispatch', () => {
       errorName: 'Error',
       errorMessage: 'second handler failed',
     });
-    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {outcome: 'failed'});
-    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {reason: 'handler'});
+    expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      outcome: 'failed',
+    });
+    expect(mocks.dispatchFailureAdd).toHaveBeenCalledWith(1, {
+      module: 'workflows',
+      reason: 'handler',
+    });
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -9,9 +9,11 @@ import {
   recordDispatchFailure,
 } from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
+import {dispatchFailureCount, drainBatchSize, eventDispatchedCount} from '#metrics/index.js';
 
 export async function drainAndDispatch(): Promise<void> {
   const rows = await drainAll();
+  drainBatchSize.record(rows.length);
   if (rows.length === 0) return;
 
   const dispatched = new Map<string, string[]>();
@@ -20,6 +22,7 @@ export async function drainAndDispatch(): Promise<void> {
     const validation = validatePayload(row);
     if (!validation.success) {
       await recordDispatchFailure(row.source, row.id, validation.failure);
+      recordFailureMetric(validation.failure.kind);
       continue;
     }
 
@@ -46,11 +49,13 @@ export async function drainAndDispatch(): Promise<void> {
       dispatched.set(row.source, ids);
     } else if (dispatchFailure) {
       await recordDispatchFailure(row.source, row.id, dispatchFailure);
+      recordFailureMetric(dispatchFailure.kind);
     }
   }
 
   for (const [source, ids] of dispatched) {
     await markDispatched(source, ids);
+    eventDispatchedCount.add(ids.length, {outcome: 'succeeded'});
   }
 }
 
@@ -92,4 +97,9 @@ function failureFromHandler(row: DrainedEvent, error: unknown): OutboxDispatchFa
     errorName: error instanceof Error ? error.name : 'NonErrorThrown',
     errorMessage: error instanceof Error ? error.message : String(error),
   };
+}
+
+function recordFailureMetric(reason: OutboxDispatchFailure['kind']): void {
+  eventDispatchedCount.add(1, {outcome: 'failed'});
+  dispatchFailureCount.add(1, {reason});
 }

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -22,7 +22,7 @@ export async function drainAndDispatch(): Promise<void> {
     const validation = validatePayload(row);
     if (!validation.success) {
       await recordDispatchFailure(row.source, row.id, validation.failure);
-      recordFailureMetric(validation.failure.kind);
+      recordFailureMetric(row.source, validation.failure.kind);
       continue;
     }
 
@@ -49,13 +49,13 @@ export async function drainAndDispatch(): Promise<void> {
       dispatched.set(row.source, ids);
     } else if (dispatchFailure) {
       await recordDispatchFailure(row.source, row.id, dispatchFailure);
-      recordFailureMetric(dispatchFailure.kind);
+      recordFailureMetric(row.source, dispatchFailure.kind);
     }
   }
 
   for (const [source, ids] of dispatched) {
     await markDispatched(source, ids);
-    eventDispatchedCount.add(ids.length, {outcome: 'succeeded'});
+    eventDispatchedCount.add(ids.length, {module: source, outcome: 'succeeded'});
   }
 }
 
@@ -99,7 +99,7 @@ function failureFromHandler(row: DrainedEvent, error: unknown): OutboxDispatchFa
   };
 }
 
-function recordFailureMetric(reason: OutboxDispatchFailure['kind']): void {
-  eventDispatchedCount.add(1, {outcome: 'failed'});
-  dispatchFailureCount.add(1, {reason});
+function recordFailureMetric(source: string, reason: OutboxDispatchFailure['kind']): void {
+  eventDispatchedCount.add(1, {module: source, outcome: 'failed'});
+  dispatchFailureCount.add(1, {module: source, reason});
 }


### PR DESCRIPTION
Adds OpenTelemetry instance metrics to the API dispatcher drain path so outbox throughput, failure reasons, and per-tick batch sizes are visible from the point where dispatch outcomes are known.

The dispatcher owns the drain-and-dispatch boundary rather than shared outbox storage, so this records inline counters and a histogram instead of adding a service gauge. The touched package is private, so no changeset is included.

Closes ENG-572

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry instance metrics to the API dispatcher drain path to track outbox throughput, failure reasons, and per-tick batch sizes, labeled by source module. Closes ENG-572.

- **New Features**
  - Counter `dispatcher_event_dispatched` (labels: `module`, `outcome` = `succeeded` | `failed`).
  - Counter `dispatcher_dispatch_failure` (labels: `module`, `reason` = `validation` | `handler`).
  - Histogram `dispatcher_drain_batch` records batch size per drain tick.

<sup>Written for commit eafa843fde07b16e6a1870b93380c7b8325097ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

