### PR TITLE
[api/auth] Instrument token metrics

### DIFF
--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -60,6 +60,7 @@
     "@shipfox/node-email": "workspace:*",
     "@shipfox/node-mailer": "workspace:*",
     "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-tokens": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -32,7 +32,7 @@ import {
   markEmailVerified,
   updateUserPassword,
 } from '#db/users.js';
-import {type AuthTokenRefreshOutcome, tokenRefreshedCount} from '#metrics/index.js';
+import {type AuthTokenRefreshOutcome, recordTokenRefreshed} from '#metrics/index.js';
 import type {RefreshToken} from './entities/refresh-token.js';
 import type {User} from './entities/user.js';
 import {
@@ -66,7 +66,7 @@ function daysFromNow(days: number): Date {
 }
 
 function recordRefreshOutcome(outcome: AuthTokenRefreshOutcome): void {
-  tokenRefreshedCount.add(1, {outcome});
+  recordTokenRefreshed(outcome);
 }
 
 async function signAccessToken(user: User): Promise<string> {

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -32,6 +32,7 @@ import {
   markEmailVerified,
   updateUserPassword,
 } from '#db/users.js';
+import {type AuthTokenRefreshOutcome, tokenRefreshedCount} from '#metrics/index.js';
 import type {RefreshToken} from './entities/refresh-token.js';
 import type {User} from './entities/user.js';
 import {
@@ -62,6 +63,10 @@ function hoursFromNow(hours: number): Date {
 
 function daysFromNow(days: number): Date {
   return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+}
+
+function recordRefreshOutcome(outcome: AuthTokenRefreshOutcome): void {
+  tokenRefreshedCount.add(1, {outcome});
 }
 
 async function signAccessToken(user: User): Promise<string> {
@@ -321,12 +326,14 @@ export async function refreshAccessToken(params: {
   const currentHashedToken = hashOpaqueToken(params.refreshToken);
   const current = await findRefreshTokenByHash({hashedToken: currentHashedToken});
   if (!current) {
+    recordRefreshOutcome('rejected');
     throw new TokenInvalidError('Refresh token is invalid or expired');
   }
 
   const user = await findUserById({id: current.userId});
   if (user?.status !== 'active') {
     await revokeRefreshTokenByHash({hashedToken: currentHashedToken});
+    recordRefreshOutcome('rejected');
     throw new TokenInvalidError('Refresh token is invalid or expired');
   }
 
@@ -335,9 +342,11 @@ export async function refreshAccessToken(params: {
   if (current.rotatedAt) {
     if (isWithinRotationGrace(current)) {
       const token = await signAccessToken(user);
+      recordRefreshOutcome('grace');
       return {token, refreshToken: undefined, user};
     }
     await revokeRefreshTokensForUser({userId: user.id});
+    recordRefreshOutcome('rejected');
     throw new TokenInvalidError('Refresh token reused after rotation');
   }
 
@@ -353,13 +362,16 @@ export async function refreshAccessToken(params: {
   if (!rotated) {
     const latest = await findRefreshTokenByHash({hashedToken: currentHashedToken});
     if (!latest || !isWithinRotationGrace(latest)) {
+      recordRefreshOutcome('rejected');
       throw new TokenInvalidError('Refresh token is invalid or expired');
     }
     const token = await signAccessToken(user);
+    recordRefreshOutcome('grace');
     return {token, refreshToken: undefined, user};
   }
 
   const token = await signAccessToken(user);
+  recordRefreshOutcome('rotated');
   return {token, refreshToken: nextRefreshToken, user};
 }
 

--- a/libs/api/auth/src/core/job-lease-token.test.ts
+++ b/libs/api/auth/src/core/job-lease-token.test.ts
@@ -33,6 +33,34 @@ describe('job-lease-token', () => {
     expect(verified?.exp).toBeGreaterThan(verified?.iat ?? 0);
   });
 
+  test('returns claims when metric recording fails after successful verification', async () => {
+    vi.resetModules();
+    vi.doMock('@shipfox/node-opentelemetry', () => ({
+      instanceMetrics: {
+        getMeter: () => ({
+          createCounter: () => ({
+            add: () => {
+              throw new Error('metrics unavailable');
+            },
+          }),
+        }),
+      },
+    }));
+
+    try {
+      const tokenModule = await import('./job-lease-token.js');
+      const input = claims();
+
+      const token = await tokenModule.issueJobLeaseToken(input);
+      const verified = await tokenModule.verifyJobLeaseToken(token);
+
+      expect(verified?.jobId).toBe(input.jobId);
+    } finally {
+      vi.doUnmock('@shipfox/node-opentelemetry');
+      vi.resetModules();
+    }
+  });
+
   test('accepts UUIDv7 ids (job/run primary keys are uuidv7)', async () => {
     const input = {
       jobId: '018f6b1e-7e2a-7b3c-8d4e-5f6a7b8c9d0e',

--- a/libs/api/auth/src/core/job-lease-token.ts
+++ b/libs/api/auth/src/core/job-lease-token.ts
@@ -5,12 +5,13 @@ import {
 } from '@shipfox/api-auth-dto';
 import {signHs256, verifyHs256} from '@shipfox/node-jwt';
 import {config} from '#config.js';
+import {tokenIssuedCount, tokenVerifiedCount} from '#metrics/index.js';
 
 // `aud`, `iat` and `exp` are set by the codec (jose); callers supply the business ids only.
 export type IssueJobLeaseTokenParams = Omit<JobLeaseTokenClaims, 'aud' | 'iat' | 'exp'>;
 
 export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Promise<string> {
-  return await signHs256({
+  const token = await signHs256({
     payload: {
       jobId: claims.jobId,
       runId: claims.runId,
@@ -22,18 +23,23 @@ export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Prom
     expiresIn: config.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN,
     audience: JOB_LEASE_TOKEN_AUDIENCE,
   });
+  tokenIssuedCount.add(1, {token_type: 'job_lease'});
+  return token;
 }
 
 /** Returns the claims on success, or `null` for any invalid input — never throws. */
 export async function verifyJobLeaseToken(token: string): Promise<JobLeaseTokenClaims | null> {
   try {
-    return await verifyHs256({
+    const claims = await verifyHs256({
       token,
       secret: config.AUTH_JOB_LEASE_TOKEN_SECRET,
       schema: jobLeaseTokenClaimsSchema,
       audience: JOB_LEASE_TOKEN_AUDIENCE,
     });
+    tokenVerifiedCount.add(1, {token_type: 'job_lease', outcome: 'ok'});
+    return claims;
   } catch {
+    tokenVerifiedCount.add(1, {token_type: 'job_lease', outcome: 'rejected'});
     return null;
   }
 }

--- a/libs/api/auth/src/core/job-lease-token.ts
+++ b/libs/api/auth/src/core/job-lease-token.ts
@@ -5,7 +5,7 @@ import {
 } from '@shipfox/api-auth-dto';
 import {signHs256, verifyHs256} from '@shipfox/node-jwt';
 import {config} from '#config.js';
-import {tokenIssuedCount, tokenVerifiedCount} from '#metrics/index.js';
+import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
 
 // `aud`, `iat` and `exp` are set by the codec (jose); callers supply the business ids only.
 export type IssueJobLeaseTokenParams = Omit<JobLeaseTokenClaims, 'aud' | 'iat' | 'exp'>;
@@ -23,7 +23,7 @@ export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Prom
     expiresIn: config.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN,
     audience: JOB_LEASE_TOKEN_AUDIENCE,
   });
-  tokenIssuedCount.add(1, {token_type: 'job_lease'});
+  recordTokenIssued('job_lease');
   return token;
 }
 
@@ -36,10 +36,10 @@ export async function verifyJobLeaseToken(token: string): Promise<JobLeaseTokenC
       schema: jobLeaseTokenClaimsSchema,
       audience: JOB_LEASE_TOKEN_AUDIENCE,
     });
-    tokenVerifiedCount.add(1, {token_type: 'job_lease', outcome: 'ok'});
+    recordTokenVerified('job_lease', 'ok');
     return claims;
   } catch {
-    tokenVerifiedCount.add(1, {token_type: 'job_lease', outcome: 'rejected'});
+    recordTokenVerified('job_lease', 'rejected');
     return null;
   }
 }

--- a/libs/api/auth/src/core/jwt.ts
+++ b/libs/api/auth/src/core/jwt.ts
@@ -1,6 +1,7 @@
 import {workspaceRoleSchema} from '@shipfox/api-workspaces-dto';
 import {signHs256, verifyHs256} from '@shipfox/node-jwt';
 import {z} from 'zod';
+import {tokenIssuedCount, tokenVerifiedCount} from '#metrics/index.js';
 
 export const tokenMembershipSchema = z.object({
   workspaceId: z.string().uuid(),
@@ -35,7 +36,7 @@ export interface VerifyUserTokenParams {
 }
 
 export async function signUserToken(params: SignUserTokenParams): Promise<string> {
-  return await signHs256({
+  const token = await signHs256({
     payload: {
       email: params.email,
       name: params.name ?? null,
@@ -45,12 +46,21 @@ export async function signUserToken(params: SignUserTokenParams): Promise<string
     expiresIn: params.expiresIn,
     subject: params.userId,
   });
+  tokenIssuedCount.add(1, {token_type: 'session'});
+  return token;
 }
 
 export async function verifyUserToken(params: VerifyUserTokenParams): Promise<UserTokenClaims> {
-  return await verifyHs256({
-    token: params.token,
-    secret: params.secret,
-    schema: userTokenClaimsSchema,
-  });
+  try {
+    const claims = await verifyHs256({
+      token: params.token,
+      secret: params.secret,
+      schema: userTokenClaimsSchema,
+    });
+    tokenVerifiedCount.add(1, {token_type: 'session', outcome: 'ok'});
+    return claims;
+  } catch (error) {
+    tokenVerifiedCount.add(1, {token_type: 'session', outcome: 'rejected'});
+    throw error;
+  }
 }

--- a/libs/api/auth/src/core/jwt.ts
+++ b/libs/api/auth/src/core/jwt.ts
@@ -1,7 +1,7 @@
 import {workspaceRoleSchema} from '@shipfox/api-workspaces-dto';
 import {signHs256, verifyHs256} from '@shipfox/node-jwt';
 import {z} from 'zod';
-import {tokenIssuedCount, tokenVerifiedCount} from '#metrics/index.js';
+import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
 
 export const tokenMembershipSchema = z.object({
   workspaceId: z.string().uuid(),
@@ -46,7 +46,7 @@ export async function signUserToken(params: SignUserTokenParams): Promise<string
     expiresIn: params.expiresIn,
     subject: params.userId,
   });
-  tokenIssuedCount.add(1, {token_type: 'session'});
+  recordTokenIssued('session');
   return token;
 }
 
@@ -57,10 +57,10 @@ export async function verifyUserToken(params: VerifyUserTokenParams): Promise<Us
       secret: params.secret,
       schema: userTokenClaimsSchema,
     });
-    tokenVerifiedCount.add(1, {token_type: 'session', outcome: 'ok'});
+    recordTokenVerified('session', 'ok');
     return claims;
   } catch (error) {
-    tokenVerifiedCount.add(1, {token_type: 'session', outcome: 'rejected'});
+    recordTokenVerified('session', 'rejected');
     throw error;
   }
 }

--- a/libs/api/auth/src/metrics/index.ts
+++ b/libs/api/auth/src/metrics/index.ts
@@ -2,7 +2,7 @@ export {
   type AuthTokenRefreshOutcome,
   type AuthTokenType,
   type AuthTokenVerificationOutcome,
-  tokenIssuedCount,
-  tokenRefreshedCount,
-  tokenVerifiedCount,
+  recordTokenIssued,
+  recordTokenRefreshed,
+  recordTokenVerified,
 } from './instance.js';

--- a/libs/api/auth/src/metrics/index.ts
+++ b/libs/api/auth/src/metrics/index.ts
@@ -1,0 +1,8 @@
+export {
+  type AuthTokenRefreshOutcome,
+  type AuthTokenType,
+  type AuthTokenVerificationOutcome,
+  tokenIssuedCount,
+  tokenRefreshedCount,
+  tokenVerifiedCount,
+} from './instance.js';

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -6,17 +6,39 @@ export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
 
 const meter = instanceMetrics.getMeter('auth');
 
-export const tokenIssuedCount = meter.createCounter<{token_type: AuthTokenType}>(
-  'auth_token_issued',
-  {description: 'Tokens issued by token type'},
-);
+const tokenIssuedCount = meter.createCounter<{token_type: AuthTokenType}>('auth_token_issued', {
+  description: 'Tokens issued by token type',
+});
 
-export const tokenVerifiedCount = meter.createCounter<{
+const tokenVerifiedCount = meter.createCounter<{
   token_type: AuthTokenType;
   outcome: AuthTokenVerificationOutcome;
 }>('auth_token_verified', {description: 'Token verification attempts by token type and outcome'});
 
-export const tokenRefreshedCount = meter.createCounter<{outcome: AuthTokenRefreshOutcome}>(
+const tokenRefreshedCount = meter.createCounter<{outcome: AuthTokenRefreshOutcome}>(
   'auth_token_refreshed',
   {description: 'Refresh-token exchanges by outcome'},
 );
+
+function recordMetric(record: () => void): void {
+  try {
+    record();
+  } catch {
+    // Metrics must not affect authentication outcomes.
+  }
+}
+
+export function recordTokenIssued(tokenType: AuthTokenType): void {
+  recordMetric(() => tokenIssuedCount.add(1, {token_type: tokenType}));
+}
+
+export function recordTokenVerified(
+  tokenType: AuthTokenType,
+  outcome: AuthTokenVerificationOutcome,
+): void {
+  recordMetric(() => tokenVerifiedCount.add(1, {token_type: tokenType, outcome}));
+}
+
+export function recordTokenRefreshed(outcome: AuthTokenRefreshOutcome): void {
+  recordMetric(() => tokenRefreshedCount.add(1, {outcome}));
+}

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -1,0 +1,22 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+export type AuthTokenType = 'session' | 'job_lease';
+export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
+export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
+
+const meter = instanceMetrics.getMeter('auth');
+
+export const tokenIssuedCount = meter.createCounter<{token_type: AuthTokenType}>(
+  'auth_token_issued',
+  {description: 'Tokens issued by token type'},
+);
+
+export const tokenVerifiedCount = meter.createCounter<{
+  token_type: AuthTokenType;
+  outcome: AuthTokenVerificationOutcome;
+}>('auth_token_verified', {description: 'Token verification attempts by token type and outcome'});
+
+export const tokenRefreshedCount = meter.createCounter<{outcome: AuthTokenRefreshOutcome}>(
+  'auth_token_refreshed',
+  {description: 'Refresh-token exchanges by outcome'},
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../shared/node/postgres


### PR DESCRIPTION
Adds OpenTelemetry instance counters to `@shipfox/api-auth` for session and job lease token issuance, token verification outcomes, and refresh-token exchange outcomes.

Auth token flows currently lack module-owned metric signals, which makes it harder to observe issuance, rejected verification attempts, and refresh behavior. The new metrics use bounded labels only and intentionally avoid token material, user ids, workspace ids, job ids, and other unbounded identifiers.

No service gauge is added because auth does not currently own shared point-in-time state worth scraping through the module metrics hook.

Closes ENG-577

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry counters to `@shipfox/api-auth` to track token issuance, verification results, and refresh outcomes for session and job-lease tokens. Metrics use bounded labels only and are best-effort so failures never affect auth (ENG-577).

- **New Features**
  - Counters: auth_token_issued, auth_token_verified, auth_token_refreshed.
  - Token types/outcomes: session, job_lease; ok/rejected and rotated/grace/rejected.
  - Hooked into session and job-lease issue/verify, plus refresh flow (rotation and grace).
  - Metrics recording errors are swallowed and never change token behavior.

- **Dependencies**
  - Added `@shipfox/node-opentelemetry`.

<sup>Written for commit 85409c4634a0bb7e13f3c038dbaaa53dfe77e129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

