### PR TITLE
[api-logs] Add OpenTelemetry metrics

### DIFF
--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -1,5 +1,10 @@
 import {Buffer} from 'node:buffer';
-import {parseAppendableLogRecordLine, parseLogRecordLine} from '@shipfox/api-logs-dto';
+import {
+  type AppendableLogRecord,
+  type LogRecord,
+  parseAppendableLogRecordLine,
+  parseLogRecordLine,
+} from '@shipfox/api-logs-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {accrueStoredBytes, claimCap, ensureJobAccounting, isJobCapped} from '#db/accounting.js';
@@ -11,7 +16,12 @@ import {
   getOrCreateAttemptStreamWithStatus,
   setDeclaredTotalBytes,
 } from '#db/streams.js';
-import {recordAppendedCount, streamClosedCount, streamOpenedCount} from '#metrics/instance.js';
+import {
+  type LogRecordMetricKind,
+  recordAppendedCount,
+  streamClosedCount,
+  streamOpenedCount,
+} from '#metrics/instance.js';
 import {allowedBudget} from './budget.js';
 import {closeStream, controlTombstone} from './close-stream.js';
 import {MalformedLogChunkError, OffsetGapError} from './errors.js';
@@ -33,9 +43,8 @@ export interface AppendLogsResult {
 }
 
 interface ParsedBody {
-  agentSessionRecordCount: number;
   declaredTotalBytes?: number;
-  processRecordCount: number;
+  recordCounts: Partial<Record<AppendableLogRecord['type'], number>>;
 }
 
 /**
@@ -51,7 +60,7 @@ interface ParsedBody {
  * its type via `forgedType` for the narrowed audit warn.
  */
 function parseAppendBody(body: Buffer): ParsedBody {
-  if (body.length === 0) return {agentSessionRecordCount: 0, processRecordCount: 0};
+  if (body.length === 0) return {recordCounts: {}};
 
   const text = body.toString('utf8');
   if (!text.endsWith('\n')) {
@@ -60,9 +69,8 @@ function parseAppendBody(body: Buffer): ParsedBody {
   const lines = text.split('\n');
   lines.pop();
 
-  let agentSessionRecordCount = 0;
   let declaredTotalBytes: number | undefined;
-  let processRecordCount = 0;
+  const recordCounts: Partial<Record<AppendableLogRecord['type'], number>> = {};
   for (const line of lines) {
     let record: ReturnType<typeof parseAppendableLogRecordLine>;
     try {
@@ -73,11 +81,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
         detectForgedType(line),
       );
     }
-    if (record.type === 'agent_session') {
-      agentSessionRecordCount += 1;
-    } else {
-      processRecordCount += 1;
-    }
+    recordCounts[record.type] = (recordCounts[record.type] ?? 0) + 1;
     if (record.type === 'end') {
       declaredTotalBytes = record.total_bytes;
     }
@@ -94,9 +98,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
     }
   }
 
-  return declaredTotalBytes === undefined
-    ? {agentSessionRecordCount, processRecordCount}
-    : {agentSessionRecordCount, declaredTotalBytes, processRecordCount};
+  return declaredTotalBytes === undefined ? {recordCounts} : {declaredTotalBytes, recordCounts};
 }
 
 /**
@@ -143,7 +145,7 @@ interface StoreChunkResult extends AppendLogsResult {
    * not whole and must not be declared-closed.
    */
   stored: boolean;
-  systemRecordCount: number;
+  recordCounts: Partial<Record<LogRecord['type'], number>>;
 }
 
 /**
@@ -160,7 +162,7 @@ async function storeChunk(
 
   // Already capped: accept-and-drop. committed_length has advanced so the runner
   // drains its spool cleanly instead of retry-looping; nothing is stored.
-  if (!accrued) return {committedLength, capped: true, stored: false, systemRecordCount: 0};
+  if (!accrued) return {committedLength, capped: true, stored: false, recordCounts: {}};
 
   await insertChunk(tx, {
     streamId,
@@ -179,7 +181,7 @@ async function storeChunk(
     elapsedMs: Date.now() - accrued.startedAt.getTime(),
   });
   if (accrued.used <= allowed) {
-    return {committedLength, capped: false, stored: true, systemRecordCount: 0};
+    return {committedLength, capped: false, stored: true, recordCounts: {}};
   }
 
   // Over budget. No hard ceiling: this crossing append is stored in full (overshoot
@@ -196,7 +198,12 @@ async function storeChunk(
       origin: 'control',
     });
   }
-  return {committedLength, capped: true, stored: true, systemRecordCount: won ? 1 : 0};
+  return {
+    committedLength,
+    capped: true,
+    stored: true,
+    recordCounts: won ? {capped: 1} : {},
+  };
 }
 
 /**
@@ -226,11 +233,9 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
   const {declaredTotalBytes} = parsed;
   const byteLen = params.body.length;
   const metrics = {
-    agentSessionRecordCount: 0,
-    processRecordCount: 0,
+    recordCounts: {} as Partial<Record<LogRecordMetricKind, number>>,
     streamClosedReason: undefined as 'declared' | undefined,
     streamOpened: false,
-    systemRecordCount: 0,
   };
 
   const result = await db().transaction(async (tx) => {
@@ -263,7 +268,7 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       return {committedLength: cas.committedLength, capped: await isJobCapped(tx, params.jobId)};
     }
 
-    const {stored, systemRecordCount, ...result} = await storeChunk(tx, {
+    const {recordCounts, stored, ...result} = await storeChunk(tx, {
       params,
       streamId: stream.id,
       byteLen,
@@ -271,10 +276,9 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       declaredTotalBytes,
     });
     if (stored) {
-      metrics.agentSessionRecordCount += parsed.agentSessionRecordCount;
-      metrics.processRecordCount += parsed.processRecordCount;
+      addRecordCounts(metrics.recordCounts, parsed.recordCounts);
     }
-    metrics.systemRecordCount += systemRecordCount;
+    addRecordCounts(metrics.recordCounts, recordCounts);
 
     // The runner's end record was committed in this append (offset-CAS guarantees
     // everything before it is already committed), so the stream is whole. Declared-close
@@ -291,18 +295,21 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
   });
 
   if (metrics.streamOpened) streamOpenedCount.add(1);
-  if (metrics.processRecordCount > 0) {
-    recordAppendedCount.add(metrics.processRecordCount, {kind: 'process'});
-  }
-  if (metrics.agentSessionRecordCount > 0) {
-    recordAppendedCount.add(metrics.agentSessionRecordCount, {kind: 'agent_session'});
-  }
-  if (metrics.systemRecordCount > 0) {
-    recordAppendedCount.add(metrics.systemRecordCount, {kind: 'system'});
+  for (const [kind, count] of Object.entries(metrics.recordCounts)) {
+    if (count > 0) recordAppendedCount.add(count, {kind: kind as LogRecordMetricKind});
   }
   if (metrics.streamClosedReason) {
     streamClosedCount.add(1, {reason: metrics.streamClosedReason});
   }
 
   return result;
+}
+
+function addRecordCounts(
+  target: Partial<Record<LogRecordMetricKind, number>>,
+  source: Partial<Record<LogRecordMetricKind, number>>,
+): void {
+  for (const [kind, count] of Object.entries(source)) {
+    target[kind as LogRecordMetricKind] = (target[kind as LogRecordMetricKind] ?? 0) + (count ?? 0);
+  }
 }

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -8,9 +8,10 @@ import {db, type Transaction} from '#db/db.js';
 import {
   casExtendCommittedLength,
   getAttemptStream,
-  getOrCreateAttemptStream,
+  getOrCreateAttemptStreamWithStatus,
   setDeclaredTotalBytes,
 } from '#db/streams.js';
+import {recordAppendedCount, streamClosedCount, streamOpenedCount} from '#metrics/instance.js';
 import {allowedBudget} from './budget.js';
 import {closeStream, controlTombstone} from './close-stream.js';
 import {MalformedLogChunkError, OffsetGapError} from './errors.js';
@@ -33,6 +34,7 @@ export interface AppendLogsResult {
 
 interface ParsedBody {
   declaredTotalBytes?: number;
+  recordCount: number;
 }
 
 /**
@@ -48,7 +50,7 @@ interface ParsedBody {
  * its type via `forgedType` for the narrowed audit warn.
  */
 function parseAppendBody(body: Buffer): ParsedBody {
-  if (body.length === 0) return {};
+  if (body.length === 0) return {recordCount: 0};
 
   const text = body.toString('utf8');
   if (!text.endsWith('\n')) {
@@ -58,6 +60,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
   lines.pop();
 
   let declaredTotalBytes: number | undefined;
+  let recordCount = 0;
   for (const line of lines) {
     let record: ReturnType<typeof parseAppendableLogRecordLine>;
     try {
@@ -68,6 +71,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
         detectForgedType(line),
       );
     }
+    recordCount += 1;
     if (record.type === 'end') {
       declaredTotalBytes = record.total_bytes;
     }
@@ -84,7 +88,7 @@ function parseAppendBody(body: Buffer): ParsedBody {
     }
   }
 
-  return declaredTotalBytes === undefined ? {} : {declaredTotalBytes};
+  return declaredTotalBytes === undefined ? {recordCount} : {declaredTotalBytes, recordCount};
 }
 
 /**
@@ -131,6 +135,7 @@ interface StoreChunkResult extends AppendLogsResult {
    * not whole and must not be declared-closed.
    */
   stored: boolean;
+  systemRecordCount: number;
 }
 
 /**
@@ -147,7 +152,7 @@ async function storeChunk(
 
   // Already capped: accept-and-drop. committed_length has advanced so the runner
   // drains its spool cleanly instead of retry-looping; nothing is stored.
-  if (!accrued) return {committedLength, capped: true, stored: false};
+  if (!accrued) return {committedLength, capped: true, stored: false, systemRecordCount: 0};
 
   await insertChunk(tx, {
     streamId,
@@ -165,7 +170,9 @@ async function storeChunk(
     ratePerMinuteBytes: config.LOG_BUDGET_RATE_BYTES_PER_MINUTE,
     elapsedMs: Date.now() - accrued.startedAt.getTime(),
   });
-  if (accrued.used <= allowed) return {committedLength, capped: false, stored: true};
+  if (accrued.used <= allowed) {
+    return {committedLength, capped: false, stored: true, systemRecordCount: 0};
+  }
 
   // Over budget. No hard ceiling: this crossing append is stored in full (overshoot
   // bounded by one body). Claim the cap once and inject an in-band `capped` tombstone
@@ -181,7 +188,7 @@ async function storeChunk(
       origin: 'control',
     });
   }
-  return {committedLength, capped: true, stored: true};
+  return {committedLength, capped: true, stored: true, systemRecordCount: won ? 1 : 0};
 }
 
 /**
@@ -210,11 +217,17 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
   }
   const {declaredTotalBytes} = parsed;
   const byteLen = params.body.length;
+  const metrics = {
+    processRecordCount: 0,
+    streamClosedReason: undefined as 'declared' | undefined,
+    streamOpened: false,
+    systemRecordCount: 0,
+  };
 
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     if (byteLen === 0) return readHeartbeat(tx, params);
 
-    const stream = await getOrCreateAttemptStream(tx, {
+    const {created, stream} = await getOrCreateAttemptStreamWithStatus(tx, {
       jobId: params.jobId,
       stepId: params.stepId,
       attempt: params.attempt,
@@ -222,6 +235,7 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       projectId: params.projectId,
       runId: params.runId,
     });
+    metrics.streamOpened = created;
 
     // Closed stream (the runner's end already landed, or the job-terminated sweep ran):
     // accept-and-drop so a late chunk can never race compaction. committed_length is
@@ -240,13 +254,15 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       return {committedLength: cas.committedLength, capped: await isJobCapped(tx, params.jobId)};
     }
 
-    const {stored, ...result} = await storeChunk(tx, {
+    const {stored, systemRecordCount, ...result} = await storeChunk(tx, {
       params,
       streamId: stream.id,
       byteLen,
       committedLength: cas.committedLength,
       declaredTotalBytes,
     });
+    if (stored) metrics.processRecordCount += parsed.recordCount;
+    metrics.systemRecordCount += systemRecordCount;
 
     // The runner's end record was committed in this append (offset-CAS guarantees
     // everything before it is already committed), so the stream is whole. Declared-close
@@ -255,9 +271,23 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
     // already capped persists nothing, so the stream is not whole and stays open for the
     // timeout sweep to close it as truncated.
     if (declaredTotalBytes !== undefined && stored) {
-      await closeStream(tx, {streamId: stream.id, reason: 'declared'});
+      const closed = await closeStream(tx, {streamId: stream.id, reason: 'declared'});
+      if (closed) metrics.streamClosedReason = 'declared';
     }
 
     return result;
   });
+
+  if (metrics.streamOpened) streamOpenedCount.add(1);
+  if (metrics.processRecordCount > 0) {
+    recordAppendedCount.add(metrics.processRecordCount, {kind: 'process'});
+  }
+  if (metrics.systemRecordCount > 0) {
+    recordAppendedCount.add(metrics.systemRecordCount, {kind: 'system'});
+  }
+  if (metrics.streamClosedReason) {
+    streamClosedCount.add(1, {reason: metrics.streamClosedReason});
+  }
+
+  return result;
 }

--- a/libs/api/logs/src/core/append-logs.ts
+++ b/libs/api/logs/src/core/append-logs.ts
@@ -33,8 +33,9 @@ export interface AppendLogsResult {
 }
 
 interface ParsedBody {
+  agentSessionRecordCount: number;
   declaredTotalBytes?: number;
-  recordCount: number;
+  processRecordCount: number;
 }
 
 /**
@@ -50,7 +51,7 @@ interface ParsedBody {
  * its type via `forgedType` for the narrowed audit warn.
  */
 function parseAppendBody(body: Buffer): ParsedBody {
-  if (body.length === 0) return {recordCount: 0};
+  if (body.length === 0) return {agentSessionRecordCount: 0, processRecordCount: 0};
 
   const text = body.toString('utf8');
   if (!text.endsWith('\n')) {
@@ -59,8 +60,9 @@ function parseAppendBody(body: Buffer): ParsedBody {
   const lines = text.split('\n');
   lines.pop();
 
+  let agentSessionRecordCount = 0;
   let declaredTotalBytes: number | undefined;
-  let recordCount = 0;
+  let processRecordCount = 0;
   for (const line of lines) {
     let record: ReturnType<typeof parseAppendableLogRecordLine>;
     try {
@@ -71,7 +73,11 @@ function parseAppendBody(body: Buffer): ParsedBody {
         detectForgedType(line),
       );
     }
-    recordCount += 1;
+    if (record.type === 'agent_session') {
+      agentSessionRecordCount += 1;
+    } else {
+      processRecordCount += 1;
+    }
     if (record.type === 'end') {
       declaredTotalBytes = record.total_bytes;
     }
@@ -88,7 +94,9 @@ function parseAppendBody(body: Buffer): ParsedBody {
     }
   }
 
-  return declaredTotalBytes === undefined ? {recordCount} : {declaredTotalBytes, recordCount};
+  return declaredTotalBytes === undefined
+    ? {agentSessionRecordCount, processRecordCount}
+    : {agentSessionRecordCount, declaredTotalBytes, processRecordCount};
 }
 
 /**
@@ -218,6 +226,7 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
   const {declaredTotalBytes} = parsed;
   const byteLen = params.body.length;
   const metrics = {
+    agentSessionRecordCount: 0,
     processRecordCount: 0,
     streamClosedReason: undefined as 'declared' | undefined,
     streamOpened: false,
@@ -261,7 +270,10 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
       committedLength: cas.committedLength,
       declaredTotalBytes,
     });
-    if (stored) metrics.processRecordCount += parsed.recordCount;
+    if (stored) {
+      metrics.agentSessionRecordCount += parsed.agentSessionRecordCount;
+      metrics.processRecordCount += parsed.processRecordCount;
+    }
     metrics.systemRecordCount += systemRecordCount;
 
     // The runner's end record was committed in this append (offset-CAS guarantees
@@ -281,6 +293,9 @@ export async function appendLogs(params: AppendLogsParams): Promise<AppendLogsRe
   if (metrics.streamOpened) streamOpenedCount.add(1);
   if (metrics.processRecordCount > 0) {
     recordAppendedCount.add(metrics.processRecordCount, {kind: 'process'});
+  }
+  if (metrics.agentSessionRecordCount > 0) {
+    recordAppendedCount.add(metrics.agentSessionRecordCount, {kind: 'agent_session'});
   }
   if (metrics.systemRecordCount > 0) {
     recordAppendedCount.add(metrics.systemRecordCount, {kind: 'system'});

--- a/libs/api/logs/src/core/reap-stale-open-streams.ts
+++ b/libs/api/logs/src/core/reap-stale-open-streams.ts
@@ -47,7 +47,7 @@ export async function reapStaleOpenStreams(
       );
       if (closed) {
         result.reaped += 1;
-        recordAppendedCount.add(1, {kind: 'system'});
+        recordAppendedCount.add(1, {kind: 'runner_lost'});
         streamClosedCount.add(1, {reason: 'timeout'});
       }
     } catch (error) {

--- a/libs/api/logs/src/core/reap-stale-open-streams.ts
+++ b/libs/api/logs/src/core/reap-stale-open-streams.ts
@@ -1,6 +1,7 @@
 import {logger} from '@shipfox/node-opentelemetry';
 import {db} from '#db/db.js';
 import {listStaleOpenStreams} from '#db/streams.js';
+import {recordAppendedCount, streamClosedCount} from '#metrics/instance.js';
 import {closeStream} from './close-stream.js';
 
 export interface ReapStaleOpenStreamsResult {
@@ -44,7 +45,11 @@ export async function reapStaleOpenStreams(
       const closed = await db().transaction((tx) =>
         closeStream(tx, {streamId: stream.id, reason: 'timeout'}),
       );
-      if (closed) result.reaped += 1;
+      if (closed) {
+        result.reaped += 1;
+        recordAppendedCount.add(1, {kind: 'system'});
+        streamClosedCount.add(1, {reason: 'timeout'});
+      }
     } catch (error) {
       result.failed += 1;
       logger().error({err: error, streamId: stream.id}, 'Failed to reap stale open log stream');

--- a/libs/api/logs/src/db/streams.test.ts
+++ b/libs/api/logs/src/db/streams.test.ts
@@ -32,7 +32,7 @@ describe('getOpenStreamCount', () => {
   it('reports zero when no streams are open', async () => {
     const count = await getOpenStreamCount();
 
-    expect(count).toBe(0);
+    expect(count).toBe(0n);
   });
 
   it('counts only streams that are still open', async () => {
@@ -48,6 +48,6 @@ describe('getOpenStreamCount', () => {
 
     const count = await getOpenStreamCount();
 
-    expect(count).toBe(1);
+    expect(count).toBe(1n);
   });
 });

--- a/libs/api/logs/src/db/streams.test.ts
+++ b/libs/api/logs/src/db/streams.test.ts
@@ -1,0 +1,53 @@
+import {sql} from 'drizzle-orm';
+import {appendLogs} from '#core/append-logs.js';
+import {db} from '#db/db.js';
+import {endLine, ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
+import {getOpenStreamCount} from './streams.js';
+
+interface Ctx {
+  jobId: string;
+  stepId: string;
+  workspaceId: string;
+  projectId: string;
+  runId: string;
+}
+
+function newCtx(): Ctx {
+  return {
+    jobId: crypto.randomUUID(),
+    stepId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    runId: crypto.randomUUID(),
+  };
+}
+
+describe('getOpenStreamCount', () => {
+  beforeEach(async () => {
+    await db().execute(
+      sql`TRUNCATE logs_chunks, logs_attempt_streams, logs_job_accounting, logs_outbox CASCADE`,
+    );
+  });
+
+  it('reports zero when no streams are open', async () => {
+    const count = await getOpenStreamCount();
+
+    expect(count).toBe(0);
+  });
+
+  it('counts only streams that are still open', async () => {
+    const open = newCtx();
+    const closed = newCtx();
+    await appendLogs({...open, attempt: 1, offset: 0, body: ndjsonBody(outputLine('open\n'))});
+    await appendLogs({
+      ...closed,
+      attempt: 1,
+      offset: 0,
+      body: ndjsonBody(outputLine('closed\n'), endLine(7)),
+    });
+
+    const count = await getOpenStreamCount();
+
+    expect(count).toBe(1);
+  });
+});

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -1,4 +1,4 @@
-import {and, asc, eq, isNull, lt, notInArray, sql} from 'drizzle-orm';
+import {and, asc, count, eq, isNull, lt, notInArray, sql} from 'drizzle-orm';
 import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
 import {LeaseStreamMismatchError} from '#core/errors.js';
 import {db, type Transaction} from './db.js';
@@ -60,28 +60,46 @@ export async function getStreamByStepAttempt(lookup: {
   return row ? toAttemptStream(row) : null;
 }
 
+export interface GetOrCreateAttemptStreamResult {
+  stream: AttemptStream;
+  created: boolean;
+}
+
 /**
  * Loads the stream for `(job, step, attempt)`, creating it on first append.
  * Scoped by `jobId` from the lease, so a lease never reaches another job's stream.
- * A single upsert with `RETURNING` (the touch-update yields the row on conflict)
- * avoids a separate read on the hot path. On conflict, asserts the lease's
- * `(workspaceId, projectId, runId)` still match the stamped row; a mismatch
- * implies a forged or cross-job-confused lease and is rejected.
+ * The create path reports whether the row was inserted so callers can record
+ * first-open side effects only after their enclosing transaction commits.
  */
-export async function getOrCreateAttemptStream(
+export async function getOrCreateAttemptStreamWithStatus(
   tx: Transaction,
   identity: AttemptStreamIdentity,
-): Promise<AttemptStream> {
-  const [row] = await tx
+): Promise<GetOrCreateAttemptStreamResult> {
+  const [inserted] = await tx
     .insert(attemptStreams)
     .values(identity)
-    .onConflictDoUpdate({
+    .onConflictDoNothing({
       target: [attemptStreams.jobId, attemptStreams.stepId, attemptStreams.attempt],
-      set: {updatedAt: sql`now()`},
     })
     .returning();
 
-  if (!row) throw new Error('attempt stream missing after upsert');
+  const row =
+    inserted ??
+    (
+      await tx
+        .update(attemptStreams)
+        .set({updatedAt: sql`now()`})
+        .where(
+          and(
+            eq(attemptStreams.jobId, identity.jobId),
+            eq(attemptStreams.stepId, identity.stepId),
+            eq(attemptStreams.attempt, identity.attempt),
+          ),
+        )
+        .returning()
+    )[0];
+
+  if (!row) throw new Error('attempt stream missing after get-or-create');
   if (
     row.workspaceId !== identity.workspaceId ||
     row.projectId !== identity.projectId ||
@@ -89,7 +107,15 @@ export async function getOrCreateAttemptStream(
   ) {
     throw new LeaseStreamMismatchError();
   }
-  return toAttemptStream(row);
+  return {stream: toAttemptStream(row), created: Boolean(inserted)};
+}
+
+export async function getOrCreateAttemptStream(
+  tx: Transaction,
+  identity: AttemptStreamIdentity,
+): Promise<AttemptStream> {
+  const result = await getOrCreateAttemptStreamWithStatus(tx, identity);
+  return result.stream;
 }
 
 export type CasOutcome = 'extended' | 'retry' | 'gap';
@@ -271,6 +297,15 @@ export async function listStaleOpenStreams(params: {
     .limit(params.limit);
 
   return rows.map(toAttemptStream);
+}
+
+export async function getOpenStreamCount(): Promise<number> {
+  const [row] = await db()
+    .select({value: count()})
+    .from(attemptStreams)
+    .where(eq(attemptStreams.state, 'open'));
+
+  return row?.value ?? 0;
 }
 
 /**

--- a/libs/api/logs/src/db/streams.ts
+++ b/libs/api/logs/src/db/streams.ts
@@ -1,4 +1,4 @@
-import {and, asc, count, eq, isNull, lt, notInArray, sql} from 'drizzle-orm';
+import {and, asc, eq, getTableColumns, isNull, lt, notInArray, sql} from 'drizzle-orm';
 import type {AttemptStream, StreamCloseReason} from '#core/entities/attempt-stream.js';
 import {LeaseStreamMismatchError} from '#core/errors.js';
 import {db, type Transaction} from './db.js';
@@ -75,29 +75,16 @@ export async function getOrCreateAttemptStreamWithStatus(
   tx: Transaction,
   identity: AttemptStreamIdentity,
 ): Promise<GetOrCreateAttemptStreamResult> {
-  const [inserted] = await tx
+  const [row] = await tx
     .insert(attemptStreams)
     .values(identity)
-    .onConflictDoNothing({
+    .onConflictDoUpdate({
       target: [attemptStreams.jobId, attemptStreams.stepId, attemptStreams.attempt],
+      set: {updatedAt: sql`now()`},
     })
-    .returning();
-
-  const row =
-    inserted ??
-    (
-      await tx
-        .update(attemptStreams)
-        .set({updatedAt: sql`now()`})
-        .where(
-          and(
-            eq(attemptStreams.jobId, identity.jobId),
-            eq(attemptStreams.stepId, identity.stepId),
-            eq(attemptStreams.attempt, identity.attempt),
-          ),
-        )
-        .returning()
-    )[0];
+    // Postgres sets `xmax` only on the conflict-update path, so this keeps
+    // first-open detection in the single upsert round trip.
+    .returning({...getTableColumns(attemptStreams), created: sql<boolean>`xmax = 0`});
 
   if (!row) throw new Error('attempt stream missing after get-or-create');
   if (
@@ -107,7 +94,7 @@ export async function getOrCreateAttemptStreamWithStatus(
   ) {
     throw new LeaseStreamMismatchError();
   }
-  return {stream: toAttemptStream(row), created: Boolean(inserted)};
+  return {stream: toAttemptStream(row), created: row.created};
 }
 
 export async function getOrCreateAttemptStream(
@@ -299,13 +286,13 @@ export async function listStaleOpenStreams(params: {
   return rows.map(toAttemptStream);
 }
 
-export async function getOpenStreamCount(): Promise<number> {
+export async function getOpenStreamCount(): Promise<bigint> {
   const [row] = await db()
-    .select({value: count()})
+    .select({value: sql<bigint>`count(*)`.mapWith(BigInt)})
     .from(attemptStreams)
     .where(eq(attemptStreams.state, 'open'));
 
-  return row?.value ?? 0;
+  return row?.value ?? 0n;
 }
 
 /**

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -4,6 +4,7 @@ import {LOG_STREAM_CLOSED, type LogsEventMap, logsEventSchemas} from '@shipfox/a
 import {WORKFLOWS_JOB_TERMINATED, type WorkflowsEventMap} from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, logsOutbox, migrationsPath} from '#db/index.js';
+import {registerLogsServiceMetrics} from '#metrics/service.js';
 import {logsRoutes} from '#presentation/routes/index.js';
 import {onJobTerminated} from '#presentation/subscribers/on-job-terminated.js';
 import {onLogStreamClosed} from '#presentation/subscribers/on-log-stream-closed.js';
@@ -21,6 +22,7 @@ export const logsModule: ShipfoxModule = {
   name: 'logs',
   database: {db, migrationsPath},
   routes: logsRoutes,
+  metrics: registerLogsServiceMetrics,
   // `logs.stream.closed` is written by the close paths: the job-terminated subscriber
   // force-closes streams the runner never ended, and the closed event drives compaction.
   publishers: [{name: 'logs', table: logsOutbox, db, eventSchemas: logsEventSchemas}],

--- a/libs/api/logs/src/metrics/index.ts
+++ b/libs/api/logs/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export {registerLogsServiceMetrics} from './service.js';

--- a/libs/api/logs/src/metrics/instance.ts
+++ b/libs/api/logs/src/metrics/instance.ts
@@ -2,10 +2,9 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
 const meter = instanceMetrics.getMeter('logs');
 
-export const recordAppendedCount = meter.createCounter<{kind: 'process' | 'system'}>(
-  'logs_record_appended',
-  {description: 'Log records appended to durable stream storage by record kind'},
-);
+export const recordAppendedCount = meter.createCounter<{
+  kind: 'agent_session' | 'process' | 'system';
+}>('logs_record_appended', {description: 'Log records appended to durable stream storage by kind'});
 
 export const streamOpenedCount = meter.createCounter<Record<string, never>>('logs_stream_opened', {
   description: 'Log streams opened by first append',

--- a/libs/api/logs/src/metrics/instance.ts
+++ b/libs/api/logs/src/metrics/instance.ts
@@ -1,0 +1,30 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('logs');
+
+export const recordAppendedCount = meter.createCounter<{kind: 'process' | 'system'}>(
+  'logs_record_appended',
+  {description: 'Log records appended to durable stream storage by record kind'},
+);
+
+export const streamOpenedCount = meter.createCounter<Record<string, never>>('logs_stream_opened', {
+  description: 'Log streams opened by first append',
+});
+
+export const streamClosedCount = meter.createCounter<{reason: 'declared' | 'timeout'}>(
+  'logs_stream_closed',
+  {description: 'Log streams closed by reason'},
+);
+
+export type CompactionMetricOutcome =
+  | 'already-compacted'
+  | 'compacted'
+  | 'failed'
+  | 'gone'
+  | 'retention-raced'
+  | 'superseded';
+
+export const compactionCount = meter.createCounter<{outcome: CompactionMetricOutcome}>(
+  'logs_compaction',
+  {description: 'Log stream compaction attempts by outcome'},
+);

--- a/libs/api/logs/src/metrics/instance.ts
+++ b/libs/api/logs/src/metrics/instance.ts
@@ -1,10 +1,14 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
 import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
 const meter = instanceMetrics.getMeter('logs');
 
-export const recordAppendedCount = meter.createCounter<{
-  kind: 'agent_session' | 'process' | 'system';
-}>('logs_record_appended', {description: 'Log records appended to durable stream storage by kind'});
+export type LogRecordMetricKind = LogRecord['type'];
+
+export const recordAppendedCount = meter.createCounter<{kind: LogRecordMetricKind}>(
+  'logs_record_appended',
+  {description: 'Log records appended to durable stream storage by record type'},
+);
 
 export const streamOpenedCount = meter.createCounter<Record<string, never>>('logs_stream_opened', {
   description: 'Log streams opened by first append',

--- a/libs/api/logs/src/metrics/service.ts
+++ b/libs/api/logs/src/metrics/service.ts
@@ -1,0 +1,17 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getOpenStreamCount} from '#db/streams.js';
+
+export function registerLogsServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('logs');
+
+  const openStreams = meter.createObservableGauge('logs_open_streams', {
+    description: 'Log streams currently open for appends',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      observer.observe(openStreams, await getOpenStreamCount());
+    },
+    [openStreams],
+  );
+}

--- a/libs/api/logs/src/metrics/service.ts
+++ b/libs/api/logs/src/metrics/service.ts
@@ -10,8 +10,14 @@ export function registerLogsServiceMetrics(): void {
 
   meter.addBatchObservableCallback(
     async (observer) => {
-      observer.observe(openStreams, await getOpenStreamCount());
+      observer.observe(openStreams, toSafeGaugeNumber(await getOpenStreamCount()));
     },
     [openStreams],
   );
+}
+
+function toSafeGaugeNumber(value: bigint): number {
+  // OpenTelemetry gauges accept numbers; clamp unrepresentable DB counts rather than round them.
+  if (value <= BigInt(Number.MAX_SAFE_INTEGER)) return Number(value);
+  return Number.MAX_SAFE_INTEGER;
 }

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
@@ -21,7 +21,7 @@ export async function closeAbandonedStreamsActivity(params: {
     );
     if (result) {
       closed += 1;
-      recordAppendedCount.add(1, {kind: 'system'});
+      recordAppendedCount.add(1, {kind: 'runner_lost'});
       streamClosedCount.add(1, {reason: 'timeout'});
     }
   }

--- a/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
+++ b/libs/api/logs/src/temporal/activities/close-abandoned-streams.ts
@@ -1,6 +1,7 @@
 import {closeStream} from '#core/close-stream.js';
 import {db} from '#db/db.js';
 import {listOpenStreamsByJob} from '#db/streams.js';
+import {recordAppendedCount, streamClosedCount} from '#metrics/instance.js';
 
 /**
  * Job termination does not guarantee the runner flushed an end record: it may have
@@ -18,7 +19,11 @@ export async function closeAbandonedStreamsActivity(params: {
     const result = await db().transaction((tx) =>
       closeStream(tx, {streamId: stream.id, reason: 'timeout'}),
     );
-    if (result) closed += 1;
+    if (result) {
+      closed += 1;
+      recordAppendedCount.add(1, {kind: 'system'});
+      streamClosedCount.add(1, {reason: 'timeout'});
+    }
   }
 
   return {closed};

--- a/libs/api/logs/src/temporal/activities/compact-stream.ts
+++ b/libs/api/logs/src/temporal/activities/compact-stream.ts
@@ -4,6 +4,7 @@ import {compactedGzipStream} from '#core/compaction.js';
 import {chunkStats} from '#db/chunks.js';
 import {db} from '#db/db.js';
 import {getAttemptStreamById, setObjectKeyAndDeleteChunks} from '#db/streams.js';
+import {type CompactionMetricOutcome, compactionCount} from '#metrics/instance.js';
 
 export type CompactStreamResult =
   | {outcome: 'gone'}
@@ -31,9 +32,7 @@ export type CompactStreamResult =
  * check (count, maxSeq, and byte total) guards a read bug from publishing a truncated object
  * before the only copy of the source is gone (S3 part checksums cover byte transfer).
  */
-export async function compactStreamActivity(params: {
-  streamId: string;
-}): Promise<CompactStreamResult> {
+async function compactStream(params: {streamId: string}): Promise<CompactStreamResult> {
   const stream = await getAttemptStreamById(params.streamId);
   if (!stream) return {outcome: 'gone'};
   if (stream.objectKey) return {outcome: 'already-compacted'};
@@ -82,4 +81,17 @@ export async function compactStreamActivity(params: {
     chunkCount: stats.chunkCount,
     uncompressedBytes: stats.uncompressedBytes,
   };
+}
+
+export async function compactStreamActivity(params: {
+  streamId: string;
+}): Promise<CompactStreamResult> {
+  let outcome: CompactionMetricOutcome = 'failed';
+  try {
+    const result = await compactStream(params);
+    outcome = result.outcome;
+    return result;
+  } finally {
+    compactionCount.add(1, {outcome});
+  }
 }


### PR DESCRIPTION
Instrument api-logs with OpenTelemetry metrics for log ingestion and lifecycle state.

The logs package now records low-cardinality instance counters for appended records, opened streams, closed streams, and compaction outcomes, plus a service gauge for currently open streams. This gives Prometheus visibility into log ingestion health without labeling by stream, job, workspace, or other unbounded ids.

The recording points are placed after durable state transitions so retries and rolled-back transactions do not inflate counts. The open-stream gauge reads shared database state through the module metrics hook, matching the runners metrics pattern.

No changeset is included because @shipfox/api-logs is private.

Closes ENG-571

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds low-cardinality OpenTelemetry metrics to `@shipfox/api-logs` to observe log ingestion and stream lifecycle. Records appended counts by DTO record type, stream open/close by reason, compaction outcomes, and current open streams. Closes ENG-571.

- **New Features**
  - Counters: appended log records by DTO type (bounded), streams opened, streams closed (`declared` | `timeout`), compaction attempts by outcome.
  - Gauge: current open streams (DB-backed via module metrics hook; precise bigint counts clamped at the metrics edge).
  - Recorded after durable transitions; first-open detected via single-upsert `getOrCreateAttemptStreamWithStatus` and emitted post-transaction; timeout reaper and job-termination add a `runner_lost` system event and timeout close.

<sup>Written for commit 108f34048756be73b400561072478be9e7f93fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

