### PR TITLE
Fail fast when module workers stop

### DIFF
--- a/.changeset/steady-workers-shutdown.md
+++ b/.changeset/steady-workers-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-module": minor
+---
+
+Adds an app-owned runtime worker failure callback and fail-fast worker startup errors so API services can treat module-declared Temporal workers as process health dependencies.

--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -1,0 +1,247 @@
+import type {ModuleWorker, StartModuleWorkersOptions} from '@shipfox/node-module';
+import {run} from './run.js';
+
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  closeApp: vi.fn(),
+  closeErrorMonitoring: vi.fn(),
+  createApp: vi.fn(),
+  createDefinitionsModule: vi.fn(),
+  createE2eAdminAuthMethod: vi.fn(),
+  createE2eRouteGroup: vi.fn(),
+  createIntegrationsContext: vi.fn(),
+  createPostgresClient: vi.fn(),
+  createProjectsModule: vi.fn(),
+  initializeModules: vi.fn(),
+  listen: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+  registerModuleMetrics: vi.fn(),
+  setSourceControl: vi.fn(),
+  startModuleWorkers: vi.fn(),
+  startServiceMetrics: vi.fn(),
+}));
+
+vi.mock('@shipfox/api-auth', () => ({authModule: {name: 'auth'}}));
+vi.mock('@shipfox/api-definitions', () => ({
+  createDefinitionsModule: mocks.createDefinitionsModule,
+}));
+vi.mock('@shipfox/api-dispatcher', () => ({dispatcherModule: {name: 'dispatcher'}}));
+vi.mock('@shipfox/api-integration-core', () => ({
+  createIntegrationsContext: mocks.createIntegrationsContext,
+}));
+vi.mock('@shipfox/api-logs', () => ({logsModule: {name: 'logs'}}));
+vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
+vi.mock('@shipfox/api-runners', () => ({runnersModule: {name: 'runners'}}));
+vi.mock('@shipfox/api-triggers', () => ({triggersModule: {name: 'triggers'}}));
+vi.mock('@shipfox/api-workflows', () => ({
+  setSourceControl: mocks.setSourceControl,
+  workflowsModule: {name: 'workflows'},
+}));
+vi.mock('@shipfox/api-workspaces', () => ({workspacesModule: {name: 'workspaces'}}));
+vi.mock('@shipfox/node-error-monitoring', () => ({
+  captureException: mocks.captureException,
+  closeErrorMonitoring: mocks.closeErrorMonitoring,
+}));
+vi.mock('@shipfox/node-fastify', () => ({
+  closeApp: mocks.closeApp,
+  createApp: mocks.createApp,
+  listen: mocks.listen,
+}));
+vi.mock('@shipfox/node-module', () => ({
+  initializeModules: mocks.initializeModules,
+  registerModuleMetrics: mocks.registerModuleMetrics,
+  startModuleWorkers: mocks.startModuleWorkers,
+}));
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => mocks.logger,
+  startServiceMetrics: mocks.startServiceMetrics,
+}));
+vi.mock('@shipfox/node-postgres', () => ({createPostgresClient: mocks.createPostgresClient}));
+vi.mock('../config.js', () => ({config: {E2E_ENABLED: false}}));
+vi.mock('./e2e.js', () => ({
+  createE2eAdminAuthMethod: mocks.createE2eAdminAuthMethod,
+  createE2eRouteGroup: mocks.createE2eRouteGroup,
+}));
+
+function worker(taskQueue = 'runtime-queue'): ModuleWorker {
+  return {
+    taskQueue,
+    workflowsPath: '/tmp/workflows.js',
+    activities: () => ({}),
+    workflows: [],
+  };
+}
+
+function lastStartModuleWorkersOptions(): StartModuleWorkersOptions {
+  const options = mocks.startModuleWorkers.mock.calls.at(-1)?.[0];
+  if (!options) throw new Error('startModuleWorkers was not called');
+  return options as StartModuleWorkersOptions;
+}
+
+describe('run', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.captureException.mockReset();
+    mocks.closeApp.mockReset();
+    mocks.closeErrorMonitoring.mockReset();
+    mocks.createApp.mockReset();
+    mocks.createDefinitionsModule.mockReset();
+    mocks.createE2eAdminAuthMethod.mockReset();
+    mocks.createE2eRouteGroup.mockReset();
+    mocks.createIntegrationsContext.mockReset();
+    mocks.createPostgresClient.mockReset();
+    mocks.createProjectsModule.mockReset();
+    mocks.initializeModules.mockReset();
+    mocks.listen.mockReset();
+    mocks.logger.error.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.registerModuleMetrics.mockReset();
+    mocks.setSourceControl.mockReset();
+    mocks.startModuleWorkers.mockReset();
+    mocks.startServiceMetrics.mockReset();
+
+    mocks.createIntegrationsContext.mockResolvedValue({
+      module: {name: 'integrations'},
+      runStartupTasks: vi.fn().mockResolvedValue(undefined),
+      sourceControl: {},
+    });
+    mocks.createProjectsModule.mockReturnValue({name: 'projects'});
+    mocks.createDefinitionsModule.mockReturnValue({name: 'definitions'});
+    mocks.initializeModules.mockResolvedValue({
+      auth: [],
+      routes: [],
+      e2eRoutes: [],
+      workers: [worker()],
+    });
+    mocks.createE2eRouteGroup.mockReturnValue([]);
+    mocks.createApp.mockResolvedValue({});
+    mocks.startModuleWorkers.mockResolvedValue(undefined);
+    mocks.listen.mockResolvedValue('http://127.0.0.1:3000');
+    mocks.closeApp.mockResolvedValue(undefined);
+    mocks.closeErrorMonitoring.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('awaits module workers before listening for HTTP requests', async () => {
+    let resolveWorkers: (() => void) | undefined;
+    const workersStarted = new Promise<void>((resolve) => {
+      mocks.startModuleWorkers.mockImplementationOnce(
+        () =>
+          new Promise<void>((innerResolve) => {
+            resolveWorkers = innerResolve;
+            resolve();
+          }),
+      );
+    });
+
+    const result = run();
+    await workersStarted;
+
+    expect(mocks.listen).not.toHaveBeenCalled();
+
+    resolveWorkers?.();
+    await result;
+
+    expect(mocks.listen).toHaveBeenCalledTimes(1);
+    expect(mocks.startModuleWorkers.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.listen.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('does not listen when module worker startup fails', async () => {
+    const failure = new Error('worker boot failed');
+    mocks.startModuleWorkers.mockRejectedValueOnce(failure);
+
+    const result = run();
+
+    await expect(result).rejects.toBe(failure);
+    expect(mocks.listen).not.toHaveBeenCalled();
+  });
+
+  it('captures runtime worker failures, closes HTTP, and exits', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    await run();
+    const failure = new Error('poller failed');
+    const failedWorker = worker('runtime-queue');
+
+    const result = Promise.resolve(
+      lastStartModuleWorkersOptions().onWorkerFailure?.(failure, failedWorker),
+    );
+    const assertion = expect(result).rejects.toThrow('exit 1');
+
+    await assertion;
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: failure, taskQueue: 'runtime-queue'},
+      'Module worker stopped unexpectedly',
+    );
+    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.closeApp).toHaveBeenCalledTimes(1);
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
+      exitSpy.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mocks.closeApp.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.closeErrorMonitoring.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('exits when graceful HTTP shutdown times out after runtime worker failure', async () => {
+    vi.useFakeTimers();
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    mocks.closeApp.mockReturnValueOnce(new Promise(() => undefined));
+    await run();
+    const failure = new Error('poller failed');
+
+    const result = Promise.resolve(
+      lastStartModuleWorkersOptions().onWorkerFailure?.(failure, worker()),
+    );
+    const assertion = expect(result).rejects.toThrow('exit 1');
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await assertion;
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {timeoutMs: 10_000},
+      'Timed out closing HTTP server after worker failure',
+    );
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('flushes error monitoring when graceful HTTP shutdown rejects', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    const closeFailure = new Error('onClose failed');
+    mocks.closeApp.mockRejectedValueOnce(closeFailure);
+    await run();
+    const failure = new Error('poller failed');
+
+    const result = Promise.resolve(
+      lastStartModuleWorkersOptions().onWorkerFailure?.(failure, worker()),
+    );
+    const assertion = expect(result).rejects.toThrow('exit 1');
+
+    await assertion;
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: closeFailure},
+      'Failed to close HTTP server after worker failure',
+    );
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
+      exitSpy.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -8,12 +8,17 @@ import {runnersModule} from '@shipfox/api-runners';
 import {triggersModule} from '@shipfox/api-triggers';
 import {setSourceControl, workflowsModule} from '@shipfox/api-workflows';
 import {workspacesModule} from '@shipfox/api-workspaces';
-import {createApp, listen} from '@shipfox/node-fastify';
+import {captureException, closeErrorMonitoring} from '@shipfox/node-error-monitoring';
+import {closeApp, createApp, listen} from '@shipfox/node-fastify';
+import type {ModuleWorker} from '@shipfox/node-module';
 import {initializeModules, registerModuleMetrics, startModuleWorkers} from '@shipfox/node-module';
 import {logger, startServiceMetrics} from '@shipfox/node-opentelemetry';
 import {createPostgresClient} from '@shipfox/node-postgres';
 import {config} from '../config.js';
 import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
+
+const WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS = 10_000;
+const WORKER_FAILURE_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 export async function run(): Promise<void> {
   startServiceMetrics({serviceName: 'api'});
@@ -54,9 +59,53 @@ export async function run(): Promise<void> {
     auth: [...auth, ...e2eAuth],
     routes: [...routes, ...mountedE2eRoutes],
   });
+  logger().info('Starting module workers');
+  await startModuleWorkers({workers, onWorkerFailure: handleModuleWorkerFailure});
+
   logger().info('Starting HTTP server');
   const address = await listen();
   logger().info({address}, 'HTTP server listening');
+}
 
-  startModuleWorkers({workers});
+export async function handleModuleWorkerFailure(
+  error: unknown,
+  worker: ModuleWorker,
+): Promise<never> {
+  logger().error({err: error, taskQueue: worker.taskQueue}, 'Module worker stopped unexpectedly');
+  captureException(error);
+
+  try {
+    await closeHttpServerAfterWorkerFailure();
+    await closeErrorMonitoring(WORKER_FAILURE_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
+  } finally {
+    process.exit(1);
+  }
+}
+
+async function closeHttpServerAfterWorkerFailure(): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS);
+  });
+  try {
+    const result = await Promise.race([closeApp().then(() => 'closed' as const), timeout]).finally(
+      () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      },
+    );
+    if (result === 'timeout') {
+      logger().error(
+        {timeoutMs: WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS},
+        'Timed out closing HTTP server after worker failure',
+      );
+    }
+  } catch (error) {
+    logger().error({err: error}, 'Failed to close HTTP server after worker failure');
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
 }

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -1,0 +1,55 @@
+const mocks = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  closeErrorMonitoring: vi.fn(),
+  logger: {
+    error: vi.fn(),
+  },
+  run: vi.fn(),
+}));
+
+vi.mock('@shipfox/node-error-monitoring', () => ({
+  captureException: mocks.captureException,
+  closeErrorMonitoring: mocks.closeErrorMonitoring,
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => mocks.logger,
+}));
+
+vi.mock('#core/run.js', () => ({
+  run: mocks.run,
+}));
+
+describe('index', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.captureException.mockReset();
+    mocks.closeErrorMonitoring.mockReset();
+    mocks.logger.error.mockReset();
+    mocks.run.mockReset();
+    mocks.closeErrorMonitoring.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('flushes error monitoring before exiting after startup failure', async () => {
+    const failure = new Error('worker boot failed');
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`exit ${code}`);
+    }) as never);
+    mocks.run.mockRejectedValueOnce(failure);
+
+    const result = import('./index.js');
+
+    await expect(result).rejects.toThrow('exit 1');
+    expect(mocks.logger.error).toHaveBeenCalledWith({error: failure}, 'Fatal startup error');
+    expect(mocks.captureException).toHaveBeenCalledWith(failure);
+    expect(mocks.closeErrorMonitoring).toHaveBeenCalledWith(2_000);
+    expect(mocks.closeErrorMonitoring.mock.invocationCallOrder[0]).toBeLessThan(
+      exitSpy.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,11 +1,17 @@
-import {captureException} from '@shipfox/node-error-monitoring';
+import {captureException, closeErrorMonitoring} from '@shipfox/node-error-monitoring';
 import {logger} from '@shipfox/node-opentelemetry';
 import {run} from '#core/run.js';
+
+const STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS = 2_000;
 
 try {
   await run();
 } catch (error) {
   logger().error({error}, 'Fatal startup error');
   captureException(error);
-  process.exit(1);
+  try {
+    await closeErrorMonitoring(STARTUP_ERROR_MONITORING_SHUTDOWN_TIMEOUT_MS);
+  } finally {
+    process.exit(1);
+  }
 }

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -159,8 +159,7 @@ export async function createIntegrationsContext(
 
   async function runStartupTasks(): Promise<void> {
     for (const task of parts.flatMap((part) => part.startupTasks ?? [])) {
-      // A provider convenience must never gate API boot. Mirrors startModuleWorkers, which
-      // catches per-worker errors and logs instead of throwing.
+      // A provider convenience must never gate API boot.
       try {
         await task();
       } catch (error) {

--- a/libs/api/triggers/README.md
+++ b/libs/api/triggers/README.md
@@ -20,8 +20,8 @@ const {auth, routes, workers} = await initializeModules({
 });
 
 await createApp({auth, routes});
-await listen();
 await startModuleWorkers({workers});
+await listen();
 ```
 
 This adds:

--- a/libs/shared/node/module/README.md
+++ b/libs/shared/node/module/README.md
@@ -6,7 +6,7 @@ Module setup helpers for Shipfox API services. A module can list its database, a
 
 - **`initializeModules({modules})`**: Sets up modules in array order.
 - **`registerModuleMetrics({modules})`**: Registers service-level metrics for modules that declare a metrics hook.
-- **`startModuleWorkers({workers})`**: Creates Temporal workers and starts declared workflows.
+- **`startModuleWorkers({workers})`**: Creates Temporal workers and starts declared workflows before the app is marked ready.
 - **`ShipfoxModule`**: Module contract used by API packages.
 - **Publisher registry**: Adds outbox tables, drains pending events, and marks events as sent.
 - **Subscriber registry**: Adds and reads in-process event handlers by event type.
@@ -25,12 +25,12 @@ const {auth, routes, workers} = await initializeModules({
 registerModuleMetrics({modules});
 
 await createApp({auth, routes});
+await startModuleWorkers({workers});
 await listen();
-
-startModuleWorkers({workers});
 ```
 
 `initializeModules` runs module migrations first. It exposes auth methods and routes after that. Put modules with shared database needs earlier in the array. Call `registerModuleMetrics` once after instrumentation has started and migrations have run, so observable gauges can query shared storage safely.
+Worker startup failures reject `startModuleWorkers`, so call it before serving traffic when workers are required for app health.
 
 ## Module Shape
 

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   InitializedModules,
   InitializeModulesOptions,
+  StartModuleWorkersOptions,
 } from './initialize.js';
 export {initializeModules, registerModuleMetrics, startModuleWorkers} from './initialize.js';
 export type {

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -1,5 +1,26 @@
-import {registerModuleMetrics} from './initialize.js';
-import type {ShipfoxModule} from './types.js';
+import {registerModuleMetrics, startModuleWorkers} from './initialize.js';
+import type {ModuleWorker, ShipfoxModule} from './types.js';
+
+const mocks = vi.hoisted(() => ({
+  createTemporalClient: vi.fn(),
+  createTemporalWorker: vi.fn(),
+  workflowStart: vi.fn(),
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@shipfox/node-temporal', () => ({
+  createTemporalClient: mocks.createTemporalClient,
+  createTemporalWorker: mocks.createTemporalWorker,
+  temporalClient: () => ({workflow: {start: mocks.workflowStart}}),
+}));
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  logger: () => mocks.logger,
+}));
 
 describe('registerModuleMetrics', () => {
   it('invokes the metrics hook for each module that declares one', () => {
@@ -40,5 +61,209 @@ describe('registerModuleMetrics', () => {
     registerModuleMetrics({modules});
 
     expect(later).toHaveBeenCalledOnce();
+  });
+});
+
+function moduleWorker(overrides: Partial<ModuleWorker> = {}): ModuleWorker {
+  return {
+    taskQueue: 'test-queue',
+    workflowsPath: '/tmp/workflows.js',
+    activities: () => ({}),
+    workflows: [],
+    ...overrides,
+  };
+}
+
+function temporalWorker(runResult: Promise<void> = new Promise(() => undefined)) {
+  return {
+    run: vi.fn(() => runResult),
+  };
+}
+
+function alreadyStartedError(): Error {
+  const error = new Error('already started');
+  error.name = 'WorkflowExecutionAlreadyStartedError';
+  return error;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('startModuleWorkers', () => {
+  beforeEach(() => {
+    mocks.createTemporalClient.mockReset();
+    mocks.createTemporalWorker.mockReset();
+    mocks.workflowStart.mockReset();
+    mocks.logger.error.mockReset();
+    mocks.logger.info.mockReset();
+    mocks.createTemporalClient.mockResolvedValue({});
+    mocks.createTemporalWorker.mockResolvedValue(temporalWorker());
+    mocks.workflowStart.mockResolvedValue({});
+  });
+
+  it('does not create a Temporal client when no workers are declared', async () => {
+    await startModuleWorkers({workers: []});
+
+    expect(mocks.createTemporalClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects when Temporal client creation fails', async () => {
+    const failure = new Error('temporal unavailable');
+    mocks.createTemporalClient.mockRejectedValueOnce(failure);
+
+    const result = startModuleWorkers({workers: [moduleWorker()]});
+
+    await expect(result).rejects.toBe(failure);
+  });
+
+  it('wraps worker creation failures with the task queue and original cause', async () => {
+    const failure = new Error('missing workflows file');
+    mocks.createTemporalWorker.mockRejectedValueOnce(failure);
+
+    const result = startModuleWorkers({workers: [moduleWorker({taskQueue: 'broken-queue'})]});
+
+    await expect(result).rejects.toThrow(
+      'Failed to start module worker for task queue broken-queue',
+    );
+    await result.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(failure);
+    });
+  });
+
+  it('wraps activity factory failures with the task queue and original cause', async () => {
+    const failure = new Error('activity config missing');
+
+    const result = startModuleWorkers({
+      workers: [
+        moduleWorker({
+          taskQueue: 'activity-queue',
+          activities: () => {
+            throw failure;
+          },
+        }),
+      ],
+    });
+
+    await expect(result).rejects.toThrow(
+      'Failed to start module worker for task queue activity-queue',
+    );
+    await result.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(failure);
+    });
+  });
+
+  it('starts declared workflows with their task queue and cron schedule', async () => {
+    await startModuleWorkers({
+      workers: [
+        moduleWorker({
+          workflows: [{name: 'pruneCron', id: 'prune-cron', cronSchedule: '0 * * * *'}],
+        }),
+      ],
+    });
+
+    expect(mocks.workflowStart).toHaveBeenCalledWith('pruneCron', {
+      taskQueue: 'test-queue',
+      workflowId: 'prune-cron',
+      cronSchedule: '0 * * * *',
+    });
+  });
+
+  it('tolerates already-started workflows', async () => {
+    mocks.workflowStart.mockRejectedValueOnce(alreadyStartedError());
+
+    await startModuleWorkers({
+      workers: [moduleWorker({workflows: [{name: 'cron', id: 'cron'}]})],
+    });
+
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      {workflowId: 'cron'},
+      'Workflow already running, skipping start',
+    );
+  });
+
+  it('wraps unexpected workflow start failures with the task queue and original cause', async () => {
+    const failure = new Error('workflow service unavailable');
+    mocks.workflowStart.mockRejectedValueOnce(failure);
+
+    const result = startModuleWorkers({
+      workers: [
+        moduleWorker({taskQueue: 'workflow-queue', workflows: [{name: 'cron', id: 'cron'}]}),
+      ],
+    });
+
+    await expect(result).rejects.toThrow(
+      'Failed to start module worker for task queue workflow-queue',
+    );
+    await result.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(failure);
+    });
+  });
+
+  it('calls the runtime failure callback when a started worker stops unexpectedly', async () => {
+    const failure = new Error('poller failed');
+    const worker = moduleWorker({taskQueue: 'runtime-queue'});
+    const onWorkerFailure = vi.fn();
+    mocks.createTemporalWorker.mockResolvedValueOnce(temporalWorker(Promise.reject(failure)));
+
+    await startModuleWorkers({workers: [worker], onWorkerFailure});
+    await flushMicrotasks();
+
+    expect(onWorkerFailure).toHaveBeenCalledWith(failure, worker);
+    expect(mocks.logger.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Worker stopped unexpectedly',
+    );
+  });
+
+  it('logs the original worker failure when the runtime failure callback rejects', async () => {
+    const failure = new Error('poller failed');
+    const handlerFailure = new Error('shutdown failed');
+    const worker = moduleWorker({taskQueue: 'runtime-queue'});
+    const onWorkerFailure = vi.fn().mockRejectedValue(handlerFailure);
+    mocks.createTemporalWorker.mockResolvedValueOnce(temporalWorker(Promise.reject(failure)));
+
+    await startModuleWorkers({workers: [worker], onWorkerFailure});
+    await flushMicrotasks();
+
+    expect(onWorkerFailure).toHaveBeenCalledWith(failure, worker);
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: handlerFailure, workerErr: failure, taskQueue: 'runtime-queue'},
+      'Module worker failure handler failed',
+    );
+  });
+
+  it('logs runtime worker failures when no failure callback is provided', async () => {
+    const failure = new Error('poller failed');
+    mocks.createTemporalWorker.mockResolvedValueOnce(temporalWorker(Promise.reject(failure)));
+
+    await startModuleWorkers({workers: [moduleWorker({taskQueue: 'runtime-queue'})]});
+    await flushMicrotasks();
+
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      {err: failure, taskQueue: 'runtime-queue'},
+      'Worker stopped unexpectedly',
+    );
+  });
+
+  it('identifies the failing task queue when a later worker fails to start', async () => {
+    const failure = new Error('second worker missing');
+    mocks.createTemporalWorker
+      .mockResolvedValueOnce(temporalWorker())
+      .mockRejectedValueOnce(failure);
+
+    const result = startModuleWorkers({
+      workers: [moduleWorker({taskQueue: 'first'}), moduleWorker({taskQueue: 'second'})],
+    });
+
+    await expect(result).rejects.toThrow('Failed to start module worker for task queue second');
+    await result.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).cause).toBe(failure);
+    });
   });
 });

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -17,6 +17,11 @@ export interface InitializedModules {
   workers: ModuleWorker[];
 }
 
+export interface StartModuleWorkersOptions {
+  workers: ModuleWorker[];
+  onWorkerFailure?: (error: unknown, worker: ModuleWorker) => void | Promise<void>;
+}
+
 /**
  * Initializes modules in array order. Modules are processed sequentially
  * so migration order is deterministic — list modules with shared dependencies first.
@@ -113,7 +118,7 @@ export function registerModuleMetrics(options: {modules: ShipfoxModule[]}): void
  * Creates Temporal workers for all module-declared workers and starts their workflows.
  * Call this after `initializeModules` so that all publishers/subscribers are registered.
  */
-export async function startModuleWorkers(options: {workers: ModuleWorker[]}): Promise<void> {
+export async function startModuleWorkers(options: StartModuleWorkersOptions): Promise<void> {
   if (options.workers.length === 0) return;
 
   await createTemporalClient();
@@ -143,15 +148,23 @@ export async function startModuleWorkers(options: {workers: ModuleWorker[]}): Pr
       }
 
       worker.run().catch((error) => {
+        if (options.onWorkerFailure) {
+          void Promise.resolve(options.onWorkerFailure(error, workerDef)).catch((handlerError) => {
+            logger().error(
+              {err: handlerError, workerErr: error, taskQueue: workerDef.taskQueue},
+              'Module worker failure handler failed',
+            );
+          });
+          return;
+        }
         logger().error({err: error, taskQueue: workerDef.taskQueue}, 'Worker stopped unexpectedly');
       });
 
       logger().info({taskQueue: workerDef.taskQueue}, 'Module worker started');
     } catch (error) {
-      logger().warn(
-        {err: error, taskQueue: workerDef.taskQueue},
-        'Failed to start module worker, will retry on next restart',
-      );
+      throw new Error(`Failed to start module worker for task queue ${workerDef.taskQueue}`, {
+        cause: error,
+      });
     }
   }
 }


### PR DESCRIPTION
Make module-declared Temporal workers part of API process health.

Worker boot failures previously logged a warning and allowed the API to serve traffic without required background safety nets such as runner maintenance. This makes worker startup reject API boot, preserving task-queue context on the thrown error.

Runtime worker loss now uses an app-owned failure callback in apps/api: it logs and captures the failure, closes the HTTP server with a bounded graceful shutdown, then exits with status 1 so the process manager can restart the app.

The shared module helper keeps logged-only runtime behavior for callers that do not provide a callback, while exposing the callback for apps that want workers to participate in process health.

Closes ENG-435

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make module-declared Temporal workers part of API health: the API waits for workers to start and shuts down if a worker stops, so we don’t serve traffic without required background tasks. Implements ENG-435.

- **New Features**
  - `@shipfox/node-module`: `startModuleWorkers` now rejects on startup errors, accepts optional `onWorkerFailure(error, worker)`, logs runtime failures when no callback is provided, wraps errors with task queue and cause, and exports `StartModuleWorkersOptions`.
  - `apps/api`: waits for workers before starting HTTP; on worker failure, logs with task queue, captures the error, tries a 10s graceful HTTP shutdown (logs on timeout), flushes error monitoring (2s), then exits with code 1; on startup failure, logs, captures, flushes error monitoring (2s), then exits with code 1.
  - Docs: examples now call `startModuleWorkers` before `listen()`.

- **Migration**
  - Call `await startModuleWorkers({workers})` before `await listen()`.
  - Ensure your process supervisor restarts on exit code 1.
  - Update to the new minor of `@shipfox/node-module`.

<sup>Written for commit f91058e3447fef7a4d97f0516987d5f28bafff2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

