### PR TITLE
Add auth endpoint rate limiting

### DIFF
--- a/.changeset/bright-routes-guard.md
+++ b/.changeset/bright-routes-guard.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-fastify": minor
+---
+
+Adds route preHandler support so module routes can run typed request hooks after schema validation.

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -21,6 +21,8 @@ describe('parseApiTrustProxy', () => {
     '-1',
     '1.5',
     'maybe',
+    '9007199254740992',
+    '1'.repeat(400),
     '10.0.0.0/99',
     '2001:db8::/129',
   ])('rejects %s', (value) => {

--- a/apps/api/src/config.test.ts
+++ b/apps/api/src/config.test.ts
@@ -1,0 +1,31 @@
+import {parseApiTrustProxy} from './config.js';
+
+describe('parseApiTrustProxy', () => {
+  it.each([
+    ['false', false],
+    [' true ', true],
+    ['1', 1],
+    ['3', 3],
+    ['127.0.0.1', '127.0.0.1'],
+    ['10.0.0.0/8', '10.0.0.0/8'],
+    ['2001:db8::/32', '2001:db8::/32'],
+  ])('parses %s', (value, expected) => {
+    const result = parseApiTrustProxy(value);
+
+    expect(result).toBe(expected);
+  });
+
+  it.each([
+    '',
+    '0',
+    '-1',
+    '1.5',
+    'maybe',
+    '10.0.0.0/99',
+    '2001:db8::/129',
+  ])('rejects %s', (value) => {
+    const act = () => parseApiTrustProxy(value);
+
+    expect(act).toThrow('API_TRUST_PROXY');
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -38,8 +38,8 @@ export function parseApiTrustProxy(value: string): ApiTrustProxy {
 
   if (INTEGER_PATTERN.test(trimmed)) {
     const hops = Number(trimmed);
-    if (hops > 0) return hops;
-    throw new Error('API_TRUST_PROXY hop count must be greater than zero');
+    if (Number.isSafeInteger(hops) && hops > 0) return hops;
+    throw new Error('API_TRUST_PROXY hop count must be a positive safe integer');
   }
 
   if (isIP(trimmed) !== 0 || parseCidr(trimmed)) return trimmed;

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,4 +1,9 @@
+import {isIP} from 'node:net';
 import {bool, createConfig, str} from '@shipfox/config';
+
+export type ApiTrustProxy = false | true | number | string;
+
+const INTEGER_PATTERN = /^\d+$/;
 
 export const config = createConfig({
   E2E_ENABLED: bool({
@@ -9,4 +14,37 @@ export const config = createConfig({
     desc: 'Bearer token that protects the E2E admin routes. Set it when E2E_ENABLED is true.',
     default: undefined,
   }),
+  API_TRUST_PROXY: str({
+    desc: 'Controls how the API trusts proxy headers for client IP detection. Use false when clients connect directly, true only when every caller is a trusted proxy, a positive hop count such as 1, or a trusted proxy IP/CIDR such as 10.0.0.0/8.',
+    default: 'false',
+  }),
 });
+
+function parseCidr(value: string): boolean {
+  const [address, prefix, extra] = value.split('/');
+  if (!address || !prefix || extra !== undefined || isIP(address) === 0) return false;
+
+  const maxPrefix = isIP(address) === 4 ? 32 : 128;
+  if (!INTEGER_PATTERN.test(prefix)) return false;
+
+  const prefixNumber = Number(prefix);
+  return prefixNumber >= 0 && prefixNumber <= maxPrefix;
+}
+
+export function parseApiTrustProxy(value: string): ApiTrustProxy {
+  const trimmed = value.trim();
+  if (trimmed === 'false') return false;
+  if (trimmed === 'true') return true;
+
+  if (INTEGER_PATTERN.test(trimmed)) {
+    const hops = Number(trimmed);
+    if (hops > 0) return hops;
+    throw new Error('API_TRUST_PROXY hop count must be greater than zero');
+  }
+
+  if (isIP(trimmed) !== 0 || parseCidr(trimmed)) return trimmed;
+
+  throw new Error(
+    'API_TRUST_PROXY must be false, true, a positive hop count, or a trusted proxy IP/CIDR',
+  );
+}

--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     error: vi.fn(),
     info: vi.fn(),
   },
+  parseApiTrustProxy: vi.fn(),
   registerModuleMetrics: vi.fn(),
   setSourceControl: vi.fn(),
   startModuleWorkers: vi.fn(),
@@ -61,7 +62,10 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
   startServiceMetrics: mocks.startServiceMetrics,
 }));
 vi.mock('@shipfox/node-postgres', () => ({createPostgresClient: mocks.createPostgresClient}));
-vi.mock('../config.js', () => ({config: {E2E_ENABLED: false}}));
+vi.mock('../config.js', () => ({
+  config: {API_TRUST_PROXY: 'false', E2E_ENABLED: false},
+  parseApiTrustProxy: mocks.parseApiTrustProxy,
+}));
 vi.mock('./e2e.js', () => ({
   createE2eAdminAuthMethod: mocks.createE2eAdminAuthMethod,
   createE2eRouteGroup: mocks.createE2eRouteGroup,
@@ -99,6 +103,7 @@ describe('run', () => {
     mocks.listen.mockReset();
     mocks.logger.error.mockReset();
     mocks.logger.info.mockReset();
+    mocks.parseApiTrustProxy.mockReset();
     mocks.registerModuleMetrics.mockReset();
     mocks.setSourceControl.mockReset();
     mocks.startModuleWorkers.mockReset();
@@ -119,6 +124,7 @@ describe('run', () => {
     });
     mocks.createE2eRouteGroup.mockReturnValue([]);
     mocks.createApp.mockResolvedValue({});
+    mocks.parseApiTrustProxy.mockReturnValue(false);
     mocks.startModuleWorkers.mockResolvedValue(undefined);
     mocks.listen.mockResolvedValue('http://127.0.0.1:3000');
     mocks.closeApp.mockResolvedValue(undefined);

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -15,7 +15,7 @@ import type {ModuleWorker} from '@shipfox/node-module';
 import {initializeModules, registerModuleMetrics, startModuleWorkers} from '@shipfox/node-module';
 import {logger, startServiceMetrics} from '@shipfox/node-opentelemetry';
 import {createPostgresClient} from '@shipfox/node-postgres';
-import {config} from '../config.js';
+import {config, parseApiTrustProxy} from '../config.js';
 import {createE2eAdminAuthMethod, createE2eRouteGroup} from './e2e.js';
 
 const WORKER_FAILURE_HTTP_SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -60,6 +60,7 @@ export async function run(): Promise<void> {
   await createApp({
     auth: [...auth, ...e2eAuth],
     routes: [...routes, ...mountedE2eRoutes],
+    fastifyOptions: {trustProxy: parseApiTrustProxy(config.API_TRUST_PROXY)},
   });
   logger().info('Starting module workers');
   await startModuleWorkers({workers, onWorkerFailure: handleModuleWorkerFailure});

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -50,6 +50,7 @@ Required environment:
 | `AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS` | `14` | Refresh token and cookie lifetime. |
 | `AUTH_REFRESH_ROTATION_GRACE_SECONDS` | `30` | Grace window for accepting a just-rotated refresh token during concurrent refreshes. |
 | `AUTH_REFRESH_COOKIE_NAME` | `shipfox_refresh_token` | HTTP cookie name for refresh sessions. |
+| `AUTH_RATE_LIMIT_IDENTIFIER_SECRET` | none | Optional secret used to HMAC emails and IP addresses before storing auth rate-limit counters. When unset, the module derives a stable key from `AUTH_JWT_SECRET`. |
 | `CLIENT_BASE_URL` | `http://localhost:5173` | Base URL used in email verification and password reset links. |
 | `MAILER_TRANSPORT` | `console` | Mail transport. Set to `smtp` to send real mail. |
 | `MAILER_FROM` | `noreply@shipfox.local` | Sender used by auth emails. |
@@ -189,6 +190,22 @@ Protected routes use the `Authorization: Bearer <token>` header. The refresh flo
 > [!IMPORTANT]
 > Refresh cookies are set with `secure: true`, `httpOnly: true`, and `sameSite: "lax"`. Local browser tests need HTTPS or a test path that handles secure cookies.
 
+### Rate limiting
+
+The public auth endpoints include an application-layer abuse baseline for open source installs:
+
+| Route | IP bucket | Email bucket |
+| --- | --- | --- |
+| `POST /auth/login` | 60 attempts per 5 minutes | 10 attempts per 15 minutes |
+| `POST /auth/password-reset` | 30 email-send attempts per hour | 3 email-send attempts per hour |
+| `POST /auth/verify-email/resend` | Shared with password reset | Shared with password reset |
+
+Counters are stored in PostgreSQL as fixed windows in `auth_rate_limits`. IP addresses and email addresses are HMAC-SHA256 values before storage; raw identifiers are not persisted. `AUTH_RATE_LIMIT_IDENTIFIER_SECRET` is optional. Set it when you want a dedicated HMAC secret, or leave it unset to derive the key from `AUTH_JWT_SECRET`.
+
+The limiter uses `request.ip`, so production deployments behind a reverse proxy must configure the API app's `API_TRUST_PROXY` setting. Keep the default `false` when clients connect directly. Use a positive hop count such as `1`, or a trusted proxy IP/CIDR such as `10.0.0.0/8`, when proxy headers are controlled by infrastructure you operate.
+
+This app-layer limiter protects semantic auth work such as Argon2 verification and email sending. It is not a volumetric DDoS control. Public production deployments should still use load balancer, CDN, WAF, or firewall rate limits at the network edge.
+
 ## API
 
 The package exports the module entry point:
@@ -217,6 +234,7 @@ The module creates tables with the `auth_` prefix:
 - `auth_refresh_tokens`
 - `auth_email_verifications`
 - `auth_password_resets`
+- `auth_rate_limits`
 
 Passwords use Argon2id. Email verification tokens, password reset tokens, and refresh tokens are opaque tokens stored as hashes.
 
@@ -228,6 +246,7 @@ Passwords use Argon2id. Email verification tokens, password reset tokens, and re
 - Password reset and email verification consume their tokens once.
 - Password change revokes other refresh sessions. It keeps the current session when the current refresh cookie is valid.
 - Password reset requests and verification resend requests do not reveal whether an account exists.
+- Login, password reset, and verification resend requests are rate-limited by IP address and email address.
 
 ## Development
 

--- a/libs/api/auth/drizzle/0000_initial.sql
+++ b/libs/api/auth/drizzle/0000_initial.sql
@@ -40,6 +40,17 @@ CREATE TABLE "auth_refresh_tokens" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "auth_rate_limits" (
+	"action" text NOT NULL,
+	"scope" text NOT NULL,
+	"identifier_hmac" text NOT NULL,
+	"window_start" timestamp with time zone NOT NULL,
+	"count" integer DEFAULT 1 NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 ALTER TABLE "auth_email_verifications" ADD CONSTRAINT "auth_email_verifications_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "auth_password_resets" ADD CONSTRAINT "auth_password_resets_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "auth_refresh_tokens" ADD CONSTRAINT "auth_refresh_tokens_user_id_auth_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."auth_users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -49,4 +60,6 @@ CREATE INDEX "auth_email_verifications_user_id_idx" ON "auth_email_verifications
 CREATE UNIQUE INDEX "auth_password_resets_hashed_token_unique" ON "auth_password_resets" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "auth_password_resets_user_id_idx" ON "auth_password_resets" USING btree ("user_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "auth_refresh_tokens_hashed_token_unique" ON "auth_refresh_tokens" USING btree ("hashed_token");--> statement-breakpoint
-CREATE INDEX "auth_refresh_tokens_user_id_idx" ON "auth_refresh_tokens" USING btree ("user_id");
+CREATE INDEX "auth_refresh_tokens_user_id_idx" ON "auth_refresh_tokens" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "auth_rate_limits_window_unique" ON "auth_rate_limits" USING btree ("action","scope","identifier_hmac","window_start");--> statement-breakpoint
+CREATE INDEX "auth_rate_limits_expires_at_idx" ON "auth_rate_limits" USING btree ("expires_at");

--- a/libs/api/auth/drizzle/meta/0000_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0000_snapshot.json
@@ -188,6 +188,119 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_rate_limits_window_unique": {
+          "name": "auth_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_rate_limits_expires_at_idx": {
+          "name": "auth_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.auth_refresh_tokens": {
       "name": "auth_refresh_tokens",
       "schema": "",

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -35,6 +35,10 @@ export const config = createConfig({
     desc: 'Name of the browser cookie that stores the refresh token.',
     default: 'shipfox_refresh_token',
   }),
+  AUTH_RATE_LIMIT_IDENTIFIER_SECRET: str({
+    desc: 'Secret used to HMAC email addresses and IP addresses before storing auth rate-limit counters. Leave it unset to derive a stable key from AUTH_JWT_SECRET.',
+    default: undefined,
+  }),
   CLIENT_BASE_URL: str({
     desc: 'Base URL of the client app. Used to build links in emails such as password resets.',
     default: 'http://localhost:5173',

--- a/libs/api/auth/src/core/rate-limit.test.ts
+++ b/libs/api/auth/src/core/rate-limit.test.ts
@@ -1,0 +1,293 @@
+import {and, eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {countAuthRateLimitsForIdentifierHmac, pruneExpiredAuthRateLimits} from '#db/rate-limits.js';
+import {authRateLimits} from '#db/schema/rate-limits.js';
+import {
+  AuthRateLimitUnavailableError,
+  checkAuthRateLimit,
+  hashAuthRateLimitIdentifier,
+} from './rate-limit.js';
+
+const HMAC_HEX_PATTERN = /^[a-f0-9]{64}$/;
+
+function identifier(prefix: string): string {
+  return `${prefix}-${crypto.randomUUID()}@example.com`;
+}
+
+async function countRows(params: {
+  action: string;
+  scope: string;
+  identifierHmac: string;
+}): Promise<number> {
+  const rows = await db()
+    .select({count: sql<number>`count(*)::int`})
+    .from(authRateLimits)
+    .where(
+      and(
+        eq(authRateLimits.action, params.action),
+        eq(authRateLimits.scope, params.scope),
+        eq(authRateLimits.identifierHmac, params.identifierHmac),
+      ),
+    );
+
+  return rows[0]?.count ?? 0;
+}
+
+describe('checkAuthRateLimit', () => {
+  it('allows attempts under the limit and rejects the first over-limit attempt', async () => {
+    const email = identifier('limit');
+    const now = new Date('2026-06-23T00:00:10Z');
+
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 2,
+      windowSeconds: 60,
+      now,
+    });
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 2,
+      windowSeconds: 60,
+      now,
+    });
+    const act = checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 2,
+      windowSeconds: 60,
+      now,
+    });
+
+    await expect(act).rejects.toMatchObject({
+      name: 'AuthRateLimitExceededError',
+      retryAfterSeconds: 50,
+    });
+  });
+
+  it('resets counters in the next fixed window', async () => {
+    const email = identifier('window-reset');
+    const firstWindow = new Date('2026-06-23T00:00:10Z');
+    const secondWindow = new Date('2026-06-23T00:01:01Z');
+
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 1,
+      windowSeconds: 60,
+      now: firstWindow,
+    });
+    const result = checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 1,
+      windowSeconds: 60,
+      now: secondWindow,
+    });
+
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  it('keeps actions and scopes separated', async () => {
+    const value = identifier('separated');
+    const now = new Date('2026-06-23T00:02:10Z');
+
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'ip',
+      identifier: value,
+      limit: 1,
+      windowSeconds: 60,
+      now,
+    });
+    const emailScope = checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: value,
+      limit: 1,
+      windowSeconds: 60,
+      now,
+    });
+    const otherAction = checkAuthRateLimit({
+      action: 'email-send',
+      scope: 'ip',
+      identifier: value,
+      limit: 1,
+      windowSeconds: 60,
+      now,
+    });
+
+    await expect(emailScope).resolves.toBeUndefined();
+    await expect(otherAction).resolves.toBeUndefined();
+  });
+
+  it('uses atomic concurrent upserts', async () => {
+    const email = identifier('concurrent');
+    const now = new Date('2026-06-23T00:03:10Z');
+    const identifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+    });
+
+    await Promise.all(
+      Array.from({length: 20}, () =>
+        checkAuthRateLimit({
+          action: 'login',
+          scope: 'email',
+          identifier: email,
+          limit: 100,
+          windowSeconds: 60,
+          now,
+        }),
+      ),
+    );
+    const rows = await db()
+      .select({count: authRateLimits.count})
+      .from(authRateLimits)
+      .where(eq(authRateLimits.identifierHmac, identifierHmac));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.count).toBe(20);
+  });
+
+  it('fails closed when the limiter query times out', async () => {
+    const email = identifier('timeout');
+
+    await db().transaction(async (tx) => {
+      await tx.execute(sql`LOCK TABLE auth_rate_limits IN ACCESS EXCLUSIVE MODE`);
+      const act = checkAuthRateLimit({
+        action: 'login',
+        scope: 'email',
+        identifier: email,
+        limit: 1,
+        windowSeconds: 60,
+        timeoutMs: 10,
+      });
+
+      await expect(act).rejects.toBeInstanceOf(AuthRateLimitUnavailableError);
+    });
+  });
+
+  it('prunes expired counters', async () => {
+    const expiredIdentifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: identifier('expired'),
+    });
+    const activeIdentifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: identifier('active'),
+    });
+    const now = new Date('2026-06-23T00:04:00Z');
+    await db()
+      .insert(authRateLimits)
+      .values([
+        {
+          action: 'login',
+          scope: 'email',
+          identifierHmac: expiredIdentifierHmac,
+          windowStart: new Date('2026-06-22T23:00:00Z'),
+          count: 1,
+          expiresAt: new Date('2026-06-22T23:15:00Z'),
+        },
+        {
+          action: 'login',
+          scope: 'email',
+          identifierHmac: activeIdentifierHmac,
+          windowStart: new Date('2026-06-23T00:00:00Z'),
+          count: 1,
+          expiresAt: new Date('2026-06-23T00:15:00Z'),
+        },
+      ]);
+
+    const result = await pruneExpiredAuthRateLimits({now, minIntervalMs: 0});
+    const expiredRows = await countAuthRateLimitsForIdentifierHmac({
+      identifierHmac: expiredIdentifierHmac,
+    });
+    const activeRows = await countAuthRateLimitsForIdentifierHmac({
+      identifierHmac: activeIdentifierHmac,
+    });
+
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(expiredRows).toBe(0);
+    expect(activeRows).toBe(1);
+  });
+
+  it('stores only HMAC identifiers, not raw emails or IPs', async () => {
+    const email = identifier('privacy');
+    const ip = '203.0.113.42';
+    const emailHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+    });
+    const ipHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'ip',
+      identifier: ip,
+    });
+
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 1,
+      windowSeconds: 60,
+    });
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'ip',
+      identifier: ip,
+      limit: 1,
+      windowSeconds: 60,
+    });
+    const stored = await db()
+      .select({
+        identifierHmac: authRateLimits.identifierHmac,
+      })
+      .from(authRateLimits)
+      .where(eq(authRateLimits.action, 'login'));
+
+    expect(stored.map((row) => row.identifierHmac)).toContain(emailHmac);
+    expect(stored.map((row) => row.identifierHmac)).toContain(ipHmac);
+    expect(await countRows({action: 'login', scope: 'email', identifierHmac: emailHmac})).toBe(1);
+    expect(JSON.stringify(stored)).not.toContain(email);
+    expect(JSON.stringify(stored)).not.toContain(ip);
+    expect(emailHmac).toMatch(HMAC_HEX_PATTERN);
+    expect(ipHmac).toMatch(HMAC_HEX_PATTERN);
+  });
+
+  it('reports blocked attempts with non-PII context', async () => {
+    const email = identifier('blocked-context');
+
+    await checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 1,
+      windowSeconds: 60,
+    });
+    const act = checkAuthRateLimit({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 1,
+      windowSeconds: 60,
+    });
+
+    await expect(act).rejects.toMatchObject({
+      name: 'AuthRateLimitExceededError',
+      action: 'login',
+      scope: 'email',
+      identifierHmacPrefix: expect.not.stringContaining(email),
+    });
+  });
+});

--- a/libs/api/auth/src/core/rate-limit.test.ts
+++ b/libs/api/auth/src/core/rate-limit.test.ts
@@ -159,15 +159,37 @@ describe('checkAuthRateLimit', () => {
 
   it('fails closed when the limiter query times out', async () => {
     const email = identifier('timeout');
+    const now = new Date('2026-06-23T00:03:30Z');
+    const identifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+    });
+    await db()
+      .insert(authRateLimits)
+      .values({
+        action: 'login',
+        scope: 'email',
+        identifierHmac,
+        windowStart: new Date('2026-06-23T00:03:00Z'),
+        count: 1,
+        expiresAt: new Date('2026-06-23T00:04:00Z'),
+      });
 
     await db().transaction(async (tx) => {
-      await tx.execute(sql`LOCK TABLE auth_rate_limits IN ACCESS EXCLUSIVE MODE`);
+      await tx.execute(sql`
+        SELECT 1
+        FROM auth_rate_limits
+        WHERE identifier_hmac = ${identifierHmac}
+        FOR UPDATE
+      `);
       const act = checkAuthRateLimit({
         action: 'login',
         scope: 'email',
         identifier: email,
         limit: 1,
         windowSeconds: 60,
+        now,
         timeoutMs: 10,
       });
 

--- a/libs/api/auth/src/core/rate-limit.test.ts
+++ b/libs/api/auth/src/core/rate-limit.test.ts
@@ -247,6 +247,58 @@ describe('checkAuthRateLimit', () => {
     expect(activeRows).toBe(1);
   });
 
+  it('does not wait for opportunistic pruning after an allowed check', async () => {
+    const now = new Date('2026-06-23T00:04:30Z');
+    const expiresAt = new Date('2026-06-23T00:05:00Z');
+    const consumeAuthRateLimit = vi.fn().mockResolvedValue({count: 1, expiresAt});
+    let finishPrune: ((value: number) => void) | undefined;
+    const pendingPrune = new Promise<number>((resolve) => {
+      finishPrune = resolve;
+    });
+    const pruneExpiredAuthRateLimits = vi.fn(() => pendingPrune);
+    vi.resetModules();
+    vi.doMock('#config.js', () => ({
+      config: {
+        AUTH_JWT_SECRET: 'jwt-secret',
+        AUTH_RATE_LIMIT_IDENTIFIER_SECRET: undefined,
+      },
+    }));
+    vi.doMock('#db/rate-limits.js', () => ({
+      consumeAuthRateLimit,
+      pruneExpiredAuthRateLimits,
+    }));
+    vi.doMock('#metrics/index.js', () => ({
+      recordAuthRateLimitCheck: vi.fn(),
+      recordAuthRateLimitPruneFailure: vi.fn(),
+    }));
+
+    try {
+      const rateLimitModule = await import('./rate-limit.js');
+      const result = await Promise.race([
+        rateLimitModule
+          .checkAuthRateLimit({
+            action: 'login',
+            scope: 'email',
+            identifier: 'person@example.com',
+            limit: 2,
+            windowSeconds: 60,
+            now,
+          })
+          .then(() => 'resolved' as const),
+        new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 20)),
+      ]);
+
+      expect(result).toBe('resolved');
+      expect(pruneExpiredAuthRateLimits).toHaveBeenCalledWith({now});
+    } finally {
+      finishPrune?.(0);
+      vi.doUnmock('#config.js');
+      vi.doUnmock('#db/rate-limits.js');
+      vi.doUnmock('#metrics/index.js');
+      vi.resetModules();
+    }
+  });
+
   it('throttles prune attempts inside the configured interval', async () => {
     const firstIdentifierHmac = hashAuthRateLimitIdentifier({
       action: 'login',

--- a/libs/api/auth/src/core/rate-limit.test.ts
+++ b/libs/api/auth/src/core/rate-limit.test.ts
@@ -1,6 +1,6 @@
 import {and, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
-import {countAuthRateLimitsForIdentifierHmac, pruneExpiredAuthRateLimits} from '#db/rate-limits.js';
+import {pruneExpiredAuthRateLimits} from '#db/rate-limits.js';
 import {authRateLimits} from '#db/schema/rate-limits.js';
 import {
   AuthRateLimitUnavailableError,
@@ -231,16 +231,71 @@ describe('checkAuthRateLimit', () => {
       ]);
 
     const result = await pruneExpiredAuthRateLimits({now, minIntervalMs: 0});
-    const expiredRows = await countAuthRateLimitsForIdentifierHmac({
+    const expiredRows = await countRows({
+      action: 'login',
+      scope: 'email',
       identifierHmac: expiredIdentifierHmac,
     });
-    const activeRows = await countAuthRateLimitsForIdentifierHmac({
+    const activeRows = await countRows({
+      action: 'login',
+      scope: 'email',
       identifierHmac: activeIdentifierHmac,
     });
 
     expect(result).toBeGreaterThanOrEqual(1);
     expect(expiredRows).toBe(0);
     expect(activeRows).toBe(1);
+  });
+
+  it('throttles prune attempts inside the configured interval', async () => {
+    const firstIdentifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: identifier('first-prune'),
+    });
+    const secondIdentifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'email',
+      identifier: identifier('second-prune'),
+    });
+    await db()
+      .insert(authRateLimits)
+      .values({
+        action: 'login',
+        scope: 'email',
+        identifierHmac: firstIdentifierHmac,
+        windowStart: new Date('2026-06-23T00:00:00Z'),
+        count: 1,
+        expiresAt: new Date('2026-06-23T00:01:00Z'),
+      });
+    const firstResult = await pruneExpiredAuthRateLimits({
+      now: new Date('2026-06-23T00:05:00Z'),
+      minIntervalMs: 60_000,
+    });
+    await db()
+      .insert(authRateLimits)
+      .values({
+        action: 'login',
+        scope: 'email',
+        identifierHmac: secondIdentifierHmac,
+        windowStart: new Date('2026-06-23T00:01:00Z'),
+        count: 1,
+        expiresAt: new Date('2026-06-23T00:02:00Z'),
+      });
+
+    const secondResult = await pruneExpiredAuthRateLimits({
+      now: new Date('2026-06-23T00:05:30Z'),
+      minIntervalMs: 60_000,
+    });
+    const secondRows = await countRows({
+      action: 'login',
+      scope: 'email',
+      identifierHmac: secondIdentifierHmac,
+    });
+
+    expect(firstResult).toBeGreaterThanOrEqual(1);
+    expect(secondResult).toBeUndefined();
+    expect(secondRows).toBe(1);
   });
 
   it('stores only HMAC identifiers, not raw emails or IPs', async () => {
@@ -311,5 +366,44 @@ describe('checkAuthRateLimit', () => {
       scope: 'email',
       identifierHmacPrefix: expect.not.stringContaining(email),
     });
+  });
+
+  it('uses the configured identifier secret when present', async () => {
+    vi.resetModules();
+    vi.doMock('#config.js', () => ({
+      config: {
+        AUTH_JWT_SECRET: 'jwt-secret',
+        AUTH_RATE_LIMIT_IDENTIFIER_SECRET: 'configured-secret',
+      },
+    }));
+
+    try {
+      const configuredSecretModule = await import('./rate-limit.js');
+      const configuredSecretHash = configuredSecretModule.hashAuthRateLimitIdentifier({
+        action: 'login',
+        scope: 'email',
+        identifier: 'person@example.com',
+      });
+      vi.doMock('#config.js', () => ({
+        config: {
+          AUTH_JWT_SECRET: 'jwt-secret',
+          AUTH_RATE_LIMIT_IDENTIFIER_SECRET: undefined,
+        },
+      }));
+      vi.resetModules();
+      const derivedSecretModule = await import('./rate-limit.js');
+      const derivedSecretHash = derivedSecretModule.hashAuthRateLimitIdentifier({
+        action: 'login',
+        scope: 'email',
+        identifier: 'person@example.com',
+      });
+
+      expect(configuredSecretHash).toMatch(HMAC_HEX_PATTERN);
+      expect(derivedSecretHash).toMatch(HMAC_HEX_PATTERN);
+      expect(configuredSecretHash).not.toBe(derivedSecretHash);
+    } finally {
+      vi.doUnmock('#config.js');
+      vi.resetModules();
+    }
   });
 });

--- a/libs/api/auth/src/core/rate-limit.ts
+++ b/libs/api/auth/src/core/rate-limit.ts
@@ -1,11 +1,18 @@
 import {createHmac} from 'node:crypto';
-import {instanceMetrics} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {consumeAuthRateLimit, pruneExpiredAuthRateLimits} from '#db/rate-limits.js';
+import {
+  type AuthRateLimitAction,
+  type AuthRateLimitScope,
+  recordAuthRateLimitCheck,
+  recordAuthRateLimitPruneFailure,
+} from '#metrics/index.js';
 
-export type AuthRateLimitAction = 'login' | 'email-send';
-export type AuthRateLimitScope = 'ip' | 'email';
-export type AuthRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
+export type {
+  AuthRateLimitAction,
+  AuthRateLimitOutcome,
+  AuthRateLimitScope,
+} from '#metrics/index.js';
 
 export interface AuthRateLimitPolicy {
   limit: number;
@@ -67,14 +74,6 @@ const HASH_PREFIX_LENGTH = 12;
 const IDENTIFIER_SECRET_DERIVATION_DOMAIN = 'shipfox.auth.rate-limit.identifier-secret.v1';
 const IDENTIFIER_HASH_DOMAIN = 'shipfox.auth.rate-limit.identifier.v1';
 
-const meter = instanceMetrics.getMeter('api-auth');
-const checksCounter = meter.createCounter('auth_rate_limit_checks_total', {
-  description: 'Authentication rate limit checks by action, scope, and outcome.',
-});
-const pruneFailuresCounter = meter.createCounter('auth_rate_limit_prune_failures_total', {
-  description: 'Authentication rate limit prune failures.',
-});
-
 function effectiveIdentifierSecret(): Buffer | string {
   if (config.AUTH_RATE_LIMIT_IDENTIFIER_SECRET) {
     return config.AUTH_RATE_LIMIT_IDENTIFIER_SECRET;
@@ -83,18 +82,6 @@ function effectiveIdentifierSecret(): Buffer | string {
   return createHmac('sha256', config.AUTH_JWT_SECRET)
     .update(IDENTIFIER_SECRET_DERIVATION_DOMAIN)
     .digest();
-}
-
-function recordAuthRateLimitCheck(params: {
-  action: AuthRateLimitAction;
-  scope: AuthRateLimitScope;
-  outcome: AuthRateLimitOutcome;
-}): void {
-  checksCounter.add(1, {
-    action: params.action,
-    scope: params.scope,
-    outcome: params.outcome,
-  });
 }
 
 export function hashAuthRateLimitIdentifier(params: {
@@ -174,6 +161,6 @@ export async function checkAuthRateLimit(params: CheckAuthRateLimitParams): Prom
   recordAuthRateLimitCheck({action: params.action, scope: params.scope, outcome: 'allowed'});
 
   await pruneExpiredAuthRateLimits({now}).catch(() => {
-    pruneFailuresCounter.add(1);
+    recordAuthRateLimitPruneFailure();
   });
 }

--- a/libs/api/auth/src/core/rate-limit.ts
+++ b/libs/api/auth/src/core/rate-limit.ts
@@ -67,11 +67,13 @@ const HASH_PREFIX_LENGTH = 12;
 const IDENTIFIER_SECRET_DERIVATION_DOMAIN = 'shipfox.auth.rate-limit.identifier-secret.v1';
 const IDENTIFIER_HASH_DOMAIN = 'shipfox.auth.rate-limit.identifier.v1';
 
-const checksCounter = instanceMetrics
-  .getMeter('api-auth')
-  .createCounter('auth_rate_limit_checks_total', {
-    description: 'Authentication rate limit checks by action, scope, and outcome.',
-  });
+const meter = instanceMetrics.getMeter('api-auth');
+const checksCounter = meter.createCounter('auth_rate_limit_checks_total', {
+  description: 'Authentication rate limit checks by action, scope, and outcome.',
+});
+const pruneFailuresCounter = meter.createCounter('auth_rate_limit_prune_failures_total', {
+  description: 'Authentication rate limit prune failures.',
+});
 
 function effectiveIdentifierSecret(): Buffer | string {
   if (config.AUTH_RATE_LIMIT_IDENTIFIER_SECRET) {
@@ -171,5 +173,7 @@ export async function checkAuthRateLimit(params: CheckAuthRateLimitParams): Prom
 
   recordAuthRateLimitCheck({action: params.action, scope: params.scope, outcome: 'allowed'});
 
-  await pruneExpiredAuthRateLimits({now}).catch(() => undefined);
+  await pruneExpiredAuthRateLimits({now}).catch(() => {
+    pruneFailuresCounter.add(1);
+  });
 }

--- a/libs/api/auth/src/core/rate-limit.ts
+++ b/libs/api/auth/src/core/rate-limit.ts
@@ -1,0 +1,175 @@
+import {createHmac} from 'node:crypto';
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+import {config} from '#config.js';
+import {consumeAuthRateLimit, pruneExpiredAuthRateLimits} from '#db/rate-limits.js';
+
+export type AuthRateLimitAction = 'login' | 'email-send';
+export type AuthRateLimitScope = 'ip' | 'email';
+export type AuthRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
+
+export interface AuthRateLimitPolicy {
+  limit: number;
+  windowSeconds: number;
+}
+
+export interface CheckAuthRateLimitParams extends AuthRateLimitPolicy {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  identifier: string;
+  now?: Date | undefined;
+  timeoutMs?: number | undefined;
+}
+
+export class AuthRateLimitExceededError extends Error {
+  readonly action: AuthRateLimitAction;
+  readonly scope: AuthRateLimitScope;
+  readonly retryAfterSeconds: number;
+  readonly identifierHmacPrefix: string;
+
+  constructor(params: {
+    action: AuthRateLimitAction;
+    scope: AuthRateLimitScope;
+    retryAfterSeconds: number;
+    identifierHmacPrefix: string;
+  }) {
+    super('Authentication rate limit exceeded');
+    this.name = 'AuthRateLimitExceededError';
+    this.action = params.action;
+    this.scope = params.scope;
+    this.retryAfterSeconds = params.retryAfterSeconds;
+    this.identifierHmacPrefix = params.identifierHmacPrefix;
+  }
+}
+
+export class AuthRateLimitUnavailableError extends Error {
+  readonly action: AuthRateLimitAction;
+  readonly scope: AuthRateLimitScope;
+  readonly identifierHmacPrefix: string;
+  override readonly cause: unknown;
+
+  constructor(params: {
+    action: AuthRateLimitAction;
+    scope: AuthRateLimitScope;
+    identifierHmacPrefix: string;
+    cause: unknown;
+  }) {
+    super('Authentication rate limiter unavailable');
+    this.name = 'AuthRateLimitUnavailableError';
+    this.action = params.action;
+    this.scope = params.scope;
+    this.identifierHmacPrefix = params.identifierHmacPrefix;
+    this.cause = params.cause;
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 250;
+const HASH_PREFIX_LENGTH = 12;
+const IDENTIFIER_SECRET_DERIVATION_DOMAIN = 'shipfox.auth.rate-limit.identifier-secret.v1';
+const IDENTIFIER_HASH_DOMAIN = 'shipfox.auth.rate-limit.identifier.v1';
+
+const checksCounter = instanceMetrics
+  .getMeter('api-auth')
+  .createCounter('auth_rate_limit_checks_total', {
+    description: 'Authentication rate limit checks by action, scope, and outcome.',
+  });
+
+function effectiveIdentifierSecret(): Buffer | string {
+  if (config.AUTH_RATE_LIMIT_IDENTIFIER_SECRET) {
+    return config.AUTH_RATE_LIMIT_IDENTIFIER_SECRET;
+  }
+
+  return createHmac('sha256', config.AUTH_JWT_SECRET)
+    .update(IDENTIFIER_SECRET_DERIVATION_DOMAIN)
+    .digest();
+}
+
+function recordAuthRateLimitCheck(params: {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  outcome: AuthRateLimitOutcome;
+}): void {
+  checksCounter.add(1, {
+    action: params.action,
+    scope: params.scope,
+    outcome: params.outcome,
+  });
+}
+
+export function hashAuthRateLimitIdentifier(params: {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  identifier: string;
+}): string {
+  return createHmac('sha256', effectiveIdentifierSecret())
+    .update(IDENTIFIER_HASH_DOMAIN)
+    .update('\0')
+    .update(params.action)
+    .update('\0')
+    .update(params.scope)
+    .update('\0')
+    .update(params.identifier)
+    .digest('hex');
+}
+
+function windowStartFor(now: Date, windowSeconds: number): Date {
+  const windowMs = windowSeconds * 1000;
+  return new Date(Math.floor(now.getTime() / windowMs) * windowMs);
+}
+
+function secondsAfter(date: Date, seconds: number): Date {
+  return new Date(date.getTime() + seconds * 1000);
+}
+
+function retryAfterSeconds(now: Date, expiresAt: Date): number {
+  return Math.max(1, Math.ceil((expiresAt.getTime() - now.getTime()) / 1000));
+}
+
+export async function checkAuthRateLimit(params: CheckAuthRateLimitParams): Promise<void> {
+  const now = params.now ?? new Date();
+  const windowStart = windowStartFor(now, params.windowSeconds);
+  const expiresAt = secondsAfter(windowStart, params.windowSeconds);
+  const identifierHmac = hashAuthRateLimitIdentifier({
+    action: params.action,
+    scope: params.scope,
+    identifier: params.identifier,
+  });
+  const identifierHmacPrefix = identifierHmac.slice(0, HASH_PREFIX_LENGTH);
+
+  let result: Awaited<ReturnType<typeof consumeAuthRateLimit>>;
+  try {
+    result = await consumeAuthRateLimit({
+      action: params.action,
+      scope: params.scope,
+      identifierHmac,
+      windowStart,
+      expiresAt,
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    });
+  } catch (error) {
+    recordAuthRateLimitCheck({
+      action: params.action,
+      scope: params.scope,
+      outcome: 'unavailable',
+    });
+    throw new AuthRateLimitUnavailableError({
+      action: params.action,
+      scope: params.scope,
+      identifierHmacPrefix,
+      cause: error,
+    });
+  }
+
+  if (result.count > params.limit) {
+    recordAuthRateLimitCheck({action: params.action, scope: params.scope, outcome: 'blocked'});
+    throw new AuthRateLimitExceededError({
+      action: params.action,
+      scope: params.scope,
+      retryAfterSeconds: retryAfterSeconds(now, result.expiresAt),
+      identifierHmacPrefix,
+    });
+  }
+
+  recordAuthRateLimitCheck({action: params.action, scope: params.scope, outcome: 'allowed'});
+
+  await pruneExpiredAuthRateLimits({now}).catch(() => undefined);
+}

--- a/libs/api/auth/src/core/rate-limit.ts
+++ b/libs/api/auth/src/core/rate-limit.ts
@@ -160,7 +160,7 @@ export async function checkAuthRateLimit(params: CheckAuthRateLimitParams): Prom
 
   recordAuthRateLimitCheck({action: params.action, scope: params.scope, outcome: 'allowed'});
 
-  await pruneExpiredAuthRateLimits({now}).catch(() => {
+  void pruneExpiredAuthRateLimits({now}).catch(() => {
     recordAuthRateLimitPruneFailure();
   });
 }

--- a/libs/api/auth/src/db/db.ts
+++ b/libs/api/auth/src/db/db.ts
@@ -3,6 +3,7 @@ import {pgClient} from '@shipfox/node-postgres';
 import {emailVerifications} from './schema/email-verifications.js';
 import {authOutbox} from './schema/outbox.js';
 import {passwordResets} from './schema/password-resets.js';
+import {authRateLimits} from './schema/rate-limits.js';
 import {refreshTokens} from './schema/refresh-tokens.js';
 import {users} from './schema/users.js';
 
@@ -12,6 +13,7 @@ export const schema = {
   refreshTokens,
   emailVerifications,
   authOutbox,
+  authRateLimits,
 };
 
 let _db: NodePgDatabase<typeof schema> | undefined;

--- a/libs/api/auth/src/db/rate-limits.ts
+++ b/libs/api/auth/src/db/rate-limits.ts
@@ -1,0 +1,83 @@
+import {eq, lt, sql} from 'drizzle-orm';
+import {db} from './db.js';
+import {authRateLimits} from './schema/rate-limits.js';
+
+export interface ConsumeAuthRateLimitParams {
+  action: string;
+  scope: string;
+  identifierHmac: string;
+  windowStart: Date;
+  expiresAt: Date;
+  timeoutMs: number;
+}
+
+export interface ConsumeAuthRateLimitResult {
+  count: number;
+  expiresAt: Date;
+}
+
+export async function consumeAuthRateLimit(
+  params: ConsumeAuthRateLimitParams,
+): Promise<ConsumeAuthRateLimitResult> {
+  return await db().transaction(async (tx) => {
+    await tx.execute(sql`select set_config('statement_timeout', ${`${params.timeoutMs}ms`}, true)`);
+
+    const rows = await tx
+      .insert(authRateLimits)
+      .values({
+        action: params.action,
+        scope: params.scope,
+        identifierHmac: params.identifierHmac,
+        windowStart: params.windowStart,
+        count: 1,
+        expiresAt: params.expiresAt,
+      })
+      .onConflictDoUpdate({
+        target: [
+          authRateLimits.action,
+          authRateLimits.scope,
+          authRateLimits.identifierHmac,
+          authRateLimits.windowStart,
+        ],
+        set: {
+          count: sql`${authRateLimits.count} + 1`,
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning({count: authRateLimits.count, expiresAt: authRateLimits.expiresAt});
+
+    const row = rows[0];
+    if (!row) throw new Error('Rate limit upsert returned no rows');
+    return row;
+  });
+}
+
+let nextPruneAt = 0;
+
+export async function pruneExpiredAuthRateLimits(
+  params: {now?: Date | undefined; minIntervalMs?: number | undefined} = {},
+): Promise<number | undefined> {
+  const now = params.now ?? new Date();
+  const minIntervalMs = params.minIntervalMs ?? 60_000;
+  if (minIntervalMs > 0 && now.getTime() < nextPruneAt) return undefined;
+
+  nextPruneAt = now.getTime() + minIntervalMs;
+
+  const rows = await db()
+    .delete(authRateLimits)
+    .where(lt(authRateLimits.expiresAt, now))
+    .returning({identifierHmac: authRateLimits.identifierHmac});
+
+  return rows.length;
+}
+
+export async function countAuthRateLimitsForIdentifierHmac(params: {
+  identifierHmac: string;
+}): Promise<number> {
+  const rows = await db()
+    .select({count: sql<number>`count(*)::int`})
+    .from(authRateLimits)
+    .where(eq(authRateLimits.identifierHmac, params.identifierHmac));
+
+  return rows[0]?.count ?? 0;
+}

--- a/libs/api/auth/src/db/rate-limits.ts
+++ b/libs/api/auth/src/db/rate-limits.ts
@@ -1,4 +1,4 @@
-import {eq, lt, sql} from 'drizzle-orm';
+import {lt, sql} from 'drizzle-orm';
 import {db} from './db.js';
 import {authRateLimits} from './schema/rate-limits.js';
 
@@ -63,21 +63,7 @@ export async function pruneExpiredAuthRateLimits(
 
   nextPruneAt = now.getTime() + minIntervalMs;
 
-  const rows = await db()
-    .delete(authRateLimits)
-    .where(lt(authRateLimits.expiresAt, now))
-    .returning({identifierHmac: authRateLimits.identifierHmac});
+  const result = await db().delete(authRateLimits).where(lt(authRateLimits.expiresAt, now));
 
-  return rows.length;
-}
-
-export async function countAuthRateLimitsForIdentifierHmac(params: {
-  identifierHmac: string;
-}): Promise<number> {
-  const rows = await db()
-    .select({count: sql<number>`count(*)::int`})
-    .from(authRateLimits)
-    .where(eq(authRateLimits.identifierHmac, params.identifierHmac));
-
-  return rows[0]?.count ?? 0;
+  return result.rowCount ?? 0;
 }

--- a/libs/api/auth/src/db/schema/rate-limits.ts
+++ b/libs/api/auth/src/db/schema/rate-limits.ts
@@ -1,0 +1,27 @@
+import {index, integer, text, timestamp, uniqueIndex} from 'drizzle-orm/pg-core';
+import {pgTable} from './common.js';
+
+export const authRateLimits = pgTable(
+  'rate_limits',
+  {
+    action: text('action').notNull(),
+    scope: text('scope').notNull(),
+    identifierHmac: text('identifier_hmac').notNull(),
+    windowStart: timestamp('window_start', {withTimezone: true}).notNull(),
+    count: integer('count').notNull().default(1),
+    expiresAt: timestamp('expires_at', {withTimezone: true}).notNull(),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('auth_rate_limits_window_unique').on(
+      table.action,
+      table.scope,
+      table.identifierHmac,
+      table.windowStart,
+    ),
+    index('auth_rate_limits_expires_at_idx').on(table.expiresAt),
+  ],
+);
+
+export type AuthRateLimitDb = typeof authRateLimits.$inferSelect;

--- a/libs/api/auth/src/metrics/index.ts
+++ b/libs/api/auth/src/metrics/index.ts
@@ -1,7 +1,12 @@
 export {
+  type AuthRateLimitAction,
+  type AuthRateLimitOutcome,
+  type AuthRateLimitScope,
   type AuthTokenRefreshOutcome,
   type AuthTokenType,
   type AuthTokenVerificationOutcome,
+  recordAuthRateLimitCheck,
+  recordAuthRateLimitPruneFailure,
   recordTokenIssued,
   recordTokenRefreshed,
   recordTokenVerified,

--- a/libs/api/auth/src/metrics/instance.test.ts
+++ b/libs/api/auth/src/metrics/instance.test.ts
@@ -1,0 +1,69 @@
+const metricMocks = vi.hoisted(() => {
+  const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
+  const createCounter = vi.fn((name: string) => {
+    const counter = {add: vi.fn()};
+    counters.set(name, counter);
+    return counter;
+  });
+
+  return {counters, createCounter};
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  instanceMetrics: {
+    getMeter: () => ({
+      createCounter: metricMocks.createCounter,
+    }),
+  },
+}));
+
+const metrics = await import('./instance.js');
+
+function counterAdd(name: string): ReturnType<typeof vi.fn> {
+  const counter = metricMocks.counters.get(name);
+  if (!counter) throw new Error(`Missing counter: ${name}`);
+  return counter.add;
+}
+
+describe('auth metrics', () => {
+  beforeEach(() => {
+    for (const counter of metricMocks.counters.values()) {
+      counter.add.mockReset();
+    }
+  });
+
+  it('records auth rate-limit checks with low-cardinality labels', () => {
+    metrics.recordAuthRateLimitCheck({
+      action: 'login',
+      scope: 'ip',
+      outcome: 'blocked',
+    });
+
+    expect(counterAdd('auth_rate_limit_checks_total')).toHaveBeenCalledWith(1, {
+      action: 'login',
+      scope: 'ip',
+      outcome: 'blocked',
+    });
+  });
+
+  it('records auth rate-limit prune failures', () => {
+    metrics.recordAuthRateLimitPruneFailure();
+
+    expect(counterAdd('auth_rate_limit_prune_failures_total')).toHaveBeenCalledWith(1);
+  });
+
+  it('does not let metric failures affect callers', () => {
+    counterAdd('auth_rate_limit_checks_total').mockImplementationOnce(() => {
+      throw new Error('metrics unavailable');
+    });
+
+    const act = () =>
+      metrics.recordAuthRateLimitCheck({
+        action: 'email-send',
+        scope: 'email',
+        outcome: 'unavailable',
+      });
+
+    expect(act).not.toThrow();
+  });
+});

--- a/libs/api/auth/src/metrics/instance.test.ts
+++ b/libs/api/auth/src/metrics/instance.test.ts
@@ -39,7 +39,7 @@ describe('auth metrics', () => {
       outcome: 'blocked',
     });
 
-    expect(counterAdd('auth_rate_limit_checks_total')).toHaveBeenCalledWith(1, {
+    expect(counterAdd('auth_rate_limit_checks')).toHaveBeenCalledWith(1, {
       action: 'login',
       scope: 'ip',
       outcome: 'blocked',
@@ -49,11 +49,11 @@ describe('auth metrics', () => {
   it('records auth rate-limit prune failures', () => {
     metrics.recordAuthRateLimitPruneFailure();
 
-    expect(counterAdd('auth_rate_limit_prune_failures_total')).toHaveBeenCalledWith(1);
+    expect(counterAdd('auth_rate_limit_prune_failures')).toHaveBeenCalledWith(1);
   });
 
   it('does not let metric failures affect callers', () => {
-    counterAdd('auth_rate_limit_checks_total').mockImplementationOnce(() => {
+    counterAdd('auth_rate_limit_checks').mockImplementationOnce(() => {
       throw new Error('metrics unavailable');
     });
 

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -3,6 +3,9 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 export type AuthTokenType = 'session' | 'job_lease' | 'runner_session';
 export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
 export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
+export type AuthRateLimitAction = 'login' | 'email-send';
+export type AuthRateLimitScope = 'ip' | 'email';
+export type AuthRateLimitOutcome = 'allowed' | 'blocked' | 'unavailable';
 
 const meter = instanceMetrics.getMeter('auth');
 
@@ -19,6 +22,18 @@ const tokenRefreshedCount = meter.createCounter<{outcome: AuthTokenRefreshOutcom
   'auth_token_refreshed',
   {description: 'Refresh-token exchanges by outcome'},
 );
+
+const rateLimitCheckCount = meter.createCounter<{
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  outcome: AuthRateLimitOutcome;
+}>('auth_rate_limit_checks_total', {
+  description: 'Authentication rate limit checks by action, scope, and outcome',
+});
+
+const rateLimitPruneFailureCount = meter.createCounter('auth_rate_limit_prune_failures_total', {
+  description: 'Authentication rate limit prune failures',
+});
 
 function recordMetric(record: () => void): void {
   try {
@@ -41,4 +56,22 @@ export function recordTokenVerified(
 
 export function recordTokenRefreshed(outcome: AuthTokenRefreshOutcome): void {
   recordMetric(() => tokenRefreshedCount.add(1, {outcome}));
+}
+
+export function recordAuthRateLimitCheck(params: {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  outcome: AuthRateLimitOutcome;
+}): void {
+  recordMetric(() =>
+    rateLimitCheckCount.add(1, {
+      action: params.action,
+      scope: params.scope,
+      outcome: params.outcome,
+    }),
+  );
+}
+
+export function recordAuthRateLimitPruneFailure(): void {
+  recordMetric(() => rateLimitPruneFailureCount.add(1));
 }

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -27,11 +27,11 @@ const rateLimitCheckCount = meter.createCounter<{
   action: AuthRateLimitAction;
   scope: AuthRateLimitScope;
   outcome: AuthRateLimitOutcome;
-}>('auth_rate_limit_checks_total', {
+}>('auth_rate_limit_checks', {
   description: 'Authentication rate limit checks by action, scope, and outcome',
 });
 
-const rateLimitPruneFailureCount = meter.createCounter('auth_rate_limit_prune_failures_total', {
+const rateLimitPruneFailureCount = meter.createCounter('auth_rate_limit_prune_failures', {
   description: 'Authentication rate limit prune failures',
 });
 

--- a/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.ts
+++ b/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.ts
@@ -1,6 +1,7 @@
 import {verifyEmailResendBodySchema, verifyEmailResendResponseSchema} from '@shipfox/api-auth-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {resendEmailVerification} from '#core/auth.js';
+import {createAuthRateLimitPreHandler} from '#presentation/routes/rate-limit.js';
 
 export const verifyEmailResendRoute = defineRoute({
   method: 'POST',
@@ -12,6 +13,7 @@ export const verifyEmailResendRoute = defineRoute({
       200: verifyEmailResendResponseSchema,
     },
   },
+  preHandler: createAuthRateLimitPreHandler('email-send'),
   handler: async (request, reply) => {
     const {email} = request.body;
 

--- a/libs/api/auth/src/presentation/routes/password/password-reset-request.ts
+++ b/libs/api/auth/src/presentation/routes/password/password-reset-request.ts
@@ -2,6 +2,7 @@ import {passwordResetRequestBodySchema} from '@shipfox/api-auth-dto';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {requestPasswordReset} from '#core/auth.js';
+import {createAuthRateLimitPreHandler} from '#presentation/routes/rate-limit.js';
 
 export const passwordResetRequestRoute = defineRoute({
   method: 'POST',
@@ -13,6 +14,7 @@ export const passwordResetRequestRoute = defineRoute({
       204: z.void(),
     },
   },
+  preHandler: createAuthRateLimitPreHandler('email-send'),
   handler: async (request, reply) => {
     const {email} = request.body;
 

--- a/libs/api/auth/src/presentation/routes/rate-limit.test.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.test.ts
@@ -1,5 +1,6 @@
+import {AUTH_PASSWORD_RESET_SEND_REQUESTED} from '@shipfox/api-auth-dto';
 import type {AppConfig, FastifyInstance} from '@shipfox/node-fastify';
-import {sql} from 'drizzle-orm';
+import {and, eq, sql} from 'drizzle-orm';
 import {
   type AuthRateLimitAction,
   type AuthRateLimitScope,
@@ -7,11 +8,10 @@ import {
   hashAuthRateLimitIdentifier,
 } from '#core/rate-limit.js';
 import {db} from '#db/db.js';
-import {countAuthRateLimitsForIdentifierHmac} from '#db/rate-limits.js';
 import {authRateLimits} from '#db/schema/rate-limits.js';
 import {
-  capturedMail,
   createAuthTestApp,
+  outboxEventsTo,
   resetCapturedMail,
   signupVerifyLogin,
   uniqueEmail,
@@ -54,8 +54,42 @@ async function countBucket(params: {
     scope: params.scope,
     identifier: params.identifier,
   });
+  const rows = await db()
+    .select({count: sql<number>`count(*)::int`})
+    .from(authRateLimits)
+    .where(
+      and(
+        eq(authRateLimits.action, params.action),
+        eq(authRateLimits.scope, params.scope),
+        eq(authRateLimits.identifierHmac, identifierHmac),
+      ),
+    );
 
-  return await countAuthRateLimitsForIdentifierHmac({identifierHmac});
+  return rows[0]?.count ?? 0;
+}
+
+async function bucketAttemptCount(params: {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  identifier: string;
+}): Promise<number> {
+  const identifierHmac = hashAuthRateLimitIdentifier({
+    action: params.action,
+    scope: params.scope,
+    identifier: params.identifier,
+  });
+  const rows = await db()
+    .select({count: authRateLimits.count})
+    .from(authRateLimits)
+    .where(
+      and(
+        eq(authRateLimits.action, params.action),
+        eq(authRateLimits.scope, params.scope),
+        eq(authRateLimits.identifierHmac, identifierHmac),
+      ),
+    );
+
+  return rows[0]?.count ?? 0;
 }
 
 function windowStartFor(now: Date, windowSeconds: number): Date {
@@ -182,9 +216,33 @@ describe('auth rate-limit routes', () => {
 
     expect(blockedReset.statusCode).toBe(429);
     expect(blockedResend.statusCode).toBe(429);
+    expect(await outboxEventsTo(account.email, AUTH_PASSWORD_RESET_SEND_REQUESTED)).toHaveLength(3);
+  });
+
+  it('blocks exhausted email-send IP buckets before consuming email buckets', async () => {
+    const ip = uniqueIp();
+    const blockedEmail = uniqueEmail('email-send-ip-blocked');
+    await exhaustBucket({
+      action: 'email-send',
+      scope: 'ip',
+      identifier: ip,
+      limit: 30,
+      windowSeconds: 60 * 60,
+    });
+
+    const blocked = await app.inject({
+      method: 'POST',
+      url: '/auth/password-reset',
+      headers: {'x-forwarded-for': ip},
+      payload: {email: blockedEmail},
+    });
+
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.json().code).toBe('rate-limited');
+    expect(await bucketAttemptCount({action: 'email-send', scope: 'ip', identifier: ip})).toBe(31);
     expect(
-      capturedMail().filter((message) => message.subject === 'Reset your password'),
-    ).toHaveLength(3);
+      await countBucket({action: 'email-send', scope: 'email', identifier: blockedEmail}),
+    ).toBe(0);
   });
 
   it('does not consume buckets for invalid bodies', async () => {

--- a/libs/api/auth/src/presentation/routes/rate-limit.test.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.test.ts
@@ -8,6 +8,7 @@ import {
 } from '#core/rate-limit.js';
 import {db} from '#db/db.js';
 import {countAuthRateLimitsForIdentifierHmac} from '#db/rate-limits.js';
+import {authRateLimits} from '#db/schema/rate-limits.js';
 import {
   capturedMail,
   createAuthTestApp,
@@ -55,6 +56,11 @@ async function countBucket(params: {
   });
 
   return await countAuthRateLimitsForIdentifierHmac({identifierHmac});
+}
+
+function windowStartFor(now: Date, windowSeconds: number): Date {
+  const windowMs = windowSeconds * 1000;
+  return new Date(Math.floor(now.getTime() / windowMs) * windowMs);
 }
 
 type LoggerInstance = NonNullable<NonNullable<AppConfig['fastifyOptions']>['loggerInstance']>;
@@ -197,9 +203,30 @@ describe('auth rate-limit routes', () => {
 
   it('fails closed when limiter storage is unavailable', async () => {
     const ip = uniqueIp();
+    const identifierHmac = hashAuthRateLimitIdentifier({
+      action: 'login',
+      scope: 'ip',
+      identifier: ip,
+    });
+    const windowStart = windowStartFor(new Date(), 5 * 60);
+    await db()
+      .insert(authRateLimits)
+      .values({
+        action: 'login',
+        scope: 'ip',
+        identifierHmac,
+        windowStart,
+        count: 1,
+        expiresAt: new Date(windowStart.getTime() + 5 * 60 * 1000),
+      });
 
     await db().transaction(async (tx) => {
-      await tx.execute(sql`LOCK TABLE auth_rate_limits IN ACCESS EXCLUSIVE MODE`);
+      await tx.execute(sql`
+        SELECT 1
+        FROM auth_rate_limits
+        WHERE identifier_hmac = ${identifierHmac}
+        FOR UPDATE
+      `);
       const res = await app.inject({
         method: 'POST',
         url: '/auth/login',

--- a/libs/api/auth/src/presentation/routes/rate-limit.test.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.test.ts
@@ -1,0 +1,251 @@
+import type {AppConfig, FastifyInstance} from '@shipfox/node-fastify';
+import {sql} from 'drizzle-orm';
+import {
+  type AuthRateLimitAction,
+  type AuthRateLimitScope,
+  checkAuthRateLimit,
+  hashAuthRateLimitIdentifier,
+} from '#core/rate-limit.js';
+import {db} from '#db/db.js';
+import {countAuthRateLimitsForIdentifierHmac} from '#db/rate-limits.js';
+import {
+  capturedMail,
+  createAuthTestApp,
+  resetCapturedMail,
+  signupVerifyLogin,
+  uniqueEmail,
+} from '#test/routes.js';
+
+let ipCounter = 1;
+
+function uniqueIp(): string {
+  ipCounter += 1;
+  return `203.0.113.${ipCounter}`;
+}
+
+async function exhaustBucket(params: {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  identifier: string;
+  limit: number;
+  windowSeconds: number;
+}): Promise<void> {
+  await Promise.all(
+    Array.from({length: params.limit}, () =>
+      checkAuthRateLimit({
+        action: params.action,
+        scope: params.scope,
+        identifier: params.identifier,
+        limit: params.limit,
+        windowSeconds: params.windowSeconds,
+      }),
+    ),
+  );
+}
+
+async function countBucket(params: {
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  identifier: string;
+}): Promise<number> {
+  const identifierHmac = hashAuthRateLimitIdentifier({
+    action: params.action,
+    scope: params.scope,
+    identifier: params.identifier,
+  });
+
+  return await countAuthRateLimitsForIdentifierHmac({identifierHmac});
+}
+
+type LoggerInstance = NonNullable<NonNullable<AppConfig['fastifyOptions']>['loggerInstance']>;
+
+function createCapturingLogger(logs: unknown[]): LoggerInstance {
+  const logger = {
+    child: () => logger,
+    level: 'info',
+    silent: (...args: unknown[]) => {
+      logs.push(['silent', ...args]);
+    },
+    fatal: (...args: unknown[]) => {
+      logs.push(['fatal', ...args]);
+    },
+    error: (...args: unknown[]) => {
+      logs.push(['error', ...args]);
+    },
+    warn: (...args: unknown[]) => {
+      logs.push(['warn', ...args]);
+    },
+    info: (...args: unknown[]) => {
+      logs.push(['info', ...args]);
+    },
+    debug: (...args: unknown[]) => {
+      logs.push(['debug', ...args]);
+    },
+    trace: (...args: unknown[]) => {
+      logs.push(['trace', ...args]);
+    },
+  };
+  return logger as unknown as LoggerInstance;
+}
+
+describe('auth rate-limit routes', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    resetCapturedMail();
+    app = await createAuthTestApp({fastifyOptions: {trustProxy: true}});
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('blocks exhausted login IP buckets before login work runs', async () => {
+    const ip = uniqueIp();
+    await exhaustBucket({
+      action: 'login',
+      scope: 'ip',
+      identifier: ip,
+      limit: 60,
+      windowSeconds: 5 * 60,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/login',
+      headers: {'x-forwarded-for': ip},
+      payload: {email: uniqueEmail('login-ip-block'), password: 'wrong password'},
+    });
+
+    expect(res.statusCode).toBe(429);
+    expect(res.json()).toEqual({
+      code: 'rate-limited',
+      details: {retry_after_seconds: expect.any(Number)},
+    });
+    expect(res.headers['retry-after']).toEqual(expect.any(String));
+  });
+
+  it('blocks exhausted login email buckets after the IP bucket passes', async () => {
+    const ip = uniqueIp();
+    const email = uniqueEmail('login-email-block');
+    await exhaustBucket({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 10,
+      windowSeconds: 15 * 60,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/login',
+      headers: {'x-forwarded-for': ip},
+      payload: {email, password: 'wrong password'},
+    });
+
+    expect(res.statusCode).toBe(429);
+    expect(res.json().code).toBe('rate-limited');
+    expect(await countBucket({action: 'login', scope: 'ip', identifier: ip})).toBe(1);
+  });
+
+  it('shares the email-send bucket across password reset and verification resend', async () => {
+    const account = await signupVerifyLogin(app, 'email-send-shared');
+    resetCapturedMail();
+
+    for (let index = 0; index < 3; index += 1) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/auth/password-reset',
+        headers: {'x-forwarded-for': uniqueIp()},
+        payload: {email: account.email},
+      });
+      expect(res.statusCode).toBe(204);
+    }
+    const blockedReset = await app.inject({
+      method: 'POST',
+      url: '/auth/password-reset',
+      headers: {'x-forwarded-for': uniqueIp()},
+      payload: {email: account.email},
+    });
+    const blockedResend = await app.inject({
+      method: 'POST',
+      url: '/auth/verify-email/resend',
+      headers: {'x-forwarded-for': uniqueIp()},
+      payload: {email: account.email},
+    });
+
+    expect(blockedReset.statusCode).toBe(429);
+    expect(blockedResend.statusCode).toBe(429);
+    expect(
+      capturedMail().filter((message) => message.subject === 'Reset your password'),
+    ).toHaveLength(3);
+  });
+
+  it('does not consume buckets for invalid bodies', async () => {
+    const ip = uniqueIp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/login',
+      headers: {'x-forwarded-for': ip},
+      payload: {email: 'not-an-email', password: 'wrong password'},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(await countBucket({action: 'login', scope: 'ip', identifier: ip})).toBe(0);
+  });
+
+  it('fails closed when limiter storage is unavailable', async () => {
+    const ip = uniqueIp();
+
+    await db().transaction(async (tx) => {
+      await tx.execute(sql`LOCK TABLE auth_rate_limits IN ACCESS EXCLUSIVE MODE`);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/auth/login',
+        headers: {'x-forwarded-for': ip},
+        payload: {email: uniqueEmail('limiter-unavailable'), password: 'wrong password'},
+      });
+
+      expect(res.statusCode).toBe(503);
+      expect(res.json()).toEqual({code: 'auth-rate-limit-unavailable'});
+    });
+  });
+
+  it('does not log raw email addresses or IP addresses for blocked requests', async () => {
+    await app.close();
+    const logs: unknown[] = [];
+    app = await createAuthTestApp({
+      fastifyOptions: {loggerInstance: createCapturingLogger(logs), trustProxy: true},
+    });
+    const ip = uniqueIp();
+    const email = uniqueEmail('log-privacy');
+    await exhaustBucket({
+      action: 'login',
+      scope: 'email',
+      identifier: email,
+      limit: 10,
+      windowSeconds: 15 * 60,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/login',
+      headers: {'x-forwarded-for': ip},
+      payload: {email, password: 'wrong password'},
+    });
+    const authLogs = logs.filter((entry) => {
+      const serializedEntry = JSON.stringify(entry);
+      return (
+        serializedEntry.includes('Auth rate limit blocked request') ||
+        serializedEntry.includes('Rate limit exceeded')
+      );
+    });
+    const serializedLogs = JSON.stringify(authLogs);
+
+    expect(res.statusCode).toBe(429);
+    expect(serializedLogs).toContain('identifierHmacPrefix');
+    expect(serializedLogs).not.toContain(email);
+    expect(serializedLogs).not.toContain(ip);
+  });
+});

--- a/libs/api/auth/src/presentation/routes/rate-limit.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.ts
@@ -1,0 +1,119 @@
+import {ClientError, type FastifyReply, type FastifyRequest} from '@shipfox/node-fastify';
+import {
+  type AuthRateLimitAction,
+  AuthRateLimitExceededError,
+  type AuthRateLimitPolicy,
+  type AuthRateLimitScope,
+  AuthRateLimitUnavailableError,
+  checkAuthRateLimit,
+} from '#core/rate-limit.js';
+
+const policies: Record<AuthRateLimitAction, Record<AuthRateLimitScope, AuthRateLimitPolicy>> = {
+  login: {
+    ip: {limit: 60, windowSeconds: 5 * 60},
+    email: {limit: 10, windowSeconds: 15 * 60},
+  },
+  'email-send': {
+    ip: {limit: 30, windowSeconds: 60 * 60},
+    email: {limit: 3, windowSeconds: 60 * 60},
+  },
+};
+
+interface EmailBody {
+  email: string;
+}
+
+function routeName(request: FastifyRequest): string {
+  return request.routeOptions.url ?? request.url.split('?')[0] ?? 'unknown';
+}
+
+async function enforceRateLimit(params: {
+  request: FastifyRequest;
+  reply: FastifyReply;
+  action: AuthRateLimitAction;
+  scope: AuthRateLimitScope;
+  identifier: string;
+}): Promise<void> {
+  try {
+    await checkAuthRateLimit({
+      action: params.action,
+      scope: params.scope,
+      identifier: params.identifier,
+      ...policies[params.action][params.scope],
+    });
+  } catch (error) {
+    if (error instanceof AuthRateLimitExceededError) {
+      params.request.log.warn(
+        {
+          action: error.action,
+          scope: error.scope,
+          route: routeName(params.request),
+          retryAfterSeconds: error.retryAfterSeconds,
+          identifierHmacPrefix: error.identifierHmacPrefix,
+        },
+        'Auth rate limit blocked request',
+      );
+      params.reply.header('Retry-After', String(error.retryAfterSeconds));
+      throw new ClientError('Rate limit exceeded', 'rate-limited', {
+        status: 429,
+        details: {retry_after_seconds: error.retryAfterSeconds},
+        data: {
+          action: error.action,
+          scope: error.scope,
+          route: routeName(params.request),
+          identifierHmacPrefix: error.identifierHmacPrefix,
+        },
+        cause: error,
+      });
+    }
+
+    if (error instanceof AuthRateLimitUnavailableError) {
+      params.request.log.error(
+        {
+          action: error.action,
+          scope: error.scope,
+          route: routeName(params.request),
+          identifierHmacPrefix: error.identifierHmacPrefix,
+          err: error,
+        },
+        'Auth rate limiter unavailable',
+      );
+      throw new ClientError(
+        'Authentication rate limiter unavailable',
+        'auth-rate-limit-unavailable',
+        {
+          status: 503,
+          data: {
+            action: error.action,
+            scope: error.scope,
+            route: routeName(params.request),
+            identifierHmacPrefix: error.identifierHmacPrefix,
+          },
+          cause: error,
+        },
+      );
+    }
+
+    throw error;
+  }
+}
+
+export function createAuthRateLimitPreHandler(action: AuthRateLimitAction) {
+  return async (request: FastifyRequest<{Body: EmailBody}>, reply: FastifyReply): Promise<void> => {
+    await enforceRateLimit({
+      request,
+      reply,
+      action,
+      scope: 'ip',
+      identifier: request.ip,
+    });
+
+    await enforceRateLimit({
+      request,
+      reply,
+      action,
+      scope: 'email',
+      identifier: request.body.email,
+    });
+  };
+}

--- a/libs/api/auth/src/presentation/routes/session/login.ts
+++ b/libs/api/auth/src/presentation/routes/session/login.ts
@@ -8,6 +8,7 @@ import {
 } from '#core/errors.js';
 import {setRefreshTokenCookie} from '#presentation/auth/refresh-cookie.js';
 import {toAuthSessionDto} from '#presentation/dto/user.js';
+import {createAuthRateLimitPreHandler} from '#presentation/routes/rate-limit.js';
 
 export const loginRoute = defineRoute({
   method: 'POST',
@@ -19,6 +20,7 @@ export const loginRoute = defineRoute({
       200: loginResponseSchema,
     },
   },
+  preHandler: createAuthRateLimitPreHandler('login'),
   errorHandler: (error) => {
     if (error instanceof InvalidCredentialsError) {
       throw new ClientError('Invalid credentials', 'invalid-credentials', {status: 401});

--- a/libs/api/auth/test/globalSetup.ts
+++ b/libs/api/auth/test/globalSetup.ts
@@ -10,7 +10,7 @@ export async function setup() {
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_auth');
   await db().execute(
-    sql`TRUNCATE auth_outbox, auth_email_verifications, auth_password_resets, auth_refresh_tokens, auth_users CASCADE`,
+    sql`TRUNCATE auth_outbox, auth_email_verifications, auth_password_resets, auth_rate_limits, auth_refresh_tokens, auth_users CASCADE`,
   );
 
   closeDb();

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -3,7 +3,7 @@ import {
   AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
   type AUTH_PASSWORD_RESET_SEND_REQUESTED,
 } from '@shipfox/api-auth-dto';
-import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {type AppConfig, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
 import {and, desc, eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
@@ -180,12 +180,16 @@ export async function latestEmailLinkTo(
   return link ?? '';
 }
 
-export async function createAuthTestApp(): Promise<FastifyInstance> {
-  return await createApp({
+export async function createAuthTestApp(params?: {
+  fastifyOptions?: AppConfig['fastifyOptions'];
+}): Promise<FastifyInstance> {
+  const appConfig: AppConfig = {
     auth: [createJwtAuthMethod()],
     routes: [authRoutes],
     swagger: false,
-  });
+  };
+  if (params?.fastifyOptions) appConfig.fastifyOptions = params.fastifyOptions;
+  return await createApp(appConfig);
 }
 
 export async function signup(

--- a/libs/client/auth/src/pages/form-errors.test.ts
+++ b/libs/client/auth/src/pages/form-errors.test.ts
@@ -28,10 +28,28 @@ describe('loginErrorToFormError', () => {
     expect(result).toEqual({kind: 'form', message: 'Email or password is incorrect.'});
   });
 
-  test('routes unknown ApiError codes to a form-level alert', () => {
+  test('routes rate-limited to a form-level alert', () => {
     const result = loginErrorToFormError(apiError('rate-limited', 429));
 
-    expect(result).toEqual({kind: 'form', message: 'rate-limited server message'});
+    expect(result).toEqual({
+      kind: 'form',
+      message: 'Too many attempts. Wait a bit and try again.',
+    });
+  });
+
+  test('routes limiter outages to a form-level alert', () => {
+    const result = loginErrorToFormError(apiError('auth-rate-limit-unavailable', 503));
+
+    expect(result).toEqual({
+      kind: 'form',
+      message: 'Sign-in protection is temporarily unavailable. Try again soon.',
+    });
+  });
+
+  test('routes unknown ApiError codes to a form-level alert', () => {
+    const result = loginErrorToFormError(apiError('unknown-code', 400));
+
+    expect(result).toEqual({kind: 'form', message: 'unknown-code server message'});
   });
 
   test('routes non-ApiError to a generic form-level alert', () => {
@@ -66,7 +84,10 @@ describe('passwordResetRequestErrorToFormError', () => {
   test('always routes to a form-level alert', () => {
     const result = passwordResetRequestErrorToFormError(apiError('rate-limited', 429));
 
-    expect(result).toEqual({kind: 'form', message: 'rate-limited server message'});
+    expect(result).toEqual({
+      kind: 'form',
+      message: 'Too many attempts. Wait a bit and try again.',
+    });
   });
 });
 

--- a/libs/client/auth/src/pages/form-utils.test.ts
+++ b/libs/client/auth/src/pages/form-utils.test.ts
@@ -7,6 +7,11 @@ describe('authErrorMessage', () => {
     ['email-not-verified', 'Verify your email before signing in.'],
     ['email-taken', 'An account already exists for this email.'],
     ['token-invalid', 'This link is invalid or expired.'],
+    ['rate-limited', 'Too many attempts. Wait a bit and try again.'],
+    [
+      'auth-rate-limit-unavailable',
+      'Sign-in protection is temporarily unavailable. Try again soon.',
+    ],
     ['network-error', 'We could not reach the API. Check your connection and try again.'],
   ])('maps %s to client copy', (code, message) => {
     const error = new ApiError({code, message: 'Server copy', status: 400});
@@ -17,7 +22,7 @@ describe('authErrorMessage', () => {
   });
 
   test('falls back to API error messages', () => {
-    const error = new ApiError({code: 'rate-limited', message: 'Try later', status: 429});
+    const error = new ApiError({code: 'unknown-api-code', message: 'Try later', status: 429});
 
     const result = authErrorMessage(error);
 

--- a/libs/client/auth/src/pages/form-utils.ts
+++ b/libs/client/auth/src/pages/form-utils.ts
@@ -15,6 +15,12 @@ export function authErrorMessage(error: unknown): string {
   if (error.code === 'token-invalid') {
     return 'This link is invalid or expired.';
   }
+  if (error.code === 'rate-limited') {
+    return 'Too many attempts. Wait a bit and try again.';
+  }
+  if (error.code === 'auth-rate-limit-unavailable') {
+    return 'Sign-in protection is temporarily unavailable. Try again soon.';
+  }
   if (error.code === 'network-error') {
     return 'We could not reach the API. Check your connection and try again.';
   }

--- a/libs/shared/node/fastify/src/index.ts
+++ b/libs/shared/node/fastify/src/index.ts
@@ -29,6 +29,7 @@ export type {
   RouteExport,
   RouteGroup,
   RouteOptions,
+  RoutePreHandler,
   RouteSchema,
 } from './types.js';
 export {defineRoute, isRouteGroup} from './types.js';

--- a/libs/shared/node/fastify/src/router.test.ts
+++ b/libs/shared/node/fastify/src/router.test.ts
@@ -223,6 +223,38 @@ describe('route mounting', () => {
     expect(handlerCalled).toBe(false);
   });
 
+  test('route preHandler arrays run in order before the handler', async () => {
+    const events: string[] = [];
+    const app = await createApp({
+      routes: [
+        {
+          method: 'GET',
+          path: '/hooked-array',
+          description: 'Hooked route',
+          preHandler: [
+            () => {
+              events.push('first');
+            },
+            async () => {
+              await Promise.resolve();
+              events.push('second');
+            },
+          ],
+          handler: () => {
+            events.push('handler');
+            return {ok: true};
+          },
+        },
+      ],
+    });
+
+    const res = await app.inject({method: 'GET', url: '/hooked-array'});
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ok: true});
+    expect(events).toEqual(['first', 'second', 'handler']);
+  });
+
   test('global error handler catches unhandled errors', async () => {
     const app = await createApp({
       routes: [

--- a/libs/shared/node/fastify/src/router.test.ts
+++ b/libs/shared/node/fastify/src/router.test.ts
@@ -156,6 +156,73 @@ describe('route mounting', () => {
     expect(res.json()).toEqual({custom: true});
   });
 
+  test('route preHandler runs after auth and schema validation', async () => {
+    const events: string[] = [];
+    const app = await createApp({
+      auth: [
+        {
+          name: 'token',
+          authenticate: () => {
+            events.push('auth');
+            return Promise.resolve();
+          },
+        },
+      ],
+      routes: [
+        {
+          method: 'POST',
+          path: '/hooked',
+          description: 'Hooked route',
+          auth: 'token',
+          schema: {body: z.object({value: z.string().transform((value) => value.toUpperCase())})},
+          preHandler: (request) => {
+            events.push(`preHandler:${(request.body as {value: string}).value}`);
+          },
+          handler: (request) => {
+            events.push(`handler:${(request.body as {value: string}).value}`);
+            return {value: (request.body as {value: string}).value};
+          },
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/hooked',
+      payload: {value: 'ok'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({value: 'OK'});
+    expect(events).toEqual(['auth', 'preHandler:OK', 'handler:OK']);
+  });
+
+  test('route preHandler can short-circuit before the handler', async () => {
+    let handlerCalled = false;
+    const app = await createApp({
+      routes: [
+        {
+          method: 'GET',
+          path: '/blocked',
+          description: 'Blocked route',
+          preHandler: (_request, reply) => {
+            reply.code(429).send({code: 'blocked'});
+          },
+          handler: () => {
+            handlerCalled = true;
+            return {ok: true};
+          },
+        },
+      ],
+    });
+
+    const res = await app.inject({method: 'GET', url: '/blocked'});
+
+    expect(res.statusCode).toBe(429);
+    expect(res.json()).toEqual({code: 'blocked'});
+    expect(handlerCalled).toBe(false);
+  });
+
   test('global error handler catches unhandled errors', async () => {
     const app = await createApp({
       routes: [

--- a/libs/shared/node/fastify/src/router.ts
+++ b/libs/shared/node/fastify/src/router.ts
@@ -1,7 +1,10 @@
 import type {FastifyInstance} from 'fastify';
 import {createAuthHook} from './auth.js';
-import type {RouteDefinition, RouteExport, RouteGroup} from './types.js';
+import type {RouteDefinition, RouteExport, RouteGroup, RoutePreHandler} from './types.js';
 import {isRouteGroup} from './types.js';
+
+type FastifyRouteConfig = Parameters<FastifyInstance['route']>[0];
+type FastifyPreHandler = NonNullable<FastifyRouteConfig['preHandler']>;
 
 export function mountRoutes({
   app,
@@ -51,7 +54,7 @@ function mountRoute(
 ): void {
   const effectiveAuth = route.auth ?? parentAuth;
 
-  const routeConfig: Parameters<FastifyInstance['route']>[0] = {
+  const routeConfig: FastifyRouteConfig = {
     method: route.method,
     url: route.path,
     handler: route.handler,
@@ -60,10 +63,25 @@ function mountRoute(
   routeConfig.schema = {...route.schema, description: route.description};
   if (route.errorHandler) routeConfig.errorHandler = route.errorHandler;
   if (effectiveAuth) routeConfig.onRequest = createAuthHook(effectiveAuth);
+  if (route.preHandler) {
+    routeConfig.preHandler = normalizePreHandler(route.preHandler);
+  }
   if (route.options?.bodyLimit !== undefined) routeConfig.bodyLimit = route.options.bodyLimit;
   if (route.options?.logLevel !== undefined) routeConfig.logLevel = route.options.logLevel;
   if (route.options?.handlerTimeout !== undefined)
     routeConfig.handlerTimeout = route.options.handlerTimeout;
 
   app.route(routeConfig);
+}
+
+function normalizePreHandler(preHandler: RoutePreHandler | RoutePreHandler[]): FastifyPreHandler {
+  if (Array.isArray(preHandler)) {
+    return preHandler.map((handler) => async (request, reply) => {
+      await handler(request, reply);
+    }) as FastifyPreHandler;
+  }
+
+  return (async (request, reply) => {
+    await preHandler(request, reply);
+  }) as FastifyPreHandler;
 }

--- a/libs/shared/node/fastify/src/types.ts
+++ b/libs/shared/node/fastify/src/types.ts
@@ -28,7 +28,7 @@ export interface RouteOptions {
 export type RoutePreHandler = (
   request: FastifyRequest,
   reply: FastifyReply,
-) => Promise<unknown> | unknown;
+) => Promise<unknown> | undefined;
 
 export interface RouteDefinition {
   method: HttpMethod;
@@ -93,11 +93,11 @@ export function defineRoute<const S extends RouteSchema | undefined>(
       | ((
           request: FastifyRequest<InferSchema<S>>,
           reply: FastifyReply,
-        ) => Promise<unknown> | unknown)
+        ) => Promise<unknown> | undefined)
       | ((
           request: FastifyRequest<InferSchema<S>>,
           reply: FastifyReply,
-        ) => Promise<unknown> | unknown)[];
+        ) => Promise<unknown> | undefined)[];
     handler: (
       request: FastifyRequest<InferSchema<S>>,
       reply: FastifyReply,

--- a/libs/shared/node/fastify/src/types.ts
+++ b/libs/shared/node/fastify/src/types.ts
@@ -25,6 +25,11 @@ export interface RouteOptions {
   handlerTimeout?: number;
 }
 
+export type RoutePreHandler = (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => Promise<unknown> | unknown;
+
 export interface RouteDefinition {
   method: HttpMethod;
   path: string;
@@ -32,6 +37,7 @@ export interface RouteDefinition {
   schema?: RouteSchema;
   auth?: string | string[];
   options?: RouteOptions;
+  preHandler?: RoutePreHandler | RoutePreHandler[];
   handler: (request: FastifyRequest, reply: FastifyReply) => Promise<unknown> | unknown;
   errorHandler?: (error: unknown, request: FastifyRequest, reply: FastifyReply) => unknown;
 }
@@ -81,8 +87,17 @@ type InferSchema<S extends RouteSchema | undefined> = S extends RouteSchema
   : {Body: unknown; Params: unknown; Querystring: unknown};
 
 export function defineRoute<const S extends RouteSchema | undefined>(
-  route: Omit<RouteDefinition, 'handler' | 'schema'> & {
+  route: Omit<RouteDefinition, 'handler' | 'preHandler' | 'schema'> & {
     schema?: S;
+    preHandler?:
+      | ((
+          request: FastifyRequest<InferSchema<S>>,
+          reply: FastifyReply,
+        ) => Promise<unknown> | unknown)
+      | ((
+          request: FastifyRequest<InferSchema<S>>,
+          reply: FastifyReply,
+        ) => Promise<unknown> | unknown)[];
     handler: (
       request: FastifyRequest<InferSchema<S>>,
       reply: FastifyReply,


### PR DESCRIPTION
Adds an application-layer auth abuse baseline for OSS installs by rate-limiting login and auth email-send routes with Postgres fixed-window counters and HMAC-scoped identifiers.

The app should protect semantic auth actions even when self-hosters do not have edge or WAF controls. Edge controls remain production hardening for volumetric abuse, while the app now enforces consistent per-IP and per-email policy after request validation.

The limiter derives its HMAC key from `AUTH_JWT_SECRET` by default, with optional `AUTH_RATE_LIMIT_IDENTIFIER_SECRET` for operators who want separation, avoiding mandatory first-boot salt config. It also adds `API_TRUST_PROXY` so deployments can opt in to trusted proxy IP handling.

Reviewers should look closely at the auth route preHandler lifecycle, folded auth baseline migration, and fail-closed behavior for limiter DB failures.

Closes ENG-422

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-IP and per-email rate limiting to auth endpoints using Postgres fixed-window counters with HMAC identifiers. Configures trust proxy handling, typed route `preHandler`s in `@shipfox/node-fastify`, and limiter metrics; pruning runs off the request path. Implements ENG-422.

- **New Features**
  - Limits via route preHandlers after auth and validation:
    - POST `/auth/login`: IP 60/5m; Email 10/15m.
    - POST `/auth/password-reset` and `/auth/verify-email/resend`: IP 30/1h; Email 3/1h (shared).
  - Counters in `auth_rate_limits`; identifiers are HMAC-SHA256 using `AUTH_RATE_LIMIT_IDENTIFIER_SECRET` or a key derived from `AUTH_JWT_SECRET`. Expired windows pruned opportunistically off-path.
  - Metrics: records rate-limit checks (allowed/blocked/unavailable) and prune failures via the auth metrics module; metric failures never affect auth outcomes.
  - On limit: 429 + Retry-After. On limiter timeout/unavailable: 503 fail-closed. Logs include only an HMAC prefix (no raw emails or IPs). Client copy updated for rate-limit and limiter-outage messages.
  - `@shipfox/node-fastify`: adds typed route `preHandler` support (runs after auth and schema validation; supports arrays). API sets Fastify `trustProxy` using validated `API_TRUST_PROXY`.

- **Migration**
  - Run the DB migration (adds `auth_rate_limits`).
  - Set `API_TRUST_PROXY` for your deployment (false when direct; or true/hop count/IP/CIDR when behind trusted proxies).
  - Optionally set `AUTH_RATE_LIMIT_IDENTIFIER_SECRET` to separate the HMAC secret from `AUTH_JWT_SECRET`.

<sup>Written for commit 5e88246752a0019ae639aecf02f2ce1aecc993b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

