### PR TITLE
[triggers] Add OpenTelemetry metrics instrumentation

### DIFF
--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -1,5 +1,10 @@
 import {isPermanentRunWorkflowError, runWorkflow} from '@shipfox/api-workflows';
 import {findMatchingSubscriptions} from '#db/subscriptions.js';
+import {
+  eventOutcomeCount,
+  eventReceivedCount,
+  subscriptionTriggeredCount,
+} from '#metrics/instance.js';
 import {readConfigInputs} from './config.js';
 import {beginTriggerHistory, toReason} from './record-trigger-history.js';
 
@@ -28,6 +33,8 @@ export interface DispatchIntegrationEventParams {
 export async function dispatchIntegrationEvent(
   params: DispatchIntegrationEventParams,
 ): Promise<void> {
+  eventReceivedCount.add(1, {source: params.source});
+
   const history = await beginTriggerHistory({
     eventRef: params.eventRef,
     origin: 'integration',
@@ -47,6 +54,7 @@ export async function dispatchIntegrationEvent(
   });
 
   if (subscriptions.length === 0) {
+    eventOutcomeCount.add(1, {source: params.source, outcome: 'discarded'});
     await history.discarded();
     return;
   }
@@ -72,6 +80,7 @@ export async function dispatchIntegrationEvent(
       });
       await history.triggered(subscription, run);
       triggeredCount += 1;
+      subscriptionTriggeredCount.add(1, {source: params.source});
     } catch (error) {
       await history.errored(subscription, toReason(error));
       // Track presence with a flag, not `firstTransientError === undefined`: a thrown
@@ -84,14 +93,17 @@ export async function dispatchIntegrationEvent(
   }
 
   if (sawTransientError) {
+    eventOutcomeCount.add(1, {source: params.source, outcome: 'failed'});
     await history.failed(subscriptions.length);
     throw firstTransientError;
   }
 
   if (triggeredCount > 0) {
+    eventOutcomeCount.add(1, {source: params.source, outcome: 'routed'});
     await history.routed(subscriptions.length);
     return;
   }
 
+  eventOutcomeCount.add(1, {source: params.source, outcome: 'errored'});
   await history.allErrored(subscriptions.length);
 }

--- a/libs/api/triggers/src/core/fire-manual.ts
+++ b/libs/api/triggers/src/core/fire-manual.ts
@@ -1,6 +1,11 @@
 import {randomUUID} from 'node:crypto';
 import {isPermanentRunWorkflowError, runWorkflow, type WorkflowRun} from '@shipfox/api-workflows';
 import {getTriggerSubscriptionById} from '#db/subscriptions.js';
+import {
+  eventOutcomeCount,
+  eventReceivedCount,
+  subscriptionTriggeredCount,
+} from '#metrics/instance.js';
 import {readConfigInputs} from './config.js';
 import {
   TriggerSubscriptionNotFoundError,
@@ -46,6 +51,8 @@ export async function fireManualSubscription(
     receivedAt: new Date(),
   };
 
+  eventReceivedCount.add(1, {source: 'manual'});
+
   let run: WorkflowRun;
   try {
     run = await runWorkflow({
@@ -63,11 +70,11 @@ export async function fireManualSubscription(
   } catch (error) {
     const failure = await beginTriggerHistory({...historyBase, eventRef: randomUUID()});
     await failure.errored(subscription, toReason(error));
-    // Manual fires do not replay, so permanent workflow errors can close history
-    // immediately while preserving the thrown error for callers.
     if (isPermanentRunWorkflowError(error)) {
+      eventOutcomeCount.add(1, {source: 'manual', outcome: 'errored'});
       await failure.allErrored(1);
     } else {
+      eventOutcomeCount.add(1, {source: 'manual', outcome: 'failed'});
       await failure.failed(1);
     }
     throw error;
@@ -75,6 +82,8 @@ export async function fireManualSubscription(
 
   const history = await beginTriggerHistory({...historyBase, eventRef: run.id});
   await history.triggered(subscription, run);
+  subscriptionTriggeredCount.add(1, {source: 'manual'});
+  eventOutcomeCount.add(1, {source: 'manual', outcome: 'routed'});
   await history.routed(1);
   return run;
 }

--- a/libs/api/triggers/src/metrics/index.ts
+++ b/libs/api/triggers/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export {eventOutcomeCount, eventReceivedCount, subscriptionTriggeredCount} from './instance.js';

--- a/libs/api/triggers/src/metrics/instance.ts
+++ b/libs/api/triggers/src/metrics/instance.ts
@@ -1,0 +1,22 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('triggers');
+
+export const eventReceivedCount = meter.createCounter<{
+  source: string;
+}>('triggers_event_received', {
+  description: 'Trigger events received by source (e.g. github, gitlab, manual)',
+});
+
+export const subscriptionTriggeredCount = meter.createCounter<{
+  source: string;
+}>('triggers_subscription_triggered', {
+  description: 'Subscriptions that resulted in a workflow run, by source',
+});
+
+export const eventOutcomeCount = meter.createCounter<{
+  source: string;
+  outcome: 'discarded' | 'routed' | 'failed' | 'errored';
+}>('triggers_event_outcome', {
+  description: 'Final outcomes of trigger events by source and outcome',
+});


### PR DESCRIPTION
Add instance counters to the triggers module for observability into trigger event processing, matching the instrumentation patterns already present in runners, dispatcher, auth, and logs.

### Metrics added

| Metric | Kind | Labels |
|---|---|---|
| `triggers_event_received` | Counter | `source` (integration source e.g. github, gitlab, or manual) |
| `triggers_subscription_triggered` | Counter | `source` |
| `triggers_event_outcome` | Counter | `source`, `outcome` (discarded/routed/failed/errored) |

Counters are recorded in `dispatchIntegrationEvent` (integration events) and `fireManualSubscription` (manual triggers) at the points where the events naturally occur. No service gauge was added — consistent with auth and dispatcher which also omit them.

Closes ENG-573