### PR TITLE
[client-workflows] Remove duplicate status icon from workflow run summary

### DIFF
--- a/.changeset/quiet-hawks-dance.md
+++ b/.changeset/quiet-hawks-dance.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Removes duplicate status icon from the workflow run summary, keeping only the status badge.

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -14,7 +14,6 @@ import type {Ref} from 'react';
 import {useId} from 'react';
 import {Identifier} from '../identifier/index.js';
 import {getWorkflowStatusVisual} from '../workflow-status/status-visuals.js';
-import {WorkflowStatusIcon} from '../workflow-status/workflow-status-icon.js';
 import {toWorkflowRunSummary} from './workflow-run-summary-model.js';
 
 const STATUS_BADGE_LABEL_WIDTH_CH = Math.max(
@@ -48,14 +47,11 @@ export function WorkflowRunSummary({
     >
       <div className="flex min-w-0 items-center gap-x-12 overflow-hidden">
         <div className="flex min-w-0 items-center gap-8">
-          <span className="inline-flex shrink-0 items-center gap-6">
-            <WorkflowStatusIcon status={model.status.kind} size={12} tooltip={false} />
-            <Badge variant={model.status.badge} size="xs">
-              <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
-                {model.status.label}
-              </span>
-            </Badge>
-          </span>
+          <Badge variant={model.status.badge} size="xs">
+            <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
+              {model.status.label}
+            </span>
+          </Badge>
           <Header id={headingId} variant="h3" className="min-w-0 truncate">
             {model.name}
           </Header>


### PR DESCRIPTION
The workflow run summary was rendering both a `WorkflowStatusIcon` and a `Badge` displaying the same status information side by side. This removes the redundant icon, keeping only the badge which already shows the full status label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate status icon from the workflow run summary, keeping only the status badge to avoid redundancy and improve readability.

<sup>Written for commit 66da2f5405e0a62b32cdf10142db922e0699ee9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

