### PR TITLE
[client-workflows] Improve trigger node design in jobs graph

### DIFF
--- a/.changeset/tidy-snails-hammer.md
+++ b/.changeset/tidy-snails-hammer.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Replaces the trigger node rectangle in the workflow jobs graph with a circle containing only the trigger source icon, and shows the source label on hover via tooltip.

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -11,9 +11,8 @@ export function TriggerNode({trigger}: {trigger: WorkflowGraphTriggerNode}) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <div
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
           aria-label={trigger.label}
           className="flex items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base"
           style={{width: TRIGGER_SIZE, height: TRIGGER_SIZE}}
@@ -23,7 +22,7 @@ export function TriggerNode({trigger}: {trigger: WorkflowGraphTriggerNode}) {
             aria-hidden
             className="size-14 shrink-0 text-foreground-neutral-muted"
           />
-        </div>
+        </button>
       </TooltipTrigger>
       <TooltipContent>
         <span>{trigger.label}</span>

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -14,7 +14,7 @@ export function TriggerNode({trigger}: {trigger: WorkflowGraphTriggerNode}) {
         <button
           type="button"
           aria-label={trigger.label}
-          className="flex items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base"
+          className="flex items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none"
           style={{width: TRIGGER_SIZE, height: TRIGGER_SIZE}}
         >
           <TriggerSourceIcon

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -1,24 +1,31 @@
+import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {Code, cn, Text, Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
 import type {KeyboardEventHandler, Ref} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import type {WorkflowGraphTriggerNode, WorkflowJobGraphNode} from './graph-model.js';
 
+const TRIGGER_SIZE = 36;
+
 export function TriggerNode({trigger}: {trigger: WorkflowGraphTriggerNode}) {
   return (
-    <div className="flex h-78 w-144 flex-col justify-center gap-6 rounded-8 border border-border-neutral-base bg-background-components-base px-12 text-left">
-      <Text size="xs" className="text-foreground-neutral-muted">
-        Trigger
-      </Text>
-      <Code
-        variant="label"
-        bold
-        className="truncate text-foreground-neutral-base"
-        title={trigger.label}
-      >
-        {trigger.label}
-      </Code>
-    </div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="flex items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base"
+          style={{width: TRIGGER_SIZE, height: TRIGGER_SIZE}}
+        >
+          <TriggerSourceIcon
+            source={trigger.source}
+            aria-hidden
+            className="size-14 shrink-0 text-foreground-neutral-muted"
+          />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{trigger.label}</span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -12,6 +12,9 @@ export function TriggerNode({trigger}: {trigger: WorkflowGraphTriggerNode}) {
     <Tooltip>
       <TooltipTrigger asChild>
         <div
+          role="button"
+          tabIndex={0}
+          aria-label={trigger.label}
           className="flex items-center justify-center rounded-full border border-border-neutral-base bg-background-components-base"
           style={{width: TRIGGER_SIZE, height: TRIGGER_SIZE}}
         >

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
@@ -9,7 +9,7 @@ const NODE_WIDTH = 208;
 const NODE_HEIGHT = 78;
 const COLUMN_GAP = 72;
 const ROW_GAP = 18;
-const TRIGGER_WIDTH = 144;
+const TRIGGER_WIDTH = 36;
 const PADDING = 16;
 
 export function WorkflowJobsGraphContent({
@@ -73,7 +73,10 @@ export function WorkflowJobsGraphContent({
     <div className="min-h-0 overflow-auto bg-background-neutral-base">
       <div className="relative" style={{width: contentWidth, minHeight: contentHeight}}>
         <GraphEdges model={model} />
-        <div className="absolute" style={{left: PADDING, top: PADDING}}>
+        <div
+          className="absolute"
+          style={{left: PADDING, top: PADDING + (NODE_HEIGHT - TRIGGER_WIDTH) / 2}}
+        >
           <TriggerNode trigger={model.trigger} />
         </div>
         {model.columns.map((column, columnIndex) => (

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -8,6 +8,7 @@ describe('WorkflowJobsGraph', () => {
     render(<WorkflowJobsGraph run={makeRun({jobs: [makeJob({name: 'build'})]})} />);
 
     expect(screen.getByRole('region', {name: 'Jobs graph'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'manual / fire'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'build, Pending'})).toBeInTheDocument();
   });
 

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -8,7 +8,6 @@ describe('WorkflowJobsGraph', () => {
     render(<WorkflowJobsGraph run={makeRun({jobs: [makeJob({name: 'build'})]})} />);
 
     expect(screen.getByRole('region', {name: 'Jobs graph'})).toBeInTheDocument();
-    expect(screen.getByText('manual / fire')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'build, Pending'})).toBeInTheDocument();
   });
 
@@ -173,7 +172,7 @@ describe('WorkflowJobsGraph', () => {
     const skippedJoinEdge = container.querySelector(
       `[data-edge-id="${securityScan.id}:${deploy.id}"]`,
     );
-    expect(skippedJoinEdge).toHaveAttribute('d', 'M 440 151 H 756 V 55 H 792');
+    expect(skippedJoinEdge).toHaveAttribute('d', 'M 332 151 H 648 V 55 H 684');
   });
 });
 


### PR DESCRIPTION
The trigger node in the workflow jobs graph was a large rectangle (144x78px) containing a label and text, making it visually indistinguishable from regular job nodes.

This replaces the rectangle with a 36px circle containing only the TriggerSourceIcon, visually differentiating the trigger from job nodes. The full trigger source/event label is still accessible via a tooltip on hover.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the trigger node a compact 36px icon-only circle with an accessible button and visible keyboard focus. The full trigger label shows on hover via tooltip and via aria-label for assistive tech.

- **Refactors**
  - Replaced 144x78 rectangle + text with a 36px circular node using `TriggerSourceIcon` from `@shipfox/client-triggers`.
  - Switched to a semantic button with an aria-label and focus-visible styles.
  - Centered the trigger node relative to job row height and updated edge paths.
  - Updated tests to query the trigger by role/name and to reflect new edge geometry.
  - Added a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit d486634d3fce8dd4f24edeeffe26a854b7ac0892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

