### PR TITLE
[client-workflows] Fix workflow run summary tooltips

### DIFF
--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -56,9 +56,18 @@ export function WorkflowRunSummary({
               </span>
             </Badge>
           </span>
-          <Header id={headingId} variant="h3" className="min-w-0 truncate">
-            {model.name}
-          </Header>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Header id={headingId} variant="h3" className="min-w-0 truncate">
+                {model.name}
+              </Header>
+            </TooltipTrigger>
+            <TooltipContent>
+              <Text as="span" size="xs" className="max-w-[360px] break-words">
+                {model.name}
+              </Text>
+            </TooltipContent>
+          </Tooltip>
         </div>
 
         <span
@@ -69,25 +78,27 @@ export function WorkflowRunSummary({
         <Identifier display={model.shortId} value={model.id} label="run id" />
 
         {model.triggerLabel ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex min-w-0 flex-1 items-center gap-4 text-foreground-neutral-subtle">
-                <TriggerSourceIcon
-                  source={model.triggerSource}
-                  aria-hidden="true"
-                  className="size-14 shrink-0"
-                />
-                <Text as="span" size="sm" className="min-w-0 truncate">
+          <span className="min-w-0 flex-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex max-w-full min-w-0 items-center gap-4 text-foreground-neutral-subtle">
+                  <TriggerSourceIcon
+                    source={model.triggerSource}
+                    aria-hidden="true"
+                    className="size-14 shrink-0"
+                  />
+                  <Text as="span" size="sm" className="min-w-0 truncate">
+                    {model.triggerLabel}
+                  </Text>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <Text as="span" size="xs" className="max-w-[360px] break-words">
                   {model.triggerLabel}
                 </Text>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <Text as="span" size="xs" className="max-w-[360px] break-words">
-                {model.triggerLabel}
-              </Text>
-            </TooltipContent>
-          </Tooltip>
+              </TooltipContent>
+            </Tooltip>
+          </span>
         ) : (
           <span className="min-w-0 flex-1" />
         )}


### PR DESCRIPTION
Fix workflow run summary tooltip behavior for truncated metadata.

Run names can be truncated in the summary header, so this adds a tooltip to expose the full name on hover. The trigger metadata tooltip previously used the flex spacer as its trigger, which made the tooltip align to the full remaining row width instead of the visible trigger text; this keeps the spacer separate from the tooltip trigger so positioning follows the label.

The touched package is private, so no changeset is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes workflow run summary tooltips so truncated run names and trigger labels show full text on hover, with the tooltip aligned to the visible label. Improves readability and ensures the hover target matches the icon + label, not the spacer.

- **Bug Fixes**
  - Added a tooltip to the truncated run name in the header (max width 360px, wraps long text).
  - Wrapped only the trigger icon + label in the tooltip trigger and moved flex growth to a container span so positioning and truncation follow the label.

<sup>Written for commit 3440649718f3ee28268142d5dfffc03884b7e2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

