### PR TITLE
[client-workflows] Simplify jobs graph surface

### DIFF
--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -4,10 +4,10 @@ import userEvent from '@testing-library/user-event';
 import {WorkflowJobsGraph} from './workflow-jobs-graph.js';
 
 describe('WorkflowJobsGraph', () => {
-  test('renders a labelled graph region and trigger', () => {
+  test('renders a graph region and trigger', () => {
     render(<WorkflowJobsGraph run={makeRun({jobs: [makeJob({name: 'build'})]})} />);
 
-    expect(screen.getByRole('region', {name: 'Jobs graph'})).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
     expect(screen.getByText('manual / fire')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'build, Pending'})).toBeInTheDocument();
   });

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.tsx
@@ -1,5 +1,5 @@
-import {cn, Text} from '@shipfox/react-ui';
-import {useId, useState} from 'react';
+import {cn} from '@shipfox/react-ui';
+import {useState} from 'react';
 import type {WorkflowJobGraphModel} from './graph-model.js';
 import {WorkflowJobsGraphContent} from './workflow-jobs-graph-content.js';
 
@@ -16,7 +16,6 @@ export function WorkflowJobsGraphView({
   onSelectedJobChange?: ((jobId: string | undefined) => void) | undefined;
   className?: string | undefined;
 }) {
-  const titleId = useId();
   const [localSelectedJobId, setLocalSelectedJobId] = useState<string | undefined>(
     defaultSelectedJobId,
   );
@@ -28,23 +27,7 @@ export function WorkflowJobsGraphView({
   }
 
   return (
-    <section
-      aria-labelledby={titleId}
-      className={cn(
-        'flex min-h-0 flex-col rounded-8 border border-border-neutral-base bg-background-components-base',
-        className,
-      )}
-    >
-      <div className="flex min-h-40 items-center justify-between gap-12 border-b border-border-neutral-base px-16">
-        <div className="flex min-w-0 items-center gap-8">
-          <Text as="h2" id={titleId} size="sm" bold className="text-foreground-neutral-base">
-            Jobs graph
-          </Text>
-          <Text size="xs" className="text-foreground-neutral-muted">
-            {model.nodes.length} {model.nodes.length === 1 ? 'job' : 'jobs'}
-          </Text>
-        </div>
-      </div>
+    <section aria-label="Workflow jobs" className={cn('min-h-0', className)}>
       <WorkflowJobsGraphContent model={model} selectedJobId={selected} onSelectJob={selectJob} />
     </section>
   );

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -28,7 +28,7 @@ describe('WorkflowRunView', () => {
     expect(within(summary).getByRole('button', {name: `Copy run id ${RUN_ID}`})).toHaveTextContent(
       '66666666',
     );
-    expect(await screen.findByRole('region', {name: 'Jobs graph'})).toBeInTheDocument();
+    expect(await screen.findByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'build, Succeeded'})).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: 'deploy, Running, Depends on build'}),


### PR DESCRIPTION
Remove the redundant jobs graph title/count surface from the workflow run view.

The title repeated information already obvious from the run detail layout, while the extra panel chrome made the jobs area feel visually heavier than the adjacent step attempts list. The graph now renders directly in the run content area while keeping a semantic region label for assistive navigation.

No changeset is included because `@shipfox/client-workflows` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the jobs graph in the workflow run view by removing the redundant title/count panel and extra chrome. The graph now renders inline with an accessible region label "Workflow jobs," and related tests in the graph and run views were updated to match.

<sup>Written for commit 272a215a1da8ccabdcd583296e6ac9de8a33da5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

