### PR TITLE
[client-workflows] Simplify workflow graph edges

### DIFF
--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
@@ -133,14 +133,6 @@ function GraphEdges({model}: {model: WorkflowJobGraphModel}) {
               stroke="currentColor"
               strokeWidth="1"
             />
-            <path
-              d={`M ${to.x - 4} ${to.y - 4} L ${to.x} ${to.y} L ${to.x - 4} ${to.y + 4}`}
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
           </g>
         );
       })}


### PR DESCRIPTION
Simplifies workflow job graph rendering by removing arrowheads from dependency edges, leaving only routed connector lines.

The graph already lays out job progression left to right, so arrowheads add extra visual noise without conveying much additional directionality. This keeps the DAG view more minimal while preserving existing edge routing and node layout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed arrowheads from dependency edges in the workflow jobs graph, keeping only routed connector lines. This declutters the DAG view while preserving left-to-right progression and existing edge routing, with no functional changes.

<sup>Written for commit 0fb3316db6f06a75f50c30e781a92384e8390675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

