### PR TITLE
[client-workflows] Compact workflow job graph nodes

### DIFF
--- a/.changeset/compact-branches-count.md
+++ b/.changeset/compact-branches-count.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Compacts workflow job graph nodes and shows only current unresolved dependency counts.

--- a/libs/client/workflows/src/components/workflow-jobs-graph/graph-model.test.ts
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/graph-model.test.ts
@@ -141,6 +141,26 @@ describe('buildWorkflowJobGraphModel', () => {
       sourceStatus: 'cancelled',
     });
   });
+
+  test('counts only pending and running known dependencies as current', () => {
+    const pending = makeJob({name: 'build', status: 'pending'});
+    const running = makeJob({name: 'test', status: 'running', position: 1});
+    const succeeded = makeJob({name: 'lint', status: 'succeeded', position: 2});
+    const failed = makeJob({name: 'security', status: 'failed', position: 3});
+    const cancelled = makeJob({name: 'docs', status: 'cancelled', position: 4});
+    const deploy = makeJob({
+      name: 'deploy',
+      position: 5,
+      dependencies: ['build', 'test', 'lint', 'security', 'docs', 'missing'],
+    });
+    const run = makeRun({jobs: [deploy, cancelled, failed, succeeded, running, pending]});
+
+    const result = buildWorkflowJobGraphModel({run});
+
+    expect(nodeByLabel(result, 'deploy')).toMatchObject({
+      currentDependencyCount: 2,
+    });
+  });
 });
 
 function nodeByLabel(result: ReturnType<typeof buildWorkflowJobGraphModel>, label: string) {

--- a/libs/client/workflows/src/components/workflow-jobs-graph/graph-model.ts
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/graph-model.ts
@@ -17,6 +17,7 @@ export interface WorkflowJobGraphNode {
   column: number;
   row: number;
   dependencies: string[];
+  currentDependencyCount: number;
 }
 
 export type WorkflowJobGraphNavigationKey =
@@ -76,6 +77,7 @@ export function buildWorkflowJobGraphModel({
     column: columnFor(job),
     row: 0,
     dependencies: job.dependencies,
+    currentDependencyCount: currentDependencyCount(job, byName),
   }));
 
   const grouped = groupColumns(nodesWithoutRows);
@@ -156,6 +158,16 @@ function buildEdges(
   );
 
   return [...triggerEdges, ...dependencyEdges];
+}
+
+function currentDependencyCount(
+  job: RunJobDetailDto,
+  byName: ReadonlyMap<string, RunJobDetailDto>,
+): number {
+  return job.dependencies.filter((dependencyName) => {
+    const dependency = byName.get(dependencyName);
+    return dependency?.status === 'pending' || dependency?.status === 'running';
+  }).length;
 }
 
 export function nextWorkflowJobGraphNodeId({

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.stories.tsx
@@ -92,5 +92,6 @@ function makeNode({
     column: 0,
     row: position,
     dependencies,
+    currentDependencyCount: dependencies.length,
   };
 }

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -1,4 +1,4 @@
-import {Code, cn, Text, Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
+import {Badge, Code, cn, Text, Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
 import type {KeyboardEventHandler, Ref} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
@@ -6,7 +6,7 @@ import type {WorkflowGraphTriggerNode, WorkflowJobGraphNode} from './graph-model
 
 export function TriggerNode({trigger}: {trigger: WorkflowGraphTriggerNode}) {
   return (
-    <div className="flex h-78 w-144 flex-col justify-center gap-6 rounded-8 border border-border-neutral-base bg-background-components-base px-12 text-left">
+    <div className="flex h-48 w-144 flex-col justify-center gap-2 rounded-8 border border-border-neutral-base bg-background-components-base px-10 text-left">
       <Text size="xs" className="text-foreground-neutral-muted">
         Trigger
       </Text>
@@ -36,11 +36,11 @@ export function WorkflowJobNode({
   ref?: Ref<HTMLButtonElement>;
 }) {
   const visual = getWorkflowStatusVisual(node.sourceStatus);
-  const dependencyText = dependencyLabel(node.dependencies);
+  const dependencyText = dependencyLabel(node.currentDependencyCount);
   const shouldShowTooltip = node.label.length > 24 || dependencyText !== undefined;
   const accessibleLabel =
     dependencyText !== undefined
-      ? `${node.label}, ${visual.label}, ${dependencyText.full}`
+      ? `${node.label}, ${visual.label}, ${dependencyText.accessible}`
       : `${node.label}, ${visual.label}`;
 
   const button = (
@@ -53,32 +53,33 @@ export function WorkflowJobNode({
       onClick={onSelect}
       onKeyDown={onKeyDown}
       className={cn(
-        'group relative flex h-78 w-208 flex-col gap-4 rounded-8 border border-border-neutral-base bg-background-components-base px-10 py-6 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
+        'group relative flex h-48 w-208 items-center gap-8 rounded-8 border border-border-neutral-base bg-background-components-base px-10 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
         selected && 'bg-background-components-hover',
       )}
     >
       {selected ? (
         <span
           aria-hidden="true"
-          className="absolute inset-y-8 left-0 w-3 rounded-full bg-border-highlights-interactive"
+          className="absolute inset-y-6 left-0 w-3 rounded-full bg-border-highlights-interactive"
         />
       ) : null}
-      <div className="flex min-w-0 items-center gap-8">
+      <div className="flex min-w-0 flex-1 items-center gap-8">
         <WorkflowStatusIcon status={node.sourceStatus} size={14} tooltip={false} />
-        <Code variant="label" bold className="truncate text-foreground-neutral-base">
+        <Code variant="label" bold className="min-w-0 truncate text-foreground-neutral-base">
           {node.label}
         </Code>
       </div>
-      <div className="flex min-w-0 flex-col">
-        <Text size="xs" className="shrink-0 text-foreground-neutral-subtle">
-          {visual.label}
-        </Text>
-        {dependencyText ? (
-          <Text size="xs" className="truncate text-foreground-neutral-muted">
-            {dependencyText.short}
-          </Text>
-        ) : null}
-      </div>
+      {dependencyText ? (
+        <Badge
+          variant="neutral"
+          size="2xs"
+          iconLeft="gitBranchLine"
+          aria-hidden="true"
+          className="font-code"
+        >
+          {dependencyText.count}
+        </Badge>
+      ) : null}
     </button>
   );
 
@@ -90,17 +91,21 @@ export function WorkflowJobNode({
       <TooltipContent>
         <div className="flex max-w-320 flex-col gap-2">
           <span>{node.label}</span>
-          {dependencyText ? <span className="opacity-70">{dependencyText.full}</span> : null}
+          <span className="opacity-70">{visual.label}</span>
+          {dependencyText ? <span className="opacity-70">{dependencyText.tooltip}</span> : null}
         </div>
       </TooltipContent>
     </Tooltip>
   );
 }
 
-function dependencyLabel(dependencies: readonly string[]) {
-  if (dependencies.length === 0) return undefined;
-  const full = `Depends on ${dependencies.join(', ')}`;
-  const short =
-    dependencies.length === 1 ? 'Depends on 1 job' : `Depends on ${dependencies.length} jobs`;
-  return {full, short};
+function dependencyLabel(count: number) {
+  if (count === 0) return undefined;
+  const dependency = count === 1 ? 'dependency is' : 'dependencies are';
+  const message = `${count} current ${dependency} still pending or running`;
+  return {
+    count,
+    accessible: message,
+    tooltip: `${message}.`,
+  };
 }

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -1,5 +1,6 @@
 import {Badge, Code, cn, Text, Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
 import type {KeyboardEventHandler, Ref} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import type {WorkflowGraphTriggerNode, WorkflowJobGraphNode} from './graph-model.js';
@@ -37,13 +38,12 @@ export function WorkflowJobNode({
 }) {
   const visual = getWorkflowStatusVisual(node.sourceStatus);
   const dependencyText = dependencyLabel(node.currentDependencyCount);
-  const shouldShowTooltip = node.label.length > 24 || dependencyText !== undefined;
   const accessibleLabel =
     dependencyText !== undefined
       ? `${node.label}, ${visual.label}, ${dependencyText.accessible}`
       : `${node.label}, ${visual.label}`;
 
-  const button = (
+  return (
     <button
       ref={ref}
       type="button"
@@ -65,36 +65,57 @@ export function WorkflowJobNode({
       ) : null}
       <div className="flex min-w-0 flex-1 items-center gap-8">
         <WorkflowStatusIcon status={node.sourceStatus} size={14} tooltip={false} />
-        <Code variant="label" bold className="min-w-0 truncate text-foreground-neutral-base">
-          {node.label}
-        </Code>
+        <JobLabel label={node.label} />
       </div>
       {dependencyText ? (
-        <Badge
-          variant="neutral"
-          size="2xs"
-          iconLeft="gitBranchLine"
-          aria-hidden="true"
-          className="font-code"
-        >
-          {dependencyText.count}
-        </Badge>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span aria-hidden="true" className="shrink-0">
+              <Badge variant="neutral" size="2xs" iconLeft="nodeTree" className="font-code">
+                {dependencyText.count}
+              </Badge>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{dependencyText.tooltip}</TooltipContent>
+        </Tooltip>
       ) : null}
     </button>
   );
+}
 
-  if (!shouldShowTooltip) return button;
+function JobLabel({label}: {label: string}) {
+  const labelRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const element = labelRef.current;
+    if (!element) return;
+    if (label.length === 0) {
+      setIsTruncated(false);
+      return;
+    }
+
+    const updateTruncation = () => {
+      setIsTruncated(element.scrollWidth > element.clientWidth);
+    };
+    updateTruncation();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateTruncation);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [label]);
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
-      <TooltipContent>
-        <div className="flex max-w-320 flex-col gap-2">
-          <span>{node.label}</span>
-          <span className="opacity-70">{visual.label}</span>
-          {dependencyText ? <span className="opacity-70">{dependencyText.tooltip}</span> : null}
-        </div>
-      </TooltipContent>
+      <TooltipTrigger asChild>
+        <span ref={labelRef} className="block min-w-0 truncate">
+          <Code as="span" variant="label" bold className="text-foreground-neutral-base">
+            {label}
+          </Code>
+        </span>
+      </TooltipTrigger>
+      {isTruncated ? <TooltipContent>{label}</TooltipContent> : null}
     </Tooltip>
   );
 }

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
@@ -6,7 +6,7 @@ import {nextWorkflowJobGraphNodeId} from './graph-model.js';
 import {TriggerNode, WorkflowJobNode} from './workflow-job-node.js';
 
 const NODE_WIDTH = 208;
-const NODE_HEIGHT = 78;
+const NODE_HEIGHT = 48;
 const COLUMN_GAP = 72;
 const ROW_GAP = 18;
 const TRIGGER_WIDTH = 144;

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -1,5 +1,5 @@
 import type {RunDetailResponseDto, RunJobDetailDto} from '@shipfox/api-workflows-dto';
-import {render, screen} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {WorkflowJobsGraph} from './workflow-jobs-graph.js';
 
@@ -72,9 +72,7 @@ describe('WorkflowJobsGraph', () => {
     );
 
     expect(screen.getByRole('button', {name: 'build, Failed'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'deploy, Cancelled, Depends on build'}),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'deploy, Cancelled'})).toBeInTheDocument();
   });
 
   test('renders an empty state', () => {
@@ -103,12 +101,14 @@ describe('WorkflowJobsGraph', () => {
     );
 
     expect(
-      screen.getByRole('button', {name: 'deploy, Running, Depends on build'}),
+      screen.getByRole('button', {
+        name: 'deploy, Running, 1 current dependency is still pending or running',
+      }),
     ).toBeInTheDocument();
-    expect(screen.getByText('Depends on 1 job')).toBeInTheDocument();
+    expect(screen.queryByText('Depends on 1 job')).not.toBeInTheDocument();
   });
 
-  test('summarizes multiple dependencies visually and keeps names accessible', () => {
+  test('summarizes multiple current dependencies visually and keeps count accessible', () => {
     render(
       <WorkflowJobsGraph
         run={makeRun({
@@ -121,10 +121,28 @@ describe('WorkflowJobsGraph', () => {
       />,
     );
 
-    expect(
-      screen.getByRole('button', {name: 'deploy, Pending, Depends on build, lint'}),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Depends on 2 jobs')).toBeInTheDocument();
+    const deploy = screen.getByRole('button', {
+      name: 'deploy, Pending, 2 current dependencies are still pending or running',
+    });
+    expect(deploy).toBeInTheDocument();
+    expect(within(deploy).getByText('2')).toBeInTheDocument();
+    expect(screen.queryByText('Depends on 2 jobs')).not.toBeInTheDocument();
+  });
+
+  test('hides the current dependency pill when upstream jobs are resolved', () => {
+    render(
+      <WorkflowJobsGraph
+        run={makeRun({
+          jobs: [
+            makeJob({name: 'build', status: 'succeeded'}),
+            makeJob({name: 'deploy', position: 1, dependencies: ['build']}),
+          ],
+        })}
+      />,
+    );
+
+    const deploy = screen.getByRole('button', {name: 'deploy, Pending'});
+    expect(within(deploy).queryByText('1')).not.toBeInTheDocument();
   });
 
   test('moves selection and focus with graph keyboard navigation', async () => {
@@ -141,7 +159,9 @@ describe('WorkflowJobsGraph', () => {
     );
 
     const build = screen.getByRole('button', {name: 'build, Pending'});
-    const deploy = screen.getByRole('button', {name: 'deploy, Pending, Depends on build'});
+    const deploy = screen.getByRole('button', {
+      name: 'deploy, Pending, 1 current dependency is still pending or running',
+    });
     build.focus();
 
     await user.keyboard('{ArrowRight}');
@@ -173,7 +193,7 @@ describe('WorkflowJobsGraph', () => {
     const skippedJoinEdge = container.querySelector(
       `[data-edge-id="${securityScan.id}:${deploy.id}"]`,
     );
-    expect(skippedJoinEdge).toHaveAttribute('d', 'M 440 151 H 756 V 55 H 792');
+    expect(skippedJoinEdge).toHaveAttribute('d', 'M 440 106 H 756 V 40 H 792');
   });
 });
 

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph.stories.tsx
@@ -104,7 +104,7 @@ export const Selected: Story = {
   play: async ({canvasElement}) => {
     await within(canvasElement)
       .getByRole('button', {
-        name: 'deploy, Running, Depends on build',
+        name: 'deploy, Running',
       })
       .click();
   },

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -30,9 +30,7 @@ describe('WorkflowRunView', () => {
     );
     expect(await screen.findByRole('region', {name: 'Jobs graph'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'build, Succeeded'})).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'deploy, Running, Depends on build'}),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'deploy, Running'})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Step attempts'})).toBeInTheDocument();
     expect(
       screen.getByRole('button', {name: '1. checkout, Succeeded, attempt 1'}),
@@ -80,9 +78,7 @@ describe('WorkflowRunView', () => {
 
     renderView();
 
-    const deployNode = await screen.findByRole('button', {
-      name: 'deploy, Running, Depends on build',
-    });
+    const deployNode = await screen.findByRole('button', {name: 'deploy, Running'});
     await user.click(deployNode);
     expect(deployNode).toHaveAttribute('aria-pressed', 'true');
 


### PR DESCRIPTION
Compact workflow job nodes into a single-row layout.

The workflow DAG was spending two text rows repeating status and static dependency information, making each node larger than the amount of information it carried. This keeps the status glyph as the state signal and moves dependency context into a neutral count pill.

The count only includes current unresolved upstream jobs, meaning dependencies that are still pending or running. Resolved upstream jobs no longer appear as active dependency context, and the tooltip explains the count without listing potentially long job names.

Considered keeping the static dependency list, but that continued to overstate resolved dependencies and kept the node visually heavy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compact the workflow job graph into a single-row node and replace dependency names with a count of unresolved upstream jobs. This reduces node height, keeps status as the main signal, and improves readability and accessibility.

- **Refactors**
  - Shrinks job/trigger node height from 78px to 48px; status icon and label inline.
  - Replaces static dependency text with a neutral count badge for current unresolved upstream jobs (pending/running only; hidden at zero); pill tooltip and the button’s accessible name explain the count.
  - Shows a label tooltip only when the job name is truncated.
  - Adds `currentDependencyCount` to the graph model (counts only known pending/running deps); updates tests/stories and adjusts edge paths for the new height.

<sup>Written for commit 1dabb2458adc4eb6613194d95133dbb02261a433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

