### PR TITLE
[workflows] Instrument workflow lifecycle metrics

### DIFF
--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -5,6 +5,10 @@ import {
   insertRunningStepAttempt,
   markStepRunning,
 } from '#db/workflow-runs.js';
+import {
+  recordWorkflowJobStepsSettled,
+  recordWorkflowStepRestartEnqueued,
+} from '#metrics/instance.js';
 import type {RuntimeCompletionStatus} from './entities/runtime-dag.js';
 import type {Step} from './entities/step.js';
 import {
@@ -15,6 +19,7 @@ import {
 } from './errors.js';
 import {
   applyStepTransition,
+  type StepProgressionMetrics,
   type StepProgressionOutcome,
 } from './step-transition/apply-step-transition.js';
 import {
@@ -68,17 +73,24 @@ export interface RecordStepResultParams {
 
 export type RecordStepResultOutcome = StepProgressionOutcome;
 
+interface RecordStepResultTransactionResult {
+  outcome: RecordStepResultOutcome;
+  metrics: StepProgressionMetrics;
+}
+
 function outcomeFromSteps(steps: Step[]): RecordStepResultOutcome {
   return steps.every((step) => isTerminal(step.status))
     ? {jobFinished: true, status: deriveCompletion(steps)}
     : {jobFinished: false};
 }
 
-export function recordStepResult(params: RecordStepResultParams): Promise<RecordStepResultOutcome> {
+export async function recordStepResult(
+  params: RecordStepResultParams,
+): Promise<RecordStepResultOutcome> {
   // One transaction keeps the attempt finalize, the step result, and any sibling
   // cancellations atomic, so a crashed-then-retried report can never leave
   // siblings stranded once the step itself is terminal.
-  return withTransaction(async (tx) => {
+  const progression = await withTransaction<RecordStepResultTransactionResult>(async (tx) => {
     const steps = await getStepsByJobIdForUpdate(params.jobId, tx);
     const target = steps.find((step) => step.id === params.stepId);
 
@@ -97,10 +109,10 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
     if (reported < current) {
       // A stale report from a superseded attempt (e.g. after a rewind bumped the
       // current attempt). No-op: leave the projection untouched.
-      return outcomeFromSteps(steps);
+      return {outcome: outcomeFromSteps(steps), metrics: {}};
     }
     // A terminal target is a duplicate report, left untouched.
-    if (isTerminal(target.status)) return outcomeFromSteps(steps);
+    if (isTerminal(target.status)) return {outcome: outcomeFromSteps(steps), metrics: {}};
     // A result may only land on a step that was actually handed out.
     if (target.status === 'pending') {
       throw new StepNotRunningError(params.stepId, params.jobId);
@@ -144,4 +156,11 @@ export function recordStepResult(params: RecordStepResultParams): Promise<Record
       tx,
     );
   });
+
+  if (progression.metrics.jobStepsSettledStatus) {
+    recordWorkflowJobStepsSettled(progression.metrics.jobStepsSettledStatus);
+  }
+  if (progression.metrics.stepRestartEnqueued) recordWorkflowStepRestartEnqueued();
+
+  return progression.outcome;
 }

--- a/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
+++ b/libs/api/workflows/src/core/step-transition/apply-step-transition.ts
@@ -19,6 +19,16 @@ export type StepProgressionOutcome =
   | {jobFinished: false}
   | {jobFinished: true; status: 'succeeded' | 'failed'};
 
+export interface StepProgressionMetrics {
+  jobStepsSettledStatus?: 'succeeded' | 'failed';
+  stepRestartEnqueued?: boolean;
+}
+
+export interface StepProgressionResult {
+  outcome: StepProgressionOutcome;
+  metrics: StepProgressionMetrics;
+}
+
 export interface ApplyStepTransitionContext {
   jobId: string;
   result: StepResult;
@@ -35,7 +45,7 @@ export async function applyStepTransition(
   decision: StepTransitionDecision,
   ctx: ApplyStepTransitionContext,
   tx: Tx,
-): Promise<StepProgressionOutcome> {
+): Promise<StepProgressionResult> {
   switch (decision.kind) {
     case 'complete-step':
     case 'complete-job': {
@@ -115,7 +125,7 @@ export async function applyStepTransition(
       });
       // The job stays running; the next pull re-dispatches restart_from. Do not
       // derive completion or emit a completion event.
-      return {jobFinished: false};
+      return {outcome: {jobFinished: false}, metrics: {stepRestartEnqueued: true}};
     }
   }
 
@@ -126,7 +136,10 @@ export async function applyStepTransition(
   if (after.every((step) => isTerminal(step.status))) {
     const status = deriveCompletion(after);
     await writeJobStepsSettledOutbox(tx, {jobId: ctx.jobId, status});
-    return {jobFinished: true, status};
+    return {
+      outcome: {jobFinished: true, status},
+      metrics: {jobStepsSettledStatus: status},
+    };
   }
-  return {jobFinished: false};
+  return {outcome: {jobFinished: false}, metrics: {}};
 }

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -11,6 +11,7 @@ export type {
   ListWorkflowRunsResult,
   UpdateJobStatusParams,
   UpdateWorkflowRunStatusParams,
+  WorkflowExecutionDepth,
   WorkflowRunAggregates,
   WorkflowRunFilters,
 } from './workflow-runs.js';
@@ -25,6 +26,7 @@ export {
   getStepsByJobId,
   getStepsByJobIdForUpdate,
   getStepsByJobIds,
+  getWorkflowExecutionDepth,
   getWorkflowRunAggregates,
   getWorkflowRunById,
   listWorkflowRuns,

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -12,6 +12,7 @@ export type {
   UpdateJobStatusParams,
   UpdateWorkflowRunStatusParams,
   WorkflowExecutionDepth,
+  WorkflowExecutionDepthParams,
   WorkflowRunAggregates,
   WorkflowRunFilters,
 } from './workflow-runs.js';

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -19,6 +19,7 @@ import {
   failJobAsTimedOut,
   getJobsByRunId,
   getStepsByJobId,
+  getWorkflowExecutionDepth,
   getWorkflowRunById,
   listWorkflowRunsByProject,
   resolveJobAfterLeaseExpiry,
@@ -666,6 +667,15 @@ jobs:
       expect(jobSteps[1]?.position).toBe(1);
       expect(jobSteps[2]?.position).toBe(2);
       expect(jobSteps[3]?.position).toBe(3);
+    });
+  });
+
+  describe('getWorkflowExecutionDepth', () => {
+    test('returns non-negative running run and job counts', async () => {
+      const depth = await getWorkflowExecutionDepth();
+
+      expect(depth.runningRuns).toBeGreaterThanOrEqual(0);
+      expect(depth.runningJobs).toBeGreaterThanOrEqual(0);
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -671,11 +671,42 @@ jobs:
   });
 
   describe('getWorkflowExecutionDepth', () => {
-    test('returns non-negative running run and job counts', async () => {
-      const depth = await getWorkflowExecutionDepth();
+    test('counts running runs and jobs for a workspace', async () => {
+      const runningRun = await createTestRun({workspaceId, projectId, definitionId});
+      const pendingRun = await createTestRun({workspaceId, projectId, definitionId});
+      const otherWorkspaceRun = await createTestRun({
+        workspaceId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        definitionId: crypto.randomUUID(),
+      });
+      const [runningJob] = await getJobsByRunId(runningRun.id);
+      const [otherWorkspaceJob] = await getJobsByRunId(otherWorkspaceRun.id);
+      if (!runningJob || !otherWorkspaceJob) throw new Error('Expected workflow jobs');
+      await updateWorkflowRunStatus({
+        runId: runningRun.id,
+        status: 'running',
+        expectedVersion: runningRun.version,
+      });
+      await updateWorkflowRunStatus({
+        runId: otherWorkspaceRun.id,
+        status: 'running',
+        expectedVersion: otherWorkspaceRun.version,
+      });
+      await updateJobStatus({
+        jobId: runningJob.id,
+        status: 'running',
+        expectedVersion: runningJob.version,
+      });
+      await updateJobStatus({
+        jobId: otherWorkspaceJob.id,
+        status: 'running',
+        expectedVersion: otherWorkspaceJob.version,
+      });
 
-      expect(depth.runningRuns).toBeGreaterThanOrEqual(0);
-      expect(depth.runningJobs).toBeGreaterThanOrEqual(0);
+      const depth = await getWorkflowExecutionDepth({workspaceId});
+
+      expect(pendingRun.status).toBe('pending');
+      expect(depth).toEqual({runningRuns: 1, runningJobs: 1});
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -14,7 +14,7 @@ import {
   timestampIdCursorWhere,
 } from '@shipfox/node-drizzle';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
-import {and, asc, count, desc, eq, gte, inArray, lte, type SQL, sql} from 'drizzle-orm';
+import {and, asc, count, desc, eq, gte, inArray, isNull, lte, type SQL, sql} from 'drizzle-orm';
 import {isJobTerminal, type Job, type JobStatus} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
@@ -28,6 +28,17 @@ import {
 import {JobNotFoundError} from '#core/errors.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import {materializeWorkflowModel} from '#core/workflow-runtime/index.js';
+import {
+  recordWorkflowJobLeaseExpiryResolved,
+  recordWorkflowJobQueued,
+  recordWorkflowJobStarted,
+  recordWorkflowJobStatusChanged,
+  recordWorkflowJobStepsSettled,
+  recordWorkflowJobTimedOut,
+  recordWorkflowRunCreated,
+  recordWorkflowRunStatusChanged,
+  recordWorkflowStepRestartEnqueued,
+} from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
 import {jobs, toJob} from './schema/jobs.js';
 import {workflowsOutbox} from './schema/outbox.js';
@@ -50,7 +61,7 @@ export interface CreateWorkflowRunParams {
 export async function createWorkflowRun(params: CreateWorkflowRunParams): Promise<WorkflowRun> {
   const materializedJobs = materializeWorkflowModel(params.model);
 
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     const insertResult = await tx
       .insert(workflowRuns)
       .values({
@@ -86,7 +97,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
           `Idempotency conflict but existing run missing for key ${params.triggerIdempotencyKey}`,
         );
       }
-      return toWorkflowRun(existingRow);
+      return {run: toWorkflowRun(existingRow), created: false};
     }
 
     let jobRows: (typeof jobs.$inferSelect)[] = [];
@@ -139,8 +150,12 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       },
     });
 
-    return toWorkflowRun(runRow);
+    return {run: toWorkflowRun(runRow), created: true};
   });
+
+  if (result.created) recordWorkflowRunCreated(result.run.triggerSource);
+
+  return result.run;
 }
 
 export async function getWorkflowRunById(id: string): Promise<WorkflowRun | undefined> {
@@ -303,6 +318,23 @@ export async function getWorkflowRunAggregates(params: {
   };
 }
 
+export interface WorkflowExecutionDepth {
+  runningRuns: number;
+  runningJobs: number;
+}
+
+export async function getWorkflowExecutionDepth(): Promise<WorkflowExecutionDepth> {
+  const [runRows, jobRows] = await Promise.all([
+    db().select({value: count()}).from(workflowRuns).where(eq(workflowRuns.status, 'running')),
+    db().select({value: count()}).from(jobs).where(eq(jobs.status, 'running')),
+  ]);
+
+  return {
+    runningRuns: runRows[0]?.value ?? 0,
+    runningJobs: jobRows[0]?.value ?? 0,
+  };
+}
+
 export async function getJobsByRunId(runId: string): Promise<Job[]> {
   const rows = await db()
     .select()
@@ -347,7 +379,7 @@ export interface UpdateWorkflowRunStatusParams {
 export async function updateWorkflowRunStatus(
   params: UpdateWorkflowRunStatusParams,
 ): Promise<WorkflowRun> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     const rows = await tx
       .update(workflowRuns)
       .set({
@@ -380,7 +412,9 @@ export async function updateWorkflowRunStatus(
         .where(eq(workflowRuns.id, params.runId))
         .limit(1);
       const existingRow = existing[0];
-      if (existingRow && existingRow.status === params.status) return toWorkflowRun(existingRow);
+      if (existingRow && existingRow.status === params.status) {
+        return {run: toWorkflowRun(existingRow), changed: false};
+      }
       throw new Error(
         `Optimistic lock failure: run ${params.runId} version ${params.expectedVersion}`,
       );
@@ -397,8 +431,12 @@ export async function updateWorkflowRunStatus(
       });
     }
 
-    return run;
+    return {run, changed: true};
   });
+
+  if (result.changed) recordWorkflowRunStatusChanged(result.run.status);
+
+  return result.run;
 }
 
 export interface UpdateJobStatusAtVersionParams {
@@ -412,7 +450,7 @@ export interface UpdateJobStatusAtVersionParams {
 async function updateJobStatusAtVersion(
   tx: Tx,
   params: UpdateJobStatusAtVersionParams,
-): Promise<Job | null> {
+): Promise<{job: Job; changed: boolean} | null> {
   const rows = await tx
     .update(jobs)
     .set({
@@ -440,7 +478,7 @@ async function updateJobStatusAtVersion(
     });
   }
 
-  return job;
+  return {job, changed: true};
 }
 
 export interface UpdateJobStatusParams {
@@ -450,7 +488,7 @@ export interface UpdateJobStatusParams {
 }
 
 export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Job> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     const updated = await updateJobStatusAtVersion(tx, {
       jobId: params.jobId,
       status: params.status,
@@ -465,29 +503,39 @@ export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Jo
     // instead of throwing an optimistic-lock error that would wedge the workflow.
     const existing = await tx.select().from(jobs).where(eq(jobs.id, params.jobId)).limit(1);
     const row = existing[0];
-    if (row && row.status === params.status) return toJob(row);
+    if (row && row.status === params.status) return {job: toJob(row), changed: false};
     throw new Error(
       `Optimistic lock failure: job ${params.jobId} version ${params.expectedVersion}`,
     );
   });
+
+  if (result.changed) recordWorkflowJobStatusChanged(result.job.status);
+
+  return result.job;
 }
 
-// Project the runner-owned queue/claim moments onto the durable job row. `coalesce`
-// makes redelivery and out-of-order delivery first-write-wins, so the at-least-once
-// outbox can replay these freely. Eventually consistent by design: the column stays
-// null until the runner event drains.
+// Project the runner-owned queue/claim moments onto the durable job row. The null
+// guard makes redelivery and out-of-order delivery first-write-wins, so the
+// at-least-once outbox can replay these freely. Eventually consistent by design:
+// the column stays null until the runner event drains.
 export async function recordJobQueuedAt(params: {jobId: string; queuedAt: Date}): Promise<void> {
-  await db()
+  const updated = await db()
     .update(jobs)
-    .set({queuedAt: sql`coalesce(${jobs.queuedAt}, ${params.queuedAt})`})
-    .where(eq(jobs.id, params.jobId));
+    .set({queuedAt: params.queuedAt})
+    .where(and(eq(jobs.id, params.jobId), isNull(jobs.queuedAt)))
+    .returning({id: jobs.id});
+
+  if (updated.length > 0) recordWorkflowJobQueued();
 }
 
 export async function recordJobStartedAt(params: {jobId: string; startedAt: Date}): Promise<void> {
-  await db()
+  const updated = await db()
     .update(jobs)
-    .set({startedAt: sql`coalesce(${jobs.startedAt}, ${params.startedAt})`})
-    .where(eq(jobs.id, params.jobId));
+    .set({startedAt: params.startedAt})
+    .where(and(eq(jobs.id, params.jobId), isNull(jobs.startedAt)))
+    .returning({id: jobs.id});
+
+  if (updated.length > 0) recordWorkflowJobStarted();
 }
 
 export interface FailJobAsTimedOutParams {
@@ -500,7 +548,7 @@ export interface FailJobAsTimedOutParams {
 // `timed_out_at` proves an earlier attempt of this same activity already
 // finalized — return its version without writing a second outbox event.
 export async function failJobAsTimedOut(params: FailJobAsTimedOutParams): Promise<Job> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     const updated = await updateJobStatusAtVersion(tx, {
       jobId: params.jobId,
       status: 'failed',
@@ -512,7 +560,7 @@ export async function failJobAsTimedOut(params: FailJobAsTimedOutParams): Promis
       const existing = await tx.select().from(jobs).where(eq(jobs.id, params.jobId)).limit(1);
       const row = existing[0];
       if (row && row.timedOutAt !== null) {
-        return toJob(row);
+        return {job: toJob(row), changed: false};
       }
       throw new Error(
         `Optimistic lock failure: job ${params.jobId} version ${params.expectedVersion}`,
@@ -526,6 +574,13 @@ export async function failJobAsTimedOut(params: FailJobAsTimedOutParams): Promis
 
     return updated;
   });
+
+  if (result.changed) {
+    recordWorkflowJobStatusChanged(result.job.status);
+    recordWorkflowJobTimedOut();
+  }
+
+  return result.job;
 }
 
 /**
@@ -550,8 +605,9 @@ export async function resolveJobAfterLeaseExpiry(params: {
   jobId: string;
   expectedVersion: number;
 }): Promise<{status: RuntimeCompletionStatus; jobVersion: number}> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     const jobSteps = await getStepsByJobIdForUpdate(params.jobId, tx);
+    let changedJob: Job | null = null;
 
     // A job with no steps is malformed, not a runner-died-mid-job failure. Surface
     // it loudly instead of silently marking the job failed and hiding the bad state.
@@ -561,25 +617,32 @@ export async function resolveJobAfterLeaseExpiry(params: {
     }
 
     if (jobSteps.every((step) => isTerminal(step.status))) {
-      await updateJobStatusAtVersion(tx, {
+      const updated = await updateJobStatusAtVersion(tx, {
         jobId: params.jobId,
         status: deriveCompletion(jobSteps),
         expectedVersion: params.expectedVersion,
       });
+      changedJob = updated?.changed ? updated.job : null;
     } else {
-      await updateJobStatusAtVersion(tx, {
+      const updated = await updateJobStatusAtVersion(tx, {
         jobId: params.jobId,
         status: 'failed',
         expectedVersion: params.expectedVersion,
       });
+      changedJob = updated?.changed ? updated.job : null;
       await bulkUpdateStepStatuses({jobId: params.jobId, status: 'cancelled'}, tx);
     }
 
     const row = (await tx.select().from(jobs).where(eq(jobs.id, params.jobId)).limit(1))[0];
     if (!row) throw new Error(`Job not found resolving lease expiry: ${params.jobId}`);
     const status: RuntimeCompletionStatus = row.status === 'succeeded' ? 'succeeded' : 'failed';
-    return {status, jobVersion: row.version};
+    return {status, jobVersion: row.version, changedJob};
   });
+
+  recordWorkflowJobLeaseExpiryResolved(result.status);
+  if (result.changedJob) recordWorkflowJobStatusChanged(result.changedJob.status);
+
+  return {status: result.status, jobVersion: result.jobVersion};
 }
 
 // Enqueue the steps-settled signal in the same transaction as the final per-step
@@ -604,6 +667,7 @@ export async function writeJobStepsSettledOutbox(
     type: WORKFLOWS_JOB_STEPS_SETTLED,
     payload: {jobId: params.jobId, runId, status: params.status},
   });
+  recordWorkflowJobStepsSettled(params.status);
 }
 
 export interface BulkUpdateStepStatusesParams {
@@ -816,6 +880,7 @@ export async function writeStepRestartEnqueuedOutbox(
       reason: params.reason,
     },
   });
+  recordWorkflowStepRestartEnqueued();
 }
 
 // Count a single step's own attempts. Used to bound the restart cap on the

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -33,11 +33,9 @@ import {
   recordWorkflowJobQueued,
   recordWorkflowJobStarted,
   recordWorkflowJobStatusChanged,
-  recordWorkflowJobStepsSettled,
   recordWorkflowJobTimedOut,
   recordWorkflowRunCreated,
   recordWorkflowRunStatusChanged,
-  recordWorkflowStepRestartEnqueued,
 } from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
 import {jobs, toJob} from './schema/jobs.js';
@@ -323,10 +321,37 @@ export interface WorkflowExecutionDepth {
   runningJobs: number;
 }
 
-export async function getWorkflowExecutionDepth(): Promise<WorkflowExecutionDepth> {
+export interface WorkflowExecutionDepthParams {
+  workspaceId?: string;
+}
+
+export async function getWorkflowExecutionDepth(
+  params: WorkflowExecutionDepthParams = {},
+): Promise<WorkflowExecutionDepth> {
+  const runConditions = [eq(workflowRuns.status, 'running')];
+  const jobConditions = [eq(jobs.status, 'running')];
+  if (params.workspaceId) {
+    runConditions.push(eq(workflowRuns.workspaceId, params.workspaceId));
+    jobConditions.push(eq(workflowRuns.workspaceId, params.workspaceId));
+  }
+
+  const jobQuery = params.workspaceId
+    ? db()
+        .select({value: count()})
+        .from(jobs)
+        .innerJoin(workflowRuns, eq(jobs.runId, workflowRuns.id))
+        .where(and(...jobConditions))
+    : db()
+        .select({value: count()})
+        .from(jobs)
+        .where(and(...jobConditions));
+
   const [runRows, jobRows] = await Promise.all([
-    db().select({value: count()}).from(workflowRuns).where(eq(workflowRuns.status, 'running')),
-    db().select({value: count()}).from(jobs).where(eq(jobs.status, 'running')),
+    db()
+      .select({value: count()})
+      .from(workflowRuns)
+      .where(and(...runConditions)),
+    jobQuery,
   ]);
 
   return {
@@ -667,7 +692,6 @@ export async function writeJobStepsSettledOutbox(
     type: WORKFLOWS_JOB_STEPS_SETTLED,
     payload: {jobId: params.jobId, runId, status: params.status},
   });
-  recordWorkflowJobStepsSettled(params.status);
 }
 
 export interface BulkUpdateStepStatusesParams {
@@ -880,7 +904,6 @@ export async function writeStepRestartEnqueuedOutbox(
       reason: params.reason,
     },
   });
-  recordWorkflowStepRestartEnqueued();
 }
 
 // Count a single step's own attempts. Used to bound the restart cap on the

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workflowsOutbox} from '#db/index.js';
+import {registerWorkflowsServiceMetrics} from '#metrics/index.js';
 import {
   onJobStepsSettled,
   onRunnerJobClaimed,
@@ -51,6 +52,7 @@ export const workflowsModule: ShipfoxModule = {
   name: 'workflows',
   database: {db, migrationsPath},
   routes,
+  metrics: registerWorkflowsServiceMetrics,
   publishers: [
     {name: 'workflows', table: workflowsOutbox, db, eventSchemas: workflowsEventSchemas},
   ],

--- a/libs/api/workflows/src/metrics/index.ts
+++ b/libs/api/workflows/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export {registerWorkflowsServiceMetrics} from './service.js';

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -1,0 +1,86 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+import type {JobStatus} from '#core/entities/job.js';
+import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
+import type {WorkflowRunStatus} from '#core/entities/workflow-run.js';
+
+const meter = instanceMetrics.getMeter('workflows');
+
+const runCreatedCount = meter.createCounter<{trigger_source: string}>('workflows_run_created', {
+  description: 'Workflow runs created by trigger source',
+});
+
+const runStatusChangedCount = meter.createCounter<{status: WorkflowRunStatus}>(
+  'workflows_run_status_changed',
+  {description: 'Workflow run status transitions by resulting status'},
+);
+
+const jobStatusChangedCount = meter.createCounter<{status: JobStatus}>(
+  'workflows_job_status_changed',
+  {description: 'Workflow job status transitions by resulting status'},
+);
+
+const jobQueuedCount = meter.createCounter<Record<string, never>>('workflows_job_queued', {
+  description: 'Workflow jobs first marked as queued from runner queue events',
+});
+
+const jobStartedCount = meter.createCounter<Record<string, never>>('workflows_job_started', {
+  description: 'Workflow jobs first marked as started from runner claim events',
+});
+
+const jobStepsSettledCount = meter.createCounter<{
+  status: Extract<RuntimeCompletionStatus, 'failed' | 'succeeded'>;
+}>('workflows_job_steps_settled', {
+  description: 'Job steps-settled events enqueued by resulting completion status',
+});
+
+const jobTimedOutCount = meter.createCounter<Record<string, never>>('workflows_job_timed_out', {
+  description: 'Workflow jobs failed by the job orchestration timeout path',
+});
+
+const jobLeaseExpiryResolvedCount = meter.createCounter<{status: RuntimeCompletionStatus}>(
+  'workflows_job_lease_expiry_resolved',
+  {description: 'Runner lease-expiry resolutions by resulting runtime status'},
+);
+
+const stepRestartEnqueuedCount = meter.createCounter<Record<string, never>>(
+  'workflows_step_restart_enqueued',
+  {description: 'Durable step restart events enqueued after a restartable gate failure'},
+);
+
+export function recordWorkflowRunCreated(triggerSource: string): void {
+  runCreatedCount.add(1, {trigger_source: triggerSource});
+}
+
+export function recordWorkflowRunStatusChanged(status: WorkflowRunStatus): void {
+  runStatusChangedCount.add(1, {status});
+}
+
+export function recordWorkflowJobStatusChanged(status: JobStatus): void {
+  jobStatusChangedCount.add(1, {status});
+}
+
+export function recordWorkflowJobQueued(): void {
+  jobQueuedCount.add(1);
+}
+
+export function recordWorkflowJobStarted(): void {
+  jobStartedCount.add(1);
+}
+
+export function recordWorkflowJobStepsSettled(
+  status: Extract<RuntimeCompletionStatus, 'failed' | 'succeeded'>,
+): void {
+  jobStepsSettledCount.add(1, {status});
+}
+
+export function recordWorkflowJobTimedOut(): void {
+  jobTimedOutCount.add(1);
+}
+
+export function recordWorkflowJobLeaseExpiryResolved(status: RuntimeCompletionStatus): void {
+  jobLeaseExpiryResolvedCount.add(1, {status});
+}
+
+export function recordWorkflowStepRestartEnqueued(): void {
+  stepRestartEnqueuedCount.add(1);
+}

--- a/libs/api/workflows/src/metrics/service.ts
+++ b/libs/api/workflows/src/metrics/service.ts
@@ -1,0 +1,22 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getWorkflowExecutionDepth} from '#db/workflow-runs.js';
+
+export function registerWorkflowsServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('workflows');
+
+  const runningRuns = meter.createObservableGauge('workflows_running_runs', {
+    description: 'Workflow runs currently marked running',
+  });
+  const runningJobs = meter.createObservableGauge('workflows_running_jobs', {
+    description: 'Workflow jobs currently marked running',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      const depth = await getWorkflowExecutionDepth();
+      observer.observe(runningRuns, depth.runningRuns);
+      observer.observe(runningJobs, depth.runningJobs);
+    },
+    [runningRuns, runningJobs],
+  );
+}


### PR DESCRIPTION
Adds OpenTelemetry metrics to `@shipfox/api-workflows` for workflow run creation, run and job status transitions, runner queue/claim projections, timeout and lease-expiry paths, step-settled events, and restart enqueue events.

The workflows module previously had no module-owned metrics, which made it hard to observe workflow execution health from Prometheus. This follows the `api-runners` pattern with instance counters recorded where lifecycle facts are known and service gauges registered through the module `metrics` hook for currently running runs and jobs.

Metric labels avoid entity identifiers. Trigger source is preserved on run creation so integration-specific sources remain visible, while other lifecycle labels stay bounded to statuses and outcomes.

Validated with `mise exec -- turbo build --filter '...[origin/main]'`, `mise exec -- turbo test --filter '...[origin/main]'`, and `mise exec -- turbo check --filter '...[origin/main]'`.

Closes ENG-570

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry metrics to `@shipfox/api-workflows` to track workflow and job lifecycle so execution health is visible in Prometheus. Uses low-cardinality counters and service gauges; fulfills ENG-570.

- New Features
  - Counters for run creation (by `trigger_source`), run/job status changes, job queued/started, job timed out, lease expiry resolved (by status), steps settled (by completion), and step restart enqueued.
  - Service gauges for running runs and running jobs via the module `metrics` hook, powered by `getWorkflowExecutionDepth()` with optional workspace scoping.
  - Idempotent and safe emission: counters fire only on real state changes; queue/claim timestamps are first-write-wins; step-settled and restart counters emit after the transaction commits.

<sup>Written for commit 0039a606f688862ac02a61f6bcaee3343560736f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

