### PR TITLE
Show logs for active workflow step attempts

### DIFF
--- a/.changeset/active-step-attempt-logs.md
+++ b/.changeset/active-step-attempt-logs.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/client-logs": patch
+"@shipfox/client-workflows": patch
+---
+
+Show logs inline under the active or selected workflow step attempt, including missing-stream retry for running attempts and stale-log retry states.

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -2,7 +2,7 @@
 
 import type {LogRecord} from '@shipfox/api-logs-dto';
 import {LogContent, LogRow, LogRows, type LogTimestampMode} from '@shipfox/react-ui';
-import {type ReactNode, useMemo} from 'react';
+import {type ReactNode, type UIEventHandler, useMemo} from 'react';
 import {
   assertNever,
   buildLogTree,
@@ -19,6 +19,8 @@ export interface LogViewProps {
   timestamps?: LogTimestampMode;
   wrap?: boolean;
   showLineNumbers?: boolean;
+  className?: string | undefined;
+  onScroll?: UIEventHandler<HTMLDivElement> | undefined;
 }
 
 export function LogView({
@@ -26,6 +28,8 @@ export function LogView({
   timestamps = 'off',
   wrap = false,
   showLineNumbers = true,
+  className,
+  onScroll,
 }: LogViewProps) {
   const tree = useMemo(() => buildLogTree(records), [records]);
   const isEmpty = tree.nodes.length === 0;
@@ -35,6 +39,8 @@ export function LogView({
       timestamps={timestamps}
       wrap={wrap}
       showLineNumbers={showLineNumbers}
+      className={className}
+      onScroll={onScroll}
       {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
     >
       {isEmpty ? (

--- a/libs/client/logs/src/hooks/api/step-logs.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs.test.tsx
@@ -141,6 +141,26 @@ describe('useStepAttemptLogsQuery', () => {
     expect(result.current.data?.records).toMatchObject([{type: 'output', data: 'alpha\n'}]);
   });
 
+  test('retries transient initial errors before surfacing a failure', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}))
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}))
+      .mockResolvedValueOnce(
+        jsonResponse(inlineBody({ndjson: outputLine('eventual logs\n', 1), nextCursor: 5})),
+      );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook(
+      {stepId: STEP_ID, attempt: 1},
+      {initialErrorRetryCount: 2, initialErrorRetryDelayMs: 10},
+    );
+
+    await waitFor(() => expect(result.current.data?.records).toHaveLength(1));
+    expect(result.current.data?.records).toMatchObject([{type: 'output', data: 'eventual logs\n'}]);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
   test('stops polling after a persistent error instead of re-polling the dead cursor', async () => {
     const fetchImpl = vi
       .fn()

--- a/libs/client/logs/src/hooks/api/step-logs.test.tsx
+++ b/libs/client/logs/src/hooks/api/step-logs.test.tsx
@@ -2,7 +2,8 @@ import {configureApiClient} from '@shipfox/client-api';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {cleanup, renderHook, waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
-import {useStepAttemptLogsQuery} from './step-logs.js';
+import {STEP_LOG_DRAIN_REFETCH_MS, STEP_LOG_LIVE_REFETCH_MS} from '#core/log-read.js';
+import {type UseStepAttemptLogsQueryOptions, useStepAttemptLogsQuery} from './step-logs.js';
 
 const STEP_ID = '11111111-1111-4111-8111-111111111111';
 
@@ -49,6 +50,7 @@ function renderStepLogsHook(
     stepId: STEP_ID,
     attempt: 1,
   },
+  options: UseStepAttemptLogsQueryOptions = {},
 ) {
   const queryClient = new QueryClient({
     defaultOptions: {queries: {retry: false}},
@@ -57,7 +59,9 @@ function renderStepLogsHook(
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 
-  return renderHook(() => useStepAttemptLogsQuery(params.stepId, params.attempt), {wrapper});
+  return renderHook(() => useStepAttemptLogsQuery(params.stepId, params.attempt, options), {
+    wrapper,
+  });
 }
 
 function requestsFrom(fetchImpl: ReturnType<typeof vi.fn>): Request[] {
@@ -67,6 +71,7 @@ function requestsFrom(fetchImpl: ReturnType<typeof vi.fn>): Request[] {
 describe('useStepAttemptLogsQuery', () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     configureApiClient({baseUrl: '', fetchImpl: undefined});
   });
@@ -152,6 +157,41 @@ describe('useStepAttemptLogsQuery', () => {
     await new Promise((resolve) => setTimeout(resolve, 350));
 
     expect(fetchImpl.mock.calls.length).toBe(callsWhenErrored);
+  });
+
+  test('keeps polling a missing stream when requested and merges the later response', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({code: 'not-found'}, {status: 404}))
+      .mockResolvedValueOnce(
+        jsonResponse(
+          inlineBody({ndjson: outputLine('stream created\n', 1), nextCursor: 5, hasMore: true}),
+        ),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(inlineBody({ndjson: outputLine('next line\n', 2), nextCursor: 6})),
+      );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook({stepId: STEP_ID, attempt: 1}, {retryMissingStream: true});
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    await waitFor(() => expect(result.current.data?.records).toHaveLength(2), {
+      timeout: STEP_LOG_LIVE_REFETCH_MS + STEP_LOG_DRAIN_REFETCH_MS + 1_500,
+    });
+    expect(result.current.data?.records.map((record) => record.type)).toEqual(['output', 'output']);
+    const urls = requestsFrom(fetchImpl).map((request) => new URL(request.url));
+    expect(urls.map((url) => url.searchParams.get('cursor'))).toEqual(['0', '0', '5']);
+  });
+
+  test('does not keep polling server errors when missing-stream retry is requested', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({code: 'server-error'}, {status: 500}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    const {result} = renderStepLogsHook({stepId: STEP_ID, attempt: 1}, {retryMissingStream: true});
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    await new Promise((resolve) => setTimeout(resolve, STEP_LOG_LIVE_REFETCH_MS + 100));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   test('does not poll after a closed drained inline stream loads', async () => {

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -56,6 +56,8 @@ export function isMissingStepLogStreamError(error: unknown): boolean {
 
 export interface UseStepAttemptLogsQueryOptions {
   retryMissingStream?: boolean;
+  initialErrorRetryCount?: number;
+  initialErrorRetryDelayMs?: number;
 }
 
 export function useStepAttemptLogsQuery(
@@ -69,6 +71,8 @@ export function useStepAttemptLogsQuery(
     enabled && stepId && attempt
       ? stepLogsQueryKeys.detail(stepId, attempt)
       : [...stepLogsQueryKeys.all, 'detail'];
+  const initialErrorRetryCount = options.initialErrorRetryCount ?? 0;
+  const initialErrorRetryDelayMs = options.initialErrorRetryDelayMs ?? STEP_LOG_LIVE_REFETCH_MS;
 
   return useQuery({
     queryKey,
@@ -89,6 +93,13 @@ export function useStepAttemptLogsQuery(
 
       return mergeLogRead(previous, {mode: 'inline', response});
     },
+    retry: (failureCount, error) => {
+      if (initialErrorRetryCount <= 0) return false;
+      if (queryClient.getQueryData<StepLogSnapshot>(queryKey) !== undefined) return false;
+      if (options.retryMissingStream && isMissingStepLogStreamError(error)) return false;
+      return failureCount < initialErrorRetryCount;
+    },
+    retryDelay: initialErrorRetryDelayMs,
     refetchInterval: (query) => {
       if (
         options.retryMissingStream &&

--- a/libs/client/logs/src/hooks/api/step-logs.ts
+++ b/libs/client/logs/src/hooks/api/step-logs.ts
@@ -1,7 +1,12 @@
 import type {ReadLogsResponseDto} from '@shipfox/api-logs-dto';
-import {apiRequest} from '@shipfox/client-api';
+import {ApiError, apiRequest} from '@shipfox/client-api';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
-import {mergeLogRead, type StepLogSnapshot, stepLogRefetchInterval} from '#core/log-read.js';
+import {
+  mergeLogRead,
+  STEP_LOG_LIVE_REFETCH_MS,
+  type StepLogSnapshot,
+  stepLogRefetchInterval,
+} from '#core/log-read.js';
 
 export const stepLogsQueryKeys = {
   all: ['step-logs'] as const,
@@ -45,7 +50,19 @@ async function readPresignedLogObject(url: string, signal?: AbortSignal): Promis
   return await response.text();
 }
 
-export function useStepAttemptLogsQuery(stepId: string | undefined, attempt: number | undefined) {
+export function isMissingStepLogStreamError(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 404 && error.code === 'not-found';
+}
+
+export interface UseStepAttemptLogsQueryOptions {
+  retryMissingStream?: boolean;
+}
+
+export function useStepAttemptLogsQuery(
+  stepId: string | undefined,
+  attempt: number | undefined,
+  options: UseStepAttemptLogsQueryOptions = {},
+) {
   const queryClient = useQueryClient();
   const enabled = Boolean(stepId && attempt && Number.isInteger(attempt) && attempt > 0);
   const queryKey =
@@ -72,8 +89,17 @@ export function useStepAttemptLogsQuery(stepId: string | undefined, attempt: num
 
       return mergeLogRead(previous, {mode: 'inline', response});
     },
-    refetchInterval: (query) =>
-      stepLogRefetchInterval(query.state.data, query.state.status === 'error'),
+    refetchInterval: (query) => {
+      if (
+        options.retryMissingStream &&
+        query.state.data === undefined &&
+        isMissingStepLogStreamError(query.state.error)
+      ) {
+        return STEP_LOG_LIVE_REFETCH_MS;
+      }
+
+      return stepLogRefetchInterval(query.state.data, query.state.status === 'error');
+    },
     refetchIntervalInBackground: false,
     refetchOnMount: (query) => !query.state.data?.complete,
     refetchOnWindowFocus: (query) => !query.state.data?.complete,

--- a/libs/client/logs/src/index.ts
+++ b/libs/client/logs/src/index.ts
@@ -9,7 +9,9 @@ export {
 } from '#core/log-tree.js';
 export * from './components/index.js';
 export {
+  isMissingStepLogStreamError,
   readStepAttemptLogsPage,
   stepLogsQueryKeys,
+  type UseStepAttemptLogsQueryOptions,
   useStepAttemptLogsQuery,
 } from './hooks/api/step-logs.js';

--- a/libs/client/workflows/package.json
+++ b/libs/client/workflows/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
+    "@shipfox/client-logs": "workspace:*",
     "@shipfox/client-triggers": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
@@ -1,0 +1,163 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {type StepLogSnapshot, stepLogsQueryKeys} from '@shipfox/client-logs';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {act, cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
+
+const STEP_ID = '99999999-9999-4999-8999-999999999999';
+type TestLogRecord = StepLogSnapshot['records'][number];
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+const outputLine = (data: string, ts = 1): string =>
+  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
+
+const inlineBody = (ndjson: string, nextCursor: number) => ({
+  mode: 'inline',
+  ndjson,
+  next_cursor: nextCursor,
+  has_more: false,
+  state: 'closed',
+  truncated: false,
+});
+
+const outputRecord = (data: string, ts = 1): TestLogRecord => ({
+  v: 1,
+  ts,
+  type: 'output',
+  stream: 'stdout',
+  data,
+});
+
+function snapshot(records: TestLogRecord[]): StepLogSnapshot {
+  return {
+    records,
+    nextCursor: records.length,
+    source: 'inline',
+    state: 'closed',
+    complete: true,
+    hasMore: false,
+    truncated: false,
+    totalBytes: null,
+    expiresAt: null,
+  };
+}
+
+function renderPanel(
+  props: Partial<Parameters<typeof StepAttemptLogPanel>[0]> = {},
+  options: {queryClient?: QueryClient} = {},
+) {
+  const queryClient =
+    options.queryClient ??
+    new QueryClient({
+      defaultOptions: {queries: {retry: false}},
+    });
+  const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return {
+    queryClient,
+    ...render(
+      <StepAttemptLogPanel stepId={STEP_ID} attempt={1} attemptStatus="running" {...props} />,
+      {wrapper},
+    ),
+  };
+}
+
+describe('StepAttemptLogPanel', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    configureApiClient({baseUrl: '', fetchImpl: undefined});
+  });
+
+  test('waits for missing logs while the attempt is running', async () => {
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(async () => jsonResponse({code: 'not-found'}, {status: 404})),
+    });
+
+    renderPanel();
+
+    expect(await screen.findByRole('status', {name: 'Waiting for logs'})).toBeInTheDocument();
+  });
+
+  test('shows a compact retry state for an initial server error', async () => {
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(async () => jsonResponse({code: 'server-error'}, {status: 500})),
+    });
+
+    renderPanel({attemptStatus: 'failed'});
+
+    expect(await screen.findByText('Could not load logs.')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+  });
+
+  test('renders loaded logs inline', async () => {
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(async () => jsonResponse(inlineBody(outputLine('hello\n'), 1))),
+    });
+
+    renderPanel({attemptStatus: 'succeeded'});
+
+    expect(await screen.findByRole('log')).toHaveTextContent('hello');
+  });
+
+  test('keeps stale logs visible when a refresh fails', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(inlineBody(outputLine('first\n'), 1)))
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    const {queryClient} = renderPanel({attemptStatus: 'running'});
+    await screen.findByText('first');
+
+    await act(async () => {
+      await queryClient.refetchQueries({queryKey: stepLogsQueryKeys.detail(STEP_ID, 1)});
+    });
+
+    expect(screen.getByText('first')).toBeInTheDocument();
+    expect(await screen.findByText('Could not refresh logs.')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
+  });
+
+  test('does not follow new log output after the user scrolls away from the tail', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: vi.fn()});
+    const queryClient = new QueryClient({
+      defaultOptions: {queries: {retry: false, staleTime: Number.POSITIVE_INFINITY}},
+    });
+    const queryKey = stepLogsQueryKeys.detail(STEP_ID, 1);
+    queryClient.setQueryData(queryKey, snapshot([outputRecord('first\n')]));
+    renderPanel({attemptStatus: 'succeeded'}, {queryClient});
+    const logRows = await screen.findByRole('log');
+    Object.defineProperty(logRows, 'scrollHeight', {configurable: true, value: 600});
+    Object.defineProperty(logRows, 'clientHeight', {configurable: true, value: 200});
+    logRows.scrollTop = 320;
+    fireEvent.scroll(logRows);
+
+    act(() => {
+      queryClient.setQueryData(
+        queryKey,
+        snapshot([outputRecord('first\n'), outputRecord('second\n', 2)]),
+      );
+    });
+
+    await waitFor(() => expect(screen.getByText('second')).toBeInTheDocument());
+    expect(logRows.scrollTop).toBe(320);
+  });
+});

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
@@ -75,6 +75,7 @@ function renderPanel(
 describe('StepAttemptLogPanel', () => {
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     configureApiClient({baseUrl: '', fetchImpl: undefined});
   });
@@ -88,15 +89,34 @@ describe('StepAttemptLogPanel', () => {
     renderPanel();
 
     expect(await screen.findByRole('status', {name: 'Waiting for logs'})).toBeInTheDocument();
+    expect(screen.getByRole('log')).toHaveTextContent('Waiting for logs');
   });
 
-  test('shows a compact retry state for an initial server error', async () => {
+  test('keeps the log loading surface through transient initial server errors', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}))
+      .mockResolvedValueOnce(jsonResponse(inlineBody(outputLine('eventual logs\n'), 1)));
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl,
+    });
+
+    renderPanel({attemptStatus: 'failed', initialErrorRetryCount: 1, initialErrorRetryDelayMs: 10});
+    expect(screen.getByRole('status', {name: 'Loading logs'})).toBeInTheDocument();
+    expect(screen.getByRole('log')).toHaveTextContent('Loading logs');
+
+    expect(await screen.findByText('eventual logs')).toBeInTheDocument();
+  });
+
+  test('shows a compact retry state after the initial error retry budget is exhausted', async () => {
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl: vi.fn(async () => jsonResponse({code: 'server-error'}, {status: 500})),
     });
 
-    renderPanel({attemptStatus: 'failed'});
+    renderPanel({attemptStatus: 'failed', initialErrorRetryCount: 1, initialErrorRetryDelayMs: 10});
+    expect(screen.getByRole('status', {name: 'Loading logs'})).toBeInTheDocument();
 
     expect(await screen.findByText('Could not load logs.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
@@ -110,7 +130,7 @@ describe('StepAttemptLogPanel', () => {
 
     renderPanel({attemptStatus: 'succeeded'});
 
-    expect(await screen.findByRole('log')).toHaveTextContent('hello');
+    expect(await screen.findByText('hello')).toBeInTheDocument();
   });
 
   test('keeps stale logs visible when a refresh fails', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
@@ -1,20 +1,35 @@
 import {isMissingStepLogStreamError, LogView, useStepAttemptLogsQuery} from '@shipfox/client-logs';
-import {Alert, Button, Icon, Text} from '@shipfox/react-ui';
+import {Alert, Button, Icon, LogContent, LogRow, LogRows, ShinyText, Text} from '@shipfox/react-ui';
 import {type UIEvent, useEffect, useRef} from 'react';
 
 const TAIL_FOLLOW_THRESHOLD_PX = 24;
+const INITIAL_LOG_ERROR_RETRY_COUNT = 5;
+const INITIAL_LOG_ERROR_RETRY_DELAY_MS = 1_500;
+const logSurfaceClasses = 'max-h-[40vh] rounded-8 md:max-h-[280px]';
 
 export interface StepAttemptLogPanelProps {
   stepId: string;
   attempt: number;
   attemptStatus: string;
+  initialErrorRetryCount?: number | undefined;
+  initialErrorRetryDelayMs?: number | undefined;
 }
 
-export function StepAttemptLogPanel({stepId, attempt, attemptStatus}: StepAttemptLogPanelProps) {
+export function StepAttemptLogPanel({
+  stepId,
+  attempt,
+  attemptStatus,
+  initialErrorRetryCount = INITIAL_LOG_ERROR_RETRY_COUNT,
+  initialErrorRetryDelayMs = INITIAL_LOG_ERROR_RETRY_DELAY_MS,
+}: StepAttemptLogPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const shouldFollowTailRef = useRef(true);
   const retryMissingStream = attemptStatus === 'running';
-  const query = useStepAttemptLogsQuery(stepId, attempt, {retryMissingStream});
+  const query = useStepAttemptLogsQuery(stepId, attempt, {
+    retryMissingStream,
+    initialErrorRetryCount,
+    initialErrorRetryDelayMs,
+  });
   const records = query.data?.records ?? [];
   const recordCount = records.length;
   const missingActiveStream =
@@ -44,25 +59,11 @@ export function StepAttemptLogPanel({stepId, attempt, attemptStatus}: StepAttemp
   }
 
   if (query.isPending) {
-    return (
-      <div role="status" aria-label="Loading step logs" className="flex items-center gap-6 py-8">
-        <Icon name="loader4Line" className="size-14 motion-safe:animate-spin" aria-hidden="true" />
-        <Text size="xs" className="text-foreground-neutral-subtle">
-          Loading logs
-        </Text>
-      </div>
-    );
+    return <StepLogsLoadingSurface label="Loading logs" />;
   }
 
   if (missingActiveStream) {
-    return (
-      <div role="status" aria-label="Waiting for logs" className="flex items-center gap-6 py-8">
-        <Icon name="loader4Line" className="size-14 motion-safe:animate-spin" aria-hidden="true" />
-        <Text size="xs" className="text-foreground-neutral-subtle">
-          Waiting for logs
-        </Text>
-      </div>
-    );
+    return <StepLogsLoadingSurface label="Waiting for logs" />;
   }
 
   if (initialError) {
@@ -87,11 +88,29 @@ export function StepAttemptLogPanel({stepId, attempt, attemptStatus}: StepAttemp
           </div>
         </Alert>
       ) : null}
-      <LogView
-        records={records}
-        className="max-h-[40vh] rounded-8 md:max-h-[280px]"
-        onScroll={handleLogScroll}
-      />
+      <LogView records={records} className={logSurfaceClasses} onScroll={handleLogScroll} />
+    </div>
+  );
+}
+
+function StepLogsLoadingSurface({label}: {label: string}) {
+  return (
+    <div role="status" aria-label={label}>
+      <LogRows className={logSurfaceClasses}>
+        <LogRow lineNumber={null}>
+          <LogContent
+            variant="code"
+            className="flex min-w-0 items-center gap-6 text-foreground-neutral-subtle"
+          >
+            <Icon
+              name="loader4Line"
+              className="size-14 shrink-0 motion-safe:animate-spin"
+              aria-hidden="true"
+            />
+            <ShinyText text={label} speed={3} className="text-foreground-neutral-subtle" />
+          </LogContent>
+        </LogRow>
+      </LogRows>
     </div>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
@@ -1,0 +1,125 @@
+import {isMissingStepLogStreamError, LogView, useStepAttemptLogsQuery} from '@shipfox/client-logs';
+import {Alert, Button, Icon, Text} from '@shipfox/react-ui';
+import {type UIEvent, useEffect, useRef} from 'react';
+
+const TAIL_FOLLOW_THRESHOLD_PX = 24;
+
+export interface StepAttemptLogPanelProps {
+  stepId: string;
+  attempt: number;
+  attemptStatus: string;
+}
+
+export function StepAttemptLogPanel({stepId, attempt, attemptStatus}: StepAttemptLogPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const shouldFollowTailRef = useRef(true);
+  const retryMissingStream = attemptStatus === 'running';
+  const query = useStepAttemptLogsQuery(stepId, attempt, {retryMissingStream});
+  const records = query.data?.records ?? [];
+  const recordCount = records.length;
+  const missingActiveStream =
+    retryMissingStream && query.data === undefined && isMissingStepLogStreamError(query.error);
+  const initialError = query.isError && query.data === undefined && !missingActiveStream;
+  const staleError = query.isError && query.data !== undefined;
+
+  useEffect(() => {
+    if (recordCount === 0) return undefined;
+    if (!shouldFollowTailRef.current) return undefined;
+
+    const frame = scheduleAnimationFrame(() => {
+      const scrollElement = panelRef.current?.querySelector<HTMLElement>('[data-slot="log-rows"]');
+      if (!scrollElement) return;
+      scrollElement.scrollTop = scrollElement.scrollHeight;
+    });
+
+    return () => {
+      cancelScheduledFrame(frame);
+    };
+  }, [recordCount]);
+
+  function handleLogScroll(event: UIEvent<HTMLDivElement>) {
+    const element = event.currentTarget;
+    const distanceFromBottom = element.scrollHeight - element.scrollTop - element.clientHeight;
+    shouldFollowTailRef.current = distanceFromBottom <= TAIL_FOLLOW_THRESHOLD_PX;
+  }
+
+  if (query.isPending) {
+    return (
+      <div role="status" aria-label="Loading step logs" className="flex items-center gap-6 py-8">
+        <Icon name="loader4Line" className="size-14 motion-safe:animate-spin" aria-hidden="true" />
+        <Text size="xs" className="text-foreground-neutral-subtle">
+          Loading logs
+        </Text>
+      </div>
+    );
+  }
+
+  if (missingActiveStream) {
+    return (
+      <div role="status" aria-label="Waiting for logs" className="flex items-center gap-6 py-8">
+        <Icon name="loader4Line" className="size-14 motion-safe:animate-spin" aria-hidden="true" />
+        <Text size="xs" className="text-foreground-neutral-subtle">
+          Waiting for logs
+        </Text>
+      </div>
+    );
+  }
+
+  if (initialError) {
+    return <StepLogsError retrying={query.isFetching} onRetry={() => void query.refetch()} />;
+  }
+
+  return (
+    <div ref={panelRef} className="flex min-w-0 flex-col gap-8">
+      {staleError ? (
+        <Alert variant="warning" animated={false} className="px-10 py-8">
+          <div className="flex min-w-0 flex-1 items-center justify-between gap-8">
+            <Text size="xs">Could not refresh logs.</Text>
+            <Button
+              type="button"
+              size="2xs"
+              variant="secondary"
+              isLoading={query.isFetching}
+              onClick={() => void query.refetch()}
+            >
+              Retry
+            </Button>
+          </div>
+        </Alert>
+      ) : null}
+      <LogView
+        records={records}
+        className="max-h-[40vh] rounded-8 md:max-h-[280px]"
+        onScroll={handleLogScroll}
+      />
+    </div>
+  );
+}
+
+function scheduleAnimationFrame(callback: FrameRequestCallback): number {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    return globalThis.requestAnimationFrame(callback);
+  }
+  return window.setTimeout(() => callback(Date.now()), 0);
+}
+
+function cancelScheduledFrame(frame: number) {
+  if (typeof globalThis.cancelAnimationFrame === 'function') {
+    globalThis.cancelAnimationFrame(frame);
+    return;
+  }
+  window.clearTimeout(frame);
+}
+
+function StepLogsError({retrying, onRetry}: {retrying: boolean; onRetry: () => void}) {
+  return (
+    <Alert variant="error" animated={false} className="px-10 py-8">
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-8">
+        <Text size="xs">Could not load logs.</Text>
+        <Button type="button" size="2xs" variant="secondary" isLoading={retrying} onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    </Alert>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -39,6 +39,54 @@ describe('WorkflowRunView', () => {
     ).toBeInTheDocument();
   });
 
+  test('renders active step attempt logs inline when the selected job is running', async () => {
+    const stepId = '99999999-9999-4999-8999-000000000001';
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.pathname === `/steps/${stepId}/attempts/1/logs`) {
+        return Promise.resolve(jsonResponse(inlineLogBody(outputLine('live output\n'), 1)));
+      }
+      return Promise.resolve(
+        jsonResponse(
+          runDetailDto({
+            jobs: [
+              jobDto({
+                id: '77777777-7777-4777-8777-777777777777',
+                name: 'build',
+                status: 'running',
+                steps: [
+                  stepDto({
+                    id: stepId,
+                    name: 'test',
+                    status: 'running',
+                    attempts: [
+                      attemptDto({
+                        id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001',
+                        step_id: stepId,
+                        status: 'running',
+                        exit_code: null,
+                        finished_at: null,
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ),
+      );
+    });
+    configureApiClient({fetchImpl: fetchImpl as typeof fetch});
+
+    renderView();
+
+    expect(await screen.findByText('live output')).toBeInTheDocument();
+    const logRequest = fetchImpl.mock.calls
+      .map((call) => new URL((call[0] as Request).url))
+      .find((url) => url.pathname === `/steps/${stepId}/attempts/1/logs`);
+    expect(logRequest?.searchParams.get('cursor')).toBe('0');
+  });
+
   test('shows the not-found surface when the run 404s', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() => Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}))),
@@ -125,8 +173,27 @@ function renderView() {
   ));
 }
 
+function requestUrl(input: RequestInfo | URL): URL {
+  if (input instanceof Request) return new URL(input.url);
+  return new URL(String(input));
+}
+
 function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}) {
   return {...baseRunDetailDto(), ...overrides};
+}
+
+const outputLine = (data: string, ts = 1): string =>
+  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
+
+function inlineLogBody(ndjson: string, nextCursor: number) {
+  return {
+    mode: 'inline',
+    ndjson,
+    next_cursor: nextCursor,
+    has_more: false,
+    state: 'closed',
+    truncated: false,
+  };
 }
 
 function baseRunDetailDto(): RunDetailResponseDto {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -7,6 +7,7 @@ import {WorkflowJobsGraph} from '../workflow-jobs-graph/index.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
 import {WorkflowSourcePanel} from '../workflow-source-panel/index.js';
 import {WorkflowStepList} from '../workflow-step-list/index.js';
+import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 import {
   WorkflowRunNotFound,
   WorkflowRunSkeleton,
@@ -87,7 +88,20 @@ function RunViewContent({query}: {query: ReturnType<typeof useWorkflowRunQuery>}
             selectedJobId={selectedJob?.id}
             onSelectedJobChange={setSelectedJobId}
           />
-          {selectedJob ? <WorkflowStepList job={selectedJob} className="max-h-[50vh]" /> : null}
+          {selectedJob ? (
+            <WorkflowStepList
+              job={selectedJob}
+              className="max-h-[50vh]"
+              autoSelectActiveAttempt
+              renderExpandedStep={({stepId, attempt, attemptStatus}) => (
+                <StepAttemptLogPanel
+                  stepId={stepId}
+                  attempt={attempt}
+                  attemptStatus={attemptStatus}
+                />
+              )}
+            />
+          ) : null}
         </div>
       </div>
       <WorkflowSourcePanel

--- a/libs/client/workflows/src/components/workflow-step-list/index.ts
+++ b/libs/client/workflows/src/components/workflow-step-list/index.ts
@@ -1,2 +1,2 @@
-export type {WorkflowStepListProps} from './workflow-step-list.js';
+export type {WorkflowStepExpandedContext, WorkflowStepListProps} from './workflow-step-list.js';
 export {WorkflowStepList} from './workflow-step-list.js';

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.test.ts
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.test.ts
@@ -100,6 +100,49 @@ describe('buildWorkflowStepListModel', () => {
     expect(result.entries.map((entry) => entry.label)).toEqual(['build']);
   });
 
+  test('has no active entry when no attempt is running', () => {
+    const step = makeStep({
+      attempts: [
+        makeAttempt({attempt: 1, status: 'failed'}),
+        makeAttempt({attempt: 2, status: 'succeeded'}),
+      ],
+    });
+
+    const result = buildWorkflowStepListModel({job: makeJob({steps: [step]})});
+
+    expect(result.activeEntryId).toBeUndefined();
+  });
+
+  test('uses the latest running attempt by execution order as the active entry', () => {
+    const earlier = makeAttempt({status: 'running', execution_order: 2});
+    const later = makeAttempt({status: 'running', execution_order: 4});
+    const finished = makeAttempt({status: 'succeeded', execution_order: 5});
+
+    const result = buildWorkflowStepListModel({
+      job: makeJob({
+        steps: [
+          makeStep({name: 'install', status: 'running', attempts: [earlier]}),
+          makeStep({name: 'deploy', position: 1, status: 'running', attempts: [later]}),
+          makeStep({name: 'notify', position: 2, status: 'succeeded', attempts: [finished]}),
+        ],
+      }),
+    });
+
+    expect(result.entries.map((entry) => entry.id)).toEqual([earlier.id, later.id, finished.id]);
+    expect(result.activeEntryId).toBe(later.id);
+  });
+
+  test('breaks active running-attempt execution-order ties by sorted entry order', () => {
+    const first = makeAttempt({attempt: 1, execution_order: 7, status: 'running'});
+    const second = makeAttempt({attempt: 2, execution_order: 7, status: 'running'});
+    const step = makeStep({attempts: [second, first]});
+
+    const result = buildWorkflowStepListModel({job: makeJob({steps: [step]})});
+
+    expect(result.entries.map((entry) => entry.id)).toEqual([first.id, second.id]);
+    expect(result.activeEntryId).toBe(second.id);
+  });
+
   test.each(
     runStatusSchema.options,
   )('maps the %s step status through the shared visual', (status) => {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.ts
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.ts
@@ -58,6 +58,7 @@ export interface WorkflowStepListModel {
   jobId: string;
   jobName: string;
   stepCount: number;
+  activeEntryId: string | undefined;
   entries: WorkflowStepListEntryModel[];
 }
 
@@ -69,6 +70,7 @@ export function buildWorkflowStepListModel({job}: {job: RunJobDetailDto}): Workf
     jobId: job.id,
     jobName: job.name,
     stepCount: steps.length,
+    activeEntryId: latestRunningEntryId(entries),
     entries,
   };
 }
@@ -177,6 +179,14 @@ function compareEntries(
     left.attempt.attempt - right.attempt.attempt ||
     left.id.localeCompare(right.id)
   );
+}
+
+function latestRunningEntryId(entries: readonly WorkflowStepListEntryModel[]): string | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.status.kind === 'running') return entry.id;
+  }
+  return undefined;
 }
 
 function normalizeStatus(status: string): string {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -1,4 +1,5 @@
 import type {RunJobDetailDto, RunStepDetailDto, StepAttemptDto} from '@shipfox/api-workflows-dto';
+import {LogView, type LogViewProps} from '@shipfox/client-logs';
 import {Text} from '@shipfox/react-ui';
 import type {Meta, StoryObj} from '@storybook/react';
 import {WorkflowStepList} from './workflow-step-list.js';
@@ -135,11 +136,63 @@ export const CollapsedAndExpanded: Story = {
     return (
       <WorkflowStepList
         job={makeJob({steps: [build, deploy]})}
-        defaultSelectedStepId={deployAttempt.id}
+        defaultSelectedAttemptId={deployAttempt.id}
         renderExpandedStep={({stepId}) => (
           <Text size="sm" className="text-foreground-neutral-subtle">
             Slot content for {stepId}
           </Text>
+        )}
+      />
+    );
+  },
+};
+
+const activeLogRecords: LogViewProps['records'] = [
+  {
+    v: 1,
+    ts: Date.parse('2026-06-21T12:00:00.000Z'),
+    type: 'output',
+    stream: 'stdout',
+    data: '$ pnpm test --filter=@shipfox/client-workflows\n',
+  },
+  {
+    v: 1,
+    ts: Date.parse('2026-06-21T12:00:01.000Z'),
+    type: 'output',
+    stream: 'stdout',
+    data: 'workflow-step-list.test.tsx 18 tests passed\n',
+  },
+  {
+    v: 1,
+    ts: Date.parse('2026-06-21T12:00:02.000Z'),
+    type: 'output',
+    stream: 'stdout',
+    data: 'step-attempt-log-panel.test.tsx running smart-tail checks\n',
+  },
+  {
+    v: 1,
+    ts: Date.parse('2026-06-21T12:00:03.000Z'),
+    type: 'output',
+    stream: 'stdout',
+    data: 'waiting for live log chunks...\n',
+  },
+];
+
+export const ActiveExpandedLogs: Story = {
+  render: () => {
+    const attempt = makeAttempt({status: 'running'});
+    const step = makeStep({
+      name: 'pnpm test --filter=@shipfox/client-workflows',
+      status: 'running',
+      attempts: [attempt],
+    });
+
+    return (
+      <WorkflowStepList
+        job={makeJob({steps: [step]})}
+        autoSelectActiveAttempt
+        renderExpandedStep={() => (
+          <LogView records={activeLogRecords} className="max-h-[280px] rounded-8" />
         )}
       />
     );
@@ -324,7 +377,7 @@ export const ExpandedSlot: Story = {
     return (
       <WorkflowStepList
         job={makeJob({steps: [step]})}
-        defaultSelectedStepId={attempt.id}
+        defaultSelectedAttemptId={attempt.id}
         renderExpandedStep={({stepId}) => (
           <Text size="sm" className="text-foreground-neutral-subtle">
             Injected detail placeholder for {stepId}

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -4,6 +4,8 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {WorkflowStepList} from './workflow-step-list.js';
 
+const LOGS_FOR_RE = /^logs for /u;
+
 describe('WorkflowStepList', () => {
   test('renders a labelled flat step list', () => {
     render(
@@ -41,32 +43,39 @@ describe('WorkflowStepList', () => {
     expect(build).toHaveAttribute('aria-expanded', 'false');
   });
 
-  test('renders expanded slot content with the selected step id', async () => {
+  test('renders expanded slot content with the selected attempt context', async () => {
     const user = userEvent.setup();
-    const step = makeStep({name: 'deploy', attempts: [makeAttempt()]});
+    const attempt = makeAttempt({status: 'running'});
+    const step = makeStep({name: 'deploy', status: 'running', attempts: [attempt]});
     render(
       <WorkflowStepList
         job={makeJob({steps: [step]})}
-        renderExpandedStep={({stepId}) => <Text size="sm">slot for {stepId}</Text>}
+        renderExpandedStep={({stepId, attempt, attemptId, attemptStatus}) => (
+          <Text size="sm">
+            slot for {stepId} attempt {attempt} id {attemptId} status {attemptStatus}
+          </Text>
+        )}
       />,
     );
-    const deploy = screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'});
+    const deploy = screen.getByRole('button', {name: '1. deploy, Running, attempt 1'});
 
     await user.click(deploy);
 
     expect(deploy).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByText(`slot for ${step.id}`)).toBeInTheDocument();
+    expect(
+      screen.getByText(`slot for ${step.id} attempt 1 id ${attempt.id} status running`),
+    ).toBeInTheDocument();
   });
 
   test('reports selection changes including collapse', async () => {
     const user = userEvent.setup();
-    const onSelectedStepChange = vi.fn();
+    const onSelectedAttemptChange = vi.fn();
     const attempt = makeAttempt();
     const step = makeStep({name: 'deploy', attempts: [attempt]});
     render(
       <WorkflowStepList
         job={makeJob({steps: [step]})}
-        onSelectedStepChange={onSelectedStepChange}
+        onSelectedAttemptChange={onSelectedAttemptChange}
       />,
     );
     const deploy = screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'});
@@ -74,8 +83,130 @@ describe('WorkflowStepList', () => {
     await user.click(deploy);
     await user.click(deploy);
 
-    expect(onSelectedStepChange).toHaveBeenNthCalledWith(1, attempt.id);
-    expect(onSelectedStepChange).toHaveBeenNthCalledWith(2, undefined);
+    expect(onSelectedAttemptChange).toHaveBeenNthCalledWith(1, attempt.id);
+    expect(onSelectedAttemptChange).toHaveBeenNthCalledWith(2, undefined);
+  });
+
+  test('opens a default selected attempt', () => {
+    const attempt = makeAttempt();
+    const step = makeStep({name: 'deploy', attempts: [attempt]});
+    render(
+      <WorkflowStepList
+        job={makeJob({steps: [step]})}
+        defaultSelectedAttemptId={attempt.id}
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+
+    expect(screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
+  });
+
+  test('auto-opens the latest running attempt', () => {
+    const installAttempt = makeAttempt({status: 'running', execution_order: 2});
+    const deployAttempt = makeAttempt({status: 'running', execution_order: 4});
+    const finishedAttempt = makeAttempt({status: 'succeeded', execution_order: 5});
+    render(
+      <WorkflowStepList
+        job={makeJob({
+          steps: [
+            makeStep({
+              name: 'install',
+              status: 'running',
+              attempts: [installAttempt],
+            }),
+            makeStep({
+              name: 'deploy',
+              position: 1,
+              status: 'running',
+              attempts: [deployAttempt],
+            }),
+            makeStep({
+              name: 'notify',
+              position: 2,
+              status: 'succeeded',
+              attempts: [finishedAttempt],
+            }),
+          ],
+        })}
+        autoSelectActiveAttempt
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+
+    expect(screen.getByRole('button', {name: '1. install, Running, attempt 1'})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.getByRole('button', {name: '2. deploy, Running, attempt 1'})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByText(`logs for ${deployAttempt.id}`)).toBeInTheDocument();
+  });
+
+  test('does not auto-open when no attempt is running', () => {
+    render(
+      <WorkflowStepList
+        job={makeJob({
+          steps: [makeStep({name: 'deploy', attempts: [makeAttempt({status: 'succeeded'})]})],
+        })}
+        autoSelectActiveAttempt
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+
+    expect(screen.getByRole('button', {name: '1. deploy, Succeeded, attempt 1'})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+    expect(screen.queryByText(LOGS_FOR_RE)).not.toBeInTheDocument();
+  });
+
+  test('preserves manual collapse across same-job polling and resets on job change', async () => {
+    const user = userEvent.setup();
+    const attempt = makeAttempt({status: 'running'});
+    const step = makeStep({name: 'deploy', status: 'running', attempts: [attempt]});
+    const job = makeJob({steps: [step]});
+    const {rerender} = render(
+      <WorkflowStepList
+        job={job}
+        autoSelectActiveAttempt
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+    const deploy = screen.getByRole('button', {name: '1. deploy, Running, attempt 1'});
+    expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
+
+    await user.click(deploy);
+    rerender(
+      <WorkflowStepList
+        job={{...job, updated_at: '2026-06-21T12:02:00.000Z'}}
+        autoSelectActiveAttempt
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+
+    expect(screen.queryByText(`logs for ${attempt.id}`)).not.toBeInTheDocument();
+
+    const nextAttempt = makeAttempt({status: 'running'});
+    const nextStep = makeStep({name: 'test', status: 'running', attempts: [nextAttempt]});
+    rerender(
+      <WorkflowStepList
+        job={makeJob({
+          id: '44444444-4444-4444-8444-000000000002',
+          name: 'test',
+          steps: [nextStep],
+        })}
+        autoSelectActiveAttempt
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+
+    expect(screen.getByText(`logs for ${nextAttempt.id}`)).toBeInTheDocument();
   });
 
   test('renders each attempt as its own flat row', () => {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -11,42 +11,85 @@ import {
   TooltipTrigger,
 } from '@shipfox/react-ui';
 import type {ReactNode} from 'react';
-import {useId, useMemo, useState} from 'react';
+import {useEffect, useId, useMemo, useState} from 'react';
 import {
   buildWorkflowStepListModel,
   humanizeStatus,
   type WorkflowStepAttemptModel,
   type WorkflowStepListEntryModel,
+  type WorkflowStepListModel,
 } from './workflow-step-list-model.js';
+
+export interface WorkflowStepExpandedContext {
+  stepId: string;
+  attempt: number;
+  attemptId: string;
+  attemptStatus: string;
+}
 
 export interface WorkflowStepListProps {
   job: RunJobDetailDto;
-  selectedStepId?: string | undefined;
-  defaultSelectedStepId?: string | undefined;
-  onSelectedStepChange?: ((stepId: string | undefined) => void) | undefined;
-  renderExpandedStep?: ((context: {stepId: string}) => ReactNode) | undefined;
+  selectedAttemptId?: string | undefined;
+  defaultSelectedAttemptId?: string | undefined;
+  onSelectedAttemptChange?: ((attemptId: string | undefined) => void) | undefined;
+  autoSelectActiveAttempt?: boolean | undefined;
+  renderExpandedStep?: ((context: WorkflowStepExpandedContext) => ReactNode) | undefined;
   className?: string | undefined;
 }
 
 export function WorkflowStepList({
   job,
-  selectedStepId,
-  defaultSelectedStepId,
-  onSelectedStepChange,
+  selectedAttemptId,
+  defaultSelectedAttemptId,
+  onSelectedAttemptChange,
+  autoSelectActiveAttempt = false,
   renderExpandedStep,
   className,
 }: WorkflowStepListProps) {
-  const titleId = useId();
   const model = useMemo(() => buildWorkflowStepListModel({job}), [job]);
-  const [localSelectedStepId, setLocalSelectedStepId] = useState<string | undefined>(
-    defaultSelectedStepId,
-  );
-  const selected = selectedStepId ?? localSelectedStepId;
 
-  function selectStep(stepId: string) {
-    const nextStepId = stepId === selected ? undefined : stepId;
-    setLocalSelectedStepId(nextStepId);
-    onSelectedStepChange?.(nextStepId);
+  return (
+    <WorkflowStepListContent
+      key={model.jobId}
+      model={model}
+      selectedAttemptId={selectedAttemptId}
+      defaultSelectedAttemptId={defaultSelectedAttemptId}
+      onSelectedAttemptChange={onSelectedAttemptChange}
+      autoSelectActiveAttempt={autoSelectActiveAttempt}
+      renderExpandedStep={renderExpandedStep}
+      className={className}
+    />
+  );
+}
+
+function WorkflowStepListContent({
+  model,
+  selectedAttemptId,
+  defaultSelectedAttemptId,
+  onSelectedAttemptChange,
+  autoSelectActiveAttempt,
+  renderExpandedStep,
+  className,
+}: Omit<WorkflowStepListProps, 'job'> & {model: WorkflowStepListModel}) {
+  const titleId = useId();
+  const [localSelectedAttemptId, setLocalSelectedAttemptId] = useState<string | undefined>(
+    defaultSelectedAttemptId,
+  );
+  const [userSelectedAttempt, setUserSelectedAttempt] = useState(false);
+  const autoSelectedAttemptId =
+    autoSelectActiveAttempt && !userSelectedAttempt ? model.activeEntryId : undefined;
+  const selected = selectedAttemptId ?? localSelectedAttemptId ?? autoSelectedAttemptId;
+
+  useEffect(() => {
+    setLocalSelectedAttemptId(defaultSelectedAttemptId);
+    setUserSelectedAttempt(false);
+  }, [defaultSelectedAttemptId]);
+
+  function selectAttempt(attemptId: string) {
+    const nextAttemptId = attemptId === selected ? undefined : attemptId;
+    setUserSelectedAttempt(true);
+    setLocalSelectedAttemptId(nextAttemptId);
+    onSelectedAttemptChange?.(nextAttemptId);
   }
 
   return (
@@ -82,9 +125,16 @@ export function WorkflowStepList({
               entry={entry}
               selected={entry.id === selected}
               hasExpandedContent={renderExpandedStep !== undefined}
-              onSelect={() => selectStep(entry.id)}
+              onSelect={() => selectAttempt(entry.id)}
               expandedContent={
-                entry.id === selected ? renderExpandedStep?.({stepId: entry.stepId}) : null
+                entry.id === selected
+                  ? renderExpandedStep?.({
+                      stepId: entry.stepId,
+                      attempt: entry.attempt.attempt,
+                      attemptId: entry.id,
+                      attemptStatus: entry.status.kind,
+                    })
+                  : null
               }
             />
           ))}
@@ -108,10 +158,14 @@ function WorkflowStepRow({
   expandedContent: ReactNode;
 }) {
   const shouldShowLabelTooltip = entry.label.length > 32;
+  const buttonId = useId();
+  const panelId = useId();
   const button = (
     <button
+      id={buttonId}
       type="button"
       aria-expanded={selected && hasExpandedContent}
+      {...(hasExpandedContent ? {'aria-controls': panelId} : {})}
       aria-label={entryAccessibleLabel(entry)}
       onClick={onSelect}
       className={cn(
@@ -160,9 +214,13 @@ function WorkflowStepRow({
         button
       )}
       {selected && expandedContent ? (
-        <div className="border-t border-border-neutral-base bg-background-neutral-base px-44 py-12">
+        <section
+          id={panelId}
+          aria-labelledby={buttonId}
+          className="border-t border-border-neutral-base bg-background-neutral-base px-44 py-12"
+        >
           {expandedContent}
-        </div>
+        </section>
       ) : null}
     </li>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2845,6 +2845,9 @@ importers:
       '@shipfox/client-api':
         specifier: workspace:*
         version: link:../api
+      '@shipfox/client-logs':
+        specifier: workspace:*
+        version: link:../logs
       '@shipfox/client-triggers':
         specifier: workspace:*
         version: link:../triggers


### PR DESCRIPTION
Display logs inline under the active or selected workflow step attempt on the workflow run page.

Today, inspecting a running workflow step requires leaving the step list context. This keeps step output attached to the selected attempt row, opens the latest running attempt by default, and preserves a user's manual row selection or collapse while run polling refreshes the page data.

The log read hook now supports retrying initial 404/not-found responses for running attempts so the UI can wait for a log stream that has not been created yet. Other initial failures still stop polling and show retry, while refresh failures keep stale logs visible.

The implementation keeps logs inline rather than adding a separate side panel, so the graph and step list remain the primary run inspection surface. Review the step-list selection prop rename and the missing-stream retry behavior closely.

Closes ENG-531

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show logs inline under the active or selected workflow step attempt on the run page. Opens the latest running attempt by default, retries missing log streams for running attempts, keeps stale logs visible on refresh failures, and adds clearer loading and retry states.

- New Features
  - Inline logs under expanded attempt rows via StepAttemptLogPanel; follows tail until the user scrolls away; shows “Loading logs” vs “Waiting for logs”; compact retry surfaces with a Retry button for initial/load and refresh errors.
  - Running attempts: useStepAttemptLogsQuery adds retryMissingStream and a configurable initial transient-error retry budget (count + delay); avoids re-polling dead cursors; export isMissingStepLogStreamError and UseStepAttemptLogsQueryOptions.
  - LogView adds className and onScroll.
  - WorkflowStepList can auto-select the active running attempt and passes attempt context to the expanded slot.

- Migration
  - In WorkflowStepList, rename: selectedStepId → selectedAttemptId, defaultSelectedStepId → defaultSelectedAttemptId, onSelectedStepChange → onSelectedAttemptChange.
  - renderExpandedStep now receives {stepId, attempt, attemptId, attemptStatus}.
  - To auto-open the active running attempt, set autoSelectActiveAttempt.

<sup>Written for commit d1e55537182bf4aa00f382bccd5f6334863f83f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

