### PR TITLE
[workflows] Stabilize run ID copy feedback

### DIFF
--- a/libs/client/workflows/src/components/identifier/identifier.tsx
+++ b/libs/client/workflows/src/components/identifier/identifier.tsx
@@ -1,6 +1,6 @@
 import {
   Code,
-  Icon,
+  cn,
   Text,
   Tooltip,
   TooltipContent,
@@ -8,6 +8,7 @@ import {
   useCopyToClipboard,
 } from '@shipfox/react-ui';
 import {useEffect, useRef, useState} from 'react';
+import {createPortal} from 'react-dom';
 
 export function Identifier({
   display,
@@ -19,11 +20,18 @@ export function Identifier({
   label?: string | undefined;
 }) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const [feedbackPosition, setFeedbackPosition] = useState<{
+    left: number;
+    top: number;
+    placement: 'top' | 'bottom';
+  } | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const {copy} = useCopyToClipboard({
     text: value,
     onCopy: () => {
-      setTemporaryCopyState('copied', 1500);
+      setTemporaryCopyState('copied', 2500);
     },
   });
 
@@ -34,10 +42,22 @@ export function Identifier({
   }, []);
 
   function setTemporaryCopyState(state: 'copied' | 'failed', timeout: number) {
+    const rect = buttonRef.current?.getBoundingClientRect();
     setCopyState(state);
+    setTooltipOpen(false);
+    setFeedbackPosition(
+      rect
+        ? {
+            left: rect.left + rect.width / 2,
+            top: rect.top > 32 ? rect.top : rect.bottom,
+            placement: rect.top > 32 ? 'top' : 'bottom',
+          }
+        : null,
+    );
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
     timeoutRef.current = setTimeout(() => {
       setCopyState('idle');
+      setFeedbackPosition(null);
     }, timeout);
   }
 
@@ -56,50 +76,62 @@ export function Identifier({
         ? `Could not copy ${label} ${value}`
         : `Copy ${label} ${value}`;
 
+  const feedback =
+    copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Could not copy' : null;
+
+  const feedbackElement =
+    feedback && feedbackPosition && typeof document !== 'undefined'
+      ? createPortal(
+          <Text
+            as="span"
+            role="status"
+            size="xs"
+            style={{
+              left: feedbackPosition.left,
+              top: feedbackPosition.top,
+              transform:
+                feedbackPosition.placement === 'top'
+                  ? 'translate(-50%, calc(-100% - 8px))'
+                  : 'translate(-50%, 8px)',
+            }}
+            className={cn(
+              'pointer-events-none fixed z-50 whitespace-nowrap rounded-8 bg-background-components-base px-8 py-4 font-medium shadow-tooltip',
+              copyState === 'failed'
+                ? 'text-foreground-highlight-error'
+                : 'text-foreground-neutral-base',
+            )}
+          >
+            {feedback}
+          </Text>,
+          document.body,
+        )
+      : null;
+
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <button
-          type="button"
-          aria-label={ariaLabel}
-          onClick={() => {
-            void handleCopy();
-          }}
-          className="inline-flex min-w-0 items-center gap-4 rounded-4 text-foreground-neutral-muted outline-none transition-colors hover:text-foreground-neutral-base focus-visible:ring-2 focus-visible:ring-background-accent-blue-base focus-visible:ring-offset-2 focus-visible:ring-offset-background-subtle-base"
-        >
-          {copyState === 'copied' ? (
-            <Icon
-              name="check"
-              aria-hidden="true"
-              className="size-12 shrink-0 text-foreground-neutral-base"
-            />
-          ) : null}
-          <Code as="span" variant="label" className="truncate">
-            {display}
-          </Code>
-          {copyState === 'copied' ? (
-            <Text as="span" size="xs" className="shrink-0 text-foreground-neutral-base">
-              Copied
-            </Text>
-          ) : null}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent>
-        <span className="flex max-w-[360px] flex-col gap-2">
-          {copyState === 'idle' ? null : (
-            <Text
-              as="span"
-              size="xs"
-              className={copyState === 'failed' ? 'text-foreground-highlight-error' : undefined}
-            >
-              {copyState === 'copied' ? 'Copied' : 'Could not copy'}
-            </Text>
-          )}
-          <Code as="span" variant="label" className="truncate">
+    <>
+      <Tooltip open={copyState === 'idle' ? tooltipOpen : false} onOpenChange={setTooltipOpen}>
+        <TooltipTrigger asChild>
+          <button
+            ref={buttonRef}
+            type="button"
+            aria-label={ariaLabel}
+            onClick={() => {
+              void handleCopy();
+            }}
+            className="inline-flex min-w-0 items-center gap-4 rounded-4 text-foreground-neutral-muted outline-none transition-colors hover:text-foreground-neutral-base focus-visible:ring-2 focus-visible:ring-background-accent-blue-base focus-visible:ring-offset-2 focus-visible:ring-offset-background-subtle-base"
+          >
+            <Code as="span" variant="label" className="truncate">
+              {display}
+            </Code>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <Code as="span" variant="label" className="block max-w-[360px] truncate">
             {value}
           </Code>
-        </span>
-      </TooltipContent>
-    </Tooltip>
+        </TooltipContent>
+      </Tooltip>
+      {feedbackElement}
+    </>
   );
 }

--- a/libs/client/workflows/src/components/identifier/identifier.tsx
+++ b/libs/client/workflows/src/components/identifier/identifier.tsx
@@ -1,14 +1,23 @@
 import {
   Code,
   cn,
-  Text,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
   useCopyToClipboard,
 } from '@shipfox/react-ui';
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
+
+const COPY_FEEDBACK_OFFSET_PX = 8;
+
+type CopyState = 'idle' | 'copied' | 'failed';
+
+interface FeedbackAnchor {
+  bottom: number;
+  left: number;
+  top: number;
+}
 
 export function Identifier({
   display,
@@ -19,13 +28,9 @@ export function Identifier({
   value: string;
   label?: string | undefined;
 }) {
-  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [copyState, setCopyState] = useState<CopyState>('idle');
   const [tooltipOpen, setTooltipOpen] = useState(false);
-  const [feedbackPosition, setFeedbackPosition] = useState<{
-    left: number;
-    top: number;
-    placement: 'top' | 'bottom';
-  } | null>(null);
+  const [feedbackAnchor, setFeedbackAnchor] = useState<FeedbackAnchor | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const {copy} = useCopyToClipboard({
@@ -41,24 +46,40 @@ export function Identifier({
     };
   }, []);
 
-  function setTemporaryCopyState(state: 'copied' | 'failed', timeout: number) {
+  const resetCopyFeedback = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    setCopyState('idle');
+    setTooltipOpen(false);
+    setFeedbackAnchor(null);
+  }, []);
+
+  useEffect(() => {
+    if (copyState === 'idle') return;
+
+    window.addEventListener('scroll', resetCopyFeedback, true);
+    window.addEventListener('resize', resetCopyFeedback);
+
+    return () => {
+      window.removeEventListener('scroll', resetCopyFeedback, true);
+      window.removeEventListener('resize', resetCopyFeedback);
+    };
+  }, [copyState, resetCopyFeedback]);
+
+  function setTemporaryCopyState(state: Exclude<CopyState, 'idle'>, timeout: number) {
     const rect = buttonRef.current?.getBoundingClientRect();
     setCopyState(state);
     setTooltipOpen(false);
-    setFeedbackPosition(
+    setFeedbackAnchor(
       rect
         ? {
             left: rect.left + rect.width / 2,
-            top: rect.top > 32 ? rect.top : rect.bottom,
-            placement: rect.top > 32 ? 'top' : 'bottom',
+            top: rect.top,
+            bottom: rect.bottom,
           }
         : null,
     );
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(() => {
-      setCopyState('idle');
-      setFeedbackPosition(null);
-    }, timeout);
+    timeoutRef.current = setTimeout(resetCopyFeedback, timeout);
   }
 
   async function handleCopy() {
@@ -77,35 +98,11 @@ export function Identifier({
         : `Copy ${label} ${value}`;
 
   const feedback =
-    copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Could not copy' : null;
-
-  const feedbackElement =
-    feedback && feedbackPosition && typeof document !== 'undefined'
-      ? createPortal(
-          <Text
-            as="span"
-            role="status"
-            size="xs"
-            style={{
-              left: feedbackPosition.left,
-              top: feedbackPosition.top,
-              transform:
-                feedbackPosition.placement === 'top'
-                  ? 'translate(-50%, calc(-100% - 8px))'
-                  : 'translate(-50%, 8px)',
-            }}
-            className={cn(
-              'pointer-events-none fixed z-50 whitespace-nowrap rounded-8 bg-background-components-base px-8 py-4 font-medium shadow-tooltip',
-              copyState === 'failed'
-                ? 'text-foreground-highlight-error'
-                : 'text-foreground-neutral-base',
-            )}
-          >
-            {feedback}
-          </Text>,
-          document.body,
-        )
-      : null;
+    copyState === 'copied'
+      ? {kind: copyState, label: 'Copied'}
+      : copyState === 'failed'
+        ? {kind: copyState, label: 'Could not copy'}
+        : null;
 
   return (
     <>
@@ -131,7 +128,53 @@ export function Identifier({
           </Code>
         </TooltipContent>
       </Tooltip>
-      {feedbackElement}
+      {feedback && feedbackAnchor ? (
+        <CopyFeedbackPortal anchor={feedbackAnchor} kind={feedback.kind}>
+          {feedback.label}
+        </CopyFeedbackPortal>
+      ) : null}
     </>
+  );
+}
+
+function CopyFeedbackPortal({
+  anchor,
+  children,
+  kind,
+}: {
+  anchor: FeedbackAnchor;
+  children: string;
+  kind: Exclude<CopyState, 'idle'>;
+}) {
+  const feedbackRef = useRef<HTMLSpanElement | null>(null);
+  const [placement, setPlacement] = useState<'top' | 'bottom'>('bottom');
+
+  useLayoutEffect(() => {
+    const height = feedbackRef.current?.offsetHeight ?? 0;
+    setPlacement(anchor.top >= height + COPY_FEEDBACK_OFFSET_PX ? 'top' : 'bottom');
+  }, [anchor.top]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <span
+      ref={feedbackRef}
+      role="status"
+      style={{
+        left: anchor.left,
+        top: placement === 'top' ? anchor.top : anchor.bottom,
+        transform:
+          placement === 'top'
+            ? `translate(-50%, calc(-100% - ${COPY_FEEDBACK_OFFSET_PX}px))`
+            : `translate(-50%, ${COPY_FEEDBACK_OFFSET_PX}px)`,
+      }}
+      className={cn(
+        'pointer-events-none fixed z-50 whitespace-nowrap rounded-8 bg-background-components-base px-8 py-4 text-xs font-display font-medium leading-20 shadow-tooltip',
+        kind === 'failed' ? 'text-foreground-highlight-error' : 'text-foreground-neutral-base',
+      )}
+    >
+      {children}
+    </span>,
+    document.body,
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -42,7 +42,9 @@ describe('WorkflowRunSummary', () => {
     expect(writeText).toHaveBeenCalledWith(RUN_ID);
     const copyButton = screen.getByRole('button', {name: `Copied run id ${RUN_ID}`});
     expect(copyButton).toBeInTheDocument();
-    expect(within(copyButton).getByText('Copied')).toBeInTheDocument();
+    expect(copyButton).toHaveTextContent('66666666');
+    expect(copyButton).not.toHaveTextContent('Copied');
+    expect(await screen.findByText('Copied')).toBeInTheDocument();
   });
 
   test('omits empty trigger metadata', () => {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -1,5 +1,5 @@
 import type {RunResponseDto} from '@shipfox/api-workflows-dto';
-import {screen, within} from '@testing-library/react';
+import {fireEvent, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {renderProjectPage} from '#test/pages.js';
 import {WorkflowRunSummary} from './workflow-run-summary.js';
@@ -44,7 +44,33 @@ describe('WorkflowRunSummary', () => {
     expect(copyButton).toBeInTheDocument();
     expect(copyButton).toHaveTextContent('66666666');
     expect(copyButton).not.toHaveTextContent('Copied');
-    expect(await screen.findByText('Copied')).toBeInTheDocument();
+    expect(await screen.findByRole('status')).toHaveTextContent('Copied');
+
+    await waitFor(
+      () => {
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      },
+      {timeout: 3000},
+    );
+    expect(screen.getByRole('button', {name: `Copy run id ${RUN_ID}`})).toBeInTheDocument();
+  });
+
+  test('dismisses copy feedback on scroll', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {writeText: vi.fn().mockResolvedValue(undefined)},
+    });
+    renderSummary();
+
+    await user.click(await screen.findByRole('button', {name: `Copy run id ${RUN_ID}`}));
+    expect(await screen.findByRole('status')).toHaveTextContent('Copied');
+
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
   });
 
   test('omits empty trigger metadata', () => {


### PR DESCRIPTION
Stabilize the run ID copy confirmation in the workflow run summary.

The ID button previously added inline confirmation text after copying, which changed the button width and shifted neighboring summary metadata. This keeps the visible button content fixed to the short ID and renders transient copy feedback outside the summary row, preserving alignment while still exposing the full ID through the normal tooltip.

Considered using the existing full-ID tooltip for the copied state, but separating transient copy feedback from the hover/focus tooltip keeps the two states from fighting each other and avoids the row's overflow clipping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized the run ID copy feedback to prevent layout shift in the workflow run summary. The button always shows the short ID; transient “Copied” feedback is rendered in a portal anchored to the button and dismissed on scroll/resize, while the full ID stays in the tooltip.

- **Bug Fixes**
  - Render copy feedback via `createPortal`, auto-placing above/below the button to avoid width changes and clipping.
  - Keep full ID in the `@shipfox/react-ui` tooltip; temporarily disable the tooltip while showing feedback to prevent conflicts.
  - Extend feedback duration from 1.5s to 2.5s.
  - Update tests to confirm the button keeps the short ID, feedback appears as an accessible status, and dismisses on scroll/timeout.

<sup>Written for commit 5abead0783d9b66729d82ce392a83712fefddb52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

