### PR TITLE
Add URL-driven workflow run selection

### DIFF
--- a/.changeset/url-run-line-highlights.md
+++ b/.changeset/url-run-line-highlights.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Add line-range highlighting support to CodeBlock content.

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
@@ -3,6 +3,7 @@ import {type StepLogSnapshot, stepLogsQueryKeys} from '@shipfox/client-logs';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {act, cleanup, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
+import {inlineLogBody, outputLine} from '#test/fixtures/logs.js';
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 
 const STEP_ID = '99999999-9999-4999-8999-999999999999';
@@ -15,18 +16,6 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
     ...init,
   });
 }
-
-const outputLine = (data: string, ts = 1): string =>
-  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
-
-const inlineBody = (ndjson: string, nextCursor: number) => ({
-  mode: 'inline',
-  ndjson,
-  next_cursor: nextCursor,
-  has_more: false,
-  state: 'closed',
-  truncated: false,
-});
 
 const outputRecord = (data: string, ts = 1): TestLogRecord => ({
   v: 1,
@@ -96,7 +85,7 @@ describe('StepAttemptLogPanel', () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}))
-      .mockResolvedValueOnce(jsonResponse(inlineBody(outputLine('eventual logs\n'), 1)));
+      .mockResolvedValueOnce(jsonResponse(inlineLogBody(outputLine('eventual logs\n'), 1)));
     configureApiClient({
       baseUrl: 'https://api.example.test',
       fetchImpl,
@@ -125,7 +114,7 @@ describe('StepAttemptLogPanel', () => {
   test('renders loaded logs inline', async () => {
     configureApiClient({
       baseUrl: 'https://api.example.test',
-      fetchImpl: vi.fn(async () => jsonResponse(inlineBody(outputLine('hello\n'), 1))),
+      fetchImpl: vi.fn(async () => jsonResponse(inlineLogBody(outputLine('hello\n'), 1))),
     });
 
     renderPanel({attemptStatus: 'succeeded'});
@@ -136,7 +125,7 @@ describe('StepAttemptLogPanel', () => {
   test('keeps stale logs visible when a refresh fails', async () => {
     const fetchImpl = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse(inlineBody(outputLine('first\n'), 1)))
+      .mockResolvedValueOnce(jsonResponse(inlineLogBody(outputLine('first\n'), 1)))
       .mockResolvedValueOnce(jsonResponse({code: 'server-error'}, {status: 500}));
     configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
     const {queryClient} = renderPanel({attemptStatus: 'running'});

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.test.ts
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.test.ts
@@ -1,0 +1,204 @@
+import {
+  workflowJobDto,
+  workflowRunDetail,
+  workflowStepAttemptDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
+import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
+
+describe('resolveWorkflowRunSelection', () => {
+  test('selects a valid job without expanding a step', () => {
+    const build = workflowJobDto({id: 'job-build', name: 'build'});
+    const deploy = workflowJobDto({id: 'job-deploy', name: 'deploy', position: 1});
+    const run = workflowRunDetail({jobs: [build, deploy]});
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {jobId: 'job-deploy'},
+    });
+
+    expect(resolved.job?.id).toBe('job-deploy');
+    expect(resolved.step).toBeUndefined();
+    expect(resolved.attempt).toBeUndefined();
+    expect(resolved.selectedAttemptId).toBeNull();
+  });
+
+  test('selects a step owner job without an explicit job id', () => {
+    const attempt = workflowStepAttemptDto({id: 'attempt-1', step_id: 'step-deploy'});
+    const step = workflowStepDto({
+      id: 'step-deploy',
+      job_id: 'job-deploy',
+      current_attempt: 1,
+      attempts: [attempt],
+    });
+    const run = workflowRunDetail({
+      jobs: [
+        workflowJobDto({id: 'job-build', name: 'build'}),
+        workflowJobDto({id: 'job-deploy', name: 'deploy', position: 1, steps: [step]}),
+      ],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {stepId: 'step-deploy'},
+    });
+
+    expect(resolved.job?.id).toBe('job-deploy');
+    expect(resolved.step?.id).toBe('step-deploy');
+    expect(resolved.attempt?.id).toBe('attempt-1');
+    expect(resolved.selectedAttemptId).toBe('attempt-1');
+  });
+
+  test('uses the exact valid attempt id when present', () => {
+    const firstAttempt = workflowStepAttemptDto({
+      id: 'attempt-1',
+      step_id: 'step-deploy',
+      attempt: 1,
+    });
+    const secondAttempt = workflowStepAttemptDto({
+      id: 'attempt-2',
+      step_id: 'step-deploy',
+      attempt: 2,
+    });
+    const step = workflowStepDto({
+      id: 'step-deploy',
+      job_id: 'job-deploy',
+      current_attempt: 1,
+      attempts: [firstAttempt, secondAttempt],
+    });
+    const run = workflowRunDetail({
+      jobs: [workflowJobDto({id: 'job-deploy', name: 'deploy', steps: [step]})],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {jobId: 'job-deploy', stepId: 'step-deploy', attemptId: 'attempt-2'},
+    });
+
+    expect(resolved.attempt?.id).toBe('attempt-2');
+    expect(resolved.selectedAttemptId).toBe('attempt-2');
+  });
+
+  test('lets a valid step override a mismatched job id', () => {
+    const step = workflowStepDto({
+      id: 'step-deploy',
+      job_id: 'job-deploy',
+      attempts: [workflowStepAttemptDto({id: 'attempt-1', step_id: 'step-deploy'})],
+    });
+    const run = workflowRunDetail({
+      jobs: [
+        workflowJobDto({id: 'job-build', name: 'build'}),
+        workflowJobDto({id: 'job-deploy', name: 'deploy', position: 1, steps: [step]}),
+      ],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {jobId: 'job-build', stepId: 'step-deploy'},
+    });
+
+    expect(resolved.job?.id).toBe('job-deploy');
+    expect(resolved.step?.id).toBe('step-deploy');
+  });
+
+  test('falls back from an invalid attempt id to the current attempt', () => {
+    const firstAttempt = workflowStepAttemptDto({
+      id: 'attempt-1',
+      step_id: 'step-deploy',
+      attempt: 1,
+    });
+    const secondAttempt = workflowStepAttemptDto({
+      id: 'attempt-2',
+      step_id: 'step-deploy',
+      attempt: 2,
+    });
+    const step = workflowStepDto({
+      id: 'step-deploy',
+      current_attempt: 2,
+      attempts: [firstAttempt, secondAttempt],
+    });
+    const run = workflowRunDetail({
+      jobs: [workflowJobDto({id: 'job-deploy', name: 'deploy', steps: [step]})],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {stepId: 'step-deploy', attemptId: 'missing-attempt'},
+    });
+
+    expect(resolved.attempt?.id).toBe('attempt-2');
+    expect(resolved.selectedAttemptId).toBe('attempt-2');
+  });
+
+  test('falls back to the latest attempt when the current attempt is missing', () => {
+    const firstAttempt = workflowStepAttemptDto({
+      id: 'attempt-1',
+      step_id: 'step-deploy',
+      attempt: 1,
+      execution_order: 1,
+    });
+    const thirdAttempt = workflowStepAttemptDto({
+      id: 'attempt-3',
+      step_id: 'step-deploy',
+      attempt: 3,
+      execution_order: 3,
+    });
+    const step = workflowStepDto({
+      id: 'step-deploy',
+      current_attempt: 2,
+      attempts: [firstAttempt, thirdAttempt],
+    });
+    const run = workflowRunDetail({
+      jobs: [workflowJobDto({id: 'job-deploy', name: 'deploy', steps: [step]})],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {stepId: 'step-deploy'},
+    });
+
+    expect(resolved.attempt?.id).toBe('attempt-3');
+  });
+
+  test('falls back to the first job for invalid job or step ids', () => {
+    const run = workflowRunDetail({
+      jobs: [
+        workflowJobDto({id: 'job-build', name: 'build'}),
+        workflowJobDto({id: 'job-deploy', name: 'deploy', position: 1}),
+      ],
+    });
+
+    const resolved = resolveWorkflowRunSelection({
+      run,
+      selection: {jobId: 'missing-job', stepId: 'missing-step'},
+    });
+
+    expect(resolved.job?.id).toBe('job-build');
+    expect(resolved.step).toBeUndefined();
+    expect(resolved.selectedAttemptId).toBeNull();
+  });
+
+  test('handles empty runs and zero-attempt steps', () => {
+    const emptyRun = workflowRunDetail({jobs: []});
+    const zeroAttemptStep = workflowStepDto({id: 'step-empty', attempts: []});
+    const run = workflowRunDetail({
+      jobs: [workflowJobDto({id: 'job-build', name: 'build', steps: [zeroAttemptStep]})],
+    });
+
+    const emptyResolved = resolveWorkflowRunSelection({
+      run: emptyRun,
+      selection: {jobId: 'job-build'},
+    });
+    const zeroAttemptResolved = resolveWorkflowRunSelection({
+      run,
+      selection: {stepId: 'step-empty'},
+    });
+
+    expect(emptyResolved.job).toBeUndefined();
+    expect(emptyResolved.selectedAttemptId).toBeNull();
+    expect(zeroAttemptResolved.job?.id).toBe('job-build');
+    expect(zeroAttemptResolved.step?.id).toBe('step-empty');
+    expect(zeroAttemptResolved.attempt).toBeUndefined();
+    expect(zeroAttemptResolved.selectedAttemptId).toBeNull();
+  });
+});

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.ts
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-selection.ts
@@ -1,0 +1,82 @@
+import type {
+  WorkflowJob,
+  WorkflowRunDetail,
+  WorkflowStep,
+  WorkflowStepAttempt,
+} from '#core/workflow-run.js';
+import type {WorkflowRunSelectionInput} from '#core/workflow-run-url-state.js';
+
+export interface ResolvedWorkflowRunSelection {
+  job: WorkflowJob | undefined;
+  step: WorkflowStep | undefined;
+  attempt: WorkflowStepAttempt | undefined;
+  selectedAttemptId: string | null;
+}
+
+export function resolveWorkflowRunSelection({
+  run,
+  selection,
+}: {
+  run: WorkflowRunDetail;
+  selection: WorkflowRunSelectionInput;
+}): ResolvedWorkflowRunSelection {
+  const jobById = new Map(run.jobs.map((job) => [job.id, job]));
+  const stepMatch = findStep(run, selection.stepId);
+
+  if (stepMatch) {
+    const attempt = resolveStepAttempt(stepMatch.step, selection.attemptId);
+    return {
+      job: stepMatch.job,
+      step: stepMatch.step,
+      attempt,
+      selectedAttemptId: attempt?.id ?? null,
+    };
+  }
+
+  return {
+    job: (selection.jobId ? jobById.get(selection.jobId) : undefined) ?? run.jobs.at(0),
+    step: undefined,
+    attempt: undefined,
+    selectedAttemptId: null,
+  };
+}
+
+function findStep(
+  run: WorkflowRunDetail,
+  stepId: string | undefined,
+): {job: WorkflowJob; step: WorkflowStep} | undefined {
+  if (!stepId) return undefined;
+
+  for (const job of run.jobs) {
+    const step = job.steps.find((candidate) => candidate.id === stepId);
+    if (step) return {job, step};
+  }
+
+  return undefined;
+}
+
+function resolveStepAttempt(
+  step: WorkflowStep,
+  attemptId: string | undefined,
+): WorkflowStepAttempt | undefined {
+  const attemptById = attemptId
+    ? step.attempts.find((attempt) => attempt.id === attemptId)
+    : undefined;
+  if (attemptById) return attemptById;
+
+  const currentAttempt = step.attempts.find((attempt) => attempt.attempt === step.currentAttempt);
+  if (currentAttempt) return currentAttempt;
+
+  return step.attempts.reduce<WorkflowStepAttempt | undefined>((latest, attempt) => {
+    if (!latest) return attempt;
+    return compareAttempts(attempt, latest) > 0 ? attempt : latest;
+  }, undefined);
+}
+
+function compareAttempts(left: WorkflowStepAttempt, right: WorkflowStepAttempt): number {
+  return (
+    left.attempt - right.attempt ||
+    left.executionOrder - right.executionOrder ||
+    left.id.localeCompare(right.id)
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -1,21 +1,29 @@
-import type {
-  JobStatusDto,
-  RunDetailResponseDto,
-  RunStepDetailDto,
-  StepAttemptDto,
-} from '@shipfox/api-workflows-dto';
+import type {RunDetailResponseDto} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {inlineLogBody, outputLine} from '#test/fixtures/logs.js';
+import {
+  workflowJobDto,
+  workflowRunDetailDto,
+  workflowStepAttemptDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
 import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
 import {WorkflowRunView} from './workflow-run-view.js';
 
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
+const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
+const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
+const BUILD_JOB_ID = '77777777-7777-4777-8777-777777777777';
+const DEPLOY_JOB_ID = '88888888-8888-4888-8888-888888888888';
+const CHECKOUT_STEP_ID = '99999999-9999-4999-8999-999999999999';
+const CHECKOUT_ATTEMPT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 describe('WorkflowRunView', () => {
   test('renders the run summary, jobs graph, and selected job step attempts when a run loads', async () => {
     configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(runDetailDto()))),
+      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(workflowRunViewDetailDto()))),
     });
 
     renderView();
@@ -46,21 +54,25 @@ describe('WorkflowRunView', () => {
       }
       return Promise.resolve(
         jsonResponse(
-          runDetailDto({
+          workflowRunViewDetailDto({
             jobs: [
-              jobDto({
-                id: '77777777-7777-4777-8777-777777777777',
+              workflowJobDto({
+                id: BUILD_JOB_ID,
+                run_id: RUN_ID,
                 name: 'build',
                 status: 'running',
                 steps: [
-                  stepDto({
+                  workflowStepDto({
                     id: stepId,
+                    job_id: BUILD_JOB_ID,
                     name: 'test',
+                    display_name: 'test',
                     status: 'running',
                     attempts: [
-                      attemptDto({
+                      workflowStepAttemptDto({
                         id: 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001',
                         step_id: stepId,
+                        job_id: BUILD_JOB_ID,
                         status: 'running',
                         exit_code: null,
                         finished_at: null,
@@ -113,7 +125,7 @@ describe('WorkflowRunView', () => {
       fetchImpl: vi.fn(() =>
         Promise.resolve(
           jsonResponse(
-            runDetailDto({
+            workflowRunViewDetailDto({
               source_snapshot: {
                 format: 'yaml',
                 content: 'jobs:\n  build:\n    steps:\n      - run: pnpm test',
@@ -157,20 +169,21 @@ describe('WorkflowRunView', () => {
       fetchImpl: vi.fn(() =>
         Promise.resolve(
           jsonResponse(
-            runDetailDto({
+            workflowRunViewDetailDto({
               source_snapshot: {
                 format: 'yaml',
                 content: 'jobs:\n  deploy:\n    steps:\n      - run: ship',
               },
               jobs: [
-                jobDto({
-                  id: '88888888-8888-4888-8888-888888888888',
+                workflowJobDto({
+                  id: DEPLOY_JOB_ID,
+                  run_id: RUN_ID,
                   name: 'deploy',
                   status: 'running',
                   steps: [
-                    stepDto({
+                    workflowStepDto({
                       id: stepId,
-                      job_id: '88888888-8888-4888-8888-888888888888',
+                      job_id: DEPLOY_JOB_ID,
                       name: 'deploy',
                       display_name: 'deploy',
                       source_location: {start_line: 2, end_line: 3},
@@ -197,7 +210,9 @@ describe('WorkflowRunView', () => {
 
   test('does not render a source control when the run has no source snapshot', async () => {
     configureApiClient({
-      fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(runDetailDto({source_snapshot: null})))),
+      fetchImpl: vi.fn(() =>
+        Promise.resolve(jsonResponse(workflowRunViewDetailDto({source_snapshot: null}))),
+      ),
     });
 
     renderView();
@@ -219,132 +234,53 @@ function requestUrl(input: RequestInfo | URL): URL {
   return new URL(String(input));
 }
 
-function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}) {
-  return {...baseRunDetailDto(), ...overrides};
-}
-
-const outputLine = (data: string, ts = 1): string =>
-  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
-
-function inlineLogBody(ndjson: string, nextCursor: number) {
-  return {
-    mode: 'inline',
-    ndjson,
-    next_cursor: nextCursor,
-    has_more: false,
-    state: 'closed',
-    truncated: false,
-  };
-}
-
-function baseRunDetailDto(): RunDetailResponseDto {
-  return {
+function workflowRunViewDetailDto(
+  overrides: Partial<RunDetailResponseDto> = {},
+): RunDetailResponseDto {
+  return workflowRunDetailDto({
     id: RUN_ID,
-    project_id: '44444444-4444-4444-8444-444444444444',
-    definition_id: '55555555-5555-4555-8555-555555555555',
+    project_id: PROJECT_ID,
+    definition_id: DEFINITION_ID,
     name: 'deploy-web',
     status: 'running',
-    trigger_source: 'manual',
-    trigger_event: 'fire',
     trigger_payload: {},
-    inputs: null,
-    source_snapshot: null,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
-    started_at: null,
-    finished_at: null,
     jobs: [
-      jobDto({
-        id: '77777777-7777-4777-8777-777777777777',
+      workflowJobDto({
+        id: BUILD_JOB_ID,
+        run_id: RUN_ID,
         name: 'build',
         status: 'succeeded',
-        steps: [stepDto({name: 'checkout', status: 'succeeded'})],
+        steps: [
+          workflowStepDto({
+            id: CHECKOUT_STEP_ID,
+            job_id: BUILD_JOB_ID,
+            name: 'checkout',
+            display_name: 'checkout',
+            status: 'succeeded',
+            attempts: [
+              workflowStepAttemptDto({
+                id: CHECKOUT_ATTEMPT_ID,
+                step_id: CHECKOUT_STEP_ID,
+                job_id: BUILD_JOB_ID,
+                status: 'succeeded',
+                exit_code: 0,
+                finished_at: '2026-05-07T01:01:20.000Z',
+              }),
+            ],
+          }),
+        ],
       }),
-      jobDto({
-        id: '88888888-8888-4888-8888-888888888888',
+      workflowJobDto({
+        id: DEPLOY_JOB_ID,
+        run_id: RUN_ID,
         name: 'deploy',
         status: 'running',
         position: 1,
         dependencies: ['build'],
       }),
     ],
-  };
-}
-
-function jobDto({
-  id,
-  name,
-  status,
-  position = 0,
-  dependencies = [],
-  steps = [],
-}: {
-  id: string;
-  name: string;
-  status: JobStatusDto;
-  position?: number;
-  dependencies?: string[];
-  steps?: RunStepDetailDto[];
-}) {
-  return {
-    id,
-    run_id: RUN_ID,
-    name,
-    status,
-    dependencies,
-    position,
-    created_at: '2026-05-07T01:01:00.000Z',
-    updated_at: '2026-05-07T01:02:00.000Z',
-    queued_at: null,
-    started_at: null,
-    finished_at: null,
-    steps,
-  };
-}
-
-function stepDto(overrides: Partial<RunStepDetailDto> = {}): RunStepDetailDto {
-  const stepId = overrides.id ?? '99999999-9999-4999-8999-999999999999';
-  const attempt = attemptDto({
-    step_id: stepId,
-    job_id: overrides.job_id ?? '77777777-7777-4777-8777-777777777777',
-    status: overrides.status ?? 'succeeded',
+    ...overrides,
   });
-
-  return {
-    id: stepId,
-    job_id: '77777777-7777-4777-8777-777777777777',
-    name: 'checkout',
-    display_name: overrides.display_name ?? overrides.name ?? 'checkout',
-    source_location: null,
-    status: 'succeeded',
-    type: 'run',
-    config: {},
-    error: null,
-    position: 0,
-    current_attempt: 1,
-    created_at: '2026-05-07T01:01:00.000Z',
-    updated_at: '2026-05-07T01:02:00.000Z',
-    attempts: [attempt],
-    ...overrides,
-  };
-}
-
-function attemptDto(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
-  return {
-    id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
-    step_id: '99999999-9999-4999-8999-999999999999',
-    job_id: '77777777-7777-4777-8777-777777777777',
-    attempt: 1,
-    execution_order: 1,
-    status: 'succeeded',
-    exit_code: 0,
-    output: null,
-    error: null,
-    gate_result: null,
-    restart_reason: null,
-    restart_result: null,
-    started_at: '2026-05-07T01:01:10.000Z',
-    finished_at: '2026-05-07T01:01:20.000Z',
-    ...overrides,
-  };
 }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -150,6 +150,51 @@ describe('WorkflowRunView', () => {
     expect(screen.getByRole('region', {name: 'Step attempts'})).toBeInTheDocument();
   });
 
+  test('highlights selected step source lines when the source panel opens', async () => {
+    const user = userEvent.setup();
+    const stepId = '99999999-9999-4999-8999-000000000003';
+    configureApiClient({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve(
+          jsonResponse(
+            runDetailDto({
+              source_snapshot: {
+                format: 'yaml',
+                content: 'jobs:\n  deploy:\n    steps:\n      - run: ship',
+              },
+              jobs: [
+                jobDto({
+                  id: '88888888-8888-4888-8888-888888888888',
+                  name: 'deploy',
+                  status: 'running',
+                  steps: [
+                    stepDto({
+                      id: stepId,
+                      job_id: '88888888-8888-4888-8888-888888888888',
+                      name: 'deploy',
+                      display_name: 'deploy',
+                      source_location: {start_line: 2, end_line: 3},
+                      status: 'running',
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ),
+        ),
+      ),
+    });
+
+    renderView({selection: {stepId}});
+    await user.click(await screen.findByRole('button', {name: 'Source'}));
+
+    await screen.findByRole('dialog', {name: 'Workflow source'});
+    const highlightedLines = document.body.querySelectorAll('.line.highlighted-line');
+    expect(highlightedLines).toHaveLength(2);
+    expect(highlightedLines[0]).toHaveTextContent('deploy:');
+    expect(highlightedLines[1]).toHaveTextContent('steps:');
+  });
+
   test('does not render a source control when the run has no source snapshot', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() => Promise.resolve(jsonResponse(runDetailDto({source_snapshot: null})))),
@@ -163,9 +208,9 @@ describe('WorkflowRunView', () => {
   });
 });
 
-function renderView() {
-  renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/x/runs/${RUN_ID}`, () => (
-    <WorkflowRunView runId={RUN_ID} />
+function renderView(props: Partial<Parameters<typeof WorkflowRunView>[0]> = {}) {
+  return renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/x/runs/${RUN_ID}`, () => (
+    <WorkflowRunView runId={RUN_ID} {...props} />
   ));
 }
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -2,12 +2,15 @@ import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {RelativeTimeProvider} from '@shipfox/react-ui';
 import {useEffect, useId, useRef, useState} from 'react';
+import type {WorkflowJob} from '#core/workflow-run.js';
+import type {WorkflowRunSelectionInput} from '#core/workflow-run-url-state.js';
 import {useWorkflowRunQuery} from '#hooks/api/workflow-runs.js';
 import {WorkflowJobsGraph} from '../workflow-jobs-graph/index.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
 import {WorkflowSourcePanel} from '../workflow-source-panel/index.js';
 import {WorkflowStepList} from '../workflow-step-list/index.js';
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
+import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
 import {
   WorkflowRunNotFound,
   WorkflowRunSkeleton,
@@ -16,6 +19,8 @@ import {
 
 export interface WorkflowRunViewProps {
   runId?: string | undefined;
+  selection?: WorkflowRunSelectionInput | undefined;
+  onSelectionChange?: ((selection: WorkflowRunSelectionInput) => void) | undefined;
 }
 
 /**
@@ -23,23 +28,36 @@ export interface WorkflowRunViewProps {
  * resolving which run to show) or the run is loading, so the page never branches on the
  * loading state itself.
  */
-export function WorkflowRunView({runId}: WorkflowRunViewProps) {
+export function WorkflowRunView({runId, selection, onSelectionChange}: WorkflowRunViewProps) {
   const runQuery = useWorkflowRunQuery(runId);
 
   return (
     <RelativeTimeProvider>
       <div className="flex min-w-0 flex-1">
-        <RunViewContent query={runQuery} />
+        <RunViewContent
+          query={runQuery}
+          selection={selection}
+          onSelectionChange={onSelectionChange}
+        />
       </div>
     </RelativeTimeProvider>
   );
 }
 
-function RunViewContent({query}: {query: ReturnType<typeof useWorkflowRunQuery>}) {
+function RunViewContent({
+  query,
+  selection,
+  onSelectionChange,
+}: {
+  query: ReturnType<typeof useWorkflowRunQuery>;
+  selection: WorkflowRunSelectionInput | undefined;
+  onSelectionChange: ((selection: WorkflowRunSelectionInput) => void) | undefined;
+}) {
   const [selectedJobId, setSelectedJobId] = useState<string | undefined>();
   const [sourcePanelOpen, setSourcePanelOpen] = useState(false);
   const sourcePanelId = useId();
   const sourceButtonRef = useRef<HTMLButtonElement>(null);
+  const selectionControlled = selection !== undefined;
   const sourceAvailable =
     query.data?.sourceSnapshot !== null && query.data?.sourceSnapshot !== undefined;
 
@@ -61,9 +79,44 @@ function RunViewContent({query}: {query: ReturnType<typeof useWorkflowRunQuery>}
 
   if (query.data === undefined) return <WorkflowRunSkeleton />;
 
-  const selectedJob =
-    query.data.jobs.find((job) => job.id === selectedJobId) ?? query.data.jobs.at(0);
+  const resolvedSelection = selectionControlled
+    ? resolveWorkflowRunSelection({run: query.data, selection})
+    : undefined;
+  const selectedJob = selectionControlled
+    ? resolvedSelection?.job
+    : (query.data.jobs.find((job) => job.id === selectedJobId) ?? query.data.jobs.at(0));
+  const selectedAttemptId = selectionControlled
+    ? (resolvedSelection?.selectedAttemptId ?? null)
+    : undefined;
+  const highlightedLineRange = resolvedSelection?.step?.sourceLocation ?? null;
   const sourceSnapshot = query.data.sourceSnapshot;
+
+  function selectJob(jobId: string | undefined) {
+    if (!selectionControlled) {
+      setSelectedJobId(jobId);
+      return;
+    }
+
+    onSelectionChange?.(jobId ? {jobId} : {});
+  }
+
+  function selectAttempt(attemptId: string | undefined) {
+    if (!selectionControlled || !selectedJob) return;
+
+    if (!attemptId) {
+      onSelectionChange?.({jobId: selectedJob.id});
+      return;
+    }
+
+    const match = findAttemptSelection(selectedJob, attemptId);
+    if (!match) return;
+
+    onSelectionChange?.({
+      jobId: selectedJob.id,
+      stepId: match.stepId,
+      attemptId: match.attemptId,
+    });
+  }
 
   function closeSourcePanel() {
     setSourcePanelOpen(false);
@@ -88,12 +141,14 @@ function RunViewContent({query}: {query: ReturnType<typeof useWorkflowRunQuery>}
           <WorkflowJobsGraph
             run={query.data}
             selectedJobId={selectedJob?.id}
-            onSelectedJobChange={setSelectedJobId}
+            onSelectedJobChange={selectJob}
           />
           {selectedJob ? (
             <WorkflowStepList
               job={selectedJob}
               className="max-h-[50vh]"
+              selectedAttemptId={selectedAttemptId}
+              onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
               autoSelectActiveAttempt
               renderExpandedStep={({stepId, attempt, attemptStatus}) => (
                 <StepAttemptLogPanel
@@ -111,7 +166,16 @@ function RunViewContent({query}: {query: ReturnType<typeof useWorkflowRunQuery>}
         source={sourceSnapshot}
         open={sourcePanelOpen && sourceAvailable}
         onClose={closeSourcePanel}
+        highlightedLineRange={highlightedLineRange}
       />
     </>
   );
+}
+
+function findAttemptSelection(job: WorkflowJob, attemptId: string) {
+  for (const step of job.steps) {
+    const attempt = step.attempts.find((candidate) => candidate.id === attemptId);
+    if (attempt) return {stepId: step.id, attemptId: attempt.id};
+  }
+  return undefined;
 }

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
@@ -3,6 +3,7 @@ import {Code, cn, RelativeTime} from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import type {WorkflowRun} from '#core/workflow-run.js';
+import {withoutWorkflowRunSelectionSearch} from '#core/workflow-run-url-state.js';
 
 export function WorkflowRunRowList({
   runs,
@@ -103,6 +104,10 @@ export function WorkflowRunRow({
     <Link
       to="/workspaces/$wid/projects/$pid/runs/$runId"
       params={{wid: workspaceId, pid: projectId, runId: run.id}}
+      search={
+        ((previous: Record<string, unknown>) =>
+          withoutWorkflowRunSelectionSearch(previous)) as never
+      }
       aria-current={selected ? 'page' : undefined}
       className={cn(
         'group relative flex w-full flex-col gap-3 rounded-8 border border-transparent px-10 py-7 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.test.tsx
@@ -43,6 +43,28 @@ describe('WorkflowSourcePanel', () => {
     expect(screen.queryByRole('button', {name: 'Close source'})).not.toBeInTheDocument();
   });
 
+  test('highlights the selected source line range', async () => {
+    renderPanel({
+      open: true,
+      highlightedLineRange: {startLine: 2, endLine: 3},
+    });
+
+    await screen.findByRole('dialog', {name: 'Workflow source'});
+
+    const highlightedLines = document.body.querySelectorAll('.line.highlighted-line');
+    expect(highlightedLines).toHaveLength(2);
+    expect(highlightedLines[0]).toHaveTextContent('build:');
+    expect(highlightedLines[1]).toHaveTextContent('steps: []');
+  });
+
+  test('renders source without highlighted lines when no range is provided', async () => {
+    renderPanel({open: true});
+
+    await screen.findByRole('dialog', {name: 'Workflow source'});
+
+    expect(document.body.querySelector('.line.highlighted-line')).toBeNull();
+  });
+
   test('does not render a sheet without source content', () => {
     renderPanel({open: true, source: null});
 
@@ -55,17 +77,20 @@ function renderPanel({
   open,
   source = {format: 'yaml', content: 'jobs:\n  build:\n    steps: []'},
   onClose = vi.fn(),
+  highlightedLineRange,
 }: {
   open: boolean;
   source?: Parameters<typeof WorkflowSourcePanel>[0]['source'];
   onClose?: () => void;
+  highlightedLineRange?: Parameters<typeof WorkflowSourcePanel>[0]['highlightedLineRange'];
 }) {
-  render(
+  return render(
     <WorkflowSourcePanel
       id="workflow-source-panel"
       open={open}
       source={source}
       onClose={onClose}
+      highlightedLineRange={highlightedLineRange}
     />,
   );
 }

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.tsx
@@ -7,6 +7,7 @@ import {
   CodeBlockFilename,
   CodeBlockFiles,
   CodeBlockHeader,
+  type CodeBlockHighlightedLineRange,
   CodeBlockItem,
   cn,
   Sheet,
@@ -27,6 +28,7 @@ export interface WorkflowSourcePanelProps {
   source: WorkflowSourceSnapshot | null;
   open: boolean;
   onClose: () => void;
+  highlightedLineRange?: CodeBlockHighlightedLineRange | null | undefined;
   className?: string | undefined;
 }
 
@@ -35,6 +37,7 @@ export function WorkflowSourcePanel({
   source,
   open,
   onClose,
+  highlightedLineRange,
   className,
 }: WorkflowSourcePanelProps) {
   const sheetOpen = open && source !== null;
@@ -59,14 +62,20 @@ export function WorkflowSourcePanel({
           )}
         >
           <SheetTitle className="sr-only">Workflow source</SheetTitle>
-          <WorkflowSourcePanelContent source={source} />
+          <WorkflowSourcePanelContent source={source} highlightedLineRange={highlightedLineRange} />
         </SheetContent>
       ) : null}
     </Sheet>
   );
 }
 
-function WorkflowSourcePanelContent({source}: {source: WorkflowSourceSnapshot}) {
+function WorkflowSourcePanelContent({
+  source,
+  highlightedLineRange,
+}: {
+  source: WorkflowSourceSnapshot;
+  highlightedLineRange: CodeBlockHighlightedLineRange | null | undefined;
+}) {
   const data = [
     {
       language: 'yaml',
@@ -109,6 +118,7 @@ function WorkflowSourcePanelContent({source}: {source: WorkflowSourceSnapshot}) 
               language="yaml"
               themes={WORKFLOW_SOURCE_CODE_THEMES}
               syntaxHighlighting
+              highlightedLineRange={highlightedLineRange}
             >
               {item.code}
             </CodeBlockContent>

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -107,6 +107,39 @@ describe('WorkflowStepList', () => {
     expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
   });
 
+  test('respects a controlled empty selected attempt', async () => {
+    const user = userEvent.setup();
+    const onSelectedAttemptChange = vi.fn();
+    const attempt = makeAttempt();
+    const step = makeStep({name: 'deploy', attempts: [attempt]});
+    const job = makeJob({steps: [step]});
+    const {rerender} = render(
+      <WorkflowStepList
+        job={job}
+        defaultSelectedAttemptId={attempt.id}
+        selectedAttemptId={attempt.id}
+        onSelectedAttemptChange={onSelectedAttemptChange}
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+    const deploy = screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'});
+    expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
+
+    rerender(
+      <WorkflowStepList
+        job={job}
+        defaultSelectedAttemptId={attempt.id}
+        selectedAttemptId={null}
+        onSelectedAttemptChange={onSelectedAttemptChange}
+        renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+      />,
+    );
+    await user.click(deploy);
+
+    expect(screen.queryByText(`logs for ${attempt.id}`)).not.toBeInTheDocument();
+    expect(onSelectedAttemptChange).toHaveBeenCalledWith(attempt.id);
+  });
+
   test('auto-opens the latest running attempt', () => {
     const installAttempt = makeAttempt({status: 'running', execution_order: 2});
     const deployAttempt = makeAttempt({status: 'running', execution_order: 4});

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -29,7 +29,7 @@ export interface WorkflowStepExpandedContext {
 
 export interface WorkflowStepListProps {
   job: WorkflowJob;
-  selectedAttemptId?: string | undefined;
+  selectedAttemptId?: string | null | undefined;
   defaultSelectedAttemptId?: string | undefined;
   onSelectedAttemptChange?: ((attemptId: string | undefined) => void) | undefined;
   autoSelectActiveAttempt?: boolean | undefined;
@@ -78,7 +78,11 @@ function WorkflowStepListContent({
   const [userSelectedAttempt, setUserSelectedAttempt] = useState(false);
   const autoSelectedAttemptId =
     autoSelectActiveAttempt && !userSelectedAttempt ? model.activeEntryId : undefined;
-  const selected = selectedAttemptId ?? localSelectedAttemptId ?? autoSelectedAttemptId;
+  // `undefined` leaves selection uncontrolled; `null` is a controlled collapsed state.
+  const selected =
+    selectedAttemptId !== undefined
+      ? selectedAttemptId
+      : (localSelectedAttemptId ?? autoSelectedAttemptId);
 
   useEffect(() => {
     setLocalSelectedAttemptId(defaultSelectedAttemptId);

--- a/libs/client/workflows/src/core/workflow-run-url-state.ts
+++ b/libs/client/workflows/src/core/workflow-run-url-state.ts
@@ -1,0 +1,44 @@
+export interface WorkflowRunSelectionInput {
+  jobId?: string | undefined;
+  stepId?: string | undefined;
+  attemptId?: string | undefined;
+}
+
+const WORKFLOW_RUN_URL_SELECTION_KEYS = ['job', 'step', 'attempt'] as const;
+
+type WorkflowRunSearch = Record<string, unknown>;
+
+export function workflowRunSelectionFromSearch(
+  search: WorkflowRunSearch,
+): WorkflowRunSelectionInput {
+  return {
+    jobId: stringSearchParam(search.job),
+    stepId: stringSearchParam(search.step),
+    attemptId: stringSearchParam(search.attempt),
+  };
+}
+
+export function withWorkflowRunSelectionSearch<TSearch extends WorkflowRunSearch>(
+  search: TSearch,
+  selection: WorkflowRunSelectionInput,
+): TSearch {
+  const nextSearch: WorkflowRunSearch = withoutWorkflowRunSelectionSearch(search);
+  if (selection.jobId) nextSearch.job = selection.jobId;
+  if (selection.stepId) nextSearch.step = selection.stepId;
+  if (selection.attemptId) nextSearch.attempt = selection.attemptId;
+  return nextSearch as TSearch;
+}
+
+export function withoutWorkflowRunSelectionSearch<TSearch extends WorkflowRunSearch>(
+  search: TSearch,
+): TSearch {
+  const nextSearch: WorkflowRunSearch = {...search};
+  for (const key of WORKFLOW_RUN_URL_SELECTION_KEYS) {
+    delete nextSearch[key];
+  }
+  return nextSearch as TSearch;
+}
+
+function stringSearchParam(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/libs/client/workflows/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-page.test.tsx
@@ -1,10 +1,29 @@
+import type {
+  JobStatusDto,
+  RunDetailResponseDto,
+  RunJobDetailDto,
+  RunResponseDto,
+  RunStepDetailDto,
+  StepAttemptDto,
+} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
-import {screen} from '@testing-library/react';
+import {act, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
 import {WorkflowRunPage} from './workflow-run-page.js';
 
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
+const SECOND_RUN_ID = '66666666-6666-4666-8666-000000000002';
+const BUILD_JOB_ID = '77777777-7777-4777-8777-777777777777';
+const BUILD_STEP_ID = '99999999-9999-4999-8999-000000000000';
+const BUILD_ATTEMPT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000000';
+const DEPLOY_JOB_ID = '88888888-8888-4888-8888-888888888888';
+const DEPLOY_STEP_ID = '99999999-9999-4999-8999-999999999999';
+const DEPLOY_ATTEMPT_ONE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001';
+const DEPLOY_ATTEMPT_TWO_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002';
+const SMOKE_WEB_RE = /smoke-web/u;
+const RUN_DETAIL_PATH_RE = /^\/workflows\/runs\/([^/]+)$/u;
 
 describe('WorkflowRunPage', () => {
   test('keeps the runs list mounted and only skeletons the run view until a run is selected', async () => {
@@ -39,12 +58,146 @@ describe('WorkflowRunPage', () => {
     expect(screen.queryByLabelText('Workflow runs')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Loading workflow run')).not.toBeInTheDocument();
   });
+
+  test('restores a deep-linked job and exact attempt after data loads', async () => {
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+
+    renderRunPath(`?job=${BUILD_JOB_ID}&step=${DEPLOY_STEP_ID}&attempt=${DEPLOY_ATTEMPT_TWO_ID}`);
+
+    const deployJob = await screen.findByRole('button', {name: 'deploy, Running'});
+    const deployAttempt = await screen.findByRole('button', {
+      name: '1. deploy, Running, attempt 2',
+    });
+
+    expect(deployJob).toHaveAttribute('aria-pressed', 'true');
+    expect(deployAttempt).toHaveAttribute('aria-expanded', 'true');
+    expect(await screen.findByText('attempt two log')).toBeInTheDocument();
+  });
+
+  test('selecting a job writes job search state and clears stale step state', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+    const {router} = renderRunPath(`?step=${DEPLOY_STEP_ID}&attempt=${DEPLOY_ATTEMPT_TWO_ID}`);
+
+    await user.click(await screen.findByRole('button', {name: 'build, Succeeded'}));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toMatchObject({job: BUILD_JOB_ID});
+    });
+    expect(currentSearch(router).step).toBeUndefined();
+    expect(currentSearch(router).attempt).toBeUndefined();
+    expect(screen.getByRole('button', {name: '1. checkout, Succeeded, attempt 1'})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  test('selecting an attempt writes job, step, and attempt search state', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+    const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
+
+    await user.click(await screen.findByRole('button', {name: '1. deploy, Running, attempt 2'}));
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toMatchObject({
+        job: DEPLOY_JOB_ID,
+        step: DEPLOY_STEP_ID,
+        attempt: DEPLOY_ATTEMPT_TWO_ID,
+      });
+    });
+  });
+
+  test('collapsing an attempt removes step and attempt while preserving job', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+    const {router} = renderRunPath(`?step=${DEPLOY_STEP_ID}&attempt=${DEPLOY_ATTEMPT_TWO_ID}`);
+
+    const deployAttempt = await screen.findByRole('button', {
+      name: '1. deploy, Running, attempt 2',
+    });
+    await user.click(deployAttempt);
+
+    await waitFor(() => {
+      expect(currentSearch(router)).toMatchObject({job: DEPLOY_JOB_ID});
+    });
+    expect(currentSearch(router).step).toBeUndefined();
+    expect(currentSearch(router).attempt).toBeUndefined();
+    expect(deployAttempt).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('back and forward navigation restores prior selections', async () => {
+    const user = userEvent.setup();
+    configureApiClient({fetchImpl: createRunDetailFetch()});
+    const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
+
+    await user.click(await screen.findByRole('button', {name: '1. deploy, Running, attempt 2'}));
+    await waitFor(() => {
+      expect(currentSearch(router).attempt).toBe(DEPLOY_ATTEMPT_TWO_ID);
+    });
+
+    await act(() => {
+      router.history.back();
+    });
+    await waitFor(() => {
+      expect(currentSearch(router)).toMatchObject({job: DEPLOY_JOB_ID});
+    });
+    expect(currentSearch(router).step).toBeUndefined();
+    expect(currentSearch(router).attempt).toBeUndefined();
+    expect(screen.getByRole('button', {name: '1. deploy, Running, attempt 2'})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+
+    await act(() => {
+      router.history.forward();
+    });
+    await waitFor(() => {
+      expect(currentSearch(router).attempt).toBe(DEPLOY_ATTEMPT_TWO_ID);
+    });
+    expect(screen.getByRole('button', {name: '1. deploy, Running, attempt 2'})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+
+  test('run rail links clear job, step, and attempt when switching runs', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      fetchImpl: createRunDetailFetch({
+        runs: [runDto({id: RUN_ID}), runDto({id: SECOND_RUN_ID, name: 'smoke-web'})],
+        details: {
+          [RUN_ID]: runDetailDto(),
+          [SECOND_RUN_ID]: runDetailDto({id: SECOND_RUN_ID, name: 'smoke-web', jobs: []}),
+        },
+      }),
+    });
+    const {router} = renderRunPath(`?step=${DEPLOY_STEP_ID}&attempt=${DEPLOY_ATTEMPT_TWO_ID}`);
+
+    await user.click(await screen.findByRole('link', {name: SMOKE_WEB_RE}));
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toContain(SECOND_RUN_ID);
+    });
+    expect(currentSearch(router).job).toBeUndefined();
+    expect(currentSearch(router).step).toBeUndefined();
+    expect(currentSearch(router).attempt).toBeUndefined();
+  });
 });
 
 function renderRunsPath() {
   renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs`, ({runId}) => (
     <WorkflowRunPage workspaceId={PROJECT_TEST_WID} projectId={PROJECT_ID} runId={runId} />
   ));
+}
+
+function renderRunPath(search = '') {
+  return renderProjectPage(
+    `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs/${RUN_ID}${search}`,
+    ({runId}) => (
+      <WorkflowRunPage workspaceId={PROJECT_TEST_WID} projectId={PROJECT_ID} runId={runId} />
+    ),
+  );
 }
 
 function createRunsListFetch() {
@@ -57,7 +210,42 @@ function createRunsListFetch() {
       );
     }
     if (url.pathname === `/workflows/runs/${RUN_ID}`) {
-      return Promise.resolve(jsonResponse({...runDto(), jobs: []}));
+      return Promise.resolve(jsonResponse(runDetailDto({jobs: []})));
+    }
+
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function createRunDetailFetch({
+  runs = [runDto()],
+  details = {[RUN_ID]: runDetailDto()},
+}: {
+  runs?: RunResponseDto[];
+  details?: Record<string, RunDetailResponseDto>;
+} = {}) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+
+    if (url.pathname === '/workflows/runs') {
+      return Promise.resolve(
+        jsonResponse({runs, next_cursor: null, filtered_total_count: runs.length}),
+      );
+    }
+
+    const runMatch = url.pathname.match(RUN_DETAIL_PATH_RE);
+    if (runMatch?.[1] && details[runMatch[1]]) {
+      return Promise.resolve(jsonResponse(details[runMatch[1]]));
+    }
+
+    if (url.pathname === `/steps/${DEPLOY_STEP_ID}/attempts/1/logs`) {
+      return Promise.resolve(jsonResponse(inlineLogBody(outputLine('attempt one log\n'), 1)));
+    }
+    if (url.pathname === `/steps/${DEPLOY_STEP_ID}/attempts/2/logs`) {
+      return Promise.resolve(jsonResponse(inlineLogBody(outputLine('attempt two log\n'), 1)));
+    }
+    if (url.pathname === `/steps/${BUILD_STEP_ID}/attempts/1/logs`) {
+      return Promise.resolve(jsonResponse(inlineLogBody(outputLine('build log\n'), 1)));
     }
 
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
@@ -82,7 +270,7 @@ function requestInputUrl(input: RequestInfo | URL) {
 }
 
 // The newest run the list returns; the page should redirect onto it when opened at /runs.
-function runDto() {
+function runDto(overrides: Partial<RunResponseDto> = {}): RunResponseDto {
   return {
     id: RUN_ID,
     project_id: PROJECT_ID,
@@ -93,7 +281,170 @@ function runDto() {
     trigger_event: 'fire',
     trigger_payload: {source: 'manual', event: 'fire'},
     inputs: null,
+    source_snapshot: null,
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
+    started_at: null,
+    finished_at: null,
+    ...overrides,
   };
+}
+
+function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailResponseDto {
+  return {
+    ...runDto(),
+    jobs: [
+      jobDto({
+        id: BUILD_JOB_ID,
+        name: 'build',
+        status: 'succeeded',
+        steps: [
+          stepDto({
+            id: BUILD_STEP_ID,
+            job_id: BUILD_JOB_ID,
+            name: 'checkout',
+            display_name: 'checkout',
+            status: 'succeeded',
+            current_attempt: 1,
+            attempts: [
+              attemptDto({
+                id: BUILD_ATTEMPT_ID,
+                step_id: BUILD_STEP_ID,
+                job_id: BUILD_JOB_ID,
+                status: 'succeeded',
+              }),
+            ],
+          }),
+        ],
+      }),
+      jobDto({
+        id: DEPLOY_JOB_ID,
+        name: 'deploy',
+        status: 'running',
+        position: 1,
+        dependencies: ['build'],
+        steps: [
+          stepDto({
+            id: DEPLOY_STEP_ID,
+            job_id: DEPLOY_JOB_ID,
+            name: 'deploy',
+            display_name: 'deploy',
+            status: 'running',
+            current_attempt: 2,
+            attempts: [
+              attemptDto({
+                id: DEPLOY_ATTEMPT_ONE_ID,
+                step_id: DEPLOY_STEP_ID,
+                job_id: DEPLOY_JOB_ID,
+                attempt: 1,
+                execution_order: 1,
+                status: 'failed',
+                exit_code: 1,
+              }),
+              attemptDto({
+                id: DEPLOY_ATTEMPT_TWO_ID,
+                step_id: DEPLOY_STEP_ID,
+                job_id: DEPLOY_JOB_ID,
+                attempt: 2,
+                execution_order: 2,
+                status: 'running',
+                exit_code: null,
+                finished_at: null,
+              }),
+            ],
+          }),
+        ],
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+function jobDto({
+  id,
+  name,
+  status,
+  position = 0,
+  dependencies = [],
+  steps = [],
+}: {
+  id: string;
+  name: string;
+  status: JobStatusDto;
+  position?: number;
+  dependencies?: string[];
+  steps?: RunStepDetailDto[];
+}): RunJobDetailDto {
+  return {
+    id,
+    run_id: RUN_ID,
+    name,
+    status,
+    dependencies,
+    position,
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+    queued_at: null,
+    started_at: null,
+    finished_at: null,
+    steps,
+  };
+}
+
+function stepDto(overrides: Partial<RunStepDetailDto> = {}): RunStepDetailDto {
+  return {
+    id: BUILD_STEP_ID,
+    job_id: BUILD_JOB_ID,
+    name: 'checkout',
+    display_name: 'checkout',
+    source_location: null,
+    status: 'succeeded',
+    type: 'run',
+    config: {},
+    error: null,
+    position: 0,
+    current_attempt: 1,
+    created_at: '2026-05-07T01:01:00.000Z',
+    updated_at: '2026-05-07T01:02:00.000Z',
+    attempts: [],
+    ...overrides,
+  };
+}
+
+function attemptDto(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
+  return {
+    id: BUILD_ATTEMPT_ID,
+    step_id: BUILD_STEP_ID,
+    job_id: BUILD_JOB_ID,
+    attempt: 1,
+    execution_order: 1,
+    status: 'succeeded',
+    exit_code: 0,
+    output: null,
+    error: null,
+    gate_result: null,
+    restart_reason: null,
+    restart_result: null,
+    started_at: '2026-05-07T01:01:10.000Z',
+    finished_at: '2026-05-07T01:01:20.000Z',
+    ...overrides,
+  };
+}
+
+const outputLine = (data: string, ts = 1): string =>
+  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
+
+function inlineLogBody(ndjson: string, nextCursor: number) {
+  return {
+    mode: 'inline',
+    ndjson,
+    next_cursor: nextCursor,
+    has_more: false,
+    state: 'closed',
+    truncated: false,
+  };
+}
+
+function currentSearch({state}: ReturnType<typeof renderRunPath>['router']) {
+  return state.location.search as Record<string, unknown>;
 }

--- a/libs/client/workflows/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-page.test.tsx
@@ -1,18 +1,20 @@
-import type {
-  JobStatusDto,
-  RunDetailResponseDto,
-  RunJobDetailDto,
-  RunResponseDto,
-  RunStepDetailDto,
-  StepAttemptDto,
-} from '@shipfox/api-workflows-dto';
+import type {RunDetailResponseDto, RunResponseDto} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {act, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {inlineLogBody, outputLine} from '#test/fixtures/logs.js';
+import {
+  workflowJobDto,
+  workflowRunDetailDto,
+  workflowRunDto,
+  workflowStepAttemptDto,
+  workflowStepDto,
+} from '#test/fixtures/workflow-run.js';
 import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
 import {WorkflowRunPage} from './workflow-run-page.js';
 
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
+const DEFINITION_ID = '55555555-5555-4555-8555-555555555555';
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const SECOND_RUN_ID = '66666666-6666-4666-8666-000000000002';
 const BUILD_JOB_ID = '77777777-7777-4777-8777-777777777777';
@@ -24,6 +26,19 @@ const DEPLOY_ATTEMPT_ONE_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000001';
 const DEPLOY_ATTEMPT_TWO_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000002';
 const SMOKE_WEB_RE = /smoke-web/u;
 const RUN_DETAIL_PATH_RE = /^\/workflows\/runs\/([^/]+)$/u;
+const RUN_OVERRIDES = {
+  id: RUN_ID,
+  project_id: PROJECT_ID,
+  definition_id: DEFINITION_ID,
+  trigger_payload: {source: 'manual', event: 'fire'},
+  created_at: '2026-05-07T01:01:00.000Z',
+  updated_at: '2026-05-07T01:02:00.000Z',
+} satisfies Partial<RunResponseDto>;
+const SECOND_RUN_OVERRIDES = {
+  ...RUN_OVERRIDES,
+  id: SECOND_RUN_ID,
+  name: 'smoke-web',
+} satisfies Partial<RunResponseDto>;
 
 describe('WorkflowRunPage', () => {
   test('keeps the runs list mounted and only skeletons the run view until a run is selected', async () => {
@@ -40,12 +55,17 @@ describe('WorkflowRunPage', () => {
   test('redirects to the most recent run when opened without a run id', async () => {
     configureApiClient({fetchImpl: createRunsListFetch()});
 
-    renderRunsPath();
+    const {router} = renderRunsPath(
+      `?job=${DEPLOY_JOB_ID}&step=${DEPLOY_STEP_ID}&attempt=${DEPLOY_ATTEMPT_TWO_ID}`,
+    );
 
     // Landing on /runs with runs present redirects to the newest run, so its row becomes the
     // selected (current) row in the rail even though the opened URL carried no run id.
     const selectedRow = await screen.findByRole('link', {current: 'page'});
     expect(selectedRow).toHaveTextContent('deploy-web');
+    expect(currentSearch(router).job).toBeUndefined();
+    expect(currentSearch(router).step).toBeUndefined();
+    expect(currentSearch(router).attempt).toBeUndefined();
   });
 
   test('shows the first-time-use surface when the project has no runs', async () => {
@@ -165,10 +185,10 @@ describe('WorkflowRunPage', () => {
     const user = userEvent.setup();
     configureApiClient({
       fetchImpl: createRunDetailFetch({
-        runs: [runDto({id: RUN_ID}), runDto({id: SECOND_RUN_ID, name: 'smoke-web'})],
+        runs: [workflowRunDto(RUN_OVERRIDES), workflowRunDto(SECOND_RUN_OVERRIDES)],
         details: {
-          [RUN_ID]: runDetailDto(),
-          [SECOND_RUN_ID]: runDetailDto({id: SECOND_RUN_ID, name: 'smoke-web', jobs: []}),
+          [RUN_ID]: defaultRunDetailDto(),
+          [SECOND_RUN_ID]: workflowRunDetailDto({...SECOND_RUN_OVERRIDES, jobs: []}),
         },
       }),
     });
@@ -185,10 +205,13 @@ describe('WorkflowRunPage', () => {
   });
 });
 
-function renderRunsPath() {
-  renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs`, ({runId}) => (
-    <WorkflowRunPage workspaceId={PROJECT_TEST_WID} projectId={PROJECT_ID} runId={runId} />
-  ));
+function renderRunsPath(search = '') {
+  return renderProjectPage(
+    `/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs${search}`,
+    ({runId}) => (
+      <WorkflowRunPage workspaceId={PROJECT_TEST_WID} projectId={PROJECT_ID} runId={runId} />
+    ),
+  );
 }
 
 function renderRunPath(search = '') {
@@ -206,11 +229,15 @@ function createRunsListFetch() {
 
     if (url.pathname === '/workflows/runs') {
       return Promise.resolve(
-        jsonResponse({runs: [runDto()], next_cursor: null, filtered_total_count: 1}),
+        jsonResponse({
+          runs: [workflowRunDto(RUN_OVERRIDES)],
+          next_cursor: null,
+          filtered_total_count: 1,
+        }),
       );
     }
     if (url.pathname === `/workflows/runs/${RUN_ID}`) {
-      return Promise.resolve(jsonResponse(runDetailDto({jobs: []})));
+      return Promise.resolve(jsonResponse(workflowRunDetailDto({...RUN_OVERRIDES, jobs: []})));
     }
 
     return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
@@ -218,8 +245,8 @@ function createRunsListFetch() {
 }
 
 function createRunDetailFetch({
-  runs = [runDto()],
-  details = {[RUN_ID]: runDetailDto()},
+  runs = [workflowRunDto(RUN_OVERRIDES)],
+  details = {[RUN_ID]: defaultRunDetailDto()},
 }: {
   runs?: RunResponseDto[];
   details?: Record<string, RunDetailResponseDto>;
@@ -269,37 +296,17 @@ function requestInputUrl(input: RequestInfo | URL) {
   return String(input);
 }
 
-// The newest run the list returns; the page should redirect onto it when opened at /runs.
-function runDto(overrides: Partial<RunResponseDto> = {}): RunResponseDto {
-  return {
-    id: RUN_ID,
-    project_id: PROJECT_ID,
-    definition_id: '55555555-5555-4555-8555-555555555555',
-    name: 'deploy-web',
-    status: 'running',
-    trigger_source: 'manual',
-    trigger_event: 'fire',
-    trigger_payload: {source: 'manual', event: 'fire'},
-    inputs: null,
-    source_snapshot: null,
-    created_at: '2026-05-07T01:01:00.000Z',
-    updated_at: '2026-05-07T01:02:00.000Z',
-    started_at: null,
-    finished_at: null,
-    ...overrides,
-  };
-}
-
-function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailResponseDto {
-  return {
-    ...runDto(),
+function defaultRunDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailResponseDto {
+  return workflowRunDetailDto({
+    ...RUN_OVERRIDES,
     jobs: [
-      jobDto({
+      workflowJobDto({
         id: BUILD_JOB_ID,
+        run_id: RUN_ID,
         name: 'build',
         status: 'succeeded',
         steps: [
-          stepDto({
+          workflowStepDto({
             id: BUILD_STEP_ID,
             job_id: BUILD_JOB_ID,
             name: 'checkout',
@@ -307,7 +314,7 @@ function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailR
             status: 'succeeded',
             current_attempt: 1,
             attempts: [
-              attemptDto({
+              workflowStepAttemptDto({
                 id: BUILD_ATTEMPT_ID,
                 step_id: BUILD_STEP_ID,
                 job_id: BUILD_JOB_ID,
@@ -317,14 +324,15 @@ function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailR
           }),
         ],
       }),
-      jobDto({
+      workflowJobDto({
         id: DEPLOY_JOB_ID,
+        run_id: RUN_ID,
         name: 'deploy',
         status: 'running',
         position: 1,
         dependencies: ['build'],
         steps: [
-          stepDto({
+          workflowStepDto({
             id: DEPLOY_STEP_ID,
             job_id: DEPLOY_JOB_ID,
             name: 'deploy',
@@ -332,7 +340,7 @@ function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailR
             status: 'running',
             current_attempt: 2,
             attempts: [
-              attemptDto({
+              workflowStepAttemptDto({
                 id: DEPLOY_ATTEMPT_ONE_ID,
                 step_id: DEPLOY_STEP_ID,
                 job_id: DEPLOY_JOB_ID,
@@ -341,7 +349,7 @@ function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailR
                 status: 'failed',
                 exit_code: 1,
               }),
-              attemptDto({
+              workflowStepAttemptDto({
                 id: DEPLOY_ATTEMPT_TWO_ID,
                 step_id: DEPLOY_STEP_ID,
                 job_id: DEPLOY_JOB_ID,
@@ -357,92 +365,7 @@ function runDetailDto(overrides: Partial<RunDetailResponseDto> = {}): RunDetailR
       }),
     ],
     ...overrides,
-  };
-}
-
-function jobDto({
-  id,
-  name,
-  status,
-  position = 0,
-  dependencies = [],
-  steps = [],
-}: {
-  id: string;
-  name: string;
-  status: JobStatusDto;
-  position?: number;
-  dependencies?: string[];
-  steps?: RunStepDetailDto[];
-}): RunJobDetailDto {
-  return {
-    id,
-    run_id: RUN_ID,
-    name,
-    status,
-    dependencies,
-    position,
-    created_at: '2026-05-07T01:01:00.000Z',
-    updated_at: '2026-05-07T01:02:00.000Z',
-    queued_at: null,
-    started_at: null,
-    finished_at: null,
-    steps,
-  };
-}
-
-function stepDto(overrides: Partial<RunStepDetailDto> = {}): RunStepDetailDto {
-  return {
-    id: BUILD_STEP_ID,
-    job_id: BUILD_JOB_ID,
-    name: 'checkout',
-    display_name: 'checkout',
-    source_location: null,
-    status: 'succeeded',
-    type: 'run',
-    config: {},
-    error: null,
-    position: 0,
-    current_attempt: 1,
-    created_at: '2026-05-07T01:01:00.000Z',
-    updated_at: '2026-05-07T01:02:00.000Z',
-    attempts: [],
-    ...overrides,
-  };
-}
-
-function attemptDto(overrides: Partial<StepAttemptDto> = {}): StepAttemptDto {
-  return {
-    id: BUILD_ATTEMPT_ID,
-    step_id: BUILD_STEP_ID,
-    job_id: BUILD_JOB_ID,
-    attempt: 1,
-    execution_order: 1,
-    status: 'succeeded',
-    exit_code: 0,
-    output: null,
-    error: null,
-    gate_result: null,
-    restart_reason: null,
-    restart_result: null,
-    started_at: '2026-05-07T01:01:10.000Z',
-    finished_at: '2026-05-07T01:01:20.000Z',
-    ...overrides,
-  };
-}
-
-const outputLine = (data: string, ts = 1): string =>
-  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
-
-function inlineLogBody(ndjson: string, nextCursor: number) {
-  return {
-    mode: 'inline',
-    ndjson,
-    next_cursor: nextCursor,
-    has_more: false,
-    state: 'closed',
-    truncated: false,
-  };
+  });
 }
 
 function currentSearch({state}: ReturnType<typeof renderRunPath>['router']) {

--- a/libs/client/workflows/src/pages/workflow-run-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-page.tsx
@@ -4,6 +4,7 @@ import {WorkflowRunView} from '#components/workflow-run-view/index.js';
 import {WorkflowRunsList} from '#components/workflow-runs-list/workflow-runs-list.js';
 import {
   type WorkflowRunSelectionInput,
+  withoutWorkflowRunSelectionSearch,
   withWorkflowRunSelectionSearch,
   workflowRunSelectionFromSearch,
 } from '#core/workflow-run-url-state.js';
@@ -41,7 +42,8 @@ function useWorkflowRunPageTarget(
     navigate({
       to: '/workspaces/$wid/projects/$pid/runs/$runId',
       params: {wid: workspaceId, pid: projectId, runId: firstRunId},
-      search: true,
+      search: ((previous: Record<string, unknown>) =>
+        withoutWorkflowRunSelectionSearch(previous)) as never,
       replace: true,
     });
   }, [navigate, workspaceId, projectId, runId, isLoaded, firstRunId]);

--- a/libs/client/workflows/src/pages/workflow-run-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-page.tsx
@@ -1,7 +1,12 @@
-import {useNavigate} from '@tanstack/react-router';
-import {useEffect} from 'react';
+import {useNavigate, useSearch} from '@tanstack/react-router';
+import {useCallback, useEffect} from 'react';
 import {WorkflowRunView} from '#components/workflow-run-view/index.js';
 import {WorkflowRunsList} from '#components/workflow-runs-list/workflow-runs-list.js';
+import {
+  type WorkflowRunSelectionInput,
+  withWorkflowRunSelectionSearch,
+  workflowRunSelectionFromSearch,
+} from '#core/workflow-run-url-state.js';
 import {useWorkflowRunsInfiniteQuery} from '#hooks/api/workflow-runs.js';
 import {WorkflowRunFirstTimeUse} from './workflow-run-first-time-use.js';
 
@@ -36,6 +41,7 @@ function useWorkflowRunPageTarget(
     navigate({
       to: '/workspaces/$wid/projects/$pid/runs/$runId',
       params: {wid: workspaceId, pid: projectId, runId: firstRunId},
+      search: true,
       replace: true,
     });
   }, [navigate, workspaceId, projectId, runId, isLoaded, firstRunId]);
@@ -45,6 +51,18 @@ function useWorkflowRunPageTarget(
 
 export function WorkflowRunPage({workspaceId, projectId, runId}: WorkflowRunPageProps) {
   const {hasNoRuns} = useWorkflowRunPageTarget(workspaceId, projectId, runId);
+  const navigate = useNavigate();
+  const search = useSearch({strict: false}) as Record<string, unknown>;
+  const selection = workflowRunSelectionFromSearch(search);
+  const onSelectionChange = useCallback(
+    (nextSelection: WorkflowRunSelectionInput) => {
+      navigate({
+        search: ((previous: Record<string, unknown>) =>
+          withWorkflowRunSelectionSearch(previous, nextSelection)) as never,
+      });
+    },
+    [navigate],
+  );
 
   if (!runId && hasNoRuns) {
     return <WorkflowRunFirstTimeUse />;
@@ -53,7 +71,7 @@ export function WorkflowRunPage({workspaceId, projectId, runId}: WorkflowRunPage
   return (
     <div className="flex min-h-0 flex-1">
       <WorkflowRunsList workspaceId={workspaceId} projectId={projectId} selectedRunId={runId} />
-      <WorkflowRunView runId={runId} />
+      <WorkflowRunView runId={runId} selection={selection} onSelectionChange={onSelectionChange} />
     </div>
   );
 }

--- a/libs/client/workflows/test/fixtures/logs.ts
+++ b/libs/client/workflows/test/fixtures/logs.ts
@@ -1,0 +1,13 @@
+export const outputLine = (data: string, ts = 1): string =>
+  `${JSON.stringify({v: 1, ts, type: 'output', stream: 'stdout', data})}\n`;
+
+export function inlineLogBody(ndjson: string, nextCursor: number) {
+  return {
+    mode: 'inline' as const,
+    ndjson,
+    next_cursor: nextCursor,
+    has_more: false,
+    state: 'closed' as const,
+    truncated: false,
+  };
+}

--- a/libs/client/workflows/test/pages.tsx
+++ b/libs/client/workflows/test/pages.tsx
@@ -55,15 +55,17 @@ function createTestRouter(
 export function renderProjectPage(
   path: string,
   renderPage: (params: {runId?: string | undefined}) => ReactElement,
-): RenderResult {
+): RenderResult & {router: ReturnType<typeof createTestRouter>} {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
   const router = createTestRouter(path, renderPage);
 
   configureApiClient({baseUrl: 'https://api.example.test'});
 
-  return render(
+  const result = render(
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
     </QueryClientProvider>,
   );
+
+  return Object.assign(result, {router});
 }

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -27,6 +27,9 @@ describe('CodeBlockContent', () => {
     expect(highlightedLines).toHaveLength(2);
     expect(highlightedLines[0]?.textContent).toContain('two');
     expect(highlightedLines[1]?.textContent).toContain('three');
+    expect(highlightedLines[0]?.classList.contains('text-foreground-highlight-interactive')).toBe(
+      false,
+    );
   });
 
   test('highlights Shiki-rendered lines without re-highlighting on range-only changes', async () => {

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -32,6 +32,17 @@ describe('CodeBlockContent', () => {
     );
   });
 
+  test('does not infer diff styling from YAML list markers', () => {
+    renderCodeBlockContent({
+      code: 'steps:\n  - uses: actions/checkout@v3',
+    });
+
+    const lines = document.body.querySelectorAll('.line');
+    expect(lines[1]?.textContent).toContain('- uses: actions/checkout@v3');
+    expect(lines[1]?.classList.contains('diff')).toBe(false);
+    expect(lines[1]?.classList.contains('remove')).toBe(false);
+  });
+
   test('highlights Shiki-rendered lines without re-highlighting on range-only changes', async () => {
     const codeToHtmlMock = vi.mocked(codeToHtml);
     codeToHtmlMock.mockResolvedValue(highlightedHtml);

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -1,0 +1,96 @@
+import {render, waitFor} from '@testing-library/react';
+import type {ReactNode} from 'react';
+import {codeToHtml} from 'shiki';
+import {ThemeProvider} from '../theme/index.js';
+import {CodeBlockContent} from './index.js';
+
+vi.mock('shiki', () => ({
+  codeToHtml: vi.fn(),
+}));
+
+const highlightedHtml = [
+  '<pre class="shiki"><code>',
+  '<span class="line">one</span>',
+  '<span class="line">two</span>',
+  '<span class="line">three</span>',
+  '</code></pre>',
+].join('');
+
+describe('CodeBlockContent', () => {
+  test('highlights fallback-rendered lines', () => {
+    renderCodeBlockContent({
+      code: 'one\ntwo\nthree',
+      highlightedLineRange: {startLine: 2, endLine: 3},
+    });
+
+    const highlightedLines = document.body.querySelectorAll('.line.highlighted-line');
+    expect(highlightedLines).toHaveLength(2);
+    expect(highlightedLines[0]?.textContent).toContain('two');
+    expect(highlightedLines[1]?.textContent).toContain('three');
+  });
+
+  test('highlights Shiki-rendered lines without re-highlighting on range-only changes', async () => {
+    const codeToHtmlMock = vi.mocked(codeToHtml);
+    codeToHtmlMock.mockResolvedValue(highlightedHtml);
+    const code = 'one\ntwo\nthree';
+
+    const {rerender} = renderCodeBlockContent({
+      code,
+      syntaxHighlighting: true,
+      highlightedLineRange: {startLine: 2, endLine: 2},
+    });
+
+    await waitFor(() => {
+      expect(document.body.querySelector('.shiki-override')).not.toBeNull();
+    });
+    expect(codeToHtmlMock).toHaveBeenCalledTimes(1);
+    expect(document.body.querySelector('.line.highlighted-line')?.textContent).toContain('two');
+
+    rerender(
+      <CodeBlockContentHost>
+        <CodeBlockContent
+          language="text"
+          syntaxHighlighting
+          highlightedLineRange={{startLine: 3, endLine: 3}}
+        >
+          {code}
+        </CodeBlockContent>
+      </CodeBlockContentHost>,
+    );
+
+    await waitFor(() => {
+      expect(document.body.querySelector('.line.highlighted-line')?.textContent).toContain('three');
+    });
+    expect(codeToHtmlMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function renderCodeBlockContent({
+  code,
+  syntaxHighlighting,
+  highlightedLineRange,
+}: {
+  code: string;
+  syntaxHighlighting?: boolean | undefined;
+  highlightedLineRange?: Parameters<typeof CodeBlockContent>[0]['highlightedLineRange'];
+}) {
+  return render(
+    <CodeBlockContentHost>
+      <CodeBlockContent
+        language="text"
+        highlightedLineRange={highlightedLineRange}
+        {...(syntaxHighlighting === undefined ? {} : {syntaxHighlighting})}
+      >
+        {code}
+      </CodeBlockContent>
+    </CodeBlockContentHost>,
+  );
+}
+
+function CodeBlockContentHost({children}: {children: ReactNode}) {
+  return (
+    <ThemeProvider defaultTheme="light" storageKey="code-block-content-test-theme">
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
@@ -2,7 +2,7 @@ import {argosScreenshot} from '@argos-ci/storybook/vitest';
 import type {Meta, StoryObj} from '@storybook/react';
 import {waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
-import type {CodeBlockData} from './index.js';
+import type {CodeBlockData, CodeBlockHighlightedLineRange} from './index.js';
 import {
   CodeBlock,
   CodeBlockBody,
@@ -62,11 +62,13 @@ function CodeBlockShowcase({
   lineNumbers,
   syntaxHighlighting,
   footer,
+  highlightedLineRange,
 }: {
   data: CodeBlockData[];
   lineNumbers?: boolean;
   syntaxHighlighting?: boolean;
   footer?: ReactNode;
+  highlightedLineRange?: CodeBlockHighlightedLineRange | undefined;
 }) {
   return (
     <CodeBlock data={data}>
@@ -79,7 +81,11 @@ function CodeBlockShowcase({
       <CodeBlockBody>
         {(item) => (
           <CodeBlockItem value={item.filename} lineNumbers={lineNumbers}>
-            <CodeBlockContent language={item.language} syntaxHighlighting={syntaxHighlighting}>
+            <CodeBlockContent
+              language={item.language}
+              syntaxHighlighting={syntaxHighlighting}
+              highlightedLineRange={highlightedLineRange}
+            >
               {item.code}
             </CodeBlockContent>
           </CodeBlockItem>
@@ -113,6 +119,12 @@ export const SyntaxHighlighting: Story = {
 
 export const DiffHighlighting: Story = {
   render: () => <CodeBlockShowcase data={[diffFile]} />,
+};
+
+export const LineHighlighting: Story = {
+  render: () => (
+    <CodeBlockShowcase data={[workflowFile]} highlightedLineRange={{startLine: 3, endLine: 5}} />
+  ),
 };
 
 export const WithoutLineNumbers: Story = {

--- a/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
@@ -117,7 +117,7 @@ export const SyntaxHighlighting: Story = {
   render: () => <CodeBlockShowcase data={[sourceFile]} syntaxHighlighting />,
 };
 
-export const DiffHighlighting: Story = {
+export const DiffContent: Story = {
   render: () => <CodeBlockShowcase data={[diffFile]} />,
 };
 

--- a/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
@@ -39,12 +39,16 @@ const workflowFile: CodeBlockData = {
 };
 
 const diffFile: CodeBlockData = {
-  language: 'yaml',
-  filename: '.github/workflows/<workflow-name>.yml',
-  code: `jobs:
-  build:
-        - runs-on: ubuntu-latest
-        + runs-on: shipfox-2vcpu-ubuntu-2404`,
+  language: 'diff',
+  filename: '.github/workflows/<workflow-name>.yml.diff',
+  code: `diff --git a/.github/workflows/<workflow-name>.yml b/.github/workflows/<workflow-name>.yml
+--- a/.github/workflows/<workflow-name>.yml
++++ b/.github/workflows/<workflow-name>.yml
+@@ -1,4 +1,4 @@
+ jobs:
+   build:
+-    runs-on: ubuntu-latest
++    runs-on: shipfox-2vcpu-ubuntu-2404`,
 };
 
 const sourceFile: CodeBlockData = {
@@ -118,7 +122,20 @@ export const SyntaxHighlighting: Story = {
 };
 
 export const DiffContent: Story = {
-  render: () => <CodeBlockShowcase data={[diffFile]} />,
+  // Cold CI can snapshot the plain fallback before Shiki's dynamic import finishes.
+  play: async (ctx) => {
+    await document.fonts.ready;
+    await waitFor(
+      () => {
+        if (!ctx.canvasElement.querySelector('.shiki-override')) {
+          throw new Error('Shiki highlighting has not rendered yet');
+        }
+      },
+      {timeout: 10_000},
+    );
+    await argosScreenshot(ctx, 'CodeBlock DiffContent');
+  },
+  render: () => <CodeBlockShowcase data={[diffFile]} syntaxHighlighting />,
 };
 
 export const LineHighlighting: Story = {
@@ -135,7 +152,7 @@ export const Footer: Story = {
   render: () => (
     <div className="flex flex-col gap-16">
       <CodeBlockShowcase
-        data={[diffFile]}
+        data={[workflowFile]}
         footer={
           <CodeBlockFooter
             state="running"
@@ -145,7 +162,7 @@ export const Footer: Story = {
         }
       />
       <CodeBlockShowcase
-        data={[diffFile]}
+        data={[workflowFile]}
         footer={<CodeBlockFooter state="done" message="Runner connected!" />}
       />
     </div>

--- a/libs/shared/react/ui/src/components/code-block/code-block.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.tsx
@@ -6,7 +6,7 @@ import {useResolvedTheme} from '#hooks/useResolvedTheme.js';
 import {useShikiHighlight} from '#hooks/useShikiHighlight.js';
 import {useShikiStyleInjection} from '#hooks/useShikiStyleInjection.js';
 import {cn} from '#utils/cn.js';
-import {CodeContent} from './code-content.js';
+import {CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE, CodeContent} from './code-content.js';
 import {CodeCopyButton} from './code-copy-button.js';
 import {type CodeBlockHighlightedLineRange, isCodeBlockLineHighlighted} from './line-highlight.js';
 
@@ -254,7 +254,7 @@ export function CodeBlockItem({
           '[&_.line.diff]:after:absolute [&_.line.diff]:after:left-0 [&_.line.diff]:after:top-0 [&_.line.diff]:after:bottom-0 [&_.line.diff]:after:w-1',
           '[&_.line.diff.add]:bg-tag-success-bg [&_.line.diff.add]:text-tag-success-text [&_.line.diff.add]:after:bg-tag-success-icon',
           '[&_.line.diff.remove]:bg-tag-error-bg [&_.line.diff.remove]:text-tag-error-text [&_.line.diff.remove]:after:bg-tag-error-icon',
-          '[&_.line.highlighted-line]:bg-background-highlight-base [&_.line.highlighted-line]:text-foreground-highlight-interactive [&_.line.highlighted-line]:shadow-[inset_2px_0_0_var(--border-highlights-interactive)]',
+          CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE,
         )}
       >
         {children}

--- a/libs/shared/react/ui/src/components/code-block/code-block.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.tsx
@@ -8,6 +8,7 @@ import {useShikiStyleInjection} from '#hooks/useShikiStyleInjection.js';
 import {cn} from '#utils/cn.js';
 import {CodeContent} from './code-content.js';
 import {CodeCopyButton} from './code-copy-button.js';
+import {type CodeBlockHighlightedLineRange, isCodeBlockLineHighlighted} from './line-highlight.js';
 
 export type BundledLanguage = string;
 
@@ -162,10 +163,16 @@ export function CodeBlockCopyButton({
 }
 
 type CodeBlockFallbackProps = Omit<HTMLAttributes<HTMLDivElement>, 'children'> & {
+  highlightedLineRange?: CodeBlockHighlightedLineRange | null | undefined;
   children: string;
 };
 
-function CodeBlockFallback({children, className, ...props}: CodeBlockFallbackProps) {
+function CodeBlockFallback({
+  children,
+  className,
+  highlightedLineRange,
+  ...props
+}: CodeBlockFallbackProps) {
   const lines = children?.toString().split('\n') ?? [];
   return (
     <pre
@@ -180,7 +187,14 @@ function CodeBlockFallback({children, className, ...props}: CodeBlockFallbackPro
           const key = `${index}-${line}`;
 
           return (
-            <span className={cn('line', diffClass)} key={key}>
+            <span
+              className={cn(
+                'line',
+                diffClass,
+                isCodeBlockLineHighlighted(index + 1, highlightedLineRange) && 'highlighted-line',
+              )}
+              key={key}
+            >
               {line}
             </span>
           );
@@ -240,6 +254,7 @@ export function CodeBlockItem({
           '[&_.line.diff]:after:absolute [&_.line.diff]:after:left-0 [&_.line.diff]:after:top-0 [&_.line.diff]:after:bottom-0 [&_.line.diff]:after:w-1',
           '[&_.line.diff.add]:bg-tag-success-bg [&_.line.diff.add]:text-tag-success-text [&_.line.diff.add]:after:bg-tag-success-icon',
           '[&_.line.diff.remove]:bg-tag-error-bg [&_.line.diff.remove]:text-tag-error-text [&_.line.diff.remove]:after:bg-tag-error-icon',
+          '[&_.line.highlighted-line]:bg-background-highlight-base [&_.line.highlighted-line]:text-foreground-highlight-interactive [&_.line.highlighted-line]:shadow-[inset_2px_0_0_var(--border-highlights-interactive)]',
         )}
       >
         {children}
@@ -255,6 +270,7 @@ export type CodeBlockContentProps = Omit<HTMLAttributes<HTMLDivElement>, 'childr
   };
   language?: BundledLanguage;
   syntaxHighlighting?: boolean;
+  highlightedLineRange?: CodeBlockHighlightedLineRange | null | undefined;
   children: string;
 };
 
@@ -266,6 +282,7 @@ export function CodeBlockContent({
   },
   language = 'typescript',
   syntaxHighlighting = false,
+  highlightedLineRange,
   ...props
 }: CodeBlockContentProps) {
   const resolvedTheme = useResolvedTheme();
@@ -281,7 +298,11 @@ export function CodeBlockContent({
   });
 
   if (!syntaxHighlighting || isLoading) {
-    return <CodeBlockFallback {...props}>{children}</CodeBlockFallback>;
+    return (
+      <CodeBlockFallback highlightedLineRange={highlightedLineRange} {...props}>
+        {children}
+      </CodeBlockFallback>
+    );
   }
 
   return (
@@ -290,6 +311,7 @@ export function CodeBlockContent({
       highlightedCode={highlightedCode}
       isLoading={isLoading}
       syntaxHighlighting={syntaxHighlighting}
+      highlightedLineRange={highlightedLineRange}
       {...props}
     />
   );

--- a/libs/shared/react/ui/src/components/code-block/code-block.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.tsx
@@ -181,16 +181,12 @@ function CodeBlockFallback({
     >
       <code>
         {lines.map((line, index) => {
-          const isDiffRemove = line.trim().startsWith('-');
-          const isDiffAdd = line.trim().startsWith('+');
-          const diffClass = isDiffRemove ? 'diff remove' : isDiffAdd ? 'diff add' : '';
           const key = `${index}-${line}`;
 
           return (
             <span
               className={cn(
                 'line',
-                diffClass,
                 isCodeBlockLineHighlighted(index + 1, highlightedLineRange) && 'highlighted-line',
               )}
               key={key}

--- a/libs/shared/react/ui/src/components/code-block/code-content.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-content.tsx
@@ -6,6 +6,12 @@ import {
   isCodeBlockLineHighlighted,
 } from './line-highlight.js';
 
+export const CODE_BLOCK_HIGHLIGHTED_LINE_STYLE =
+  'bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
+
+export const CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE =
+  '[&_.line.highlighted-line]:bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:[&_.line.highlighted-line]:bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] [&_.line.highlighted-line]:shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
+
 type CodeContentProps = HTMLAttributes<HTMLElement> & {
   code: string;
   highlightedCode?: string | undefined;
@@ -26,8 +32,6 @@ export function CodeContent({
   ...props
 }: CodeContentProps) {
   const shouldShowHighlighted = syntaxHighlighting && !isLoading && highlightedCode;
-  const lineHighlightClasses =
-    '[&_.line.highlighted-line]:bg-background-highlight-base [&_.line.highlighted-line]:text-foreground-highlight-interactive [&_.line.highlighted-line]:shadow-[inset_2px_0_0_var(--border-highlights-interactive)]';
 
   if (shouldShowHighlighted) {
     const codeHtml = highlightCodeBlockHtmlLines(highlightedCode, highlightedLineRange);
@@ -40,7 +44,7 @@ export function CodeContent({
           lineNumbers &&
             '[&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-neutral-subtle [&_.line]:before:font-code [&_.line]:before:select-none',
           '[&_.line]:block [&_.line]:px-12 [&_.line]:w-full [&_.line]:relative [&_.line]:font-code [&_.line]:text-xs [&_.line]:leading-20 [&_.line]:min-h-[1.25rem]',
-          lineHighlightClasses,
+          CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE,
           className,
         )}
         // biome-ignore lint/security/noDangerouslySetInnerHtml: only Shiki-generated markup is rendered here.
@@ -68,7 +72,7 @@ export function CodeContent({
               className={cn(
                 'line px-12 w-full relative font-code text-xs leading-20 min-h-[1.25rem]',
                 isCodeBlockLineHighlighted(index + 1, highlightedLineRange) &&
-                  'highlighted-line bg-background-highlight-base text-foreground-highlight-interactive shadow-[inset_2px_0_0_var(--border-highlights-interactive)]',
+                  `highlighted-line ${CODE_BLOCK_HIGHLIGHTED_LINE_STYLE}`,
               )}
               key={key}
             >

--- a/libs/shared/react/ui/src/components/code-block/code-content.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-content.tsx
@@ -1,5 +1,10 @@
 import type {HTMLAttributes} from 'react';
 import {cn} from '#utils/cn.js';
+import {
+  type CodeBlockHighlightedLineRange,
+  highlightCodeBlockHtmlLines,
+  isCodeBlockLineHighlighted,
+} from './line-highlight.js';
 
 type CodeContentProps = HTMLAttributes<HTMLElement> & {
   code: string;
@@ -7,6 +12,7 @@ type CodeContentProps = HTMLAttributes<HTMLElement> & {
   isLoading: boolean;
   syntaxHighlighting: boolean;
   lineNumbers?: boolean;
+  highlightedLineRange?: CodeBlockHighlightedLineRange | null | undefined;
 };
 
 export function CodeContent({
@@ -15,12 +21,17 @@ export function CodeContent({
   isLoading,
   syntaxHighlighting,
   lineNumbers = false,
+  highlightedLineRange,
   className,
   ...props
 }: CodeContentProps) {
   const shouldShowHighlighted = syntaxHighlighting && !isLoading && highlightedCode;
+  const lineHighlightClasses =
+    '[&_.line.highlighted-line]:bg-background-highlight-base [&_.line.highlighted-line]:text-foreground-highlight-interactive [&_.line.highlighted-line]:shadow-[inset_2px_0_0_var(--border-highlights-interactive)]';
 
   if (shouldShowHighlighted) {
+    const codeHtml = highlightCodeBlockHtmlLines(highlightedCode, highlightedLineRange);
+
     return (
       <div
         {...props}
@@ -29,10 +40,11 @@ export function CodeContent({
           lineNumbers &&
             '[&_code]:[counter-reset:line] [&_code]:[counter-increment:line_0] [&_.line]:before:content-[counter(line)] [&_.line]:before:inline-block [&_.line]:before:[counter-increment:line] [&_.line]:before:w-16 [&_.line]:before:mr-16 [&_.line]:before:text-xs [&_.line]:before:text-right [&_.line]:before:text-foreground-neutral-subtle [&_.line]:before:font-code [&_.line]:before:select-none',
           '[&_.line]:block [&_.line]:px-12 [&_.line]:w-full [&_.line]:relative [&_.line]:font-code [&_.line]:text-xs [&_.line]:leading-20 [&_.line]:min-h-[1.25rem]',
+          lineHighlightClasses,
           className,
         )}
         // biome-ignore lint/security/noDangerouslySetInnerHtml: only Shiki-generated markup is rendered here.
-        dangerouslySetInnerHTML={{__html: highlightedCode}}
+        dangerouslySetInnerHTML={{__html: codeHtml}}
       />
     );
   }
@@ -53,7 +65,11 @@ export function CodeContent({
           const key = `${index}-${line}`;
           return (
             <span
-              className="line px-12 w-full relative font-code text-xs leading-20 min-h-[1.25rem]"
+              className={cn(
+                'line px-12 w-full relative font-code text-xs leading-20 min-h-[1.25rem]',
+                isCodeBlockLineHighlighted(index + 1, highlightedLineRange) &&
+                  'highlighted-line bg-background-highlight-base text-foreground-highlight-interactive shadow-[inset_2px_0_0_var(--border-highlights-interactive)]',
+              )}
               key={key}
             >
               {line}

--- a/libs/shared/react/ui/src/components/code-block/index.ts
+++ b/libs/shared/react/ui/src/components/code-block/index.ts
@@ -1,3 +1,4 @@
 export * from './code-block.js';
 export * from './code-block-footer.js';
 export * from './code-tabs.js';
+export type {CodeBlockHighlightedLineRange} from './line-highlight.js';

--- a/libs/shared/react/ui/src/components/code-block/line-highlight.test.ts
+++ b/libs/shared/react/ui/src/components/code-block/line-highlight.test.ts
@@ -1,0 +1,39 @@
+import {highlightCodeBlockHtmlLines, isCodeBlockLineHighlighted} from './line-highlight.js';
+
+describe('code block line highlighting', () => {
+  test('detects inclusive highlighted line ranges', () => {
+    expect(isCodeBlockLineHighlighted(2, {startLine: 2, endLine: 4})).toBe(true);
+    expect(isCodeBlockLineHighlighted(4, {startLine: 2, endLine: 4})).toBe(true);
+    expect(isCodeBlockLineHighlighted(5, {startLine: 2, endLine: 4})).toBe(false);
+  });
+
+  test('normalizes reversed ranges and ignores invalid ranges', () => {
+    expect(isCodeBlockLineHighlighted(3, {startLine: 4, endLine: 2})).toBe(true);
+    expect(isCodeBlockLineHighlighted(1, {startLine: 0, endLine: 2})).toBe(false);
+    expect(isCodeBlockLineHighlighted(1, null)).toBe(false);
+  });
+
+  test('decorates Shiki line spans without changing unselected lines', () => {
+    const html = [
+      '<pre class="shiki"><code>',
+      '<span class="line">one</span>',
+      '<span class="line">two</span>',
+      '<span class="line diff add">three</span>',
+      '</code></pre>',
+    ].join('');
+
+    const decorated = highlightCodeBlockHtmlLines(html, {startLine: 2, endLine: 3});
+
+    expect(decorated).toContain('<span class="line">one</span>');
+    expect(decorated).toContain('<span class="line highlighted-line">two</span>');
+    expect(decorated).toContain('<span class="line diff add highlighted-line">three</span>');
+  });
+
+  test('does not duplicate highlight classes on already highlighted spans', () => {
+    const html = '<span class="line highlighted-line">one</span>';
+
+    const decorated = highlightCodeBlockHtmlLines(html, {startLine: 1, endLine: 1});
+
+    expect(decorated).toBe(html);
+  });
+});

--- a/libs/shared/react/ui/src/components/code-block/line-highlight.ts
+++ b/libs/shared/react/ui/src/components/code-block/line-highlight.ts
@@ -1,0 +1,52 @@
+export interface CodeBlockHighlightedLineRange {
+  startLine: number;
+  endLine: number;
+}
+
+export const CODE_BLOCK_HIGHLIGHTED_LINE_CLASS = 'highlighted-line';
+
+const CODE_BLOCK_LINE_SPAN_RE = /<span class="([^"]*\bline\b[^"]*)"/gu;
+const CLASS_NAME_SEPARATOR_RE = /\s+/u;
+
+export function isCodeBlockLineHighlighted(
+  lineNumber: number,
+  range: CodeBlockHighlightedLineRange | null | undefined,
+): boolean {
+  const normalized = normalizeCodeBlockHighlightedLineRange(range);
+  if (!normalized) return false;
+  return lineNumber >= normalized.startLine && lineNumber <= normalized.endLine;
+}
+
+export function highlightCodeBlockHtmlLines(
+  html: string,
+  range: CodeBlockHighlightedLineRange | null | undefined,
+): string {
+  const normalized = normalizeCodeBlockHighlightedLineRange(range);
+  if (!normalized) return html;
+
+  let lineNumber = 0;
+  return html.replace(CODE_BLOCK_LINE_SPAN_RE, (match, className: string) => {
+    lineNumber += 1;
+    if (lineNumber < normalized.startLine || lineNumber > normalized.endLine) return match;
+    if (className.split(CLASS_NAME_SEPARATOR_RE).includes(CODE_BLOCK_HIGHLIGHTED_LINE_CLASS)) {
+      return match;
+    }
+    return `<span class="${className} ${CODE_BLOCK_HIGHLIGHTED_LINE_CLASS}"`;
+  });
+}
+
+function normalizeCodeBlockHighlightedLineRange(
+  range: CodeBlockHighlightedLineRange | null | undefined,
+): CodeBlockHighlightedLineRange | undefined {
+  if (!range) return undefined;
+  if (!Number.isFinite(range.startLine) || !Number.isFinite(range.endLine)) return undefined;
+
+  const startLine = Math.trunc(range.startLine);
+  const endLine = Math.trunc(range.endLine);
+  if (startLine < 1 || endLine < 1) return undefined;
+
+  return {
+    startLine: Math.min(startLine, endLine),
+    endLine: Math.max(startLine, endLine),
+  };
+}


### PR DESCRIPTION
Add URL-owned workflow run view state for job, step, and attempt selection.

Workflow run pages previously kept selection in local component state, so deep links, reloads, and browser history could lose the selected job or expanded attempt. This moves search-param parsing and updates to the page boundary while keeping run-data resolution in a pure helper, so invalid or mismatched URL state resolves consistently after data loads.

The source panel now uses the selected step source range to highlight matching workflow source lines. `@shipfox/react-ui` CodeBlock content supports that by decorating fallback and Shiki-rendered line markup without re-running Shiki on selection-only changes.

Review note: TanStack Router search writes are intentionally localized to the run page and run rail links; `WorkflowRunView` remains uncontrolled when no selection prop is supplied.

Closes ENG-590

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make workflow run selection URL-driven so deep links, reloads, and browser navigation restore the same job/step/attempt view. Add line-range highlighting to `@shipfox/react-ui` CodeBlock for the selected step and remove implicit diff styling to avoid false positives. Fixes ENG-590.

- **New Features**
  - Persist selection in search params: `?job=<id>&step=<id>&attempt=<id>`. Back/forward and reload restore the view.
  - Consistent fallbacks: valid step overrides a mismatched job; invalid attempt falls back to current or latest; invalid IDs fall back to the first job; empty runs are handled.
  - Run page reads/writes search: selecting an attempt writes `job`/`step`/`attempt`; selecting a job writes only `job` and clears `step`/`attempt`; collapsing clears `step`/`attempt` but keeps `job`; run-rail links and the index→latest redirect clear stale selection.
  - `WorkflowRunView` supports controlled selection via `selection` and `onSelectionChange`.
  - `WorkflowSourcePanel` highlights the selected step’s source lines using CodeBlock line-range highlighting. `@shipfox/react-ui` CodeBlock decorates Shiki and fallback markup without re-running `shiki` on range-only changes, and uses a subtle background wash with a slim gutter marker without altering syntax colors.
  - Stop inferring diff styling from `+`/`-` lines in CodeBlock so YAML list markers render normally; diff styling can be added via `shiki` when needed. Updated diff stories to render with `diff` syntax via `shiki`, and kept footer/line-number examples on YAML.

- **Migration**
  - Deep-link params: `job`, `step`, `attempt`.
  - Optional control: pass `selection` and `onSelectionChange` to `WorkflowRunView`; omit to keep existing behavior.
  - `WorkflowStepList` now accepts `selectedAttemptId: string | null` (use `null` for a controlled collapsed state).

<sup>Written for commit e9cf16dccf507d4889df8a4b468477490088d88e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

