### PR TITLE
Queue transactional emails through outbox

### DIFF
--- a/.changeset/brisk-mails-queue.md
+++ b/.changeset/brisk-mails-queue.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-auth-dto": minor
+"@shipfox/api-workspaces-dto": minor
+"@shipfox/api-auth": patch
+"@shipfox/api-workspaces": patch
+---
+
+Queues auth and workspace transactional emails through module-owned outbox events so account verification, password reset, and invitation sends retry outside request transactions.

--- a/libs/api/auth-dto/src/events.ts
+++ b/libs/api/auth-dto/src/events.ts
@@ -1,0 +1,34 @@
+import {z} from 'zod';
+
+const emailLinkSchema = z.string().url();
+
+export const AUTH_EMAIL_VERIFICATION_SEND_REQUESTED =
+  'auth.email_verification.send_requested' as const;
+export const AUTH_PASSWORD_RESET_SEND_REQUESTED = 'auth.password_reset.send_requested' as const;
+
+export const authEmailVerificationSendRequestedSchema = z.object({
+  email: z.string().email(),
+  verifyLink: emailLinkSchema,
+});
+export type AuthEmailVerificationSendRequestedEvent = z.infer<
+  typeof authEmailVerificationSendRequestedSchema
+>;
+
+export const authPasswordResetSendRequestedSchema = z.object({
+  email: z.string().email(),
+  resetLink: emailLinkSchema,
+  expiresInHours: z.number().int().positive(),
+});
+export type AuthPasswordResetSendRequestedEvent = z.infer<
+  typeof authPasswordResetSendRequestedSchema
+>;
+
+export interface AuthEventMap {
+  [AUTH_EMAIL_VERIFICATION_SEND_REQUESTED]: AuthEmailVerificationSendRequestedEvent;
+  [AUTH_PASSWORD_RESET_SEND_REQUESTED]: AuthPasswordResetSendRequestedEvent;
+}
+
+export const authEventSchemas = {
+  [AUTH_EMAIL_VERIFICATION_SEND_REQUESTED]: authEmailVerificationSendRequestedSchema,
+  [AUTH_PASSWORD_RESET_SEND_REQUESTED]: authPasswordResetSendRequestedSchema,
+} satisfies Record<keyof AuthEventMap, z.ZodType>;

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -1,4 +1,14 @@
 export {
+  AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+  AUTH_PASSWORD_RESET_SEND_REQUESTED,
+  type AuthEmailVerificationSendRequestedEvent,
+  type AuthEventMap,
+  type AuthPasswordResetSendRequestedEvent,
+  authEmailVerificationSendRequestedSchema,
+  authEventSchemas,
+  authPasswordResetSendRequestedSchema,
+} from '../events.js';
+export {
   type ChangePasswordBodyDto,
   changePasswordBodySchema,
   EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,

--- a/libs/api/auth/drizzle/0001_famous_wendell_rand.sql
+++ b/libs/api/auth/drizzle/0001_famous_wendell_rand.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "auth_outbox" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"event_type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX "auth_outbox_pending_idx" ON "auth_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "auth_outbox_dispatched_retention_idx" ON "auth_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;

--- a/libs/api/auth/drizzle/meta/0001_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,524 @@
+{
+  "id": "11d732fa-229a-40c2-86d7-d9cfc36e7bf2",
+  "prevId": "6116801e-1d22-4407-994c-71574663bb86",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_email_verifications": {
+      "name": "auth_email_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_email_verifications_hashed_token_unique": {
+          "name": "auth_email_verifications_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_email_verifications_user_id_idx": {
+          "name": "auth_email_verifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_email_verifications_user_id_auth_users_id_fk": {
+          "name": "auth_email_verifications_user_id_auth_users_id_fk",
+          "tableFrom": "auth_email_verifications",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_outbox": {
+      "name": "auth_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "auth_outbox_pending_idx": {
+          "name": "auth_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_outbox_dispatched_retention_idx": {
+          "name": "auth_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_password_resets": {
+      "name": "auth_password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_password_resets_hashed_token_unique": {
+          "name": "auth_password_resets_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_password_resets_user_id_idx": {
+          "name": "auth_password_resets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_password_resets_user_id_auth_users_id_fk": {
+          "name": "auth_password_resets_user_id_auth_users_id_fk",
+          "tableFrom": "auth_password_resets",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_refresh_tokens": {
+      "name": "auth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_refresh_tokens_hashed_token_unique": {
+          "name": "auth_refresh_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_refresh_tokens_user_id_idx": {
+          "name": "auth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_refresh_tokens_user_id_auth_users_id_fk": {
+          "name": "auth_refresh_tokens_user_id_auth_users_id_fk",
+          "tableFrom": "auth_refresh_tokens",
+          "tableTo": "auth_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_users": {
+      "name": "auth_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_password": {
+          "name": "hashed_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified_at": {
+          "name": "email_verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "auth_user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_user_status": {
+      "name": "auth_user_status",
+      "schema": "public",
+      "values": ["active", "suspended", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/auth/drizzle/meta/_journal.json
+++ b/libs/api/auth/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777229181112,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1782352215051,
+      "tag": "0001_famous_wendell_rand",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -61,6 +61,7 @@
     "@shipfox/node-mailer": "workspace:*",
     "@shipfox/node-module": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-tokens": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/libs/api/auth/src/core/auth.test.ts
+++ b/libs/api/auth/src/core/auth.test.ts
@@ -1,7 +1,11 @@
-import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
+import {
+  AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+  AUTH_PASSWORD_RESET_SEND_REQUESTED,
+  EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+} from '@shipfox/api-auth-dto';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
-import {eq} from 'drizzle-orm';
+import {and, desc, eq, sql} from 'drizzle-orm';
 import {
   changePassword,
   confirmEmailVerification,
@@ -26,6 +30,7 @@ import {verifyUserToken} from '#core/jwt.js';
 import {db} from '#db/db.js';
 import * as refreshTokenDb from '#db/refresh-tokens.js';
 import {emailVerifications} from '#db/schema/email-verifications.js';
+import {authOutbox} from '#db/schema/outbox.js';
 import {refreshTokens} from '#db/schema/refresh-tokens.js';
 import {users} from '#db/schema/users.js';
 import {findUserByEmail, findUserById} from '#db/users.js';
@@ -73,12 +78,31 @@ const listMembershipsByUserMock = vi.mocked(listMembershipsByUser);
 
 const TOKEN_RE = /token=([\w\-_=]+)/;
 
-function extractToken(message: MailMessage | undefined): string {
-  const match = message?.text?.match(TOKEN_RE);
+function extractToken(link: string | undefined): string {
+  const match = link?.match(TOKEN_RE);
   if (!match?.[1]) {
-    throw new Error('Expected message to contain a token link');
+    throw new Error('Expected link to contain a token');
   }
   return match[1];
+}
+
+async function outboxEventsTo(email: string, eventType: string) {
+  return await db()
+    .select()
+    .from(authOutbox)
+    .where(
+      and(eq(authOutbox.eventType, eventType), sql`${authOutbox.payload}->>'email' = ${email}`),
+    )
+    .orderBy(desc(authOutbox.createdAt));
+}
+
+async function latestEmailLinkTo(email: string, eventType: string): Promise<string> {
+  const event = (await outboxEventsTo(email, eventType))[0];
+  const payload = event?.payload as {verifyLink?: string; resetLink?: string} | undefined;
+  const link =
+    eventType === AUTH_EMAIL_VERIFICATION_SEND_REQUESTED ? payload?.verifyLink : payload?.resetLink;
+  if (!link) throw new Error(`No ${eventType} outbox link for ${email}`);
+  return link;
 }
 
 describe('auth core', () => {
@@ -101,9 +125,10 @@ describe('auth core', () => {
     expect(user.email).toBe(email);
     expect(user.name).toBe('Sign Up');
     expect(user.emailVerifiedAt).toBeNull();
-    expect(captured).toHaveLength(1);
-    expect(captured[0]?.to).toBe(email);
-    expect(captured[0]?.text).toContain(`${testConfig.clientBaseUrl}/auth/verify-email?token=`);
+    expect(captured).toHaveLength(0);
+    expect(await latestEmailLinkTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toContain(
+      `${testConfig.clientBaseUrl}/auth/verify-email?token=`,
+    );
   });
 
   test('signup rejects duplicate email with a business error', async () => {
@@ -221,7 +246,9 @@ describe('auth core', () => {
       email: `verify-${crypto.randomUUID()}@example.com`,
       password: 'correct horse battery staple',
     });
-    const token = extractToken(captured[0]);
+    const token = extractToken(
+      await latestEmailLinkTo(user.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+    );
 
     const result = await confirmEmailVerification({token});
     const verified = await findUserById({id: user.id});
@@ -250,8 +277,16 @@ describe('auth core', () => {
       email: `missing-${crypto.randomUUID()}@example.com`,
     });
 
-    expect(captured).toHaveLength(1);
-    expect(captured[0]?.to).toBe(unverified.email);
+    expect(captured).toHaveLength(0);
+    expect(
+      await outboxEventsTo(unverified.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+    ).toHaveLength(1);
+    expect(
+      await outboxEventsTo(verified.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+    ).toHaveLength(0);
+    expect(
+      await outboxEventsTo(inactive.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+    ).toHaveLength(0);
     expect(sent.nextResendAvailableAt).toBeInstanceOf(Date);
     expect(verifiedResult.nextResendAvailableAt).toBeInstanceOf(Date);
     expect(inactiveResult.nextResendAvailableAt).toBeInstanceOf(Date);
@@ -263,7 +298,9 @@ describe('auth core', () => {
       email: `resend-cooldown-${crypto.randomUUID()}@example.com`,
       password: 'correct horse battery staple',
     });
-    const token = extractToken(captured[0]);
+    const token = extractToken(
+      await latestEmailLinkTo(user.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+    );
     const existingCreatedAt = new Date(
       Date.now() - (EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS / 2) * 1000,
     );
@@ -281,7 +318,10 @@ describe('auth core', () => {
     expect(result.nextResendAvailableAt.getTime()).toBeGreaterThanOrEqual(
       beforeCall + EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS * 1000,
     );
-    expect(captured).toHaveLength(1);
+    expect(captured).toHaveLength(0);
+    expect(await outboxEventsTo(user.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(
+      1,
+    );
     expect(verified.user.id).toBe(user.id);
   });
 
@@ -301,8 +341,10 @@ describe('auth core', () => {
     const result = await resendEmailVerification({email: user.email});
 
     expect(result.nextResendAvailableAt).toBeInstanceOf(Date);
-    expect(captured).toHaveLength(2);
-    expect(captured[1]?.to).toBe(user.email);
+    expect(captured).toHaveLength(0);
+    expect(await outboxEventsTo(user.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(
+      2,
+    );
   });
 
   test('resendEmailVerification serializes duplicate requests for one user', async () => {
@@ -314,8 +356,10 @@ describe('auth core', () => {
     ]);
 
     expect(results).toHaveLength(2);
-    expect(captured).toHaveLength(1);
-    expect(captured[0]?.to).toBe(user.email);
+    expect(captured).toHaveLength(0);
+    expect(await outboxEventsTo(user.email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(
+      1,
+    );
   });
 
   test('password reset request and confirm update the password and invalidate the token', async () => {
@@ -324,7 +368,9 @@ describe('auth core', () => {
     const newPassword = 'new password is also long';
 
     await requestPasswordReset({email: user.email});
-    const resetToken = extractToken(captured[0]);
+    const resetToken = extractToken(
+      await latestEmailLinkTo(user.email, AUTH_PASSWORD_RESET_SEND_REQUESTED),
+    );
     const resetResult = await confirmPasswordReset({token: resetToken, newPassword});
 
     const oldLogin = login({email: user.email, password: user.plainPassword});
@@ -349,6 +395,7 @@ describe('auth core', () => {
     await requestPasswordReset({email});
 
     expect(captured).toHaveLength(0);
+    expect(await outboxEventsTo(email, AUTH_PASSWORD_RESET_SEND_REQUESTED)).toHaveLength(0);
   });
 
   test('changePassword validates the current password and updates the password', async () => {
@@ -437,9 +484,10 @@ describe('auth core', () => {
 
     await requestPasswordReset({email: user.email});
 
-    expect(captured).toHaveLength(1);
-    expect(captured[0]?.to).toBe(user.email);
-    expect(captured[0]?.text).toContain(`${testConfig.clientBaseUrl}/auth/reset?token=`);
+    expect(captured).toHaveLength(0);
+    expect(await latestEmailLinkTo(user.email, AUTH_PASSWORD_RESET_SEND_REQUESTED)).toContain(
+      `${testConfig.clientBaseUrl}/auth/reset?token=`,
+    );
   });
 
   test('signup persists a hashed password', async () => {

--- a/libs/api/auth/src/core/auth.ts
+++ b/libs/api/auth/src/core/auth.ts
@@ -8,9 +8,8 @@ import {
   TokenExpiredError,
   TokenInvalidError as WorkspacesTokenInvalidError,
 } from '@shipfox/api-workspaces';
-import {renderEmail} from '@shipfox/node-email';
 import {generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
-import {config, mailer} from '#config.js';
+import {config} from '#config.js';
 import {
   consumeEmailVerification,
   createEmailVerification,
@@ -99,21 +98,25 @@ async function createRefreshSession(user: User): Promise<string> {
   return refreshToken;
 }
 
-async function sendVerificationEmail(user: User, rawToken: string): Promise<void> {
-  const link = `${config.CLIENT_BASE_URL}/auth/verify-email?token=${rawToken}`;
-  const email = await renderEmail('verify-email', {verifyLink: link});
-  await mailer.send({to: user.email, ...email});
+function verificationLink(rawToken: string): string {
+  return `${config.CLIENT_BASE_URL}/auth/verify-email?token=${rawToken}`;
 }
 
-async function createAndSendEmailVerification(user: User): Promise<void> {
+function passwordResetLink(rawToken: string): string {
+  return `${config.CLIENT_BASE_URL}/auth/reset?token=${rawToken}`;
+}
+
+async function createAndQueueEmailVerification(user: User): Promise<void> {
   const rawToken = generateOpaqueToken('emailVerification');
   await createEmailVerification({
     userId: user.id,
     hashedToken: hashOpaqueToken(rawToken),
     expiresAt: hoursFromNow(VERIFICATION_TTL_HOURS),
+    sendEmail: {
+      email: user.email,
+      verifyLink: verificationLink(rawToken),
+    },
   });
-
-  await sendVerificationEmail(user, rawToken);
 }
 
 export interface SignupParams {
@@ -135,7 +138,7 @@ export async function signup(params: SignupParams): Promise<User> {
     name: params.name ?? null,
   });
 
-  await createAndSendEmailVerification(user);
+  await createAndQueueEmailVerification(user);
 
   return user;
 }
@@ -413,11 +416,10 @@ export async function resendEmailVerification(params: {
     hashedToken: hashOpaqueToken(rawToken),
     expiresAt: hoursFromNow(VERIFICATION_TTL_HOURS),
     cooldownSeconds: EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+    sendEmail: {
+      verifyLink: verificationLink(rawToken),
+    },
   });
-
-  if (result.user && result.verification) {
-    await sendVerificationEmail(result.user, rawToken);
-  }
 
   return {nextResendAvailableAt: result.nextResendAvailableAt};
 }
@@ -433,14 +435,12 @@ export async function requestPasswordReset(params: {email: string}): Promise<voi
     userId: user.id,
     hashedToken: hashOpaqueToken(rawToken),
     expiresAt: hoursFromNow(RESET_TTL_HOURS),
+    sendEmail: {
+      email: user.email,
+      resetLink: passwordResetLink(rawToken),
+      expiresInHours: RESET_TTL_HOURS,
+    },
   });
-
-  const link = `${config.CLIENT_BASE_URL}/auth/reset?token=${rawToken}`;
-  const email = await renderEmail('reset-password', {
-    resetLink: link,
-    expiresInHours: RESET_TTL_HOURS,
-  });
-  await mailer.send({to: user.email, ...email});
 }
 
 export interface ConfirmPasswordResetResult {

--- a/libs/api/auth/src/db/db.ts
+++ b/libs/api/auth/src/db/db.ts
@@ -1,6 +1,7 @@
 import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
 import {emailVerifications} from './schema/email-verifications.js';
+import {authOutbox} from './schema/outbox.js';
 import {passwordResets} from './schema/password-resets.js';
 import {refreshTokens} from './schema/refresh-tokens.js';
 import {users} from './schema/users.js';
@@ -10,6 +11,7 @@ export const schema = {
   passwordResets,
   refreshTokens,
   emailVerifications,
+  authOutbox,
 };
 
 let _db: NodePgDatabase<typeof schema> | undefined;

--- a/libs/api/auth/src/db/email-verifications.test.ts
+++ b/libs/api/auth/src/db/email-verifications.test.ts
@@ -14,6 +14,7 @@ describe('email-verifications db', () => {
       userId: user.id,
       hashedToken: hashOpaqueToken(raw),
       expiresAt: new Date(Date.now() + 60_000),
+      skipEmail: true,
     });
 
     const first = await consumeEmailVerification({hashedToken: verification.hashedToken});
@@ -29,6 +30,7 @@ describe('email-verifications db', () => {
       userId: user.id,
       hashedToken: hashOpaqueToken(`expired-v-${crypto.randomUUID()}`),
       expiresAt: new Date(Date.now() - 60_000),
+      skipEmail: true,
     });
 
     const consumed = await consumeEmailVerification({hashedToken: verification.hashedToken});
@@ -42,12 +44,14 @@ describe('email-verifications db', () => {
       userId: user.id,
       hashedToken: hashOpaqueToken(`first-v-${crypto.randomUUID()}`),
       expiresAt: new Date(Date.now() + 60_000),
+      skipEmail: true,
     });
 
     await createEmailVerification({
       userId: user.id,
       hashedToken: hashOpaqueToken(`second-v-${crypto.randomUUID()}`),
       expiresAt: new Date(Date.now() + 60_000),
+      skipEmail: true,
     });
 
     const consumeFirst = await consumeEmailVerification({hashedToken: first.hashedToken});

--- a/libs/api/auth/src/db/email-verifications.ts
+++ b/libs/api/auth/src/db/email-verifications.ts
@@ -8,12 +8,17 @@ import {emailVerifications, toEmailVerification} from './schema/email-verificati
 import {authOutbox} from './schema/outbox.js';
 import {toUser, users} from './schema/users.js';
 
-export interface CreateEmailVerificationParams {
+interface CreateEmailVerificationBaseParams {
   userId: string;
   hashedToken: string;
   expiresAt: Date;
-  sendEmail?: {email: string; verifyLink: string} | undefined;
 }
+
+export type CreateEmailVerificationParams = CreateEmailVerificationBaseParams &
+  (
+    | {sendEmail: {email: string; verifyLink: string}; skipEmail?: never}
+    | {sendEmail?: never; skipEmail: true}
+  );
 
 export async function createEmailVerification(
   params: CreateEmailVerificationParams,
@@ -50,7 +55,7 @@ export interface CreateResendEmailVerificationParams {
   hashedToken: string;
   expiresAt: Date;
   cooldownSeconds: number;
-  sendEmail?: {verifyLink: string} | undefined;
+  sendEmail: {verifyLink: string};
   now?: Date | undefined;
 }
 

--- a/libs/api/auth/src/db/email-verifications.ts
+++ b/libs/api/auth/src/db/email-verifications.ts
@@ -1,14 +1,18 @@
+import {AUTH_EMAIL_VERIFICATION_SEND_REQUESTED, type AuthEventMap} from '@shipfox/api-auth-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, desc, eq, gt, isNull, sql} from 'drizzle-orm';
 import type {EmailVerification} from '#core/entities/email-verification.js';
 import type {User} from '#core/entities/user.js';
 import {db} from './db.js';
 import {emailVerifications, toEmailVerification} from './schema/email-verifications.js';
+import {authOutbox} from './schema/outbox.js';
 import {toUser, users} from './schema/users.js';
 
 export interface CreateEmailVerificationParams {
   userId: string;
   hashedToken: string;
   expiresAt: Date;
+  sendEmail?: {email: string; verifyLink: string} | undefined;
 }
 
 export async function createEmailVerification(
@@ -31,6 +35,12 @@ export async function createEmailVerification(
 
     const row = rows[0];
     if (!row) throw new Error('Insert returned no rows');
+    if (params.sendEmail) {
+      await writeOutboxEvent<AuthEventMap>(tx, authOutbox, {
+        type: AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+        payload: params.sendEmail,
+      });
+    }
     return toEmailVerification(row);
   });
 }
@@ -40,6 +50,7 @@ export interface CreateResendEmailVerificationParams {
   hashedToken: string;
   expiresAt: Date;
   cooldownSeconds: number;
+  sendEmail?: {verifyLink: string} | undefined;
   now?: Date | undefined;
 }
 
@@ -106,6 +117,15 @@ export async function createResendEmailVerification(
     const row = rows[0];
     if (!row) throw new Error('Insert returned no rows');
     const verification = toEmailVerification(row);
+    if (params.sendEmail) {
+      await writeOutboxEvent<AuthEventMap>(tx, authOutbox, {
+        type: AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+        payload: {
+          email: user.email,
+          verifyLink: params.sendEmail.verifyLink,
+        },
+      });
+    }
     return {
       user,
       verification,

--- a/libs/api/auth/src/db/password-resets.test.ts
+++ b/libs/api/auth/src/db/password-resets.test.ts
@@ -14,6 +14,7 @@ describe('password-resets db', () => {
       userId: user.id,
       hashedToken: hashOpaqueToken(raw),
       expiresAt: new Date(Date.now() + 60_000),
+      skipEmail: true,
     });
 
     const first = await consumePasswordReset({hashedToken: reset.hashedToken});
@@ -29,6 +30,7 @@ describe('password-resets db', () => {
       userId: user.id,
       hashedToken: hashOpaqueToken(`expired-${crypto.randomUUID()}`),
       expiresAt: new Date(Date.now() - 60_000),
+      skipEmail: true,
     });
 
     const consumed = await consumePasswordReset({hashedToken: reset.hashedToken});
@@ -42,12 +44,14 @@ describe('password-resets db', () => {
       userId: user.id,
       hashedToken: hashOpaqueToken(`first-${crypto.randomUUID()}`),
       expiresAt: new Date(Date.now() + 60_000),
+      skipEmail: true,
     });
 
     await createPasswordReset({
       userId: user.id,
       hashedToken: hashOpaqueToken(`second-${crypto.randomUUID()}`),
       expiresAt: new Date(Date.now() + 60_000),
+      skipEmail: true,
     });
 
     const consumeFirst = await consumePasswordReset({hashedToken: first.hashedToken});

--- a/libs/api/auth/src/db/password-resets.ts
+++ b/libs/api/auth/src/db/password-resets.ts
@@ -6,12 +6,17 @@ import {db} from './db.js';
 import {authOutbox} from './schema/outbox.js';
 import {passwordResets, toPasswordReset} from './schema/password-resets.js';
 
-export interface CreatePasswordResetParams {
+interface CreatePasswordResetBaseParams {
   userId: string;
   hashedToken: string;
   expiresAt: Date;
-  sendEmail?: {email: string; resetLink: string; expiresInHours: number} | undefined;
 }
+
+export type CreatePasswordResetParams = CreatePasswordResetBaseParams &
+  (
+    | {sendEmail: {email: string; resetLink: string; expiresInHours: number}; skipEmail?: never}
+    | {sendEmail?: never; skipEmail: true}
+  );
 
 export async function createPasswordReset(
   params: CreatePasswordResetParams,

--- a/libs/api/auth/src/db/password-resets.ts
+++ b/libs/api/auth/src/db/password-resets.ts
@@ -1,12 +1,16 @@
+import {AUTH_PASSWORD_RESET_SEND_REQUESTED, type AuthEventMap} from '@shipfox/api-auth-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, eq, gt, isNull, sql} from 'drizzle-orm';
 import type {PasswordReset} from '#core/entities/password-reset.js';
 import {db} from './db.js';
+import {authOutbox} from './schema/outbox.js';
 import {passwordResets, toPasswordReset} from './schema/password-resets.js';
 
 export interface CreatePasswordResetParams {
   userId: string;
   hashedToken: string;
   expiresAt: Date;
+  sendEmail?: {email: string; resetLink: string; expiresInHours: number} | undefined;
 }
 
 export async function createPasswordReset(
@@ -29,6 +33,12 @@ export async function createPasswordReset(
 
     const row = rows[0];
     if (!row) throw new Error('Insert returned no rows');
+    if (params.sendEmail) {
+      await writeOutboxEvent<AuthEventMap>(tx, authOutbox, {
+        type: AUTH_PASSWORD_RESET_SEND_REQUESTED,
+        payload: params.sendEmail,
+      });
+    }
     return toPasswordReset(row);
   });
 }

--- a/libs/api/auth/src/db/schema/outbox.ts
+++ b/libs/api/auth/src/db/schema/outbox.ts
@@ -1,0 +1,4 @@
+import {createOutboxTable} from '@shipfox/node-outbox';
+import {pgTable} from './common.js';
+
+export const authOutbox = createOutboxTable(pgTable);

--- a/libs/api/auth/src/index.test.ts
+++ b/libs/api/auth/src/index.test.ts
@@ -1,0 +1,39 @@
+import {
+  AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+  AUTH_PASSWORD_RESET_SEND_REQUESTED,
+  authEventSchemas,
+} from '@shipfox/api-auth-dto';
+import {authModule} from './index.js';
+
+vi.mock('#config.js', () => ({
+  config: {
+    AUTH_JWT_SECRET: 'auth-module-test-secret',
+    AUTH_JWT_EXPIRES_IN: '15m',
+    AUTH_JOB_LEASE_TOKEN_SECRET: 'auth-module-test-job-secret',
+    AUTH_JOB_LEASE_TOKEN_EXPIRES_IN: '90m',
+    AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: 14,
+    AUTH_REFRESH_ROTATION_GRACE_SECONDS: 30,
+    AUTH_REFRESH_COOKIE_NAME: 'shipfox_refresh_token',
+    CLIENT_BASE_URL: 'https://app.example.test',
+  },
+  mailer: {send: vi.fn()},
+}));
+
+describe('authModule', () => {
+  test('registers auth email outbox publisher and subscribers', () => {
+    const publisher = authModule.publishers?.find((pub) => pub.name === 'auth');
+    const events = authModule.subscribers?.map((subscriber) => subscriber.event);
+
+    expect(publisher?.eventSchemas).toBe(authEventSchemas);
+    expect(Object.keys(publisher?.eventSchemas ?? {}).sort()).toEqual([
+      AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+      AUTH_PASSWORD_RESET_SEND_REQUESTED,
+    ]);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+        AUTH_PASSWORD_RESET_SEND_REQUESTED,
+      ]),
+    );
+  });
+});

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -1,15 +1,29 @@
+import {
+  AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+  AUTH_PASSWORD_RESET_SEND_REQUESTED,
+  type AuthEventMap,
+  authEventSchemas,
+} from '@shipfox/api-auth-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
+import {subscriberFactory} from '@shipfox/node-module';
 import {db} from '#db/db.js';
 import {migrationsPath} from '#db/migrations.js';
+import {authOutbox} from '#db/schema/outbox.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js';
 import {authE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {authRoutes} from '#presentation/routes/index.js';
+import {
+  onEmailVerificationSendRequested,
+  onPasswordResetSendRequested,
+} from '#presentation/subscribers/index.js';
 
 export type {JobLeaseTokenClaims} from '@shipfox/api-auth-dto';
 export type {User, UserStatus} from '#core/entities/user.js';
 export {issueJobLeaseToken, verifyJobLeaseToken} from '#core/job-lease-token.js';
 export {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js';
+
+const subscriber = subscriberFactory<AuthEventMap>();
 
 export const authModule: ShipfoxModule = {
   name: 'auth',
@@ -17,4 +31,9 @@ export const authModule: ShipfoxModule = {
   auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod()],
   routes: [authRoutes],
   e2eRoutes: [authE2eRoutes],
+  publishers: [{name: 'auth', table: authOutbox, db, eventSchemas: authEventSchemas}],
+  subscribers: [
+    subscriber(AUTH_EMAIL_VERIFICATION_SEND_REQUESTED, onEmailVerificationSendRequested),
+    subscriber(AUTH_PASSWORD_RESET_SEND_REQUESTED, onPasswordResetSendRequested),
+  ],
 };

--- a/libs/api/auth/src/presentation/routes/email-verification/verify-email-confirm.test.ts
+++ b/libs/api/auth/src/presentation/routes/email-verification/verify-email-confirm.test.ts
@@ -1,10 +1,11 @@
+import {AUTH_EMAIL_VERIFICATION_SEND_REQUESTED} from '@shipfox/api-auth-dto';
 import type {FastifyInstance} from 'fastify';
 import {
   cookieHeader,
   createAuthTestApp,
   extractToken,
   getSetCookie,
-  latestMailTo,
+  latestEmailLinkTo,
   resetCapturedMail,
   signup,
   uniqueEmail,
@@ -29,7 +30,9 @@ describe('POST /auth/verify-email/confirm', () => {
     const email = uniqueEmail('verify-confirm');
     const password = 'correct horse battery staple';
     await signup(app, {email, password});
-    const token = extractToken(latestMailTo(email).text ?? '');
+    const token = extractToken(
+      await latestEmailLinkTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+    );
 
     const confirm = await app.inject({
       method: 'POST',

--- a/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.test.ts
+++ b/libs/api/auth/src/presentation/routes/email-verification/verify-email-resend.test.ts
@@ -1,11 +1,14 @@
-import {EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} from '@shipfox/api-auth-dto';
+import {
+  AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+  EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS,
+} from '@shipfox/api-auth-dto';
 import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
 import {emailVerifications} from '#db/schema/email-verifications.js';
 import {
-  capturedMail,
   createAuthTestApp,
+  outboxEventsTo,
   resetCapturedMail,
   signup,
   uniqueEmail,
@@ -39,7 +42,7 @@ describe('POST /auth/verify-email/resend', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().next_resend_available_at).toEqual(expect.any(String));
-    expect(capturedMail().filter((message) => message.to === email)).toHaveLength(1);
+    expect(await outboxEventsTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(1);
   });
 
   test('returns 200 and sends a new token after cooldown', async () => {
@@ -61,7 +64,7 @@ describe('POST /auth/verify-email/resend', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().next_resend_available_at).toEqual(expect.any(String));
-    expect(capturedMail().filter((message) => message.to === email)).toHaveLength(2);
+    expect(await outboxEventsTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(2);
   });
 
   test('returns 200 without sending mail for a verified account', async () => {
@@ -78,18 +81,20 @@ describe('POST /auth/verify-email/resend', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().next_resend_available_at).toEqual(expect.any(String));
-    expect(capturedMail()).toHaveLength(0);
+    expect(await outboxEventsTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(1);
   });
 
   test('returns the same response shape for a missing account', async () => {
+    const email = uniqueEmail('verify-resend-missing');
+
     const res = await app.inject({
       method: 'POST',
       url: '/auth/verify-email/resend',
-      payload: {email: uniqueEmail('verify-resend-missing')},
+      payload: {email},
     });
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({next_resend_available_at: expect.any(String)});
-    expect(capturedMail()).toHaveLength(0);
+    expect(await outboxEventsTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(0);
   });
 });

--- a/libs/api/auth/src/presentation/routes/password/password-reset-confirm.test.ts
+++ b/libs/api/auth/src/presentation/routes/password/password-reset-confirm.test.ts
@@ -1,9 +1,10 @@
+import {AUTH_PASSWORD_RESET_SEND_REQUESTED} from '@shipfox/api-auth-dto';
 import type {FastifyInstance} from 'fastify';
 import {
   createAuthTestApp,
   extractToken,
   getSetCookie,
-  latestMailTo,
+  latestEmailLinkTo,
   login,
   resetCapturedMail,
   signupVerifyLogin,
@@ -31,7 +32,9 @@ describe('POST /auth/password-reset/confirm', () => {
       url: '/auth/password-reset',
       payload: {email: account.email},
     });
-    const resetToken = extractToken(latestMailTo(account.email).text ?? '');
+    const resetToken = extractToken(
+      await latestEmailLinkTo(account.email, AUTH_PASSWORD_RESET_SEND_REQUESTED),
+    );
 
     const confirm = await app.inject({
       method: 'POST',

--- a/libs/api/auth/src/presentation/routes/password/password-reset-request.test.ts
+++ b/libs/api/auth/src/presentation/routes/password/password-reset-request.test.ts
@@ -1,9 +1,13 @@
+import {AUTH_PASSWORD_RESET_SEND_REQUESTED} from '@shipfox/api-auth-dto';
 import type {FastifyInstance} from 'fastify';
 import {
+  capturedMail,
   createAuthTestApp,
-  latestMailTo,
+  latestEmailLinkTo,
+  outboxEventsTo,
   resetCapturedMail,
   signupVerifyLogin,
+  uniqueEmail,
 } from '#test/routes.js';
 
 describe('POST /auth/password-reset', () => {
@@ -31,16 +35,22 @@ describe('POST /auth/password-reset', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(latestMailTo(account.email).subject).toBe('Reset your password');
+    expect(await latestEmailLinkTo(account.email, AUTH_PASSWORD_RESET_SEND_REQUESTED)).toContain(
+      '/auth/reset?token=',
+    );
+    expect(capturedMail()).toHaveLength(0);
   });
 
   test('returns 204 without revealing missing accounts', async () => {
+    const email = uniqueEmail('missing-reset');
+
     const res = await app.inject({
       method: 'POST',
       url: '/auth/password-reset',
-      payload: {email: 'missing@example.com'},
+      payload: {email},
     });
 
     expect(res.statusCode).toBe(204);
+    expect(await outboxEventsTo(email, AUTH_PASSWORD_RESET_SEND_REQUESTED)).toHaveLength(0);
   });
 });

--- a/libs/api/auth/src/presentation/routes/registration/signup.test.ts
+++ b/libs/api/auth/src/presentation/routes/registration/signup.test.ts
@@ -1,11 +1,14 @@
+import {AUTH_EMAIL_VERIFICATION_SEND_REQUESTED} from '@shipfox/api-auth-dto';
 import type {FastifyInstance} from 'fastify';
 import {verifyUserToken} from '#core/jwt.js';
 import {
   acceptWorkspaceInvitationMock,
+  capturedMail,
   createAuthTestApp,
   getSetCookie,
-  latestMailTo,
+  latestEmailLinkTo,
   listMembershipsByUserMock,
+  outboxEventsTo,
   peekInvitationByRawTokenMock,
   ROUTE_TEST_SECRET,
   resetCapturedMail,
@@ -42,7 +45,10 @@ describe('POST /auth/signup', () => {
     expect(res.json().user.email).toBe(email);
     expect(res.json().user.name).toBe('New User');
     expect(res.json().user.email_verified_at).toBeNull();
-    expect(latestMailTo(email).subject).toBe('Verify your email');
+    expect(await latestEmailLinkTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toContain(
+      '/auth/verify-email?token=',
+    );
+    expect(capturedMail()).toHaveLength(0);
   });
 
   test.each([
@@ -156,7 +162,8 @@ describe('POST /auth/signup', () => {
     });
     expect(body.accept_error).toBeUndefined();
     expect(claims.memberships).toEqual([{workspaceId, role: 'admin'}]);
-    expect(() => latestMailTo(email)).toThrow();
+    expect(await outboxEventsTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED)).toHaveLength(0);
+    expect(capturedMail()).toHaveLength(0);
   });
 
   test('returns partial success when invitation acceptance fails after user creation', async () => {

--- a/libs/api/auth/src/presentation/subscribers/email-send-requested.test.ts
+++ b/libs/api/auth/src/presentation/subscribers/email-send-requested.test.ts
@@ -1,0 +1,77 @@
+import type {Mailer, MailMessage} from '@shipfox/node-mailer';
+import {onEmailVerificationSendRequested, onPasswordResetSendRequested} from './index.js';
+
+const testMailer = vi.hoisted(
+  (): {
+    captured: MailMessage[];
+    send: ReturnType<typeof vi.fn<Mailer['send']>>;
+    mailer: Mailer;
+  } => {
+    const captured: MailMessage[] = [];
+    const send = vi.fn<Mailer['send']>((message) => {
+      captured.push(message);
+      return Promise.resolve();
+    });
+    return {captured, send, mailer: {send}};
+  },
+);
+
+vi.mock('#config.js', () => ({
+  mailer: testMailer.mailer,
+}));
+
+describe('auth email subscribers', () => {
+  beforeEach(() => {
+    testMailer.captured.length = 0;
+    testMailer.send.mockReset();
+    testMailer.send.mockImplementation((message) => {
+      testMailer.captured.push(message);
+      return Promise.resolve();
+    });
+  });
+
+  test('sends a rendered email verification message', async () => {
+    await onEmailVerificationSendRequested({
+      email: 'verify@example.com',
+      verifyLink: 'https://app.example.test/auth/verify-email?token=verify-token',
+    });
+
+    expect(testMailer.captured).toHaveLength(1);
+    expect(testMailer.captured[0]).toMatchObject({
+      to: 'verify@example.com',
+      subject: 'Verify your email',
+    });
+    expect(testMailer.captured[0]?.text).toContain('/auth/verify-email?token=verify-token');
+    expect(testMailer.captured[0]?.html).toContain('/auth/verify-email?token');
+    expect(testMailer.captured[0]?.html).toContain('verify-token');
+  });
+
+  test('sends a rendered password reset message', async () => {
+    await onPasswordResetSendRequested({
+      email: 'reset@example.com',
+      resetLink: 'https://app.example.test/auth/reset?token=reset-token',
+      expiresInHours: 1,
+    });
+
+    expect(testMailer.captured).toHaveLength(1);
+    expect(testMailer.captured[0]).toMatchObject({
+      to: 'reset@example.com',
+      subject: 'Reset your password',
+    });
+    expect(testMailer.captured[0]?.text).toContain('/auth/reset?token=reset-token');
+    expect(testMailer.captured[0]?.html).toContain('/auth/reset?token');
+    expect(testMailer.captured[0]?.html).toContain('reset-token');
+  });
+
+  test('rethrows mailer failures so the outbox dispatcher retries', async () => {
+    const failure = new Error('smtp unavailable');
+    testMailer.send.mockRejectedValueOnce(failure);
+
+    const promise = onEmailVerificationSendRequested({
+      email: 'verify-failure@example.com',
+      verifyLink: 'https://app.example.test/auth/verify-email?token=verify-token',
+    });
+
+    await expect(promise).rejects.toBe(failure);
+  });
+});

--- a/libs/api/auth/src/presentation/subscribers/index.ts
+++ b/libs/api/auth/src/presentation/subscribers/index.ts
@@ -1,0 +1,2 @@
+export {onEmailVerificationSendRequested} from './on-email-verification-send-requested.js';
+export {onPasswordResetSendRequested} from './on-password-reset-send-requested.js';

--- a/libs/api/auth/src/presentation/subscribers/on-email-verification-send-requested.ts
+++ b/libs/api/auth/src/presentation/subscribers/on-email-verification-send-requested.ts
@@ -1,0 +1,10 @@
+import type {AuthEmailVerificationSendRequestedEvent} from '@shipfox/api-auth-dto';
+import {renderEmail} from '@shipfox/node-email';
+import {mailer} from '#config.js';
+
+export async function onEmailVerificationSendRequested(
+  payload: AuthEmailVerificationSendRequestedEvent,
+): Promise<void> {
+  const email = await renderEmail('verify-email', {verifyLink: payload.verifyLink});
+  await mailer.send({to: payload.email, ...email});
+}

--- a/libs/api/auth/src/presentation/subscribers/on-password-reset-send-requested.ts
+++ b/libs/api/auth/src/presentation/subscribers/on-password-reset-send-requested.ts
@@ -1,0 +1,13 @@
+import type {AuthPasswordResetSendRequestedEvent} from '@shipfox/api-auth-dto';
+import {renderEmail} from '@shipfox/node-email';
+import {mailer} from '#config.js';
+
+export async function onPasswordResetSendRequested(
+  payload: AuthPasswordResetSendRequestedEvent,
+): Promise<void> {
+  const email = await renderEmail('reset-password', {
+    resetLink: payload.resetLink,
+    expiresInHours: payload.expiresInHours,
+  });
+  await mailer.send({to: payload.email, ...email});
+}

--- a/libs/api/auth/test/globalSetup.ts
+++ b/libs/api/auth/test/globalSetup.ts
@@ -10,7 +10,7 @@ export async function setup() {
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_auth');
   await db().execute(
-    sql`TRUNCATE auth_email_verifications, auth_password_resets, auth_refresh_tokens, auth_users CASCADE`,
+    sql`TRUNCATE auth_outbox, auth_email_verifications, auth_password_resets, auth_refresh_tokens, auth_users CASCADE`,
   );
 
   closeDb();

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -1,6 +1,13 @@
 import type {OutgoingHttpHeaders} from 'node:http';
+import {
+  AUTH_EMAIL_VERIFICATION_SEND_REQUESTED,
+  type AUTH_PASSWORD_RESET_SEND_REQUESTED,
+} from '@shipfox/api-auth-dto';
 import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
+import {and, desc, eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {authOutbox} from '#db/schema/outbox.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {authRoutes} from '#presentation/routes/index.js';
 
@@ -94,6 +101,9 @@ const {acceptWorkspaceInvitation, peekInvitationByRawToken, listMembershipsByUse
 );
 
 const TOKEN_RE = /token=([\w\-_=]+)/;
+type AuthEmailEventType =
+  | typeof AUTH_EMAIL_VERIFICATION_SEND_REQUESTED
+  | typeof AUTH_PASSWORD_RESET_SEND_REQUESTED;
 
 export const ROUTE_TEST_SECRET = testConfig.secret;
 export const acceptWorkspaceInvitationMock = vi.mocked(acceptWorkspaceInvitation);
@@ -116,6 +126,16 @@ export function resetCapturedMail(): void {
 
 export function capturedMail(): MailMessage[] {
   return testConfig.captured;
+}
+
+export async function outboxEventsTo(email: string, eventType: AuthEmailEventType) {
+  return await db()
+    .select()
+    .from(authOutbox)
+    .where(
+      and(eq(authOutbox.eventType, eventType), sql`${authOutbox.payload}->>'email' = ${email}`),
+    )
+    .orderBy(desc(authOutbox.createdAt));
 }
 
 export function uniqueEmail(prefix: string): string {
@@ -147,6 +167,19 @@ export function latestMailTo(email: string): MailMessage {
   return message as MailMessage;
 }
 
+export async function latestEmailLinkTo(
+  email: string,
+  eventType: AuthEmailEventType,
+): Promise<string> {
+  const event = (await outboxEventsTo(email, eventType))[0];
+  expect(event).toBeDefined();
+  const payload = event?.payload as {verifyLink?: string; resetLink?: string} | undefined;
+  const link =
+    eventType === AUTH_EMAIL_VERIFICATION_SEND_REQUESTED ? payload?.verifyLink : payload?.resetLink;
+  expect(link).toBeDefined();
+  return link ?? '';
+}
+
 export async function createAuthTestApp(): Promise<FastifyInstance> {
   return await createApp({
     auth: [createJwtAuthMethod()],
@@ -167,7 +200,9 @@ export async function signup(
 }
 
 export async function verifyEmail(app: FastifyInstance, email: string): Promise<void> {
-  const token = extractToken(latestMailTo(email).text ?? '');
+  const token = extractToken(
+    await latestEmailLinkTo(email, AUTH_EMAIL_VERIFICATION_SEND_REQUESTED),
+  );
 
   const res = await app.inject({
     method: 'POST',

--- a/libs/api/workspaces-dto/src/events.ts
+++ b/libs/api/workspaces-dto/src/events.ts
@@ -1,0 +1,23 @@
+import {z} from 'zod';
+
+const nonEmptyStringSchema = z.string().nonempty();
+
+export const WORKSPACES_INVITATION_SEND_REQUESTED = 'workspaces.invitation.send_requested' as const;
+
+export const workspacesInvitationSendRequestedSchema = z.object({
+  email: z.string().email(),
+  workspaceName: nonEmptyStringSchema,
+  inviterName: nonEmptyStringSchema,
+  inviteLink: z.string().url(),
+});
+export type WorkspacesInvitationSendRequestedEvent = z.infer<
+  typeof workspacesInvitationSendRequestedSchema
+>;
+
+export interface WorkspacesEventMap {
+  [WORKSPACES_INVITATION_SEND_REQUESTED]: WorkspacesInvitationSendRequestedEvent;
+}
+
+export const workspacesEventSchemas = {
+  [WORKSPACES_INVITATION_SEND_REQUESTED]: workspacesInvitationSendRequestedSchema,
+} satisfies Record<keyof WorkspacesEventMap, z.ZodType>;

--- a/libs/api/workspaces-dto/src/events.ts
+++ b/libs/api/workspaces-dto/src/events.ts
@@ -1,13 +1,11 @@
 import {z} from 'zod';
 
-const nonEmptyStringSchema = z.string().nonempty();
-
 export const WORKSPACES_INVITATION_SEND_REQUESTED = 'workspaces.invitation.send_requested' as const;
 
 export const workspacesInvitationSendRequestedSchema = z.object({
   email: z.string().email(),
-  workspaceName: nonEmptyStringSchema,
-  inviterName: nonEmptyStringSchema,
+  workspaceName: z.string(),
+  inviterName: z.string(),
   inviteLink: z.string().url(),
 });
 export type WorkspacesInvitationSendRequestedEvent = z.infer<

--- a/libs/api/workspaces-dto/src/schemas/index.ts
+++ b/libs/api/workspaces-dto/src/schemas/index.ts
@@ -1,4 +1,11 @@
 export {
+  WORKSPACES_INVITATION_SEND_REQUESTED,
+  type WorkspacesEventMap,
+  type WorkspacesInvitationSendRequestedEvent,
+  workspacesEventSchemas,
+  workspacesInvitationSendRequestedSchema,
+} from '../events.js';
+export {
   type ApiKeyDto,
   apiKeyDtoSchema,
   type CreateApiKeyBodyDto,

--- a/libs/api/workspaces/drizzle/0003_outgoing_enchantress.sql
+++ b/libs/api/workspaces/drizzle/0003_outgoing_enchantress.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "workspaces_outbox" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"event_type" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"dispatched_at" timestamp with time zone,
+	"dispatch_attempts" integer DEFAULT 0 NOT NULL,
+	"next_dispatch_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_dispatch_error" jsonb,
+	"last_dispatch_failed_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE INDEX "workspaces_outbox_pending_idx" ON "workspaces_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
+CREATE INDEX "workspaces_outbox_dispatched_retention_idx" ON "workspaces_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;

--- a/libs/api/workspaces/drizzle/meta/0003_snapshot.json
+++ b/libs/api/workspaces/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,548 @@
+{
+  "id": "86af97dc-249d-4cc9-98bc-52681d4ca30f",
+  "prevId": "71580355-da9f-475d-ab24-8d5e8cb5bb47",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.workspaces_api_keys": {
+      "name": "workspaces_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_api_keys_hashed_key_unique": {
+          "name": "workspaces_api_keys_hashed_key_unique",
+          "columns": [
+            {
+              "expression": "hashed_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_api_keys_workspace_id_idx": {
+          "name": "workspaces_api_keys_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_api_keys_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_api_keys_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_api_keys",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_invitations": {
+      "name": "workspaces_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_display": {
+          "name": "invited_by_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_invitations_hashed_token_unique": {
+          "name": "workspaces_invitations_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_invitations_workspace_email_idx": {
+          "name": "workspaces_invitations_workspace_email_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_invitations_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_invitations_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_invitations",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_memberships": {
+      "name": "workspaces_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workspaces_memberships_user_workspace_unique": {
+          "name": "workspaces_memberships_user_workspace_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_memberships_workspace_id_idx": {
+          "name": "workspaces_memberships_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspaces_memberships_workspace_id_workspaces_id_fk": {
+          "name": "workspaces_memberships_workspace_id_workspaces_id_fk",
+          "tableFrom": "workspaces_memberships",
+          "tableTo": "workspaces",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces_outbox": {
+      "name": "workspaces_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workspaces_outbox_pending_idx": {
+          "name": "workspaces_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workspaces_outbox_dispatched_retention_idx": {
+          "name": "workspaces_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "workspaces_workspace_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.workspaces_workspace_status": {
+      "name": "workspaces_workspace_status",
+      "schema": "public",
+      "values": ["active", "suspended", "deleted"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/workspaces/drizzle/meta/_journal.json
+++ b/libs/api/workspaces/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777297640000,
       "tag": "0002_membership_user_snapshots",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782352229611,
+      "tag": "0003_outgoing_enchantress",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -45,6 +45,7 @@
     "@shipfox/node-email": "workspace:*",
     "@shipfox/node-mailer": "workspace:*",
     "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-tokens": "workspace:*",
     "drizzle-orm": "^0.45.2",

--- a/libs/api/workspaces/src/core/invitations.test.ts
+++ b/libs/api/workspaces/src/core/invitations.test.ts
@@ -1,5 +1,9 @@
+import {WORKSPACES_INVITATION_SEND_REQUESTED} from '@shipfox/api-workspaces-dto';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
+import {and, desc, eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
 import {createMembership} from '#db/memberships.js';
+import {workspacesOutbox} from '#db/schema/outbox.js';
 import {userFactory, workspaceFactory} from '#test/index.js';
 import {
   InvitationEmailMismatchError,
@@ -40,12 +44,36 @@ vi.mock('#config.js', () => ({
 
 const TOKEN_RE = /token=([\w\-_=]+)/;
 
-function extractToken(message: MailMessage | undefined): string {
-  const match = message?.text?.match(TOKEN_RE);
+function extractToken(link: string | undefined): string {
+  const match = link?.match(TOKEN_RE);
   if (!match?.[1]) {
-    throw new Error('Expected message to contain a token link');
+    throw new Error('Expected link to contain a token');
   }
   return match[1];
+}
+
+async function invitationEventsTo(email: string) {
+  return await db()
+    .select()
+    .from(workspacesOutbox)
+    .where(
+      and(
+        eq(workspacesOutbox.eventType, WORKSPACES_INVITATION_SEND_REQUESTED),
+        sql`${workspacesOutbox.payload}->>'email' = ${email}`,
+      ),
+    )
+    .orderBy(desc(workspacesOutbox.createdAt));
+}
+
+async function latestInvitationPayload(email: string) {
+  const row = (await invitationEventsTo(email))[0];
+  if (!row) throw new Error(`No invitation outbox event for ${email}`);
+  return row.payload as {
+    email: string;
+    workspaceName: string;
+    inviterName: string;
+    inviteLink: string;
+  };
 }
 
 describe('invitations core', () => {
@@ -56,7 +84,7 @@ describe('invitations core', () => {
     captured.length = 0;
   });
 
-  test('createWorkspaceInvitation creates an invitation and sends an email', async () => {
+  test('createWorkspaceInvitation creates an invitation and queues an email', async () => {
     const inviter = userFactory.build();
     const workspace = await workspaceFactory.create();
     await createMembership({
@@ -75,11 +103,11 @@ describe('invitations core', () => {
     });
 
     expect(invitation.email).toBe(email);
-    expect(captured).toHaveLength(1);
-    expect(captured[0]?.to).toBe(email);
+    expect(captured).toHaveLength(0);
+    expect(await invitationEventsTo(email)).toHaveLength(1);
   });
 
-  test('createWorkspaceInvitation sends a branded email with the workspace name and inviter', async () => {
+  test('createWorkspaceInvitation queues the workspace name and inviter', async () => {
     const inviter = userFactory.build();
     const workspace = await workspaceFactory.create();
     await createMembership({
@@ -98,14 +126,17 @@ describe('invitations core', () => {
       invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
     });
 
-    const message = captured[0];
-    expect(message?.subject).toBe(`Join ${workspace.name} on Shipfox`);
-    expect(message?.text).toContain(workspace.name);
-    expect(message?.html).toContain('Dana Scully');
-    expect(message?.text).toContain('Dana Scully has invited you');
+    const payload = await latestInvitationPayload(email);
+    expect(captured).toHaveLength(0);
+    expect(payload).toMatchObject({
+      email,
+      workspaceName: workspace.name,
+      inviterName: 'Dana Scully',
+    });
+    expect(payload.inviteLink).toContain(`${testConfig.clientBaseUrl}/invitations/accept?token=`);
   });
 
-  test('createWorkspaceInvitation falls back to "A teammate" when no inviter display is given', async () => {
+  test('createWorkspaceInvitation queues the teammate fallback when no inviter display is given', async () => {
     const inviter = userFactory.build();
     const workspace = await workspaceFactory.create();
     await createMembership({
@@ -123,7 +154,9 @@ describe('invitations core', () => {
       invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
     });
 
-    expect(captured[0]?.text).toContain('A teammate has invited you');
+    const payload = await latestInvitationPayload(email);
+    expect(captured).toHaveLength(0);
+    expect(payload.inviterName).toBe('A teammate');
   });
 
   test('createWorkspaceInvitation rejects duplicate open invitations', async () => {
@@ -151,6 +184,8 @@ describe('invitations core', () => {
     });
 
     await expect(promise).rejects.toBeInstanceOf(OpenInvitationExistsError);
+    expect(captured).toHaveLength(0);
+    expect(await invitationEventsTo(email)).toHaveLength(1);
   });
 
   test('acceptWorkspaceInvitation accepts once and enforces the invited email', async () => {
@@ -169,7 +204,7 @@ describe('invitations core', () => {
       invitedByUserId: inviter.userId,
       invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
     });
-    const token = extractToken(captured[0]);
+    const token = extractToken((await latestInvitationPayload(invitee.email)).inviteLink);
 
     const wrongEmail = acceptWorkspaceInvitation({
       token,

--- a/libs/api/workspaces/src/core/invitations.test.ts
+++ b/libs/api/workspaces/src/core/invitations.test.ts
@@ -159,6 +159,31 @@ describe('invitations core', () => {
     expect(payload.inviterName).toBe('A teammate');
   });
 
+  test('createWorkspaceInvitation queues fallbacks for blank display values', async () => {
+    const inviter = userFactory.build();
+    const workspace = await workspaceFactory.create({name: '   '});
+    await createMembership({
+      userId: inviter.userId,
+      userEmail: inviter.email,
+      userName: inviter.name,
+      workspaceId: workspace.id,
+    });
+    const email = `invitee-${crypto.randomUUID()}@example.com`;
+
+    await createWorkspaceInvitation({
+      workspaceId: workspace.id,
+      email,
+      invitedByUserId: inviter.userId,
+      invitedByDisplay: '   ',
+      invitedByMemberships: [{workspaceId: workspace.id, role: 'admin'}],
+    });
+
+    const payload = await latestInvitationPayload(email);
+    expect(captured).toHaveLength(0);
+    expect(payload.workspaceName).toBe('your workspace');
+    expect(payload.inviterName).toBe('A teammate');
+  });
+
   test('createWorkspaceInvitation rejects duplicate open invitations', async () => {
     const inviter = userFactory.build();
     const workspace = await workspaceFactory.create();

--- a/libs/api/workspaces/src/core/invitations.ts
+++ b/libs/api/workspaces/src/core/invitations.ts
@@ -28,6 +28,11 @@ function daysFromNow(days: number): Date {
   return new Date(Date.now() + days * 24 * 60 * 60 * 1000);
 }
 
+function nonBlankOrFallback(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
 export async function createWorkspaceInvitation(params: {
   workspaceId: string;
   email: string;
@@ -50,8 +55,8 @@ export async function createWorkspaceInvitation(params: {
     invitedByUserId: params.invitedByUserId,
     invitedByDisplay: params.invitedByDisplay ?? null,
     sendEmail: {
-      workspaceName: workspace.name,
-      inviterName: params.invitedByDisplay ?? 'A teammate',
+      workspaceName: nonBlankOrFallback(workspace.name, 'your workspace'),
+      inviterName: nonBlankOrFallback(params.invitedByDisplay, 'A teammate'),
       inviteLink: `${config.CLIENT_BASE_URL}/invitations/accept?token=${rawToken}`,
     },
   });

--- a/libs/api/workspaces/src/core/invitations.ts
+++ b/libs/api/workspaces/src/core/invitations.ts
@@ -1,7 +1,6 @@
 import type {UserContextMembership} from '@shipfox/api-auth-context';
-import {renderEmail} from '@shipfox/node-email';
 import {generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
-import {config, mailer} from '#config.js';
+import {config} from '#config.js';
 import {
   type AcceptInvitationResult,
   acceptInvitation,
@@ -50,16 +49,12 @@ export async function createWorkspaceInvitation(params: {
     expiresAt: daysFromNow(INVITATION_TTL_DAYS),
     invitedByUserId: params.invitedByUserId,
     invitedByDisplay: params.invitedByDisplay ?? null,
+    sendEmail: {
+      workspaceName: workspace.name,
+      inviterName: params.invitedByDisplay ?? 'A teammate',
+      inviteLink: `${config.CLIENT_BASE_URL}/invitations/accept?token=${rawToken}`,
+    },
   });
-
-  const link = `${config.CLIENT_BASE_URL}/invitations/accept?token=${rawToken}`;
-  const email = await renderEmail('workspace-invitation', {
-    email: params.email,
-    workspaceName: workspace.name,
-    inviterName: params.invitedByDisplay ?? 'A teammate',
-    inviteLink: link,
-  });
-  await mailer.send({to: params.email, ...email});
 
   return invitation;
 }

--- a/libs/api/workspaces/src/db/db.ts
+++ b/libs/api/workspaces/src/db/db.ts
@@ -3,6 +3,7 @@ import {pgClient} from '@shipfox/node-postgres';
 import {apiKeys} from './schema/api-keys.js';
 import {invitations} from './schema/invitations.js';
 import {memberships} from './schema/memberships.js';
+import {workspacesOutbox} from './schema/outbox.js';
 import {workspaces} from './schema/workspaces.js';
 
 export const schema = {
@@ -10,6 +11,7 @@ export const schema = {
   apiKeys,
   memberships,
   invitations,
+  workspacesOutbox,
 };
 
 let _db: NodePgDatabase<typeof schema> | undefined;

--- a/libs/api/workspaces/src/db/index.ts
+++ b/libs/api/workspaces/src/db/index.ts
@@ -36,6 +36,7 @@ export {
 } from './memberships.js';
 export type {ResolvedApiKey} from './resolve-api-key.js';
 export {resolveApiKeyWithWorkspace} from './resolve-api-key.js';
+export {workspacesOutbox} from './schema/outbox.js';
 export type {CreateWorkspaceParams, UpdateWorkspaceParams} from './workspaces.js';
 export {createWorkspace, getWorkspaceById, updateWorkspace} from './workspaces.js';
 

--- a/libs/api/workspaces/src/db/invitations.test.ts
+++ b/libs/api/workspaces/src/db/invitations.test.ts
@@ -32,6 +32,7 @@ describe('invitations db', () => {
       hashedToken: hashOpaqueToken('inv-1'),
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     expect(invitation.workspaceId).toBe(workspace.id);
@@ -48,6 +49,7 @@ describe('invitations db', () => {
       hashedToken: hashOpaqueToken('first'),
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     await expect(
@@ -57,6 +59,7 @@ describe('invitations db', () => {
         hashedToken: hashOpaqueToken('second'),
         expiresAt: new Date(Date.now() + 86_400_000),
         invitedByUserId: inviter.userId,
+        skipEmail: true,
       }),
     ).rejects.toBeInstanceOf(OpenInvitationExistsError);
   });
@@ -80,6 +83,7 @@ describe('invitations db', () => {
       hashedToken: hashOpaqueToken('fresh-inv'),
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     expect(fresh.id).toBeDefined();
@@ -100,6 +104,7 @@ describe('invitations db', () => {
       hashedToken: hashOpaqueToken('inv-accept'),
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     const result = await acceptInvitation({
@@ -125,6 +130,7 @@ describe('invitations db', () => {
       hashedToken: hashOpaqueToken('inv-idem'),
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     const result = await acceptInvitation({invitationId: inv.id, acceptedByUserId: member.userId});
@@ -167,6 +173,7 @@ describe('invitations db', () => {
       hashedToken: hashOpaqueToken('inv-list'),
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     const before = await listOpenInvitationsByWorkspace({workspaceId: workspace.id});
@@ -187,6 +194,7 @@ describe('invitations db', () => {
       hashedToken: tokenHash,
       expiresAt: new Date(Date.now() + 86_400_000),
       invitedByUserId: inviter.userId,
+      skipEmail: true,
     });
 
     const found = await findInvitationByToken({hashedToken: tokenHash});

--- a/libs/api/workspaces/src/db/invitations.ts
+++ b/libs/api/workspaces/src/db/invitations.ts
@@ -12,21 +12,27 @@ import {invitations, toInvitation} from './schema/invitations.js';
 import {memberships, toMembership} from './schema/memberships.js';
 import {workspacesOutbox} from './schema/outbox.js';
 
-export interface CreateInvitationParams {
+interface CreateInvitationBaseParams {
   workspaceId: string;
   email: string;
   hashedToken: string;
   expiresAt: Date;
   invitedByUserId: string;
   invitedByDisplay?: string | null;
-  sendEmail?:
-    | {
-        workspaceName: string;
-        inviterName: string;
-        inviteLink: string;
-      }
-    | undefined;
 }
+
+export type CreateInvitationParams = CreateInvitationBaseParams &
+  (
+    | {
+        sendEmail: {
+          workspaceName: string;
+          inviterName: string;
+          inviteLink: string;
+        };
+        skipEmail?: never;
+      }
+    | {sendEmail?: never; skipEmail: true}
+  );
 
 export async function createInvitation(params: CreateInvitationParams): Promise<Invitation> {
   return await db().transaction(async (tx) => {

--- a/libs/api/workspaces/src/db/invitations.ts
+++ b/libs/api/workspaces/src/db/invitations.ts
@@ -1,3 +1,8 @@
+import {
+  WORKSPACES_INVITATION_SEND_REQUESTED,
+  type WorkspacesEventMap,
+} from '@shipfox/api-workspaces-dto';
+import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, eq, gt, isNull, lt, sql} from 'drizzle-orm';
 import type {Invitation} from '#core/entities/invitation.js';
 import type {Membership} from '#core/entities/membership.js';
@@ -5,6 +10,7 @@ import {OpenInvitationExistsError} from '#core/errors.js';
 import {db} from './db.js';
 import {invitations, toInvitation} from './schema/invitations.js';
 import {memberships, toMembership} from './schema/memberships.js';
+import {workspacesOutbox} from './schema/outbox.js';
 
 export interface CreateInvitationParams {
   workspaceId: string;
@@ -13,6 +19,13 @@ export interface CreateInvitationParams {
   expiresAt: Date;
   invitedByUserId: string;
   invitedByDisplay?: string | null;
+  sendEmail?:
+    | {
+        workspaceName: string;
+        inviterName: string;
+        inviteLink: string;
+      }
+    | undefined;
 }
 
 export async function createInvitation(params: CreateInvitationParams): Promise<Invitation> {
@@ -58,6 +71,15 @@ export async function createInvitation(params: CreateInvitationParams): Promise<
 
     const row = rows[0];
     if (!row) throw new Error('Insert returned no rows');
+    if (params.sendEmail) {
+      await writeOutboxEvent<WorkspacesEventMap>(tx, workspacesOutbox, {
+        type: WORKSPACES_INVITATION_SEND_REQUESTED,
+        payload: {
+          email: params.email,
+          ...params.sendEmail,
+        },
+      });
+    }
     return toInvitation(row);
   });
 }

--- a/libs/api/workspaces/src/db/schema/outbox.ts
+++ b/libs/api/workspaces/src/db/schema/outbox.ts
@@ -1,0 +1,4 @@
+import {createOutboxTable} from '@shipfox/node-outbox';
+import {pgTable} from './common.js';
+
+export const workspacesOutbox = createOutboxTable(pgTable);

--- a/libs/api/workspaces/src/index.test.ts
+++ b/libs/api/workspaces/src/index.test.ts
@@ -1,0 +1,25 @@
+import {
+  WORKSPACES_INVITATION_SEND_REQUESTED,
+  workspacesEventSchemas,
+} from '@shipfox/api-workspaces-dto';
+import {workspacesModule} from './index.js';
+
+vi.mock('#config.js', () => ({
+  config: {
+    CLIENT_BASE_URL: 'https://app.example.test',
+  },
+  mailer: {send: vi.fn()},
+}));
+
+describe('workspacesModule', () => {
+  test('registers workspace invitation outbox publisher and subscriber', () => {
+    const publisher = workspacesModule.publishers?.find((pub) => pub.name === 'workspaces');
+    const events = workspacesModule.subscribers?.map((subscriber) => subscriber.event);
+
+    expect(publisher?.eventSchemas).toBe(workspacesEventSchemas);
+    expect(Object.keys(publisher?.eventSchemas ?? {})).toEqual([
+      WORKSPACES_INVITATION_SEND_REQUESTED,
+    ]);
+    expect(events).toContain(WORKSPACES_INVITATION_SEND_REQUESTED);
+  });
+});

--- a/libs/api/workspaces/src/index.ts
+++ b/libs/api/workspaces/src/index.ts
@@ -1,8 +1,15 @@
+import {
+  WORKSPACES_INVITATION_SEND_REQUESTED,
+  type WorkspacesEventMap,
+  workspacesEventSchemas,
+} from '@shipfox/api-workspaces-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
-import {db, migrationsPath} from '#db/index.js';
+import {subscriberFactory} from '@shipfox/node-module';
+import {db, migrationsPath, workspacesOutbox} from '#db/index.js';
 import {createApiKeyAuthMethod} from '#presentation/auth/api-key-auth.js';
 import {workspacesE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {workspacesRoutes} from '#presentation/routes/index.js';
+import {onInvitationSendRequested} from '#presentation/subscribers/index.js';
 
 export type {ApiKey} from '#core/entities/api-key.js';
 export type {Invitation} from '#core/entities/invitation.js';
@@ -22,10 +29,16 @@ export {createApiKeyAuthMethod} from '#presentation/auth/api-key-auth.js';
 export {requireMembership} from '#presentation/auth/require-membership.js';
 export {workspacesRoutes as routes} from '#presentation/routes/index.js';
 
+const subscriber = subscriberFactory<WorkspacesEventMap>();
+
 export const workspacesModule: ShipfoxModule = {
   name: 'workspaces',
   database: {db, migrationsPath},
   auth: [createApiKeyAuthMethod()],
   routes: workspacesRoutes,
   e2eRoutes: [workspacesE2eRoutes],
+  publishers: [
+    {name: 'workspaces', table: workspacesOutbox, db, eventSchemas: workspacesEventSchemas},
+  ],
+  subscribers: [subscriber(WORKSPACES_INVITATION_SEND_REQUESTED, onInvitationSendRequested)],
 };

--- a/libs/api/workspaces/src/presentation/e2eRoutes/create-invitation.ts
+++ b/libs/api/workspaces/src/presentation/e2eRoutes/create-invitation.ts
@@ -32,6 +32,7 @@ export const createE2eInvitationRoute = defineRoute({
       expiresAt: daysFromNow(INVITATION_TTL_DAYS),
       invitedByUserId: request.body.invited_by_user_id,
       invitedByDisplay: request.body.invited_by_display ?? null,
+      skipEmail: true,
     });
 
     reply.code(201);

--- a/libs/api/workspaces/src/presentation/routes/invitations/create.test.ts
+++ b/libs/api/workspaces/src/presentation/routes/invitations/create.test.ts
@@ -1,8 +1,10 @@
 import type {FastifyInstance} from 'fastify';
 import {
+  capturedMail,
   createInvite,
   createWorkspace,
   createWorkspacesTestApp,
+  invitationOutboxEventsTo,
   resetCapturedMail,
   signupVerifyLogin,
   uniqueEmail,
@@ -42,6 +44,8 @@ describe('POST /workspaces/:workspaceId/invitations', () => {
       accepted_at: null,
       invited_by_user_id: owner.userId,
     });
+    expect(await invitationOutboxEventsTo(inviteeEmail)).toHaveLength(1);
+    expect(capturedMail()).toHaveLength(0);
   });
 
   test('transforms duplicate open invitation into 409', async () => {
@@ -59,22 +63,25 @@ describe('POST /workspaces/:workspaceId/invitations', () => {
 
     expect(res.statusCode).toBe(409);
     expect(res.json().code).toBe('open-invitation-exists');
+    expect(await invitationOutboxEventsTo(inviteeEmail)).toHaveLength(1);
   });
 
   test('transforms missing membership into 403', async () => {
     const owner = await signupVerifyLogin(app, 'invite-create-member-owner');
     const outsider = await signupVerifyLogin(app, 'invite-create-outsider');
     const workspaceId = await createWorkspace(app, owner.token);
+    const inviteeEmail = uniqueEmail('forbidden-invite');
 
     const res = await app.inject({
       method: 'POST',
       url: `/workspaces/${workspaceId}/invitations`,
       headers: {authorization: `Bearer ${outsider.token}`},
-      payload: {email: uniqueEmail('forbidden-invite')},
+      payload: {email: inviteeEmail},
     });
 
     expect(res.statusCode).toBe(403);
     expect(res.json().code).toBe('forbidden');
+    expect(await invitationOutboxEventsTo(inviteeEmail)).toHaveLength(0);
   });
 
   test('returns 403 when caller has no claim to the workspace (whether or not it exists)', async () => {

--- a/libs/api/workspaces/src/presentation/subscribers/index.ts
+++ b/libs/api/workspaces/src/presentation/subscribers/index.ts
@@ -1,0 +1,1 @@
+export {onInvitationSendRequested} from './on-invitation-send-requested.js';

--- a/libs/api/workspaces/src/presentation/subscribers/invitation-send-requested.test.ts
+++ b/libs/api/workspaces/src/presentation/subscribers/invitation-send-requested.test.ts
@@ -1,0 +1,64 @@
+import type {Mailer, MailMessage} from '@shipfox/node-mailer';
+import {onInvitationSendRequested} from './index.js';
+
+const testMailer = vi.hoisted(
+  (): {
+    captured: MailMessage[];
+    send: ReturnType<typeof vi.fn<Mailer['send']>>;
+    mailer: Mailer;
+  } => {
+    const captured: MailMessage[] = [];
+    const send = vi.fn<Mailer['send']>((message) => {
+      captured.push(message);
+      return Promise.resolve();
+    });
+    return {captured, send, mailer: {send}};
+  },
+);
+
+vi.mock('#config.js', () => ({
+  mailer: testMailer.mailer,
+}));
+
+describe('workspace invitation email subscriber', () => {
+  beforeEach(() => {
+    testMailer.captured.length = 0;
+    testMailer.send.mockReset();
+    testMailer.send.mockImplementation((message) => {
+      testMailer.captured.push(message);
+      return Promise.resolve();
+    });
+  });
+
+  test('sends a rendered workspace invitation message', async () => {
+    await onInvitationSendRequested({
+      email: 'invitee@example.com',
+      workspaceName: 'Acme Ops',
+      inviterName: 'Dana Scully',
+      inviteLink: 'https://app.example.test/invitations/accept?token=invite-token',
+    });
+
+    expect(testMailer.captured).toHaveLength(1);
+    expect(testMailer.captured[0]).toMatchObject({
+      to: 'invitee@example.com',
+      subject: 'Join Acme Ops on Shipfox',
+    });
+    expect(testMailer.captured[0]?.text).toContain('Dana Scully has invited you');
+    expect(testMailer.captured[0]?.text).toContain('/invitations/accept?token=invite-token');
+    expect(testMailer.captured[0]?.html).toContain('Dana Scully');
+  });
+
+  test('rethrows mailer failures so the outbox dispatcher retries', async () => {
+    const failure = new Error('smtp unavailable');
+    testMailer.send.mockRejectedValueOnce(failure);
+
+    const promise = onInvitationSendRequested({
+      email: 'invite-failure@example.com',
+      workspaceName: 'Acme Ops',
+      inviterName: 'Dana Scully',
+      inviteLink: 'https://app.example.test/invitations/accept?token=invite-token',
+    });
+
+    await expect(promise).rejects.toBe(failure);
+  });
+});

--- a/libs/api/workspaces/src/presentation/subscribers/on-invitation-send-requested.ts
+++ b/libs/api/workspaces/src/presentation/subscribers/on-invitation-send-requested.ts
@@ -1,0 +1,15 @@
+import type {WorkspacesInvitationSendRequestedEvent} from '@shipfox/api-workspaces-dto';
+import {renderEmail} from '@shipfox/node-email';
+import {mailer} from '#config.js';
+
+export async function onInvitationSendRequested(
+  payload: WorkspacesInvitationSendRequestedEvent,
+): Promise<void> {
+  const email = await renderEmail('workspace-invitation', {
+    email: payload.email,
+    workspaceName: payload.workspaceName,
+    inviterName: payload.inviterName,
+    inviteLink: payload.inviteLink,
+  });
+  await mailer.send({to: payload.email, ...email});
+}

--- a/libs/api/workspaces/test/globalSetup.ts
+++ b/libs/api/workspaces/test/globalSetup.ts
@@ -8,7 +8,7 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_workspaces');
-  await db().execute(sql`TRUNCATE workspaces_api_keys, workspaces CASCADE`);
+  await db().execute(sql`TRUNCATE workspaces_outbox, workspaces_api_keys, workspaces CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/libs/api/workspaces/test/routes.ts
+++ b/libs/api/workspaces/test/routes.ts
@@ -1,11 +1,15 @@
 import type {OutgoingHttpHeaders} from 'node:http';
 import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {WORKSPACES_INVITATION_SEND_REQUESTED} from '@shipfox/api-workspaces-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import type {Mailer, MailMessage} from '@shipfox/node-mailer';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
+import {and, desc, eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
 import {createInvitation} from '#db/invitations.js';
 import {listMembershipsByUser} from '#db/memberships.js';
+import {workspacesOutbox} from '#db/schema/outbox.js';
 import {createApiKeyAuthMethod} from '#presentation/auth/api-key-auth.js';
 import {workspacesRoutes} from '#presentation/routes/index.js';
 
@@ -85,6 +89,19 @@ export function capturedMail(): MailMessage[] {
   return testConfig.captured;
 }
 
+export async function invitationOutboxEventsTo(email: string) {
+  return await db()
+    .select()
+    .from(workspacesOutbox)
+    .where(
+      and(
+        eq(workspacesOutbox.eventType, WORKSPACES_INVITATION_SEND_REQUESTED),
+        sql`${workspacesOutbox.payload}->>'email' = ${email}`,
+      ),
+    )
+    .orderBy(desc(workspacesOutbox.createdAt));
+}
+
 export function uniqueEmail(prefix: string): string {
   return `${prefix}-${crypto.randomUUID()}@example.com`;
 }
@@ -112,6 +129,14 @@ export function latestMailTo(email: string): MailMessage {
   const message = [...testConfig.captured].reverse().find((mail) => mail.to === email);
   expect(message).toBeDefined();
   return message as MailMessage;
+}
+
+export async function latestInvitationLinkTo(email: string): Promise<string> {
+  const event = (await invitationOutboxEventsTo(email))[0];
+  expect(event).toBeDefined();
+  const payload = event?.payload as {inviteLink?: string} | undefined;
+  expect(payload?.inviteLink).toBeDefined();
+  return payload?.inviteLink ?? '';
 }
 
 export async function createWorkspacesTestApp(): Promise<FastifyInstance> {
@@ -209,7 +234,7 @@ export async function createInvite(
   expect(res.statusCode).toBe(201);
   return {
     id: res.json().id,
-    rawToken: extractToken(latestMailTo(params.email).text ?? ''),
+    rawToken: extractToken(await latestInvitationLinkTo(params.email)),
   };
 }
 

--- a/libs/api/workspaces/test/routes.ts
+++ b/libs/api/workspaces/test/routes.ts
@@ -250,6 +250,7 @@ export async function createExpiredInvite(params: {
     hashedToken: hashOpaqueToken(rawToken),
     expiresAt: new Date(Date.now() - 60_000),
     invitedByUserId: params.invitedByUserId,
+    skipEmail: true,
   });
   return rawToken;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -473,6 +473,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/node-outbox':
+        specifier: workspace:*
+        version: link:../../shared/node/outbox
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../shared/node/postgres
@@ -1973,6 +1976,9 @@ importers:
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
+      '@shipfox/node-outbox':
+        specifier: workspace:*
+        version: link:../../shared/node/outbox
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../shared/node/postgres


### PR DESCRIPTION
Queue transactional email send requests through module-owned outbox events for auth verification, password reset, and workspace invitations.

These paths previously rendered and sent email inline after creating one-time tokens or invitations, which made request success depend on mail delivery and gave failures no dispatcher retry or dead-letter behavior. This writes the full one-time link into the auth/workspaces outbox rows in the same transaction as the token or invitation row, then sends from subscribers so existing outbox retry semantics apply.

This stays with the existing module outbox, publisher, and subscriber pattern rather than adding a generic email service. Reviewers should pay close attention to the new outbox migrations and event payload schemas because the payloads intentionally contain one-time links for reliable retry.

Closes ENG-564

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes auth verification, password reset, and workspace invitation emails through module-owned outbox events, removing email sending from request paths and enabling reliable retries and dead-lettering. Tightens event payload contracts. Closes ENG-564.

- New Features
  - Write outbox rows in the same transaction as token/invitation creation; payloads include full verify/reset/invite links; subscribers render and send emails with existing retry semantics; add explicit `skipEmail` for setup-only writes and normalize blank invitation display values to sensible defaults.
  - Register module publishers/subscribers and add event schemas in `@shipfox/api-auth-dto` and `@shipfox/api-workspaces-dto`; add `@shipfox/node-outbox` to `@shipfox/api-auth` and `@shipfox/api-workspaces`.
  - Replace inline email sends in auth and workspaces flows; update tests to assert outbox events instead of captured mail.

- Migration
  - Run new migrations to create module outbox tables and indexes for auth and workspaces.
  - Ensure the outbox dispatcher is running for these modules. No API changes.

<sup>Written for commit 4c44057de188a989654e41a619c7efe5a8370248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

