### PR TITLE
[runner] Add structured command logs

### DIFF
--- a/.changeset/eng-587-command-logs.md
+++ b/.changeset/eng-587-command-logs.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/runner-execution": patch
+"@shipfox/runner-logs": patch
+"@shipfox/runner-orchestration": patch
+---
+
+Adds runner-produced command metadata groups and terminal failure context to command step log streams.

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -2,10 +2,12 @@ import {mkdtemp, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
-import {executeRunStep, type OutputSink} from '#core/run-step.js';
+import {type CommandStartMetadata, executeRunStep, type OutputSink} from '#core/run-step.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const ESRCH_REGEX = /ESRCH/;
+const SHELL_EXECUTABLE_REGEX = /^(bash|sh)$/;
+const SCRIPT_PATH_REGEX = /shipfox-runner-.*\.sh$/;
 
 function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
   const chunks: Buffer[] = [];
@@ -107,6 +109,57 @@ describe('executeRunStep', () => {
     } finally {
       await rm(dir, {recursive: true, force: true});
     }
+  });
+
+  it('emits resolved command metadata before stdout or stderr', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'shipfox-command-metadata-test-'));
+    try {
+      const step = buildStep({config: {run: 'echo hello'}});
+      const events: string[] = [];
+      let metadata: CommandStartMetadata | undefined;
+
+      const result = await executeRunStep(step, {
+        cwd: dir,
+        onCommandStart: (value) => {
+          events.push('metadata');
+          metadata = value;
+        },
+        onOutput: () => {
+          events.push('output');
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(events[0]).toBe('metadata');
+      expect(events).toContain('output');
+      expect(metadata).toBeDefined();
+      if (!metadata) throw new Error('expected command metadata');
+      expect(metadata).toMatchObject({
+        command: 'echo hello',
+        cwd: dir,
+      });
+      expect(metadata.shell.executable).toMatch(SHELL_EXECUTABLE_REGEX);
+      expect(metadata.shell.args.at(-1)).toMatch(SCRIPT_PATH_REGEX);
+      expect(metadata.shell.display).toContain('{0}');
+      expect(metadata.shell.display).not.toContain(metadata.shell.args.at(-1) ?? '');
+    } finally {
+      await rm(dir, {recursive: true, force: true});
+    }
+  });
+
+  it('continues running the command when command metadata emission throws', async () => {
+    const step = buildStep({config: {run: 'echo still-runs'}});
+    const output = collectOutput();
+
+    const result = await executeRunStep(step, {
+      onCommandStart: () => {
+        throw new Error('capture unavailable');
+      },
+      onOutput: output.sink,
+    });
+
+    expect(result.success).toBe(true);
+    expect(output.text()).toContain('still-runs');
   });
 
   it('handles multi-line scripts', async () => {

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -162,6 +162,23 @@ describe('executeRunStep', () => {
     expect(output.text()).toContain('still-runs');
   });
 
+  it('isolates command metadata mutation from the spawned shell', async () => {
+    const step = buildStep({config: {run: 'echo safe-spawn'}});
+    const output = collectOutput();
+
+    const result = await executeRunStep(step, {
+      onCommandStart: (metadata) => {
+        const shell = metadata.shell as unknown as {executable: string; args: string[]};
+        shell.executable = 'shipfox-missing-shell';
+        shell.args.splice(0, shell.args.length, '-c', 'exit 42');
+      },
+      onOutput: output.sink,
+    });
+
+    expect(result.success).toBe(true);
+    expect(output.text()).toContain('safe-spawn');
+  });
+
   it('handles multi-line scripts', async () => {
     const step = buildStep({
       config: {run: 'echo first\necho second'},

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -19,15 +19,15 @@ export type OutputSink = (chunk: Buffer, source: 'stdout' | 'stderr') => void;
 export type CommandStartSink = (metadata: CommandStartMetadata) => void;
 
 export interface CommandStartMetadata {
-  command: string;
-  shell: CommandShellMetadata;
-  cwd?: string;
+  readonly command: string;
+  readonly shell: CommandShellMetadata;
+  readonly cwd?: string;
 }
 
 export interface CommandShellMetadata {
-  executable: string;
-  args: readonly string[];
-  display: string;
+  readonly executable: string;
+  readonly args: readonly string[];
+  readonly display: string;
 }
 
 interface RunStepOptions {
@@ -61,7 +61,7 @@ export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Pro
 async function runShellCommand(command: string, options: RunStepOptions): Promise<StepResult> {
   const scriptPath = join(tmpdir(), `shipfox-runner-${randomUUID()}.sh`);
   const metadata = commandStartMetadata({command, scriptPath, cwd: options.cwd});
-  notifyCommandStart(options.onCommandStart, metadata);
+  notifyCommandStart(options.onCommandStart, cloneCommandStartMetadata(metadata));
 
   try {
     await writeFile(scriptPath, command, {mode: 0o700});
@@ -220,4 +220,16 @@ function notifyCommandStart(
   } catch (err) {
     logger().error({err}, 'Failed to emit command metadata; continuing command execution');
   }
+}
+
+function cloneCommandStartMetadata(metadata: CommandStartMetadata): CommandStartMetadata {
+  return {
+    command: metadata.command,
+    shell: {
+      executable: metadata.shell.executable,
+      args: [...metadata.shell.args],
+      display: metadata.shell.display,
+    },
+    ...(metadata.cwd !== undefined ? {cwd: metadata.cwd} : {}),
+  };
 }

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -16,10 +16,25 @@ import type {StepResult} from '#core/step-result.js';
  */
 export type OutputSink = (chunk: Buffer, source: 'stdout' | 'stderr') => void;
 
+export type CommandStartSink = (metadata: CommandStartMetadata) => void;
+
+export interface CommandStartMetadata {
+  command: string;
+  shell: CommandShellMetadata;
+  cwd?: string;
+}
+
+export interface CommandShellMetadata {
+  executable: string;
+  args: readonly string[];
+  display: string;
+}
+
 interface RunStepOptions {
   signal?: AbortSignal;
   cwd?: string;
   onOutput?: OutputSink;
+  onCommandStart?: CommandStartSink;
 }
 
 export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Promise<StepResult> {
@@ -45,27 +60,28 @@ export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Pro
 
 async function runShellCommand(command: string, options: RunStepOptions): Promise<StepResult> {
   const scriptPath = join(tmpdir(), `shipfox-runner-${randomUUID()}.sh`);
+  const metadata = commandStartMetadata({command, scriptPath, cwd: options.cwd});
+  notifyCommandStart(options.onCommandStart, metadata);
 
   try {
     await writeFile(scriptPath, command, {mode: 0o700});
-    return await spawnAndCapture(scriptPath, options);
+    return await spawnAndCapture(metadata, options);
   } finally {
     await unlink(scriptPath).catch(() => undefined);
   }
 }
 
-function spawnAndCapture(scriptPath: string, options: RunStepOptions): Promise<StepResult> {
+function spawnAndCapture(
+  metadata: CommandStartMetadata,
+  options: RunStepOptions,
+): Promise<StepResult> {
   return new Promise((resolve) => {
-    const shell = findShell();
-    const args =
-      shell === 'bash'
-        ? ['--noprofile', '--norc', '-eo', 'pipefail', scriptPath]
-        : ['-e', scriptPath];
+    const {shell} = metadata;
 
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
     // parent chain). We don't unref() — output capture still needs `close`.
-    const child = spawn(shell, args, {
+    const child = spawn(shell.executable, shell.args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
       cwd: options.cwd,
@@ -169,5 +185,39 @@ function findShell(): string {
     return 'bash';
   } catch {
     return 'sh';
+  }
+}
+
+function commandStartMetadata(args: {
+  command: string;
+  scriptPath: string;
+  cwd: string | undefined;
+}): CommandStartMetadata {
+  const executable = findShell();
+  const shellArgs =
+    executable === 'bash'
+      ? ['--noprofile', '--norc', '-eo', 'pipefail', args.scriptPath]
+      : ['-e', args.scriptPath];
+  const displayArgs = shellArgs.map((arg) => (arg === args.scriptPath ? '{0}' : arg));
+
+  return {
+    command: args.command,
+    shell: {
+      executable,
+      args: shellArgs,
+      display: [executable, ...displayArgs].join(' '),
+    },
+    ...(args.cwd !== undefined ? {cwd: args.cwd} : {}),
+  };
+}
+
+function notifyCommandStart(
+  onCommandStart: CommandStartSink | undefined,
+  metadata: CommandStartMetadata,
+): void {
+  try {
+    onCommandStart?.(metadata);
+  } catch (err) {
+    logger().error({err}, 'Failed to emit command metadata; continuing command execution');
   }
 }

--- a/libs/runner/execution/src/index.ts
+++ b/libs/runner/execution/src/index.ts
@@ -1,3 +1,9 @@
-export {executeRunStep, type OutputSink} from '#core/run-step.js';
+export {
+  type CommandShellMetadata,
+  type CommandStartMetadata,
+  type CommandStartSink,
+  executeRunStep,
+  type OutputSink,
+} from '#core/run-step.js';
 export {executeSetupStep} from '#core/setup-step.js';
 export type {StepResult} from '#core/step-result.js';

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -454,6 +454,94 @@ describe('createStepLogStream', () => {
     expect(records.some((r) => r.type === 'gap')).toBe(true);
   });
 
+  it('writes runner-originated groups as control records sharing the user group id space', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 15,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.writeGroup({
+      name: 'Run npm test',
+      lines: ['npm test', 'shell: bash -e {0}', '::group::not parsed'],
+    });
+    stream.write(Buffer.from('::group::User group\nwork\n::endgroup::\n'), 'stdout');
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(15);
+    expect(groupStarts(records)).toEqual([
+      {id: 'g1', parent: null, name: 'Run npm test'},
+      {id: 'g2', parent: null, name: 'User group'},
+    ]);
+    expect(groupEndIds(records)).toEqual(['g1', 'g2']);
+    expect(
+      records.filter((r) => r.type === 'output').map((r) => (r.type === 'output' ? r.data : '')),
+    ).toEqual(['  npm test\n', '  shell: bash -e {0}\n', '  ::group::not parsed\n', 'work\n']);
+  });
+
+  it('redacts runner-originated group metadata before it reaches the spool', async () => {
+    const secret = 'sf/rt+METADATA=34';
+    const forms = secretWireForms(secret);
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 16,
+      append: hangingAppend,
+      secrets: [secret],
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.writeGroup({
+      name: `Run ${secret}`,
+      lines: [`token=${secret}`, `encoded=${encodeURIComponent(secret)}`],
+    });
+    stream.writeOutputLine(`Process failed: https://user:${secret}@example.com/repo`, 'stderr');
+    await stream.close();
+    stream.dispose();
+
+    const raw = await readFile(join(dir, 'logs', `${STEP_ID}-16.ndjson`), 'utf8');
+    for (const form of forms) {
+      expect(raw).not.toContain(form);
+    }
+    expect(raw).not.toContain(`user:${secret}@`);
+    expect(raw).toContain('***');
+  });
+
+  it('abandons capture without crashing when a runner-originated metadata write fails', async () => {
+    let appends = 0;
+    const appendSpy = vi.spyOn(AttemptSpool.prototype, 'append').mockImplementation(() => {
+      appends += 1;
+      if (appends >= 2) throw Object.assign(new Error('ENOSPC'), {code: 'ENOSPC'});
+    });
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 17,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    expect(() =>
+      stream.writeGroup({
+        name: 'Run test',
+        lines: ['test', 'shell: bash -e {0}'],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      stream.writeOutputLine('Process completed with exit code 1.', 'stderr'),
+    ).not.toThrow();
+    await expect(stream.close()).resolves.toBeDefined();
+    stream.dispose();
+
+    appendSpy.mockRestore();
+  });
+
   describe('nested groups', () => {
     function nestingStream(attempt: number) {
       return createStepLogStream({

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -1,8 +1,10 @@
 import {Buffer} from 'node:buffer';
+import {redactSecrets} from '@shipfox/redact';
 import type {LogAppendFn} from '@shipfox/runner-protocol';
 import {type FramedOutput, type OutputSource, StreamFramer} from '#core/framing.js';
 import type {LogStreamLifecycle} from '#core/lifecycle.js';
 import {createRecordSink} from '#core/record-sink.js';
+import {buildSecretVariants} from '#core/secrets.js';
 import {LogTransformer, type TransformEvent} from '#core/transform.js';
 
 const EMPTY_FRAMED: FramedOutput = {bytes: Buffer.alloc(0), payloadBytes: 0};
@@ -29,6 +31,16 @@ export interface StepLogStreamOptions {
 export interface StepLogStream extends LogStreamLifecycle {
   /** Frames and spools a captured output chunk. Safe to call from a pipe handler. */
   write(chunk: Buffer, source: OutputSource): void;
+  /** Frames a runner-originated group using the same group records as `::group::` markers. */
+  writeGroup(options: StepLogGroupOptions): void;
+  /** Frames a runner-originated output line, ensuring it ends with a newline. */
+  writeOutputLine(line: string, source?: OutputSource): void;
+}
+
+export interface StepLogGroupOptions {
+  name: string;
+  lines: readonly string[];
+  source?: OutputSource;
 }
 
 /**
@@ -41,6 +53,7 @@ export interface StepLogStream extends LogStreamLifecycle {
 export function createStepLogStream(options: StepLogStreamOptions): StepLogStream {
   const now = options.now ?? Date.now;
   const framer = new StreamFramer(now);
+  const secretVariants = buildSecretVariants(options.secrets ?? []);
   const transformer = new LogTransformer(options.secrets ?? []);
   const sink = createRecordSink({
     logsDir: options.logsDir,
@@ -98,11 +111,31 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
     return {bytes: framer.frameGroupEnd(groupId), payloadBytes: 0};
   }
 
+  function canWrite(): boolean {
+    return !sink.isClosed() && !sink.isFailed() && !sink.isCapped() && !sink.isStopped();
+  }
+
+  function writeEvents(events: TransformEvent[]): void {
+    if (!canWrite()) return;
+
+    try {
+      for (const event of events) sink.spool(frameEvent(event));
+    } catch (err) {
+      sink.fail(err);
+      return;
+    }
+    sink.notify();
+  }
+
+  function safeText(text: string): string {
+    return redactSecrets(text, secretVariants);
+  }
+
   return {
     write(chunk, source) {
       // Once the server caps the budget the runner stops emitting; the cap
       // tombstone is server-side, so no gap is recorded here.
-      if (sink.isClosed() || sink.isFailed() || sink.isCapped() || sink.isStopped()) return;
+      if (!canWrite()) return;
 
       let events: TransformEvent[];
       try {
@@ -114,13 +147,24 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
         return;
       }
 
-      try {
-        for (const event of events) sink.spool(frameEvent(event));
-      } catch (err) {
-        sink.fail(err);
-        return;
-      }
-      sink.notify();
+      writeEvents(events);
+    },
+
+    writeGroup({name, lines, source = 'stdout'}) {
+      const events: TransformEvent[] = [
+        {type: 'group_start', name: safeText(name)},
+        ...lines.map((line) => ({
+          type: 'output' as const,
+          src: source,
+          data: safeText(indentLine(ensureTrailingNewline(line))),
+        })),
+        {type: 'group_end'},
+      ];
+      writeEvents(events);
+    },
+
+    writeOutputLine(line, source = 'stdout') {
+      writeEvents([{type: 'output', src: source, data: safeText(ensureTrailingNewline(line))}]);
     },
 
     close() {
@@ -144,4 +188,15 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       sink.dispose();
     },
   };
+}
+
+function ensureTrailingNewline(line: string): string {
+  return line.endsWith('\n') ? line : `${line}\n`;
+}
+
+function indentLine(line: string): string {
+  return line
+    .split('\n')
+    .map((part, index, parts) => (index === parts.length - 1 && part === '' ? '' : `  ${part}`))
+    .join('\n');
 }

--- a/libs/runner/logs/src/index.ts
+++ b/libs/runner/logs/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from '#core/session-log-stream.js';
 export {
   createStepLogStream,
+  type StepLogGroupOptions,
   type StepLogStream,
   type StepLogStreamOptions,
 } from '#core/step-log-stream.js';

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -43,6 +43,8 @@ let events: string[];
 
 interface FakeStream {
   write: ReturnType<typeof vi.fn>;
+  writeGroup: ReturnType<typeof vi.fn>;
+  writeOutputLine: ReturnType<typeof vi.fn>;
   writeEntry: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   drain: ReturnType<typeof vi.fn>;
@@ -51,7 +53,15 @@ interface FakeStream {
 
 function makeFakeStream(label: string): FakeStream {
   return {
-    write: vi.fn(),
+    write: vi.fn(() => {
+      events.push(`write:${label}`);
+    }),
+    writeGroup: vi.fn(() => {
+      events.push(`group:${label}`);
+    }),
+    writeOutputLine: vi.fn(() => {
+      events.push(`line:${label}`);
+    }),
     writeEntry: vi.fn(),
     close: vi.fn(() => {
       events.push(`close:${label}`);
@@ -111,6 +121,7 @@ describe('runJobSteps', () => {
     expect(executeRunStepMock).toHaveBeenCalledWith(run, {
       signal: ac.signal,
       cwd: '/work',
+      onCommandStart: expect.any(Function),
       onOutput: expect.any(Function),
     });
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
@@ -171,6 +182,55 @@ describe('runJobSteps', () => {
     await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
 
     expect(captured?.write).toHaveBeenCalledWith(Buffer.from('hello'), 'stdout');
+  });
+
+  it('writes command metadata before captured output', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep({config: {run: 'echo hello'}});
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    let captured: FakeStream | undefined;
+    createStepLogStreamMock.mockImplementation((opts: {stepId: string}) => {
+      captured = makeFakeStream(opts.stepId);
+      return captured;
+    });
+    executeRunStepMock.mockImplementation(
+      (
+        _step,
+        opts: {
+          onCommandStart: (metadata: {
+            command: string;
+            shell: {display: string};
+            cwd?: string;
+          }) => void;
+          onOutput: (chunk: Buffer, src: string) => void;
+        },
+      ) => {
+        opts.onCommandStart({
+          command: 'echo hello',
+          shell: {display: 'bash --noprofile --norc -eo pipefail {0}'},
+          cwd: '/work',
+        });
+        opts.onOutput(Buffer.from('hello'), 'stdout');
+        return Promise.resolve({success: true, error: null, exit_code: 0});
+      },
+    );
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+
+    expect(captured?.writeGroup).toHaveBeenCalledWith({
+      name: 'Run echo hello',
+      lines: [
+        'echo hello',
+        'shell: bash --noprofile --norc -eo pipefail {0}',
+        'working-directory: /work',
+      ],
+      source: 'stdout',
+    });
+    expect(events.indexOf(`group:${run.id}`)).toBeLessThan(events.indexOf(`write:${run.id}`));
   });
 
   it('runs and reports the step when opening the log stream fails (capture abandoned)', async () => {
@@ -362,6 +422,35 @@ describe('runJobSteps', () => {
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(2);
+    const stream = createStepLogStreamMock.mock.results[0]?.value as FakeStream;
+    expect(stream.writeOutputLine).toHaveBeenCalledWith(
+      'Process completed with exit code 1.',
+      'stderr',
+    );
+    expect(events.indexOf(`line:${run.id}`)).toBeLessThan(events.indexOf(`close:${run.id}`));
+  });
+
+  it('writes terminal signal context for a failed run step before closing the stream', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    const error = {message: 'Killed by signal SIGKILL', exit_code: null, signal: 'SIGKILL'};
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    executeRunStepMock.mockResolvedValueOnce({success: false, error, exit_code: null});
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+
+    const stream = createStepLogStreamMock.mock.results[0]?.value as FakeStream;
+    expect(stream.writeOutputLine).toHaveBeenCalledWith(
+      'Process terminated by signal SIGKILL.',
+      'stderr',
+    );
+    expect(events.indexOf(`line:${run.id}`)).toBeLessThan(events.indexOf(`close:${run.id}`));
   });
 
   it('reports the step failed when executeRunStep throws (no leaked error, no hung step)', async () => {
@@ -388,6 +477,11 @@ describe('runJobSteps', () => {
       exitCode: null,
       signal: ac.signal,
     });
+    const stream = createStepLogStreamMock.mock.results[0]?.value as FakeStream;
+    expect(stream.writeOutputLine).toHaveBeenCalledWith(
+      'Process failed: ENOSPC: no space left on device',
+      'stderr',
+    );
   });
 
   it('does not report when the signal aborts during setup', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -2,7 +2,12 @@ import {join} from 'node:path';
 import type {NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {executeAgentStep} from '@shipfox/runner-agent';
-import {executeRunStep, executeSetupStep, type StepResult} from '@shipfox/runner-execution';
+import {
+  type CommandStartMetadata,
+  executeRunStep,
+  executeSetupStep,
+  type StepResult,
+} from '@shipfox/runner-execution';
 import {
   createSessionLogStream,
   createStepLogStream,
@@ -18,6 +23,8 @@ import {
   requestNextStep,
 } from '@shipfox/runner-protocol';
 import type {KyInstance} from 'ky';
+
+const WHITESPACE_REGEX = /\s+/;
 
 // Reporting a step before pulling the next one is the safety invariant: a lost report is
 // retried in place (next/report are idempotent), so a step is never re-pulled or
@@ -166,6 +173,7 @@ export async function executeStep(params: {
     params;
 
   let stream: LogStreamLifecycle | undefined;
+  let runStream: StepLogStream | undefined;
   try {
     if (step.type === 'setup') {
       const result = await executeSetupStep({cwd, leaseClient, signal});
@@ -245,28 +253,66 @@ export async function executeStep(params: {
       );
     }
     stream = stepStream;
+    runStream = stepStream;
 
     const result = await executeRunStep(step, {
       signal,
       cwd,
+      onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
       onOutput: (chunk, source) => stepStream?.write(chunk, source),
     });
+    writeRunFailureContext(stepStream, result);
     return {result, stream, preparedWorkspace: false};
   } catch (error) {
     logger().error(
       {err: error, jobId, stepId: step.id},
       `Step ${stepLabel} crashed before producing a result`,
     );
+    const result: StepResult = {
+      success: false,
+      error: {message: error instanceof Error ? error.message : String(error)},
+      exit_code: null,
+    };
+    writeRunFailureContext(runStream, result);
     return {
-      result: {
-        success: false,
-        error: {message: error instanceof Error ? error.message : String(error)},
-        exit_code: null,
-      },
+      result,
       stream,
       preparedWorkspace: false,
     };
   }
+}
+
+function writeCommandMetadata(
+  stream: StepLogStream | undefined,
+  metadata: CommandStartMetadata,
+): void {
+  stream?.writeGroup({
+    name: `Run ${summarizeCommand(metadata.command)}`,
+    lines: [
+      metadata.command,
+      `shell: ${metadata.shell.display}`,
+      ...(metadata.cwd !== undefined ? [`working-directory: ${metadata.cwd}`] : []),
+    ],
+    source: 'stdout',
+  });
+}
+
+function writeRunFailureContext(stream: StepLogStream | undefined, result: StepResult): void {
+  if (result.success) return;
+  stream?.writeOutputLine(runFailureContext(result), 'stderr');
+}
+
+function runFailureContext(result: StepResult): string {
+  if (result.error?.signal) return `Process terminated by signal ${result.error.signal}.`;
+  if (result.exit_code !== null) return `Process completed with exit code ${result.exit_code}.`;
+  if (result.error?.message) return `Process failed: ${result.error.message}`;
+  return 'Process failed.';
+}
+
+function summarizeCommand(command: string): string {
+  const summary = command.trim().split(WHITESPACE_REGEX).join(' ');
+  if (summary.length <= 120) return summary;
+  return `${summary.slice(0, 117)}...`;
 }
 
 // Logs the outcome, seals the stream to learn its declared length, and reports the step.


### PR DESCRIPTION
Command steps now start their log stream with a grouped command summary that shows the resolved command, shell, and working directory before stdout/stderr begins. This makes run-step logs readable even when the command emits little or no output.

The runner writes these records through the existing step-attempt log model, so the frontend can render the group without a UI change. Metadata uses the same redaction path as captured output, and failed commands append terminal context before the stream closes.

Considered routing metadata through synthetic `::group::` marker text, but a small direct stream API keeps runner-originated records separate from user output while still sharing the same group stack and record framing.

Closes ENG-587

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured command logs to runner steps. Each command step now starts with a grouped summary (command, shell, working directory) and ends with terminal failure context; observers get a copied metadata payload so they can’t mutate the spawned shell. Implements ENG-587.

- **New Features**
  - Emits a runner-originated command group before stdout/stderr with command text, shell display (`{0}`), and cwd; secrets are redacted.
  - Uses the existing grouped log record model and ID space; the UI needs no changes.
  - Adds `writeGroup` and `writeOutputLine` to `@shipfox/runner-logs`; redacts runner-originated metadata and tolerates write failures without crashing capture.
  - Orchestrator writes the metadata via `onCommandStart` and appends failure context on non-zero exit, signals, or crashes.
  - Exposes command metadata types and hooks in `@shipfox/runner-execution`; metadata is copied for observers, and emission failures don’t stop command execution.

<sup>Written for commit c249ff6b57f56522ec16ae3a002b4f68e49f7b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

