### PR TITLE
[runner] Emit setup and checkout logs

### DIFF
--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -30,6 +30,10 @@ const {CheckoutError} = await import('@shipfox/runner-workspace');
 const CWD = '/tmp/shipfox-test-root/job-1';
 const leaseClient = {} as never;
 const signal = new AbortController().signal;
+const jobContext = {
+  jobId: '00000000-0000-0000-0000-0000000000aa',
+  runId: '00000000-0000-0000-0000-0000000000ab',
+};
 
 function checkoutResponse(auth?: unknown) {
   return {
@@ -39,8 +43,17 @@ function checkoutResponse(auth?: unknown) {
   };
 }
 
-function run() {
-  return executeSetupStep({cwd: CWD, leaseClient, signal});
+function run(log?: ReturnType<typeof fakeLog>) {
+  return executeSetupStep({cwd: CWD, leaseClient, signal, ...(log ? {log, jobContext} : {})});
+}
+
+function fakeLog() {
+  return {
+    writeGroup: vi.fn(),
+    writeOutputLine: vi.fn(),
+    write: vi.fn(),
+    addSecrets: vi.fn(),
+  };
 }
 
 // ky populates `error.data` with the pre-parsed body and consumes `error.response`, so
@@ -59,10 +72,10 @@ function httpError(status: number, body?: unknown): HTTPError {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  assertGitAvailableMock.mockResolvedValue(undefined);
+  assertGitAvailableMock.mockResolvedValue('git version 2.51.0');
   createJobDirMock.mockResolvedValue(undefined);
   requestCheckoutTokenMock.mockResolvedValue(checkoutResponse());
-  checkoutRepositoryMock.mockResolvedValue(undefined);
+  checkoutRepositoryMock.mockResolvedValue('abc123');
 });
 
 describe('executeSetupStep', () => {
@@ -76,14 +89,64 @@ describe('executeSetupStep', () => {
     expect(assertGitAvailableMock).toHaveBeenCalledOnce();
     expect(createJobDirMock).toHaveBeenCalledWith(CWD);
     expect(requestCheckoutTokenMock).toHaveBeenCalledWith(leaseClient, {signal});
-    expect(checkoutRepositoryMock).toHaveBeenCalledWith({
-      repositoryUrl: 'https://github.com/acme/repo.git',
-      ref: 'main',
-      auth: {kind: 'bearer', token: 't', expires_at: '2026-01-01T00:00:00Z'},
-      cwd: CWD,
-      signal,
-    });
+    expect(checkoutRepositoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositoryUrl: 'https://github.com/acme/repo.git',
+        ref: 'main',
+        auth: {kind: 'bearer', token: 't', expires_at: '2026-01-01T00:00:00Z'},
+        cwd: CWD,
+        signal,
+        onSecrets: expect.any(Function),
+        onCommandStart: expect.any(Function),
+      }),
+    );
     expect(result).toEqual({success: true, error: null, exit_code: 0});
+  });
+
+  it('writes setup groups and the final checked-out commit', async () => {
+    const log = fakeLog();
+
+    const result = await run(log);
+
+    expect(result.success).toBe(true);
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Job context',
+      lines: [`job id: ${jobContext.jobId}`, `run id: ${jobContext.runId}`],
+    });
+    expect(log.writeGroup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Runner environment',
+        lines: expect.arrayContaining(['git: git version 2.51.0']),
+      }),
+    );
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Checkout complete',
+      lines: ['checked-out commit: abc123'],
+    });
+    expect(log.writeOutputLine).toHaveBeenCalledWith('Setup completed successfully.');
+  });
+
+  it('routes checkout callbacks to the setup log sink', async () => {
+    const log = fakeLog();
+
+    await run(log);
+    const [{onSecrets, onCommandStart, onOutput}] = checkoutRepositoryMock.mock.calls[0] as [
+      {
+        onSecrets: (secrets: string[]) => void;
+        onCommandStart: (metadata: {phase: 'fetch'; command: string; cwd: string}) => void;
+        onOutput: (chunk: Buffer, source: 'stdout') => void;
+      },
+    ];
+    onSecrets(['tok-123']);
+    onCommandStart({phase: 'fetch', command: 'git fetch origin main', cwd: CWD});
+    onOutput(Buffer.from('remote output'), 'stdout');
+
+    expect(log.addSecrets).toHaveBeenCalledWith(['tok-123']);
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Checkout fetch',
+      lines: ['git fetch origin main', `working-directory: ${CWD}`],
+    });
+    expect(log.write).toHaveBeenCalledWith(Buffer.from('remote output'), 'stdout');
   });
 
   it('checks git before minting a credential', async () => {
@@ -149,7 +212,7 @@ describe('executeSetupStep', () => {
     {kind: 'unavailable' as const, reason: 'checkout_unavailable'},
     {kind: 'failed' as const, reason: 'checkout_failed'},
     {kind: 'aborted' as const, reason: 'setup_aborted'},
-  ])('maps a $kind clone failure to $reason', async ({kind, reason}) => {
+  ])('maps a $kind checkout failure to $reason', async ({kind, reason}) => {
     checkoutRepositoryMock.mockRejectedValue(new CheckoutError(kind, 'boom'));
 
     const result = await run();
@@ -158,7 +221,22 @@ describe('executeSetupStep', () => {
     expect(result.error?.reason).toBe(reason);
   });
 
-  it('maps an unexpected clone error to checkout_failed', async () => {
+  it('logs the checkout phase that failed', async () => {
+    const log = fakeLog();
+    checkoutRepositoryMock.mockRejectedValue(
+      new CheckoutError('failed', 'remote rejected', {phase: 'fetch'}),
+    );
+
+    const result = await run(log);
+
+    expect(result.error?.reason).toBe('checkout_failed');
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Setup failed during checkout fetch: remote rejected',
+      'stderr',
+    );
+  });
+
+  it('maps an unexpected checkout error to checkout_failed', async () => {
     checkoutRepositoryMock.mockRejectedValue(new Error('weird'));
 
     const result = await run();

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -112,30 +112,32 @@ describe('executeSetupStep', () => {
 
     expect(result.success).toBe(true);
     expect(log.writeGroup).toHaveBeenCalledWith({
-      name: 'Job context',
-      lines: [`job id: ${jobContext.jobId}`, `run id: ${jobContext.runId}`],
+      name: 'Job details',
+      lines: [`Job: ${jobContext.jobId}`, `Run: ${jobContext.runId}`],
     });
     expect(log.writeGroupStart).toHaveBeenCalledWith('Checkout');
     expect(log.writeGroupEnd).toHaveBeenCalledTimes(1);
     expect(log.writeGroup).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Runner environment',
-        lines: expect.arrayContaining(['git: git version 2.51.0']),
+        lines: expect.arrayContaining(['Git: git version 2.51.0']),
       }),
     );
     expect(log.writeGroup).toHaveBeenCalledWith({
-      name: 'Request checkout credentials',
-      lines: ['Requesting checkout credentials'],
+      name: 'Request repository access',
+      lines: ['Requesting short-lived repository access from Shipfox.'],
     });
     expect(log.writeGroup).toHaveBeenCalledWith({
-      name: 'Checkout authentication',
-      lines: ['credential kind: none', 'expires at: n/a'],
+      name: 'Repository access granted',
+      lines: ['No repository credential was required.'],
     });
     expect(log.writeGroup).toHaveBeenCalledWith({
       name: 'Checkout complete',
-      lines: ['checked-out commit: abc123'],
+      lines: ['Checked out commit: abc123'],
     });
-    expect(log.writeOutputLine).toHaveBeenCalledWith('Setup completed successfully.');
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Setup completed successfully. The job is ready to run.',
+    );
   });
 
   it('routes checkout callbacks to the setup log sink', async () => {
@@ -155,30 +157,48 @@ describe('executeSetupStep', () => {
 
     expect(log.addSecrets).toHaveBeenCalledWith(['tok-123']);
     expect(log.writeGroup).toHaveBeenCalledWith({
-      name: 'Checkout fetch',
-      lines: ['git fetch origin main', `working-directory: ${CWD}`],
+      name: 'Fetch requested ref',
+      lines: ['Command: git fetch origin main', `Working directory: ${CWD}`],
     });
     expect(log.write).toHaveBeenCalledWith(Buffer.from('remote output'), 'stdout');
   });
 
   it('checks git before minting a credential', async () => {
+    const log = fakeLog();
     assertGitAvailableMock.mockRejectedValue(new Error('git is not available on the runner host'));
 
-    const result = await run();
+    const result = await run(log);
 
     expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
     expect(createJobDirMock).not.toHaveBeenCalled();
     expect(result.success).toBe(false);
     expect(result.error?.reason).toBe('git_unavailable');
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Setup failed because Git is not available on the runner. Details: git is not available on the runner host',
+      'stderr',
+    );
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Next step: Install Git in the runner image or use a runner image that includes Git.',
+      'stderr',
+    );
   });
 
   it('reports workspace_prep_failed when creating the directory fails', async () => {
+    const log = fakeLog();
     createJobDirMock.mockRejectedValue(new Error('mkdir denied'));
 
-    const result = await run();
+    const result = await run(log);
 
     expect(requestCheckoutTokenMock).not.toHaveBeenCalled();
     expect(result.error).toEqual({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Setup failed because the runner could not prepare the workspace. Details: mkdir denied',
+      'stderr',
+    );
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Next step: Check the runner workspace permissions and available disk space.',
+      'stderr',
+    );
   });
 
   it.each([
@@ -245,7 +265,11 @@ describe('executeSetupStep', () => {
     expect(log.writeGroupStart).toHaveBeenCalledWith('Checkout');
     expect(log.writeGroupEnd).toHaveBeenCalledTimes(1);
     expect(log.writeOutputLine).toHaveBeenCalledWith(
-      'Setup failed during checkout fetch: remote rejected',
+      'Setup failed while fetching the requested ref. Details: remote rejected',
+      'stderr',
+    );
+    expect(log.writeOutputLine).toHaveBeenCalledWith(
+      'Next step: Check that the repository URL and requested ref are valid. The git output above may include provider details.',
       'stderr',
     );
   });

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -49,6 +49,8 @@ function run(log?: ReturnType<typeof fakeLog>) {
 
 function fakeLog() {
   return {
+    writeGroupStart: vi.fn(),
+    writeGroupEnd: vi.fn(),
     writeGroup: vi.fn(),
     writeOutputLine: vi.fn(),
     write: vi.fn(),
@@ -113,6 +115,8 @@ describe('executeSetupStep', () => {
       name: 'Job context',
       lines: [`job id: ${jobContext.jobId}`, `run id: ${jobContext.runId}`],
     });
+    expect(log.writeGroupStart).toHaveBeenCalledWith('Checkout');
+    expect(log.writeGroupEnd).toHaveBeenCalledTimes(1);
     expect(log.writeGroup).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Runner environment',
@@ -238,6 +242,8 @@ describe('executeSetupStep', () => {
     const result = await run(log);
 
     expect(result.error?.reason).toBe('checkout_failed');
+    expect(log.writeGroupStart).toHaveBeenCalledWith('Checkout');
+    expect(log.writeGroupEnd).toHaveBeenCalledTimes(1);
     expect(log.writeOutputLine).toHaveBeenCalledWith(
       'Setup failed during checkout fetch: remote rejected',
       'stderr',

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -120,6 +120,14 @@ describe('executeSetupStep', () => {
       }),
     );
     expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Request checkout credentials',
+      lines: ['Requesting checkout credentials'],
+    });
+    expect(log.writeGroup).toHaveBeenCalledWith({
+      name: 'Checkout authentication',
+      lines: ['credential kind: none', 'expires at: n/a'],
+    });
+    expect(log.writeGroup).toHaveBeenCalledWith({
       name: 'Checkout complete',
       lines: ['checked-out commit: abc123'],
     });

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -17,6 +17,8 @@ import type {StepResult} from '#core/step-result.js';
 const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
 
 interface SetupLogSink {
+  writeGroupStart(name: string): void;
+  writeGroupEnd(): void;
   writeGroup(options: {name: string; lines: readonly string[]; source?: 'stdout' | 'stderr'}): void;
   writeOutputLine(line: string, source?: 'stdout' | 'stderr'): void;
   write(chunk: Buffer, source: 'stdout' | 'stderr'): void;
@@ -46,10 +48,24 @@ export async function executeSetupStep(params: {
 
   writeJobContext(log, jobContext);
 
-  // Check git before minting a credential: a host without git never hits the provider.
-  let gitVersion: string;
+  const gitFailure = await checkGit(log);
+  if (gitFailure) return gitFailure;
+
+  const workspaceFailure = await prepareWorkspace({cwd, log});
+  if (workspaceFailure) return workspaceFailure;
+
+  const checkoutFailure = await runCheckoutSetup({cwd, leaseClient, signal, log});
+  if (checkoutFailure) return checkoutFailure;
+
+  log?.writeOutputLine('Setup completed successfully.');
+  return {success: true, error: null, exit_code: 0};
+}
+
+async function checkGit(log: SetupLogSink | undefined): Promise<StepResult | null> {
   try {
-    gitVersion = await assertGitAvailable();
+    const gitVersion = await assertGitAvailable();
+    writeRunnerEnvironment(log, gitVersion);
+    return null;
   } catch (error) {
     writeRunnerEnvironment(log, 'unavailable');
     log?.writeOutputLine(
@@ -58,8 +74,13 @@ export async function executeSetupStep(params: {
     );
     return fail(error, 'git_unavailable');
   }
-  writeRunnerEnvironment(log, gitVersion);
+}
 
+async function prepareWorkspace(params: {
+  cwd: string;
+  log?: SetupLogSink | undefined;
+}): Promise<StepResult | null> {
+  const {cwd, log} = params;
   try {
     log?.writeGroup({
       name: 'Prepare workspace',
@@ -76,14 +97,41 @@ export async function executeSetupStep(params: {
     );
     return fail(error, 'workspace_prep_failed');
   }
+  return null;
+}
 
-  let checkout: CheckoutTokenResponseDto;
+async function runCheckoutSetup(params: {
+  cwd: string;
+  leaseClient: KyInstance;
+  signal: AbortSignal;
+  log?: SetupLogSink | undefined;
+}): Promise<StepResult | null> {
+  const {log} = params;
+  log?.writeGroupStart('Checkout');
+  try {
+    const checkout = await requestCheckoutCredentials(params);
+    if (!checkout.ok) return checkout.result;
+
+    return await checkoutRepositoryForSetup({...params, checkout: checkout.value});
+  } finally {
+    log?.writeGroupEnd();
+  }
+}
+
+type SetupPhaseResult<T> = {ok: true; value: T} | {ok: false; result: StepResult};
+
+async function requestCheckoutCredentials(params: {
+  leaseClient: KyInstance;
+  signal: AbortSignal;
+  log?: SetupLogSink | undefined;
+}): Promise<SetupPhaseResult<CheckoutTokenResponseDto>> {
+  const {leaseClient, signal, log} = params;
   try {
     log?.writeGroup({
       name: 'Request checkout credentials',
       lines: ['Requesting checkout credentials'],
     });
-    checkout = await requestCheckoutToken(leaseClient, {signal});
+    const checkout = await requestCheckoutToken(leaseClient, {signal});
     log?.writeGroup({
       name: 'Checkout authentication',
       lines: [
@@ -91,14 +139,23 @@ export async function executeSetupStep(params: {
         checkout.auth?.expires_at ? `expires at: ${checkout.auth.expires_at}` : 'expires at: n/a',
       ],
     });
+    return {ok: true, value: checkout};
   } catch (error) {
     log?.writeOutputLine(
       `Setup failed while requesting checkout credentials: ${messageOf(error)}`,
       'stderr',
     );
-    return fail(error, classifyCheckoutTokenError(error));
+    return {ok: false, result: fail(error, classifyCheckoutTokenError(error))};
   }
+}
 
+async function checkoutRepositoryForSetup(params: {
+  cwd: string;
+  checkout: CheckoutTokenResponseDto;
+  signal: AbortSignal;
+  log?: SetupLogSink | undefined;
+}): Promise<StepResult | null> {
+  const {cwd, checkout, signal, log} = params;
   try {
     log?.writeGroup({
       name: 'Checkout repository',
@@ -115,6 +172,7 @@ export async function executeSetupStep(params: {
       onOutput: checkoutOutput(log),
     });
     log?.writeGroup({name: 'Checkout complete', lines: [`checked-out commit: ${commit}`]});
+    return null;
   } catch (error) {
     const reason =
       error instanceof CheckoutError ? CHECKOUT_KIND_REASON[error.kind] : 'checkout_failed';
@@ -128,9 +186,6 @@ export async function executeSetupStep(params: {
     }
     return fail(error, reason);
   }
-
-  log?.writeOutputLine('Setup completed successfully.');
-  return {success: true, error: null, exit_code: 0};
 }
 
 const CHECKOUT_KIND_REASON: Record<CheckoutFailureKind, StepErrorReason> = {

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -1,14 +1,32 @@
+import {arch, platform, release} from 'node:os';
 import type {CheckoutTokenResponseDto, StepErrorReason} from '@shipfox/api-workflows-dto';
 import {HTTPError, requestCheckoutToken} from '@shipfox/runner-protocol';
 import {
   assertGitAvailable,
+  type CheckoutCommandStartMetadata,
   CheckoutError,
   type CheckoutFailureKind,
+  type CheckoutOutputSink,
+  type CheckoutPhase,
   checkoutRepository,
   createJobDir,
 } from '@shipfox/runner-workspace';
 import type {KyInstance} from 'ky';
 import type {StepResult} from '#core/step-result.js';
+
+const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
+
+interface SetupLogSink {
+  writeGroup(options: {name: string; lines: readonly string[]; source?: 'stdout' | 'stderr'}): void;
+  writeOutputLine(line: string, source?: 'stdout' | 'stderr'): void;
+  write(chunk: Buffer, source: 'stdout' | 'stderr'): void;
+  addSecrets(secrets: string[]): void;
+}
+
+export interface SetupJobContext {
+  jobId: string;
+  runId: string;
+}
 
 // The synthetic "Set up job" step body. It owns per-job workspace preparation and the
 // repository checkout, reporting failures through the normal step protocol so a setup
@@ -21,43 +39,94 @@ export async function executeSetupStep(params: {
   cwd: string;
   leaseClient: KyInstance;
   signal: AbortSignal;
+  log?: SetupLogSink | undefined;
+  jobContext?: SetupJobContext | undefined;
 }): Promise<StepResult> {
-  const {cwd, leaseClient, signal} = params;
+  const {cwd, leaseClient, signal, log, jobContext} = params;
+
+  writeJobContext(log, jobContext);
 
   // Check git before minting a credential: a host without git never hits the provider.
+  let gitVersion: string;
   try {
-    await assertGitAvailable();
+    gitVersion = await assertGitAvailable();
   } catch (error) {
+    writeRunnerEnvironment(log, 'unavailable');
+    log?.writeOutputLine(
+      `Setup failed during git availability check: ${messageOf(error)}`,
+      'stderr',
+    );
     return fail(error, 'git_unavailable');
   }
+  writeRunnerEnvironment(log, gitVersion);
 
   try {
+    log?.writeGroup({
+      name: 'Prepare workspace',
+      lines: [
+        `workspace: ${cwd}`,
+        'operation: remove any previous job directory and create a clean checkout directory',
+      ],
+    });
     await createJobDir(cwd);
   } catch (error) {
+    log?.writeOutputLine(
+      `Setup failed during workspace preparation: ${messageOf(error)}`,
+      'stderr',
+    );
     return fail(error, 'workspace_prep_failed');
   }
 
   let checkout: CheckoutTokenResponseDto;
   try {
+    log?.writeGroup({name: 'Checkout authentication', lines: ['Requesting checkout credentials']});
     checkout = await requestCheckoutToken(leaseClient, {signal});
+    log?.writeGroup({
+      name: 'Checkout authentication',
+      lines: [
+        checkout.auth ? `credential kind: ${checkout.auth.kind}` : 'credential kind: none',
+        checkout.auth?.expires_at ? `expires at: ${checkout.auth.expires_at}` : 'expires at: n/a',
+      ],
+    });
   } catch (error) {
+    log?.writeOutputLine(
+      `Setup failed while requesting checkout credentials: ${messageOf(error)}`,
+      'stderr',
+    );
     return fail(error, classifyCheckoutTokenError(error));
   }
 
   try {
-    await checkoutRepository({
+    log?.writeGroup({
+      name: 'Checkout repository',
+      lines: [`repository: ${safeRepositoryUrl(checkout.repository_url)}`, `ref: ${checkout.ref}`],
+    });
+    const commit = await checkoutRepository({
       repositoryUrl: checkout.repository_url,
       ref: checkout.ref,
       auth: checkout.auth,
       cwd,
       signal,
+      onSecrets: (secrets) => log?.addSecrets(secrets),
+      onCommandStart: (metadata) => writeCheckoutCommand(log, metadata),
+      onOutput: checkoutOutput(log),
     });
+    log?.writeGroup({name: 'Checkout complete', lines: [`checked-out commit: ${commit}`]});
   } catch (error) {
     const reason =
       error instanceof CheckoutError ? CHECKOUT_KIND_REASON[error.kind] : 'checkout_failed';
+    if (error instanceof CheckoutError && error.phase) {
+      log?.writeOutputLine(
+        `Setup failed during checkout ${phaseLabel(error.phase)}: ${messageOf(error)}`,
+        'stderr',
+      );
+    } else {
+      log?.writeOutputLine(`Setup failed during checkout: ${messageOf(error)}`, 'stderr');
+    }
     return fail(error, reason);
   }
 
+  log?.writeOutputLine('Setup completed successfully.');
   return {success: true, error: null, exit_code: 0};
 }
 
@@ -108,7 +177,67 @@ function readErrorCode(error: HTTPError): string | undefined {
 function fail(error: unknown, reason: StepErrorReason): StepResult {
   return {
     success: false,
-    error: {message: error instanceof Error ? error.message : String(error), reason},
+    error: {message: messageOf(error), reason},
     exit_code: null,
   };
+}
+
+function writeJobContext(
+  log: SetupLogSink | undefined,
+  jobContext: SetupJobContext | undefined,
+): void {
+  if (!jobContext) return;
+  log?.writeGroup({
+    name: 'Job context',
+    lines: [`job id: ${jobContext.jobId}`, `run id: ${jobContext.runId}`],
+  });
+}
+
+function writeRunnerEnvironment(log: SetupLogSink | undefined, gitVersion: string): void {
+  log?.writeGroup({
+    name: 'Runner environment',
+    lines: [
+      `node: ${process.version}`,
+      `os: ${platform()} ${release()}`,
+      `architecture: ${arch()}`,
+      `git: ${gitVersion}`,
+      ...buildMetadataLines(),
+    ],
+  });
+}
+
+function buildMetadataLines(): string[] {
+  const lines: string[] = [];
+  if (process.env.npm_package_version)
+    lines.push(`package version: ${process.env.npm_package_version}`);
+  if (process.env.IMAGE_REVISION) lines.push(`image revision: ${process.env.IMAGE_REVISION}`);
+  if (process.env.BUILD_NUMBER) lines.push(`build number: ${process.env.BUILD_NUMBER}`);
+  return lines;
+}
+
+function writeCheckoutCommand(
+  log: SetupLogSink | undefined,
+  metadata: CheckoutCommandStartMetadata,
+): void {
+  log?.writeGroup({
+    name: `Checkout ${phaseLabel(metadata.phase)}`,
+    lines: [metadata.command, `working-directory: ${metadata.cwd}`],
+  });
+}
+
+function checkoutOutput(log: SetupLogSink | undefined): CheckoutOutputSink | undefined {
+  if (!log) return undefined;
+  return (chunk, source) => log.write(chunk, source);
+}
+
+function phaseLabel(phase: CheckoutPhase): string {
+  return phase.replace('-', ' ');
+}
+
+function safeRepositoryUrl(repositoryUrl: string): string {
+  return repositoryUrl.replace(URL_CREDENTIAL_RE, '$1***@');
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -57,7 +57,7 @@ export async function executeSetupStep(params: {
   const checkoutFailure = await runCheckoutSetup({cwd, leaseClient, signal, log});
   if (checkoutFailure) return checkoutFailure;
 
-  log?.writeOutputLine('Setup completed successfully.');
+  log?.writeOutputLine('Setup completed successfully. The job is ready to run.');
   return {success: true, error: null, exit_code: 0};
 }
 
@@ -68,9 +68,11 @@ async function checkGit(log: SetupLogSink | undefined): Promise<StepResult | nul
     return null;
   } catch (error) {
     writeRunnerEnvironment(log, 'unavailable');
-    log?.writeOutputLine(
-      `Setup failed during git availability check: ${messageOf(error)}`,
-      'stderr',
+    writeFailure(
+      log,
+      'Setup failed because Git is not available on the runner.',
+      'Install Git in the runner image or use a runner image that includes Git.',
+      error,
     );
     return fail(error, 'git_unavailable');
   }
@@ -84,16 +86,15 @@ async function prepareWorkspace(params: {
   try {
     log?.writeGroup({
       name: 'Prepare workspace',
-      lines: [
-        `workspace: ${cwd}`,
-        'operation: remove any previous job directory and create a clean checkout directory',
-      ],
+      lines: ['Creating a clean working directory for this job.', `Path: ${cwd}`],
     });
     await createJobDir(cwd);
   } catch (error) {
-    log?.writeOutputLine(
-      `Setup failed during workspace preparation: ${messageOf(error)}`,
-      'stderr',
+    writeFailure(
+      log,
+      'Setup failed because the runner could not prepare the workspace.',
+      'Check the runner workspace permissions and available disk space.',
+      error,
     );
     return fail(error, 'workspace_prep_failed');
   }
@@ -128,24 +129,24 @@ async function requestCheckoutCredentials(params: {
   const {leaseClient, signal, log} = params;
   try {
     log?.writeGroup({
-      name: 'Request checkout credentials',
-      lines: ['Requesting checkout credentials'],
+      name: 'Request repository access',
+      lines: ['Requesting short-lived repository access from Shipfox.'],
     });
     const checkout = await requestCheckoutToken(leaseClient, {signal});
     log?.writeGroup({
-      name: 'Checkout authentication',
-      lines: [
-        checkout.auth ? `credential kind: ${checkout.auth.kind}` : 'credential kind: none',
-        checkout.auth?.expires_at ? `expires at: ${checkout.auth.expires_at}` : 'expires at: n/a',
-      ],
+      name: 'Repository access granted',
+      lines: credentialLines(checkout.auth),
     });
     return {ok: true, value: checkout};
   } catch (error) {
-    log?.writeOutputLine(
-      `Setup failed while requesting checkout credentials: ${messageOf(error)}`,
-      'stderr',
+    const reason = classifyCheckoutTokenError(error);
+    writeFailure(
+      log,
+      'Setup failed because Shipfox could not grant repository access.',
+      checkoutTokenFailureHelp(reason),
+      error,
     );
-    return {ok: false, result: fail(error, classifyCheckoutTokenError(error))};
+    return {ok: false, result: fail(error, reason)};
   }
 }
 
@@ -158,8 +159,11 @@ async function checkoutRepositoryForSetup(params: {
   const {cwd, checkout, signal, log} = params;
   try {
     log?.writeGroup({
-      name: 'Checkout repository',
-      lines: [`repository: ${safeRepositoryUrl(checkout.repository_url)}`, `ref: ${checkout.ref}`],
+      name: 'Repository details',
+      lines: [
+        `Repository: ${safeRepositoryUrl(checkout.repository_url)}`,
+        `Requested ref: ${checkout.ref}`,
+      ],
     });
     const commit = await checkoutRepository({
       repositoryUrl: checkout.repository_url,
@@ -171,18 +175,25 @@ async function checkoutRepositoryForSetup(params: {
       onCommandStart: (metadata) => writeCheckoutCommand(log, metadata),
       onOutput: checkoutOutput(log),
     });
-    log?.writeGroup({name: 'Checkout complete', lines: [`checked-out commit: ${commit}`]});
+    log?.writeGroup({name: 'Checkout complete', lines: [`Checked out commit: ${commit}`]});
     return null;
   } catch (error) {
     const reason =
       error instanceof CheckoutError ? CHECKOUT_KIND_REASON[error.kind] : 'checkout_failed';
     if (error instanceof CheckoutError && error.phase) {
-      log?.writeOutputLine(
-        `Setup failed during checkout ${phaseLabel(error.phase)}: ${messageOf(error)}`,
-        'stderr',
+      writeFailure(
+        log,
+        `Setup failed while ${checkoutPhaseAction(error.phase)}.`,
+        checkoutFailureHelp(reason),
+        error,
       );
     } else {
-      log?.writeOutputLine(`Setup failed during checkout: ${messageOf(error)}`, 'stderr');
+      writeFailure(
+        log,
+        'Setup failed while checking out the repository.',
+        checkoutFailureHelp(reason),
+        error,
+      );
     }
     return fail(error, reason);
   }
@@ -246,8 +257,8 @@ function writeJobContext(
 ): void {
   if (!jobContext) return;
   log?.writeGroup({
-    name: 'Job context',
-    lines: [`job id: ${jobContext.jobId}`, `run id: ${jobContext.runId}`],
+    name: 'Job details',
+    lines: [`Job: ${jobContext.jobId}`, `Run: ${jobContext.runId}`],
   });
 }
 
@@ -255,10 +266,10 @@ function writeRunnerEnvironment(log: SetupLogSink | undefined, gitVersion: strin
   log?.writeGroup({
     name: 'Runner environment',
     lines: [
-      `node: ${process.version}`,
-      `os: ${platform()} ${release()}`,
-      `architecture: ${arch()}`,
-      `git: ${gitVersion}`,
+      `Node.js: ${process.version}`,
+      `Operating system: ${platform()} ${release()}`,
+      `CPU architecture: ${arch()}`,
+      `Git: ${gitVersion}`,
       ...buildMetadataLines(),
     ],
   });
@@ -267,9 +278,10 @@ function writeRunnerEnvironment(log: SetupLogSink | undefined, gitVersion: strin
 function buildMetadataLines(): string[] {
   const lines: string[] = [];
   if (process.env.npm_package_version)
-    lines.push(`package version: ${process.env.npm_package_version}`);
-  if (process.env.IMAGE_REVISION) lines.push(`image revision: ${process.env.IMAGE_REVISION}`);
-  if (process.env.BUILD_NUMBER) lines.push(`build number: ${process.env.BUILD_NUMBER}`);
+    lines.push(`Runner package version: ${process.env.npm_package_version}`);
+  if (process.env.IMAGE_REVISION)
+    lines.push(`Runner image revision: ${process.env.IMAGE_REVISION}`);
+  if (process.env.BUILD_NUMBER) lines.push(`Runner build number: ${process.env.BUILD_NUMBER}`);
   return lines;
 }
 
@@ -278,8 +290,8 @@ function writeCheckoutCommand(
   metadata: CheckoutCommandStartMetadata,
 ): void {
   log?.writeGroup({
-    name: `Checkout ${phaseLabel(metadata.phase)}`,
-    lines: [metadata.command, `working-directory: ${metadata.cwd}`],
+    name: checkoutPhaseTitle(metadata.phase),
+    lines: [`Command: ${metadata.command}`, `Working directory: ${metadata.cwd}`],
   });
 }
 
@@ -288,8 +300,77 @@ function checkoutOutput(log: SetupLogSink | undefined): CheckoutOutputSink | und
   return (chunk, source) => log.write(chunk, source);
 }
 
-function phaseLabel(phase: CheckoutPhase): string {
-  return phase.replace('-', ' ');
+function credentialLines(auth: CheckoutTokenResponseDto['auth']): string[] {
+  if (!auth) return ['No repository credential was required.'];
+  return [
+    auth.kind === 'bearer'
+      ? 'Using a short-lived repository token.'
+      : 'Using a short-lived username/password repository credential.',
+    auth.expires_at ? `Expires at: ${auth.expires_at}` : 'No expiration was provided.',
+  ];
+}
+
+function checkoutPhaseTitle(phase: CheckoutPhase): string {
+  switch (phase) {
+    case 'init':
+      return 'Initialize repository';
+    case 'remote':
+      return 'Add repository remote';
+    case 'fetch':
+      return 'Fetch requested ref';
+    case 'checkout':
+      return 'Check out commit';
+    case 'resolve':
+      return 'Read checked-out commit';
+  }
+}
+
+function checkoutPhaseAction(phase: CheckoutPhase): string {
+  switch (phase) {
+    case 'init':
+      return 'initializing the local Git repository';
+    case 'remote':
+      return 'adding the repository remote';
+    case 'fetch':
+      return 'fetching the requested ref';
+    case 'checkout':
+      return 'checking out the fetched commit';
+    case 'resolve':
+      return 'reading the checked-out commit';
+  }
+}
+
+function checkoutTokenFailureHelp(reason: StepErrorReason): string {
+  if (reason === 'checkout_auth_failed') {
+    return 'Check that the runner is connected to this workspace and the job is allowed to read this repository.';
+  }
+  if (reason === 'checkout_unavailable') {
+    return 'Retry the job; Shipfox or the repository provider may be temporarily unavailable.';
+  }
+  return 'Check the repository connection and job permissions in Shipfox, then retry the job.';
+}
+
+function checkoutFailureHelp(reason: StepErrorReason): string {
+  if (reason === 'checkout_auth_failed') {
+    return 'Check the repository connection in Shipfox and confirm it has permission to read this repository.';
+  }
+  if (reason === 'checkout_unavailable') {
+    return 'Check the runner network and DNS access to the Git provider, then retry the job.';
+  }
+  if (reason === 'setup_aborted') {
+    return 'The job was cancelled or timed out before checkout completed.';
+  }
+  return 'Check that the repository URL and requested ref are valid. The git output above may include provider details.';
+}
+
+function writeFailure(
+  log: SetupLogSink | undefined,
+  summary: string,
+  nextStep: string,
+  error: unknown,
+): void {
+  log?.writeOutputLine(`${summary} Details: ${messageOf(error)}`, 'stderr');
+  log?.writeOutputLine(`Next step: ${nextStep}`, 'stderr');
 }
 
 function safeRepositoryUrl(repositoryUrl: string): string {

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -79,7 +79,10 @@ export async function executeSetupStep(params: {
 
   let checkout: CheckoutTokenResponseDto;
   try {
-    log?.writeGroup({name: 'Checkout authentication', lines: ['Requesting checkout credentials']});
+    log?.writeGroup({
+      name: 'Request checkout credentials',
+      lines: ['Requesting checkout credentials'],
+    });
     checkout = await requestCheckoutToken(leaseClient, {signal});
     log?.writeGroup({
       name: 'Checkout authentication',

--- a/libs/runner/execution/src/index.ts
+++ b/libs/runner/execution/src/index.ts
@@ -5,5 +5,5 @@ export {
   executeRunStep,
   type OutputSink,
 } from '#core/run-step.js';
-export {executeSetupStep} from '#core/setup-step.js';
+export {executeSetupStep, type SetupJobContext} from '#core/setup-step.js';
 export type {StepResult} from '#core/step-result.js';

--- a/libs/runner/logs/src/core/secrets.ts
+++ b/libs/runner/logs/src/core/secrets.ts
@@ -13,3 +13,9 @@ export function buildSecretVariants(secrets: string[]): string[] {
   }
   return [...variants].sort((a, b) => b.length - a.length);
 }
+
+export function mergeSecretVariants(existing: string[], secrets: string[]): string[] {
+  const variants = new Set(existing);
+  for (const form of buildSecretVariants(secrets)) variants.add(form);
+  return [...variants].sort((a, b) => b.length - a.length);
+}

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -483,6 +483,34 @@ describe('createStepLogStream', () => {
     ).toEqual(['  npm test\n', '  shell: bash -e {0}\n', '  ::group::not parsed\n', 'work\n']);
   });
 
+  it('nests structured runner groups under an explicitly opened parent group', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 26,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.writeGroupStart('Checkout');
+    stream.writeGroup({name: 'Checkout fetch', lines: ['git fetch origin main']});
+    stream.write(Buffer.from('remote output\n'), 'stderr');
+    stream.writeGroupEnd();
+    await stream.close();
+    stream.dispose();
+
+    const records = await readRecords(26);
+    expect(groupStarts(records)).toEqual([
+      {id: 'g1', parent: null, name: 'Checkout'},
+      {id: 'g2', parent: 'g1', name: 'Checkout fetch'},
+    ]);
+    expect(groupEndIds(records)).toEqual(['g2', 'g1']);
+    expect(
+      records.filter((r) => r.type === 'output').map((r) => (r.type === 'output' ? r.data : '')),
+    ).toEqual(['  git fetch origin main\n', 'remote output\n']);
+  });
+
   it('redacts runner-originated group metadata before it reaches the spool', async () => {
     const secret = 'sf/rt+METADATA=34';
     const forms = secretWireForms(secret);

--- a/libs/runner/logs/src/core/step-log-stream.test.ts
+++ b/libs/runner/logs/src/core/step-log-stream.test.ts
@@ -512,6 +512,27 @@ describe('createStepLogStream', () => {
     expect(raw).toContain('***');
   });
 
+  it('redacts secrets registered after the stream is created', async () => {
+    const stream = createStepLogStream({
+      logsDir: join(dir, 'logs'),
+      stepId: STEP_ID,
+      attempt: 18,
+      append: hangingAppend,
+      flushIntervalMs: 100000,
+      now: () => 1,
+    });
+
+    stream.addSecrets(['late-token']);
+    stream.writeGroup({name: 'Checkout auth', lines: ['token=late-token']});
+    stream.write(Buffer.from('remote late-token\n'), 'stderr');
+    await stream.close();
+    stream.dispose();
+
+    const raw = await readFile(join(dir, 'logs', `${STEP_ID}-18.ndjson`), 'utf8');
+    expect(raw).not.toContain('late-token');
+    expect(raw).toContain('***');
+  });
+
   it('abandons capture without crashing when a runner-originated metadata write fails', async () => {
     let appends = 0;
     const appendSpy = vi.spyOn(AttemptSpool.prototype, 'append').mockImplementation(() => {

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -4,7 +4,7 @@ import type {LogAppendFn} from '@shipfox/runner-protocol';
 import {type FramedOutput, type OutputSource, StreamFramer} from '#core/framing.js';
 import type {LogStreamLifecycle} from '#core/lifecycle.js';
 import {createRecordSink} from '#core/record-sink.js';
-import {buildSecretVariants} from '#core/secrets.js';
+import {buildSecretVariants, mergeSecretVariants} from '#core/secrets.js';
 import {LogTransformer, type TransformEvent} from '#core/transform.js';
 
 const EMPTY_FRAMED: FramedOutput = {bytes: Buffer.alloc(0), payloadBytes: 0};
@@ -196,12 +196,6 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       sink.dispose();
     },
   };
-}
-
-function mergeSecretVariants(existing: string[], secrets: string[]): string[] {
-  const variants = new Set(existing);
-  for (const form of buildSecretVariants(secrets)) variants.add(form);
-  return [...variants].sort((a, b) => b.length - a.length);
 }
 
 function ensureTrailingNewline(line: string): string {

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -31,6 +31,8 @@ export interface StepLogStreamOptions {
 export interface StepLogStream extends LogStreamLifecycle {
   /** Frames and spools a captured output chunk. Safe to call from a pipe handler. */
   write(chunk: Buffer, source: OutputSource): void;
+  /** Registers additional secrets for subsequent runner metadata and captured output. */
+  addSecrets(secrets: string[]): void;
   /** Frames a runner-originated group using the same group records as `::group::` markers. */
   writeGroup(options: StepLogGroupOptions): void;
   /** Frames a runner-originated output line, ensuring it ends with a newline. */
@@ -53,7 +55,7 @@ export interface StepLogGroupOptions {
 export function createStepLogStream(options: StepLogStreamOptions): StepLogStream {
   const now = options.now ?? Date.now;
   const framer = new StreamFramer(now);
-  const secretVariants = buildSecretVariants(options.secrets ?? []);
+  let secretVariants = buildSecretVariants(options.secrets ?? []);
   const transformer = new LogTransformer(options.secrets ?? []);
   const sink = createRecordSink({
     logsDir: options.logsDir,
@@ -132,6 +134,12 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
   }
 
   return {
+    addSecrets(secrets) {
+      if (secrets.length === 0) return;
+      secretVariants = mergeSecretVariants(secretVariants, secrets);
+      transformer.addSecrets(secrets);
+    },
+
     write(chunk, source) {
       // Once the server caps the budget the runner stops emitting; the cap
       // tombstone is server-side, so no gap is recorded here.
@@ -188,6 +196,12 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       sink.dispose();
     },
   };
+}
+
+function mergeSecretVariants(existing: string[], secrets: string[]): string[] {
+  const variants = new Set(existing);
+  for (const form of buildSecretVariants(secrets)) variants.add(form);
+  return [...variants].sort((a, b) => b.length - a.length);
 }
 
 function ensureTrailingNewline(line: string): string {

--- a/libs/runner/logs/src/core/step-log-stream.ts
+++ b/libs/runner/logs/src/core/step-log-stream.ts
@@ -33,6 +33,10 @@ export interface StepLogStream extends LogStreamLifecycle {
   write(chunk: Buffer, source: OutputSource): void;
   /** Registers additional secrets for subsequent runner metadata and captured output. */
   addSecrets(secrets: string[]): void;
+  /** Opens a runner-originated group without writing marker text into the output stream. */
+  writeGroupStart(name: string): void;
+  /** Closes the most recent open runner-originated or marker-originated group. */
+  writeGroupEnd(): void;
   /** Frames a runner-originated group using the same group records as `::group::` markers. */
   writeGroup(options: StepLogGroupOptions): void;
   /** Frames a runner-originated output line, ensuring it ends with a newline. */
@@ -156,6 +160,14 @@ export function createStepLogStream(options: StepLogStreamOptions): StepLogStrea
       }
 
       writeEvents(events);
+    },
+
+    writeGroupStart(name) {
+      writeEvents([{type: 'group_start', name: safeText(name)}]);
+    },
+
+    writeGroupEnd() {
+      writeEvents([{type: 'group_end'}]);
     },
 
     writeGroup({name, lines, source = 'stdout'}) {

--- a/libs/runner/logs/src/core/transform.test.ts
+++ b/libs/runner/logs/src/core/transform.test.ts
@@ -159,6 +159,15 @@ describe('LogTransformer secret masking', () => {
 
     expect(outputText(events)).toBe('token=sf_rt_SECRET123456\n');
   });
+
+  it('masks secrets registered after construction', () => {
+    const transformer = new LogTransformer([]);
+
+    transformer.addSecrets([SECRET]);
+    const events = transformer.push(Buffer.from(`token=${SECRET}\n`), 'stdout');
+
+    expect(outputText(events)).toBe('token=***\n');
+  });
 });
 
 describe('LogTransformer live streaming', () => {

--- a/libs/runner/logs/src/core/transform.ts
+++ b/libs/runner/logs/src/core/transform.ts
@@ -2,7 +2,7 @@ import {TextDecoder} from 'node:util';
 import {redactSecrets} from '@shipfox/redact';
 import {type OutputSource, PIPES} from '#core/framing.js';
 import {couldBeMarker, parseMarker} from '#core/markers.js';
-import {buildSecretVariants} from '#core/secrets.js';
+import {buildSecretVariants, mergeSecretVariants} from '#core/secrets.js';
 
 /** What the transform hands the framer: masked output text, or a swallowed group marker. */
 export type TransformEvent =
@@ -168,12 +168,6 @@ export class LogTransformer {
     }
     return cut;
   }
-}
-
-function mergeSecretVariants(existing: string[], secrets: string[]): string[] {
-  const variants = new Set(existing);
-  for (const form of buildSecretVariants(secrets)) variants.add(form);
-  return [...variants].sort((a, b) => b.length - a.length);
 }
 
 function newDecoder(): TextDecoder {

--- a/libs/runner/logs/src/core/transform.ts
+++ b/libs/runner/logs/src/core/transform.ts
@@ -35,8 +35,8 @@ interface SourceState {
  * forced mid-line flush.
  */
 export class LogTransformer {
-  private readonly variants: string[];
-  private readonly maxVariantLen: number;
+  private variants: string[];
+  private maxVariantLen: number;
   private readonly sources: Record<OutputSource, SourceState>;
 
   constructor(secrets: string[]) {
@@ -49,6 +49,12 @@ export class LogTransformer {
       stdout: {decoder: newDecoder(), buffer: ''},
       stderr: {decoder: newDecoder(), buffer: ''},
     };
+  }
+
+  addSecrets(secrets: string[]): void {
+    if (secrets.length === 0) return;
+    this.variants = mergeSecretVariants(this.variants, secrets);
+    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
   }
 
   push(chunk: Buffer, source: OutputSource): TransformEvent[] {
@@ -162,6 +168,12 @@ export class LogTransformer {
     }
     return cut;
   }
+}
+
+function mergeSecretVariants(existing: string[], secrets: string[]): string[] {
+  const variants = new Set(existing);
+  for (const form of buildSecretVariants(secrets)) variants.add(form);
+  return [...variants].sort((a, b) => b.length - a.length);
 }
 
 function newDecoder(): TextDecoder {

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -13,7 +13,9 @@ vi.mock('#core/heartbeat-loop.js', () => ({
 
 vi.mock('@shipfox/runner-workspace', async (importActual) => ({
   ...(await importActual<typeof import('@shipfox/runner-workspace')>()),
+  cleanupJobLogs: vi.fn(),
   jobWorkspacePath: vi.fn(),
+  jobLogsPath: vi.fn(),
   cleanupWorkspace: vi.fn(),
   resolveWorkspaceRootFromEnv: vi.fn(),
 }));
@@ -31,8 +33,10 @@ vi.mock('@shipfox/runner-protocol', () => ({
 
 import {createLeaseClient, requestJob} from '@shipfox/runner-protocol';
 import {
+  cleanupJobLogs,
   cleanupWorkspace,
   InvalidJobIdError,
+  jobLogsPath,
   jobWorkspacePath,
   resolveWorkspaceRootFromEnv,
   UnsafeWorkspaceRootError,
@@ -41,7 +45,9 @@ import {runJob, startRunner} from '#core/runner.js';
 import {runJobSteps} from '#core/step-loop.js';
 
 const mockJobWorkspacePath = vi.mocked(jobWorkspacePath);
+const mockJobLogsPath = vi.mocked(jobLogsPath);
 const mockCleanupWorkspace = vi.mocked(cleanupWorkspace);
+const mockCleanupJobLogs = vi.mocked(cleanupJobLogs);
 const mockResolveWorkspaceRoot = vi.mocked(resolveWorkspaceRootFromEnv);
 const mockRunJobSteps = vi.mocked(runJobSteps);
 const mockCreateLeaseClient = vi.mocked(createLeaseClient);
@@ -57,6 +63,7 @@ const JOB = {
 
 const WORKSPACE_ROOT = '/tmp/shipfox-test-root';
 const JOB_CWD = '/tmp/shipfox-test-root/job-1';
+const JOB_LOGS_DIR = '/tmp/shipfox-test-root/.shipfox-runner-logs/job-1';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -65,24 +72,33 @@ beforeEach(() => {
 describe('runJob', () => {
   it('runs the step loop with the per-job cwd and lease client, then cleans up', async () => {
     mockJobWorkspacePath.mockReturnValue(JOB_CWD);
+    mockJobLogsPath.mockReturnValue(JOB_LOGS_DIR);
     mockRunJobSteps.mockResolvedValue();
 
     await runJob(JOB, WORKSPACE_ROOT);
 
     expect(mockCreateLeaseClient).toHaveBeenCalledWith(JOB.lease_token);
     expect(mockRunJobSteps).toHaveBeenCalledWith(
-      expect.objectContaining({jobId: JOB.job_id, cwd: JOB_CWD}),
+      expect.objectContaining({
+        jobId: JOB.job_id,
+        cwd: JOB_CWD,
+        logsDir: JOB_LOGS_DIR,
+        jobContext: {jobId: JOB.job_id, runId: JOB.run_id},
+      }),
     );
     expect(mockCleanupWorkspace).toHaveBeenCalledWith(JOB_CWD);
+    expect(mockCleanupJobLogs).toHaveBeenCalledWith(JOB_LOGS_DIR);
   });
 
   it('cleans up the per-job cwd when the step loop throws', async () => {
     mockJobWorkspacePath.mockReturnValue(JOB_CWD);
+    mockJobLogsPath.mockReturnValue(JOB_LOGS_DIR);
     mockRunJobSteps.mockRejectedValue(new Error('aborted'));
 
     await runJob(JOB, WORKSPACE_ROOT);
 
     expect(mockCleanupWorkspace).toHaveBeenCalledWith(JOB_CWD);
+    expect(mockCleanupJobLogs).toHaveBeenCalledWith(JOB_LOGS_DIR);
   });
 
   it('skips the job without running the loop or cleaning up when the job id is invalid', async () => {
@@ -94,6 +110,7 @@ describe('runJob', () => {
 
     expect(mockRunJobSteps).not.toHaveBeenCalled();
     expect(mockCleanupWorkspace).not.toHaveBeenCalled();
+    expect(mockCleanupJobLogs).not.toHaveBeenCalled();
   });
 });
 

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -2,7 +2,9 @@ import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
 import {logger} from '@shipfox/node-opentelemetry';
 import {createLeaseClient, requestJob, runnerToken} from '@shipfox/runner-protocol';
 import {
+  cleanupJobLogs,
   cleanupWorkspace,
+  jobLogsPath,
   jobWorkspacePath,
   resolveWorkspaceRootFromEnv,
 } from '@shipfox/runner-workspace';
@@ -66,8 +68,10 @@ export async function runJob(
   // path; the setup step (position 0) creates the directory. An invalid job id is
   // an internal/claim error: bail before starting any per-job resources.
   let cwd: string;
+  let logsDir: string;
   try {
     cwd = jobWorkspacePath(job.job_id, workspaceRoot);
+    logsDir = jobLogsPath(job.job_id, workspaceRoot);
   } catch (error) {
     logger().error({err: error, jobId: job.job_id}, 'Invalid job id; skipping job');
     return;
@@ -86,7 +90,15 @@ export async function runJob(
     // Both runner credentials can reach a step's environment, so scrub them from
     // captured output before it touches the spool.
     const secrets = [runnerToken(), job.lease_token];
-    await runJobSteps({jobId: job.job_id, leaseClient, secrets, signal: ac.signal, cwd});
+    await runJobSteps({
+      jobId: job.job_id,
+      leaseClient,
+      secrets,
+      signal: ac.signal,
+      cwd,
+      logsDir,
+      jobContext: {jobId: job.job_id, runId: job.run_id},
+    });
     logger().info({jobId: job.job_id}, 'Job step loop finished');
   } catch (stepLoopError) {
     // A non-retryable error surfaced (e.g. an unexpected throw from the loop).
@@ -98,6 +110,7 @@ export async function runJob(
     heartbeatLoop.stop();
     if (currentJobAbortController === ac) currentJobAbortController = undefined;
     await cleanupWorkspace(cwd);
+    await cleanupJobLogs(logsDir);
   }
 }
 

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -34,15 +34,20 @@ vi.mock('@shipfox/runner-agent', () => ({
 const {runJobSteps} = await import('#core/step-loop.js');
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
+const RUN_ID = '00000000-0000-0000-0000-0000000000ab';
+const LOGS_DIR = '/runner-logs/job-1';
+const JOB_CONTEXT = {jobId: JOB_ID, runId: RUN_ID};
 const leaseClient = {} as never;
 const STREAM_LENGTH = 128;
 
 // Ordered log of stream lifecycle events across all created streams, so tests can
 // assert "prior attempt drained before the next opens".
 let events: string[];
+let createdStreams: Map<string, FakeStream[]>;
 
 interface FakeStream {
   write: ReturnType<typeof vi.fn>;
+  addSecrets: ReturnType<typeof vi.fn>;
   writeGroup: ReturnType<typeof vi.fn>;
   writeOutputLine: ReturnType<typeof vi.fn>;
   writeEntry: ReturnType<typeof vi.fn>;
@@ -55,9 +60,12 @@ function makeFakeStream(
   label: string,
   drainOutcome: 'drained' | 'abandoned' = 'drained',
 ): FakeStream {
-  return {
+  const stream = {
     write: vi.fn(() => {
       events.push(`write:${label}`);
+    }),
+    addSecrets: vi.fn(() => {
+      events.push(`secrets:${label}`);
     }),
     writeGroup: vi.fn(() => {
       events.push(`group:${label}`);
@@ -78,6 +86,28 @@ function makeFakeStream(
       events.push(`dispose:${label}`);
     }),
   };
+  const prior = createdStreams.get(label) ?? [];
+  prior.push(stream);
+  createdStreams.set(label, prior);
+  return stream;
+}
+
+function streamFor(stepId: string): FakeStream {
+  const stream = createdStreams.get(stepId)?.at(-1);
+  if (!stream) throw new Error(`No stream created for ${stepId}`);
+  return stream;
+}
+
+function runLoop(params: {signal: AbortSignal; secrets?: string[]; cwd?: string}): Promise<void> {
+  return runJobSteps({
+    jobId: JOB_ID,
+    leaseClient,
+    secrets: params.secrets ?? [],
+    signal: params.signal,
+    cwd: params.cwd ?? '/work',
+    logsDir: LOGS_DIR,
+    jobContext: JOB_CONTEXT,
+  });
 }
 
 describe('runJobSteps', () => {
@@ -91,6 +121,7 @@ describe('runJobSteps', () => {
     createSessionLogStreamMock.mockReset();
     executeAgentStepMock.mockReset();
     events = [];
+    createdStreams = new Map();
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
     // Setup succeeds by default; tests that exercise setup failure override it.
     executeSetupStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
@@ -114,12 +145,14 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeSetupStepMock).toHaveBeenCalledWith({
       cwd: '/work',
       leaseClient,
       signal: ac.signal,
+      log: expect.any(Object),
+      jobContext: JOB_CONTEXT,
     });
     expect(executeRunStepMock).toHaveBeenCalledWith(run, {
       signal: ac.signal,
@@ -149,16 +182,23 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(createStepLogStreamMock).toHaveBeenCalledWith({
-      logsDir: '/work/logs',
+      logsDir: LOGS_DIR,
       stepId: run.id,
       attempt: 3,
       secrets: [],
       append: expect.any(Function),
     });
-    expect(createStepLogStreamMock).toHaveBeenCalledTimes(1);
+    expect(createStepLogStreamMock).toHaveBeenCalledWith({
+      logsDir: LOGS_DIR,
+      stepId: setup.id,
+      attempt: 1,
+      secrets: [],
+      append: expect.any(Function),
+    });
+    expect(createStepLogStreamMock).toHaveBeenCalledTimes(2);
     expect(events).toContain(`drain:${run.id}`);
     expect(events).toContain(`dispose:${run.id}`);
   });
@@ -183,7 +223,7 @@ describe('runJobSteps', () => {
     );
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(captured?.write).toHaveBeenCalledWith(Buffer.from('hello'), 'stdout');
   });
@@ -223,7 +263,7 @@ describe('runJobSteps', () => {
     );
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(captured?.writeGroup).toHaveBeenCalledWith({
       name: 'Run echo hello',
@@ -244,14 +284,19 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce(stepResponse(setup, 1))
       .mockResolvedValueOnce(stepResponse(run, 1))
       .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
-    // Opening the spool throws (e.g. a broken logs dir): capture must be abandoned, not fatal.
-    createStepLogStreamMock.mockImplementationOnce(() => {
-      throw new Error('logs dir is a file');
-    });
+    // Opening the run spool throws (e.g. a broken logs dir): capture must be abandoned, not fatal.
+    createStepLogStreamMock
+      .mockImplementationOnce((opts: {stepId: string}) => {
+        events.push(`create:${opts.stepId}`);
+        return makeFakeStream(opts.stepId);
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('logs dir is a file');
+      });
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeRunStepMock).toHaveBeenCalled();
     expect(reportStepMock).toHaveBeenCalledWith(
@@ -267,7 +312,15 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce(stepResponse(setup, 1))
       .mockResolvedValueOnce(stepResponse(run, 1))
       .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
-    createStepLogStreamMock.mockReturnValueOnce(makeFakeStream(run.id, 'abandoned'));
+    createStepLogStreamMock
+      .mockImplementationOnce((opts: {stepId: string}) => {
+        events.push(`create:${opts.stepId}`);
+        return makeFakeStream(opts.stepId);
+      })
+      .mockImplementationOnce((opts: {stepId: string}) => {
+        events.push(`create:${opts.stepId}`);
+        return makeFakeStream(opts.stepId, 'abandoned');
+      });
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     reportStepMock.mockImplementation((_client, params: {stepId: string; logOutcome: string}) => {
       events.push(`report:${params.stepId}:${params.logOutcome}`);
@@ -275,7 +328,7 @@ describe('runJobSteps', () => {
     });
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(events.indexOf(`drain:${run.id}`)).toBeLessThan(
       events.indexOf(`report:${run.id}:abandoned`),
@@ -298,7 +351,7 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(events.indexOf(`dispose:${run1.id}`)).toBeLessThan(events.indexOf(`create:${run2.id}`));
     expect(events).toContain(`dispose:${run2.id}`);
@@ -323,7 +376,7 @@ describe('runJobSteps', () => {
     executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     // pull index 2 is the request that claims run2. run1's stream must be disposed before it,
     // so a slow drain delays only the (unclaimed) pull, never a freshly claimed step.
@@ -342,7 +395,7 @@ describe('runJobSteps', () => {
       return Promise.resolve({success: true, error: null, exit_code: 0});
     });
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     // Setup completed and was reported; the aborted run step is not.
     const reportedSteps = reportStepMock.mock.calls.map((call) => call[1].stepId);
@@ -359,7 +412,7 @@ describe('runJobSteps', () => {
     reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: setup.id,
@@ -371,7 +424,15 @@ describe('runJobSteps', () => {
       signal: ac.signal,
     });
     expect(executeRunStepMock).not.toHaveBeenCalled();
-    expect(createStepLogStreamMock).not.toHaveBeenCalled();
+    expect(createStepLogStreamMock).toHaveBeenCalledWith({
+      logsDir: LOGS_DIR,
+      stepId: setup.id,
+      attempt: 1,
+      secrets: [],
+      append: expect.any(Function),
+    });
+    expect(events).toContain(`drain:${setup.id}`);
+    expect(events).toContain(`dispose:${setup.id}`);
     expect(requestNextStepMock).toHaveBeenCalledTimes(1);
   });
 
@@ -381,7 +442,7 @@ describe('runJobSteps', () => {
     reportStepMock.mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(executeRunStepMock).not.toHaveBeenCalled();
@@ -401,7 +462,7 @@ describe('runJobSteps', () => {
     requestNextStepMock.mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(reportStepMock).not.toHaveBeenCalled();
@@ -411,9 +472,7 @@ describe('runJobSteps', () => {
     requestNextStepMock.mockRejectedValueOnce(buildHTTPError(404));
     const ac = new AbortController();
 
-    await expect(
-      runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'}),
-    ).resolves.toBeUndefined();
+    await expect(runLoop({signal: ac.signal})).resolves.toBeUndefined();
 
     expect(executeSetupStepMock).not.toHaveBeenCalled();
     expect(reportStepMock).not.toHaveBeenCalled();
@@ -423,9 +482,7 @@ describe('runJobSteps', () => {
     requestNextStepMock.mockRejectedValueOnce(buildHTTPError(500));
     const ac = new AbortController();
 
-    await expect(
-      runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'}),
-    ).rejects.toThrow();
+    await expect(runLoop({signal: ac.signal})).rejects.toThrow();
 
     expect(requestNextStepMock).toHaveBeenCalledTimes(1);
   });
@@ -443,7 +500,7 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: run.id,
@@ -455,7 +512,7 @@ describe('runJobSteps', () => {
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(2);
-    const stream = createStepLogStreamMock.mock.results[0]?.value as FakeStream;
+    const stream = streamFor(run.id);
     expect(stream.writeOutputLine).toHaveBeenCalledWith(
       'Process completed with exit code 1.',
       'stderr',
@@ -476,9 +533,9 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
-    const stream = createStepLogStreamMock.mock.results[0]?.value as FakeStream;
+    const stream = streamFor(run.id);
     expect(stream.writeOutputLine).toHaveBeenCalledWith(
       'Process terminated by signal SIGKILL.',
       'stderr',
@@ -498,9 +555,7 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce({ok: true, cancel: true});
     const ac = new AbortController();
 
-    await expect(
-      runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'}),
-    ).resolves.toBeUndefined();
+    await expect(runLoop({signal: ac.signal})).resolves.toBeUndefined();
 
     expect(reportStepMock).toHaveBeenCalledWith(leaseClient, {
       stepId: run.id,
@@ -511,7 +566,7 @@ describe('runJobSteps', () => {
       logOutcome: 'drained',
       signal: ac.signal,
     });
-    const stream = createStepLogStreamMock.mock.results[0]?.value as FakeStream;
+    const stream = streamFor(run.id);
     expect(stream.writeOutputLine).toHaveBeenCalledWith(
       'Process failed: ENOSPC: no space left on device',
       'stderr',
@@ -527,7 +582,7 @@ describe('runJobSteps', () => {
       return Promise.resolve({success: true, error: null, exit_code: 0});
     });
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeSetupStepMock).toHaveBeenCalledTimes(1);
     expect(reportStepMock).not.toHaveBeenCalled();
@@ -537,7 +592,7 @@ describe('runJobSteps', () => {
     const ac = new AbortController();
     ac.abort();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(requestNextStepMock).not.toHaveBeenCalled();
   });
@@ -552,7 +607,7 @@ describe('runJobSteps', () => {
     executeAgentStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {
       signal: ac.signal,
@@ -588,16 +643,10 @@ describe('runJobSteps', () => {
     );
     const ac = new AbortController();
 
-    await runJobSteps({
-      jobId: JOB_ID,
-      leaseClient,
-      secrets: ['s3cr3t'],
-      signal: ac.signal,
-      cwd: '/work',
-    });
+    await runLoop({signal: ac.signal, secrets: ['s3cr3t']});
 
     expect(createSessionLogStreamMock).toHaveBeenCalledWith({
-      logsDir: '/work/logs',
+      logsDir: LOGS_DIR,
       stepId: agent.id,
       attempt: 1,
       secrets: ['s3cr3t'],
@@ -624,7 +673,7 @@ describe('runJobSteps', () => {
     executeAgentStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
     const ac = new AbortController();
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {signal: ac.signal, cwd: '/work'});
     expect(reportStepMock).toHaveBeenCalledWith(
@@ -650,7 +699,7 @@ describe('runJobSteps', () => {
       });
     });
 
-    await runJobSteps({jobId: JOB_ID, leaseClient, secrets: [], signal: ac.signal, cwd: '/work'});
+    await runLoop({signal: ac.signal});
 
     expect(executeAgentStepMock).toHaveBeenCalledTimes(1);
     // Only the setup step is reported; the aborted agent step is not.

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -48,6 +48,8 @@ let createdStreams: Map<string, FakeStream[]>;
 interface FakeStream {
   write: ReturnType<typeof vi.fn>;
   addSecrets: ReturnType<typeof vi.fn>;
+  writeGroupStart: ReturnType<typeof vi.fn>;
+  writeGroupEnd: ReturnType<typeof vi.fn>;
   writeGroup: ReturnType<typeof vi.fn>;
   writeOutputLine: ReturnType<typeof vi.fn>;
   writeEntry: ReturnType<typeof vi.fn>;
@@ -66,6 +68,12 @@ function makeFakeStream(
     }),
     addSecrets: vi.fn(() => {
       events.push(`secrets:${label}`);
+    }),
+    writeGroupStart: vi.fn(() => {
+      events.push(`groupStart:${label}`);
+    }),
+    writeGroupEnd: vi.fn(() => {
+      events.push(`groupEnd:${label}`);
     }),
     writeGroup: vi.fn(() => {
       events.push(`group:${label}`);

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1,4 +1,3 @@
-import {join} from 'node:path';
 import type {LogOutcomeDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {executeAgentStep} from '@shipfox/runner-agent';
@@ -6,6 +5,7 @@ import {
   type CommandStartMetadata,
   executeRunStep,
   executeSetupStep,
+  type SetupJobContext,
   type StepResult,
 } from '@shipfox/runner-execution';
 import {
@@ -32,25 +32,27 @@ const WHITESPACE_REGEX = /\s+/;
 // re-executed. The per-attempt log stream is settled before that report so the server can
 // close the durable stream immediately from the reported log outcome.
 //
-// Each run step gets a per-attempt log stream: capture → spool → upload. The prior
+// Each step gets a per-attempt log stream: capture -> spool -> upload. The prior
 // attempt's stream is drained and disposed before the report, and the `finally`
-// drains an aborted last one (bounded) before runJob deletes the workspace the spool lives in.
+// drains an aborted last one (bounded) before runJob deletes the runner-owned spool directory.
 export async function runJobSteps(params: {
   jobId: string;
   leaseClient: KyInstance;
-  /** Secrets masked out of every run step's captured output before it reaches the spool. */
+  /** Secrets masked out of captured output before it reaches the spool. */
   secrets: string[];
   signal: AbortSignal;
   cwd: string;
+  logsDir: string;
+  jobContext: SetupJobContext;
 }): Promise<void> {
-  const {jobId, leaseClient, secrets, signal, cwd} = params;
+  const {jobId, leaseClient, secrets, signal, cwd, logsDir, jobContext} = params;
 
   // The setup step prepares the workspace; every run step assumes it ran. A run
   // step pulled before a successful setup is failed cleanly rather than spawned
   // against an unprepared cwd.
   let workspacePrepared = false;
 
-  // The most recent step's stream (run output or agent session), kept until the next
+  // The most recent step's stream, kept until the next
   // iteration settles it (or the finally does at job end). The step loop is sequential, so
   // at most one tail drains.
   let activeStream: LogStreamLifecycle | undefined;
@@ -83,6 +85,8 @@ export async function runJobSteps(params: {
         workspacePrepared,
         jobId,
         stepLabel,
+        logsDir,
+        jobContext,
       });
       activeStream = execution.stream;
       if (execution.preparedWorkspace) workspacePrepared = true;
@@ -112,7 +116,7 @@ export async function runJobSteps(params: {
       }
     }
   } finally {
-    // Drain the last stream (bounded) before runJob deletes the workspace; an abort
+    // Drain the last stream (bounded) before runJob deletes the log spool; an abort
     // cuts the wait short. Whatever did not drain is timeout-closed server-side.
     await settleStream({stream: activeStream, signal});
   }
@@ -162,12 +166,14 @@ export interface StepExecution {
 
 // Runs one step and always yields a StepResult, never throws: a crash before a result
 // exists (e.g. writing the temp script) becomes a reported failure so the step does not
-// hang `running`. The log stream is opened for run steps only and returned even on a
+// hang `running`. The log stream is returned even on a
 // throw, so the caller can still settle it.
 export async function executeStep(params: {
   step: StepDto;
   attempt: number;
   cwd: string;
+  logsDir: string;
+  jobContext: SetupJobContext;
   leaseClient: KyInstance;
   secrets: string[];
   signal: AbortSignal;
@@ -175,15 +181,65 @@ export async function executeStep(params: {
   jobId: string;
   stepLabel: string;
 }): Promise<StepExecution> {
-  const {step, attempt, cwd, leaseClient, secrets, signal, workspacePrepared, jobId, stepLabel} =
-    params;
+  const {
+    step,
+    attempt,
+    cwd,
+    logsDir,
+    jobContext,
+    leaseClient,
+    secrets,
+    signal,
+    workspacePrepared,
+    jobId,
+    stepLabel,
+  } = params;
 
   let stream: LogStreamLifecycle | undefined;
   let runStream: StepLogStream | undefined;
   try {
+    // Both step kinds capture to the same per-attempt stream contract (one stream per
+    // job/step/attempt). The append port is bound to the lease client, step, and attempt.
+    const append: LogAppendFn = ({offset, body, signal: appendSignal}) =>
+      appendStepLogs(leaseClient, {
+        stepId: step.id,
+        attempt,
+        offset,
+        body,
+        ...(appendSignal ? {signal: appendSignal} : {}),
+      });
+
     if (step.type === 'setup') {
-      const result = await executeSetupStep({cwd, leaseClient, signal});
-      return {result, logOutcome: 'drained', preparedWorkspace: result.success};
+      let setupStream: StepLogStream | undefined;
+      try {
+        setupStream = createStepLogStream({
+          logsDir,
+          stepId: step.id,
+          attempt,
+          secrets,
+          append,
+        });
+      } catch (error) {
+        logger().error(
+          {err: error, jobId, stepId: step.id, attempt},
+          'Failed to open setup log capture; running setup without it',
+        );
+      }
+      stream = setupStream;
+
+      const result = await executeSetupStep({
+        cwd,
+        leaseClient,
+        signal,
+        ...(setupStream ? {log: setupStream} : {}),
+        jobContext,
+      });
+      return {
+        result,
+        stream,
+        logOutcome: setupStream ? undefined : 'abandoned',
+        preparedWorkspace: result.success,
+      };
     }
 
     if (!workspacePrepared) {
@@ -201,17 +257,6 @@ export async function executeStep(params: {
       };
     }
 
-    // Both step kinds capture to the same per-attempt stream contract (one stream per
-    // job/step/attempt). The append port is bound to the lease client, step, and attempt.
-    const append: LogAppendFn = ({offset, body, signal: appendSignal}) =>
-      appendStepLogs(leaseClient, {
-        stepId: step.id,
-        attempt,
-        offset,
-        body,
-        ...(appendSignal ? {signal: appendSignal} : {}),
-      });
-
     // Agent steps run the embedded pi harness and forward every session entry into the log
     // pipeline as opaque `agent_session` records. Capture is best-effort: if the spool cannot
     // be opened, run the agent without it rather than failing the step.
@@ -219,7 +264,7 @@ export async function executeStep(params: {
       let sessionStream: SessionLogStream | undefined;
       try {
         sessionStream = createSessionLogStream({
-          logsDir: join(cwd, 'logs'),
+          logsDir,
           stepId: step.id,
           attempt,
           secrets,
@@ -252,7 +297,7 @@ export async function executeStep(params: {
     let stepStream: StepLogStream | undefined;
     try {
       stepStream = createStepLogStream({
-        logsDir: join(cwd, 'logs'),
+        logsDir,
         stepId: step.id,
         attempt,
         secrets,

--- a/libs/runner/workspace/src/checkout.realgit.test.ts
+++ b/libs/runner/workspace/src/checkout.realgit.test.ts
@@ -10,6 +10,8 @@ import {assertGitAvailable, CheckoutError, checkoutRepository} from '#checkout.j
 // present in CI. Only the network/auth/abort paths (which a local remote cannot produce)
 // stay mocked in checkout.test.ts.
 const execFileAsync = promisify(execFile);
+const COMMIT_SHA_RE = /^[0-9a-f]{40}$/;
+const GIT_VERSION_RE = /^git version /;
 
 let workdir: string;
 let sourceRepo: string;
@@ -42,11 +44,16 @@ afterEach(async () => {
 });
 
 describe('checkoutRepository (real git)', () => {
-  it('clones the requested ref into the per-job directory', async () => {
-    await checkoutRepository({repositoryUrl: `file://${sourceRepo}`, ref: 'main', cwd});
+  it('checks out the requested ref into the per-job directory', async () => {
+    const commit = await checkoutRepository({
+      repositoryUrl: `file://${sourceRepo}`,
+      ref: 'main',
+      cwd,
+    });
 
     const readme = await readFile(join(cwd, 'README.md'), 'utf8');
     expect(readme).toBe('# hello\n');
+    expect(commit).toMatch(COMMIT_SHA_RE);
   });
 
   it('never persists the credential to .git/config', async () => {
@@ -95,6 +102,6 @@ describe('checkoutRepository (real git)', () => {
 
 describe('assertGitAvailable (real git)', () => {
   it('resolves when git is on PATH', async () => {
-    await expect(assertGitAvailable()).resolves.toBeUndefined();
+    await expect(assertGitAvailable()).resolves.toMatch(GIT_VERSION_RE);
   });
 });

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -1,31 +1,65 @@
-// Mocked-execFile tests: assert the exact git argv, failure classification, and redaction
-// without spawning git. The real-git happy path lives in checkout.realgit.test.ts.
+import {EventEmitter} from 'node:events';
+
 const execFileMock = vi.fn();
+const spawnMock = vi.fn();
 
 vi.mock('node:child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
+  spawn: (...args: unknown[]) => spawnMock(...args),
 }));
 
 const {checkoutRepository, CheckoutError, redactSecrets} = await import('#checkout.js');
 
-type ExecCallback = (error: unknown, result?: {stdout: string; stderr: string}) => void;
+type SpawnResult =
+  | {kind: 'success'; stdout?: string; stderr?: string}
+  | {kind: 'failure'; stderr: string; code?: number; signal?: NodeJS.Signals | null}
+  | {kind: 'error'; error: Error};
 
-function callbackOf(args: unknown[]): ExecCallback {
-  return args[args.length - 1] as ExecCallback;
+function queueGitResults(results: SpawnResult[]) {
+  const queue = [...results];
+  spawnMock.mockImplementation(() => {
+    const result = queue.shift();
+    if (!result) throw new Error('Unexpected git command');
+
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+
+    queueMicrotask(() => {
+      if (result.kind === 'error') {
+        child.emit('error', result.error);
+        return;
+      }
+      if (result.kind === 'success' && result.stdout) {
+        child.stdout.emit('data', Buffer.from(result.stdout));
+      }
+      if (result.stderr) child.stderr.emit('data', Buffer.from(result.stderr));
+      if (result.kind === 'success') {
+        child.emit('close', 0, null);
+        return;
+      }
+      child.emit('close', result.code ?? 1, result.signal ?? null);
+    });
+
+    return child;
+  });
 }
 
-function resolveExec() {
-  execFileMock.mockImplementation((...args: unknown[]) =>
-    callbackOf(args)(null, {stdout: '', stderr: ''}),
-  );
+function queueSuccessfulCheckout(commit = 'abc123') {
+  queueGitResults([
+    {kind: 'success'},
+    {kind: 'success'},
+    {kind: 'success', stderr: 'fetch progress\n'},
+    {kind: 'success', stderr: 'checkout progress\n'},
+    {kind: 'success', stdout: `${commit}\n`},
+  ]);
 }
 
-function rejectExec(error: unknown) {
-  execFileMock.mockImplementation((...args: unknown[]) => callbackOf(args)(error));
-}
-
-function gitError(stderr: string): Error & {stderr: string} {
-  return Object.assign(new Error('Command failed'), {stderr});
+function queueFetchFailure(stderr: string) {
+  queueGitResults([{kind: 'success'}, {kind: 'success'}, {kind: 'failure', stderr}]);
 }
 
 const BASE = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main', cwd: '/work/job-1'};
@@ -35,43 +69,49 @@ beforeEach(() => {
 });
 
 describe('checkoutRepository argv', () => {
-  it('shallow-clones the single branch with no -c when there is no auth', async () => {
-    resolveExec();
+  it('runs explicit checkout phases without auth when there is no auth', async () => {
+    queueSuccessfulCheckout();
 
-    await checkoutRepository(BASE);
+    const commit = await checkoutRepository(BASE);
 
-    expect(execFileMock).toHaveBeenCalledOnce();
-    const [file, args] = execFileMock.mock.calls[0] as [string, string[]];
-    expect(file).toBe('git');
-    expect(args).toEqual([
-      'clone',
-      '--depth=1',
-      '--single-branch',
-      '--branch',
-      'main',
-      'https://github.com/acme/repo.git',
-      '/work/job-1',
+    expect(commit).toBe('abc123');
+    expect(spawnMock.mock.calls.map((call) => call[1])).toEqual([
+      ['init'],
+      ['remote', 'add', 'origin', 'https://github.com/acme/repo.git'],
+      ['fetch', '--progress', '--no-tags', '--prune', '--depth=1', 'origin', 'main'],
+      ['checkout', '--progress', '--force', 'FETCH_HEAD'],
+      ['rev-parse', 'HEAD'],
     ]);
   });
 
-  it('injects a bearer credential via a one-shot http.extraHeader', async () => {
-    resolveExec();
+  it('injects a bearer credential only on fetch and excludes it from displayed commands', async () => {
+    queueSuccessfulCheckout();
+    const onCommandStart = vi.fn();
+    const onSecrets = vi.fn();
 
     await checkoutRepository({
       ...BASE,
       auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00Z'},
+      onCommandStart,
+      onSecrets,
     });
 
-    const [, args] = execFileMock.mock.calls[0] as [string, string[]];
-    expect(args.slice(0, 3)).toEqual([
+    const fetchArgs = spawnMock.mock.calls[2]?.[1] as string[];
+    expect(fetchArgs.slice(0, 3)).toEqual([
       '-c',
       'http.extraHeader=Authorization: Bearer tok-123',
-      'clone',
+      'fetch',
     ]);
+    expect(onSecrets).toHaveBeenCalledWith(['tok-123']);
+    expect(onCommandStart.mock.calls.map((call) => call[0].command).join('\n')).not.toContain(
+      'tok-123',
+    );
   });
 
-  it('injects a basic credential as a base64 Authorization header', async () => {
-    resolveExec();
+  it('injects a basic credential as a base64 Authorization header and registers both secrets', async () => {
+    queueSuccessfulCheckout();
+    const onSecrets = vi.fn();
+    const expected = Buffer.from('x-token:tok-123').toString('base64');
 
     await checkoutRepository({
       ...BASE,
@@ -81,83 +121,99 @@ describe('checkoutRepository argv', () => {
         token: 'tok-123',
         expires_at: '2026-01-01T00:00:00Z',
       },
+      onSecrets,
     });
 
-    const [, args] = execFileMock.mock.calls[0] as [string, string[]];
-    const expected = Buffer.from('x-token:tok-123').toString('base64');
-    expect(args[1]).toBe(`http.extraHeader=Authorization: Basic ${expected}`);
+    const fetchArgs = spawnMock.mock.calls[2]?.[1] as string[];
+    expect(fetchArgs[1]).toBe(`http.extraHeader=Authorization: Basic ${expected}`);
+    expect(onSecrets).toHaveBeenCalledWith(['tok-123', expected]);
   });
 
-  it('disables interactive credential prompts', async () => {
-    resolveExec();
+  it('disables interactive credential prompts on every git process', async () => {
+    queueSuccessfulCheckout();
 
     await checkoutRepository(BASE);
 
-    const options = execFileMock.mock.calls[0]?.[2] as {env: Record<string, string>};
-    expect(options.env.GIT_TERMINAL_PROMPT).toBe('0');
+    for (const call of spawnMock.mock.calls) {
+      const options = call[2] as {env: Record<string, string>};
+      expect(options.env.GIT_TERMINAL_PROMPT).toBe('0');
+    }
+  });
+
+  it('streams git output through the provided sink', async () => {
+    queueSuccessfulCheckout();
+    const onOutput = vi.fn();
+
+    await checkoutRepository({...BASE, onOutput});
+
+    expect(onOutput).toHaveBeenCalledWith(Buffer.from('fetch progress\n'), 'stderr');
+    expect(onOutput).toHaveBeenCalledWith(Buffer.from('checkout progress\n'), 'stderr');
+    expect(onOutput).toHaveBeenCalledWith(Buffer.from('abc123\n'), 'stdout');
   });
 });
 
 describe('checkoutRepository failure classification', () => {
   it('classifies a rejected credential as an auth failure', async () => {
-    rejectExec(gitError("fatal: Authentication failed for 'https://github.com/acme/repo.git/'"));
+    queueFetchFailure("fatal: Authentication failed for 'https://github.com/acme/repo.git/'");
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({
       name: 'CheckoutError',
       kind: 'auth',
+      phase: 'fetch',
     });
   });
 
   it('classifies an unreachable provider as unavailable', async () => {
-    rejectExec(gitError('fatal: unable to access: Could not resolve host: github.com'));
+    queueFetchFailure('fatal: unable to access: Could not resolve host: github.com');
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
   });
 
   it('classifies a git-side 403 as an auth failure', async () => {
-    rejectExec(
-      gitError(
-        "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 403",
-      ),
+    queueFetchFailure(
+      "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 403",
     );
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'auth'});
   });
 
   it('classifies a git-side 5xx as unavailable', async () => {
-    rejectExec(
-      gitError(
-        "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 503",
-      ),
+    queueFetchFailure(
+      "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 503",
     );
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
   });
 
-  it('classifies a git-side 429 (rate limit) as unavailable', async () => {
-    rejectExec(
-      gitError(
-        "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 429",
-      ),
+  it('classifies a git-side 429 as unavailable', async () => {
+    queueFetchFailure(
+      "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 429",
     );
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'unavailable'});
   });
 
-  it('classifies an unknown clone failure as a generic failure', async () => {
-    rejectExec(gitError('fatal: Remote branch main not found in upstream origin'));
+  it('classifies an unknown checkout failure as a generic failure', async () => {
+    queueFetchFailure('fatal: Remote branch main not found in upstream origin');
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'failed'});
   });
 
-  it('classifies an aborted clone as aborted', async () => {
-    rejectExec(Object.assign(new Error('The operation was aborted'), {name: 'AbortError'}));
+  it('classifies an aborted checkout as aborted with its phase', async () => {
+    queueGitResults([
+      {kind: 'success'},
+      {kind: 'success'},
+      {
+        kind: 'error',
+        error: Object.assign(new Error('The operation was aborted'), {name: 'AbortError'}),
+      },
+    ]);
 
-    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'aborted'});
+    await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'aborted', phase: 'fetch'});
   });
 
   it('redacts the token from a failure message', async () => {
-    rejectExec(gitError('fatal: bad request sending tok-123 to remote'));
+    queueFetchFailure('fatal: bad request sending tok-123 to remote');
 
     const error = await checkoutRepository({
       ...BASE,
@@ -171,7 +227,7 @@ describe('checkoutRepository failure classification', () => {
 
   it('redacts the base64 form of a basic credential from a failure message', async () => {
     const base64 = Buffer.from('x-token:tok-123').toString('base64');
-    rejectExec(gitError(`fatal: bad request sending ${base64} to remote`));
+    queueFetchFailure(`fatal: bad request sending ${base64} to remote`);
 
     const error = await checkoutRepository({
       ...BASE,
@@ -184,43 +240,11 @@ describe('checkoutRepository failure classification', () => {
     }).catch((e: unknown) => e);
 
     expect((error as Error).message).not.toContain(base64);
-    expect((error as Error).message).toContain('***');
-  });
-
-  it('redacts a basic credential when stderr is empty and the argv leaks into error.message', async () => {
-    const base64 = Buffer.from('x-token:tok-123').toString('base64');
-    // No stderr: classifyCloneError falls back to the execFile error.message, which on
-    // Node carries the full argv including the Authorization header value.
-    rejectExec(
-      Object.assign(
-        new Error(
-          `Command failed: git -c http.extraHeader=Authorization: Basic ${base64} clone --depth=1`,
-        ),
-        {stderr: ''},
-      ),
-    );
-
-    const error = await checkoutRepository({
-      ...BASE,
-      auth: {
-        kind: 'basic',
-        username: 'x-token',
-        token: 'tok-123',
-        expires_at: '2026-01-01T00:00:00Z',
-      },
-    }).catch((e: unknown) => e);
-
-    expect((error as Error).message).not.toContain(base64);
-    expect((error as Error).message).not.toContain('tok-123');
     expect((error as Error).message).toContain('***');
   });
 
   it('scrubs the token from the error cause so it cannot ride the cause chain into a log', async () => {
-    const raw = Object.assign(
-      new Error('Command failed: git -c http.extraHeader=Authorization: Bearer tok-123 clone ...'),
-      {stderr: 'fatal: Authentication failed'},
-    );
-    rejectExec(raw);
+    queueFetchFailure('fatal: Authentication failed for token tok-123');
 
     const error = await checkoutRepository({
       ...BASE,
@@ -229,7 +253,6 @@ describe('checkoutRepository failure classification', () => {
 
     const cause = (error as Error).cause as Error;
     expect(cause.message).not.toContain('tok-123');
-    expect(cause.message).toContain('***');
   });
 });
 

--- a/libs/runner/workspace/src/checkout.test.ts
+++ b/libs/runner/workspace/src/checkout.test.ts
@@ -200,16 +200,11 @@ describe('checkoutRepository failure classification', () => {
   });
 
   it('classifies an aborted checkout as aborted with its phase', async () => {
-    queueGitResults([
-      {kind: 'success'},
-      {kind: 'success'},
-      {
-        kind: 'error',
-        error: Object.assign(new Error('The operation was aborted'), {name: 'AbortError'}),
-      },
-    ]);
+    const abortError = Object.assign(new Error('The operation was aborted'), {name: 'AbortError'});
+    queueGitResults([{kind: 'success'}, {kind: 'success'}, {kind: 'error', error: abortError}]);
 
     await expect(checkoutRepository(BASE)).rejects.toMatchObject({kind: 'aborted', phase: 'fetch'});
+    expect('phase' in abortError).toBe(false);
   });
 
   it('redacts the token from a failure message', async () => {

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -233,10 +233,7 @@ function runGitCommand(params: {
     child.on('error', (error) => {
       if (settled) return;
       settled = true;
-      if (error instanceof Error && error.name === 'AbortError') {
-        (error as Error & {phase?: CheckoutPhase}).phase = phase;
-      }
-      reject(error);
+      reject(new GitSpawnError(phase, error));
     });
 
     child.on('close', (code, signalName) => {
@@ -249,6 +246,16 @@ function runGitCommand(params: {
       reject(new GitCommandError(phase, stderr, code, signalName));
     });
   });
+}
+
+class GitSpawnError extends Error {
+  constructor(
+    public readonly phase: CheckoutPhase,
+    error: Error,
+  ) {
+    super(error.message, {cause: error});
+    this.name = error.name;
+  }
 }
 
 class GitCommandError extends Error {

--- a/libs/runner/workspace/src/checkout.ts
+++ b/libs/runner/workspace/src/checkout.ts
@@ -1,8 +1,10 @@
-import {execFile} from 'node:child_process';
+import {execFile, spawn} from 'node:child_process';
 import {promisify} from 'node:util';
 import type {CheckoutTokenAuthDto} from '@shipfox/api-workflows-dto';
 
 const execFileAsync = promisify(execFile);
+const URL_CREDENTIAL_RE = /(https?:\/\/)[^/@\s]+@/gi;
+const SHELL_SAFE_ARG_RE = /^[A-Za-z0-9_./:=@+-]+$/;
 
 /** Thrown when `git` is not on the runner host's PATH; surfaced as `git_unavailable`. */
 export class GitUnavailableError extends Error {
@@ -12,27 +14,41 @@ export class GitUnavailableError extends Error {
   }
 }
 
+export type CheckoutOutputSink = (chunk: Buffer, source: 'stdout' | 'stderr') => void;
+
+export type CheckoutPhase = 'init' | 'remote' | 'fetch' | 'checkout' | 'resolve';
+
 /**
- * Why a clone failed, kept abstract here so the workspace layer does not depend on the
+ * Why checkout failed, kept abstract here so the workspace layer does not depend on the
  * step-error DTO. The setup step maps each kind to a machine-readable `reason`.
  */
 export type CheckoutFailureKind = 'auth' | 'unavailable' | 'failed' | 'aborted';
 
 export class CheckoutError extends Error {
+  public readonly phase: CheckoutPhase | undefined;
+
   constructor(
     public readonly kind: CheckoutFailureKind,
     message: string,
-    options?: ErrorOptions,
+    options?: ErrorOptions & {phase?: CheckoutPhase | undefined},
   ) {
     super(message, options);
     this.name = 'CheckoutError';
+    this.phase = options?.phase;
   }
 }
 
+export interface CheckoutCommandStartMetadata {
+  readonly phase: CheckoutPhase;
+  readonly command: string;
+  readonly cwd: string;
+}
+
 /** Throws {@link GitUnavailableError} when `git` cannot be invoked on the host. */
-export async function assertGitAvailable(): Promise<void> {
+export async function assertGitAvailable(): Promise<string> {
   try {
-    await execFileAsync('git', ['--version']);
+    const {stdout} = await execFileAsync('git', ['--version']);
+    return stdout.trim();
   } catch (error) {
     throw new GitUnavailableError({cause: error});
   }
@@ -40,14 +56,14 @@ export async function assertGitAvailable(): Promise<void> {
 
 /**
  * Removes every occurrence of each secret plus any URL-embedded `user:pass@` credential
- * from `text`, so a clone error never carries token material into a log or step result.
+ * from `text`, so a checkout error never carries token material into a log or step result.
  */
 export function redactSecrets(text: string, secrets: string[]): string {
   let redacted = text;
   for (const secret of secrets) {
     if (secret) redacted = redacted.split(secret).join('***');
   }
-  return redacted.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
+  return redacted.replace(URL_CREDENTIAL_RE, '$1***@');
 }
 
 // git surfaces credential rejection and provider-availability failures only through
@@ -59,10 +75,10 @@ const PROVIDER_UNAVAILABLE =
   /could not resolve host|could not connect|connection timed out|failed to connect|temporary failure in name resolution|the requested url returned error: (?:429|5\d\d)/i;
 
 /**
- * Shallow-clones `ref` of `repositoryUrl` into `cwd` (which must already exist and be empty).
+ * Initializes `cwd` and checks out `ref` of `repositoryUrl` into it.
  *
  * The credential is injected with a one-shot `-c http.extraHeader`, never embedded in the
- * clone URL, so it is not persisted to `.git/config` where later user steps could read it.
+ * remote URL, so it is not persisted to `.git/config` where later user steps could read it.
  * `GIT_TERMINAL_PROMPT=0` turns a missing or denied credential into an immediate error
  * instead of a hang on an interactive prompt. Failures are classified into a
  * {@link CheckoutError} and have any token material redacted from their message.
@@ -73,22 +89,68 @@ export async function checkoutRepository(params: {
   auth?: CheckoutTokenAuthDto | undefined;
   cwd: string;
   signal?: AbortSignal | undefined;
-}): Promise<void> {
-  const {repositoryUrl, ref, auth, cwd, signal} = params;
+  onOutput?: CheckoutOutputSink | undefined;
+  onCommandStart?: ((metadata: CheckoutCommandStartMetadata) => void) | undefined;
+  onSecrets?: ((secrets: string[]) => void) | undefined;
+}): Promise<string> {
+  const {repositoryUrl, ref, auth, cwd, signal, onCommandStart, onOutput, onSecrets} = params;
 
-  const args: string[] = [];
-  if (auth) {
-    args.push('-c', `http.extraHeader=Authorization: ${authorizationValue(auth)}`);
-  }
-  args.push('clone', '--depth=1', '--single-branch', '--branch', ref, repositoryUrl, cwd);
+  const secrets = secretsOf(auth);
+  onSecrets?.(secrets);
 
   try {
-    await execFileAsync('git', args, {
-      env: {...process.env, GIT_TERMINAL_PROMPT: '0'},
-      ...(signal ? {signal} : {}),
+    await runGitCommand({
+      phase: 'init',
+      args: ['init'],
+      displayArgs: ['init'],
+      cwd,
+      signal,
+      onCommandStart,
+      onOutput,
     });
+    await runGitCommand({
+      phase: 'remote',
+      args: ['remote', 'add', 'origin', repositoryUrl],
+      displayArgs: ['remote', 'add', 'origin', redactSecrets(repositoryUrl, secrets)],
+      cwd,
+      signal,
+      onCommandStart,
+      onOutput,
+    });
+
+    const fetchArgs = ['fetch', '--progress', '--no-tags', '--prune', '--depth=1', 'origin', ref];
+    await runGitCommand({
+      phase: 'fetch',
+      args: auth
+        ? ['-c', `http.extraHeader=Authorization: ${authorizationValue(auth)}`, ...fetchArgs]
+        : fetchArgs,
+      displayArgs: fetchArgs,
+      cwd,
+      signal,
+      onCommandStart,
+      onOutput,
+    });
+    await runGitCommand({
+      phase: 'checkout',
+      args: ['checkout', '--progress', '--force', 'FETCH_HEAD'],
+      displayArgs: ['checkout', '--progress', '--force', 'FETCH_HEAD'],
+      cwd,
+      signal,
+      onCommandStart,
+      onOutput,
+    });
+    const {stdout} = await runGitCommand({
+      phase: 'resolve',
+      args: ['rev-parse', 'HEAD'],
+      displayArgs: ['rev-parse', 'HEAD'],
+      cwd,
+      signal,
+      onCommandStart,
+      onOutput,
+    });
+    return stdout.trim();
   } catch (error) {
-    throw classifyCloneError(error, auth);
+    throw classifyCheckoutError(error, auth);
   }
 }
 
@@ -110,23 +172,121 @@ function secretsOf(auth: CheckoutTokenAuthDto | undefined): string[] {
   return [auth.token, basicCredential(auth)];
 }
 
-function classifyCloneError(error: unknown, auth: CheckoutTokenAuthDto | undefined): CheckoutError {
+function classifyCheckoutError(
+  error: unknown,
+  auth: CheckoutTokenAuthDto | undefined,
+): CheckoutError {
   if (isAbortError(error)) {
-    return new CheckoutError('aborted', 'Checkout aborted', {cause: error});
+    return new CheckoutError('aborted', 'Checkout aborted', {cause: error, phase: phaseOf(error)});
   }
 
   const secrets = secretsOf(auth);
   const stderr = stderrOf(error);
   const message = redactSecrets(stderr.trim() || errorMessage(error), secrets);
-  // The raw execFile error carries the full argv (including the Authorization header) in
-  // its `message`/`cmd`, so it can never ride the cause chain into a logger un-redacted.
-  const cause = secrets.length > 0 ? redactedCause(error, secrets) : error;
+  // Raw process errors can carry provider output or credential-bearing URLs, so
+  // the cause chain is rebuilt before it can ride into a logger unredacted.
+  const cause = redactedCause(error, secrets);
 
-  if (AUTH_FAILURE.test(stderr)) return new CheckoutError('auth', message, {cause});
+  const phase = phaseOf(error);
+
+  if (AUTH_FAILURE.test(stderr)) return new CheckoutError('auth', message, {cause, phase});
   if (PROVIDER_UNAVAILABLE.test(stderr)) {
-    return new CheckoutError('unavailable', message, {cause});
+    return new CheckoutError('unavailable', message, {cause, phase});
   }
-  return new CheckoutError('failed', message, {cause});
+  return new CheckoutError('failed', message, {cause, phase});
+}
+
+function runGitCommand(params: {
+  phase: CheckoutPhase;
+  args: string[];
+  displayArgs: string[];
+  cwd: string;
+  signal?: AbortSignal | undefined;
+  onOutput?: CheckoutOutputSink | undefined;
+  onCommandStart?: ((metadata: CheckoutCommandStartMetadata) => void) | undefined;
+}): Promise<{stdout: string; stderr: string}> {
+  const {phase, args, displayArgs, cwd, signal, onCommandStart, onOutput} = params;
+  onCommandStart?.({phase, command: formatGitCommand(displayArgs), cwd});
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      env: {...process.env, GIT_TERMINAL_PROMPT: '0'},
+      stdio: ['ignore', 'pipe', 'pipe'],
+      ...(signal ? {signal} : {}),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      onOutput?.(chunk, 'stdout');
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      onOutput?.(chunk, 'stderr');
+    });
+
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      if (error instanceof Error && error.name === 'AbortError') {
+        (error as Error & {phase?: CheckoutPhase}).phase = phase;
+      }
+      reject(error);
+    });
+
+    child.on('close', (code, signalName) => {
+      if (settled) return;
+      settled = true;
+      if (code === 0) {
+        resolve({stdout, stderr});
+        return;
+      }
+      reject(new GitCommandError(phase, stderr, code, signalName));
+    });
+  });
+}
+
+class GitCommandError extends Error {
+  constructor(
+    public readonly phase: CheckoutPhase,
+    public readonly stderr: string,
+    public readonly code: number | null,
+    public readonly signal: NodeJS.Signals | null,
+  ) {
+    super('Git command failed');
+    this.name = 'GitCommandError';
+  }
+}
+
+function phaseOf(error: unknown): CheckoutPhase | undefined {
+  if (error instanceof GitCommandError) return error.phase;
+  if (error && typeof error === 'object' && 'phase' in error) {
+    const {phase} = error as {phase?: unknown};
+    if (
+      phase === 'init' ||
+      phase === 'remote' ||
+      phase === 'fetch' ||
+      phase === 'checkout' ||
+      phase === 'resolve'
+    ) {
+      return phase;
+    }
+  }
+  return undefined;
+}
+
+function formatGitCommand(args: string[]): string {
+  return `git ${args.map(shellQuote).join(' ')}`;
+}
+
+function shellQuote(value: string): string {
+  if (SHELL_SAFE_ARG_RE.test(value)) return value;
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 // Rebuilds the failure cause with every secret stripped from its message, preserving the

--- a/libs/runner/workspace/src/index.ts
+++ b/libs/runner/workspace/src/index.ts
@@ -1,15 +1,20 @@
 export {
   assertGitAvailable,
+  type CheckoutCommandStartMetadata,
   CheckoutError,
   type CheckoutFailureKind,
+  type CheckoutOutputSink,
+  type CheckoutPhase,
   checkoutRepository,
   GitUnavailableError,
   redactSecrets,
 } from '#checkout.js';
 export {
+  cleanupJobLogs,
   cleanupWorkspace,
   createJobDir,
   InvalidJobIdError,
+  jobLogsPath,
   jobWorkspacePath,
   resolveWorkspaceRoot,
   resolveWorkspaceRootFromEnv,

--- a/libs/runner/workspace/src/workspace.test.ts
+++ b/libs/runner/workspace/src/workspace.test.ts
@@ -1,4 +1,4 @@
-import {mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
+import {mkdir, mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
@@ -122,8 +122,31 @@ describe('cleanupWorkspace', () => {
 });
 
 describe('cleanupJobLogs', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'shipfox-job-logs-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, {recursive: true, force: true});
+  });
+
+  it('removes an existing job log directory without touching the root', async () => {
+    const logsDir = join(root, 'job-33333333-3333-4333-8333-333333333333');
+    await mkdir(logsDir, {recursive: true});
+    await writeFile(join(logsDir, 'setup.ndjson'), '{}\n');
+
+    const result = await cleanupJobLogs(logsDir);
+
+    const readLogsDir = () => stat(logsDir);
+    await expect(readLogsDir()).rejects.toThrow();
+    expect((await stat(root)).isDirectory()).toBe(true);
+    expect(result).toBeUndefined();
+  });
+
   it('does not throw when the directory is missing', async () => {
-    const missing = join(tmpdir(), 'shipfox-job-logs-does-not-exist-xyz');
+    const missing = join(root, 'shipfox-job-logs-does-not-exist-xyz');
 
     const result = await cleanupJobLogs(missing);
 

--- a/libs/runner/workspace/src/workspace.test.ts
+++ b/libs/runner/workspace/src/workspace.test.ts
@@ -2,9 +2,11 @@ import {mkdtemp, rm, stat, writeFile} from 'node:fs/promises';
 import {homedir, tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {
+  cleanupJobLogs,
   cleanupWorkspace,
   createJobDir,
   InvalidJobIdError,
+  jobLogsPath,
   jobWorkspacePath,
   resolveWorkspaceRoot,
   UnsafeWorkspaceRootError,
@@ -60,6 +62,24 @@ describe('jobWorkspacePath', () => {
   });
 });
 
+describe('jobLogsPath', () => {
+  const root = '/var/shipfox/work';
+
+  it('names the runner-owned log directory after the job id under the root', () => {
+    const jobId = '55555555-5555-4555-8555-555555555555';
+
+    const logsDir = jobLogsPath(jobId, root);
+
+    expect(logsDir).toBe(join(root, '.shipfox-runner-logs', `job-${jobId}`));
+  });
+
+  it('rejects a job id that is not a UUID', () => {
+    const resolve = () => jobLogsPath('../../etc/passwd', root);
+
+    expect(resolve).toThrow(InvalidJobIdError);
+  });
+});
+
 describe('createJobDir', () => {
   let root: string;
 
@@ -96,6 +116,16 @@ describe('cleanupWorkspace', () => {
     const missing = join(tmpdir(), 'shipfox-job-does-not-exist-xyz');
 
     const result = await cleanupWorkspace(missing);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('cleanupJobLogs', () => {
+  it('does not throw when the directory is missing', async () => {
+    const missing = join(tmpdir(), 'shipfox-job-logs-does-not-exist-xyz');
+
+    const result = await cleanupJobLogs(missing);
 
     expect(result).toBeUndefined();
   });

--- a/libs/runner/workspace/src/workspace.ts
+++ b/libs/runner/workspace/src/workspace.ts
@@ -5,6 +5,8 @@ import {logger} from '@shipfox/node-opentelemetry';
 import {isUuid} from '@shipfox/regex';
 import {config} from '#config.js';
 
+const RUNNER_LOGS_DIR = '.shipfox-runner-logs';
+
 /**
  * Thrown when `SHIPFOX_RUNNER_WORKSPACE_ROOT` resolves to a path we refuse to
  * manage per-job directories under (empty, the filesystem root, or a home
@@ -72,6 +74,13 @@ export function jobWorkspacePath(jobId: string, root: string): string {
   return join(root, `job-${jobId}`);
 }
 
+export function jobLogsPath(jobId: string, root: string): string {
+  if (!isUuid(jobId)) {
+    throw new InvalidJobIdError(jobId);
+  }
+  return join(root, RUNNER_LOGS_DIR, `job-${jobId}`);
+}
+
 /**
  * Pre-cleans the per-job directory before creating it, so a directory left by a
  * previous crash is never reused. Run inside the setup step so a prep failure is
@@ -92,5 +101,13 @@ export async function cleanupWorkspace(cwd: string): Promise<void> {
     await rm(cwd, {recursive: true, force: true});
   } catch (err) {
     logger().warn({err, cwd}, 'Failed to clean up job workspace');
+  }
+}
+
+export async function cleanupJobLogs(logsDir: string): Promise<void> {
+  try {
+    await rm(logsDir, {recursive: true, force: true});
+  } catch (err) {
+    logger().warn({err, logsDir}, 'Failed to clean up job logs');
   }
 }


### PR DESCRIPTION
Adds structured setup and checkout log capture for runner jobs. Setup now writes grouped runner-authored records through the existing command-log stream API, while git checkout streams actual process output through generic workspace callbacks.

Runner setup logs were previously invisible when workspace preparation or checkout failed early. This moves setup, run, and agent capture into an external per-job runner log spool so setup failures can still leave diagnostic logs behind, and it dynamically registers checkout credential forms before git output is captured.

Checkout is intentionally kept decoupled from runner-log internals: `@shipfox/runner-workspace` exposes generic phase/output/secret callbacks, and orchestration maps those onto `StepLogStream` behavior.

The runner image/build metadata standardization is tracked separately in ENG-592; this PR only logs best-effort runtime/build values when available.

Local validation passed with affected build, test, and check tasks.

Closes ENG-588
Related to ENG-592

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured setup and checkout logging for runner jobs, nesting all checkout details under a single "Checkout" group and streaming git output into a per‑job external spool so early failures leave diagnostics. Closes ENG-588; adds clearer setup messages with next‑step guidance, job/run details, and runner environment info, and opens/cleans up per‑job setup logs; build metadata polish remains pending ENG-592.

- **New Features**
  - Setup writes grouped logs: job details; runner environment (Node/OS/arch/Git); workspace prep; request/grant repository access; repository details; per‑phase commands; final commit; success line; phase‑aware failure lines with “Next step:” guidance.
  - Checkout via `@shipfox/runner-workspace`: explicit `init/remote/fetch/checkout/resolve` phases with spawned git; emits command‑start metadata, streams stdout/stderr, and registers secrets for masking (late secrets masked too); returns the checked‑out commit.
  - Per‑job log spool outside the workspace (`.shipfox-runner-logs`) with cleanup: `jobLogsPath()` and `cleanupJobLogs()` used by orchestration; setup, run, and agent steps capture to the same per‑attempt stream (setup capture is best‑effort); cleanup path covered by tests.

- **Refactors**
  - `checkoutRepository()` phases as above; raises `CheckoutError` with `kind` and optional `phase` while preserving redacted causes.
  - `assertGitAvailable()` returns the git version for environment logging.
  - `StepLogStream`/`LogTransformer`: add `addSecrets()` with shared `mergeSecretVariants()` and `writeGroupStart`/`writeGroupEnd` to nest runner groups.
  - Orchestration passes `logsDir` and `jobContext` to open setup capture and cleans up per‑job logs; renamed the checkout credential request group to avoid duplicates.

<sup>Written for commit bc28f867566067601e7d2f2d88f8c463561f4b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

