### PR TITLE
[react-ui] Fix code block line highlight backgrounds

### DIFF
--- a/.changeset/bright-lines-glow.md
+++ b/.changeset/bright-lines-glow.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Fixes syntax-highlighted code block line highlights so the row background remains visible above Shiki's transparent reset.

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
@@ -39,6 +39,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test --filter=@shipfox/client-workflows`,
     },
+    highlightedLineRange: {startLine: 10, endLine: 11},
     onClose: () => undefined,
   },
 } satisfies Meta<typeof WorkflowSourcePanel>;

--- a/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block-content.test.tsx
@@ -2,6 +2,10 @@ import {render, waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
 import {codeToHtml} from 'shiki';
 import {ThemeProvider} from '../theme/index.js';
+import {
+  CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE,
+  CODE_BLOCK_HIGHLIGHTED_LINE_STYLE,
+} from './code-content.js';
 import {CodeBlockContent} from './index.js';
 
 vi.mock('shiki', () => ({
@@ -76,6 +80,11 @@ describe('CodeBlockContent', () => {
       expect(document.body.querySelector('.line.highlighted-line')?.textContent).toContain('three');
     });
     expect(codeToHtmlMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps highlighted line backgrounds above the Shiki transparent reset', () => {
+    expect(CODE_BLOCK_HIGHLIGHTED_LINE_STYLE).toContain('!bg-[');
+    expect(CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE).toContain(':!bg-[');
   });
 });
 

--- a/libs/shared/react/ui/src/components/code-block/code-content.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-content.tsx
@@ -7,10 +7,10 @@ import {
 } from './line-highlight.js';
 
 export const CODE_BLOCK_HIGHLIGHTED_LINE_STYLE =
-  'bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
+  '!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
 
 export const CODE_BLOCK_HIGHLIGHTED_LINE_DESCENDANT_STYLE =
-  '[&_.line.highlighted-line]:bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:[&_.line.highlighted-line]:bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] [&_.line.highlighted-line]:shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
+  '[&_.line.highlighted-line]:!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_7%,transparent)] dark:[&_.line.highlighted-line]:!bg-[color-mix(in_srgb,var(--border-highlights-interactive)_12%,transparent)] [&_.line.highlighted-line]:shadow-[inset_2px_0_0_color-mix(in_srgb,var(--border-highlights-interactive)_65%,transparent)]';
 
 type CodeContentProps = HTMLAttributes<HTMLElement> & {
   code: string;


### PR DESCRIPTION
Fix syntax-highlighted code block line highlights so the selected row background remains visible alongside the existing left rail.

Shiki injects a transparent background reset with `!important`, which allowed the rail shadow to show while the intended row fill was suppressed. This raises the highlight background utilities to the same cascade level and keeps the SourcePanel Storybook story exercising a highlighted range for visual coverage.

Includes a patch changeset for `@shipfox/react-ui`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code block line highlights so the row background stays visible with Shiki, while keeping the left rail indicator.

- **Bug Fixes**
  - Force highlight backgrounds with `!bg-…` to override Shiki’s `!important` transparent reset.
  - Keep the `WorkflowSourcePanel` story highlighting a range for visual coverage.
  - Add tests to assert the elevated specificity for highlighted lines.
  - Add a patch changeset for `@shipfox/react-ui`.

<sup>Written for commit 80682680d5fd853189ca318dba4911170cffe3ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

