### PR TITLE
[client-logs] Collapse log groups by default

### DIFF
--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -113,7 +113,8 @@ export const Showcase: Story = {
 /**
  * Groups nested three levels deep (Deploy > Build > Compile, Deploy > Test >
  * unit/e2e). Each level indents; the failing `e2e` leaf bubbles its error up to
- * `Test` and `Deploy pipeline`. Collapse any group to see its "N lines" summary,
+ * `Test` and `Deploy pipeline`. Expand any group to reveal its nested output; the
+ * collapsed header shows its "N lines" summary,
  * duration, and (for a branch with a failure) the inset error bar.
  */
 export const NestedGroups: Story = {

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -113,11 +113,11 @@ export const Showcase: Story = {
 /**
  * Groups nested three levels deep (Deploy > Build > Compile, Deploy > Test >
  * unit/e2e). Each level indents; the failing `e2e` leaf bubbles its error up to
- * `Test` and `Deploy pipeline`. Expand any group to reveal its nested output; the
- * collapsed header shows its "N lines" summary,
+ * `Test` and `Deploy pipeline`. Collapse any group to see its "N lines" summary,
  * duration, and (for a branch with a failure) the inset error bar.
  */
 export const NestedGroups: Story = {
+  args: {defaultGroupsOpen: true},
   render: (args) => (
     <div className="max-w-3xl">
       <LogView {...args} records={nestedRecords} />

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -19,6 +19,7 @@ export interface LogViewProps {
   timestamps?: LogTimestampMode;
   wrap?: boolean;
   showLineNumbers?: boolean;
+  defaultGroupsOpen?: boolean;
   className?: string | undefined;
   onScroll?: UIEventHandler<HTMLDivElement> | undefined;
 }
@@ -28,6 +29,7 @@ export function LogView({
   timestamps = 'off',
   wrap = false,
   showLineNumbers = true,
+  defaultGroupsOpen = false,
   className,
   onScroll,
 }: LogViewProps) {
@@ -50,13 +52,18 @@ export function LogView({
           </LogContent>
         </LogRow>
       ) : (
-        renderNodes(tree.nodes, 0, tree)
+        renderNodes(tree.nodes, 0, tree, defaultGroupsOpen)
       )}
     </LogRows>
   );
 }
 
-function renderNodes(nodes: readonly LogNode[], depth: number, tree: LogTree): ReactNode[] {
+function renderNodes(
+  nodes: readonly LogNode[],
+  depth: number,
+  tree: LogTree,
+  defaultGroupsOpen: boolean,
+): ReactNode[] {
   // `node.seq` is the stable, unique render key (see `LogNodeBase`): a concatenated
   // multi-step/retry stream can repeat a `group_id` or a marker's `(type, ts)` at one
   // level, which a key derived from those fields would collide on.
@@ -73,8 +80,14 @@ function renderNodes(nodes: readonly LogNode[], depth: number, tree: LogTree): R
         );
       case 'group':
         return (
-          <LogGroup key={node.seq} node={node} depth={depth} terminated={tree.terminated}>
-            {renderNodes(node.children, depth + 1, tree)}
+          <LogGroup
+            key={node.seq}
+            node={node}
+            depth={depth}
+            terminated={tree.terminated}
+            defaultOpen={defaultGroupsOpen}
+          >
+            {renderNodes(node.children, depth + 1, tree, defaultGroupsOpen)}
           </LogGroup>
         );
       case 'marker':

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -73,13 +73,7 @@ function renderNodes(nodes: readonly LogNode[], depth: number, tree: LogTree): R
         );
       case 'group':
         return (
-          <LogGroup
-            key={node.seq}
-            node={node}
-            depth={depth}
-            terminated={tree.terminated}
-            defaultOpen
-          >
+          <LogGroup key={node.seq} node={node} depth={depth} terminated={tree.terminated}>
             {renderNodes(node.children, depth + 1, tree)}
           </LogGroup>
         );


### PR DESCRIPTION
Collapse grouped log sections by default in the shared client log viewer.

Workflow run logs can contain dense nested groups, and opening every group by default makes the panel harder to scan. This lets `LogGroup` use its existing closed default while preserving manual expansion behavior.

The updated Storybook copy now describes expanding groups from the collapsed state. No changeset is included because `@shipfox/client-logs` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapse grouped log sections by default in the `@shipfox/client-logs` viewer to make nested logs easier to scan. Add a `defaultGroupsOpen` prop to `LogView` (default false) to control initial group state, and set it to true in the `NestedGroups` Storybook story so those groups start open.

<sup>Written for commit 24931fe6d634153c1f5f351e056e8a758e4b52ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

