### PR TITLE
[client-workflows] Condense workflow step attempts

### DIFF
--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -39,9 +39,9 @@ describe('WorkflowRunView', () => {
     expect(await screen.findByRole('region', {name: 'Workflow jobs'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'build, Succeeded'})).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'deploy, Running'})).toBeInTheDocument();
-    expect(screen.getByRole('region', {name: 'Step attempts'})).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'build'})).toBeInTheDocument();
     expect(
-      screen.getByRole('button', {name: '1. checkout, Succeeded, attempt 1'}),
+      screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'}),
     ).toBeInTheDocument();
   });
 
@@ -159,7 +159,7 @@ describe('WorkflowRunView', () => {
     await waitFor(() => expect(sourceButton).toHaveFocus());
     expect(sourceButton).toHaveAttribute('aria-expanded', 'false');
     expect(deployNode).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByRole('region', {name: 'Step attempts'})).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'deploy'})).toBeInTheDocument();
   });
 
   test('highlights selected step source lines when the source panel opens', async () => {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -18,9 +18,9 @@ describe('WorkflowStepList', () => {
       />,
     );
 
-    expect(screen.getByRole('region', {name: 'Step attempts'})).toBeInTheDocument();
+    expect(screen.getByRole('region', {name: 'build'})).toBeInTheDocument();
     expect(screen.queryByText('1 step')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', {name: '1. build, Running, attempt 1'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'build, Running, attempt 1'})).toBeInTheDocument();
     expect(screen.queryByText('Grouped')).not.toBeInTheDocument();
   });
 
@@ -33,7 +33,7 @@ describe('WorkflowStepList', () => {
         })}
       />,
     );
-    const build = screen.getByRole('button', {name: '1. build, Running, attempt 1'});
+    const build = screen.getByRole('button', {name: 'build, Running, attempt 1'});
 
     await user.click(build);
 
@@ -59,7 +59,7 @@ describe('WorkflowStepList', () => {
         )}
       />,
     );
-    const deploy = screen.getByRole('button', {name: '1. deploy, Running, attempt 1'});
+    const deploy = screen.getByRole('button', {name: 'deploy, Running, attempt 1'});
 
     await user.click(deploy);
 
@@ -80,7 +80,7 @@ describe('WorkflowStepList', () => {
         onSelectedAttemptChange={onSelectedAttemptChange}
       />,
     );
-    const deploy = screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'});
+    const deploy = screen.getByRole('button', {name: 'deploy, Pending, attempt 1'});
 
     await user.click(deploy);
     await user.click(deploy);
@@ -100,7 +100,7 @@ describe('WorkflowStepList', () => {
       />,
     );
 
-    expect(screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'deploy, Pending, attempt 1'})).toHaveAttribute(
       'aria-expanded',
       'true',
     );
@@ -122,7 +122,7 @@ describe('WorkflowStepList', () => {
         renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
       />,
     );
-    const deploy = screen.getByRole('button', {name: '1. deploy, Pending, attempt 1'});
+    const deploy = screen.getByRole('button', {name: 'deploy, Pending, attempt 1'});
     expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
 
     rerender(
@@ -172,11 +172,11 @@ describe('WorkflowStepList', () => {
       />,
     );
 
-    expect(screen.getByRole('button', {name: '1. install, Running, attempt 1'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'install, Running, attempt 1'})).toHaveAttribute(
       'aria-expanded',
       'false',
     );
-    expect(screen.getByRole('button', {name: '2. deploy, Running, attempt 1'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'deploy, Running, attempt 1'})).toHaveAttribute(
       'aria-expanded',
       'true',
     );
@@ -194,7 +194,7 @@ describe('WorkflowStepList', () => {
       />,
     );
 
-    expect(screen.getByRole('button', {name: '1. deploy, Succeeded, attempt 1'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'deploy, Succeeded, attempt 1'})).toHaveAttribute(
       'aria-expanded',
       'false',
     );
@@ -213,7 +213,7 @@ describe('WorkflowStepList', () => {
         renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
       />,
     );
-    const deploy = screen.getByRole('button', {name: '1. deploy, Running, attempt 1'});
+    const deploy = screen.getByRole('button', {name: 'deploy, Running, attempt 1'});
     expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
 
     await user.click(deploy);
@@ -265,12 +265,12 @@ describe('WorkflowStepList', () => {
 
     expect(
       screen.getByRole('button', {
-        name: '1. gate, Failed, attempt 1, User',
+        name: 'gate, Failed, attempt 1, User',
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: '1. gate, Failed, attempt 2, User',
+        name: 'gate, Failed, attempt 2, User',
       }),
     ).toBeInTheDocument();
     expect(screen.queryByText('User')).not.toBeInTheDocument();
@@ -299,10 +299,8 @@ describe('WorkflowStepList', () => {
       />,
     );
 
-    expect(screen.queryByRole('button', {name: '1. queued, Pending'})).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: '2. build, Succeeded, attempt 1'}),
-    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'queued, Pending'})).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'build, Succeeded, attempt 1'})).toBeInTheDocument();
     expect(screen.queryByText('#1')).not.toBeInTheDocument();
     expect(screen.queryByText('1 attempt')).not.toBeInTheDocument();
   });
@@ -319,9 +317,7 @@ describe('WorkflowStepList', () => {
       <WorkflowStepList job={makeJob({steps: [makeStep({name, attempts: [makeAttempt()]})]})} />,
     );
 
-    expect(
-      screen.getByRole('button', {name: `1. ${name}, Pending, attempt 1`}),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: `${name}, Pending, attempt 1`})).toBeInTheDocument();
   });
 });
 

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -11,7 +11,8 @@ import {
 } from '@shipfox/react-ui';
 import type {ReactNode} from 'react';
 import {useEffect, useId, useMemo, useState} from 'react';
-import type {WorkflowJob} from '#core/workflow-run.js';
+import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
+import {isWorkflowStatus, type WorkflowJob} from '#core/workflow-run.js';
 import {
   buildWorkflowStepListModel,
   humanizeStatus,
@@ -104,11 +105,8 @@ function WorkflowStepListContent({
         className,
       )}
     >
-      <div className="flex min-h-52 flex-col justify-center gap-2 border-b border-border-neutral-base px-16 py-8">
+      <div className="flex min-h-40 items-center border-b border-border-neutral-base px-16 py-8">
         <Text as="h2" id={titleId} size="sm" bold className="text-foreground-neutral-base">
-          Step attempts
-        </Text>
-        <Text size="xs" className="min-w-0 truncate text-foreground-neutral-subtle">
           {model.jobName}
         </Text>
       </div>
@@ -173,7 +171,7 @@ function WorkflowStepRow({
       aria-label={entryAccessibleLabel(entry)}
       onClick={onSelect}
       className={cn(
-        'group flex min-h-56 w-full items-center gap-10 px-12 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
+        'group flex min-h-44 w-full items-center gap-8 px-12 py-6 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
         selected && 'bg-background-components-hover',
       )}
     >
@@ -185,25 +183,13 @@ function WorkflowStepRow({
           selected && 'rotate-90',
         )}
       />
-      <Text size="xs" className="w-20 shrink-0 text-right font-code text-foreground-neutral-muted">
-        {entry.step.index}
-      </Text>
-      <Dot
-        variant={entry.statusVisual.dot}
-        ripple={entry.statusVisual.ripple}
-        className="size-8 shrink-0"
-      />
+      <WorkflowStepStatusIcon entry={entry} />
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-8">
           <Text size="sm" bold className="truncate text-foreground-neutral-base">
             {entry.step.label}
           </Text>
           {entry.step.attempts.length > 1 ? <WorkflowAttemptChip attempt={entry} /> : null}
-        </div>
-        <div className="flex min-w-0 flex-wrap items-center gap-x-8 gap-y-2">
-          <Text size="xs" className="text-foreground-neutral-subtle">
-            {entry.statusVisual.label}
-          </Text>
         </div>
       </div>
     </button>
@@ -234,6 +220,28 @@ function WorkflowStepRow({
   );
 }
 
+function WorkflowStepStatusIcon({entry}: {entry: WorkflowStepListEntryModel}) {
+  if (isWorkflowStatus(entry.statusVisual.kind)) {
+    return (
+      <WorkflowStatusIcon
+        status={entry.statusVisual.kind}
+        ripple={entry.statusVisual.ripple}
+        size={14}
+      />
+    );
+  }
+
+  return (
+    <span role="img" aria-label={entry.statusVisual.label} className="inline-flex shrink-0">
+      <Dot
+        variant={entry.statusVisual.dot}
+        ripple={entry.statusVisual.ripple}
+        className="size-12 shrink-0"
+      />
+    </span>
+  );
+}
+
 const attemptChipClasses: Record<NonNullable<BadgeVariant>, string> = {
   neutral: 'bg-tag-neutral-bg border-tag-neutral-border',
   info: 'bg-tag-blue-bg border-tag-blue-border',
@@ -259,11 +267,7 @@ function WorkflowAttemptChip({attempt}: {attempt: WorkflowStepAttemptModel}) {
 }
 
 function entryAccessibleLabel(entry: WorkflowStepListEntryModel): string {
-  const parts = [
-    `${entry.step.index}. ${entry.step.label}`,
-    entry.statusVisual.label,
-    `attempt ${entry.attempt}`,
-  ];
+  const parts = [entry.step.label, entry.statusVisual.label, `attempt ${entry.attempt}`];
   if (entry.step.error?.category) parts.push(humanizeStatus(entry.step.error.category));
   return parts.join(', ');
 }

--- a/libs/client/workflows/src/pages/workflow-run-page.test.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-page.test.tsx
@@ -86,7 +86,7 @@ describe('WorkflowRunPage', () => {
 
     const deployJob = await screen.findByRole('button', {name: 'deploy, Running'});
     const deployAttempt = await screen.findByRole('button', {
-      name: '1. deploy, Running, attempt 2',
+      name: 'deploy, Running, attempt 2',
     });
 
     expect(deployJob).toHaveAttribute('aria-pressed', 'true');
@@ -106,7 +106,7 @@ describe('WorkflowRunPage', () => {
     });
     expect(currentSearch(router).step).toBeUndefined();
     expect(currentSearch(router).attempt).toBeUndefined();
-    expect(screen.getByRole('button', {name: '1. checkout, Succeeded, attempt 1'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'checkout, Succeeded, attempt 1'})).toHaveAttribute(
       'aria-expanded',
       'false',
     );
@@ -117,7 +117,7 @@ describe('WorkflowRunPage', () => {
     configureApiClient({fetchImpl: createRunDetailFetch()});
     const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
 
-    await user.click(await screen.findByRole('button', {name: '1. deploy, Running, attempt 2'}));
+    await user.click(await screen.findByRole('button', {name: 'deploy, Running, attempt 2'}));
 
     await waitFor(() => {
       expect(currentSearch(router)).toMatchObject({
@@ -134,7 +134,7 @@ describe('WorkflowRunPage', () => {
     const {router} = renderRunPath(`?step=${DEPLOY_STEP_ID}&attempt=${DEPLOY_ATTEMPT_TWO_ID}`);
 
     const deployAttempt = await screen.findByRole('button', {
-      name: '1. deploy, Running, attempt 2',
+      name: 'deploy, Running, attempt 2',
     });
     await user.click(deployAttempt);
 
@@ -151,7 +151,7 @@ describe('WorkflowRunPage', () => {
     configureApiClient({fetchImpl: createRunDetailFetch()});
     const {router} = renderRunPath(`?job=${DEPLOY_JOB_ID}`);
 
-    await user.click(await screen.findByRole('button', {name: '1. deploy, Running, attempt 2'}));
+    await user.click(await screen.findByRole('button', {name: 'deploy, Running, attempt 2'}));
     await waitFor(() => {
       expect(currentSearch(router).attempt).toBe(DEPLOY_ATTEMPT_TWO_ID);
     });
@@ -164,7 +164,7 @@ describe('WorkflowRunPage', () => {
     });
     expect(currentSearch(router).step).toBeUndefined();
     expect(currentSearch(router).attempt).toBeUndefined();
-    expect(screen.getByRole('button', {name: '1. deploy, Running, attempt 2'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'deploy, Running, attempt 2'})).toHaveAttribute(
       'aria-expanded',
       'false',
     );
@@ -175,7 +175,7 @@ describe('WorkflowRunPage', () => {
     await waitFor(() => {
       expect(currentSearch(router).attempt).toBe(DEPLOY_ATTEMPT_TWO_ID);
     });
-    expect(screen.getByRole('button', {name: '1. deploy, Running, attempt 2'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'deploy, Running, attempt 2'})).toHaveAttribute(
       'aria-expanded',
       'true',
     );


### PR DESCRIPTION
Condense the workflow step attempts panel so it reads as a compact job-specific list instead of a labelled report section.

The old layout repeated low-signal metadata: the header said "Step attempts" while the job name lived underneath, each row showed a visual index even though row order already conveys sequence, and the status appeared both as text and as a side indicator. This makes the job name the panel heading, removes the visual row numbers and status copy, and reuses `WorkflowStatusIcon` for known step-attempt states so dense rows retain shape-based status semantics.

Unknown/custom attempt statuses still fall back to an accessible neutral dot, and row accessible labels keep status and attempt details for assistive tech and test selectors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Condensed the workflow step attempts panel into a compact, job-scoped list. Removes redundant labels and numbers, uses icons for status, and keeps accessible labels intact.

- **Refactors**
  - The panel heading is now the job name (region name equals the job).
  - Removed row index and status text; status shown via `WorkflowStatusIcon`. Unknown states fall back to an accessible neutral dot.
  - Tightened spacing and row height for denser lists.
  - Updated accessible labels to “step label, Status, attempt N”.
  - Updated tests to match new region names and button labels.

<sup>Written for commit 3897927ebc7122a59e9e233c3e081e69d12d7eee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

