### PR TITLE
Polish workflow run page spacing

### DIFF
--- a/libs/client/app-shell/src/components/main-layout.tsx
+++ b/libs/client/app-shell/src/components/main-layout.tsx
@@ -30,7 +30,7 @@ export function MainLayout() {
       <NavBar />
       <ProjectTabs />
       {fullBleed ? (
-        <main className="flex-1 min-h-0 flex flex-col overflow-auto">
+        <main className="flex-1 min-h-0 flex flex-col overflow-hidden">
           <Outlet />
         </main>
       ) : (

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
@@ -7,8 +7,8 @@ import {TriggerNode, WorkflowJobNode} from './workflow-job-node.js';
 
 const NODE_WIDTH = 208;
 const NODE_HEIGHT = 48;
-const COLUMN_GAP = 72;
-const ROW_GAP = 18;
+const COLUMN_GAP = 64;
+const ROW_GAP = 20;
 const TRIGGER_WIDTH = 36;
 const PADDING = 16;
 
@@ -82,7 +82,7 @@ export function WorkflowJobsGraphContent({
         {model.columns.map((column, columnIndex) => (
           <div
             key={column.map((node) => node.id).join(':')}
-            className="absolute flex flex-col gap-18"
+            className="absolute flex flex-col gap-20"
             style={{left: jobLeft(columnIndex), top: PADDING}}
           >
             {column.map((node) => (

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -195,7 +195,7 @@ describe('WorkflowJobsGraph', () => {
     const skippedJoinEdge = container.querySelector(
       `[data-edge-id="${securityScan.id}:${deploy.id}"]`,
     );
-    expect(skippedJoinEdge).toHaveAttribute('d', 'M 332 106 H 648 V 40 H 684');
+    expect(skippedJoinEdge).toHaveAttribute('d', 'M 324 108 H 628 V 40 H 660');
   });
 });
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -33,7 +33,7 @@ export function WorkflowRunView({runId, selection, onSelectionChange}: WorkflowR
 
   return (
     <RelativeTimeProvider>
-      <div className="flex min-w-0 flex-1">
+      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
         <RunViewContent
           query={runQuery}
           selection={selection}
@@ -137,28 +137,30 @@ function RunViewContent({
           onSourceToggle={() => setSourcePanelOpen((open) => !open)}
         />
         {query.isError ? <WorkflowRunStaleError query={query} /> : null}
-        <div className="flex min-h-0 flex-1 flex-col gap-16 overflow-auto bg-background-neutral-base p-16">
-          <WorkflowJobsGraph
-            run={query.data}
-            selectedJobId={selectedJob?.id}
-            onSelectedJobChange={selectJob}
-          />
-          {selectedJob ? (
-            <WorkflowStepList
-              job={selectedJob}
-              className="max-h-[50vh]"
-              selectedAttemptId={selectedAttemptId}
-              onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
-              autoSelectActiveAttempt
-              renderExpandedStep={({stepId, attempt, attemptStatus}) => (
-                <StepAttemptLogPanel
-                  stepId={stepId}
-                  attempt={attempt}
-                  attemptStatus={attemptStatus}
-                />
-              )}
+        <div className="min-h-0 flex-1 overflow-auto bg-background-neutral-base p-16">
+          <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-16">
+            <WorkflowJobsGraph
+              run={query.data}
+              selectedJobId={selectedJob?.id}
+              onSelectedJobChange={selectJob}
             />
-          ) : null}
+            {selectedJob ? (
+              <WorkflowStepList
+                job={selectedJob}
+                className="max-h-[50vh]"
+                selectedAttemptId={selectedAttemptId}
+                onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
+                autoSelectActiveAttempt
+                renderExpandedStep={({stepId, attempt, attemptStatus}) => (
+                  <StepAttemptLogPanel
+                    stepId={stepId}
+                    attempt={attempt}
+                    attemptStatus={attemptStatus}
+                  />
+                )}
+              />
+            ) : null}
+          </div>
         </div>
       </div>
       <WorkflowSourcePanel

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
@@ -54,14 +54,14 @@ export function WorkflowRunRow({
         />
       ) : null}
 
-      <div className="flex min-w-0 items-center gap-7">
+      <div className="flex min-w-0 items-center gap-8">
         <WorkflowStatusIcon status={run.status} size={14} />
         <Code variant="label" bold className="truncate text-foreground-neutral-base">
           {run.name}
         </Code>
       </div>
 
-      <div className="flex min-w-0 items-center gap-7">
+      <div className="flex min-w-0 items-center gap-8">
         {run.triggerLabel ? (
           <>
             <TriggerSourceIcon
@@ -77,7 +77,7 @@ export function WorkflowRunRow({
             </Code>
           </>
         ) : (
-          <span className="flex min-w-0 flex-1 items-center gap-7 truncate text-foreground-neutral-muted">
+          <span className="flex min-w-0 flex-1 items-center gap-8 truncate text-foreground-neutral-muted">
             <span aria-hidden="true" className="size-14 shrink-0" />
             <span className="sr-only">Run updated </span>
           </span>
@@ -94,7 +94,7 @@ export function WorkflowRunRow({
   // that would navigate to a run id the detail route rejects.
   if (run.isTemporary) {
     return (
-      <div className="relative flex w-full flex-col gap-3 rounded-8 border border-transparent px-10 py-7 text-left">
+      <div className="relative flex w-full flex-col gap-4 rounded-8 border border-transparent px-10 py-8 text-left">
         {body}
       </div>
     );
@@ -110,7 +110,7 @@ export function WorkflowRunRow({
       }
       aria-current={selected ? 'page' : undefined}
       className={cn(
-        'group relative flex w-full flex-col gap-3 rounded-8 border border-transparent px-10 py-7 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
+        'group relative flex w-full flex-col gap-4 rounded-8 border border-transparent px-10 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
         selected && 'bg-background-components-hover',
       )}
     >

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-header.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-header.tsx
@@ -21,7 +21,7 @@ export function WorkflowRunsListHeader({
   onStatusFilterChange,
 }: WorkflowRunsListHeaderProps) {
   return (
-    <div className="flex flex-col gap-8 border-b border-border-neutral-base px-8 py-12">
+    <div className="flex flex-col gap-8 border-b border-border-neutral-base px-12 py-12">
       <Input
         value={query}
         onChange={(event) => onQueryChange(event.target.value)}
@@ -31,7 +31,7 @@ export function WorkflowRunsListHeader({
         iconLeft={<Icon name="searchLine" className="size-14 text-foreground-neutral-muted" />}
       />
 
-      <fieldset className="flex items-center gap-6">
+      <fieldset className="flex items-center gap-8">
         <legend className="sr-only">Run status filter</legend>
         {STATUS_FILTERS.map((filter) => (
           <Button

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-view.tsx
@@ -30,7 +30,7 @@ export function WorkflowRunsListView({
     <RelativeTimeProvider>
       <aside
         className={cn(
-          'flex w-[280px] shrink-0 flex-col border-r border-border-neutral-base bg-background-subtle-base',
+          'flex w-304 shrink-0 flex-col border-r border-border-neutral-base bg-background-subtle-base',
           className,
         )}
         aria-label="Workflow runs"

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -171,7 +171,7 @@ function WorkflowStepRow({
       aria-label={entryAccessibleLabel(entry)}
       onClick={onSelect}
       className={cn(
-        'group flex min-h-44 w-full items-center gap-8 px-12 py-6 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
+        'group grid min-h-44 w-full grid-cols-[14px_14px_minmax(0,1fr)] items-center gap-x-8 px-12 py-6 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
         selected && 'bg-background-components-hover',
       )}
     >
@@ -211,9 +211,13 @@ function WorkflowStepRow({
         <section
           id={panelId}
           aria-labelledby={buttonId}
-          className="border-t border-border-neutral-base bg-background-neutral-base px-44 py-12"
+          className="border-t border-border-neutral-base bg-background-neutral-base px-12 py-12"
         >
-          {expandedContent}
+          <div className="grid grid-cols-[14px_14px_minmax(0,1fr)] gap-x-8">
+            <span aria-hidden="true" />
+            <span aria-hidden="true" />
+            <div className="min-w-0">{expandedContent}</div>
+          </div>
         </section>
       ) : null}
     </li>

--- a/libs/client/workflows/src/pages/workflow-run-page.tsx
+++ b/libs/client/workflows/src/pages/workflow-run-page.tsx
@@ -71,7 +71,7 @@ export function WorkflowRunPage({workspaceId, projectId, runId}: WorkflowRunPage
   }
 
   return (
-    <div className="flex min-h-0 flex-1">
+    <div className="flex min-h-0 flex-1 overflow-hidden">
       <WorkflowRunsList workspaceId={workspaceId} projectId={projectId} selectedRunId={runId} />
       <WorkflowRunView runId={runId} selection={selection} onSelectionChange={onSelectionChange} />
     </div>


### PR DESCRIPTION
Polishes the workflow run page so the run viewer reads as a single compact operator surface.

The current full-bleed run page had nested scrolling and several off-scale local spacing values, which made the rail, DAG, step attempts, and expanded logs feel slightly misaligned. This contains full-bleed overflow at the shell/page boundary, widens the run rail, normalizes rail and DAG spacing, caps the detail stack, and aligns expanded logs to the step row grid.

Footer removal is intentionally left to the follow-up tracked in ENG-593; this PR keeps the footer in place and focuses on the other layout wins.

Refs ENG-593

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the workflow run page so the console feels cohesive. Removed nested scrolling and normalized spacing across the rail, job graph, step list, and logs.

- **UI Improvements**
  - Contained full-bleed overflow at the app shell and run page (`overflow-hidden`) to remove nested scrolling.
  - Capped run console width at `max-w-[1280px]`; aligned expanded logs to the step row grid.
  - Normalized jobs graph spacing: column gap 64, row gap 20; updated the test.
  - Widened runs rail to `w-304`; tightened list header/row gaps and padding.
  - Kept the footer; removal tracked in ENG-593.

<sup>Written for commit a67ad9490bbd4127e9e878b3053c696f0dda084c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

