### PR TITLE
Add richer Gitea demo workflow states

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml
@@ -6,11 +6,27 @@ triggers:
     event: push
     filter: 'event.ref == "refs/heads/main"'
 jobs:
-  build:
+  prepare:
     steps:
-      - run: node --check src/index.js
-      - run: node --test
+      - name: checkout-summary
+        run: echo "Preparing demo workspace"
+      - name: validate-package
+        run: node --check src/index.js
+  test:
+    needs: prepare
+    steps:
+      - name: unit-tests
+        run: node --test
+      - name: forced-failure
+        run: |
+          echo "Intentional demo failure"
+          exit 1
+      - name: skipped-after-failure
+        run: echo "This step is cancelled after the forced failure"
   deploy:
-    needs: build
+    needs: test
     steps:
-      - run: echo "Deploying demo"
+      - name: package
+        run: echo "Packaging demo"
+      - name: publish
+        run: echo "Deploying demo"


### PR DESCRIPTION
Add a richer seeded workflow for the local Gitea demo repository.

The demo workflow now creates a more representative run graph: one successful preparation job, a dependent test job with a successful step followed by an intentional fast failure, and a deploy job that is blocked after the failed dependency. This gives the workflow UI seed data for success, failure, dependency, and cancelled/skipped states without adding slow commands.

The change is limited to the local Gitea seed repository fixture under dev/gitea.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the local Gitea demo workflow to generate realistic run states for the UI: a passing prepare job, a test job that fails fast after one success, and a deploy job blocked by the failure. Change is scoped to `dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml`.

- **New Features**
  - Renamed `build` to `prepare` with `checkout-summary` and `validate-package` steps.
  - Added `test` job (needs `prepare`) with `unit-tests`, an intentional `forced-failure`, and a step that gets skipped.
  - Updated `deploy` to depend on `test` and split into `package` and `publish` steps to show blocked/cancelled behavior.

<sup>Written for commit 9f2949e02481c88349854da53d481324d926c2de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

