### PR TITLE
[client-workflows] Highlight graph edges on node hover

### DIFF
--- a/.changeset/sober-edges-highlight.md
+++ b/.changeset/sober-edges-highlight.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-workflows": patch
+---
+
+Highlights workflow job graph edges on node hover with a neutral emphasis instead of the selected-job accent.

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.tsx
@@ -46,12 +46,16 @@ export function WorkflowJobNode({
   selected,
   onSelect,
   onKeyDown,
+  onHoverStart,
+  onHoverEnd,
   ref,
 }: {
   node: WorkflowJobGraphNode;
   selected: boolean;
   onSelect: () => void;
   onKeyDown: KeyboardEventHandler<HTMLButtonElement>;
+  onHoverStart: () => void;
+  onHoverEnd: () => void;
   ref?: Ref<HTMLButtonElement>;
 }) {
   const visual = getWorkflowStatusVisual(node.status);
@@ -70,6 +74,8 @@ export function WorkflowJobNode({
       data-job-id={node.id}
       onClick={onSelect}
       onKeyDown={onKeyDown}
+      onPointerEnter={onHoverStart}
+      onPointerLeave={onHoverEnd}
       className={cn(
         'group relative flex h-48 w-208 items-center gap-8 rounded-8 border border-border-neutral-base bg-background-components-base px-10 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
         selected && 'bg-background-components-hover',

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
@@ -1,6 +1,6 @@
-import {EmptyState} from '@shipfox/react-ui';
+import {cn, EmptyState} from '@shipfox/react-ui';
 import type {KeyboardEvent} from 'react';
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import type {WorkflowJobGraphModel, WorkflowJobGraphNavigationKey} from './graph-model.js';
 import {nextWorkflowJobGraphNodeId} from './graph-model.js';
 import {TriggerNode, WorkflowJobNode} from './workflow-job-node.js';
@@ -22,6 +22,7 @@ export function WorkflowJobsGraphContent({
   onSelectJob: (jobId: string | undefined) => void;
 }) {
   const nodeRefs = useRef(new Map<string, HTMLButtonElement>());
+  const [hoveredJobId, setHoveredJobId] = useState<string | undefined>();
 
   if (model.nodes.length === 0) {
     return (
@@ -72,7 +73,7 @@ export function WorkflowJobsGraphContent({
   return (
     <div className="min-h-0 overflow-auto bg-background-neutral-base">
       <div className="relative" style={{width: contentWidth, minHeight: contentHeight}}>
-        <GraphEdges model={model} />
+        <GraphEdges model={model} hoveredJobId={hoveredJobId} />
         <div
           className="absolute"
           style={{left: PADDING, top: PADDING + (NODE_HEIGHT - TRIGGER_WIDTH) / 2}}
@@ -93,6 +94,10 @@ export function WorkflowJobsGraphContent({
                 ref={setNodeRef(node.id)}
                 onSelect={() => onSelectJob(node.id === selectedJobId ? undefined : node.id)}
                 onKeyDown={handleKeyDown}
+                onHoverStart={() => setHoveredJobId(node.id)}
+                onHoverEnd={() =>
+                  setHoveredJobId((current) => (current === node.id ? undefined : current))
+                }
               />
             ))}
           </div>
@@ -116,7 +121,13 @@ function navigationKey(key: string): WorkflowJobGraphNavigationKey | undefined {
   return undefined;
 }
 
-function GraphEdges({model}: {model: WorkflowJobGraphModel}) {
+function GraphEdges({
+  model,
+  hoveredJobId,
+}: {
+  model: WorkflowJobGraphModel;
+  hoveredJobId?: string | undefined;
+}) {
   const byId = new Map(model.nodes.map((node) => [node.id, node]));
 
   return (
@@ -127,14 +138,21 @@ function GraphEdges({model}: {model: WorkflowJobGraphModel}) {
         const from = edge.from === 'trigger' ? triggerPoint() : jobRightPoint(fromNode);
         const to = jobLeftPoint(toNode);
         if (!from || !to) return null;
+        const highlighted = edge.from === hoveredJobId || edge.to === hoveredJobId;
         return (
-          <g key={edge.id} className="text-foreground-neutral-muted">
+          <g
+            key={edge.id}
+            className={cn(
+              'text-foreground-neutral-muted transition-colors',
+              highlighted && 'text-foreground-neutral-base',
+            )}
+          >
             <path
               data-edge-id={edge.id}
               d={edgePath({from, fromNode, to, toNode})}
               fill="none"
               stroke="currentColor"
-              strokeWidth="1"
+              strokeWidth={highlighted ? 1.5 : 1}
             />
           </g>
         );

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-content.tsx
@@ -129,30 +129,40 @@ function GraphEdges({
   hoveredJobId?: string | undefined;
 }) {
   const byId = new Map(model.nodes.map((node) => [node.id, node]));
+  const edgeViews = model.edges
+    .map((edge) => {
+      const fromNode = byId.get(edge.from);
+      const toNode = byId.get(edge.to);
+      const from = edge.from === 'trigger' ? triggerPoint() : jobRightPoint(fromNode);
+      const to = jobLeftPoint(toNode);
+      if (!from || !to) return undefined;
+
+      return {
+        id: edge.id,
+        highlighted: edge.from === hoveredJobId || edge.to === hoveredJobId,
+        path: edgePath({from, fromNode, to, toNode}),
+      };
+    })
+    .filter((edgeView): edgeView is NonNullable<typeof edgeView> => edgeView !== undefined)
+    .sort((left, right) => Number(left.highlighted) - Number(right.highlighted));
 
   return (
     <svg className="pointer-events-none absolute inset-0 size-full" aria-hidden="true">
-      {model.edges.map((edge) => {
-        const fromNode = byId.get(edge.from);
-        const toNode = byId.get(edge.to);
-        const from = edge.from === 'trigger' ? triggerPoint() : jobRightPoint(fromNode);
-        const to = jobLeftPoint(toNode);
-        if (!from || !to) return null;
-        const highlighted = edge.from === hoveredJobId || edge.to === hoveredJobId;
+      {edgeViews.map((edge) => {
         return (
           <g
             key={edge.id}
             className={cn(
               'text-foreground-neutral-muted transition-colors',
-              highlighted && 'text-foreground-neutral-base',
+              edge.highlighted && 'text-foreground-neutral-base',
             )}
           >
             <path
               data-edge-id={edge.id}
-              d={edgePath({from, fromNode, to, toNode})}
+              d={edge.path}
               fill="none"
               stroke="currentColor"
-              strokeWidth={highlighted ? 1.5 : 1}
+              strokeWidth={edge.highlighted ? 1.5 : 1}
             />
           </g>
         );

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -1,5 +1,5 @@
 import type {RunJobDetailDto} from '@shipfox/api-workflows-dto';
-import {render, screen, within} from '@testing-library/react';
+import {fireEvent, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {WorkflowJob, WorkflowRunDetail} from '#core/workflow-run.js';
 import {workflowJob, workflowRunDetail} from '#test/fixtures/workflow-run.js';
@@ -171,6 +171,31 @@ describe('WorkflowJobsGraph', () => {
     expect(deploy).toHaveFocus();
     expect(deploy).toHaveAttribute('aria-pressed', 'true');
     expect(build).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('highlights adjacent edges only while hovering a job', async () => {
+    const user = userEvent.setup();
+    const build = makeJob({name: 'build'});
+    const deploy = makeJob({name: 'deploy', position: 1, dependencies: ['build']});
+    const {container} = render(<WorkflowJobsGraph run={makeRun({jobs: [build, deploy]})} />);
+    const triggerEdge = container.querySelector(`[data-edge-id="trigger:${build.id}"]`);
+    const deployEdge = container.querySelector(`[data-edge-id="${build.id}:${deploy.id}"]`);
+    const deployNode = screen.getByRole('button', {
+      name: 'deploy, Pending, 1 current dependency is still pending or running',
+    });
+
+    fireEvent.click(deployNode);
+
+    expect(deployEdge).toHaveAttribute('stroke-width', '1');
+
+    await user.hover(deployNode);
+
+    expect(deployEdge).toHaveAttribute('stroke-width', '1.5');
+    expect(triggerEdge).toHaveAttribute('stroke-width', '1');
+
+    await user.unhover(deployNode);
+
+    expect(deployEdge).toHaveAttribute('stroke-width', '1');
   });
 
   test('routes skipped-column join edges away from intermediate nodes', () => {

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph-view.test.tsx
@@ -198,6 +198,47 @@ describe('WorkflowJobsGraph', () => {
     expect(deployEdge).toHaveAttribute('stroke-width', '1');
   });
 
+  test('draws highlighted edges above overlapping normal edges', async () => {
+    const user = userEvent.setup();
+    const build = makeJob({name: 'build', status: 'succeeded'});
+    const lint = makeJob({
+      name: 'lint',
+      position: 1,
+      dependencies: ['build'],
+      status: 'succeeded',
+    });
+    const testJob = makeJob({
+      name: 'test',
+      position: 2,
+      dependencies: ['build'],
+      status: 'running',
+    });
+    const deploy = makeJob({
+      name: 'deploy',
+      position: 3,
+      dependencies: ['lint', 'test'],
+    });
+    const {container} = render(
+      <WorkflowJobsGraph run={makeRun({jobs: [build, lint, testJob, deploy]})} />,
+    );
+    const buildToLintEdge = container.querySelector(`[data-edge-id="${build.id}:${lint.id}"]`);
+    const buildToTestEdge = container.querySelector(`[data-edge-id="${build.id}:${testJob.id}"]`);
+    const testNode = screen.getByRole('button', {
+      name: 'test, Running',
+    });
+
+    await user.hover(testNode);
+
+    expect(buildToTestEdge).toHaveAttribute('stroke-width', '1.5');
+    expect(buildToLintEdge).toHaveAttribute('stroke-width', '1');
+    if (!buildToLintEdge || !buildToTestEdge) {
+      throw new Error('Expected branch edges to render');
+    }
+    expect(buildToLintEdge.compareDocumentPosition(buildToTestEdge)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
   test('routes skipped-column join edges away from intermediate nodes', () => {
     const packageJob = makeJob({name: 'package', position: 0, status: 'succeeded'});
     const securityScan = makeJob({name: 'security-scan', position: 1, status: 'succeeded'});


### PR DESCRIPTION
Highlights incoming and outgoing workflow job graph edges while the user hovers a job node.

Previously edge emphasis was not tied to hover, which made it harder to trace a job's immediate dependencies without selecting it. This keeps selected-job styling separate and uses neutral foreground emphasis rather than the primary highlight color.

Includes a patch changeset for `@shipfox/client-workflows` and regression coverage for hover-only edge highlighting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlights incoming and outgoing edges in the workflow jobs graph when you hover a job node, using neutral emphasis. Highlighted edges now render above overlapping edges for better visibility.

- **New Features**
  - Hovering a node sets `hoveredJobId`, highlights adjacent edges with a neutral color at 1.5 stroke, and draws them on top of normal edges.
  - Added tests for hover-only highlighting and edge stacking, plus a patch changeset for `@shipfox/client-workflows`.

<sup>Written for commit 8005f4b17c758502c16977011aabaa1d4c0d321b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

