### PR TITLE
[client-workflows] Polish workflow run header hierarchy

### DIFF
--- a/libs/client/workflows/src/components/identifier/identifier.tsx
+++ b/libs/client/workflows/src/components/identifier/identifier.tsx
@@ -1,6 +1,7 @@
 import {
   Code,
   cn,
+  Icon,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -115,8 +116,9 @@ export function Identifier({
             onClick={() => {
               void handleCopy();
             }}
-            className="inline-flex min-w-0 items-center gap-4 rounded-4 text-foreground-neutral-muted outline-none transition-colors hover:text-foreground-neutral-base focus-visible:ring-2 focus-visible:ring-background-accent-blue-base focus-visible:ring-offset-2 focus-visible:ring-offset-background-subtle-base"
+            className="inline-flex h-20 min-w-0 shrink-0 items-center gap-4 rounded-4 px-2 text-foreground-neutral-muted outline-none transition-colors hover:bg-background-components-hover hover:text-foreground-neutral-base focus-visible:shadow-border-interactive-with-active"
           >
+            <Icon name="copy" aria-hidden="true" className="size-12 shrink-0" />
             <Code as="span" variant="label" className="truncate">
               {display}
             </Code>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -45,6 +45,18 @@ export const WithSourceButton: Story = {
   },
 };
 
+export const SourceOpen: Story = {
+  args: {
+    run: workflowRun({
+      status: 'succeeded',
+      source_snapshot: {format: 'yaml', content: 'jobs:\n  build:\n    steps: []'},
+    }),
+    sourceAvailable: true,
+    sourceOpen: true,
+    sourcePanelId: 'workflow-source-panel',
+  },
+};
+
 const ALL_STATUSES: WorkflowRunStatus[] = [
   'pending',
   'running',

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -9,6 +9,7 @@ const {useIsTextTruncatedMock} = vi.hoisted(() => ({
 }));
 
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
+const RELATIVE_TIME_TEXT_PATTERN = /ago$/;
 
 vi.mock('@shipfox/react-ui', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shipfox/react-ui')>();
@@ -35,7 +36,8 @@ describe('WorkflowRunSummary', () => {
     expect(within(summary).getByRole('heading', {name: 'deploy-web'})).toBeInTheDocument();
     expect(within(summary).getAllByText('Running')).not.toHaveLength(0);
     expect(within(summary).getByText('manual / fire')).toBeInTheDocument();
-    expect(within(summary).getByText('Triggered')).toBeInTheDocument();
+    expect(within(summary).getByText(RELATIVE_TIME_TEXT_PATTERN)).toBeInTheDocument();
+    expect(within(summary).queryByText('Triggered')).not.toBeInTheDocument();
     expect(within(summary).queryByText('Updated')).not.toBeInTheDocument();
   });
 

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -2,6 +2,8 @@ import {TriggerSourceIcon} from '@shipfox/client-triggers';
 import {
   Badge,
   Button,
+  Code,
+  cn,
   Header,
   RelativeTime,
   Text,
@@ -45,15 +47,16 @@ export function WorkflowRunSummary({
   return (
     <section
       aria-labelledby={headingId}
-      className="border-b border-border-neutral-base bg-background-subtle-base px-16 py-12"
+      className="border-b border-border-neutral-base bg-background-subtle-base px-16 py-8"
     >
-      <div className="flex min-w-0 items-center gap-x-12 overflow-hidden">
-        <div className="flex min-w-0 items-center gap-8">
+      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-4 overflow-hidden">
+        <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-8">
           <Badge variant={status.badge} size="xs">
             <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
               {status.label}
             </span>
           </Badge>
+
           <Tooltip>
             <TooltipTrigger asChild>
               <Header id={headingId} variant="h3" className="min-w-0 truncate">
@@ -72,61 +75,66 @@ export function WorkflowRunSummary({
           </Tooltip>
         </div>
 
-        <span
-          aria-hidden="true"
-          className="hidden h-20 w-px shrink-0 bg-border-neutral-base sm:block"
-        />
-
-        <Identifier display={run.shortId} value={run.id} label="run id" />
-
-        {run.triggerLabel ? (
-          <span className="min-w-0 flex-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex max-w-full min-w-0 items-center gap-4 text-foreground-neutral-subtle">
-                  <TriggerSourceIcon
-                    source={run.triggerSource}
-                    aria-hidden="true"
-                    className="size-14 shrink-0"
-                  />
-                  <Text as="span" size="sm" className="min-w-0 truncate">
-                    {run.triggerLabel}
-                  </Text>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <Text as="span" size="xs" className="max-w-[360px] break-words">
-                  {run.triggerLabel}
-                </Text>
-              </TooltipContent>
-            </Tooltip>
-          </span>
-        ) : (
-          <span className="min-w-0 flex-1" />
-        )}
-
-        <div className="shrink-0 whitespace-nowrap text-foreground-neutral-muted">
-          <Text as="span" size="xs" className="inline-flex items-center gap-4 whitespace-nowrap">
-            Triggered
-            <RelativeTime value={run.createdAt} className="font-code text-xs leading-20" />
-          </Text>
-        </div>
-
         {sourceAvailable ? (
           <Button
             ref={sourceButtonRef}
             type="button"
             variant="transparentMuted"
-            size="sm"
-            iconLeft="bookOpen"
+            size="xs"
+            iconLeft="fileCodeLine"
             aria-controls={sourcePanelId}
             aria-expanded={sourceOpen}
+            className={cn(
+              'col-start-2 row-start-1 justify-self-end text-foreground-neutral-subtle',
+              sourceOpen && 'bg-background-components-hover text-foreground-neutral-base',
+            )}
             onClick={onSourceToggle}
           >
             Source
           </Button>
         ) : null}
+
+        <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-8 overflow-hidden text-foreground-neutral-muted">
+          <Identifier display={run.shortId} value={run.id} label="run id" />
+
+          {run.triggerLabel ? (
+            <>
+              <MetadataSeparator />
+              <span className="min-w-0">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex max-w-full min-w-0 items-center gap-4">
+                      <TriggerSourceIcon
+                        source={run.triggerSource}
+                        aria-hidden="true"
+                        className="size-12 shrink-0"
+                      />
+                      <Code as="span" variant="label" className="min-w-0 truncate">
+                        {run.triggerLabel}
+                      </Code>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <Code as="span" variant="label" className="block max-w-[360px] break-words">
+                      {run.triggerLabel}
+                    </Code>
+                  </TooltipContent>
+                </Tooltip>
+              </span>
+            </>
+          ) : null}
+
+          <MetadataSeparator />
+          <RelativeTime
+            value={run.createdAt}
+            className="shrink-0 whitespace-nowrap font-code text-xs leading-20 text-foreground-neutral-muted"
+          />
+        </div>
       </div>
     </section>
   );
+}
+
+function MetadataSeparator() {
+  return <span aria-hidden="true" className="h-12 w-px shrink-0 bg-border-neutral-base" />;
 }


### PR DESCRIPTION
Polishes the workflow run header into a compact two-row identity stack.

The previous header mixed run identity, trigger metadata, timing, and the Source action in a cramped trail. This moves status and run name into the primary row, keeps run id, trigger, and relative time as a lighter metadata rail, makes the run id copy affordance explicit, and keeps Source as a softer utility action.

The layout follows the Datadog-style reference from review: a clear identity line with dense metadata beneath it, rather than a second row hanging after the status badge. Reviewers should pay closest attention to the visual balance of the metadata separators and Source action in light and dark modes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the workflow run header into a compact two-row layout for clearer hierarchy and faster scanning. Adds a clear run ID copy action and refines the Source button behavior and styling.

- **New Features**
  - Two-row layout: status + run name on top; metadata row with run ID, trigger label, and relative time.
  - Run ID: explicit copy icon/button with improved hover and focus states.
  - Source action: smaller `fileCodeLine` icon button, right-aligned, highlights when open; added `SourceOpen` story.
  - Tests updated to assert relative time (e.g., “ago”) and remove the “Triggered” label.

<sup>Written for commit ac4766090e95cb1515c87423b5d5e04e3af272bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

