### PR TITLE
[react-ui] Use date-fns for relative time labels

### DIFF
--- a/.changeset/quiet-clocks-format.md
+++ b/.changeset/quiet-clocks-format.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Uses date-fns for compact relative time formatting while preserving reduced-motion behavior.

--- a/libs/shared/react/ui/src/utils/relative-time.ts
+++ b/libs/shared/react/ui/src/utils/relative-time.ts
@@ -1,3 +1,5 @@
+import {intlFormatDistance} from 'date-fns';
+
 /**
  * Formats the signed distance between `iso` and now as a short relative
  * string ("12s ago", "3m ago", "in 2h"). Returns '' for unparseable input
@@ -16,17 +18,10 @@ export function formatRelative(iso: string, {reducedMotion}: {reducedMotion: boo
 
   if (absMs < 60_000) {
     if (reducedMotion) return past ? 'just now' : 'in <1m';
-    const sec = Math.max(0, Math.floor(absMs / 1000));
-    return past ? `${sec}s ago` : `in ${sec}s`;
   }
-  if (absMs < 3_600_000) {
-    const min = Math.floor(absMs / 60_000);
-    return past ? `${min}m ago` : `in ${min}m`;
-  }
-  if (absMs < 86_400_000) {
-    const hr = Math.floor(absMs / 3_600_000);
-    return past ? `${hr}h ago` : `in ${hr}h`;
-  }
-  const day = Math.floor(absMs / 86_400_000);
-  return past ? `${day}d ago` : `in ${day}d`;
+
+  return intlFormatDistance(new Date(ts), Date.now(), {
+    numeric: 'always',
+    style: 'narrow',
+  });
 }


### PR DESCRIPTION
[react-ui] Use date-fns for compact relative time labels

The relative time utility previously hand-rolled elapsed-time unit selection even though react-ui already depends on date-fns. This switches the normal formatting path to `intlFormatDistance` with narrow numeric output, preserving compact labels like `12s ago`, `5m ago`, and `in 30s`.

`formatRelative` was considered, but it produces calendar phrases such as `today at 7:00 AM`, which does not match the dashboard-style elapsed labels this component renders. The reduced-motion sub-minute copy remains custom so it still avoids frequent visual ticking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches relative time formatting in `@shipfox/react-ui` to `date-fns` `intlFormatDistance` with narrow numeric output, keeping compact labels like 12s ago, 5m ago, and in 30s. Preserves reduced-motion behavior for sub-minute ranges (just now / in <1m) and removes the custom unit selection logic.

<sup>Written for commit e2cecfde046547c046530290f7812e8ca7303abb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

