### PR TITLE
Add log viewer empty and skeleton states

### DIFF
--- a/libs/client/logs/src/components/index.ts
+++ b/libs/client/logs/src/components/index.ts
@@ -1,5 +1,10 @@
 export {LogGroup, type LogGroupProps} from './log-group.js';
-export {LogView, type LogViewProps} from './log-view.js';
+export {
+  LogView,
+  type LogViewProps,
+  LogViewSkeleton,
+  type LogViewSkeletonProps,
+} from './log-view.js';
 export {OutputLogRow, type OutputLogRowProps} from './output-log-row.js';
 export {
   CappedMarker,

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -1,6 +1,6 @@
 import type {LogRecord} from '@shipfox/api-logs-dto';
 import type {Meta, StoryObj} from '@storybook/react';
-import {LogView} from './log-view.js';
+import {LogView, LogViewSkeleton} from './log-view.js';
 
 const ESC = String.fromCharCode(27);
 const origin = new Date('2026-06-23T10:00:00.000Z').getTime();
@@ -125,11 +125,41 @@ export const NestedGroups: Story = {
   ),
 };
 
-export const Empty: Story = {
+export const ClosedEmpty: Story = {
   args: {showLineNumbers: true},
   render: (args) => (
     <div className="max-w-3xl">
       <LogView {...args} records={[]} />
+    </div>
+  ),
+};
+
+export const PendingEmpty: Story = {
+  args: {showLineNumbers: true, emptyState: 'pending'},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={[]} />
+    </div>
+  ),
+};
+
+export const MinimalOutput: Story = {
+  args: {showLineNumbers: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={[{v: 1, ts: at(1), type: 'end', total_bytes: 0}]} />
+    </div>
+  ),
+};
+
+export const LoadingSkeleton: Story = {
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogViewSkeleton
+        timestamps={args.timestamps}
+        wrap={args.wrap}
+        showLineNumbers={args.showLineNumbers}
+      />
     </div>
   ),
 };

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -1,0 +1,72 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import {render, screen} from '@testing-library/react';
+import {LogView, LogViewSkeleton} from './log-view.js';
+
+const ts = new Date('2026-06-23T10:00:00.000Z').getTime();
+
+const output = (data: string): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'output',
+  stream: 'stdout',
+  data,
+});
+
+describe('LogView', () => {
+  test('renders the complete empty state for an empty closed stream', () => {
+    render(<LogView records={[]} />);
+
+    expect(screen.getByText('Step produced no output')).toBeDefined();
+    expect(screen.getByText('This log stream closed without stdout or stderr.')).toBeDefined();
+    expect(screen.getByRole('log')).toBeDefined();
+  });
+
+  test('renders the pending empty state for an empty open stream', () => {
+    render(<LogView records={[]} emptyState="pending" />);
+
+    expect(screen.getByText('No output yet')).toBeDefined();
+    expect(screen.getByText('New lines will appear here as the step writes them.')).toBeDefined();
+    expect(screen.queryByText('Step produced no output')).toBeNull();
+  });
+
+  test('renders no-output copy before the end marker for an end-marker-only stream', () => {
+    render(<LogView records={[{v: 1, ts, type: 'end', total_bytes: 0}]} />);
+
+    expect(screen.getByText('Step produced no output')).toBeDefined();
+    expect(screen.getByText('End of log')).toBeDefined();
+    expect(screen.getByText('0 lines · 0 B · 0ms')).toBeDefined();
+  });
+
+  test.each([
+    {record: {v: 1, ts, type: 'runner_lost'} as const, label: 'Runner disconnected'},
+    {record: {v: 1, ts, type: 'gap', dropped_bytes: 2048} as const, label: 'Output missing'},
+    {record: {v: 1, ts, type: 'capped'} as const, label: 'Log size limit reached'},
+  ])('does not show no-output copy for a $record.type marker-only stream', ({record, label}) => {
+    render(<LogView records={[record]} />);
+
+    expect(screen.getByText(label)).toBeDefined();
+    expect(screen.queryByText('Step produced no output')).toBeNull();
+    expect(screen.queryByText('No output yet')).toBeNull();
+  });
+
+  test('does not render empty copy when output exists', () => {
+    render(<LogView records={[output('hello\n')]} />);
+
+    expect(screen.getByText('hello')).toBeDefined();
+    expect(screen.queryByText('Step produced no output')).toBeNull();
+    expect(screen.queryByText('No output yet')).toBeNull();
+  });
+});
+
+describe('LogViewSkeleton', () => {
+  test('keeps visual log chrome without exposing fake log content', () => {
+    const {container} = render(<LogViewSkeleton rows={3} />);
+
+    expect(screen.queryByRole('log')).toBeNull();
+    expect(container.querySelector('[data-slot="log-rows"]')?.getAttribute('aria-hidden')).toBe(
+      'true',
+    );
+    expect(container.querySelectorAll('[data-slot="log-row"]')).toHaveLength(3);
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(3);
+  });
+});

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import type {LogRecord} from '@shipfox/api-logs-dto';
-import {LogContent, LogRow, LogRows, type LogTimestampMode} from '@shipfox/react-ui';
+import {
+  Icon,
+  LogContent,
+  LogRow,
+  LogRows,
+  type LogTimestampMode,
+  Skeleton,
+} from '@shipfox/react-ui';
 import {type ReactNode, type UIEventHandler, useMemo} from 'react';
 import {
   assertNever,
@@ -19,9 +26,15 @@ export interface LogViewProps {
   timestamps?: LogTimestampMode;
   wrap?: boolean;
   showLineNumbers?: boolean;
+  emptyState?: 'complete' | 'pending';
   defaultGroupsOpen?: boolean;
   className?: string | undefined;
   onScroll?: UIEventHandler<HTMLDivElement> | undefined;
+}
+
+export interface LogViewSkeletonProps
+  extends Pick<LogViewProps, 'timestamps' | 'wrap' | 'showLineNumbers' | 'className'> {
+  rows?: number;
 }
 
 export function LogView({
@@ -29,12 +42,13 @@ export function LogView({
   timestamps = 'off',
   wrap = false,
   showLineNumbers = true,
+  emptyState = 'complete',
   defaultGroupsOpen = false,
   className,
   onScroll,
 }: LogViewProps) {
   const tree = useMemo(() => buildLogTree(records), [records]);
-  const isEmpty = tree.nodes.length === 0;
+  const noOutputState = getNoOutputState(tree, emptyState);
 
   return (
     <LogRows
@@ -45,16 +59,90 @@ export function LogView({
       onScroll={onScroll}
       {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
     >
-      {isEmpty ? (
-        <LogRow lineNumber={null}>
-          <LogContent variant="code" className="text-foreground-neutral-muted">
-            No output
-          </LogContent>
-        </LogRow>
-      ) : (
-        renderNodes(tree.nodes, 0, tree, defaultGroupsOpen)
-      )}
+      {noOutputState ? <NoOutputRow state={noOutputState} /> : null}
+      {renderNodes(tree.nodes, 0, tree, defaultGroupsOpen)}
     </LogRows>
+  );
+}
+
+export function LogViewSkeleton({
+  rows = 5,
+  timestamps = 'off',
+  wrap = false,
+  showLineNumbers = true,
+  className,
+}: LogViewSkeletonProps) {
+  const widths = ['w-[62%]', 'w-[44%]', 'w-[74%]', 'w-[36%]', 'w-[55%]'];
+  const skeletonRows = getSkeletonRows(rows);
+
+  return (
+    <LogRows
+      timestamps={timestamps}
+      wrap={wrap}
+      showLineNumbers={showLineNumbers}
+      className={className}
+      role="presentation"
+      aria-live="off"
+      aria-hidden="true"
+    >
+      {skeletonRows.map((row) => (
+        <LogRow key={row.id} lineNumber={row.lineNumber}>
+          <Skeleton
+            className={`my-4 h-12 ${widths[(row.lineNumber - 1) % widths.length] ?? 'w-[48%]'}`}
+          />
+        </LogRow>
+      ))}
+    </LogRows>
+  );
+}
+
+function getSkeletonRows(rows: number): {id: string; lineNumber: number}[] {
+  return Array.from({length: rows}, (_, index) => {
+    const lineNumber = index + 1;
+    return {id: `log-view-skeleton-row-${lineNumber}`, lineNumber};
+  });
+}
+
+function getNoOutputState(
+  tree: LogTree,
+  emptyState: NonNullable<LogViewProps['emptyState']>,
+): LogViewProps['emptyState'] | null {
+  if (tree.nodes.length === 0) return emptyState;
+
+  if (tree.lineCount !== 0) return null;
+  if (tree.nodes.length !== 1) return null;
+
+  const [node] = tree.nodes;
+  if (node?.kind === 'marker' && node.record.type === 'end') return 'complete';
+
+  return null;
+}
+
+function NoOutputRow({state}: {state: NonNullable<LogViewProps['emptyState']>}) {
+  const copy =
+    state === 'pending'
+      ? {
+          title: 'No output yet',
+          detail: 'New lines will appear here as the step writes them.',
+        }
+      : {
+          title: 'Step produced no output',
+          detail: 'This log stream closed without stdout or stderr.',
+        };
+
+  return (
+    <LogRow lineNumber={null}>
+      <LogContent className="text-foreground-neutral-muted">
+        <span className="inline-flex min-w-0 items-center gap-8">
+          <Icon name="info" className="size-14 flex-none" aria-hidden="true" />
+          <span className="min-w-0">
+            <span className="font-medium">{copy.title}</span>
+            {' · '}
+            <span className="text-foreground-neutral-subtle">{copy.detail}</span>
+          </span>
+        </span>
+      </LogContent>
+    </LogRow>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
@@ -75,10 +75,14 @@ describe('StepAttemptLogPanel', () => {
       fetchImpl: vi.fn(async () => jsonResponse({code: 'not-found'}, {status: 404})),
     });
 
-    renderPanel();
+    const {container} = renderPanel();
 
     expect(await screen.findByRole('status', {name: 'Waiting for logs'})).toBeInTheDocument();
-    expect(screen.getByRole('log')).toHaveTextContent('Waiting for logs');
+    expect(screen.queryByRole('log')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="log-rows"]')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
   });
 
   test('keeps the log loading surface through transient initial server errors', async () => {
@@ -91,11 +95,20 @@ describe('StepAttemptLogPanel', () => {
       fetchImpl,
     });
 
-    renderPanel({attemptStatus: 'failed', initialErrorRetryCount: 1, initialErrorRetryDelayMs: 10});
+    const {container} = renderPanel({
+      attemptStatus: 'failed',
+      initialErrorRetryCount: 1,
+      initialErrorRetryDelayMs: 10,
+    });
     expect(screen.getByRole('status', {name: 'Loading logs'})).toBeInTheDocument();
-    expect(screen.getByRole('log')).toHaveTextContent('Loading logs');
+    expect(screen.queryByRole('log')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="log-rows"]')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
 
     expect(await screen.findByText('eventual logs')).toBeInTheDocument();
+    expect(screen.getByRole('log')).toBeInTheDocument();
   });
 
   test('shows a compact retry state after the initial error retry budget is exhausted', async () => {
@@ -120,6 +133,22 @@ describe('StepAttemptLogPanel', () => {
     renderPanel({attemptStatus: 'succeeded'});
 
     expect(await screen.findByText('hello')).toBeInTheDocument();
+  });
+
+  test('renders a terminal closed empty stream as no output', async () => {
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(async () => jsonResponse(inlineLogBody('', 0))),
+    });
+
+    renderPanel({attemptStatus: 'succeeded'});
+
+    expect(await screen.findByText('Step produced no output')).toBeInTheDocument();
+    expect(
+      screen.getByText('This log stream closed without stdout or stderr.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByRole('log')).toBeInTheDocument();
   });
 
   test('keeps stale logs visible when a refresh fails', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
@@ -1,5 +1,10 @@
-import {isMissingStepLogStreamError, LogView, useStepAttemptLogsQuery} from '@shipfox/client-logs';
-import {Alert, Button, Icon, LogContent, LogRow, LogRows, ShinyText, Text} from '@shipfox/react-ui';
+import {
+  isMissingStepLogStreamError,
+  LogView,
+  LogViewSkeleton,
+  useStepAttemptLogsQuery,
+} from '@shipfox/client-logs';
+import {Alert, Button, Text} from '@shipfox/react-ui';
 import {type UIEvent, useEffect, useRef} from 'react';
 
 const TAIL_FOLLOW_THRESHOLD_PX = 24;
@@ -88,7 +93,12 @@ export function StepAttemptLogPanel({
           </div>
         </Alert>
       ) : null}
-      <LogView records={records} className={logSurfaceClasses} onScroll={handleLogScroll} />
+      <LogView
+        records={records}
+        emptyState={query.data?.complete ? 'complete' : 'pending'}
+        className={logSurfaceClasses}
+        onScroll={handleLogScroll}
+      />
     </div>
   );
 }
@@ -96,21 +106,7 @@ export function StepAttemptLogPanel({
 function StepLogsLoadingSurface({label}: {label: string}) {
   return (
     <div role="status" aria-label={label}>
-      <LogRows className={logSurfaceClasses}>
-        <LogRow lineNumber={null}>
-          <LogContent
-            variant="code"
-            className="flex min-w-0 items-center gap-6 text-foreground-neutral-subtle"
-          >
-            <Icon
-              name="loader4Line"
-              className="size-14 shrink-0 motion-safe:animate-spin"
-              aria-hidden="true"
-            />
-            <ShinyText text={label} speed={3} className="text-foreground-neutral-subtle" />
-          </LogContent>
-        </LogRow>
-      </LogRows>
+      <LogViewSkeleton className={logSurfaceClasses} />
     </div>
   );
 }


### PR DESCRIPTION
Adds explicit closed and pending empty states to the log viewer, and exports a skeleton surface that workflow step logs reuse while initial loads or missing running streams wait for data.

The previous loading row lived inside the live log surface. This keeps the same log chrome for loading states while hiding placeholder bars from log semantics, and it distinguishes completed end-marker-only streams from marker-only runner-lost, gap, or capped streams.

Both touched client packages are private, so this intentionally does not include a changeset.

Closes ENG-589

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit empty states to the log viewer and a skeleton log surface to keep the chrome during loading without treating placeholders as real logs. Meets ENG-589 by clarifying no-output vs marker-only streams and improving the workflow step loading experience.

- **New Features**
  - `LogView` now supports `emptyState="complete" | "pending"` and shows clear copy with an info icon.
  - End-marker-only streams show “no output” before the end marker; `runner_lost`/`gap`/`capped` marker-only streams do not.
  - New `LogViewSkeleton` from `@shipfox/client-logs`: renders aria-hidden skeleton rows (no `role="log"`) to preserve log chrome during loading.
  - Workflow step panel now uses `LogViewSkeleton` while waiting/retrying and passes `emptyState` based on completion status.

<sup>Written for commit 28cc162837ffa5c5eba65e8c82d8fb72f54cbe43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

