### PR TITLE
Configure local Garage CORS for log reads

### DIFF
--- a/dev/garage/README.md
+++ b/dev/garage/README.md
@@ -26,8 +26,11 @@ lifecycle rule. `bootstrap.sh` provisions it on the local Garage bucket; set the
 same rule (for example, abort one day after initiation) on any shared or
 production bucket.
 
-## Browser reads (later)
+## Browser reads
 
 The log read path serves compacted objects through presigned URLs fetched
 directly by the browser, so the bucket needs CORS configured to allow the
-dashboard origin. That is set up with the read path (ENG-443), not here.
+dashboard origin. `bootstrap.sh` provisions a read-only browser CORS rule for
+`http://localhost:5173` on the local Garage buckets. Override it with
+`GARAGE_CORS_ALLOWED_ORIGINS` when your local client uses another origin; use a
+comma-separated list for several origins.

--- a/dev/garage/bootstrap.sh
+++ b/dev/garage/bootstrap.sh
@@ -11,6 +11,7 @@ set -eu
 GARAGE_URL="${GARAGE_URL:-http://localhost:3903}"
 ADMIN_TOKEN="${GARAGE_ADMIN_TOKEN:-shipfox-dev-admin-token}"
 S3_ENDPOINT="${GARAGE_S3_ENDPOINT:-http://localhost:3900}"
+CORS_ALLOWED_ORIGINS="${GARAGE_CORS_ALLOWED_ORIGINS:-http://localhost:5173}"
 # Dev bucket plus the test bucket the @shipfox/api-logs suite uploads to against real Garage.
 BUCKETS="shipfox-logs shipfox-logs-test"
 KEY_NAME="local-dev"
@@ -58,13 +59,21 @@ done
 # skipped when the aws CLI or the store's lifecycle API is unavailable (dev then relies on the
 # upload's abort-on-cancel; the rule only matters for a hard crash mid-upload).
 if command -v aws >/dev/null 2>&1; then
+  cors_configuration="$(printf '%s' "$CORS_ALLOWED_ORIGINS" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)) | {CORSRules: [{AllowedOrigins: ., AllowedMethods: ["GET", "HEAD"], AllowedHeaders: ["*"], ExposeHeaders: ["ETag", "Content-Length", "Content-Type", "Content-Range", "Accept-Ranges"], MaxAgeSeconds: 3600}]}')"
+
   for bucket in $BUCKETS; do
     AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY" AWS_REGION=garage \
       aws --endpoint-url "$S3_ENDPOINT" s3api put-bucket-lifecycle-configuration \
       --bucket "$bucket" \
       --lifecycle-configuration '{"Rules":[{"ID":"shipfox-abort-incomplete-multipart","Status":"Enabled","Filter":{"Prefix":""},"AbortIncompleteMultipartUpload":{"DaysAfterInitiation":1}}]}' \
       >/dev/null 2>&1 || echo "Lifecycle rule skipped for '$bucket' (aws CLI or lifecycle API unavailable)."
+
+    AWS_ACCESS_KEY_ID="$ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$SECRET_ACCESS_KEY" AWS_REGION=garage \
+      aws --endpoint-url "$S3_ENDPOINT" s3api put-bucket-cors \
+      --bucket "$bucket" \
+      --cors-configuration "$cors_configuration" \
+      >/dev/null 2>&1 || echo "CORS rule skipped for '$bucket' (aws CLI or CORS API unavailable)."
   done
 fi
 
-echo "Garage ready: buckets [$BUCKETS], key '$KEY_NAME' ($ACCESS_KEY_ID)."
+echo "Garage ready: buckets [$BUCKETS], key '$KEY_NAME' ($ACCESS_KEY_ID), CORS origins [$CORS_ALLOWED_ORIGINS]."


### PR DESCRIPTION
Configure the local Garage bootstrap to apply a browser-read CORS rule to the log buckets.

Compacted logs are fetched by the dashboard through presigned Garage URLs. Without bucket CORS, the browser receives a 200 from Garage but blocks access because `Access-Control-Allow-Origin` is missing for the local Vite client at `http://localhost:5173`.

This keeps the rule in local infrastructure setup, applies it to both dev and test log buckets, and allows alternate local origins through `GARAGE_CORS_ALLOWED_ORIGINS`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures local CORS on Garage log buckets so the dashboard can read compacted logs via presigned URLs without browser blocks. Defaults to allow http://localhost:5173, with configurable origins.

- **New Features**
  - Provisions read-only CORS on `shipfox-logs` and `shipfox-logs-test` in `bootstrap.sh` (GET/HEAD; exposes ETag, Content-Length, Content-Type, Content-Range, Accept-Ranges; max-age 3600s).
  - Override origins with `GARAGE_CORS_ALLOWED_ORIGINS` (comma-separated).
  - README updated with local browser read instructions.

<sup>Written for commit d5d863d7253a9ed2db084c0123303f6279e33ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

