### PR TITLE
[client-triggers] Add events settings heading

### DIFF
--- a/libs/client/triggers/src/pages/events-page.tsx
+++ b/libs/client/triggers/src/pages/events-page.tsx
@@ -1,5 +1,5 @@
 import type {TriggerEventListItemDto} from '@shipfox/api-triggers-dto';
-import {RelativeTimeProvider} from '@shipfox/react-ui';
+import {Header, RelativeTimeProvider, Text} from '@shipfox/react-ui';
 import {useMemo} from 'react';
 import {EventsList} from '#components/events-list.js';
 import {
@@ -29,19 +29,31 @@ export function EventsPage({workspaceId, filters, onFiltersChange}: EventsPagePr
 
   return (
     <RelativeTimeProvider>
-      <EventsList
-        events={events}
-        query={query}
-        facets={facetsQuery.data}
-        filters={filters}
-        onFiltersChange={onFiltersChange}
-        workspaceId={workspaceId}
-        hasNextPage={query.hasNextPage}
-        isFetchingNextPage={query.isFetchingNextPage}
-        onLoadMore={() => {
-          void query.fetchNextPage();
-        }}
-      />
+      <section className="flex min-w-0 flex-col gap-16" aria-labelledby="trigger-events-heading">
+        <div className="flex flex-col gap-4">
+          <Header id="trigger-events-heading" variant="h3">
+            Events
+          </Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            A workspace-wide audit log of trigger events received from integrations, schedules, and
+            manual trigger calls.
+          </Text>
+        </div>
+
+        <EventsList
+          events={events}
+          query={query}
+          facets={facetsQuery.data}
+          filters={filters}
+          onFiltersChange={onFiltersChange}
+          workspaceId={workspaceId}
+          hasNextPage={query.hasNextPage}
+          isFetchingNextPage={query.isFetchingNextPage}
+          onLoadMore={() => {
+            void query.fetchNextPage();
+          }}
+        />
+      </section>
     </RelativeTimeProvider>
   );
 }


### PR DESCRIPTION
Adds a local Events section heading and concise subtitle above the trigger events list in workspace settings.

The events settings page previously dropped directly into filters and rows, unlike the other settings surfaces. The heading gives the page a clear anchor, and the subtitle explains that the list is a workspace-wide audit log of trigger events from integrations, schedules, and manual calls.

No changeset is included because `@shipfox/client-triggers` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Events heading and short subtitle above the trigger events list in workspace settings to anchor the page and clarify scope. Uses `Header` and `Text` from `@shipfox/react-ui`, wrapped in a `<section>` with `aria-labelledby` for better structure and accessibility.

<sup>Written for commit 54a6c32e0ae0a4da5a7756e8a56550d3ee8df099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

