### PR TITLE
[client-integrations] Add integration section subtitles

### DIFF
--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -108,6 +108,7 @@ describe('IntegrationGallery — installed section', () => {
 
     expect(await screen.findByText('acme-one')).toBeVisible();
     expect(screen.getByText('acme-two')).toBeVisible();
+    expect(screen.getByText('Provider accounts linked to this workspace.')).toBeVisible();
   });
 
   test('sorts stably by provider name then created_at regardless of input order', async () => {
@@ -320,6 +321,7 @@ describe('IntegrationGallery — available section', () => {
 
     expect(await screen.findByRole('link', {name: 'Connect GitHub'})).toBeVisible();
     expect(screen.getByRole('link', {name: 'Connect Sentry'})).toBeVisible();
+    expect(screen.getByText('Providers available to connect to this workspace.')).toBeVisible();
   });
 
   test('exposes each available tile as a single link with no nested button', async () => {

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -102,7 +102,12 @@ export function IntegrationGallery({
     <div className="flex flex-col gap-24">
       {showInstalled ? (
         <section className="flex flex-col gap-16" aria-label="Installed integrations">
-          <Header variant="h3">Installed integrations</Header>
+          <div className="flex flex-col gap-4">
+            <Header variant="h3">Installed integrations</Header>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Provider accounts linked to this workspace.
+            </Text>
+          </div>
 
           {connectionsQuery.isPending ? <InstalledSkeleton label="Loading integrations" /> : null}
 
@@ -137,7 +142,12 @@ export function IntegrationGallery({
       ) : null}
 
       <section className="flex flex-col gap-16" aria-label="Available integrations">
-        <Header variant="h3">Available integrations</Header>
+        <div className="flex flex-col gap-4">
+          <Header variant="h3">Available integrations</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Providers available to connect to this workspace.
+          </Text>
+        </div>
 
         {providersQuery.isPending ? <AvailableSkeleton label="Loading providers" /> : null}
 


### PR DESCRIPTION
Adds concise subtitles to the Installed integrations and Available integrations sections in the integration gallery.

The workspace settings page showed integration sections without the explanatory context used by neighboring settings areas, making the distinction between connected accounts and connectable providers less clear. The new copy keeps the sections scannable while clarifying what each list represents.

No changeset is included because `@shipfox/client-integrations` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds subtitles under “Installed integrations” and “Available integrations” in the workspace integration gallery to clarify each list. Copy: “Provider accounts linked to this workspace.” (Installed) and “Providers available to connect to this workspace.” (Available); tests updated accordingly.

<sup>Written for commit 1f980ad6564db4d3a64101928a64f627e72fe7e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

