### PR TITLE
[client-workflows] Stabilize workflow summary snapshots

### DIFF
--- a/libs/client/workflows/.storybook/preview.tsx
+++ b/libs/client/workflows/.storybook/preview.tsx
@@ -9,6 +9,13 @@ import {
   RouterProvider,
 } from '@tanstack/react-router';
 
+const STORYBOOK_NOW_MS = Date.parse('2026-06-26T12:00:00.000Z');
+
+Object.defineProperty(Date, 'now', {
+  configurable: true,
+  value: () => STORYBOOK_NOW_MS,
+});
+
 const withTheme: Decorator = (Story, context) => {
   const theme = context.globals.theme;
   return (

--- a/libs/client/workflows/.storybook/preview.tsx
+++ b/libs/client/workflows/.storybook/preview.tsx
@@ -13,6 +13,7 @@ const STORYBOOK_NOW_MS = Date.parse('2026-06-26T12:00:00.000Z');
 
 Object.defineProperty(Date, 'now', {
   configurable: true,
+  writable: true,
   value: () => STORYBOOK_NOW_MS,
 });
 


### PR DESCRIPTION
Freeze the workflows Storybook clock so workflow summary snapshots render relative timestamps against a deterministic date.

The `WorkflowRunSummary` Argos capture includes relative time text. Because Storybook previously used the real current date, the baseline drifted as time moved forward and the dark-mode status screenshot could change day by day.

This keeps production relative-time behavior unchanged and only stabilizes the visual test environment for client workflow stories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze the Storybook clock for `client/workflows` so `WorkflowRunSummary` snapshots render relative times against a fixed date, preventing Argos baseline drift while leaving production behavior unchanged.

- **Bug Fixes**
  - Override `Date.now` in Storybook to `2026-06-26T12:00:00Z` and keep it writable to stabilize relative time text in snapshots.
  - Storybook-only; no impact on runtime or users.

<sup>Written for commit 790f1701504be509e4cf1175b5d02a0a0954558b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

