### PR TITLE
[client-triggers] Add Storybook Vercel config

### DIFF
--- a/libs/client/triggers/vercel.json
+++ b/libs/client/triggers/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo build && pnpm run storybook:build",
+  "devCommand": "pnpm run storybook",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
+}


### PR DESCRIPTION
Add a Vercel config for `@shipfox/client-triggers` so its Storybook can be built and served the same way as the logs and workflows client modules.

The triggers module already has Storybook scripts, but lacked the package-local Vercel settings that point Vercel at the generated `storybook-static` output. This keeps the deployment setup consistent across client Storybook modules.

Validated with the affected build, test, and check Turbo tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Vercel config to `@shipfox/client-triggers` so its Storybook builds and deploys like the other client modules. It runs turbo build then storybook:build, uses pnpm storybook for dev, and serves from ./storybook-static.

<sup>Written for commit b365894848bf070b96aa2c7921197e89fd4150d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

