### PR TITLE
Add provisioner token credentials

### DIFF
--- a/.changeset/brisk-tokens-provision.md
+++ b/.changeset/brisk-tokens-provision.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/node-tokens": minor
+"@shipfox/api-auth-context": minor
+"@shipfox/api-workspaces": minor
+---
+
+Adds provisioner token and auth context primitives for workspace-scoped control-plane credentials.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-logs": "workspace:*",
     "@shipfox/api-projects": "workspace:*",
+    "@shipfox/api-provisioners": "workspace:*",
     "@shipfox/api-runners": "workspace:*",
     "@shipfox/api-triggers": "workspace:*",
     "@shipfox/api-workspaces": "workspace:*",

--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -34,6 +34,7 @@ vi.mock('@shipfox/api-integration-core', () => ({
 }));
 vi.mock('@shipfox/api-logs', () => ({logsModule: {name: 'logs'}}));
 vi.mock('@shipfox/api-projects', () => ({createProjectsModule: mocks.createProjectsModule}));
+vi.mock('@shipfox/api-provisioners', () => ({provisionersModule: {name: 'provisioners'}}));
 vi.mock('@shipfox/api-runners', () => ({runnersModule: {name: 'runners'}}));
 vi.mock('@shipfox/api-triggers', () => ({triggersModule: {name: 'triggers'}}));
 vi.mock('@shipfox/api-workflows', () => ({

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -4,6 +4,7 @@ import {dispatcherModule} from '@shipfox/api-dispatcher';
 import {createIntegrationsContext} from '@shipfox/api-integration-core';
 import {logsModule} from '@shipfox/api-logs';
 import {createProjectsModule} from '@shipfox/api-projects';
+import {provisionersModule} from '@shipfox/api-provisioners';
 import {runnersModule} from '@shipfox/api-runners';
 import {triggersModule} from '@shipfox/api-triggers';
 import {setSourceControl, workflowsModule} from '@shipfox/api-workflows';
@@ -40,6 +41,7 @@ export async function run(): Promise<void> {
     definitionsModule,
     workflowsModule,
     runnersModule,
+    provisionersModule,
     logsModule,
     triggersModule,
     dispatcherModule,

--- a/libs/api/auth-context/src/index.ts
+++ b/libs/api/auth-context/src/index.ts
@@ -4,6 +4,7 @@ import type {WorkspaceRole} from '@shipfox/api-workspaces-dto';
 export const AUTH_USER = 'user';
 export const AUTH_RUNNER_TOKEN = 'runner-token';
 export const AUTH_LEASED_JOB = 'leased-job';
+export const AUTH_PROVISIONER_TOKEN = 'provisioner-token';
 
 export type WorkspaceStatus = 'active' | 'suspended' | 'deleted';
 
@@ -41,12 +42,18 @@ export function buildUserContext(params: BuildUserContextParams): UserContext {
   };
 }
 
+export interface ProvisionerContext {
+  provisionerTokenId: string;
+  workspaceId: string;
+}
+
 export type LeasedJobContext = JobLeaseTokenClaims;
 
 type RequestWithContext = object;
 
 const USER_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/user');
 const LEASED_JOB_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/leased-job');
+const PROVISIONER_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/provisioner');
 
 export function setUserContext(request: RequestWithContext, context: UserContext): void {
   (request as Record<symbol, unknown>)[USER_CONTEXT_KEY] = context;
@@ -62,6 +69,29 @@ export function requireUserContext(request: RequestWithContext): UserContext {
   const context = getUserContext(request);
   if (!context) {
     throw new Error('User context is not available on this request');
+  }
+  return context;
+}
+
+export function setProvisionerContext(
+  request: RequestWithContext,
+  context: ProvisionerContext,
+): void {
+  (request as Record<symbol, unknown>)[PROVISIONER_CONTEXT_KEY] = context;
+}
+
+export function getProvisionerContext(request: RequestWithContext): ProvisionerContext | null {
+  return (
+    ((request as Record<symbol, unknown>)[PROVISIONER_CONTEXT_KEY] as
+      | ProvisionerContext
+      | undefined) ?? null
+  );
+}
+
+export function requireProvisionerContext(request: RequestWithContext): ProvisionerContext {
+  const context = getProvisionerContext(request);
+  if (!context) {
+    throw new Error('Provisioner context is not available on this request');
   }
   return context;
 }

--- a/libs/api/provisioners-dto/package.json
+++ b/libs/api/provisioners-dto/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@shipfox/api-provisioners-dto",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/provisioners-dto"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/provisioners-dto/src/index.ts
+++ b/libs/api/provisioners-dto/src/index.ts
@@ -1,0 +1,1 @@
+export * from './schemas/index.js';

--- a/libs/api/provisioners-dto/src/schemas/index.ts
+++ b/libs/api/provisioners-dto/src/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './provisioner-token.js';

--- a/libs/api/provisioners-dto/src/schemas/provisioner-token.test.ts
+++ b/libs/api/provisioners-dto/src/schemas/provisioner-token.test.ts
@@ -1,0 +1,38 @@
+import {
+  createProvisionerTokenBodySchema,
+  MAX_PROVISIONER_TOKEN_TTL_SECONDS,
+  provisionerIdentityResponseSchema,
+} from './provisioner-token.js';
+
+describe('provisioner token schemas', () => {
+  it('accepts a valid create body', () => {
+    const result = createProvisionerTokenBodySchema.parse({
+      name: 'autoscaler',
+      ttl_seconds: MAX_PROVISIONER_TOKEN_TTL_SECONDS,
+    });
+
+    expect(result).toEqual({
+      name: 'autoscaler',
+      ttl_seconds: MAX_PROVISIONER_TOKEN_TTL_SECONDS,
+    });
+  });
+
+  it('rejects token TTLs above one year', () => {
+    const result = createProvisionerTokenBodySchema.safeParse({
+      ttl_seconds: MAX_PROVISIONER_TOKEN_TTL_SECONDS + 1,
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('parses provisioner identity responses', () => {
+    const identity = {
+      id: crypto.randomUUID(),
+      workspace_id: crypto.randomUUID(),
+    };
+
+    const result = provisionerIdentityResponseSchema.parse(identity);
+
+    expect(result).toEqual(identity);
+  });
+});

--- a/libs/api/provisioners-dto/src/schemas/provisioner-token.ts
+++ b/libs/api/provisioners-dto/src/schemas/provisioner-token.ts
@@ -1,0 +1,62 @@
+import {z} from 'zod';
+
+export const MAX_PROVISIONER_TOKEN_TTL_SECONDS = 31_536_000;
+
+export const createProvisionerTokenBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  ttl_seconds: z.number().int().positive().max(MAX_PROVISIONER_TOKEN_TTL_SECONDS).optional(),
+});
+
+export type CreateProvisionerTokenBodyDto = z.infer<typeof createProvisionerTokenBodySchema>;
+
+export const createProvisionerTokenResponseSchema = z.object({
+  id: z.string().uuid(),
+  raw_token: z.string(),
+  prefix: z.string(),
+  name: z.string().nullable(),
+  workspace_id: z.string().uuid(),
+  created_by_user_id: z.string().uuid(),
+  revoked_by_user_id: z.string().uuid().nullable(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type CreateProvisionerTokenResponseDto = z.infer<
+  typeof createProvisionerTokenResponseSchema
+>;
+
+export const provisionerTokenDtoSchema = z.object({
+  id: z.string().uuid(),
+  workspace_id: z.string().uuid(),
+  prefix: z.string(),
+  name: z.string().nullable(),
+  created_by_user_id: z.string().uuid(),
+  revoked_by_user_id: z.string().uuid().nullable(),
+  expires_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type ProvisionerTokenDto = z.infer<typeof provisionerTokenDtoSchema>;
+
+export const listProvisionerTokensResponseSchema = z.object({
+  tokens: z.array(provisionerTokenDtoSchema),
+});
+
+export type ListProvisionerTokensResponseDto = z.infer<typeof listProvisionerTokensResponseSchema>;
+
+export const revokeProvisionerTokenResponseSchema = provisionerTokenDtoSchema;
+
+export type RevokeProvisionerTokenResponseDto = z.infer<
+  typeof revokeProvisionerTokenResponseSchema
+>;
+
+export const provisionerIdentityResponseSchema = z.object({
+  id: z.string().uuid(),
+  workspace_id: z.string().uuid(),
+});
+
+export type ProvisionerIdentityResponseDto = z.infer<typeof provisionerIdentityResponseSchema>;

--- a/libs/api/provisioners-dto/tsconfig.build.json
+++ b/libs/api/provisioners-dto/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/provisioners-dto/tsconfig.json
+++ b/libs/api/provisioners-dto/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/provisioners-dto/tsconfig.test.json
+++ b/libs/api/provisioners-dto/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/provisioners-dto/vitest.config.ts
+++ b/libs/api/provisioners-dto/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/api/provisioners/drizzle.config.ts
+++ b/libs/api/provisioners/drizzle.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema/*.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+});

--- a/libs/api/provisioners/drizzle/0000_conscious_doctor_strange.sql
+++ b/libs/api/provisioners/drizzle/0000_conscious_doctor_strange.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "provisioners_provisioner_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"hashed_token" text NOT NULL,
+	"prefix" text NOT NULL,
+	"name" text,
+	"created_by_user_id" uuid NOT NULL,
+	"revoked_by_user_id" uuid,
+	"expires_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "provisioners_provisioner_tokens_hashed_token_unique" ON "provisioners_provisioner_tokens" USING btree ("hashed_token");--> statement-breakpoint
+CREATE INDEX "provisioners_provisioner_tokens_workspace_id_idx" ON "provisioners_provisioner_tokens" USING btree ("workspace_id");

--- a/libs/api/provisioners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/provisioners/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,132 @@
+{
+  "id": "1e4855d8-99db-418d-bcb1-b5fdf263c43f",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provisioners_provisioner_tokens": {
+      "name": "provisioners_provisioner_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "provisioners_provisioner_tokens_hashed_token_unique": {
+          "name": "provisioners_provisioner_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "provisioners_provisioner_tokens_workspace_id_idx": {
+          "name": "provisioners_provisioner_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/provisioners/drizzle/meta/_journal.json
+++ b/libs/api/provisioners/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1782571056073,
+      "tag": "0000_conscious_doctor_strange",
+      "breakpoints": true
+    }
+  ]
+}

--- a/libs/api/provisioners/package.json
+++ b/libs/api/provisioners/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@shipfox/api-provisioners",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/provisioners"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-auth-context": "workspace:*",
+    "@shipfox/api-provisioners-dto": "workspace:*",
+    "@shipfox/api-workspaces": "workspace:*",
+    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-fastify": "workspace:*",
+    "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*",
+    "@shipfox/node-tokens": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/pg": "^8.15.5",
+    "drizzle-kit": "^0.31.10",
+    "fastify": "^5.3.3",
+    "fastify-type-provider-zod": "^6.0.0",
+    "fishery": "^2.2.2"
+  }
+}

--- a/libs/api/provisioners/src/core/entities/provisioner-token.ts
+++ b/libs/api/provisioners/src/core/entities/provisioner-token.ts
@@ -1,0 +1,13 @@
+export interface ProvisionerToken {
+  id: string;
+  workspaceId: string;
+  hashedToken: string;
+  prefix: string;
+  name: string | null;
+  createdByUserId: string;
+  revokedByUserId: string | null;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/provisioners/src/core/errors.ts
+++ b/libs/api/provisioners/src/core/errors.ts
@@ -1,0 +1,6 @@
+export class ProvisionerTokenNotFoundError extends Error {
+  constructor(tokenId: string) {
+    super(`Provisioner token not found: ${tokenId}`);
+    this.name = 'ProvisionerTokenNotFoundError';
+  }
+}

--- a/libs/api/provisioners/src/core/index.ts
+++ b/libs/api/provisioners/src/core/index.ts
@@ -1,0 +1,9 @@
+export type {ProvisionerToken} from './entities/provisioner-token.js';
+export {ProvisionerTokenNotFoundError} from './errors.js';
+export {
+  type CreateWorkspaceProvisionerTokenParams,
+  type CreateWorkspaceProvisionerTokenResult,
+  createWorkspaceProvisionerToken,
+  listUsableProvisionerTokens,
+  revokeWorkspaceProvisionerToken,
+} from './provisioner-tokens.js';

--- a/libs/api/provisioners/src/core/provisioner-tokens.test.ts
+++ b/libs/api/provisioners/src/core/provisioner-tokens.test.ts
@@ -1,0 +1,65 @@
+import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
+import {eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
+import {provisionerTokenFactory} from '#test/index.js';
+import {
+  createWorkspaceProvisionerToken,
+  listUsableProvisionerTokens,
+  revokeWorkspaceProvisionerToken,
+} from './provisioner-tokens.js';
+
+describe('provisioner token core', () => {
+  beforeEach(async () => {
+    await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
+  });
+
+  it('creates a workspace provisioner token and stores only the hash', async () => {
+    const workspaceId = crypto.randomUUID();
+    const createdByUserId = crypto.randomUUID();
+
+    const result = await createWorkspaceProvisionerToken({
+      workspaceId,
+      createdByUserId,
+      name: 'local provisioner',
+      ttlSeconds: 3600,
+    });
+
+    expect(result.rawToken.startsWith(`sf_${tokenTypeParts.provisionerToken}_`)).toBe(true);
+    expect(result.token.workspaceId).toBe(workspaceId);
+    expect(result.token.createdByUserId).toBe(createdByUserId);
+    expect(result.token.expiresAt).toBeInstanceOf(Date);
+    expect(result.token.prefix).toBe(result.rawToken.slice(0, 12));
+    const rows = await db()
+      .select()
+      .from(provisionerTokens)
+      .where(eq(provisionerTokens.id, result.token.id));
+    expect(rows[0]?.hashedToken).toBe(hashOpaqueToken(result.rawToken));
+    expect(rows[0]?.hashedToken).not.toBe(result.rawToken);
+  });
+
+  it('lists usable tokens and excludes revoked tokens after revoke', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = await provisionerTokenFactory.create({workspaceId});
+    const revokedByUserId = crypto.randomUUID();
+
+    const beforeRevoke = await listUsableProvisionerTokens(workspaceId);
+    await revokeWorkspaceProvisionerToken({tokenId: token.id, workspaceId, revokedByUserId});
+    const afterRevoke = await listUsableProvisionerTokens(workspaceId);
+
+    expect(beforeRevoke.map((item) => item.id)).toEqual([token.id]);
+    expect(afterRevoke).toEqual([]);
+  });
+
+  it('throws when revoking a token outside the workspace', async () => {
+    const token = await provisionerTokenFactory.create({workspaceId: crypto.randomUUID()});
+
+    const result = revokeWorkspaceProvisionerToken({
+      tokenId: token.id,
+      workspaceId: crypto.randomUUID(),
+      revokedByUserId: crypto.randomUUID(),
+    });
+
+    await expect(result).rejects.toThrow(`Provisioner token not found: ${token.id}`);
+  });
+});

--- a/libs/api/provisioners/src/core/provisioner-tokens.ts
+++ b/libs/api/provisioners/src/core/provisioner-tokens.ts
@@ -1,0 +1,52 @@
+import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {
+  createProvisionerToken,
+  listUsableProvisionerTokensByWorkspaceId,
+  revokeProvisionerToken,
+} from '#db/provisioner-tokens.js';
+import type {ProvisionerToken} from './entities/provisioner-token.js';
+import {ProvisionerTokenNotFoundError} from './errors.js';
+
+export interface CreateWorkspaceProvisionerTokenParams {
+  workspaceId: string;
+  createdByUserId: string;
+  name?: string | undefined;
+  ttlSeconds?: number | undefined;
+}
+
+export interface CreateWorkspaceProvisionerTokenResult {
+  token: ProvisionerToken;
+  rawToken: string;
+}
+
+export async function createWorkspaceProvisionerToken(
+  params: CreateWorkspaceProvisionerTokenParams,
+): Promise<CreateWorkspaceProvisionerTokenResult> {
+  const rawToken = generateOpaqueToken('provisionerToken');
+  const expiresAt = params.ttlSeconds ? new Date(Date.now() + params.ttlSeconds * 1000) : undefined;
+
+  const token = await createProvisionerToken({
+    workspaceId: params.workspaceId,
+    hashedToken: hashOpaqueToken(rawToken),
+    prefix: extractDisplayPrefix(rawToken),
+    name: params.name,
+    createdByUserId: params.createdByUserId,
+    expiresAt,
+  });
+
+  return {token, rawToken};
+}
+
+export function listUsableProvisionerTokens(workspaceId: string): Promise<ProvisionerToken[]> {
+  return listUsableProvisionerTokensByWorkspaceId(workspaceId);
+}
+
+export async function revokeWorkspaceProvisionerToken(params: {
+  tokenId: string;
+  workspaceId: string;
+  revokedByUserId: string;
+}): Promise<ProvisionerToken> {
+  const token = await revokeProvisionerToken(params);
+  if (!token) throw new ProvisionerTokenNotFoundError(params.tokenId);
+  return token;
+}

--- a/libs/api/provisioners/src/db/db.ts
+++ b/libs/api/provisioners/src/db/db.ts
@@ -1,0 +1,16 @@
+import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
+import {pgClient} from '@shipfox/node-postgres';
+import {provisionerTokens} from './schema/provisioner-tokens.js';
+
+export const schema = {provisionerTokens};
+
+let _db: NodePgDatabase<typeof schema> | undefined;
+
+export function db() {
+  if (!_db) _db = drizzle(pgClient(), {schema});
+  return _db;
+}
+
+export function closeDb(): void {
+  _db = undefined;
+}

--- a/libs/api/provisioners/src/db/index.ts
+++ b/libs/api/provisioners/src/db/index.ts
@@ -1,0 +1,13 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export {closeDb, db, schema} from './db.js';
+export type {CreateProvisionerTokenParams} from './provisioner-tokens.js';
+export {
+  createProvisionerToken,
+  listUsableProvisionerTokensByWorkspaceId,
+  resolveProvisionerTokenByHash,
+  revokeProvisionerToken,
+} from './provisioner-tokens.js';
+
+export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/provisioners/src/db/provisioner-tokens.test.ts
+++ b/libs/api/provisioners/src/db/provisioner-tokens.test.ts
@@ -1,0 +1,111 @@
+import {hashOpaqueToken} from '@shipfox/node-tokens';
+import {sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {
+  createProvisionerToken,
+  listUsableProvisionerTokensByWorkspaceId,
+  resolveProvisionerTokenByHash,
+  revokeProvisionerToken,
+} from '#db/provisioner-tokens.js';
+import {provisionerTokenFactory} from '#test/index.js';
+
+describe('provisioner token db', () => {
+  beforeEach(async () => {
+    await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
+    await db().execute(sql`TRUNCATE workspaces CASCADE`);
+  });
+
+  it('creates and resolves a token', async () => {
+    const workspaceId = await createWorkspace();
+    const rawToken = 'sf_pt_test-token';
+    const createdByUserId = crypto.randomUUID();
+    const token = await createProvisionerToken({
+      workspaceId,
+      hashedToken: hashOpaqueToken(rawToken),
+      prefix: rawToken.slice(0, 12),
+      name: 'scaler',
+      createdByUserId,
+    });
+
+    const result = await resolveProvisionerTokenByHash(hashOpaqueToken(rawToken));
+
+    expect(result?.id).toBe(token.id);
+    expect(result?.workspaceId).toBe(workspaceId);
+    expect(result?.createdByUserId).toBe(createdByUserId);
+  });
+
+  it('returns undefined when resolving an unknown token hash', async () => {
+    const result = await resolveProvisionerTokenByHash(hashOpaqueToken('sf_pt_unknown-token'));
+
+    expect(result).toBeUndefined();
+  });
+
+  it('lists usable tokens for a workspace', async () => {
+    const workspaceId = crypto.randomUUID();
+    const usable = await provisionerTokenFactory.create({workspaceId, name: 'usable'});
+    const expired = await provisionerTokenFactory.create({
+      workspaceId,
+      name: 'expired',
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    const revoked = await provisionerTokenFactory.create({workspaceId, name: 'revoked'});
+    await provisionerTokenFactory.create({
+      workspaceId: crypto.randomUUID(),
+      name: 'other workspace',
+    });
+    await revokeProvisionerToken({
+      tokenId: revoked.id,
+      workspaceId,
+      revokedByUserId: crypto.randomUUID(),
+    });
+
+    const tokens = await listUsableProvisionerTokensByWorkspaceId(workspaceId);
+
+    expect(tokens.map((token) => token.id)).toEqual([usable.id]);
+    expect(tokens.map((token) => token.id)).not.toContain(expired.id);
+  });
+
+  it('revokes a token and records the revoking user', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = await provisionerTokenFactory.create({workspaceId});
+    const revokedByUserId = crypto.randomUUID();
+
+    const revoked = await revokeProvisionerToken({tokenId: token.id, workspaceId, revokedByUserId});
+
+    expect(revoked?.id).toBe(token.id);
+    expect(revoked?.revokedAt).toBeInstanceOf(Date);
+    expect(revoked?.revokedByUserId).toBe(revokedByUserId);
+  });
+
+  it('preserves the original revocation audit fields on repeat revoke', async () => {
+    const workspaceId = crypto.randomUUID();
+    const token = await provisionerTokenFactory.create({workspaceId});
+    const firstRevokedByUserId = crypto.randomUUID();
+    const secondRevokedByUserId = crypto.randomUUID();
+
+    const first = await revokeProvisionerToken({
+      tokenId: token.id,
+      workspaceId,
+      revokedByUserId: firstRevokedByUserId,
+    });
+    const second = await revokeProvisionerToken({
+      tokenId: token.id,
+      workspaceId,
+      revokedByUserId: secondRevokedByUserId,
+    });
+
+    expect(second?.id).toBe(token.id);
+    expect(second?.revokedAt?.toISOString()).toBe(first?.revokedAt?.toISOString());
+    expect(second?.revokedByUserId).toBe(firstRevokedByUserId);
+  });
+});
+
+async function createWorkspace(params?: {status?: 'active' | 'suspended' | 'deleted'}) {
+  const id = crypto.randomUUID();
+  await db().execute(
+    sql`INSERT INTO workspaces (id, name, status) VALUES (${id}, 'Test Workspace', ${
+      params?.status ?? 'active'
+    })`,
+  );
+  return id;
+}

--- a/libs/api/provisioners/src/db/provisioner-tokens.ts
+++ b/libs/api/provisioners/src/db/provisioner-tokens.ts
@@ -1,0 +1,102 @@
+import {and, desc, eq, gt, isNull, or} from 'drizzle-orm';
+import type {ProvisionerToken} from '#core/entities/provisioner-token.js';
+import {db} from './db.js';
+import {provisionerTokens, toProvisionerToken} from './schema/provisioner-tokens.js';
+
+export interface CreateProvisionerTokenParams {
+  workspaceId: string;
+  hashedToken: string;
+  prefix: string;
+  createdByUserId: string;
+  name?: string | undefined;
+  expiresAt?: Date | undefined;
+}
+
+export async function createProvisionerToken(
+  params: CreateProvisionerTokenParams,
+): Promise<ProvisionerToken> {
+  const rows = await db()
+    .insert(provisionerTokens)
+    .values({
+      workspaceId: params.workspaceId,
+      hashedToken: params.hashedToken,
+      prefix: params.prefix,
+      createdByUserId: params.createdByUserId,
+      name: params.name ?? null,
+      expiresAt: params.expiresAt ?? null,
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) throw new Error('Insert returned no rows');
+  return toProvisionerToken(row);
+}
+
+export async function listUsableProvisionerTokensByWorkspaceId(
+  workspaceId: string,
+): Promise<ProvisionerToken[]> {
+  const now = new Date();
+  const rows = await db()
+    .select()
+    .from(provisionerTokens)
+    .where(
+      and(
+        eq(provisionerTokens.workspaceId, workspaceId),
+        isNull(provisionerTokens.revokedAt),
+        or(isNull(provisionerTokens.expiresAt), gt(provisionerTokens.expiresAt, now)),
+      ),
+    )
+    .orderBy(desc(provisionerTokens.createdAt), desc(provisionerTokens.id));
+
+  return rows.map(toProvisionerToken);
+}
+
+export async function resolveProvisionerTokenByHash(
+  hashedToken: string,
+): Promise<ProvisionerToken | undefined> {
+  const rows = await db()
+    .select()
+    .from(provisionerTokens)
+    .where(eq(provisionerTokens.hashedToken, hashedToken))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toProvisionerToken(row);
+}
+
+export async function revokeProvisionerToken(params: {
+  tokenId: string;
+  workspaceId: string;
+  revokedByUserId: string;
+}): Promise<ProvisionerToken | undefined> {
+  const rows = await db()
+    .update(provisionerTokens)
+    .set({revokedAt: new Date(), revokedByUserId: params.revokedByUserId, updatedAt: new Date()})
+    .where(
+      and(
+        eq(provisionerTokens.id, params.tokenId),
+        eq(provisionerTokens.workspaceId, params.workspaceId),
+        isNull(provisionerTokens.revokedAt),
+      ),
+    )
+    .returning();
+
+  const row = rows[0];
+  if (row) return toProvisionerToken(row);
+
+  const existingRows = await db()
+    .select()
+    .from(provisionerTokens)
+    .where(
+      and(
+        eq(provisionerTokens.id, params.tokenId),
+        eq(provisionerTokens.workspaceId, params.workspaceId),
+      ),
+    )
+    .limit(1);
+
+  const existingRow = existingRows[0];
+  if (!existingRow) return undefined;
+  return toProvisionerToken(existingRow);
+}

--- a/libs/api/provisioners/src/db/schema/common.ts
+++ b/libs/api/provisioners/src/db/schema/common.ts
@@ -1,0 +1,3 @@
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+
+export const pgTable = pgTableCreator((name) => `provisioners_${name}`);

--- a/libs/api/provisioners/src/db/schema/provisioner-tokens.ts
+++ b/libs/api/provisioners/src/db/schema/provisioner-tokens.ts
@@ -1,0 +1,44 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import type {ProvisionerToken} from '#core/entities/provisioner-token.js';
+import {pgTable} from './common.js';
+
+export const provisionerTokens = pgTable(
+  'provisioner_tokens',
+  {
+    id: uuidv7PrimaryKey(),
+    workspaceId: uuid('workspace_id').notNull(),
+    hashedToken: text('hashed_token').notNull(),
+    prefix: text('prefix').notNull(),
+    name: text('name'),
+    createdByUserId: uuid('created_by_user_id').notNull(),
+    revokedByUserId: uuid('revoked_by_user_id'),
+    expiresAt: timestamp('expires_at', {withTimezone: true}),
+    revokedAt: timestamp('revoked_at', {withTimezone: true}),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('provisioners_provisioner_tokens_hashed_token_unique').on(table.hashedToken),
+    index('provisioners_provisioner_tokens_workspace_id_idx').on(table.workspaceId),
+  ],
+);
+
+export type ProvisionerTokenDb = typeof provisionerTokens.$inferSelect;
+export type ProvisionerTokenInsertDb = typeof provisionerTokens.$inferInsert;
+
+export function toProvisionerToken(row: ProvisionerTokenDb): ProvisionerToken {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    hashedToken: row.hashedToken,
+    prefix: row.prefix,
+    name: row.name,
+    createdByUserId: row.createdByUserId,
+    revokedByUserId: row.revokedByUserId,
+    expiresAt: row.expiresAt,
+    revokedAt: row.revokedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/provisioners/src/index.ts
+++ b/libs/api/provisioners/src/index.ts
@@ -1,0 +1,10 @@
+import type {ShipfoxModule} from '@shipfox/node-module';
+import {db, migrationsPath} from '#db/index.js';
+import {createProvisionerTokenAuthMethod, routes} from '#presentation/index.js';
+
+export const provisionersModule: ShipfoxModule = {
+  name: 'provisioners',
+  database: {db, migrationsPath},
+  auth: [createProvisionerTokenAuthMethod()],
+  routes,
+};

--- a/libs/api/provisioners/src/presentation/auth/index.ts
+++ b/libs/api/provisioners/src/presentation/auth/index.ts
@@ -1,0 +1,1 @@
+export {createProvisionerTokenAuthMethod} from './provisioner-token-auth.js';

--- a/libs/api/provisioners/src/presentation/auth/provisioner-token-auth.ts
+++ b/libs/api/provisioners/src/presentation/auth/provisioner-token-auth.ts
@@ -1,0 +1,91 @@
+import {
+  AUTH_PROVISIONER_TOKEN,
+  type ProvisionerContext,
+  setProvisionerContext,
+} from '@shipfox/api-auth-context';
+import {getWorkspace, WorkspaceNotFoundError} from '@shipfox/api-workspaces';
+import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import {extractDisplayPrefix, getTokenType, hashOpaqueToken} from '@shipfox/node-tokens';
+import {resolveProvisionerTokenByHash} from '#db/provisioner-tokens.js';
+
+type AuthFailureReason =
+  | 'missing'
+  | 'type'
+  | 'not-found'
+  | 'revoked'
+  | 'expired'
+  | 'workspace-not-found'
+  | 'workspace-inactive';
+
+export function createProvisionerTokenAuthMethod(): AuthMethod {
+  return {
+    name: AUTH_PROVISIONER_TOKEN,
+    authenticate: async (request) => {
+      const rawToken = extractBearerToken(request.headers.authorization);
+      if (!rawToken) {
+        logAuthFailure({reason: 'missing'});
+        throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {
+          status: 401,
+        });
+      }
+
+      if (getTokenType(rawToken) !== 'provisionerToken') {
+        logAuthFailure({rawToken, reason: 'type'});
+        throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
+      }
+
+      const provisionerToken = await resolveProvisionerTokenByHash(hashOpaqueToken(rawToken));
+      if (!provisionerToken) {
+        logAuthFailure({rawToken, reason: 'not-found'});
+        throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
+      }
+
+      if (provisionerToken.revokedAt) {
+        logAuthFailure({rawToken, reason: 'revoked'});
+        throw new ClientError('Provisioner token has been revoked', 'provisioner-token-revoked', {
+          status: 401,
+        });
+      }
+
+      if (provisionerToken.expiresAt && provisionerToken.expiresAt < new Date()) {
+        logAuthFailure({rawToken, reason: 'expired'});
+        throw new ClientError('Provisioner token has expired', 'provisioner-token-expired', {
+          status: 401,
+        });
+      }
+
+      const workspace = await getWorkspace({workspaceId: provisionerToken.workspaceId}).catch(
+        (error: unknown) => {
+          if (error instanceof WorkspaceNotFoundError) {
+            logAuthFailure({rawToken, reason: 'workspace-not-found'});
+            throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
+          }
+          throw error;
+        },
+      );
+
+      if (workspace.status !== 'active') {
+        logAuthFailure({rawToken, reason: 'workspace-inactive'});
+        throw new ClientError('Workspace is not active', 'workspace-inactive', {status: 403});
+      }
+
+      const context: ProvisionerContext = {
+        provisionerTokenId: provisionerToken.id,
+        workspaceId: workspace.id,
+      };
+
+      setProvisionerContext(request, context);
+    },
+  };
+}
+
+function logAuthFailure(params: {rawToken?: string | undefined; reason: AuthFailureReason}): void {
+  logger().warn(
+    {
+      prefix: params.rawToken ? extractDisplayPrefix(params.rawToken) : undefined,
+      reason: params.reason,
+    },
+    'provisioner token auth failed',
+  );
+}

--- a/libs/api/provisioners/src/presentation/auth/provisioner-token-auth.ts
+++ b/libs/api/provisioners/src/presentation/auth/provisioner-token-auth.ts
@@ -48,7 +48,7 @@ export function createProvisionerTokenAuthMethod(): AuthMethod {
         });
       }
 
-      if (provisionerToken.expiresAt && provisionerToken.expiresAt < new Date()) {
+      if (provisionerToken.expiresAt && provisionerToken.expiresAt <= new Date()) {
         logAuthFailure({rawToken, reason: 'expired'});
         throw new ClientError('Provisioner token has expired', 'provisioner-token-expired', {
           status: 401,

--- a/libs/api/provisioners/src/presentation/dto/index.ts
+++ b/libs/api/provisioners/src/presentation/dto/index.ts
@@ -1,0 +1,1 @@
+export {toProvisionerTokenDto} from './provisioner-token.js';

--- a/libs/api/provisioners/src/presentation/dto/provisioner-token.ts
+++ b/libs/api/provisioners/src/presentation/dto/provisioner-token.ts
@@ -1,0 +1,27 @@
+import type {ProvisionerToken} from '#core/entities/provisioner-token.js';
+
+export function toProvisionerTokenDto(token: ProvisionerToken): {
+  id: string;
+  workspace_id: string;
+  prefix: string;
+  name: string | null;
+  created_by_user_id: string;
+  revoked_by_user_id: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+  updated_at: string;
+} {
+  return {
+    id: token.id,
+    workspace_id: token.workspaceId,
+    prefix: token.prefix,
+    name: token.name,
+    created_by_user_id: token.createdByUserId,
+    revoked_by_user_id: token.revokedByUserId,
+    expires_at: token.expiresAt?.toISOString() ?? null,
+    revoked_at: token.revokedAt?.toISOString() ?? null,
+    created_at: token.createdAt.toISOString(),
+    updated_at: token.updatedAt.toISOString(),
+  };
+}

--- a/libs/api/provisioners/src/presentation/index.ts
+++ b/libs/api/provisioners/src/presentation/index.ts
@@ -1,0 +1,2 @@
+export {createProvisionerTokenAuthMethod} from './auth/index.js';
+export {provisionerRoutes as routes} from './routes/index.js';

--- a/libs/api/provisioners/src/presentation/routes/create-provisioner-token.ts
+++ b/libs/api/provisioners/src/presentation/routes/create-provisioner-token.ts
@@ -1,0 +1,42 @@
+import {requireUserContext} from '@shipfox/api-auth-context';
+import {
+  createProvisionerTokenBodySchema,
+  createProvisionerTokenResponseSchema,
+} from '@shipfox/api-provisioners-dto';
+import {requireMembership} from '@shipfox/api-workspaces';
+import {defineRoute} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {createWorkspaceProvisionerToken} from '#core/index.js';
+import {toProvisionerTokenDto} from '#presentation/dto/index.js';
+
+export const createProvisionerTokenRoute = defineRoute({
+  method: 'POST',
+  path: '/',
+  description: 'Create a token that lets a provisioner connect to your account',
+  schema: {
+    params: z.object({workspaceId: z.string().uuid()}),
+    body: createProvisionerTokenBodySchema,
+    response: {
+      201: createProvisionerTokenResponseSchema,
+    },
+  },
+  handler: async (request, reply) => {
+    const {workspaceId} = request.params;
+    await requireMembership({request, workspaceId});
+    const user = requireUserContext(request);
+    const {name, ttl_seconds} = request.body;
+
+    const {token, rawToken} = await createWorkspaceProvisionerToken({
+      workspaceId,
+      createdByUserId: user.userId,
+      name,
+      ttlSeconds: ttl_seconds,
+    });
+
+    reply.code(201);
+    return {
+      ...toProvisionerTokenDto(token),
+      raw_token: rawToken,
+    };
+  },
+});

--- a/libs/api/provisioners/src/presentation/routes/get-provisioner-me.ts
+++ b/libs/api/provisioners/src/presentation/routes/get-provisioner-me.ts
@@ -1,0 +1,22 @@
+import {requireProvisionerContext} from '@shipfox/api-auth-context';
+import {provisionerIdentityResponseSchema} from '@shipfox/api-provisioners-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+
+export const getProvisionerMeRoute = defineRoute({
+  method: 'GET',
+  path: '/me',
+  description: 'Return the authenticated provisioner token identity',
+  schema: {
+    response: {
+      200: provisionerIdentityResponseSchema,
+    },
+  },
+  handler: (request) => {
+    const context = requireProvisionerContext(request);
+
+    return {
+      id: context.provisionerTokenId,
+      workspace_id: context.workspaceId,
+    };
+  },
+});

--- a/libs/api/provisioners/src/presentation/routes/index.ts
+++ b/libs/api/provisioners/src/presentation/routes/index.ts
@@ -1,0 +1,19 @@
+import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createProvisionerTokenRoute} from './create-provisioner-token.js';
+import {getProvisionerMeRoute} from './get-provisioner-me.js';
+import {listProvisionerTokensRoute} from './list-provisioner-tokens.js';
+import {revokeProvisionerTokenRoute} from './revoke-provisioner-token.js';
+
+export const provisionerRoutes: RouteGroup[] = [
+  {
+    prefix: '/workspaces/:workspaceId/provisioners/tokens',
+    auth: AUTH_USER,
+    routes: [listProvisionerTokensRoute, createProvisionerTokenRoute, revokeProvisionerTokenRoute],
+  },
+  {
+    prefix: '/provisioners',
+    auth: AUTH_PROVISIONER_TOKEN,
+    routes: [getProvisionerMeRoute],
+  },
+];

--- a/libs/api/provisioners/src/presentation/routes/list-provisioner-tokens.ts
+++ b/libs/api/provisioners/src/presentation/routes/list-provisioner-tokens.ts
@@ -1,0 +1,25 @@
+import {listProvisionerTokensResponseSchema} from '@shipfox/api-provisioners-dto';
+import {requireMembership} from '@shipfox/api-workspaces';
+import {defineRoute} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {listUsableProvisionerTokens} from '#core/index.js';
+import {toProvisionerTokenDto} from '#presentation/dto/index.js';
+
+export const listProvisionerTokensRoute = defineRoute({
+  method: 'GET',
+  path: '/',
+  description: 'List currently usable provisioner tokens for a workspace',
+  schema: {
+    params: z.object({workspaceId: z.string().uuid()}),
+    response: {
+      200: listProvisionerTokensResponseSchema,
+    },
+  },
+  handler: async (request) => {
+    const {workspaceId} = request.params;
+    await requireMembership({request, workspaceId});
+
+    const tokens = await listUsableProvisionerTokens(workspaceId);
+    return {tokens: tokens.map(toProvisionerTokenDto)};
+  },
+});

--- a/libs/api/provisioners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/provisioners/src/presentation/routes/provisioner-me.test.ts
@@ -1,0 +1,207 @@
+import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
+import type {AuthMethod} from '@shipfox/node-fastify';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {generateOpaqueToken} from '@shipfox/node-tokens';
+import {sql} from 'drizzle-orm';
+import type {FastifyInstance} from 'fastify';
+import {db} from '#db/db.js';
+import {revokeProvisionerToken} from '#db/provisioner-tokens.js';
+import {createProvisionerTokenAuthMethod} from '#presentation/auth/index.js';
+import {provisionerTokenFactory} from '#test/index.js';
+import {provisionerRoutes} from './index.js';
+
+const mocks = vi.hoisted(() => ({
+  logger: {
+    child: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    info: vi.fn(),
+    trace: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+mocks.logger.child.mockReturnValue(mocks.logger);
+
+vi.mock('@shipfox/node-opentelemetry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@shipfox/node-opentelemetry')>()),
+  logger: () => mocks.logger,
+}));
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: () => Promise.resolve(),
+};
+
+describe('provisioner me route', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    await closeApp();
+    await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
+    await db().execute(sql`TRUNCATE workspaces CASCADE`);
+    mocks.logger.warn.mockReset();
+    app = await createApp({
+      auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],
+      routes: provisionerRoutes,
+      swagger: false,
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  test('uses provisioner auth for provisioner routes', () => {
+    expect(provisionerRoutes[1]?.auth).toBe(AUTH_PROVISIONER_TOKEN);
+  });
+
+  it('returns the authenticated provisioner identity', async () => {
+    const workspaceId = await createWorkspace();
+    const rawToken = generateOpaqueToken('provisionerToken');
+    const token = await provisionerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({id: token.id, workspace_id: workspaceId});
+  });
+
+  it('returns 401 without an authorization header', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('unauthorized');
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {prefix: undefined, reason: 'missing'},
+      'provisioner token auth failed',
+    );
+  });
+
+  it('returns 401 for a non-provisioner token type before lookup', async () => {
+    const rawToken = generateOpaqueToken('runnerToken');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('unauthorized');
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {prefix: rawToken.slice(0, 12), reason: 'type'},
+      'provisioner token auth failed',
+    );
+  });
+
+  it('returns 401 for an unknown provisioner token', async () => {
+    const rawToken = generateOpaqueToken('provisionerToken');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('unauthorized');
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {prefix: rawToken.slice(0, 12), reason: 'not-found'},
+      'provisioner token auth failed',
+    );
+  });
+
+  it('returns 401 for a revoked provisioner token', async () => {
+    const workspaceId = await createWorkspace();
+    const rawToken = generateOpaqueToken('provisionerToken');
+    const token = await provisionerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+    await revokeProvisionerToken({
+      tokenId: token.id,
+      workspaceId,
+      revokedByUserId: crypto.randomUUID(),
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('provisioner-token-revoked');
+  });
+
+  it('returns 401 for an expired provisioner token', async () => {
+    const workspaceId = await createWorkspace();
+    const rawToken = generateOpaqueToken('provisionerToken');
+    await provisionerTokenFactory.create(
+      {workspaceId, expiresAt: new Date(Date.now() - 60_000)},
+      {transient: {rawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('provisioner-token-expired');
+  });
+
+  it('returns 401 for a provisioner token whose workspace does not exist', async () => {
+    const rawToken = generateOpaqueToken('provisionerToken');
+    await provisionerTokenFactory.create(
+      {workspaceId: crypto.randomUUID()},
+      {transient: {rawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('unauthorized');
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      {prefix: rawToken.slice(0, 12), reason: 'workspace-not-found'},
+      'provisioner token auth failed',
+    );
+  });
+
+  it('returns 403 for a provisioner token in a suspended workspace', async () => {
+    const workspaceId = await createWorkspace({status: 'suspended'});
+    const rawToken = generateOpaqueToken('provisionerToken');
+    await provisionerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().code).toBe('workspace-inactive');
+  });
+});
+
+async function createWorkspace(params?: {status?: 'active' | 'suspended' | 'deleted'}) {
+  const id = crypto.randomUUID();
+  await db().execute(
+    sql`INSERT INTO workspaces (id, name, status) VALUES (${id}, 'Test Workspace', ${
+      params?.status ?? 'active'
+    })`,
+  );
+  return id;
+}

--- a/libs/api/provisioners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/provisioners/src/presentation/routes/provisioner-me.test.ts
@@ -159,6 +159,25 @@ describe('provisioner me route', () => {
     expect(res.json().code).toBe('provisioner-token-expired');
   });
 
+  it('returns 401 for a provisioner token expiring at the current instant', async () => {
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    const workspaceId = await createWorkspace();
+    const rawToken = generateOpaqueToken('provisionerToken');
+    await provisionerTokenFactory.create({workspaceId, expiresAt: now}, {transient: {rawToken}});
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const res = await app.inject({
+      method: 'GET',
+      url: '/provisioners/me',
+      headers: {authorization: `Bearer ${rawToken}`},
+    });
+    vi.useRealTimers();
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('provisioner-token-expired');
+  });
+
   it('returns 401 for a provisioner token whose workspace does not exist', async () => {
     const rawToken = generateOpaqueToken('provisionerToken');
     await provisionerTokenFactory.create(

--- a/libs/api/provisioners/src/presentation/routes/provisioner-tokens.test.ts
+++ b/libs/api/provisioners/src/presentation/routes/provisioner-tokens.test.ts
@@ -1,0 +1,205 @@
+import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {requireMembership} from '@shipfox/api-workspaces';
+import type {AuthMethod} from '@shipfox/node-fastify';
+import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
+import {eq, sql} from 'drizzle-orm';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import {db} from '#db/db.js';
+import {revokeProvisionerToken} from '#db/provisioner-tokens.js';
+import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
+import {createProvisionerTokenAuthMethod} from '#presentation/auth/index.js';
+import {provisionerTokenFactory} from '#test/index.js';
+import {provisionerRoutes} from './index.js';
+
+vi.mock('@shipfox/api-workspaces', () => ({
+  requireMembership: vi.fn(),
+}));
+
+const userId = crypto.randomUUID();
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: (request: FastifyRequest) => {
+    if (request.headers.authorization !== 'Bearer user') {
+      throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
+    }
+
+    setUserContext(
+      request,
+      buildUserContext({
+        userId,
+        email: 'user@example.com',
+        memberships: [{workspaceId: 'workspace-from-auth', role: 'admin'}],
+      }),
+    );
+    return Promise.resolve();
+  },
+};
+
+describe('provisioner token routes', () => {
+  let app: FastifyInstance;
+  let workspaceId: string;
+
+  beforeEach(async () => {
+    await closeApp();
+    await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
+    workspaceId = crypto.randomUUID();
+    vi.mocked(requireMembership).mockResolvedValue({
+      workspaceId,
+      workspace: {
+        id: workspaceId,
+        name: 'Workspace',
+        status: 'active',
+        settings: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      userId,
+      role: 'admin',
+    });
+    app = await createApp({
+      auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],
+      routes: provisionerRoutes,
+      swagger: false,
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  test('uses user auth for provisioner token management routes', () => {
+    expect(provisionerRoutes[0]?.auth).toBe(AUTH_USER);
+  });
+
+  describe('GET /workspaces/:workspaceId/provisioners/tokens', () => {
+    it('returns 401 without user auth', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/workspaces/${workspaceId}/provisioners/tokens`,
+      });
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 403 when the user is not a workspace member', async () => {
+      vi.mocked(requireMembership).mockRejectedValueOnce(
+        new ClientError('Not a member of this workspace', 'forbidden', {status: 403}),
+      );
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/workspaces/${workspaceId}/provisioners/tokens`,
+        headers: {authorization: 'Bearer user'},
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.json().code).toBe('forbidden');
+    });
+
+    it('returns only usable tokens for the workspace', async () => {
+      const usable = await provisionerTokenFactory.create({workspaceId, name: 'usable'});
+      const expired = await provisionerTokenFactory.create({
+        workspaceId,
+        name: 'expired',
+        expiresAt: new Date(Date.now() - 60_000),
+      });
+      const revoked = await provisionerTokenFactory.create({workspaceId, name: 'revoked'});
+      await provisionerTokenFactory.create({
+        workspaceId: crypto.randomUUID(),
+        name: 'other workspace',
+      });
+      await revokeProvisionerToken({tokenId: revoked.id, workspaceId, revokedByUserId: userId});
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/workspaces/${workspaceId}/provisioners/tokens`,
+        headers: {authorization: 'Bearer user'},
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().tokens.map((token: {id: string}) => token.id)).toEqual([usable.id]);
+      expect(res.json().tokens.map((token: {id: string}) => token.id)).not.toContain(expired.id);
+    });
+  });
+
+  describe('POST /workspaces/:workspaceId/provisioners/tokens', () => {
+    it('returns 401 without user auth', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/workspaces/${workspaceId}/provisioners/tokens`,
+        payload: {name: 'scaler'},
+      });
+
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('creates a workspace-scoped provisioner token and returns the raw token once', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/workspaces/${workspaceId}/provisioners/tokens`,
+        headers: {authorization: 'Bearer user'},
+        payload: {name: 'scaler', ttl_seconds: 3600},
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.raw_token.startsWith(`sf_${tokenTypeParts.provisionerToken}_`)).toBe(true);
+      expect(body.prefix).toBe(body.raw_token.slice(0, 12));
+      expect(body.name).toBe('scaler');
+      expect(body.workspace_id).toBe(workspaceId);
+      expect(body.created_by_user_id).toBe(userId);
+      expect(body.expires_at).not.toBeNull();
+
+      const rows = await db()
+        .select()
+        .from(provisionerTokens)
+        .where(eq(provisionerTokens.id, body.id));
+      expect(rows[0]?.hashedToken).toBe(hashOpaqueToken(body.raw_token));
+      expect(rows[0]?.hashedToken).not.toBe(body.raw_token);
+    });
+
+    it('rejects a token TTL above one year', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/workspaces/${workspaceId}/provisioners/tokens`,
+        headers: {authorization: 'Bearer user'},
+        payload: {ttl_seconds: 31_536_001},
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('POST /workspaces/:workspaceId/provisioners/tokens/:tokenId/revoke', () => {
+    it('revokes a token owned by the authenticated workspace', async () => {
+      const token = await provisionerTokenFactory.create({workspaceId});
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/workspaces/${workspaceId}/provisioners/tokens/${token.id}/revoke`,
+        headers: {authorization: 'Bearer user'},
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().id).toBe(token.id);
+      expect(res.json().revoked_at).not.toBeNull();
+      expect(res.json().revoked_by_user_id).toBe(userId);
+    });
+
+    it('returns 404 for a token owned by another workspace', async () => {
+      const token = await provisionerTokenFactory.create({workspaceId: crypto.randomUUID()});
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `/workspaces/${workspaceId}/provisioners/tokens/${token.id}/revoke`,
+        headers: {authorization: 'Bearer user'},
+      });
+
+      expect(res.statusCode).toBe(404);
+      expect(res.json().code).toBe('not-found');
+    });
+  });
+});

--- a/libs/api/provisioners/src/presentation/routes/revoke-provisioner-token.ts
+++ b/libs/api/provisioners/src/presentation/routes/revoke-provisioner-token.ts
@@ -1,0 +1,38 @@
+import {requireUserContext} from '@shipfox/api-auth-context';
+import {revokeProvisionerTokenResponseSchema} from '@shipfox/api-provisioners-dto';
+import {requireMembership} from '@shipfox/api-workspaces';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {ProvisionerTokenNotFoundError, revokeWorkspaceProvisionerToken} from '#core/index.js';
+import {toProvisionerTokenDto} from '#presentation/dto/index.js';
+
+export const revokeProvisionerTokenRoute = defineRoute({
+  method: 'POST',
+  path: '/:tokenId/revoke',
+  description: 'Stop a provisioner token from being used to connect to your account',
+  schema: {
+    params: z.object({workspaceId: z.string().uuid(), tokenId: z.string().uuid()}),
+    response: {
+      200: revokeProvisionerTokenResponseSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof ProvisionerTokenNotFoundError) {
+      throw new ClientError('Provisioner token not found', 'not-found', {status: 404});
+    }
+    throw error;
+  },
+  handler: async (request) => {
+    const {workspaceId, tokenId} = request.params;
+    await requireMembership({request, workspaceId});
+    const user = requireUserContext(request);
+
+    const revoked = await revokeWorkspaceProvisionerToken({
+      tokenId,
+      workspaceId,
+      revokedByUserId: user.userId,
+    });
+
+    return toProvisionerTokenDto(revoked);
+  },
+});

--- a/libs/api/provisioners/test/env.ts
+++ b/libs/api/provisioners/test/env.ts
@@ -1,0 +1,10 @@
+process.env.POSTGRES_HOST = 'localhost';
+process.env.POSTGRES_PORT = '5432';
+process.env.POSTGRES_USERNAME = 'shipfox';
+process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_DATABASE = 'api_test';
+process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.WORKSPACE_JWT_SECRET = 'test-secret';
+process.env.AUTH_JWT_SECRET = 'test-secret';
+process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
+process.env.TZ = 'UTC';

--- a/libs/api/provisioners/test/factories/provisioner-token.ts
+++ b/libs/api/provisioners/test/factories/provisioner-token.ts
@@ -1,0 +1,40 @@
+import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {Factory} from 'fishery';
+import type {ProvisionerToken} from '#core/entities/provisioner-token.js';
+import {createProvisionerToken} from '#db/provisioner-tokens.js';
+
+export interface ProvisionerTokenFactoryTransientParams {
+  rawToken?: string;
+}
+
+export const provisionerTokenFactory = Factory.define<
+  ProvisionerToken,
+  ProvisionerTokenFactoryTransientParams
+>(({onCreate, transientParams}) => {
+  const rawToken = transientParams.rawToken ?? generateOpaqueToken('provisionerToken');
+
+  onCreate((token) => {
+    return createProvisionerToken({
+      workspaceId: token.workspaceId,
+      hashedToken: token.hashedToken,
+      prefix: token.prefix,
+      name: token.name ?? undefined,
+      createdByUserId: token.createdByUserId,
+      expiresAt: token.expiresAt ?? undefined,
+    });
+  });
+
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    hashedToken: hashOpaqueToken(rawToken),
+    prefix: extractDisplayPrefix(rawToken),
+    name: 'test provisioner',
+    createdByUserId: crypto.randomUUID(),
+    revokedByUserId: null,
+    expiresAt: null,
+    revokedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+});

--- a/libs/api/provisioners/test/globalSetup.ts
+++ b/libs/api/provisioners/test/globalSetup.ts
@@ -1,0 +1,18 @@
+import './env.js';
+import {migrationsPath as workspacesMigrationsPath} from '@shipfox/api-workspaces';
+import {runMigrations} from '@shipfox/node-drizzle';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {sql} from 'drizzle-orm';
+import {closeDb, db, migrationsPath} from '#db/index.js';
+
+export async function setup() {
+  createPostgresClient();
+
+  await runMigrations(db(), workspacesMigrationsPath, '__drizzle_migrations_workspaces');
+  await runMigrations(db(), migrationsPath, '__drizzle_migrations_provisioners');
+  await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
+  await db().execute(sql`TRUNCATE workspaces CASCADE`);
+
+  closeDb();
+  await closePostgresClient();
+}

--- a/libs/api/provisioners/test/index.ts
+++ b/libs/api/provisioners/test/index.ts
@@ -1,0 +1,1 @@
+export {provisionerTokenFactory} from './factories/provisioner-token.js';

--- a/libs/api/provisioners/test/setup.ts
+++ b/libs/api/provisioners/test/setup.ts
@@ -1,0 +1,17 @@
+import './env.js';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {afterAll, afterEach, beforeAll, vi} from '@shipfox/vitest/vi';
+import {closeDb} from '#db/index.js';
+
+beforeAll(() => {
+  createPostgresClient();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(async () => {
+  closeDb();
+  await closePostgresClient();
+});

--- a/libs/api/provisioners/tsconfig.build.json
+++ b/libs/api/provisioners/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/provisioners/tsconfig.json
+++ b/libs/api/provisioners/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/provisioners/tsconfig.test.json
+++ b/libs/api/provisioners/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/provisioners/vitest.config.ts
+++ b/libs/api/provisioners/vitest.config.ts
@@ -1,0 +1,12 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      fileParallelism: false,
+      globalSetup: ['test/globalSetup.ts'],
+      setupFiles: ['test/setup.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/libs/api/workspaces/src/index.ts
+++ b/libs/api/workspaces/src/index.ts
@@ -18,9 +18,10 @@ export {
   TokenAlreadyUsedError,
   TokenExpiredError,
   TokenInvalidError,
+  WorkspaceNotFoundError,
 } from '#core/errors.js';
 export {acceptWorkspaceInvitation, peekInvitationByRawToken} from '#core/invitations.js';
-export {requireWorkspaceMembership} from '#core/workspaces.js';
+export {getWorkspace, requireWorkspaceMembership} from '#core/workspaces.js';
 export {db, migrationsPath} from '#db/index.js';
 export {listMembershipsByUser} from '#db/memberships.js';
 export {requireMembership} from '#presentation/auth/require-membership.js';

--- a/libs/shared/node/tokens/src/index.ts
+++ b/libs/shared/node/tokens/src/index.ts
@@ -11,6 +11,7 @@ export const tokenTypeParts = {
   passwordReset: 'pr',
   refreshToken: 'r',
   runnerToken: 'rt',
+  provisionerToken: 'pt',
 } as const;
 
 const tokenPrefixRegexes = createShipfoxTokenPrefixRegexes(Object.values(tokenTypeParts));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@shipfox/api-projects':
         specifier: workspace:*
         version: link:../../libs/api/projects
+      '@shipfox/api-provisioners':
+        specifier: workspace:*
+        version: link:../../libs/api/provisioners
       '@shipfox/api-runners':
         specifier: workspace:*
         version: link:../../libs/api/runners
@@ -1580,6 +1583,98 @@ importers:
       '@shipfox/api-common-dto':
         specifier: workspace:*
         version: link:../common-dto
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
+  libs/api/provisioners:
+    dependencies:
+      '@shipfox/api-auth-context':
+        specifier: workspace:*
+        version: link:../auth-context
+      '@shipfox/api-provisioners-dto':
+        specifier: workspace:*
+        version: link:../provisioners-dto
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../workspaces
+      '@shipfox/node-drizzle':
+        specifier: workspace:*
+        version: link:../../shared/node/drizzle
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../shared/node/fastify
+      '@shipfox/node-module':
+        specifier: workspace:*
+        version: link:../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../shared/node/postgres
+      '@shipfox/node-tokens':
+        specifier: workspace:*
+        version: link:../../shared/node/tokens
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      fastify:
+        specifier: ^5.3.3
+        version: 5.8.5
+      fastify-type-provider-zod:
+        specifier: ^6.0.0
+        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3)
+      fishery:
+        specifier: ^2.2.2
+        version: 2.4.0
+
+  libs/api/provisioners-dto:
+    dependencies:
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Add workspace-scoped provisioner tokens for the provisioner control plane.

Provisioners need a narrow long-lived credential that can authenticate only provisioner routes, without inheriting runner-token or workspace API-key authority. This adds the DTO and backend modules for creating, listing, revoking, and authenticating provisioner tokens, stores only token hashes, returns the raw token once, and adds GET /provisioners/me to exercise the new auth method.

The auth path validates the provisioner token prefix before lookup, rejects revoked or expired tokens, gates on active workspace state, and records auth failures with only the display prefix. Management routes continue to use user auth plus workspace membership.

Closes ENG-612

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace-scoped provisioner tokens with a dedicated auth method for provisioner-only control-plane access. Fixes token expiry boundary to reject tokens expiring at the current instant (ENG-612).

- **New Features**
  - New `@shipfox/api-provisioners` module with DB schema, auth, and routes; integrated into `apps/api`.
  - Provisioner token auth (`AUTH_PROVISIONER_TOKEN`): checks type `pt`, rejects revoked/expired, requires active workspace, logs failures by token prefix.
  - Routes:
    - User + membership: GET/POST `/workspaces/:workspaceId/provisioners/tokens`, POST `/workspaces/:workspaceId/provisioners/tokens/:tokenId/revoke`
    - Provisioner: GET `/provisioners/me` (returns token and workspace IDs)
  - Token handling: create returns `raw_token` once; only hashed token + display prefix stored; optional TTL up to 1 year.
  - Added provisioner context helpers in `@shipfox/api-auth-context` and token type `pt` in `@shipfox/node-tokens`.

- **Dependencies**
  - Added `@shipfox/api-provisioners` and `@shipfox/api-provisioners-dto`.
  - New DB table `provisioners_provisioner_tokens` with indexes and migrations.

<sup>Written for commit 8f14ca249980e5c496427a98c3284f2ed7e97a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

