### PR TITLE
Add runner registration sessions

### DIFF
--- a/.changeset/steady-runners-register.md
+++ b/.changeset/steady-runners-register.md
@@ -1,0 +1,12 @@
+---
+"@shipfox/api-auth": minor
+"@shipfox/api-auth-context": minor
+"@shipfox/api-auth-dto": minor
+"@shipfox/api-runners": minor
+"@shipfox/api-runners-dto": minor
+"@shipfox/client-runners": patch
+"@shipfox/runner-orchestration": patch
+"@shipfox/runner-protocol": minor
+---
+
+Adds runner registration sessions with bounded label contracts, session-token auth, and lease-token heartbeat ownership.

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -20,6 +20,8 @@ AUTH_JWT_EXPIRES_IN=15m
 # Job lease capability token (job-scoped, HS256) — minted by Scheduling, verified by Orchestration
 AUTH_JOB_LEASE_TOKEN_SECRET=dev-only-lease-secret-change-me
 # AUTH_JOB_LEASE_TOKEN_EXPIRES_IN=90m
+AUTH_RUNNER_SESSION_TOKEN_SECRET=dev-only-runner-session-secret-change-me
+# AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN=1h
 
 # Mailer (console = log to stdout, smtp = real SMTP)
 MAILER_TRANSPORT=console

--- a/apps/runner/.env
+++ b/apps/runner/.env
@@ -1,1 +1,2 @@
 SHIPFOX_API_URL=http://localhost:16101
+SHIPFOX_RUNNER_LABELS=local

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -22,6 +22,11 @@ logs or step errors. A setup failure (missing `git`, a denied credential, or an
 unreachable provider) fails the job before any step runs, with a machine-readable
 reason recorded on the step.
 
+At startup, the runner exchanges `SHIPFOX_RUNNER_TOKEN` for a short-lived runner
+session token using `SHIPFOX_RUNNER_LABELS`. Job polling uses that session token.
+Heartbeat, step, checkout, and log calls use the per-job lease token returned by
+the claim response.
+
 ### `SHIPFOX_RUNNER_WORKSPACE_ROOT` (optional)
 
 Parent directory under which per-job working directories are created.
@@ -43,7 +48,8 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SHIPFOX_API_URL` | — | Base URL of the Shipfox API. |
-| `SHIPFOX_RUNNER_TOKEN` | `static-poc-token` | Bearer token used to authenticate with the API. |
+| `SHIPFOX_RUNNER_TOKEN` | — | Registration token copied from the workspace runner settings. The runner exchanges it for a session token at startup. |
+| `SHIPFOX_RUNNER_LABELS` | — | Comma-separated labels registered on this runner session, such as `linux,x64,self-hosted`. |
 | `SHIPFOX_RUNNER_WORKSPACE_ROOT` | OS temp dir | Parent directory for per-job workspaces (see above). |
 | `SHIPFOX_POLL_INTERVAL_MS` | `5000` | Base poll interval when requesting jobs. |
 | `SHIPFOX_POLL_MAX_INTERVAL_MS` | `30000` | Maximum backoff interval when no jobs are available. |

--- a/libs/api/auth-context/src/index.ts
+++ b/libs/api/auth-context/src/index.ts
@@ -1,8 +1,9 @@
-import type {JobLeaseTokenClaims} from '@shipfox/api-auth-dto';
+import type {JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
 import type {WorkspaceRole} from '@shipfox/api-workspaces-dto';
 
 export const AUTH_USER = 'user';
 export const AUTH_RUNNER_TOKEN = 'runner-token';
+export const AUTH_RUNNER_SESSION = 'runner-session';
 export const AUTH_LEASED_JOB = 'leased-job';
 export const AUTH_PROVISIONER_TOKEN = 'provisioner-token';
 
@@ -48,12 +49,14 @@ export interface ProvisionerContext {
 }
 
 export type LeasedJobContext = JobLeaseTokenClaims;
+export type RunnerSessionContext = RunnerSessionTokenClaims;
 
 type RequestWithContext = object;
 
 const USER_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/user');
 const LEASED_JOB_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/leased-job');
 const PROVISIONER_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/provisioner');
+const RUNNER_SESSION_CONTEXT_KEY = Symbol.for('@shipfox/api-auth-context/runner-session');
 
 export function setUserContext(request: RequestWithContext, context: UserContext): void {
   (request as Record<symbol, unknown>)[USER_CONTEXT_KEY] = context;
@@ -112,6 +115,29 @@ export function requireLeasedJobContext(request: RequestWithContext): LeasedJobC
   const context = getLeasedJobContext(request);
   if (!context) {
     throw new Error('Leased job context is not available on this request');
+  }
+  return context;
+}
+
+export function setRunnerSessionContext(
+  request: RequestWithContext,
+  context: RunnerSessionContext,
+): void {
+  (request as Record<symbol, unknown>)[RUNNER_SESSION_CONTEXT_KEY] = context;
+}
+
+export function getRunnerSessionContext(request: RequestWithContext): RunnerSessionContext | null {
+  return (
+    ((request as Record<symbol, unknown>)[RUNNER_SESSION_CONTEXT_KEY] as
+      | RunnerSessionContext
+      | undefined) ?? null
+  );
+}
+
+export function requireRunnerSessionContext(request: RequestWithContext): RunnerSessionContext {
+  const context = getRunnerSessionContext(request);
+  if (!context) {
+    throw new Error('Runner session context is not available on this request');
   }
   return context;
 }

--- a/libs/api/auth-dto/src/schemas/index.ts
+++ b/libs/api/auth-dto/src/schemas/index.ts
@@ -63,4 +63,9 @@ export {
   type JobLeaseTokenClaims,
   jobLeaseTokenClaimsSchema,
 } from './job-lease-token.js';
+export {
+  RUNNER_SESSION_TOKEN_AUDIENCE,
+  type RunnerSessionTokenClaims,
+  runnerSessionTokenClaimsSchema,
+} from './runner-session-token.js';
 export {type UserDto, userDtoSchema, userStatusSchema} from './user.js';

--- a/libs/api/auth-dto/src/schemas/job-lease-token.ts
+++ b/libs/api/auth-dto/src/schemas/job-lease-token.ts
@@ -12,7 +12,7 @@ export const jobLeaseTokenClaimsSchema = z.object({
   runId: z.string().uuid(),
   projectId: z.string().uuid(),
   workspaceId: z.string().uuid(),
-  runnerTokenId: z.string().uuid(),
+  runnerSessionId: z.string().uuid(),
   aud: z.literal(JOB_LEASE_TOKEN_AUDIENCE),
   iat: z.number().int(),
   exp: z.number().int(),

--- a/libs/api/auth-dto/src/schemas/runner-session-token.ts
+++ b/libs/api/auth-dto/src/schemas/runner-session-token.ts
@@ -1,0 +1,20 @@
+import {z} from 'zod';
+
+/**
+ * Audience claim binding a token to runner-session data-plane auth. Distinct from
+ * job lease tokens (separate secret) so session tokens and per-job capabilities
+ * stay non-interchangeable.
+ */
+export const RUNNER_SESSION_TOKEN_AUDIENCE = 'runner-session';
+
+export const runnerSessionTokenClaimsSchema = z.object({
+  runnerSessionId: z.string().uuid(),
+  workspaceId: z.string().uuid(),
+  scope: z.literal('workspace'),
+  labels: z.array(z.string()).min(1),
+  aud: z.literal(RUNNER_SESSION_TOKEN_AUDIENCE),
+  iat: z.number().int(),
+  exp: z.number().int(),
+});
+
+export type RunnerSessionTokenClaims = z.infer<typeof runnerSessionTokenClaimsSchema>;

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -45,6 +45,8 @@ Required environment:
 | `AUTH_JWT_EXPIRES_IN` | `15m` | Access token lifetime. |
 | `AUTH_JOB_LEASE_TOKEN_SECRET` | none | Secret used to sign and verify job lease tokens. |
 | `AUTH_JOB_LEASE_TOKEN_EXPIRES_IN` | `90m` | Job lease token lifetime. |
+| `AUTH_RUNNER_SESSION_TOKEN_SECRET` | none | Secret used to sign and verify runner session tokens. |
+| `AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN` | `1h` | Runner session token lifetime. |
 | `AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS` | `14` | Refresh token and cookie lifetime. |
 | `AUTH_REFRESH_ROTATION_GRACE_SECONDS` | `30` | Grace window for accepting a just-rotated refresh token during concurrent refreshes. |
 | `AUTH_REFRESH_COOKIE_NAME` | `shipfox_refresh_token` | HTTP cookie name for refresh sessions. |
@@ -58,13 +60,13 @@ Required environment:
 
 ## Security model
 
-The module issues two kinds of bearer token, both presented as
-`Authorization: Bearer <token>`. Both are **stateless**: each is signed with
+The module issues three kinds of bearer token, all presented as
+`Authorization: Bearer <token>`. All are **stateless**: each is signed with
 HMAC-SHA256 and verified by checking its signature and expiry alone, with no
 database read on the request path. They differ in who they authenticate and what
 they grant, and the stateless tradeoff is accepted for a different reason in each
-case. Each is signed with its own dedicated secret, so neither token type can be
-used in place of the other.
+case. Each token class has a dedicated secret and audience, so one token type
+cannot be used in place of another.
 
 ### User session token
 
@@ -87,6 +89,32 @@ used in place of the other.
   membership change only takes effect on the next refresh. Accepted because the
   token is short-lived, so the staleness window is bounded and a per-request
   membership read is avoided.
+
+### Runner session token
+
+A runner session token is the data-plane identity for a running manual runner.
+The runner exchanges its long-lived registration token at startup, then uses the
+short-lived session token to claim jobs. Heartbeat and step/report/log operations
+use the per-job lease token instead.
+
+- **Scope — one workspace's runner data plane.** The token names one runner
+  session, one workspace, the fixed `workspace` scope, and the session's immutable
+  label set. It can claim jobs for that workspace. It is not a user identity and
+  does not authorize dashboard management routes.
+- **Labels are self-attested.** A holder of a valid registration token chooses
+  the labels it registers with. The labels are immutable after registration and
+  signed into the session token, but they are not an authorization boundary in v1.
+  Treat the registration token's workspace scope as the trust boundary.
+- **Mechanics.** Signed with HMAC-SHA256 using `AUTH_RUNNER_SESSION_TOKEN_SECRET`
+  and the `runner-session` audience. The default lifetime is `1h`, short enough
+  to bound the residual claim window when a registration token is revoked.
+- **Tradeoff — no per-session revocation in v1.** Claim stays stateless and does
+  not check the runner session row on each poll. Revoking the registration token
+  blocks new sessions, but an existing session can keep claiming until
+  `AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN` elapses. If it claimed a job just before
+  session expiry, that job can keep heartbeating until its already-issued
+  `AUTH_JOB_LEASE_TOKEN_EXPIRES_IN` lease expires. With the defaults, the
+  worst-case residual window is about 2.5 hours.
 
 ### Job lease token
 
@@ -174,7 +202,9 @@ It also exports lower-level pieces for tests and advanced integration:
 - `routes`: the `/auth` route group.
 - `db` and `migrationsPath`: the Drizzle database handle and migration path.
 - `createJwtAuthMethod()`: the Fastify auth method for user JWTs.
+- `createRunnerSessionAuthMethod()`: the Fastify auth method for runner session tokens.
 - `createLeaseTokenAuthMethod()`: the Fastify auth method for job lease tokens.
+- `issueRunnerSessionToken(claims)` / `verifyRunnerSessionToken(token)`: mint and verify runner session tokens.
 - `issueJobLeaseToken(claims)` / `verifyJobLeaseToken(token)`: mint and verify job lease tokens.
 - `getClientContext(request)`: reads the authenticated user context from a Fastify request.
 - Entity types: `User`, `UserStatus`, `RefreshToken`, `EmailVerification`, and `PasswordReset`.

--- a/libs/api/auth/src/config.ts
+++ b/libs/api/auth/src/config.ts
@@ -16,6 +16,13 @@ export const config = createConfig({
     desc: 'How long a job lease token stays valid. Set it longer than the longest job (JOB_MAX_DURATION is 60 minutes) plus a safety margin.',
     default: '90m',
   }),
+  AUTH_RUNNER_SESSION_TOKEN_SECRET: str({
+    desc: 'Secret used to sign and verify runner session tokens. Required, with no default, so startup fails when it is missing.',
+  }),
+  AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN: str({
+    desc: 'How long a runner session token stays valid. A revoked registration token can leave existing sessions usable until this lifetime ends.',
+    default: '1h',
+  }),
   AUTH_REFRESH_TOKEN_EXPIRES_IN_DAYS: num({
     desc: 'How many days a refresh token stays valid before the user must sign in again.',
     default: 14,

--- a/libs/api/auth/src/core/job-lease-token.test.ts
+++ b/libs/api/auth/src/core/job-lease-token.test.ts
@@ -11,7 +11,7 @@ function claims() {
     runId: crypto.randomUUID(),
     projectId: crypto.randomUUID(),
     workspaceId: crypto.randomUUID(),
-    runnerTokenId: crypto.randomUUID(),
+    runnerSessionId: crypto.randomUUID(),
   };
 }
 
@@ -27,7 +27,7 @@ describe('job-lease-token', () => {
     expect(verified?.runId).toBe(input.runId);
     expect(verified?.projectId).toBe(input.projectId);
     expect(verified?.workspaceId).toBe(input.workspaceId);
-    expect(verified?.runnerTokenId).toBe(input.runnerTokenId);
+    expect(verified?.runnerSessionId).toBe(input.runnerSessionId);
     expect(verified?.aud).toBe(JOB_LEASE_TOKEN_AUDIENCE);
     expect(verified?.iat).toBeTypeOf('number');
     expect(verified?.exp).toBeGreaterThan(verified?.iat ?? 0);
@@ -67,7 +67,7 @@ describe('job-lease-token', () => {
       runId: '018f6b1e-7e2a-7b3c-8d4e-5f6a7b8c9d0f',
       projectId: crypto.randomUUID(),
       workspaceId: crypto.randomUUID(),
-      runnerTokenId: crypto.randomUUID(),
+      runnerSessionId: crypto.randomUUID(),
     };
 
     const token = await issueJobLeaseToken(input);

--- a/libs/api/auth/src/core/job-lease-token.ts
+++ b/libs/api/auth/src/core/job-lease-token.ts
@@ -17,7 +17,7 @@ export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Prom
       runId: claims.runId,
       projectId: claims.projectId,
       workspaceId: claims.workspaceId,
-      runnerTokenId: claims.runnerTokenId,
+      runnerSessionId: claims.runnerSessionId,
     },
     secret: config.AUTH_JOB_LEASE_TOKEN_SECRET,
     expiresIn: config.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN,

--- a/libs/api/auth/src/core/runner-session-token.test.ts
+++ b/libs/api/auth/src/core/runner-session-token.test.ts
@@ -1,0 +1,122 @@
+import {JOB_LEASE_TOKEN_AUDIENCE, RUNNER_SESSION_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
+import {signHs256} from '@shipfox/node-jwt';
+import {generateKeyPair, SignJWT} from 'jose';
+import {issueJobLeaseToken, verifyJobLeaseToken} from './job-lease-token.js';
+import {issueRunnerSessionToken, verifyRunnerSessionToken} from './runner-session-token.js';
+
+const SECRET = process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET ?? 'test-runner-session-secret';
+
+function claims() {
+  return {
+    runnerSessionId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    scope: 'workspace' as const,
+    labels: ['linux', 'x64'],
+  };
+}
+
+describe('runner-session-token', () => {
+  test('issues a token that verifies round-trip', async () => {
+    const input = claims();
+
+    const token = await issueRunnerSessionToken(input);
+    const verified = await verifyRunnerSessionToken(token);
+
+    expect(verified).not.toBeNull();
+    expect(verified?.runnerSessionId).toBe(input.runnerSessionId);
+    expect(verified?.workspaceId).toBe(input.workspaceId);
+    expect(verified?.scope).toBe(input.scope);
+    expect(verified?.labels).toEqual(input.labels);
+    expect(verified?.aud).toBe(RUNNER_SESSION_TOKEN_AUDIENCE);
+    expect(verified?.iat).toBeTypeOf('number');
+    expect(verified?.exp).toBeGreaterThan(verified?.iat ?? 0);
+  });
+
+  test('rejects a job lease token', async () => {
+    const leaseToken = await issueJobLeaseToken({
+      jobId: crypto.randomUUID(),
+      runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      workspaceId: crypto.randomUUID(),
+      runnerSessionId: crypto.randomUUID(),
+    });
+
+    const verified = await verifyRunnerSessionToken(leaseToken);
+
+    expect(verified).toBeNull();
+  });
+
+  test('job lease verifier rejects a runner session token', async () => {
+    const sessionToken = await issueRunnerSessionToken(claims());
+
+    const verified = await verifyJobLeaseToken(sessionToken);
+
+    expect(verified).toBeNull();
+  });
+
+  test('returns null for a token signed with a different secret', async () => {
+    const token = await signHs256({
+      payload: claims(),
+      secret: 'a-different-secret',
+      expiresIn: '1h',
+      audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+    });
+
+    const verified = await verifyRunnerSessionToken(token);
+
+    expect(verified).toBeNull();
+  });
+
+  test('returns null for an expired token', async () => {
+    const token = await signHs256({
+      payload: claims(),
+      secret: SECRET,
+      expiresIn: '-1s',
+      audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+    });
+
+    const verified = await verifyRunnerSessionToken(token);
+
+    expect(verified).toBeNull();
+  });
+
+  test('returns null for an RS256-signed token', async () => {
+    const {privateKey} = await generateKeyPair('RS256');
+    const token = await new SignJWT(claims())
+      .setProtectedHeader({alg: 'RS256'})
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .setAudience(RUNNER_SESSION_TOKEN_AUDIENCE)
+      .sign(privateKey);
+
+    const verified = await verifyRunnerSessionToken(token);
+
+    expect(verified).toBeNull();
+  });
+
+  test('returns null for a token with the wrong audience', async () => {
+    const token = await signHs256({
+      payload: claims(),
+      secret: SECRET,
+      expiresIn: '1h',
+      audience: JOB_LEASE_TOKEN_AUDIENCE,
+    });
+
+    const verified = await verifyRunnerSessionToken(token);
+
+    expect(verified).toBeNull();
+  });
+
+  test('returns null for a token whose claims fail the schema', async () => {
+    const token = await signHs256({
+      payload: {...claims(), labels: []},
+      secret: SECRET,
+      expiresIn: '1h',
+      audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+    });
+
+    const verified = await verifyRunnerSessionToken(token);
+
+    expect(verified).toBeNull();
+  });
+});

--- a/libs/api/auth/src/core/runner-session-token.ts
+++ b/libs/api/auth/src/core/runner-session-token.ts
@@ -1,0 +1,48 @@
+import {
+  RUNNER_SESSION_TOKEN_AUDIENCE,
+  type RunnerSessionTokenClaims,
+  runnerSessionTokenClaimsSchema,
+} from '@shipfox/api-auth-dto';
+import {signHs256, verifyHs256} from '@shipfox/node-jwt';
+import {config} from '#config.js';
+import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
+
+// `aud`, `iat` and `exp` are set by the codec (jose); callers supply the business ids only.
+export type IssueRunnerSessionTokenParams = Omit<RunnerSessionTokenClaims, 'aud' | 'iat' | 'exp'>;
+
+export async function issueRunnerSessionToken(
+  claims: IssueRunnerSessionTokenParams,
+): Promise<string> {
+  const token = await signHs256({
+    payload: {
+      runnerSessionId: claims.runnerSessionId,
+      workspaceId: claims.workspaceId,
+      scope: claims.scope,
+      labels: claims.labels,
+    },
+    secret: config.AUTH_RUNNER_SESSION_TOKEN_SECRET,
+    expiresIn: config.AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN,
+    audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+  });
+  recordTokenIssued('runner_session');
+  return token;
+}
+
+/** Returns the claims on success, or `null` for any invalid input — never throws. */
+export async function verifyRunnerSessionToken(
+  token: string,
+): Promise<RunnerSessionTokenClaims | null> {
+  try {
+    const claims = await verifyHs256({
+      token,
+      secret: config.AUTH_RUNNER_SESSION_TOKEN_SECRET,
+      schema: runnerSessionTokenClaimsSchema,
+      audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+    });
+    recordTokenVerified('runner_session', 'ok');
+    return claims;
+  } catch {
+    recordTokenVerified('runner_session', 'rejected');
+    return null;
+  }
+}

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -11,6 +11,7 @@ import {migrationsPath} from '#db/migrations.js';
 import {authOutbox} from '#db/schema/outbox.js';
 import {createJwtAuthMethod} from '#presentation/auth/jwt-auth.js';
 import {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js';
+import {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
 import {authE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {authRoutes} from '#presentation/routes/index.js';
 import {
@@ -18,17 +19,22 @@ import {
   onPasswordResetSendRequested,
 } from '#presentation/subscribers/index.js';
 
-export type {JobLeaseTokenClaims} from '@shipfox/api-auth-dto';
+export type {JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
 export type {User, UserStatus} from '#core/entities/user.js';
 export {issueJobLeaseToken, verifyJobLeaseToken} from '#core/job-lease-token.js';
+export {
+  issueRunnerSessionToken,
+  verifyRunnerSessionToken,
+} from '#core/runner-session-token.js';
 export {createLeaseTokenAuthMethod} from '#presentation/auth/lease-token-auth.js';
+export {createRunnerSessionAuthMethod} from '#presentation/auth/runner-session-auth.js';
 
 const subscriber = subscriberFactory<AuthEventMap>();
 
 export const authModule: ShipfoxModule = {
   name: 'auth',
   database: {db, migrationsPath},
-  auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod()],
+  auth: [createJwtAuthMethod(), createLeaseTokenAuthMethod(), createRunnerSessionAuthMethod()],
   routes: [authRoutes],
   e2eRoutes: [authE2eRoutes],
   publishers: [{name: 'auth', table: authOutbox, db, eventSchemas: authEventSchemas}],

--- a/libs/api/auth/src/metrics/instance.ts
+++ b/libs/api/auth/src/metrics/instance.ts
@@ -1,6 +1,6 @@
 import {instanceMetrics} from '@shipfox/node-opentelemetry';
 
-export type AuthTokenType = 'session' | 'job_lease';
+export type AuthTokenType = 'session' | 'job_lease' | 'runner_session';
 export type AuthTokenVerificationOutcome = 'ok' | 'rejected';
 export type AuthTokenRefreshOutcome = 'rotated' | 'grace' | 'rejected';
 

--- a/libs/api/auth/src/presentation/auth/lease-token-auth.ts
+++ b/libs/api/auth/src/presentation/auth/lease-token-auth.ts
@@ -7,8 +7,8 @@ import {verifyJobLeaseToken} from '#core/job-lease-token.js';
  * every runner request to exactly one job. `runId`/`workspaceId` are carried for
  * consumers but are NOT verified against the database here.
  *
- * Revocation tradeoff: `runnerTokenId` is carried in the claims but is not checked
- * against the runner-token table, so a lease minted before its runner token is
+ * Revocation tradeoff: `runnerSessionId` is carried in the claims but is not checked
+ * against runner-session storage, so a lease minted before its registration token is
  * revoked stays usable until it expires (`AUTH_JOB_LEASE_TOKEN_EXPIRES_IN`, 90m).
  * Accepted deliberately for a short-lived, job-scoped capability token; tightening
  * this would mean a per-request DB lookup on the hot status-reporting path. See the

--- a/libs/api/auth/src/presentation/auth/runner-session-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/runner-session-auth.test.ts
@@ -1,12 +1,12 @@
-import {getLeasedJobContext} from '@shipfox/api-auth-context';
-import {JOB_LEASE_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
+import {getRunnerSessionContext} from '@shipfox/api-auth-context';
+import {RUNNER_SESSION_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
 import type {FastifyInstance} from 'fastify';
 import Fastify from 'fastify';
 import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
-import {issueJobLeaseToken} from '#core/job-lease-token.js';
-import {createLeaseTokenAuthMethod} from './lease-token-auth.js';
+import {issueRunnerSessionToken} from '#core/runner-session-token.js';
+import {createRunnerSessionAuthMethod} from './runner-session-auth.js';
 
-describe('lease-token-auth', () => {
+describe('runner-session-auth', () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
@@ -14,13 +14,13 @@ describe('lease-token-auth', () => {
     app.setValidatorCompiler(validatorCompiler);
     app.setSerializerCompiler(serializerCompiler);
 
-    const authMethod = createLeaseTokenAuthMethod();
+    const authMethod = createRunnerSessionAuthMethod();
     app.addHook('onRequest', async (request, reply) => {
       await authMethod.authenticate(request, reply);
     });
 
     app.get('/protected', (request) => {
-      return {leasedJob: getLeasedJobContext(request)};
+      return {runnerSession: getRunnerSessionContext(request)};
     });
     await app.ready();
   });
@@ -29,15 +29,14 @@ describe('lease-token-auth', () => {
     await app.close();
   });
 
-  test('valid lease token sets leased job context on the request', async () => {
+  test('valid session token sets runner session context on the request', async () => {
     const claims = {
-      jobId: crypto.randomUUID(),
-      runId: crypto.randomUUID(),
-      projectId: crypto.randomUUID(),
-      workspaceId: crypto.randomUUID(),
       runnerSessionId: crypto.randomUUID(),
+      workspaceId: crypto.randomUUID(),
+      scope: 'workspace' as const,
+      labels: ['linux', 'x64'],
     };
-    const token = await issueJobLeaseToken(claims);
+    const token = await issueRunnerSessionToken(claims);
 
     const res = await app.inject({
       method: 'GET',
@@ -46,9 +45,9 @@ describe('lease-token-auth', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().leasedJob).toMatchObject({
+    expect(res.json().runnerSession).toMatchObject({
       ...claims,
-      aud: JOB_LEASE_TOKEN_AUDIENCE,
+      aud: RUNNER_SESSION_TOKEN_AUDIENCE,
     });
   });
 });

--- a/libs/api/auth/src/presentation/auth/runner-session-auth.ts
+++ b/libs/api/auth/src/presentation/auth/runner-session-auth.ts
@@ -1,0 +1,26 @@
+import {AUTH_RUNNER_SESSION, setRunnerSessionContext} from '@shipfox/api-auth-context';
+import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
+import {verifyRunnerSessionToken} from '#core/runner-session-token.js';
+
+export function createRunnerSessionAuthMethod(): AuthMethod {
+  return {
+    name: AUTH_RUNNER_SESSION,
+    authenticate: async (request) => {
+      const token = extractBearerToken(request.headers.authorization);
+      if (!token) {
+        throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {
+          status: 401,
+        });
+      }
+
+      const claims = await verifyRunnerSessionToken(token);
+      if (!claims) {
+        throw new ClientError('Invalid or expired runner session token', 'unauthorized', {
+          status: 401,
+        });
+      }
+
+      setRunnerSessionContext(request, claims);
+    },
+  };
+}

--- a/libs/api/auth/test/env.ts
+++ b/libs/api/auth/test/env.ts
@@ -6,4 +6,5 @@ process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS = '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
+process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
 process.env.TZ = 'UTC';

--- a/libs/api/logs/test/env.ts
+++ b/libs/api/logs/test/env.ts
@@ -6,6 +6,7 @@ process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS = '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
+process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
 
 // Small accrual budget so cap/budget tests use tiny payloads: base 100 bytes,
 // rate 60 bytes/min (1 byte/second).

--- a/libs/api/logs/test/fixtures/lease-token.ts
+++ b/libs/api/logs/test/fixtures/lease-token.ts
@@ -21,7 +21,7 @@ export function mintLeaseToken(params: MintLeaseTokenParams): Promise<string> {
       runId: params.runId ?? crypto.randomUUID(),
       projectId: params.projectId ?? crypto.randomUUID(),
       workspaceId: params.workspaceId ?? crypto.randomUUID(),
-      runnerTokenId: crypto.randomUUID(),
+      runnerSessionId: crypto.randomUUID(),
     },
     secret: params.secret ?? SECRET,
     expiresIn: params.expiresIn ?? '90m',

--- a/libs/api/runners-dto/src/index.ts
+++ b/libs/api/runners-dto/src/index.ts
@@ -9,8 +9,12 @@ export {
   heartbeatResponseSchema,
   type ListRunnerTokensResponseDto,
   listRunnerTokensResponseSchema,
+  type RegisterRunnerBodyDto,
+  type RegisterRunnerResponseDto,
   type RevokeRunnerTokenResponseDto,
   type RunnerTokenDto,
+  registerRunnerBodySchema,
+  registerRunnerResponseSchema,
   revokeRunnerTokenResponseSchema,
   runnerTokenDtoSchema,
 } from '#schemas/index.js';
@@ -27,3 +31,4 @@ export {
   runnerJobQueuedEventSchema,
   runnersEventSchemas,
 } from './events.js';
+export {canonicalizeRunnerLabels} from './labels.js';

--- a/libs/api/runners-dto/src/labels.test.ts
+++ b/libs/api/runners-dto/src/labels.test.ts
@@ -1,0 +1,23 @@
+import {canonicalizeRunnerLabels} from './labels.js';
+
+describe('canonicalizeRunnerLabels', () => {
+  it('trims, lowercases, dedupes, and sorts labels', () => {
+    const result = canonicalizeRunnerLabels([' Linux ', 'x64', 'linux', 'ARM64']);
+
+    expect(result).toEqual(['arm64', 'linux', 'x64']);
+  });
+
+  it('drops empty labels after trimming', () => {
+    const result = canonicalizeRunnerLabels([' ', '\t', 'linux']);
+
+    expect(result).toEqual(['linux']);
+  });
+
+  it('returns stable ordering regardless of input order', () => {
+    const first = canonicalizeRunnerLabels(['z', 'a', 'm']);
+    const second = canonicalizeRunnerLabels(['m', 'z', 'a']);
+
+    expect(first).toEqual(['a', 'm', 'z']);
+    expect(second).toEqual(first);
+  });
+});

--- a/libs/api/runners-dto/src/labels.ts
+++ b/libs/api/runners-dto/src/labels.ts
@@ -1,0 +1,10 @@
+export function canonicalizeRunnerLabels(labels: string[]): string[] {
+  const canonical = new Set<string>();
+
+  for (const label of labels) {
+    const value = label.trim().toLowerCase();
+    if (value.length > 0) canonical.add(value);
+  }
+
+  return [...canonical].sort();
+}

--- a/libs/api/runners-dto/src/schemas/index.ts
+++ b/libs/api/runners-dto/src/schemas/index.ts
@@ -1,6 +1,13 @@
 export {type ClaimedJobResponseDto, claimedJobResponseSchema} from './claim-job.js';
 export {type HeartbeatResponseDto, heartbeatResponseSchema} from './heartbeat.js';
 export {
+  type RegisterRunnerBodyDto,
+  type RegisterRunnerResponseDto,
+  registerRunnerBodySchema,
+  registerRunnerResponseSchema,
+  runnerLabelSchema,
+} from './register.js';
+export {
   type CreateRunnerTokenBodyDto,
   type CreateRunnerTokenResponseDto,
   createRunnerTokenBodySchema,

--- a/libs/api/runners-dto/src/schemas/register.ts
+++ b/libs/api/runners-dto/src/schemas/register.ts
@@ -1,0 +1,21 @@
+import {z} from 'zod';
+
+export const runnerLabelSchema = z
+  .string()
+  .min(1)
+  .max(63)
+  .regex(/^[a-z0-9][a-z0-9._-]*$/i);
+
+export const registerRunnerBodySchema = z.object({
+  labels: z.array(runnerLabelSchema).min(1).max(50),
+});
+
+export const registerRunnerResponseSchema = z.object({
+  session_token: z.string().min(1),
+  session_id: z.string().uuid(),
+  mode: z.enum(['manual', 'ephemeral']),
+  max_claims: z.number().int().positive().nullable(),
+});
+
+export type RegisterRunnerBodyDto = z.infer<typeof registerRunnerBodySchema>;
+export type RegisterRunnerResponseDto = z.infer<typeof registerRunnerResponseSchema>;

--- a/libs/api/runners/drizzle/0001_runner_tokens.sql
+++ b/libs/api/runners/drizzle/0001_runner_tokens.sql
@@ -1,3 +1,5 @@
+CREATE TYPE "public"."runners_runner_session_scope" AS ENUM('workspace');
+--> statement-breakpoint
 CREATE TABLE "runners_runner_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
@@ -13,7 +15,7 @@ CREATE TABLE "runners_runner_tokens" (
 CREATE TABLE "runners_runner_sessions" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
-	"scope" text DEFAULT 'workspace' NOT NULL,
+	"scope" "runners_runner_session_scope" DEFAULT 'workspace' NOT NULL,
 	"registration_token_id" uuid NOT NULL,
 	"labels" text[] NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/libs/api/runners/drizzle/0001_runner_tokens.sql
+++ b/libs/api/runners/drizzle/0001_runner_tokens.sql
@@ -10,9 +10,19 @@ CREATE TABLE "runners_runner_tokens" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_token_id" uuid DEFAULT uuidv7() NOT NULL;--> statement-breakpoint
+CREATE TABLE "runners_runner_sessions" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"scope" text DEFAULT 'workspace' NOT NULL,
+	"registration_token_id" uuid NOT NULL,
+	"labels" text[] NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_session_id" uuid DEFAULT uuidv7() NOT NULL;--> statement-breakpoint
 ALTER TABLE "runners_running_jobs" DROP COLUMN "runner_token";--> statement-breakpoint
-ALTER TABLE "runners_running_jobs" ALTER COLUMN "runner_token_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ALTER COLUMN "runner_session_id" DROP DEFAULT;--> statement-breakpoint
 CREATE INDEX "runners_pending_jobs_workspace_created_idx" ON "runners_pending_jobs" USING btree ("workspace_id","created_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_tokens_hashed_token_unique" ON "runners_runner_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_runner_tokens_workspace_id_idx" ON "runners_runner_tokens" USING btree ("workspace_id");--> statement-breakpoint

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -367,7 +367,8 @@
         },
         "scope": {
           "name": "scope",
-          "type": "text",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
           "primaryKey": false,
           "notNull": true,
           "default": "'workspace'"
@@ -500,7 +501,13 @@
       "isRLSEnabled": false
     }
   },
-  "enums": {},
+  "enums": {
+    "public.runners_runner_session_scope": {
+      "name": "runners_runner_session_scope",
+      "schema": "public",
+      "values": ["workspace"]
+    }
+  },
   "schemas": {},
   "sequences": {},
   "roles": {},

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -348,6 +348,65 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.runners_running_jobs": {
       "name": "runners_running_jobs",
       "schema": "",
@@ -383,8 +442,8 @@
           "primaryKey": false,
           "notNull": true
         },
-        "runner_token_id": {
-          "name": "runner_token_id",
+        "runner_session_id": {
+          "name": "runner_session_id",
           "type": "uuid",
           "primaryKey": false,
           "notNull": true

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -55,7 +55,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@shipfox/api-auth-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
+    "@shipfox/node-jwt": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/libs/api/runners/src/core/entities/runner-session.ts
+++ b/libs/api/runners/src/core/entities/runner-session.ts
@@ -1,0 +1,9 @@
+export interface RunnerSession {
+  id: string;
+  workspaceId: string;
+  scope: 'workspace';
+  registrationTokenId: string;
+  labels: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/runners/src/core/errors.ts
+++ b/libs/api/runners/src/core/errors.ts
@@ -11,3 +11,10 @@ export class RunnerTokenNotFoundError extends Error {
     this.name = 'RunnerTokenNotFoundError';
   }
 }
+
+export class EmptyRunnerLabelsError extends Error {
+  constructor() {
+    super('Runner labels cannot be empty');
+    this.name = 'EmptyRunnerLabelsError';
+  }
+}

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -1,6 +1,8 @@
+export type {RunnerSession} from './entities/runner-session.js';
 export type {RunnerToken} from './entities/runner-token.js';
 export {RunnerTokenNotFoundError, RunningJobNotFoundError} from './errors.js';
 export {type ClaimJobResult, claimJob} from './jobs.js';
+export {type RegisterRunnerSessionResult, registerRunnerSession} from './runner-sessions.js';
 export {
   createWorkspaceRunnerToken,
   listUsableRunnerTokens,

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -10,7 +10,7 @@ export interface ClaimJobResult {
 
 export async function claimJob(params: {
   workspaceId: string;
-  runnerTokenId: string;
+  runnerSessionId: string;
 }): Promise<ClaimJobResult | null> {
   const claimed = await claimPendingJob(params);
   if (!claimed) {
@@ -24,7 +24,7 @@ export async function claimJob(params: {
     runId: claimed.runId,
     projectId: claimed.projectId,
     workspaceId: params.workspaceId,
-    runnerTokenId: params.runnerTokenId,
+    runnerSessionId: params.runnerSessionId,
   });
 
   return {jobId: claimed.jobId, runId: claimed.runId, leaseToken};

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -1,0 +1,46 @@
+import {verifyRunnerSessionToken} from '@shipfox/api-auth';
+import {eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
+import {runnerTokenFactory} from '#test/index.js';
+import {EmptyRunnerLabelsError} from './errors.js';
+import {registerRunnerSession} from './runner-sessions.js';
+
+describe('registerRunnerSession', () => {
+  let workspaceId: string;
+  let registrationTokenId: string;
+
+  beforeEach(async () => {
+    await db().execute(sql`TRUNCATE runners_runner_sessions, runners_runner_tokens CASCADE`);
+    workspaceId = crypto.randomUUID();
+    const token = await runnerTokenFactory.create({workspaceId});
+    registrationTokenId = token.id;
+  });
+
+  it('canonicalizes labels, stores them, and embeds them in the session token', async () => {
+    const result = await registerRunnerSession({
+      registrationTokenId,
+      workspaceId,
+      labels: [' Linux ', 'x64', 'linux'],
+    });
+
+    expect(result.mode).toBe('manual');
+    expect(result.maxClaims).toBeNull();
+    expect(result.session.labels).toEqual(['linux', 'x64']);
+
+    const rows = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, result.session.id));
+    expect(rows[0]?.labels).toEqual(['linux', 'x64']);
+
+    const claims = await verifyRunnerSessionToken(result.sessionToken);
+    expect(claims?.labels).toEqual(['linux', 'x64']);
+  });
+
+  it('throws EmptyRunnerLabelsError when labels canonicalize to empty', async () => {
+    await expect(
+      registerRunnerSession({registrationTokenId, workspaceId, labels: [' ', '\t']}),
+    ).rejects.toBeInstanceOf(EmptyRunnerLabelsError);
+  });
+});

--- a/libs/api/runners/src/core/runner-sessions.ts
+++ b/libs/api/runners/src/core/runner-sessions.ts
@@ -1,0 +1,36 @@
+import {issueRunnerSessionToken} from '@shipfox/api-auth';
+import {canonicalizeRunnerLabels} from '@shipfox/api-runners-dto';
+import {createRunnerSession} from '#db/runner-sessions.js';
+import type {RunnerSession} from './entities/runner-session.js';
+import {EmptyRunnerLabelsError} from './errors.js';
+
+export interface RegisterRunnerSessionResult {
+  session: RunnerSession;
+  sessionToken: string;
+  mode: 'manual';
+  maxClaims: null;
+}
+
+export async function registerRunnerSession(params: {
+  registrationTokenId: string;
+  workspaceId: string;
+  labels: string[];
+}): Promise<RegisterRunnerSessionResult> {
+  const labels = canonicalizeRunnerLabels(params.labels);
+  if (labels.length === 0) throw new EmptyRunnerLabelsError();
+
+  const session = await createRunnerSession({
+    workspaceId: params.workspaceId,
+    scope: 'workspace',
+    registrationTokenId: params.registrationTokenId,
+    labels,
+  });
+  const sessionToken = await issueRunnerSessionToken({
+    runnerSessionId: session.id,
+    workspaceId: session.workspaceId,
+    scope: session.scope,
+    labels: session.labels,
+  });
+
+  return {session, sessionToken, mode: 'manual', maxClaims: null};
+}

--- a/libs/api/runners/src/db/db.ts
+++ b/libs/api/runners/src/db/db.ts
@@ -2,10 +2,11 @@ import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
+import {runnerSessions} from './schema/runner-sessions.js';
 import {runnerTokens} from './schema/runner-tokens.js';
 import {runningJobs} from './schema/running-jobs.js';
 
-export const schema = {pendingJobs, runnerTokens, runningJobs, runnersOutbox};
+export const schema = {pendingJobs, runnerSessions, runnerTokens, runningJobs, runnersOutbox};
 
 let _db: NodePgDatabase<typeof schema> | undefined;
 

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -10,6 +10,8 @@ export {
   recordHeartbeat,
   releaseJob,
 } from './jobs.js';
+export type {CreateRunnerSessionParams} from './runner-sessions.js';
+export {createRunnerSession} from './runner-sessions.js';
 export type {CreateRunnerTokenParams} from './runner-tokens.js';
 export {
   createRunnerToken,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
 import {claimJob, detectAndExpireStuckJobs} from '#core/jobs.js';
-import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
+import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {db} from './db.js';
 import {
   claimPendingJob,
@@ -24,7 +24,7 @@ import {runningJobs} from './schema/running-jobs.js';
 describe('enqueueJob', () => {
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_outbox CASCADE`,
     );
   });
 
@@ -100,21 +100,21 @@ describe('enqueueJob', () => {
 
 describe('claimPendingJob', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('emits runners.job.claimed carrying the claim instant on a real claim', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     const [running] = await db()
       .select()
@@ -132,7 +132,7 @@ describe('claimPendingJob', () => {
   });
 
   it('emits no claimed event when there is nothing to claim', async () => {
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(claimed).toBeNull();
     expect(
@@ -145,7 +145,7 @@ describe('claimPendingJob', () => {
 
   it('emits no claimed event when dropping an orphan pending row', async () => {
     const created = await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerSessionId});
     await db().insert(pendingJobs).values({
       workspaceId,
       jobId: created.jobId,
@@ -155,7 +155,7 @@ describe('claimPendingJob', () => {
     // Clear the initial claim's events so this assertion only covers the orphan claim.
     await db().delete(runnersOutbox);
 
-    const second = await claimPendingJob({workspaceId, runnerTokenId});
+    const second = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(second).toBeNull();
     expect(await db().select().from(runnersOutbox)).toHaveLength(0);
@@ -164,7 +164,7 @@ describe('claimPendingJob', () => {
   it('returns the job ids when a job is available', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
@@ -173,18 +173,18 @@ describe('claimPendingJob', () => {
   });
 
   it('returns null when no jobs are pending', async () => {
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(claimed).toBeNull();
   });
 
   it('only one caller wins when two claim concurrently', async () => {
-    const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
+    const otherRunnerSession = await runnerSessionFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
 
     const [claim1, claim2] = await Promise.all([
-      claimPendingJob({workspaceId, runnerTokenId}),
-      claimPendingJob({workspaceId, runnerTokenId: otherRunnerToken.id}),
+      claimPendingJob({workspaceId, runnerSessionId}),
+      claimPendingJob({workspaceId, runnerSessionId: otherRunnerSession.id}),
     ]);
 
     const claimed = [claim1, claim2].filter(Boolean);
@@ -195,7 +195,7 @@ describe('claimPendingJob', () => {
     const older = await pendingJobFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(claimed?.jobId).toBe(older.jobId);
   });
@@ -203,27 +203,27 @@ describe('claimPendingJob', () => {
   it('moves the job from pending to running', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    await claimPendingJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerSessionId});
 
     const pending = await db().select().from(pendingJobs);
     const running = await db().select().from(runningJobs);
     expect(pending).toHaveLength(0);
     expect(running).toHaveLength(1);
-    expect(running[0]?.runnerTokenId).toBe(runnerTokenId);
+    expect(running[0]?.runnerSessionId).toBe(runnerSessionId);
     expect(running[0]?.projectId).toBe(created.projectId);
   });
 
   it('does not claim jobs from another workspace', async () => {
     await pendingJobFactory.create({workspaceId: crypto.randomUUID()});
 
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(claimed).toBeNull();
   });
 
   it('drops an orphan pending row whose job is already running, without a poison loop', async () => {
     const created = await pendingJobFactory.create({workspaceId});
-    const first = await claimPendingJob({workspaceId, runnerTokenId});
+    const first = await claimPendingJob({workspaceId, runnerSessionId});
     expect(first?.jobId).toBe(created.jobId);
 
     // Simulate an enqueue retry that re-inserts a pending row after the claim.
@@ -234,7 +234,7 @@ describe('claimPendingJob', () => {
       projectId: created.projectId,
     });
 
-    const second = await claimPendingJob({workspaceId, runnerTokenId});
+    const second = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(second).toBeNull();
     expect(await db().select().from(pendingJobs)).toHaveLength(0);
@@ -245,7 +245,7 @@ describe('claimPendingJob', () => {
 
   it('claims a real pending job ahead of a newer orphan', async () => {
     const alreadyRunning = await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerSessionId});
 
     // A genuinely new pending job (older), then an orphan re-insert for the running job (newer).
     const real = await pendingJobFactory.create({workspaceId});
@@ -256,7 +256,7 @@ describe('claimPendingJob', () => {
       projectId: alreadyRunning.projectId,
     });
 
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     expect(claimed?.jobId).toBe(real.jobId);
   });
@@ -264,21 +264,21 @@ describe('claimPendingJob', () => {
 
 describe('claimJob', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens CASCADE`,
     );
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('mints a lease token whose claims match the claimed job', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimJob({workspaceId, runnerSessionId});
 
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
@@ -291,12 +291,12 @@ describe('claimJob', () => {
       runId: created.runId,
       projectId: created.projectId,
       workspaceId,
-      runnerTokenId,
+      runnerSessionId,
     });
   });
 
   it('returns null and mints no token when the queue is empty', async () => {
-    const claimed = await claimJob({workspaceId, runnerTokenId});
+    const claimed = await claimJob({workspaceId, runnerSessionId});
 
     expect(claimed).toBeNull();
   });
@@ -304,20 +304,20 @@ describe('claimJob', () => {
 
 describe('releaseJob', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('deletes the running row and writes no outbox event', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     const before = await db().select().from(runnersOutbox);
 
     await releaseJob({jobId: claimed?.jobId as string});
@@ -330,9 +330,9 @@ describe('releaseJob', () => {
     await expect(releaseJob({jobId: crypto.randomUUID()})).resolves.toBeUndefined();
   });
 
-  it('releases regardless of which runner token holds the lease', async () => {
+  it('releases regardless of which session holds the lease', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     // No token is passed: the workflow is authoritative over the lease.
     await releaseJob({jobId: claimed?.jobId as string});
@@ -342,7 +342,7 @@ describe('releaseJob', () => {
 
   it('also sweeps a lingering pending row for the same job', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     // An orphan pending row left by a post-claim enqueue retry.
     await db()
       .insert(pendingJobs)
@@ -362,17 +362,17 @@ describe('releaseJob', () => {
 
 describe('recordHeartbeat', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('returns cancel:false on a fresh row and bumps last_heartbeat_at', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     const before = await db()
       .select()
@@ -386,7 +386,7 @@ describe('recordHeartbeat', () => {
 
     const result = await recordHeartbeat({
       jobId: claimed?.jobId as string,
-      runnerTokenId,
+      runnerSessionId,
     });
 
     expect(result).toEqual({cancellationRequested: false});
@@ -402,33 +402,33 @@ describe('recordHeartbeat', () => {
 
   it('returns cancel:true after requestJobCancellation', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
 
     const result = await recordHeartbeat({
       jobId: claimed?.jobId as string,
-      runnerTokenId,
+      runnerSessionId,
     });
 
     expect(result).toEqual({cancellationRequested: true});
   });
 
   it('throws RunningJobNotFoundError when jobId is unknown', async () => {
-    await expect(recordHeartbeat({jobId: crypto.randomUUID(), runnerTokenId})).rejects.toThrow(
+    await expect(recordHeartbeat({jobId: crypto.randomUUID(), runnerSessionId})).rejects.toThrow(
       'Running job not found',
     );
   });
 
-  it('throws when jobId belongs to a different runner token', async () => {
-    const otherRunnerToken = await runnerTokenFactory.create({workspaceId});
+  it('throws when jobId belongs to a different session', async () => {
+    const otherRunnerSession = await runnerSessionFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     await expect(
       recordHeartbeat({
         jobId: claimed?.jobId as string,
-        runnerTokenId: otherRunnerToken.id,
+        runnerSessionId: otherRunnerSession.id,
       }),
     ).rejects.toThrow('Running job not found');
   });
@@ -436,17 +436,17 @@ describe('recordHeartbeat', () => {
 
 describe('requestJobCancellation', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('sets cancellation_requested_at on a fresh row', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
 
@@ -459,7 +459,7 @@ describe('requestJobCancellation', () => {
 
   it('is idempotent: second call preserves the first timestamp', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
     const after1 = await db()
@@ -485,19 +485,19 @@ describe('requestJobCancellation', () => {
 
 describe('detectAndExpireStuckJobs', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   async function makeStaleJob(
     staleSeconds: number,
   ): Promise<{jobId: string; runId: string; projectId: string}> {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     await db()
       .update(runningJobs)
       .set({
@@ -667,7 +667,7 @@ describe('detectAndExpireStuckJobs', () => {
     // a deadlock loser rolls back, so either side may settle as rejected.
     await Promise.allSettled([
       detectAndExpireStuckJobs({thresholdSeconds: 180}),
-      claimPendingJob({workspaceId, runnerTokenId}),
+      claimPendingJob({workspaceId, runnerSessionId}),
     ]);
 
     // A follow-up tick finishes any reap that lost a deadlock race.
@@ -678,21 +678,21 @@ describe('detectAndExpireStuckJobs', () => {
     expect(await db().select().from(pendingJobs).where(eq(pendingJobs.jobId, jobId))).toHaveLength(
       0,
     );
-    expect(await claimPendingJob({workspaceId, runnerTokenId})).toBeNull();
+    expect(await claimPendingJob({workspaceId, runnerSessionId})).toBeNull();
   });
 });
 
 describe('getJobQueueDepth', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('reports zero on an empty queue', async () => {
@@ -704,7 +704,7 @@ describe('getJobQueueDepth', () => {
   it('counts pending and running jobs separately', async () => {
     await pendingJobFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerTokenId});
+    await claimPendingJob({workspaceId, runnerSessionId});
 
     const depth = await getJobQueueDepth();
 

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -67,7 +67,7 @@ export interface ClaimedJob {
 
 export async function claimPendingJob(params: {
   workspaceId: string;
-  runnerTokenId: string;
+  runnerSessionId: string;
 }): Promise<ClaimedJob | null> {
   return await db().transaction(async (tx) => {
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
@@ -97,7 +97,7 @@ export async function claimPendingJob(params: {
         jobId: row.jobId,
         runId: row.runId,
         projectId: row.projectId,
-        runnerTokenId: params.runnerTokenId,
+        runnerSessionId: params.runnerSessionId,
       })
       .onConflictDoNothing({target: runningJobs.jobId})
       .returning({claimedAt: runningJobs.startedAt});
@@ -211,13 +211,16 @@ export async function getJobQueueDepth(): Promise<{pending: number; running: num
 
 export async function recordHeartbeat(params: {
   jobId: string;
-  runnerTokenId: string;
+  runnerSessionId: string;
 }): Promise<{cancellationRequested: boolean}> {
   const updated = await db()
     .update(runningJobs)
     .set({lastHeartbeatAt: sql`now()`})
     .where(
-      and(eq(runningJobs.jobId, params.jobId), eq(runningJobs.runnerTokenId, params.runnerTokenId)),
+      and(
+        eq(runningJobs.jobId, params.jobId),
+        eq(runningJobs.runnerSessionId, params.runnerSessionId),
+      ),
     )
     .returning({cancellationRequestedAt: runningJobs.cancellationRequestedAt});
 

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -1,0 +1,28 @@
+import type {RunnerSession} from '#core/entities/runner-session.js';
+import {db} from './db.js';
+import {runnerSessions, toRunnerSession} from './schema/runner-sessions.js';
+
+export interface CreateRunnerSessionParams {
+  workspaceId: string;
+  scope: 'workspace';
+  registrationTokenId: string;
+  labels: string[];
+}
+
+export async function createRunnerSession(
+  params: CreateRunnerSessionParams,
+): Promise<RunnerSession> {
+  const rows = await db()
+    .insert(runnerSessions)
+    .values({
+      workspaceId: params.workspaceId,
+      scope: params.scope,
+      registrationTokenId: params.registrationTokenId,
+      labels: params.labels,
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) throw new Error('Insert returned no rows');
+  return toRunnerSession(row);
+}

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -1,12 +1,14 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import type {RunnerSession} from '#core/entities/runner-session.js';
 import {pgTable} from './common.js';
+
+export const runnerSessionScopeEnum = pgEnum('runners_runner_session_scope', ['workspace']);
 
 export const runnerSessions = pgTable('runner_sessions', {
   id: uuidv7PrimaryKey(),
   workspaceId: uuid('workspace_id').notNull(),
-  scope: text('scope').notNull().default('workspace'),
+  scope: runnerSessionScopeEnum('scope').notNull().default('workspace'),
   registrationTokenId: uuid('registration_token_id').notNull(),
   labels: text('labels').array().notNull(),
   createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -1,0 +1,33 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import type {RunnerSession} from '#core/entities/runner-session.js';
+import {pgTable} from './common.js';
+
+export const runnerSessions = pgTable('runner_sessions', {
+  id: uuidv7PrimaryKey(),
+  workspaceId: uuid('workspace_id').notNull(),
+  scope: text('scope').notNull().default('workspace'),
+  registrationTokenId: uuid('registration_token_id').notNull(),
+  labels: text('labels').array().notNull(),
+  createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+});
+
+export type RunnerSessionDb = typeof runnerSessions.$inferSelect;
+export type RunnerSessionInsertDb = typeof runnerSessions.$inferInsert;
+
+export function toRunnerSession(row: RunnerSessionDb): RunnerSession {
+  if (row.scope !== 'workspace') {
+    throw new Error(`Unexpected runner session scope: ${row.scope}`);
+  }
+
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    scope: row.scope,
+    registrationTokenId: row.registrationTokenId,
+    labels: row.labels,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/runners/src/db/schema/running-jobs.ts
+++ b/libs/api/runners/src/db/schema/running-jobs.ts
@@ -10,7 +10,7 @@ export const runningJobs = pgTable(
     jobId: uuid('job_id').notNull().unique(),
     runId: uuid('run_id').notNull(),
     projectId: uuid('project_id').notNull(),
-    runnerTokenId: uuid('runner_token_id').notNull(),
+    runnerSessionId: uuid('runner_session_id').notNull(),
     startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
     lastHeartbeatAt: timestamp('last_heartbeat_at', {withTimezone: true}).notNull().defaultNow(),
     cancellationRequestedAt: timestamp('cancellation_requested_at', {withTimezone: true}),

--- a/libs/api/runners/src/presentation/auth/runner-token-auth.ts
+++ b/libs/api/runners/src/presentation/auth/runner-token-auth.ts
@@ -1,3 +1,4 @@
+import {AUTH_RUNNER_TOKEN} from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
 import {hashOpaqueToken} from '@shipfox/node-tokens';
 import type {FastifyRequest} from 'fastify';
@@ -8,7 +9,6 @@ const RUNNER_CONTEXT_KEY = 'runner';
 export interface RunnerAuthContext {
   runnerTokenId: string;
   workspaceId: string;
-  revokedAt: Date | null;
 }
 
 export function getRunnerContext(request: FastifyRequest): RunnerAuthContext {
@@ -23,7 +23,7 @@ export function getRunnerContext(request: FastifyRequest): RunnerAuthContext {
 
 export function createRunnerTokenAuthMethod(): AuthMethod {
   return {
-    name: 'runner-token',
+    name: AUTH_RUNNER_TOKEN,
     authenticate: async (request) => {
       const rawToken = extractBearerToken(request.headers.authorization);
       if (!rawToken) {
@@ -40,11 +40,15 @@ export function createRunnerTokenAuthMethod(): AuthMethod {
       if (token.expiresAt && token.expiresAt < new Date()) {
         throw new ClientError('Runner token has expired', 'runner-token-expired', {status: 401});
       }
+      if (token.revokedAt) {
+        throw new ClientError('Runner token has been revoked', 'runner-token-revoked', {
+          status: 401,
+        });
+      }
 
       (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = {
         runnerTokenId: token.id,
         workspaceId: token.workspaceId,
-        revokedAt: token.revokedAt,
       } satisfies RunnerAuthContext;
     },
   };

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -1,13 +1,24 @@
-import {AUTH_USER} from '@shipfox/api-auth-context';
+import {
+  createLeaseTokenAuthMethod,
+  createRunnerSessionAuthMethod,
+  issueJobLeaseToken,
+} from '@shipfox/api-auth';
+import {AUTH_API_KEY, AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
+import {claimJob} from '#core/jobs.js';
 import {db} from '#db/db.js';
-import {claimPendingJob, requestJobCancellation} from '#db/jobs.js';
+import {requestJobCancellation} from '#db/jobs.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
-import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
+import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
+
+const fakeApiKeyAuth: AuthMethod = {
+  name: AUTH_API_KEY,
+  authenticate: () => Promise.resolve(),
+};
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -16,13 +27,18 @@ const fakeUserAuth: AuthMethod = {
 
 describe('POST /runners/jobs/:jobId/heartbeat', () => {
   let app: FastifyInstance;
-  let rawToken: string;
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeAll(async () => {
     app = await createApp({
-      auth: [fakeUserAuth, createRunnerTokenAuthMethod()],
+      auth: [
+        fakeApiKeyAuth,
+        fakeUserAuth,
+        createRunnerTokenAuthMethod(),
+        createRunnerSessionAuthMethod(),
+        createLeaseTokenAuthMethod(),
+      ],
       routes: runnerRoutes,
       swagger: false,
     });
@@ -35,13 +51,19 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
-    rawToken = `sf_r_${crypto.randomUUID()}`;
     workspaceId = crypto.randomUUID();
-    const token = await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
-    runnerTokenId = token.id;
+    const session = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = session.id;
   });
+
+  async function claimAvailableJob(): Promise<{jobId: string; leaseToken: string}> {
+    const pending = await pendingJobFactory.create({workspaceId});
+    const claimed = await claimJob({workspaceId, runnerSessionId});
+    expect(claimed).not.toBeNull();
+    return {jobId: pending.jobId, leaseToken: claimed?.leaseToken as string};
+  }
 
   it('returns 401 without authorization', async () => {
     const res = await app.inject({
@@ -53,13 +75,12 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
   });
 
   it('returns 200 + cancel:false on a fresh row', async () => {
-    const pending = await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerTokenId});
+    const {jobId, leaseToken} = await claimAvailableJob();
 
     const res = await app.inject({
       method: 'POST',
-      url: `/runners/jobs/${pending.jobId}/heartbeat`,
-      headers: {authorization: `Bearer ${rawToken}`},
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
     });
 
     expect(res.statusCode).toBe(200);
@@ -67,14 +88,13 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
   });
 
   it('returns 200 + cancel:true after requestJobCancellation', async () => {
-    const pending = await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerTokenId});
-    await requestJobCancellation({jobId: pending.jobId});
+    const {jobId, leaseToken} = await claimAvailableJob();
+    await requestJobCancellation({jobId});
 
     const res = await app.inject({
       method: 'POST',
-      url: `/runners/jobs/${pending.jobId}/heartbeat`,
-      headers: {authorization: `Bearer ${rawToken}`},
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
     });
 
     expect(res.statusCode).toBe(200);
@@ -82,29 +102,56 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
   });
 
   it('returns 404 when the jobId is unknown', async () => {
+    const jobId = crypto.randomUUID();
+    const leaseToken = await issueJobLeaseToken({
+      jobId,
+      runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      workspaceId,
+      runnerSessionId,
+    });
+
     const res = await app.inject({
       method: 'POST',
-      url: `/runners/jobs/${crypto.randomUUID()}/heartbeat`,
-      headers: {authorization: `Bearer ${rawToken}`},
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
     });
 
     expect(res.statusCode).toBe(404);
     expect(res.json().code).toBe('running-job-not-found');
   });
 
-  it('returns 404 when the job belongs to a different runner token', async () => {
-    const pending = await pendingJobFactory.create({workspaceId});
-    const otherRawToken = `sf_r_${crypto.randomUUID()}`;
-    await runnerTokenFactory.create({workspaceId}, {transient: {rawToken: otherRawToken}});
-    await claimPendingJob({workspaceId, runnerTokenId});
+  it('returns 404 when the job belongs to a different session', async () => {
+    const {jobId} = await claimAvailableJob();
+    const otherSession = await runnerSessionFactory.create({workspaceId});
+    const leaseToken = await issueJobLeaseToken({
+      jobId,
+      runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      workspaceId,
+      runnerSessionId: otherSession.id,
+    });
 
     const res = await app.inject({
       method: 'POST',
-      url: `/runners/jobs/${pending.jobId}/heartbeat`,
-      headers: {authorization: `Bearer ${otherRawToken}`},
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
     });
 
     expect(res.statusCode).toBe(404);
     expect(res.json().code).toBe('running-job-not-found');
+  });
+
+  it('returns 404 when the path job id does not match the lease token job id', async () => {
+    const {leaseToken} = await claimAvailableJob();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${crypto.randomUUID()}/heartbeat`,
+      headers: {authorization: `Bearer ${leaseToken}`},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('lease-job-mismatch');
   });
 });

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -3,7 +3,7 @@ import {
   createRunnerSessionAuthMethod,
   issueJobLeaseToken,
 } from '@shipfox/api-auth';
-import {AUTH_API_KEY, AUTH_USER} from '@shipfox/api-auth-context';
+import {AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {sql} from 'drizzle-orm';
@@ -14,11 +14,6 @@ import {requestJobCancellation} from '#db/jobs.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
-
-const fakeApiKeyAuth: AuthMethod = {
-  name: AUTH_API_KEY,
-  authenticate: () => Promise.resolve(),
-};
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -33,7 +28,6 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [
-        fakeApiKeyAuth,
         fakeUserAuth,
         createRunnerTokenAuthMethod(),
         createRunnerSessionAuthMethod(),

--- a/libs/api/runners/src/presentation/routes/heartbeat.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.ts
@@ -1,9 +1,9 @@
+import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {heartbeatResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {RunningJobNotFoundError} from '#core/errors.js';
 import {recordHeartbeat} from '#db/jobs.js';
-import {getRunnerContext} from '#presentation/auth/index.js';
 
 export const heartbeatRoute = defineRoute({
   method: 'POST',
@@ -24,11 +24,16 @@ export const heartbeatRoute = defineRoute({
   },
   handler: async (request) => {
     const {jobId} = request.params;
-    const runner = getRunnerContext(request);
+    const lease = requireLeasedJobContext(request);
+    if (lease.jobId !== jobId) {
+      throw new ClientError('Lease token does not match job', 'lease-job-mismatch', {
+        status: 404,
+      });
+    }
 
     const {cancellationRequested} = await recordHeartbeat({
       jobId,
-      runnerTokenId: runner.runnerTokenId,
+      runnerSessionId: lease.runnerSessionId,
     });
 
     return {cancel: cancellationRequested};

--- a/libs/api/runners/src/presentation/routes/index.ts
+++ b/libs/api/runners/src/presentation/routes/index.ts
@@ -1,8 +1,14 @@
-import {AUTH_USER} from '@shipfox/api-auth-context';
+import {
+  AUTH_LEASED_JOB,
+  AUTH_RUNNER_SESSION,
+  AUTH_RUNNER_TOKEN,
+  AUTH_USER,
+} from '@shipfox/api-auth-context';
 import type {RouteGroup} from '@shipfox/node-fastify';
 import {createRunnerTokenRoute} from './create-runner-token.js';
 import {heartbeatRoute} from './heartbeat.js';
 import {listRunnerTokensRoute} from './list-runner-tokens.js';
+import {registerRoute} from './register.js';
 import {requestJobRoute} from './request-job.js';
 import {revokeRunnerTokenRoute} from './revoke-runner-token.js';
 
@@ -13,8 +19,18 @@ export const runnerRoutes: RouteGroup[] = [
     routes: [listRunnerTokensRoute, createRunnerTokenRoute, revokeRunnerTokenRoute],
   },
   {
+    prefix: '/runners',
+    auth: AUTH_RUNNER_TOKEN,
+    routes: [registerRoute],
+  },
+  {
     prefix: '/runners/jobs',
-    auth: 'runner-token',
-    routes: [requestJobRoute, heartbeatRoute],
+    auth: AUTH_RUNNER_SESSION,
+    routes: [requestJobRoute],
+  },
+  {
+    prefix: '/runners/jobs',
+    auth: AUTH_LEASED_JOB,
+    routes: [heartbeatRoute],
   },
 ];

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -1,0 +1,162 @@
+import {
+  createLeaseTokenAuthMethod,
+  createRunnerSessionAuthMethod,
+  verifyRunnerSessionToken,
+} from '@shipfox/api-auth';
+import {AUTH_API_KEY, AUTH_USER} from '@shipfox/api-auth-context';
+import type {AuthMethod} from '@shipfox/node-fastify';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {eq, sql} from 'drizzle-orm';
+import type {FastifyInstance} from 'fastify';
+import {db} from '#db/db.js';
+import {revokeRunnerToken} from '#db/runner-tokens.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
+import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
+import {runnerTokenFactory} from '#test/index.js';
+import {runnerRoutes} from './index.js';
+
+const fakeApiKeyAuth: AuthMethod = {
+  name: AUTH_API_KEY,
+  authenticate: () => Promise.resolve(),
+};
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: () => Promise.resolve(),
+};
+
+describe('POST /runners/register', () => {
+  let app: FastifyInstance;
+  let rawToken: string;
+  let workspaceId: string;
+
+  beforeAll(async () => {
+    app = await createApp({
+      auth: [
+        fakeApiKeyAuth,
+        fakeUserAuth,
+        createRunnerTokenAuthMethod(),
+        createRunnerSessionAuthMethod(),
+        createLeaseTokenAuthMethod(),
+      ],
+      routes: runnerRoutes,
+      swagger: false,
+    });
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  beforeEach(async () => {
+    await db().execute(sql`TRUNCATE runners_runner_sessions, runners_runner_tokens CASCADE`);
+    rawToken = `sf_r_${crypto.randomUUID()}`;
+    workspaceId = crypto.randomUUID();
+    await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+  });
+
+  it('exchanges a registration token for a manual runner session', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['Linux', 'x64', 'linux']},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(typeof body.session_token).toBe('string');
+    expect(body.session_id).toEqual(expect.any(String));
+    expect(body.mode).toBe('manual');
+    expect(body.max_claims).toBeNull();
+
+    const claims = await verifyRunnerSessionToken(body.session_token);
+    expect(claims).toMatchObject({
+      runnerSessionId: body.session_id,
+      workspaceId,
+      scope: 'workspace',
+      labels: ['linux', 'x64'],
+    });
+
+    const rows = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, body.session_id));
+    expect(rows[0]?.labels).toEqual(['linux', 'x64']);
+  });
+
+  it('creates independent sessions from the same registration token', async () => {
+    const first = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['linux']},
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload: {labels: ['macos']},
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(first.json().session_id).not.toBe(second.json().session_id);
+
+    const rows = await db().select().from(runnerSessions);
+    expect(rows.map((row) => row.labels).sort()).toEqual([['linux'], ['macos']]);
+  });
+
+  it('returns 401 when the registration token is expired', async () => {
+    const expiredRawToken = `sf_r_${crypto.randomUUID()}`;
+    await runnerTokenFactory.create(
+      {workspaceId, expiresAt: new Date(Date.now() - 1000)},
+      {transient: {rawToken: expiredRawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${expiredRawToken}`},
+      payload: {labels: ['linux']},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('runner-token-expired');
+  });
+
+  it('returns 401 when the registration token is revoked', async () => {
+    const revokedRawToken = `sf_r_${crypto.randomUUID()}`;
+    const token = await runnerTokenFactory.create(
+      {workspaceId},
+      {transient: {rawToken: revokedRawToken}},
+    );
+    await revokeRunnerToken({tokenId: token.id, workspaceId});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${revokedRawToken}`},
+      payload: {labels: ['linux']},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('runner-token-revoked');
+  });
+
+  it.each([
+    ['too many labels', {labels: Array.from({length: 51}, (_, index) => `label-${index}`)}],
+    ['too long label', {labels: ['a'.repeat(64)]}],
+    ['bad charset', {labels: ['linux/amd64']}],
+  ])('returns 400 for %s', async (_case, payload) => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -3,7 +3,7 @@ import {
   createRunnerSessionAuthMethod,
   verifyRunnerSessionToken,
 } from '@shipfox/api-auth';
-import {AUTH_API_KEY, AUTH_USER} from '@shipfox/api-auth-context';
+import {AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {eq, sql} from 'drizzle-orm';
@@ -14,11 +14,6 @@ import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
 import {runnerTokenFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
-
-const fakeApiKeyAuth: AuthMethod = {
-  name: AUTH_API_KEY,
-  authenticate: () => Promise.resolve(),
-};
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -33,7 +28,6 @@ describe('POST /runners/register', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [
-        fakeApiKeyAuth,
         fakeUserAuth,
         createRunnerTokenAuthMethod(),
         createRunnerSessionAuthMethod(),

--- a/libs/api/runners/src/presentation/routes/register.ts
+++ b/libs/api/runners/src/presentation/routes/register.ts
@@ -1,0 +1,38 @@
+import {registerRunnerBodySchema, registerRunnerResponseSchema} from '@shipfox/api-runners-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {EmptyRunnerLabelsError} from '#core/errors.js';
+import {registerRunnerSession} from '#core/runner-sessions.js';
+import {getRunnerContext} from '#presentation/auth/index.js';
+
+export const registerRoute = defineRoute({
+  method: 'POST',
+  path: '/register',
+  description: 'Exchange a runner registration token for a runner session token',
+  schema: {
+    body: registerRunnerBodySchema,
+    response: {
+      200: registerRunnerResponseSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof EmptyRunnerLabelsError) {
+      throw new ClientError(error.message, 'empty-runner-labels', {status: 400});
+    }
+    throw error;
+  },
+  handler: async (request) => {
+    const runner = getRunnerContext(request);
+    const result = await registerRunnerSession({
+      registrationTokenId: runner.runnerTokenId,
+      workspaceId: runner.workspaceId,
+      labels: request.body.labels,
+    });
+
+    return {
+      session_token: result.sessionToken,
+      session_id: result.session.id,
+      mode: result.mode,
+      max_claims: result.maxClaims,
+    };
+  },
+});

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -3,7 +3,7 @@ import {
   createRunnerSessionAuthMethod,
   verifyJobLeaseToken,
 } from '@shipfox/api-auth';
-import {AUTH_API_KEY, AUTH_USER} from '@shipfox/api-auth-context';
+import {AUTH_USER} from '@shipfox/api-auth-context';
 import {RUNNER_SESSION_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
@@ -14,11 +14,6 @@ import {db} from '#db/db.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
-
-const fakeApiKeyAuth: AuthMethod = {
-  name: AUTH_API_KEY,
-  authenticate: () => Promise.resolve(),
-};
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -35,7 +30,6 @@ describe('POST /runners/jobs/request', () => {
   beforeAll(async () => {
     app = await createApp({
       auth: [
-        fakeApiKeyAuth,
         fakeUserAuth,
         createRunnerTokenAuthMethod(),
         createRunnerSessionAuthMethod(),

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -1,14 +1,24 @@
-import {verifyJobLeaseToken} from '@shipfox/api-auth';
-import {AUTH_USER} from '@shipfox/api-auth-context';
+import {
+  createLeaseTokenAuthMethod,
+  createRunnerSessionAuthMethod,
+  verifyJobLeaseToken,
+} from '@shipfox/api-auth';
+import {AUTH_API_KEY, AUTH_USER} from '@shipfox/api-auth-context';
+import {RUNNER_SESSION_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
+import {signHs256} from '@shipfox/node-jwt';
 import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
-import {revokeRunnerToken} from '#db/runner-tokens.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
+
+const fakeApiKeyAuth: AuthMethod = {
+  name: AUTH_API_KEY,
+  authenticate: () => Promise.resolve(),
+};
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -19,11 +29,18 @@ describe('POST /runners/jobs/request', () => {
   let app: FastifyInstance;
   let rawToken: string;
   let workspaceId: string;
-  let runnerTokenId: string;
+  let sessionToken: string;
+  let runnerSessionId: string;
 
   beforeAll(async () => {
     app = await createApp({
-      auth: [fakeUserAuth, createRunnerTokenAuthMethod()],
+      auth: [
+        fakeApiKeyAuth,
+        fakeUserAuth,
+        createRunnerTokenAuthMethod(),
+        createRunnerSessionAuthMethod(),
+        createLeaseTokenAuthMethod(),
+      ],
       routes: runnerRoutes,
       swagger: false,
     });
@@ -36,13 +53,29 @@ describe('POST /runners/jobs/request', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens CASCADE`,
     );
     rawToken = `sf_r_${crypto.randomUUID()}`;
     workspaceId = crypto.randomUUID();
-    const token = await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
-    runnerTokenId = token.id;
+    await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
+    const registered = await registerSession(rawToken);
+    sessionToken = registered.sessionToken;
+    runnerSessionId = registered.runnerSessionId;
   });
+
+  async function registerSession(
+    token: string,
+  ): Promise<{sessionToken: string; runnerSessionId: string}> {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${token}`},
+      payload: {labels: ['Linux', 'x64']},
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    return {sessionToken: body.session_token, runnerSessionId: body.session_id};
+  }
 
   it('returns 401 without authorization', async () => {
     const res = await app.inject({
@@ -53,7 +86,7 @@ describe('POST /runners/jobs/request', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  it('returns 401 with an invalid runner token', async () => {
+  it('returns 401 with an invalid runner session token', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/runners/jobs/request',
@@ -69,7 +102,7 @@ describe('POST /runners/jobs/request', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/runners/jobs/request',
-      headers: {authorization: `Bearer ${rawToken}`},
+      headers: {authorization: `Bearer ${sessionToken}`},
     });
 
     expect(res.statusCode).toBe(200);
@@ -86,50 +119,60 @@ describe('POST /runners/jobs/request', () => {
       runId: created.runId,
       projectId: created.projectId,
       workspaceId,
-      runnerTokenId,
+      runnerSessionId,
     });
   });
 
-  it('returns 204 when no jobs are available for the token workspace', async () => {
+  it('returns 204 when no jobs are available for the session workspace', async () => {
     await pendingJobFactory.create({workspaceId: crypto.randomUUID()});
 
     const res = await app.inject({
       method: 'POST',
       url: '/runners/jobs/request',
-      headers: {authorization: `Bearer ${rawToken}`},
+      headers: {authorization: `Bearer ${sessionToken}`},
     });
 
     expect(res.statusCode).toBe(204);
   });
 
-  it('returns 401 when the runner token is expired', async () => {
-    const expiredRawToken = `sf_r_${crypto.randomUUID()}`;
-    await runnerTokenFactory.create(
-      {workspaceId, expiresAt: new Date(Date.now() - 1000)},
-      {transient: {rawToken: expiredRawToken}},
-    );
+  it('claims multiple jobs from one manual session', async () => {
+    const first = await pendingJobFactory.create({workspaceId});
+    const second = await pendingJobFactory.create({workspaceId});
 
-    const res = await app.inject({
+    const firstRes = await app.inject({
       method: 'POST',
       url: '/runners/jobs/request',
-      headers: {authorization: `Bearer ${expiredRawToken}`},
+      headers: {authorization: `Bearer ${sessionToken}`},
+    });
+    const secondRes = await app.inject({
+      method: 'POST',
+      url: '/runners/jobs/request',
+      headers: {authorization: `Bearer ${sessionToken}`},
     });
 
-    expect(res.statusCode).toBe(401);
+    expect(firstRes.statusCode).toBe(200);
+    expect(firstRes.json().job_id).toBe(first.jobId);
+    expect(secondRes.statusCode).toBe(200);
+    expect(secondRes.json().job_id).toBe(second.jobId);
   });
 
-  it('returns 401 when the runner token is revoked', async () => {
-    const revokedRawToken = `sf_r_${crypto.randomUUID()}`;
-    const token = await runnerTokenFactory.create(
-      {workspaceId},
-      {transient: {rawToken: revokedRawToken}},
-    );
-    await revokeRunnerToken({tokenId: token.id, workspaceId});
+  it('returns 401 when the runner session token is expired', async () => {
+    const expiredSessionToken = await signHs256({
+      payload: {
+        runnerSessionId,
+        workspaceId,
+        scope: 'workspace',
+        labels: ['linux', 'x64'],
+      },
+      secret: process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET ?? 'test-runner-session-secret',
+      expiresIn: '-1s',
+      audience: RUNNER_SESSION_TOKEN_AUDIENCE,
+    });
 
     const res = await app.inject({
       method: 'POST',
       url: '/runners/jobs/request',
-      headers: {authorization: `Bearer ${revokedRawToken}`},
+      headers: {authorization: `Bearer ${expiredSessionToken}`},
     });
 
     expect(res.statusCode).toBe(401);

--- a/libs/api/runners/src/presentation/routes/request-job.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.ts
@@ -1,7 +1,7 @@
+import {requireRunnerSessionContext} from '@shipfox/api-auth-context';
 import {claimedJobResponseSchema} from '@shipfox/api-runners-dto';
-import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {defineRoute} from '@shipfox/node-fastify';
 import {claimJob} from '#core/jobs.js';
-import {getRunnerContext} from '#presentation/auth/index.js';
 
 export const requestJobRoute = defineRoute({
   method: 'POST',
@@ -13,16 +13,11 @@ export const requestJobRoute = defineRoute({
     },
   },
   handler: async (_request, reply) => {
-    const runner = getRunnerContext(_request);
-    if (runner.revokedAt) {
-      throw new ClientError('Runner token has been revoked', 'runner-token-revoked', {
-        status: 401,
-      });
-    }
+    const runner = requireRunnerSessionContext(_request);
 
     const job = await claimJob({
       workspaceId: runner.workspaceId,
-      runnerTokenId: runner.runnerTokenId,
+      runnerSessionId: runner.runnerSessionId,
     });
 
     if (!job) {

--- a/libs/api/runners/src/presentation/routes/runner-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-tokens.test.ts
@@ -1,4 +1,12 @@
-import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {createLeaseTokenAuthMethod, createRunnerSessionAuthMethod} from '@shipfox/api-auth';
+import {
+  AUTH_LEASED_JOB,
+  AUTH_RUNNER_SESSION,
+  AUTH_RUNNER_TOKEN,
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+} from '@shipfox/api-auth-context';
 import {requireMembership} from '@shipfox/api-workspaces';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
@@ -57,7 +65,12 @@ describe('runner token routes', () => {
       role: 'admin',
     });
     app = await createApp({
-      auth: [fakeUserAuth, createRunnerTokenAuthMethod()],
+      auth: [
+        fakeUserAuth,
+        createRunnerTokenAuthMethod(),
+        createRunnerSessionAuthMethod(),
+        createLeaseTokenAuthMethod(),
+      ],
       routes: runnerRoutes,
       swagger: false,
     });
@@ -68,8 +81,11 @@ describe('runner token routes', () => {
     await closeApp();
   });
 
-  test('uses user auth for runner token management routes', () => {
+  test('uses the expected auth method for each runner route group', () => {
     expect(runnerRoutes[0]?.auth).toBe(AUTH_USER);
+    expect(runnerRoutes[1]?.auth).toBe(AUTH_RUNNER_TOKEN);
+    expect(runnerRoutes[2]?.auth).toBe(AUTH_RUNNER_SESSION);
+    expect(runnerRoutes[3]?.auth).toBe(AUTH_LEASED_JOB);
   });
 
   describe('GET /workspaces/:workspaceId/runners/tokens', () => {

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
@@ -3,7 +3,7 @@ import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {claimPendingJob} from '#db/jobs.js';
 import {runningJobs} from '#db/schema/running-jobs.js';
-import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
+import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {onWorkflowsJobTimedOut} from './on-workflows-job-timed-out.js';
 
 function buildPayload(jobId: string, runId: string): WorkflowsJobTimedOutEvent {
@@ -12,17 +12,17 @@ function buildPayload(jobId: string, runId: string): WorkflowsJobTimedOutEvent {
 
 describe('onWorkflowsJobTimedOut', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('sets cancellation_requested_at on the matching running_jobs row', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     expect(claimed).not.toBeNull();
 
     await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
@@ -36,7 +36,7 @@ describe('onWorkflowsJobTimedOut', () => {
 
   it('idempotent under double delivery: second call preserves the first timestamp', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
 
     await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
     const after1 = await db()

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -4,22 +4,22 @@ import {db} from '#db/db.js';
 import {claimPendingJob} from '#db/jobs.js';
 import {runnersOutbox} from '#db/schema/outbox.js';
 import {runningJobs} from '#db/schema/running-jobs.js';
-import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
+import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {detectAndExpireStuckJobsActivity} from './maintenance-activities.js';
 
 describe('detectAndExpireStuckJobsActivity', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('delegates to detectAndExpireStuckJobs and returns the expired count', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     await db()
       .update(runningJobs)
       .set({lastHeartbeatAt: sql`now() - interval '10 minutes'`})

--- a/libs/api/runners/test/env.ts
+++ b/libs/api/runners/test/env.ts
@@ -7,4 +7,5 @@ process.env.POSTGRES_MAX_CONNECTIONS = '5';
 process.env.WORKSPACE_JWT_SECRET = 'test-secret';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
+process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
 process.env.TZ = 'UTC';

--- a/libs/api/runners/test/factories/runner-session.ts
+++ b/libs/api/runners/test/factories/runner-session.ts
@@ -1,0 +1,24 @@
+import {Factory} from 'fishery';
+import type {RunnerSession} from '#core/entities/runner-session.js';
+import {createRunnerSession} from '#db/runner-sessions.js';
+
+export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) => {
+  onCreate((session) => {
+    return createRunnerSession({
+      workspaceId: session.workspaceId,
+      scope: session.scope,
+      registrationTokenId: session.registrationTokenId,
+      labels: session.labels,
+    });
+  });
+
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    scope: 'workspace',
+    registrationTokenId: crypto.randomUUID(),
+    labels: ['linux', 'x64'],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+});

--- a/libs/api/runners/test/globalSetup.ts
+++ b/libs/api/runners/test/globalSetup.ts
@@ -8,6 +8,7 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_runners');
+  await db().execute(sql`TRUNCATE runners_runner_sessions CASCADE`);
   await db().execute(sql`TRUNCATE runners_runner_tokens CASCADE`);
   await db().execute(sql`TRUNCATE runners_pending_jobs CASCADE`);
   await db().execute(sql`TRUNCATE runners_running_jobs CASCADE`);

--- a/libs/api/runners/test/index.ts
+++ b/libs/api/runners/test/index.ts
@@ -1,4 +1,5 @@
 export {pendingJobFactory} from './factories/pending-job.js';
+export {runnerSessionFactory} from './factories/runner-session.js';
 export {
   type RunnerTokenFactoryTransientParams,
   runnerTokenFactory,

--- a/libs/api/workflows/test/env.ts
+++ b/libs/api/workflows/test/env.ts
@@ -6,4 +6,5 @@ process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS = '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
+process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
 process.env.TZ = 'UTC';

--- a/libs/api/workflows/test/fixtures/lease-token.ts
+++ b/libs/api/workflows/test/fixtures/lease-token.ts
@@ -23,7 +23,7 @@ export function mintLeaseToken(params: MintLeaseTokenParams): Promise<string> {
       runId: params.runId ?? crypto.randomUUID(),
       projectId: params.projectId ?? crypto.randomUUID(),
       workspaceId: params.workspaceId ?? crypto.randomUUID(),
-      runnerTokenId: crypto.randomUUID(),
+      runnerSessionId: crypto.randomUUID(),
     },
     secret: params.secret ?? SECRET,
     expiresIn: params.expiresIn ?? '90m',

--- a/libs/client/runners/src/components/create-runner-token-form.tsx
+++ b/libs/client/runners/src/components/create-runner-token-form.tsx
@@ -214,7 +214,9 @@ export function CreatedRunnerTokenPanel({token}: {token: CreateRunnerTokenRespon
       <InlineTipsContent className="flex flex-col gap-12">
         <div className="flex flex-col gap-2">
           <InlineTipsTitle className="mb-0">Token created</InlineTipsTitle>
-          <InlineTipsDescription>Copy it now. It will not be shown again.</InlineTipsDescription>
+          <InlineTipsDescription>
+            Copy this registration token now. It will not be shown again.
+          </InlineTipsDescription>
         </div>
         <div className="flex items-center gap-8 max-[640px]:flex-col max-[640px]:items-stretch">
           <Code variant="paragraph" className="min-w-0 flex-1 break-all">

--- a/libs/client/runners/src/components/runner-token-list.tsx
+++ b/libs/client/runners/src/components/runner-token-list.tsx
@@ -143,7 +143,8 @@ function RevokeRunnerTokenButton({
               Revoke token?
             </Text>
             <Text size="sm" className="text-foreground-neutral-muted">
-              {tokenName} will stop being usable immediately.
+              {tokenName} will stop creating new runner sessions. Existing sessions and job leases
+              expire on their own.
             </Text>
           </div>
           {revokeToken.isError ? (

--- a/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
@@ -3,7 +3,8 @@ import {HTTPError} from 'ky';
 const heartbeatMock = vi.fn();
 
 vi.mock('@shipfox/runner-protocol', () => ({
-  heartbeat: (jobId: string, opts?: {signal?: AbortSignal}) => heartbeatMock(jobId, opts),
+  heartbeat: (jobId: string, leaseToken: string, opts?: {signal?: AbortSignal}) =>
+    heartbeatMock(jobId, leaseToken, opts),
   HTTPError,
 }));
 
@@ -27,7 +28,10 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockResolvedValue({cancel: false});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 1000});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 1000,
+    });
 
     // Flush any pending microtasks before asserting the timer has not fired —
     // a regression that resolved the first tick synchronously would leak past
@@ -37,6 +41,7 @@ describe('startHeartbeatLoop', () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
     expect(heartbeatMock.mock.calls[0]?.[0]).toBe('job-1');
+    expect(heartbeatMock.mock.calls[0]?.[1]).toBe('lease-1');
     expect(ac.signal.aborted).toBe(false);
 
     handle.stop();
@@ -47,7 +52,10 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockImplementation(() => new Promise<{cancel: boolean}>((r) => (resolve = r)));
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 10_000});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 10_000,
+    });
 
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
@@ -65,7 +73,7 @@ describe('startHeartbeatLoop', () => {
   test('max-stale guard aborts the in-flight call and schedules the next tick', async () => {
     let receivedSignal: AbortSignal | undefined;
     heartbeatMock.mockImplementation(
-      (_jobId: string, opts?: {signal?: AbortSignal}) =>
+      (_jobId: string, _leaseToken: string, opts?: {signal?: AbortSignal}) =>
         new Promise<{cancel: boolean}>((_resolve, reject) => {
           receivedSignal = opts?.signal;
           opts?.signal?.addEventListener('abort', () => {
@@ -77,7 +85,10 @@ describe('startHeartbeatLoop', () => {
     );
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 200});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 200,
+    });
 
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
@@ -99,7 +110,10 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockResolvedValueOnce({cancel: true});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 1000});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 1000,
+    });
 
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
@@ -115,7 +129,10 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockRejectedValueOnce(buildHTTPError(404));
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 1000});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 1000,
+    });
 
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
@@ -131,7 +148,10 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockRejectedValueOnce(buildHTTPError(500)).mockResolvedValueOnce({cancel: false});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 1000});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 1000,
+    });
 
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
@@ -146,7 +166,7 @@ describe('startHeartbeatLoop', () => {
   test('stop() prevents future ticks and aborts any in-flight call', async () => {
     let aborted = false;
     heartbeatMock.mockImplementation(
-      (_jobId: string, opts?: {signal?: AbortSignal}) =>
+      (_jobId: string, _leaseToken: string, opts?: {signal?: AbortSignal}) =>
         new Promise<{cancel: boolean}>((_resolve, reject) => {
           opts?.signal?.addEventListener('abort', () => {
             aborted = true;
@@ -158,7 +178,10 @@ describe('startHeartbeatLoop', () => {
     );
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', ac, {intervalMs: 100, maxStaleMs: 10_000});
+    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+      intervalMs: 100,
+      maxStaleMs: 10_000,
+    });
     await vi.advanceTimersByTimeAsync(100);
     expect(heartbeatMock).toHaveBeenCalledTimes(1);
 

--- a/libs/runner/orchestration/src/core/heartbeat-loop.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.ts
@@ -29,6 +29,7 @@ export interface HeartbeatLoopHandle {
  */
 export function startHeartbeatLoop(
   jobId: string,
+  leaseToken: string,
   jobAbortController: AbortController,
   options: HeartbeatLoopOptions,
 ): HeartbeatLoopHandle {
@@ -56,7 +57,7 @@ export function startHeartbeatLoop(
     }, options.maxStaleMs);
 
     try {
-      const {cancel} = await heartbeat(jobId, {signal: httpAc.signal});
+      const {cancel} = await heartbeat(jobId, leaseToken, {signal: httpAc.signal});
       if (stopped) return;
       if (cancel) {
         logger().info({jobId}, 'Heartbeat returned cancel:true; aborting job');

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -25,13 +25,14 @@ vi.mock('#core/step-loop.js', () => ({
 }));
 
 vi.mock('@shipfox/runner-protocol', () => ({
+  registerRunnerSession: vi.fn(),
   requestJob: vi.fn(),
   createLeaseClient: vi.fn(() => ({}) as never),
   runnerToken: vi.fn(() => 'runner-token'),
   HTTPError: class HTTPError extends Error {},
 }));
 
-import {createLeaseClient, requestJob} from '@shipfox/runner-protocol';
+import {createLeaseClient, registerRunnerSession, requestJob} from '@shipfox/runner-protocol';
 import {
   cleanupJobLogs,
   cleanupWorkspace,
@@ -41,6 +42,7 @@ import {
   resolveWorkspaceRootFromEnv,
   UnsafeWorkspaceRootError,
 } from '@shipfox/runner-workspace';
+import {startHeartbeatLoop} from '#core/heartbeat-loop.js';
 import {runJob, startRunner} from '#core/runner.js';
 import {runJobSteps} from '#core/step-loop.js';
 
@@ -51,7 +53,9 @@ const mockCleanupJobLogs = vi.mocked(cleanupJobLogs);
 const mockResolveWorkspaceRoot = vi.mocked(resolveWorkspaceRootFromEnv);
 const mockRunJobSteps = vi.mocked(runJobSteps);
 const mockCreateLeaseClient = vi.mocked(createLeaseClient);
+const mockRegisterRunnerSession = vi.mocked(registerRunnerSession);
 const mockRequestJob = vi.mocked(requestJob);
+const mockStartHeartbeatLoop = vi.mocked(startHeartbeatLoop);
 
 const JOB = {
   job_id: '00000000-0000-0000-0000-000000000001',
@@ -77,6 +81,15 @@ describe('runJob', () => {
 
     await runJob(JOB, WORKSPACE_ROOT);
 
+    expect(mockStartHeartbeatLoop).toHaveBeenCalledWith(
+      JOB.job_id,
+      JOB.lease_token,
+      expect.any(AbortController),
+      expect.objectContaining({
+        intervalMs: 10_000,
+        maxStaleMs: 10_000,
+      }),
+    );
     expect(mockCreateLeaseClient).toHaveBeenCalledWith(JOB.lease_token);
     expect(mockRunJobSteps).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -121,6 +134,7 @@ describe('startRunner', () => {
     });
 
     await expect(startRunner()).rejects.toThrow(UnsafeWorkspaceRootError);
+    expect(mockRegisterRunnerSession).not.toHaveBeenCalled();
     expect(mockRequestJob).not.toHaveBeenCalled();
   });
 });

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -1,6 +1,12 @@
 import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
 import {logger} from '@shipfox/node-opentelemetry';
-import {createLeaseClient, requestJob, runnerToken} from '@shipfox/runner-protocol';
+import {
+  createLeaseClient,
+  HTTPError,
+  registerRunnerSession,
+  requestJob,
+  runnerToken,
+} from '@shipfox/runner-protocol';
 import {
   cleanupJobLogs,
   cleanupWorkspace,
@@ -34,10 +40,12 @@ export async function startRunner(): Promise<void> {
   );
 
   let currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
+  let runnerSession = await registerRunnerSession();
+  logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session registered');
 
   while (running) {
     try {
-      const job = await requestJob();
+      const job = await requestJob(runnerSession.session_token);
 
       if (!job) {
         logger().debug({interval: currentInterval}, 'No jobs available, backing off');
@@ -51,6 +59,16 @@ export async function startRunner(): Promise<void> {
 
       await runJob(job, workspaceRoot);
     } catch (pollError) {
+      if (isUnauthorized(pollError)) {
+        try {
+          runnerSession = await registerRunnerSession();
+          logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session refreshed');
+          currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
+          continue;
+        } catch (registrationError) {
+          logger().error({err: registrationError}, 'Runner session refresh failed');
+        }
+      }
       logger().error({err: pollError}, 'Poll cycle failed');
       currentInterval = Math.min(currentInterval * 1.5, config.SHIPFOX_POLL_MAX_INTERVAL_MS);
       await interruptableSleep(currentInterval);
@@ -80,7 +98,7 @@ export async function runJob(
   const ac = new AbortController();
   currentJobAbortController = ac;
 
-  const heartbeatLoop = startHeartbeatLoop(job.job_id, ac, {
+  const heartbeatLoop = startHeartbeatLoop(job.job_id, job.lease_token, ac, {
     intervalMs: config.SHIPFOX_HEARTBEAT_INTERVAL_MS,
     maxStaleMs: config.SHIPFOX_HEARTBEAT_MAX_STALE_MS,
   });
@@ -112,6 +130,10 @@ export async function runJob(
     await cleanupWorkspace(cwd);
     await cleanupJobLogs(logsDir);
   }
+}
+
+function isUnauthorized(error: unknown): boolean {
+  return error instanceof HTTPError && error.response.status === 401;
 }
 
 function setupSignalHandlers(): void {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -23,6 +23,7 @@ let shuttingDown = false;
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
+type RunnerSession = Awaited<ReturnType<typeof registerRunnerSession>>;
 
 export async function startRunner(): Promise<void> {
   setupSignalHandlers();
@@ -40,11 +41,15 @@ export async function startRunner(): Promise<void> {
   );
 
   let currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
-  let runnerSession = await registerRunnerSession();
-  logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session registered');
+  let runnerSession: RunnerSession | undefined;
 
   while (running) {
     try {
+      if (!runnerSession) {
+        runnerSession = await registerRunnerSession();
+        logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session registered');
+      }
+
       const job = await requestJob(runnerSession.session_token);
 
       if (!job) {
@@ -60,14 +65,10 @@ export async function startRunner(): Promise<void> {
       await runJob(job, workspaceRoot);
     } catch (pollError) {
       if (isUnauthorized(pollError)) {
-        try {
-          runnerSession = await registerRunnerSession();
-          logger().info({runnerSessionId: runnerSession.session_id}, 'Runner session refreshed');
-          currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
-          continue;
-        } catch (registrationError) {
-          logger().error({err: registrationError}, 'Runner session refresh failed');
-        }
+        runnerSession = undefined;
+        logger().info('Runner session rejected; registering a new session');
+        currentInterval = config.SHIPFOX_POLL_INTERVAL_MS;
+        continue;
       }
       logger().error({err: pollError}, 'Poll cycle failed');
       currentInterval = Math.min(currentInterval * 1.5, config.SHIPFOX_POLL_MAX_INTERVAL_MS);

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -1,11 +1,12 @@
-// Exercises the real api-client (the mocked step-loop tests can't) to prove claim/heartbeat
-// use the runner token and step calls use the lease token. SHIPFOX_API_URL comes from
-// test/env.ts (setupFiles), loaded before config is imported.
+// Exercises the real api-client (the mocked step-loop tests can't) to prove registration,
+// claim, heartbeat, and step calls use the right bearer token class. SHIPFOX_API_URL comes
+// from test/env.ts (setupFiles), loaded before config is imported.
 
 import {
   appendStepLogs,
   createLeaseClient,
   heartbeat,
+  registerRunnerSession,
   reportStep,
   requestCheckoutToken,
   requestJob,
@@ -16,8 +17,9 @@ import {config} from '#config.js';
 const JOB_ID = crypto.randomUUID();
 const RUN_ID = crypto.randomUUID();
 const STEP_ID = crypto.randomUUID();
+const SESSION_ID = crypto.randomUUID();
 
-let calls: Array<{url: string; method: string; authorization: string | null}>;
+let calls: Array<{url: string; method: string; authorization: string | null; body: string}>;
 let originalFetch: typeof globalThis.fetch;
 
 beforeAll(() => {
@@ -33,10 +35,21 @@ beforeEach(() => {
 });
 
 describe('api-client auth contexts', () => {
-  it('requestJob sends the runner token and parses the step-less claim + lease token', async () => {
+  it('registerRunnerSession sends the registration token and configured labels', async () => {
+    stubFetch(() => jsonResponse(registerResponse()));
+
+    const session = await registerRunnerSession();
+
+    expect(session).toEqual(registerResponse());
+    expect(calls[0]?.url).toContain('runners/register');
+    expect(calls[0]?.authorization).toBe(`Bearer ${config.SHIPFOX_RUNNER_TOKEN}`);
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({labels: ['linux', 'x64']});
+  });
+
+  it('requestJob sends the runner session token and parses the step-less claim + lease token', async () => {
     stubFetch(() => jsonResponse(claimResponse()));
 
-    const job = await requestJob();
+    const job = await requestJob('session-abc');
 
     expect(job?.job_id).toBe(JOB_ID);
     expect(job?.run_id).toBe(RUN_ID);
@@ -45,24 +58,24 @@ describe('api-client auth contexts', () => {
     expect(job).not.toHaveProperty('steps');
     expect(job).not.toHaveProperty('job_name');
     expect(calls[0]?.url).toContain('runners/jobs/request');
-    expect(calls[0]?.authorization).toBe(`Bearer ${config.SHIPFOX_RUNNER_TOKEN}`);
+    expect(calls[0]?.authorization).toBe('Bearer session-abc');
   });
 
   it('requestJob returns null on 204', async () => {
     stubFetch(() => new Response(null, {status: 204}));
 
-    const job = await requestJob();
+    const job = await requestJob('session-abc');
 
     expect(job).toBeNull();
   });
 
-  it('heartbeat sends the runner token', async () => {
+  it('heartbeat sends the job lease token', async () => {
     stubFetch(() => jsonResponse({cancel: false}));
 
-    await heartbeat(JOB_ID);
+    await heartbeat(JOB_ID, 'lease-heartbeat');
 
     expect(calls[0]?.url).toContain(`runners/jobs/${JOB_ID}/heartbeat`);
-    expect(calls[0]?.authorization).toBe(`Bearer ${config.SHIPFOX_RUNNER_TOKEN}`);
+    expect(calls[0]?.authorization).toBe('Bearer lease-heartbeat');
   });
 
   it('requestNextStep sends the lease token, not the runner token', async () => {
@@ -280,6 +293,15 @@ function claimResponse() {
   };
 }
 
+function registerResponse() {
+  return {
+    session_token: 'session-abc',
+    session_id: SESSION_ID,
+    mode: 'manual',
+    max_claims: null,
+  };
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -288,13 +310,14 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 function stubFetch(handler: (url: string) => Response): void {
-  globalThis.fetch = vi.fn((input: Request | string | URL, init?: RequestInit) => {
+  globalThis.fetch = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(String(input), init);
     calls.push({
       url: request.url,
       method: request.method,
       authorization: request.headers.get('authorization'),
+      body: await request.clone().text(),
     });
-    return Promise.resolve(handler(request.url));
+    return handler(request.url);
   }) as unknown as typeof globalThis.fetch;
 }

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -1,9 +1,13 @@
 import {appendLogsResponseSchema, offsetGapResponseSchema} from '@shipfox/api-logs-dto';
 import {
   type ClaimedJobResponseDto,
+  canonicalizeRunnerLabels,
   claimedJobResponseSchema,
   type HeartbeatResponseDto,
   heartbeatResponseSchema,
+  type RegisterRunnerResponseDto,
+  registerRunnerBodySchema,
+  registerRunnerResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {
   type CheckoutTokenResponseDto,
@@ -50,8 +54,7 @@ const baseUrl = config.SHIPFOX_API_URL.endsWith('/')
   ? config.SHIPFOX_API_URL
   : `${config.SHIPFOX_API_URL}/`;
 
-// Runner token (long-lived) authes claim + heartbeat; step calls use a per-job lease token.
-const api = ky.create({
+const registrationApi = ky.create({
   baseUrl,
   headers: {
     Authorization: `Bearer ${config.SHIPFOX_RUNNER_TOKEN}`,
@@ -67,12 +70,36 @@ export function runnerToken(): string {
   return config.SHIPFOX_RUNNER_TOKEN;
 }
 
+export function configuredRunnerLabels(): string[] {
+  return canonicalizeRunnerLabels(config.SHIPFOX_RUNNER_LABELS.split(','));
+}
+
+export async function registerRunnerSession(): Promise<RegisterRunnerResponseDto> {
+  const labels = configuredRunnerLabels();
+
+  logger().debug({labels}, 'Registering runner session');
+
+  const body = registerRunnerBodySchema.parse({labels});
+  const response = await registrationApi.post('runners/register', {json: body});
+
+  return registerRunnerResponseSchema.parse(await response.json());
+}
+
+function createRunnerSessionClient(sessionToken: string): KyInstance {
+  return ky.create({
+    baseUrl,
+    headers: {
+      Authorization: `Bearer ${sessionToken}`,
+    },
+  });
+}
+
 // Scheduling is step-less: the claim returns only the job/run ids and the lease
 // token. Steps are pulled one at a time from the step API using that token.
-export async function requestJob(): Promise<ClaimedJobResponseDto | null> {
+export async function requestJob(sessionToken: string): Promise<ClaimedJobResponseDto | null> {
   logger().debug('Polling for job');
 
-  const response = await api.post('runners/jobs/request');
+  const response = await createRunnerSessionClient(sessionToken).post('runners/jobs/request');
 
   if (response.status === 204) {
     return null;
@@ -206,9 +233,10 @@ export async function appendStepLogs(
 
 export async function heartbeat(
   jobId: string,
+  leaseToken: string,
   options: {signal?: AbortSignal} = {},
 ): Promise<HeartbeatResponseDto> {
-  const response = await api.post(
+  const response = await createLeaseClient(leaseToken).post(
     `runners/jobs/${jobId}/heartbeat`,
     options.signal ? {signal: options.signal} : undefined,
   );

--- a/libs/runner/protocol/src/config.ts
+++ b/libs/runner/protocol/src/config.ts
@@ -5,6 +5,9 @@ export const config = createConfig({
     desc: 'Base URL of the Shipfox API the runner connects to, such as https://api.shipfox.io. Required.',
   }),
   SHIPFOX_RUNNER_TOKEN: str({
-    desc: 'Bearer token the runner uses to authenticate with the API. Required, with no default, so startup fails when it is missing rather than sending a predictable token.',
+    desc: 'Registration token the runner exchanges for a short-lived runner session token at startup. Required, with no default, so startup fails when it is missing rather than sending a predictable token.',
+  }),
+  SHIPFOX_RUNNER_LABELS: str({
+    desc: 'Comma-separated labels this runner registers with, such as linux,x64,self-hosted. Required, with no default, so startup fails when labels are missing.',
   }),
 });

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -1,10 +1,12 @@
 export {
   appendStepLogs,
+  configuredRunnerLabels,
   createLeaseClient,
   HTTPError,
   heartbeat,
   type LogAppendFn,
   type LogAppendOutcome,
+  registerRunnerSession,
   reportStep,
   requestCheckoutToken,
   requestJob,

--- a/libs/runner/protocol/test/env.ts
+++ b/libs/runner/protocol/test/env.ts
@@ -1,4 +1,5 @@
-// config.ts requires SHIPFOX_API_URL and SHIPFOX_RUNNER_TOKEN with no defaults. Set via
-// setupFiles so they land before any test imports config.
+// config.ts requires runner connection env with no defaults. Set via setupFiles
+// so they land before any test imports config.
 process.env.SHIPFOX_API_URL = 'https://api.test';
 process.env.SHIPFOX_RUNNER_TOKEN = 'test-runner-token';
+process.env.SHIPFOX_RUNNER_LABELS = 'Linux,x64,linux';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1749,9 +1749,15 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@shipfox/api-auth-dto':
+        specifier: workspace:*
+        version: link:../auth-dto
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
+      '@shipfox/node-jwt':
+        specifier: workspace:*
+        version: link:../../shared/node/jwt
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../tools/swc


### PR DESCRIPTION
Add short-lived runner registration sessions between long-lived runner registration tokens and per-job lease tokens.

Runner registration tokens were previously used directly for polling and heartbeat paths. This introduces a `/runners/register` handshake that records immutable runner session labels, mints a bounded runner session token for job polling, and keeps heartbeat/step APIs scoped to the single-job lease token. The runner app now registers at startup, polls with the returned session token, refreshes on polling `401`, and sends `job.lease_token` for heartbeat and step APIs.

The auth model deliberately keeps runner sessions stateless after issuance: registration tokens are checked for revocation/expiry at registration time, runner session tokens are bounded by TTL, and lease tokens remain single-job capabilities with server state as the final gate.

Known validation note: `mise exec -- turbo test --filter '...[origin/main]'` fails under normal Turbo parallelism in unchanged `@shipfox/runner-execution` abort/process-group tests. The same changed-surface suite passes with `--concurrency=1`, and the flake is tracked in ENG-623.

Closes ENG-609
Refs ENG-623

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce short‑lived runner registration sessions to decouple long‑lived registration tokens from per‑job lease tokens. Runners register with labels to get a session token for polling; heartbeats and steps use the per‑job lease token. Closes ENG-609.

- **New Features**
  - API: `POST /runners/register` accepts labels, creates a runner session, and returns `session_token` + `session_id`.
  - Auth: New runner session JWT (`aud: "runner-session"`) with `AUTH_RUNNER_SESSION_TOKEN_SECRET` and TTL; added `runner-session` auth in `@shipfox/api-auth`.
  - Data model: New `runner_sessions` table with enum-constrained `scope`; running jobs reference `runner_session_id`; job lease claims now carry `runnerSessionId`.
  - Routing: `POST /runners/register` requires `runner-token`; `POST /runners/jobs/request` requires `runner-session`; `POST /runners/jobs/:jobId/heartbeat` (and steps/logs) require the job’s lease token.
  - Runner protocol: Added `registerRunnerSession`, `configuredRunnerLabels`, and session-token polling; `heartbeat(jobId, leaseToken)`; label canonicalization. Registration runs inside the poll retry loop to back off on transient failures.
  - DTOs: Added register body/response schemas and label schema in `@shipfox/api-runners-dto`; added runner session token claims in `@shipfox/api-auth-dto`. Metrics include token type `runner_session`; UI copy clarifies revocation stops new sessions only.

- **Migration**
  - Env: Set `AUTH_RUNNER_SESSION_TOKEN_SECRET` (required) and optional `AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN`; set `SHIPFOX_RUNNER_LABELS` (comma‑separated).
  - DB: Apply migrations (adds `runner_sessions`; adds `runners_runner_session_scope` enum; `running_jobs.runner_session_id`).
  - Integrations: Replace job lease claim `runnerTokenId` with `runnerSessionId`; job polling uses a runner session token; heartbeat/steps send the job’s lease token.
  - Runner ops: `SHIPFOX_RUNNER_TOKEN` is now a registration token; the runner registers within the poll retry loop and refreshes the session on 401. Note: a known test flake is tracked in ENG-623.

<sup>Written for commit ace9099e6623c016e28a957260d351c402767582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

