### PR TITLE
[client-logs] Render agent session logs inline

### DIFF
--- a/.changeset/brave-logs-render.md
+++ b/.changeset/brave-logs-render.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-logs": minor
+---
+
+Renders agent session log records inline with process output so agent steps show prompts, assistant messages, thinking, tool activity, and failure anchors.

--- a/libs/client/logs/package.json
+++ b/libs/client/logs/package.json
@@ -42,7 +42,8 @@
     "@shipfox/client-api": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.101.0",
+    "zod": "^4.4.3"
   },
   "peerDependencies": {
     "react": "^19.0.0",

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -23,9 +23,10 @@ export interface AgentSessionRowsProps {
 }
 
 export function AgentSessionRows({rows, resolvedToolCallIds, indent}: AgentSessionRowsProps) {
-  return rows.map((row) => (
+  return rows.map((row, index) => (
     <AgentSessionRowView
-      key={rowKey(row)}
+      // biome-ignore lint/suspicious/noArrayIndexKey: a record's rows are immutable and never reordered (deterministic expandSessionRecord), so the index is a stable identity; content keys would balloon to megabyte strings and collide on a repeated id-less tool call.
+      key={`${row.kind}-${index}`}
       row={row}
       resolvedToolCallIds={resolvedToolCallIds}
       indent={indent}
@@ -217,7 +218,7 @@ function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: bo
     <Icon
       name={name}
       className={cn(
-        'mt-3 size-14 flex-none',
+        'mt-2 size-14 flex-none',
         terminalFailure ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
       )}
       aria-hidden="true"
@@ -247,7 +248,10 @@ function PreviewText({text}: {text: string}) {
 }
 
 function compactPreview(value: string): string {
-  const singleLine = value.replace(WHITESPACE, ' ').trim();
+  // Normalize only a bounded head: tool output can be megabytes, and this runs
+  // per render for every disclosure trigger.
+  const head = value.length > 200 ? value.slice(0, 200) : value;
+  const singleLine = head.replace(WHITESPACE, ' ').trim();
   if (singleLine.length <= 80) return singleLine;
   return `${singleLine.slice(0, 80)}…`;
 }
@@ -255,25 +259,6 @@ function compactPreview(value: string): string {
 function wordSummary(value: string): string {
   const count = value.trim().split(WORD_SEPARATOR).filter(Boolean).length;
   return `${count} ${count === 1 ? 'word' : 'words'}`;
-}
-
-function rowKey(row: AgentSessionRow): string {
-  switch (row.kind) {
-    case 'message':
-      return `${row.kind}-${row.timestamp}-${row.role}-${row.label}-${row.text}`;
-    case 'thinking':
-      return `${row.kind}-${row.timestamp}-${row.text}`;
-    case 'tool-call':
-      return `${row.kind}-${row.timestamp}-${row.id ?? ''}-${row.name}-${row.input}`;
-    case 'tool-result':
-      return `${row.kind}-${row.timestamp}-${row.toolCallId ?? ''}-${row.toolName}-${row.output}`;
-    case 'lifecycle':
-      return `${row.kind}-${row.timestamp}-${row.label}-${row.detail ?? ''}`;
-    case 'fallback':
-      return `${row.kind}-${row.timestamp}-${row.label}-${row.raw}`;
-    default:
-      return assertNever(row);
-  }
 }
 
 function assertNever(value: never): never {

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -8,9 +8,12 @@ import {
   LogDisclosureContent,
   LogDisclosureTrigger,
   LogRow,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '@shipfox/react-ui';
-import {useState} from 'react';
-import type {AgentSessionRow} from '#core/agent-session/selector.js';
+import {Fragment, useState} from 'react';
+import type {AgentRowMeta, AgentSessionRow} from '#core/agent-session/selector.js';
 
 const PREVIEW_CHAR_LIMIT = 1200;
 const WHITESPACE = /\s+/g;
@@ -56,9 +59,14 @@ function AgentSessionRowView({
           <LogContent className="text-foreground-neutral-base">
             <span className="flex min-w-0 items-start gap-8">
               <MessageIcon role={row.role} terminalFailure={row.terminalFailure} />
-              <span className="min-w-0 flex-1">
-                <span className="mr-8 font-code text-foreground-neutral-muted">{row.label}</span>
-                <PreviewText text={row.text} />
+              <span className="flex min-w-0 flex-1 flex-col gap-2">
+                <span className="flex min-w-0 items-center gap-8">
+                  <MessageRoleLabel label={row.label} terminalFailure={row.terminalFailure} />
+                  <RowMetadata meta={row.meta} className="ml-auto flex-none" />
+                </span>
+                <span className="block min-w-0">
+                  <PreviewText text={row.text} />
+                </span>
               </span>
             </span>
           </LogContent>
@@ -176,6 +184,7 @@ function AgentSessionRowView({
                 aria-hidden="true"
                 className="h-px flex-1 border-t border-dashed border-current opacity-30"
               />
+              <RowMetadata meta={row.meta} />
             </span>
           </LogContent>
         </LogRow>
@@ -223,6 +232,69 @@ function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: bo
       )}
       aria-hidden="true"
     />
+  );
+}
+
+function MessageRoleLabel({label, terminalFailure}: {label: string; terminalFailure: boolean}) {
+  return (
+    <span
+      className={cn(
+        'min-w-0 font-code text-foreground-neutral-muted',
+        terminalFailure && 'text-foreground-highlight-error',
+      )}
+    >
+      <span className="truncate">{label}</span>
+    </span>
+  );
+}
+
+function RowMetadata({meta, className}: {meta: readonly AgentRowMeta[]; className?: string}) {
+  if (meta.length === 0) return null;
+
+  const inlineMeta = meta.length === 1 && meta[0]?.inline !== false ? meta[0] : null;
+  if (inlineMeta != null) {
+    return (
+      <span
+        className={cn('font-code text-xs text-foreground-neutral-muted', className)}
+        title={`${inlineMeta.label}: ${inlineMeta.value}`}
+      >
+        {inlineMeta.value}
+      </span>
+    );
+  }
+
+  return (
+    <span className={className}>
+      <MetadataTrigger meta={meta} />
+    </span>
+  );
+}
+
+function MetadataTrigger({meta}: {meta: readonly AgentRowMeta[]}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-20 flex-none items-center justify-center rounded-4 text-foreground-neutral-muted opacity-60 transition-opacity hover:bg-background-components-hover hover:text-foreground-neutral-base hover:opacity-100 focus-visible:opacity-100 focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)] group-hover/log-row:opacity-100"
+          aria-label="Show message metadata"
+        >
+          <Icon name="informationLine" className="size-12" aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent align="end" variant="inverted" className="max-w-360 px-8 py-6">
+        <span className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-8 gap-y-2 font-code text-xs">
+          {meta.map((item) => (
+            <Fragment key={`${item.label}-${item.value}`}>
+              <span className="text-foreground-contrast-secondary">{item.label}</span>
+              <span className="min-w-0 break-all text-foreground-contrast-primary">
+                {item.value}
+              </span>
+            </Fragment>
+          ))}
+        </span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+import {
+  cn,
+  Icon,
+  LogContent,
+  LogDisclosure,
+  LogDisclosureContent,
+  LogDisclosureTrigger,
+  LogRow,
+} from '@shipfox/react-ui';
+import {useState} from 'react';
+import type {AgentSessionRow} from '#core/agent-session/selector.js';
+
+const PREVIEW_CHAR_LIMIT = 1200;
+const WHITESPACE = /\s+/g;
+const WORD_SEPARATOR = /\s+/;
+
+export interface AgentSessionRowsProps {
+  rows: readonly AgentSessionRow[];
+  resolvedToolCallIds: ReadonlySet<string>;
+  indent: number;
+}
+
+export function AgentSessionRows({rows, resolvedToolCallIds, indent}: AgentSessionRowsProps) {
+  return rows.map((row) => (
+    <AgentSessionRowView
+      key={rowKey(row)}
+      row={row}
+      resolvedToolCallIds={resolvedToolCallIds}
+      indent={indent}
+    />
+  ));
+}
+
+function AgentSessionRowView({
+  row,
+  resolvedToolCallIds,
+  indent,
+}: {
+  row: AgentSessionRow;
+  resolvedToolCallIds: ReadonlySet<string>;
+  indent: number;
+}) {
+  switch (row.kind) {
+    case 'message':
+      return (
+        <LogRow
+          lineNumber={null}
+          timestamp={new Date(row.timestamp)}
+          indent={indent}
+          tone={row.terminalFailure ? 'error' : 'default'}
+          data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
+        >
+          <LogContent className="text-foreground-neutral-base">
+            <span className="flex min-w-0 items-start gap-8">
+              <MessageIcon role={row.role} terminalFailure={row.terminalFailure} />
+              <span className="min-w-0 flex-1">
+                <span className="mr-8 font-code text-foreground-neutral-muted">{row.label}</span>
+                <PreviewText text={row.text} />
+              </span>
+            </span>
+          </LogContent>
+        </LogRow>
+      );
+    case 'thinking':
+      return (
+        <LogDisclosure indent={indent}>
+          <LogDisclosureTrigger
+            summary={wordSummary(row.text)}
+            timestamp={new Date(row.timestamp)}
+            className="text-foreground-neutral-subtle"
+          >
+            thinking
+          </LogDisclosureTrigger>
+          <LogDisclosureContent className="text-foreground-neutral-subtle">
+            <LogContent className="text-foreground-neutral-subtle">
+              <PreviewText text={row.text} />
+            </LogContent>
+          </LogDisclosureContent>
+        </LogDisclosure>
+      );
+    case 'tool-call': {
+      const awaitingResult = row.id != null && !resolvedToolCallIds.has(row.id);
+      return (
+        <LogDisclosure indent={indent}>
+          <LogDisclosureTrigger
+            timestamp={new Date(row.timestamp)}
+            summary={compactPreview(row.input)}
+            trailing={
+              awaitingResult ? (
+                <span className="inline-flex items-center gap-4">
+                  <Icon
+                    name="loader4Line"
+                    className="size-12 motion-safe:animate-spin"
+                    aria-hidden="true"
+                  />
+                  awaiting result
+                </span>
+              ) : null
+            }
+          >
+            <span className="inline-flex min-w-0 items-center gap-6">
+              <Icon name="terminalBoxLine" className="size-14 flex-none" aria-hidden="true" />
+              <span className="truncate">tool {row.name}</span>
+            </span>
+          </LogDisclosureTrigger>
+          <LogDisclosureContent>
+            <LogContent variant="code">
+              <PreviewText text={row.input} />
+            </LogContent>
+          </LogDisclosureContent>
+        </LogDisclosure>
+      );
+    }
+    case 'tool-result':
+      return (
+        <LogDisclosure indent={indent}>
+          <LogDisclosureTrigger
+            timestamp={new Date(row.timestamp)}
+            summary={compactPreview(row.output)}
+            trailing={
+              <span
+                className={cn(
+                  'inline-flex items-center gap-4',
+                  row.isError ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
+                )}
+              >
+                <Icon
+                  name={row.isError ? 'closeCircleLine' : 'checkLine'}
+                  className="size-12"
+                  aria-hidden="true"
+                />
+                {row.isError ? 'error' : 'ok'}
+              </span>
+            }
+          >
+            <span className="inline-flex min-w-0 items-center gap-6">
+              <Icon name="terminalWindowLine" className="size-14 flex-none" aria-hidden="true" />
+              <span className="truncate">result {row.toolName}</span>
+            </span>
+          </LogDisclosureTrigger>
+          <LogDisclosureContent>
+            <LogContent
+              variant="code"
+              className={cn(row.isError && 'text-red-600 dark:text-red-400')}
+            >
+              <PreviewText text={row.output} />
+            </LogContent>
+          </LogDisclosureContent>
+        </LogDisclosure>
+      );
+    case 'lifecycle':
+      return (
+        <LogRow
+          lineNumber={null}
+          timestamp={new Date(row.timestamp)}
+          indent={indent}
+          tone={row.tone}
+          data-log-terminal-failure={row.terminalFailure ? 'true' : undefined}
+        >
+          <LogContent className="text-foreground-neutral-muted">
+            <span className="inline-flex w-full items-center gap-8">
+              <Icon name="informationLine" className="size-14 flex-none" aria-hidden="true" />
+              <span className="min-w-0">
+                <span className="font-medium">{row.label}</span>
+                {row.detail != null ? (
+                  <>
+                    {' · '}
+                    <span className="text-foreground-neutral-subtle">{row.detail}</span>
+                  </>
+                ) : null}
+              </span>
+              <span
+                aria-hidden="true"
+                className="h-px flex-1 border-t border-dashed border-current opacity-30"
+              />
+            </span>
+          </LogContent>
+        </LogRow>
+      );
+    case 'fallback':
+      return (
+        <LogDisclosure indent={indent}>
+          <LogDisclosureTrigger
+            timestamp={new Date(row.timestamp)}
+            summary={compactPreview(row.raw)}
+            className="text-orange-600 dark:text-orange-400"
+          >
+            <span className="inline-flex min-w-0 items-center gap-6">
+              <Icon name="errorWarningLine" className="size-14 flex-none" aria-hidden="true" />
+              <span className="truncate">{row.label}</span>
+            </span>
+          </LogDisclosureTrigger>
+          <LogDisclosureContent>
+            <LogContent variant="code">
+              <PreviewText text={row.raw} />
+            </LogContent>
+          </LogDisclosureContent>
+        </LogDisclosure>
+      );
+    default:
+      return assertNever(row);
+  }
+}
+
+function MessageIcon({role, terminalFailure}: {role: string; terminalFailure: boolean}) {
+  const name = terminalFailure
+    ? 'closeCircleLine'
+    : role === 'user'
+      ? 'userLine'
+      : role === 'assistant'
+        ? 'robot2Line'
+        : 'message2Line';
+
+  return (
+    <Icon
+      name={name}
+      className={cn(
+        'mt-3 size-14 flex-none',
+        terminalFailure ? 'text-red-600 dark:text-red-400' : 'text-foreground-neutral-muted',
+      )}
+      aria-hidden="true"
+    />
+  );
+}
+
+function PreviewText({text}: {text: string}) {
+  const [expanded, setExpanded] = useState(false);
+  const truncated = text.length > PREVIEW_CHAR_LIMIT;
+  const visible = truncated && !expanded ? `${text.slice(0, PREVIEW_CHAR_LIMIT)}…` : text;
+
+  return (
+    <>
+      {visible}
+      {truncated ? (
+        <button
+          type="button"
+          className="ml-8 inline-flex min-h-24 items-center rounded-4 px-6 font-display text-xs text-foreground-highlight-interactive focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)]"
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? 'show less' : 'show more'}
+        </button>
+      ) : null}
+    </>
+  );
+}
+
+function compactPreview(value: string): string {
+  const singleLine = value.replace(WHITESPACE, ' ').trim();
+  if (singleLine.length <= 80) return singleLine;
+  return `${singleLine.slice(0, 80)}…`;
+}
+
+function wordSummary(value: string): string {
+  const count = value.trim().split(WORD_SEPARATOR).filter(Boolean).length;
+  return `${count} ${count === 1 ? 'word' : 'words'}`;
+}
+
+function rowKey(row: AgentSessionRow): string {
+  switch (row.kind) {
+    case 'message':
+      return `${row.kind}-${row.timestamp}-${row.role}-${row.label}-${row.text}`;
+    case 'thinking':
+      return `${row.kind}-${row.timestamp}-${row.text}`;
+    case 'tool-call':
+      return `${row.kind}-${row.timestamp}-${row.id ?? ''}-${row.name}-${row.input}`;
+    case 'tool-result':
+      return `${row.kind}-${row.timestamp}-${row.toolCallId ?? ''}-${row.toolName}-${row.output}`;
+    case 'lifecycle':
+      return `${row.kind}-${row.timestamp}-${row.label}-${row.detail ?? ''}`;
+    case 'fallback':
+      return `${row.kind}-${row.timestamp}-${row.label}-${row.raw}`;
+    default:
+      return assertNever(row);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unexpected agent session row: ${JSON.stringify(value)}`);
+}

--- a/libs/client/logs/src/components/agent-session-rows.tsx
+++ b/libs/client/logs/src/components/agent-session-rows.tsx
@@ -16,6 +16,7 @@ import {Fragment, useState} from 'react';
 import type {AgentRowMeta, AgentSessionRow} from '#core/agent-session/selector.js';
 
 const PREVIEW_CHAR_LIMIT = 1200;
+const WORD_SUMMARY_CHAR_LIMIT = 5000;
 const WHITESPACE = /\s+/g;
 const WORD_SEPARATOR = /\s+/;
 
@@ -309,6 +310,7 @@ function PreviewText({text}: {text: string}) {
       {truncated ? (
         <button
           type="button"
+          aria-expanded={expanded}
           className="ml-8 inline-flex min-h-24 items-center rounded-4 px-6 font-display text-xs text-foreground-highlight-interactive focus-visible:shadow-[inset_0_0_0_2px_var(--color-primary-500)]"
           onClick={() => setExpanded((value) => !value)}
         >
@@ -329,8 +331,11 @@ function compactPreview(value: string): string {
 }
 
 function wordSummary(value: string): string {
-  const count = value.trim().split(WORD_SEPARATOR).filter(Boolean).length;
-  return `${count} ${count === 1 ? 'word' : 'words'}`;
+  const truncated = value.length > WORD_SUMMARY_CHAR_LIMIT;
+  const head = truncated ? value.slice(0, WORD_SUMMARY_CHAR_LIMIT) : value;
+  const count = head.trim().split(WORD_SEPARATOR).filter(Boolean).length;
+  const marker = truncated ? '+' : '';
+  return `${count}${marker} ${count === 1 ? 'word' : 'words'}`;
 }
 
 function assertNever(value: never): never {

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -172,15 +172,21 @@ const failedAgentRecords: LogRecord[] = [
 ];
 
 const allAgentSessionTypeRecords: LogRecord[] = [
-  session({type: 'session', id: 'session-2026-06-23', cwd: '/workspace/platform'}, 0),
+  session({type: 'session', version: 2, id: 'session-2026-06-23', cwd: '/workspace/platform'}, 0),
   session({type: 'session_info', message: 'Restored 14 messages from prior context.'}, 1),
-  session({type: 'label', label: 'Review setup'}, 2),
+  session({type: 'label', label: 'Review setup', targetId: 'entry-review'}, 2),
   session({type: 'thinking_level_change', thinkingLevel: 'high'}, 3),
-  session({type: 'model_change', model: 'gpt-5-codex', provider: 'openai'}, 4),
+  session({type: 'model_change', modelId: 'gpt-5-codex', provider: 'openai'}, 4),
   session(
     {
       type: 'message',
-      message: {role: 'user', content: 'Review the failed workflow attempt and patch the tests.'},
+      message: {
+        role: 'user',
+        content: [
+          {type: 'text', text: 'Review the failed workflow attempt and patch the tests.'},
+          {type: 'image', mimeType: 'image/png', data: 'base64-payload'},
+        ],
+      },
     },
     5,
   ),
@@ -195,7 +201,8 @@ const allAgentSessionTypeRecords: LogRecord[] = [
           {type: 'text', text: 'I will inspect the failure anchor and the log selector.'},
           {
             type: 'thinking',
-            text: 'The UI needs to preserve the terminal assistant message while still showing the tool activity inline.',
+            thinking:
+              'The UI needs to preserve the terminal assistant message while still showing the tool activity inline.',
           },
           {
             type: 'tool_call',
@@ -212,7 +219,7 @@ const allAgentSessionTypeRecords: LogRecord[] = [
     {
       type: 'message',
       message: {
-        role: 'tool',
+        role: 'toolResult',
         toolCallId: 'call-read',
         toolName: 'read_file',
         content: [{type: 'text', text: 'function expandSessionRecord(record) { /* ... */ }'}],
@@ -236,12 +243,30 @@ const allAgentSessionTypeRecords: LogRecord[] = [
     {
       type: 'branch_summary',
       summary: 'Kept the parser scoped to agent_session records and log-tree ordering.',
+      fromId: 'entry-review',
     },
     9,
   ),
-  session({type: 'compaction', summary: 'Previous context summarized into 3 decisions.'}, 10),
-  session({type: 'custom', message: 'Specialist review: parser coverage looks complete.'}, 11),
-  session({type: 'custom_message', text: 'Operator note: retry after the fixture update.'}, 12),
+  session(
+    {
+      type: 'compaction',
+      summary: 'Previous context summarized into 3 decisions.',
+      tokensBefore: 42000,
+    },
+    10,
+  ),
+  session(
+    {type: 'custom', customType: 'review', data: {verdict: 'parser coverage looks complete'}},
+    11,
+  ),
+  session(
+    {
+      type: 'custom_message',
+      customType: 'operator-note',
+      content: 'Retry after the fixture update.',
+    },
+    12,
+  ),
   session(
     {
       type: 'message',
@@ -254,9 +279,58 @@ const allAgentSessionTypeRecords: LogRecord[] = [
     },
     13,
   ),
-  session({type: 'future_entry', payload: {feature: 'new-session-event'}}, 14),
-  {v: 1, ts: at(15), type: 'agent_session', data: '{not-json'},
-  {v: 1, ts: at(16), type: 'end', total_bytes: 12_288},
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'bashExecution',
+        command: 'pnpm test',
+        output: 'FAIL selector.test.ts > parses tool results',
+        exitCode: 1,
+        cancelled: false,
+        truncated: true,
+        fullOutputPath: '/tmp/shipfox-agent-output.log',
+      },
+    },
+    14,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'custom',
+        customType: 'status',
+        content: 'Extension status update.',
+        display: true,
+      },
+    },
+    15,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'branchSummary',
+        summary: 'Created a branch for selector fixes.',
+        fromId: 'entry-review',
+      },
+    },
+    16,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'compactionSummary',
+        summary: 'Summarized earlier tool output.',
+        tokensBefore: 96000,
+      },
+    },
+    17,
+  ),
+  session({type: 'future_entry', payload: {feature: 'new-session-event'}}, 18),
+  {v: 1, ts: at(19), type: 'agent_session', data: '{not-json'},
+  {v: 1, ts: at(20), type: 'end', total_bytes: 12_288},
 ];
 
 const meta = {

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -126,7 +126,7 @@ const unifiedAgentRecords: LogRecord[] = [
       message: {
         toolCallId: 'call-1',
         toolName: 'read_file',
-        content: 'export function LoginForm() { /* ... */ }',
+        content: [{type: 'text', text: 'export function LoginForm() { /* ... */ }'}],
       },
     },
     3,

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -13,6 +13,12 @@ const out = (data: string, offset: number, stream: 'stdout' | 'stderr' = 'stdout
   stream,
   data,
 });
+const session = (data: unknown, offset: number): LogRecord => ({
+  v: 1,
+  ts: at(offset),
+  type: 'agent_session',
+  data: typeof data === 'string' ? data : JSON.stringify(data),
+});
 const groupStart = (
   groupId: string,
   name: string,
@@ -82,6 +88,89 @@ const nestedRecords: LogRecord[] = [
   {v: 1, ts: at(15.2), type: 'end', total_bytes: 9_216},
 ];
 
+const unifiedAgentRecords: LogRecord[] = [
+  session(
+    {
+      type: 'message',
+      message: {role: 'user', content: 'Update the auth form error handling.'},
+    },
+    0,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        model: 'gpt-5-codex',
+        content: [
+          {type: 'text', text: 'I will inspect the form and the existing tests first.'},
+          {
+            type: 'thinking',
+            text: 'The likely risk is server errors being written to the wrong form meta slot.',
+          },
+          {
+            type: 'toolCall',
+            id: 'call-1',
+            name: 'read_file',
+            arguments: {path: 'src/login-form.tsx'},
+          },
+        ],
+      },
+    },
+    1,
+  ),
+  out('$ pnpm --filter @shipfox/client-auth test\n', 2),
+  session(
+    {
+      type: 'message',
+      message: {
+        toolCallId: 'call-1',
+        toolName: 'read_file',
+        content: 'export function LoginForm() { /* ... */ }',
+      },
+    },
+    3,
+  ),
+  session({type: 'model_change', model: 'gpt-5-codex', provider: 'openai'}, 4),
+  {v: 1, ts: at(5), type: 'end', total_bytes: 4096},
+];
+
+const awaitingAgentRecords: LogRecord[] = [
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            id: 'call-2',
+            name: 'run_tests',
+            arguments: {filter: '@shipfox/client-logs'},
+          },
+        ],
+      },
+    },
+    0,
+  ),
+  out('running tests...\n', 1),
+];
+
+const failedAgentRecords: LogRecord[] = [
+  out('$ pnpm test\n', 0),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [{type: 'text', text: 'The run cannot continue because the harness aborted.'}],
+        stopReason: 'error',
+      },
+    },
+    1,
+  ),
+];
+
 const meta = {
   title: 'Logs/LogView',
   component: LogView,
@@ -148,6 +237,65 @@ export const MinimalOutput: Story = {
   render: (args) => (
     <div className="max-w-3xl">
       <LogView {...args} records={[{v: 1, ts: at(1), type: 'end', total_bytes: 0}]} />
+    </div>
+  ),
+};
+
+export const UnifiedAgentSession: Story = {
+  args: {showLineNumbers: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={unifiedAgentRecords} />
+    </div>
+  ),
+};
+
+export const RunningAgentToolCall: Story = {
+  args: {showLineNumbers: true, emptyState: 'pending'},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={awaitingAgentRecords} />
+    </div>
+  ),
+};
+
+export const FailedAgentSession: Story = {
+  args: {showLineNumbers: true, anchorToFailure: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={failedAgentRecords} />
+    </div>
+  ),
+};
+
+export const UnknownAgentEntry: Story = {
+  args: {showLineNumbers: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={[session({type: 'future_entry', payload: {value: true}}, 0)]} />
+    </div>
+  ),
+};
+
+export const LargeAgentPayload: Story = {
+  args: {showLineNumbers: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView
+        {...args}
+        records={[
+          session(
+            {
+              type: 'message',
+              message: {
+                role: 'assistant',
+                content: [{type: 'text', text: 'Large payload '.repeat(180)}],
+              },
+            },
+            0,
+          ),
+        ]}
+      />
     </div>
   ),
 };

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -171,6 +171,94 @@ const failedAgentRecords: LogRecord[] = [
   ),
 ];
 
+const allAgentSessionTypeRecords: LogRecord[] = [
+  session({type: 'session', id: 'session-2026-06-23', cwd: '/workspace/platform'}, 0),
+  session({type: 'session_info', message: 'Restored 14 messages from prior context.'}, 1),
+  session({type: 'label', label: 'Review setup'}, 2),
+  session({type: 'thinking_level_change', thinkingLevel: 'high'}, 3),
+  session({type: 'model_change', model: 'gpt-5-codex', provider: 'openai'}, 4),
+  session(
+    {
+      type: 'message',
+      message: {role: 'user', content: 'Review the failed workflow attempt and patch the tests.'},
+    },
+    5,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        model: 'gpt-5-codex',
+        provider: 'openai',
+        content: [
+          {type: 'text', text: 'I will inspect the failure anchor and the log selector.'},
+          {
+            type: 'thinking',
+            text: 'The UI needs to preserve the terminal assistant message while still showing the tool activity inline.',
+          },
+          {
+            type: 'tool_call',
+            id: 'call-read',
+            name: 'read_file',
+            arguments: {path: 'libs/client/logs/src/core/agent-session/selector.ts'},
+          },
+        ],
+      },
+    },
+    6,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'tool',
+        toolCallId: 'call-read',
+        toolName: 'read_file',
+        content: [{type: 'text', text: 'function expandSessionRecord(record) { /* ... */ }'}],
+      },
+    },
+    7,
+  ),
+  session(
+    {
+      type: 'message',
+      message: {
+        toolCallId: 'call-test',
+        toolName: 'run_tests',
+        content: [{type: 'text', text: 'FAIL selector.test.ts > parses tool results'}],
+        isError: true,
+      },
+    },
+    8,
+  ),
+  session(
+    {
+      type: 'branch_summary',
+      summary: 'Kept the parser scoped to agent_session records and log-tree ordering.',
+    },
+    9,
+  ),
+  session({type: 'compaction', summary: 'Previous context summarized into 3 decisions.'}, 10),
+  session({type: 'custom', message: 'Specialist review: parser coverage looks complete.'}, 11),
+  session({type: 'custom_message', text: 'Operator note: retry after the fixture update.'}, 12),
+  session(
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [{type: 'text', text: 'I cannot continue because the test harness aborted.'}],
+        stopReason: 'aborted',
+        errorMessage: 'Harness aborted before the retry finished.',
+      },
+    },
+    13,
+  ),
+  session({type: 'future_entry', payload: {feature: 'new-session-event'}}, 14),
+  {v: 1, ts: at(15), type: 'agent_session', data: '{not-json'},
+  {v: 1, ts: at(16), type: 'end', total_bytes: 12_288},
+];
+
 const meta = {
   title: 'Logs/LogView',
   component: LogView,
@@ -246,6 +334,15 @@ export const UnifiedAgentSession: Story = {
   render: (args) => (
     <div className="max-w-3xl">
       <LogView {...args} records={unifiedAgentRecords} />
+    </div>
+  ),
+};
+
+export const AllAgentSessionTypes: Story = {
+  args: {showLineNumbers: true, anchorToFailure: true},
+  render: (args) => (
+    <div className="max-w-3xl">
+      <LogView {...args} records={allAgentSessionTypeRecords} />
     </div>
   ),
 };

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -1,8 +1,9 @@
 import type {LogRecord} from '@shipfox/api-logs-dto';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {LogView, LogViewSkeleton} from './log-view.js';
 
 const ts = new Date('2026-06-23T10:00:00.000Z').getTime();
+const THINKING_BUTTON_NAME = /thinking/i;
 
 const output = (data: string): LogRecord => ({
   v: 1,
@@ -11,13 +12,26 @@ const output = (data: string): LogRecord => ({
   stream: 'stdout',
   data,
 });
+const agentSession = (data: unknown, offsetMs = 0): LogRecord => ({
+  v: 1,
+  ts: ts + offsetMs,
+  type: 'agent_session',
+  data: typeof data === 'string' ? data : JSON.stringify(data),
+});
 
 describe('LogView', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   test('renders the complete empty state for an empty closed stream', () => {
     render(<LogView records={[]} />);
 
     expect(screen.getByText('Step produced no output')).toBeDefined();
-    expect(screen.getByText('This log stream closed without stdout or stderr.')).toBeDefined();
+    expect(
+      screen.getByText('This log stream closed without session entries or process output.'),
+    ).toBeDefined();
     expect(screen.getByRole('log')).toBeDefined();
   });
 
@@ -55,6 +69,123 @@ describe('LogView', () => {
     expect(screen.getByText('hello')).toBeDefined();
     expect(screen.queryByText('Step produced no output')).toBeNull();
     expect(screen.queryByText('No output yet')).toBeNull();
+  });
+
+  test('renders assistant session text and collapsed thinking', () => {
+    render(
+      <LogView
+        records={[
+          agentSession({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [
+                {type: 'text', text: 'I will inspect the failure.'},
+                {type: 'thinking', text: 'The stack trace points at validation.'},
+              ],
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('I will inspect the failure.')).toBeDefined();
+    expect(screen.getByRole('button', {name: THINKING_BUTTON_NAME})).toBeDefined();
+    expect(screen.queryByText('The stack trace points at validation.')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', {name: THINKING_BUTTON_NAME}));
+
+    expect(screen.getByText('The stack trace points at validation.')).toBeDefined();
+  });
+
+  test('renders tool calls with awaiting state until a result appears later in the stream', () => {
+    render(
+      <LogView
+        records={[
+          agentSession({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{type: 'toolCall', id: 'call-1', name: 'edit_file', arguments: {}}],
+            },
+          }),
+          output('stdout between call and result\n'),
+          agentSession(
+            {
+              type: 'message',
+              message: {
+                toolCallId: 'call-1',
+                toolName: 'edit_file',
+                content: 'patched',
+                isError: false,
+              },
+            },
+            1,
+          ),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('tool edit_file')).toBeDefined();
+    expect(screen.getByText('stdout between call and result')).toBeDefined();
+    expect(screen.getByText('result edit_file')).toBeDefined();
+    expect(screen.queryByText('awaiting result')).toBeNull();
+  });
+
+  test('renders unknown session entries without crashing', () => {
+    render(<LogView records={[agentSession({type: 'future_entry', payload: {value: true}})]} />);
+
+    expect(screen.getByText('Unknown session entry: future_entry')).toBeDefined();
+  });
+
+  test('truncates large payloads with a show-more control', () => {
+    render(
+      <LogView
+        records={[
+          agentSession({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{type: 'text', text: 'x'.repeat(1500)}],
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('button', {name: 'show more'})).toBeDefined();
+  });
+
+  test('anchors terminal failures when requested', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    render(
+      <LogView
+        anchorToFailure
+        records={[
+          output('setup\n'),
+          agentSession({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{type: 'text', text: 'I cannot continue.'}],
+              stopReason: 'error',
+            },
+          }),
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({block: 'center'}));
   });
 });
 

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -20,9 +20,21 @@ const agentSession = (data: unknown, offsetMs = 0): LogRecord => ({
 });
 
 describe('LogView', () => {
+  let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
+  let scrollIntoViewWasStubbed = false;
+
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    if (scrollIntoViewWasStubbed) {
+      if (scrollIntoViewDescriptor != null) {
+        Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', scrollIntoViewDescriptor);
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
+      }
+    }
+    scrollIntoViewDescriptor = undefined;
+    scrollIntoViewWasStubbed = false;
   });
 
   test('renders the complete empty state for an empty closed stream', () => {
@@ -172,7 +184,14 @@ describe('LogView', () => {
       />,
     );
 
-    expect(screen.getByRole('button', {name: 'show more'})).toBeDefined();
+    const toggle = screen.getByRole('button', {name: 'show more'});
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole('button', {name: 'show less'}).getAttribute('aria-expanded')).toBe(
+      'true',
+    );
   });
 
   test('anchors terminal failures when requested', async () => {
@@ -181,11 +200,20 @@ describe('LogView', () => {
       return 1;
     });
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
-    const scrollIntoView = vi.fn();
-    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
-      configurable: true,
-      value: scrollIntoView,
-    });
+    scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollIntoView',
+    );
+    scrollIntoViewWasStubbed = true;
+    if (scrollIntoViewDescriptor == null) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+        configurable: true,
+        value: () => undefined,
+      });
+    }
+    const scrollIntoView = vi
+      .spyOn(HTMLElement.prototype, 'scrollIntoView')
+      .mockImplementation(() => undefined);
 
     render(
       <LogView

--- a/libs/client/logs/src/components/log-view.test.tsx
+++ b/libs/client/logs/src/components/log-view.test.tsx
@@ -116,7 +116,7 @@ describe('LogView', () => {
               message: {
                 toolCallId: 'call-1',
                 toolName: 'edit_file',
-                content: 'patched',
+                content: [{type: 'text', text: 'patched'}],
                 isError: false,
               },
             },
@@ -130,6 +130,25 @@ describe('LogView', () => {
     expect(screen.getByText('stdout between call and result')).toBeDefined();
     expect(screen.getByText('result edit_file')).toBeDefined();
     expect(screen.queryByText('awaiting result')).toBeNull();
+  });
+
+  test('shows the awaiting-result state for a tool call with no matching result', () => {
+    render(
+      <LogView
+        records={[
+          agentSession({
+            type: 'message',
+            message: {
+              role: 'assistant',
+              content: [{type: 'toolCall', id: 'call-1', name: 'edit_file', arguments: {}}],
+            },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('tool edit_file')).toBeDefined();
+    expect(screen.getByText('awaiting result')).toBeDefined();
   });
 
   test('renders unknown session entries without crashing', () => {

--- a/libs/client/logs/src/components/log-view.tsx
+++ b/libs/client/logs/src/components/log-view.tsx
@@ -9,7 +9,8 @@ import {
   type LogTimestampMode,
   Skeleton,
 } from '@shipfox/react-ui';
-import {type ReactNode, type UIEventHandler, useMemo} from 'react';
+import {type ReactNode, type UIEventHandler, useEffect, useMemo, useRef} from 'react';
+import {expandSessionRecord} from '#core/agent-session/selector.js';
 import {
   assertNever,
   buildLogTree,
@@ -17,6 +18,7 @@ import {
   type LogTree,
   type MarkerLogRecord,
 } from '#core/log-tree.js';
+import {AgentSessionRows} from './agent-session-rows.js';
 import {LogGroup} from './log-group.js';
 import {OutputLogRow} from './output-log-row.js';
 import {CappedMarker, EndMarker, GapMarker, RunnerLostMarker} from './system-markers.js';
@@ -28,6 +30,7 @@ export interface LogViewProps {
   showLineNumbers?: boolean;
   emptyState?: 'complete' | 'pending';
   defaultGroupsOpen?: boolean;
+  anchorToFailure?: boolean;
   className?: string | undefined;
   onScroll?: UIEventHandler<HTMLDivElement> | undefined;
 }
@@ -44,14 +47,39 @@ export function LogView({
   showLineNumbers = true,
   emptyState = 'complete',
   defaultGroupsOpen = false,
+  anchorToFailure = false,
   className,
   onScroll,
 }: LogViewProps) {
+  const rowsRef = useRef<HTMLDivElement>(null);
   const tree = useMemo(() => buildLogTree(records), [records]);
+  const resolvedToolCallIds = useMemo(() => collectResolvedToolCallIds(tree.nodes), [tree.nodes]);
   const noOutputState = getNoOutputState(tree, emptyState);
+  const anchorRecordCount = records.length;
+
+  useEffect(() => {
+    if (!anchorToFailure) return;
+    if (anchorRecordCount === 0) return;
+
+    const frame = scheduleAnimationFrame(() => {
+      const rows = rowsRef.current;
+      if (!rows) return;
+
+      const failure = rows.querySelector<HTMLElement>('[data-log-terminal-failure="true"]');
+      if (failure) {
+        failure.scrollIntoView({block: 'center'});
+        return;
+      }
+
+      rows.scrollTop = rows.scrollHeight;
+    });
+
+    return () => cancelScheduledFrame(frame);
+  }, [anchorToFailure, anchorRecordCount]);
 
   return (
     <LogRows
+      ref={rowsRef}
       timestamps={timestamps}
       wrap={wrap}
       showLineNumbers={showLineNumbers}
@@ -60,7 +88,7 @@ export function LogView({
       {...(tree.originTs != null ? {timestampOrigin: new Date(tree.originTs)} : {})}
     >
       {noOutputState ? <NoOutputRow state={noOutputState} /> : null}
-      {renderNodes(tree.nodes, 0, tree, defaultGroupsOpen)}
+      {renderNodes(tree.nodes, 0, tree, defaultGroupsOpen, resolvedToolCallIds)}
     </LogRows>
   );
 }
@@ -127,7 +155,7 @@ function NoOutputRow({state}: {state: NonNullable<LogViewProps['emptyState']>}) 
         }
       : {
           title: 'Step produced no output',
-          detail: 'This log stream closed without stdout or stderr.',
+          detail: 'This log stream closed without session entries or process output.',
         };
 
   return (
@@ -151,6 +179,7 @@ function renderNodes(
   depth: number,
   tree: LogTree,
   defaultGroupsOpen: boolean,
+  resolvedToolCallIds: ReadonlySet<string>,
 ): ReactNode[] {
   // `node.seq` is the stable, unique render key (see `LogNodeBase`): a concatenated
   // multi-step/retry stream can repeat a `group_id` or a marker's `(type, ts)` at one
@@ -175,15 +204,65 @@ function renderNodes(
             terminated={tree.terminated}
             defaultOpen={defaultGroupsOpen}
           >
-            {renderNodes(node.children, depth + 1, tree, defaultGroupsOpen)}
+            {renderNodes(node.children, depth + 1, tree, defaultGroupsOpen, resolvedToolCallIds)}
           </LogGroup>
         );
       case 'marker':
         return <MarkerRow key={node.seq} record={node.record} tree={tree} />;
+      case 'session':
+        return (
+          <AgentSessionRows
+            key={node.seq}
+            rows={expandSessionRecord(node.record)}
+            resolvedToolCallIds={resolvedToolCallIds}
+            indent={depth}
+          />
+        );
       default:
         return assertNever(node);
     }
   });
+}
+
+function collectResolvedToolCallIds(nodes: readonly LogNode[]): ReadonlySet<string> {
+  const ids = new Set<string>();
+  collectResolvedToolCallIdsInto(nodes, ids);
+  return ids;
+}
+
+function collectResolvedToolCallIdsInto(nodes: readonly LogNode[], ids: Set<string>): void {
+  for (const node of nodes) {
+    switch (node.kind) {
+      case 'session':
+        for (const row of expandSessionRecord(node.record)) {
+          if (row.kind === 'tool-result' && row.toolCallId != null) ids.add(row.toolCallId);
+        }
+        break;
+      case 'group':
+        collectResolvedToolCallIdsInto(node.children, ids);
+        break;
+      case 'output':
+      case 'marker':
+        break;
+      default:
+        assertNever(node);
+    }
+  }
+}
+
+function scheduleAnimationFrame(callback: FrameRequestCallback): number {
+  if (typeof globalThis.requestAnimationFrame === 'function') {
+    return globalThis.requestAnimationFrame(callback);
+  }
+  return window.setTimeout(() => callback(Date.now()), 0);
+}
+
+function cancelScheduledFrame(frame: number) {
+  if (typeof globalThis.cancelAnimationFrame === 'function') {
+    globalThis.cancelAnimationFrame(frame);
+    return;
+  }
+  window.clearTimeout(frame);
 }
 
 function MarkerRow({record, tree}: {record: MarkerLogRecord; tree: LogTree}): ReactNode {

--- a/libs/client/logs/src/components/system-markers.tsx
+++ b/libs/client/logs/src/components/system-markers.tsx
@@ -30,6 +30,7 @@ interface LogMarkerRowProps {
   detail?: string;
   /** Right-aligned `font-code` figures (bytes, line count, duration). */
   meta?: string;
+  terminalFailure?: boolean;
   children: string;
 }
 
@@ -40,9 +41,22 @@ interface LogMarkerRowProps {
  * names the event, the icon/tone carry severity), so the copy reads helpfully rather
  * than mechanically.
  */
-function LogMarkerRow({icon, tone, timestamp = null, detail, meta, children}: LogMarkerRowProps) {
+function LogMarkerRow({
+  icon,
+  tone,
+  timestamp = null,
+  detail,
+  meta,
+  terminalFailure = false,
+  children,
+}: LogMarkerRowProps) {
   return (
-    <LogRow lineNumber={null} timestamp={timestamp} tone={tone}>
+    <LogRow
+      lineNumber={null}
+      timestamp={timestamp}
+      tone={tone}
+      data-log-terminal-failure={terminalFailure ? 'true' : undefined}
+    >
       <LogContent className={cn('block', toneText[tone])}>
         <span className="inline-flex w-full items-center gap-8">
           <Icon name={icon} className="size-14 flex-none" aria-hidden="true" />
@@ -132,6 +146,7 @@ export function RunnerLostMarker({record}: {record: RunnerLostLogRecord}) {
       tone="error"
       timestamp={new Date(record.ts)}
       detail="the log ends here and may be incomplete"
+      terminalFailure
     >
       Runner disconnected
     </LogMarkerRow>

--- a/libs/client/logs/src/core/agent-session/entry-schema.ts
+++ b/libs/client/logs/src/core/agent-session/entry-schema.ts
@@ -1,0 +1,82 @@
+import {z} from 'zod';
+
+const looseObjectSchema = z.object({}).catchall(z.unknown());
+
+export const sessionEntrySchema = z
+  .object({
+    type: z.string().min(1),
+  })
+  .catchall(z.unknown());
+
+export const agentMessageSchema = z
+  .object({
+    type: z.string().optional(),
+    role: z.string().optional(),
+    content: z.unknown().optional(),
+    model: z.string().optional(),
+    provider: z.string().optional(),
+    stopReason: z.string().optional(),
+    errorMessage: z.string().optional(),
+    toolCallId: z.string().optional(),
+    toolName: z.string().optional(),
+    isError: z.boolean().optional(),
+  })
+  .catchall(z.unknown());
+
+export const sessionMessageEntrySchema = z
+  .object({
+    type: z.literal('message'),
+    message: agentMessageSchema,
+  })
+  .catchall(z.unknown());
+
+export const contentBlockSchema = z
+  .object({
+    type: z.string().optional(),
+  })
+  .catchall(z.unknown());
+
+export type SessionEntry = z.infer<typeof sessionEntrySchema>;
+export type AgentMessage = z.infer<typeof agentMessageSchema>;
+export type ContentBlock = z.infer<typeof contentBlockSchema>;
+
+export interface ParsedSessionEntry {
+  ok: true;
+  entry: SessionEntry;
+}
+
+export interface MalformedSessionEntry {
+  ok: false;
+  raw: string;
+  reason: 'invalid-json' | 'invalid-entry';
+}
+
+export type SessionEntryParseResult = ParsedSessionEntry | MalformedSessionEntry;
+
+export function parseSessionEntry(data: string): SessionEntryParseResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(data);
+  } catch {
+    return {ok: false, raw: data, reason: 'invalid-json'};
+  }
+
+  const parsed = sessionEntrySchema.safeParse(json);
+  if (!parsed.success) return {ok: false, raw: data, reason: 'invalid-entry'};
+
+  return {ok: true, entry: parsed.data};
+}
+
+export function asLooseObject(value: unknown): Record<string, unknown> | null {
+  const parsed = looseObjectSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+export function asContentBlocks(value: unknown): ContentBlock[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((item) => {
+    const parsed = contentBlockSchema.safeParse(item);
+    return parsed.success ? [parsed.data] : [];
+  });
+}

--- a/libs/client/logs/src/core/agent-session/selector.test.ts
+++ b/libs/client/logs/src/core/agent-session/selector.test.ts
@@ -76,7 +76,7 @@ describe('expandSessionRecord', () => {
         message: {
           toolCallId: 'call-1',
           toolName: 'read_file',
-          content: 'file contents',
+          content: [{type: 'text', text: 'file contents'}],
           isError,
         },
       }),
@@ -96,7 +96,7 @@ describe('expandSessionRecord', () => {
 
   test.each([
     [{type: 'session', id: 'session-1'}, 'Session started', 'session-1'],
-    [{type: 'thinking_level_change', level: 'high'}, 'Thinking level changed', 'high'],
+    [{type: 'thinking_level_change', thinkingLevel: 'high'}, 'Thinking level changed', 'high'],
     [{type: 'model_change', model: 'gpt-5-codex'}, 'Model changed', 'gpt-5-codex'],
     [
       {type: 'compaction', summary: 'summarized old context'},
@@ -136,5 +136,103 @@ describe('expandSessionRecord', () => {
 
     expect(first).toBe(second);
     expect(parseSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('expands a tool result with no id', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {role: 'tool', toolName: 'read_file', content: [{type: 'text', text: 'data'}]},
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'tool-result',
+        timestamp: 1,
+        toolCallId: null,
+        toolName: 'read_file',
+        output: 'data',
+        isError: false,
+      },
+    ]);
+  });
+
+  test('expands a tool call with no id', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{type: 'tool_call', name: 'run', arguments: {cmd: 'ls'}}],
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {kind: 'tool-call', timestamp: 1, id: null, name: 'run', input: '{\n  "cmd": "ls"\n}'},
+    ]);
+  });
+
+  test('falls back to the raw message when assistant content has no renderable blocks', () => {
+    const rows = expandSessionRecord(
+      record({type: 'message', message: {role: 'assistant', content: [{type: 'image'}]}}),
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({kind: 'message', role: 'assistant'});
+  });
+
+  test('renders a branch summary as a system message row', () => {
+    const rows = expandSessionRecord(record({type: 'branch_summary', summary: 'merged main'}));
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'system',
+        label: 'branch summary',
+        text: 'merged main',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  test('renders a custom entry as a message row', () => {
+    const rows = expandSessionRecord(record({type: 'custom', message: 'hello there'}));
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'custom',
+        label: 'custom',
+        text: 'hello there',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  test('renders a session_info entry as a lifecycle row', () => {
+    const rows = expandSessionRecord(record({type: 'session_info', message: 'resumed'}));
+
+    expect(rows).toEqual([
+      {
+        kind: 'lifecycle',
+        timestamp: 1,
+        label: 'Session info',
+        detail: 'resumed',
+        tone: 'default',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  test('returns an unsupported fallback when the entry has no type', () => {
+    const rows = expandSessionRecord(record({payload: {x: 1}}));
+
+    expect(rows).toEqual([
+      {kind: 'fallback', timestamp: 1, label: 'Unsupported entry', raw: '{"payload":{"x":1}}'},
+    ]);
   });
 });

--- a/libs/client/logs/src/core/agent-session/selector.test.ts
+++ b/libs/client/logs/src/core/agent-session/selector.test.ts
@@ -7,6 +7,8 @@ const record = (data: unknown, ts = 1): Extract<LogRecord, {type: 'agent_session
   type: 'agent_session',
   data: typeof data === 'string' ? data : JSON.stringify(data),
 });
+const meta = (label: string, value: string, inline?: boolean) =>
+  inline == null ? {label, value} : {label, value, inline};
 
 describe('expandSessionRecord', () => {
   test('returns a fallback row for malformed JSON', () => {
@@ -51,7 +53,8 @@ describe('expandSessionRecord', () => {
         kind: 'message',
         timestamp: 1,
         role: 'assistant',
-        label: 'assistant · claude-opus-4',
+        label: 'assistant',
+        meta: [meta('model', 'claude-opus-4')],
         text: 'I will edit the file.',
         terminalFailure: false,
       },
@@ -95,33 +98,45 @@ describe('expandSessionRecord', () => {
   });
 
   test.each([
-    [{type: 'session', id: 'session-1'}, 'Session started', 'session-1'],
+    [{type: 'session', id: 'session-1'}, 'Session started', 'session-1', []],
     [
       {type: 'session', version: 2, id: 'session-1', cwd: '/workspace'},
       'Session started',
       'v2 · session-1 · /workspace',
+      [],
     ],
-    [{type: 'thinking_level_change', thinkingLevel: 'high'}, 'Thinking level changed', 'high'],
+    [{type: 'thinking_level_change', thinkingLevel: 'high'}, 'Thinking level changed', 'high', []],
     [
       {type: 'model_change', modelId: 'gpt-5-codex', provider: 'openai'},
       'Model changed',
       'gpt-5-codex · openai',
+      [],
     ],
     [
       {type: 'compaction', summary: 'summarized old context', tokensBefore: 12_345},
       'Context compacted',
-      'summarized old context · 12345 tokens summarized',
+      'summarized old context',
+      [meta('tokens before', '12.3K tokens')],
     ],
     [
       {type: 'label', label: 'Implement tests', targetId: 'entry-1'},
       'Label',
-      'Implement tests · target entry-1',
+      'Implement tests',
+      [meta('target', 'entry-1', false)],
     ],
-  ])('expands lifecycle entry %#', (entry, label, detail) => {
+  ])('expands lifecycle entry %#', (entry, label, detail, meta) => {
     const rows = expandSessionRecord(record(entry));
 
     expect(rows).toEqual([
-      {kind: 'lifecycle', timestamp: 1, label, detail, tone: 'default', terminalFailure: false},
+      {
+        kind: 'lifecycle',
+        timestamp: 1,
+        label,
+        detail,
+        meta,
+        tone: 'default',
+        terminalFailure: false,
+      },
     ]);
   });
 
@@ -145,6 +160,7 @@ describe('expandSessionRecord', () => {
         timestamp: 1,
         role: 'user',
         label: 'user',
+        meta: [],
         text: 'Inspect this screenshot.\n\n[image/png image]',
         terminalFailure: false,
       },
@@ -173,7 +189,12 @@ describe('expandSessionRecord', () => {
         timestamp: 1,
         role: 'bash-execution',
         label: 'bash execution',
-        text: '$ pnpm test\n1 failed\nexit 1 · truncated · full output: /tmp/output.log',
+        meta: [
+          meta('exit', '1'),
+          meta('truncated', 'yes'),
+          meta('full output', '/tmp/output.log', false),
+        ],
+        text: '$ pnpm test\n1 failed',
         terminalFailure: false,
       },
     ]);
@@ -184,25 +205,28 @@ describe('expandSessionRecord', () => {
       {role: 'branchSummary', summary: 'branched for fix', fromId: 'entry-1'},
       'branch-summary',
       'branch summary',
-      'branched for fix · from entry-1',
+      [meta('from', 'entry-1')],
+      'branched for fix',
     ],
     [
       {role: 'compactionSummary', summary: 'summarized history', tokensBefore: 42_000},
       'compaction-summary',
       'compaction summary',
-      'summarized history · 42000 tokens summarized',
+      [meta('tokens before', '42K tokens')],
+      'summarized history',
     ],
     [
       {role: 'custom', customType: 'extension', content: 'extension output', display: true},
       'custom',
-      'custom · extension',
+      'custom',
+      [meta('type', 'extension'), meta('display', 'on')],
       'extension output',
     ],
-  ])('renders extended message role %#', (message, role, label, text) => {
+  ])('renders extended message role %#', (message, role, label, meta, text) => {
     const rows = expandSessionRecord(record({type: 'message', message}));
 
     expect(rows).toEqual([
-      {kind: 'message', timestamp: 1, role, label, text, terminalFailure: false},
+      {kind: 'message', timestamp: 1, role, label, meta, text, terminalFailure: false},
     ]);
   });
 
@@ -288,7 +312,8 @@ describe('expandSessionRecord', () => {
         timestamp: 1,
         role: 'system',
         label: 'branch summary',
-        text: 'merged main · from entry-1',
+        meta: [meta('from', 'entry-1')],
+        text: 'merged main',
         terminalFailure: false,
       },
     ]);
@@ -304,7 +329,8 @@ describe('expandSessionRecord', () => {
         kind: 'message',
         timestamp: 1,
         role: 'custom',
-        label: 'custom · extension',
+        label: 'custom',
+        meta: [meta('type', 'extension')],
         text: '{\n  "ok": true\n}',
         terminalFailure: false,
       },
@@ -321,7 +347,8 @@ describe('expandSessionRecord', () => {
         kind: 'message',
         timestamp: 1,
         role: 'custom',
-        label: 'custom message · extension',
+        label: 'custom message',
+        meta: [meta('type', 'extension')],
         text: 'hello there',
         terminalFailure: false,
       },
@@ -337,6 +364,7 @@ describe('expandSessionRecord', () => {
         timestamp: 1,
         label: 'Session info',
         detail: 'resumed',
+        meta: [],
         tone: 'default',
         terminalFailure: false,
       },

--- a/libs/client/logs/src/core/agent-session/selector.test.ts
+++ b/libs/client/logs/src/core/agent-session/selector.test.ts
@@ -69,6 +69,64 @@ describe('expandSessionRecord', () => {
     ]);
   });
 
+  test('preserves interleaved assistant text and thinking block order', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            {type: 'text', text: 'First visible update.'},
+            {type: 'thinking', text: 'First private thought.'},
+            {type: 'text', text: 'Second visible update.'},
+            {type: 'toolCall', id: 'call-1', name: 'read_file', arguments: {path: 'src/a.ts'}},
+            {type: 'thinking', text: 'Thought after tool call.'},
+            {type: 'text', text: 'Final visible update.'},
+          ],
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [],
+        text: 'First visible update.',
+        terminalFailure: false,
+      },
+      {kind: 'thinking', timestamp: 1, text: 'First private thought.'},
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [],
+        text: 'Second visible update.',
+        terminalFailure: false,
+      },
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'call-1',
+        name: 'read_file',
+        input: '{\n  "path": "src/a.ts"\n}',
+      },
+      {kind: 'thinking', timestamp: 1, text: 'Thought after tool call.'},
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [],
+        text: 'Final visible update.',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
   test.each([
     ['success', false],
     ['error', true],
@@ -243,6 +301,32 @@ describe('expandSessionRecord', () => {
     );
 
     expect(rows[0]).toMatchObject({kind: 'message', terminalFailure: true});
+  });
+
+  test('adds a failure anchor for thinking-only assistant terminal errors', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{type: 'thinking', text: 'No visible response before failure.'}],
+          stopReason: 'error',
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {kind: 'thinking', timestamp: 1, text: 'No visible response before failure.'},
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant',
+        meta: [meta('stop', 'error')],
+        text: 'Assistant stopped with an error.',
+        terminalFailure: true,
+      },
+    ]);
   });
 
   test('memoizes rows per record object', () => {

--- a/libs/client/logs/src/core/agent-session/selector.test.ts
+++ b/libs/client/logs/src/core/agent-session/selector.test.ts
@@ -1,0 +1,140 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import {expandSessionRecord} from './selector.js';
+
+const record = (data: unknown, ts = 1): Extract<LogRecord, {type: 'agent_session'}> => ({
+  v: 1,
+  ts,
+  type: 'agent_session',
+  data: typeof data === 'string' ? data : JSON.stringify(data),
+});
+
+describe('expandSessionRecord', () => {
+  test('returns a fallback row for malformed JSON', () => {
+    const rows = expandSessionRecord(record('{not json'));
+
+    expect(rows).toEqual([
+      {kind: 'fallback', timestamp: 1, label: 'Malformed session entry', raw: '{not json'},
+    ]);
+  });
+
+  test('returns a fallback row for an unknown entry type', () => {
+    const rows = expandSessionRecord(record({type: 'future_entry', payload: {x: 1}}));
+
+    expect(rows).toEqual([
+      {
+        kind: 'fallback',
+        timestamp: 1,
+        label: 'Unknown session entry: future_entry',
+        raw: '{"type":"future_entry","payload":{"x":1}}',
+      },
+    ]);
+  });
+
+  test('expands assistant text, thinking, and tool calls into ordered rows', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          model: 'claude-opus-4',
+          content: [
+            {type: 'text', text: 'I will edit the file.'},
+            {type: 'thinking', text: 'Need to inspect the module.'},
+            {type: 'toolCall', id: 'call-1', name: 'read_file', arguments: {path: 'src/a.ts'}},
+          ],
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'assistant',
+        label: 'assistant · claude-opus-4',
+        text: 'I will edit the file.',
+        terminalFailure: false,
+      },
+      {kind: 'thinking', timestamp: 1, text: 'Need to inspect the module.'},
+      {
+        kind: 'tool-call',
+        timestamp: 1,
+        id: 'call-1',
+        name: 'read_file',
+        input: '{\n  "path": "src/a.ts"\n}',
+      },
+    ]);
+  });
+
+  test.each([
+    ['success', false],
+    ['error', true],
+  ])('expands a tool result with %s state', (_label, isError) => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          toolCallId: 'call-1',
+          toolName: 'read_file',
+          content: 'file contents',
+          isError,
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'tool-result',
+        timestamp: 1,
+        toolCallId: 'call-1',
+        toolName: 'read_file',
+        output: 'file contents',
+        isError,
+      },
+    ]);
+  });
+
+  test.each([
+    [{type: 'session', id: 'session-1'}, 'Session started', 'session-1'],
+    [{type: 'thinking_level_change', level: 'high'}, 'Thinking level changed', 'high'],
+    [{type: 'model_change', model: 'gpt-5-codex'}, 'Model changed', 'gpt-5-codex'],
+    [
+      {type: 'compaction', summary: 'summarized old context'},
+      'Context compacted',
+      'summarized old context',
+    ],
+    [{type: 'label', label: 'Implement tests'}, 'Label', 'Implement tests'],
+  ])('expands lifecycle entry %#', (entry, label, detail) => {
+    const rows = expandSessionRecord(record(entry));
+
+    expect(rows).toEqual([
+      {kind: 'lifecycle', timestamp: 1, label, detail, tone: 'default', terminalFailure: false},
+    ]);
+  });
+
+  test('marks assistant terminal errors as failure anchors', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{type: 'text', text: 'I cannot continue.'}],
+          stopReason: 'error',
+        },
+      }),
+    );
+
+    expect(rows[0]).toMatchObject({kind: 'message', terminalFailure: true});
+  });
+
+  test('memoizes rows per record object', () => {
+    const agentRecord = record({type: 'session', id: 'session-1'});
+    const parseSpy = vi.spyOn(JSON, 'parse');
+
+    const first = expandSessionRecord(agentRecord);
+    const second = expandSessionRecord(agentRecord);
+
+    expect(first).toBe(second);
+    expect(parseSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/client/logs/src/core/agent-session/selector.test.ts
+++ b/libs/client/logs/src/core/agent-session/selector.test.ts
@@ -96,19 +96,113 @@ describe('expandSessionRecord', () => {
 
   test.each([
     [{type: 'session', id: 'session-1'}, 'Session started', 'session-1'],
-    [{type: 'thinking_level_change', thinkingLevel: 'high'}, 'Thinking level changed', 'high'],
-    [{type: 'model_change', model: 'gpt-5-codex'}, 'Model changed', 'gpt-5-codex'],
     [
-      {type: 'compaction', summary: 'summarized old context'},
-      'Context compacted',
-      'summarized old context',
+      {type: 'session', version: 2, id: 'session-1', cwd: '/workspace'},
+      'Session started',
+      'v2 · session-1 · /workspace',
     ],
-    [{type: 'label', label: 'Implement tests'}, 'Label', 'Implement tests'],
+    [{type: 'thinking_level_change', thinkingLevel: 'high'}, 'Thinking level changed', 'high'],
+    [
+      {type: 'model_change', modelId: 'gpt-5-codex', provider: 'openai'},
+      'Model changed',
+      'gpt-5-codex · openai',
+    ],
+    [
+      {type: 'compaction', summary: 'summarized old context', tokensBefore: 12_345},
+      'Context compacted',
+      'summarized old context · 12345 tokens summarized',
+    ],
+    [
+      {type: 'label', label: 'Implement tests', targetId: 'entry-1'},
+      'Label',
+      'Implement tests · target entry-1',
+    ],
   ])('expands lifecycle entry %#', (entry, label, detail) => {
     const rows = expandSessionRecord(record(entry));
 
     expect(rows).toEqual([
       {kind: 'lifecycle', timestamp: 1, label, detail, tone: 'default', terminalFailure: false},
+    ]);
+  });
+
+  test('renders message content blocks without exposing image data', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'user',
+          content: [
+            {type: 'text', text: 'Inspect this screenshot.'},
+            {type: 'image', mimeType: 'image/png', data: 'base64-payload'},
+          ],
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'user',
+        label: 'user',
+        text: 'Inspect this screenshot.\n\n[image/png image]',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  test('renders bash execution messages without falling back to raw JSON', () => {
+    const rows = expandSessionRecord(
+      record({
+        type: 'message',
+        message: {
+          role: 'bashExecution',
+          command: 'pnpm test',
+          output: '1 failed',
+          exitCode: 1,
+          cancelled: false,
+          truncated: true,
+          fullOutputPath: '/tmp/output.log',
+        },
+      }),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'bash-execution',
+        label: 'bash execution',
+        text: '$ pnpm test\n1 failed\nexit 1 · truncated · full output: /tmp/output.log',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  test.each([
+    [
+      {role: 'branchSummary', summary: 'branched for fix', fromId: 'entry-1'},
+      'branch-summary',
+      'branch summary',
+      'branched for fix · from entry-1',
+    ],
+    [
+      {role: 'compactionSummary', summary: 'summarized history', tokensBefore: 42_000},
+      'compaction-summary',
+      'compaction summary',
+      'summarized history · 42000 tokens summarized',
+    ],
+    [
+      {role: 'custom', customType: 'extension', content: 'extension output', display: true},
+      'custom',
+      'custom · extension',
+      'extension output',
+    ],
+  ])('renders extended message role %#', (message, role, label, text) => {
+    const rows = expandSessionRecord(record({type: 'message', message}));
+
+    expect(rows).toEqual([
+      {kind: 'message', timestamp: 1, role, label, text, terminalFailure: false},
     ]);
   });
 
@@ -184,7 +278,9 @@ describe('expandSessionRecord', () => {
   });
 
   test('renders a branch summary as a system message row', () => {
-    const rows = expandSessionRecord(record({type: 'branch_summary', summary: 'merged main'}));
+    const rows = expandSessionRecord(
+      record({type: 'branch_summary', summary: 'merged main', fromId: 'entry-1'}),
+    );
 
     expect(rows).toEqual([
       {
@@ -192,21 +288,40 @@ describe('expandSessionRecord', () => {
         timestamp: 1,
         role: 'system',
         label: 'branch summary',
-        text: 'merged main',
+        text: 'merged main · from entry-1',
         terminalFailure: false,
       },
     ]);
   });
 
   test('renders a custom entry as a message row', () => {
-    const rows = expandSessionRecord(record({type: 'custom', message: 'hello there'}));
+    const rows = expandSessionRecord(
+      record({type: 'custom', customType: 'extension', data: {ok: true}}),
+    );
 
     expect(rows).toEqual([
       {
         kind: 'message',
         timestamp: 1,
         role: 'custom',
-        label: 'custom',
+        label: 'custom · extension',
+        text: '{\n  "ok": true\n}',
+        terminalFailure: false,
+      },
+    ]);
+  });
+
+  test('renders a custom message entry from content', () => {
+    const rows = expandSessionRecord(
+      record({type: 'custom_message', customType: 'extension', content: 'hello there'}),
+    );
+
+    expect(rows).toEqual([
+      {
+        kind: 'message',
+        timestamp: 1,
+        role: 'custom',
+        label: 'custom message · extension',
         text: 'hello there',
         terminalFailure: false,
       },

--- a/libs/client/logs/src/core/agent-session/selector.ts
+++ b/libs/client/logs/src/core/agent-session/selector.ts
@@ -1,0 +1,405 @@
+import type {LogRecord} from '@shipfox/api-logs-dto';
+import {
+  type AgentMessage,
+  asContentBlocks,
+  asLooseObject,
+  type ContentBlock,
+  parseSessionEntry,
+  type SessionEntry,
+  sessionMessageEntrySchema,
+} from './entry-schema.js';
+
+const MESSAGE_SUFFIX = /Message$/;
+const CAMEL_CASE_BOUNDARY = /([a-z])([A-Z])/g;
+
+export type AgentSessionLogRecord = Extract<LogRecord, {type: 'agent_session'}>;
+
+export type AgentSessionRow =
+  | AgentMessageRow
+  | AgentThinkingRow
+  | AgentToolCallRow
+  | AgentToolResultRow
+  | AgentLifecycleRow
+  | AgentFallbackRow;
+
+export interface AgentSessionRowBase {
+  timestamp: number;
+}
+
+export interface AgentMessageRow extends AgentSessionRowBase {
+  kind: 'message';
+  role: string;
+  label: string;
+  text: string;
+  terminalFailure: boolean;
+}
+
+export interface AgentThinkingRow extends AgentSessionRowBase {
+  kind: 'thinking';
+  text: string;
+}
+
+export interface AgentToolCallRow extends AgentSessionRowBase {
+  kind: 'tool-call';
+  id: string | null;
+  name: string;
+  input: string;
+}
+
+export interface AgentToolResultRow extends AgentSessionRowBase {
+  kind: 'tool-result';
+  toolCallId: string | null;
+  toolName: string;
+  output: string;
+  isError: boolean;
+}
+
+export interface AgentLifecycleRow extends AgentSessionRowBase {
+  kind: 'lifecycle';
+  label: string;
+  detail: string | null;
+  tone: 'default' | 'warning' | 'error';
+  terminalFailure: boolean;
+}
+
+export interface AgentFallbackRow extends AgentSessionRowBase {
+  kind: 'fallback';
+  label: string;
+  raw: string;
+}
+
+const rowCache = new WeakMap<AgentSessionLogRecord, readonly AgentSessionRow[]>();
+
+export function expandSessionRecord(record: AgentSessionLogRecord): readonly AgentSessionRow[] {
+  const cached = rowCache.get(record);
+  if (cached) return cached;
+
+  const rows = expandSessionRecordUncached(record);
+  rowCache.set(record, rows);
+  return rows;
+}
+
+function expandSessionRecordUncached(record: AgentSessionLogRecord): readonly AgentSessionRow[] {
+  const parsed = parseSessionEntry(record.data);
+  if (!parsed.ok) {
+    return [
+      {
+        kind: 'fallback',
+        timestamp: record.ts,
+        label: parsed.reason === 'invalid-json' ? 'Malformed session entry' : 'Unsupported entry',
+        raw: record.data,
+      },
+    ];
+  }
+
+  const entry = parsed.entry;
+  switch (entry.type) {
+    case 'message':
+      return expandMessageEntry(record.ts, entry, record.data);
+    case 'session':
+      return [lifecycleRow(record.ts, 'Session started', sessionDetail(entry), 'default', false)];
+    case 'session_info':
+      return [lifecycleRow(record.ts, 'Session info', entryDetail(entry), 'default', false)];
+    case 'thinking_level_change':
+      return [
+        lifecycleRow(record.ts, 'Thinking level changed', entryDetail(entry), 'default', false),
+      ];
+    case 'model_change':
+      return [lifecycleRow(record.ts, 'Model changed', modelChangeDetail(entry), 'default', false)];
+    case 'compaction':
+      return [lifecycleRow(record.ts, 'Context compacted', entryDetail(entry), 'default', false)];
+    case 'branch_summary':
+      return [
+        messageRow(
+          record.ts,
+          'system',
+          'branch summary',
+          entryDetail(entry) ?? toJson(entry),
+          false,
+        ),
+      ];
+    case 'custom':
+    case 'custom_message':
+      return [
+        messageRow(
+          record.ts,
+          'custom',
+          entry.type.replace('_', ' '),
+          entryDetail(entry) ?? toJson(entry),
+          false,
+        ),
+      ];
+    case 'label':
+      return [lifecycleRow(record.ts, 'Label', entryDetail(entry), 'default', false)];
+    default:
+      return [
+        {
+          kind: 'fallback',
+          timestamp: record.ts,
+          label: `Unknown session entry: ${entry.type}`,
+          raw: record.data,
+        },
+      ];
+  }
+}
+
+function expandMessageEntry(
+  timestamp: number,
+  entry: SessionEntry,
+  raw: string,
+): readonly AgentSessionRow[] {
+  const parsedEntry = sessionMessageEntrySchema.safeParse(entry);
+  if (!parsedEntry.success) {
+    return [{kind: 'fallback', timestamp, label: 'Unsupported message entry', raw}];
+  }
+
+  const message = parsedEntry.data.message;
+  const role = normalizeRole(message);
+
+  if (isToolResultMessage(message)) return [toolResultRow(timestamp, message)];
+
+  if (role === 'assistant') return expandAssistantMessage(timestamp, message);
+
+  const text = messageText(message);
+  return [
+    messageRow(timestamp, role, roleLabel(role), text || toJson(message), isTerminalStop(message)),
+  ];
+}
+
+function expandAssistantMessage(
+  timestamp: number,
+  message: AgentMessage,
+): readonly AgentSessionRow[] {
+  const blocks = asContentBlocks(message.content);
+  if (blocks.length === 0) {
+    const text = messageText(message);
+    return [
+      messageRow(
+        timestamp,
+        'assistant',
+        assistantLabel(message),
+        text || terminalStopDetail(message) || toJson(message),
+        isTerminalStop(message),
+      ),
+    ];
+  }
+
+  const rows: AgentSessionRow[] = [];
+  const textParts: string[] = [];
+  const thinkingParts: string[] = [];
+
+  for (const block of blocks) {
+    if (isToolCallBlock(block)) {
+      if (textParts.length > 0) {
+        rows.push(
+          messageRow(
+            timestamp,
+            'assistant',
+            assistantLabel(message),
+            textParts.join('\n\n'),
+            isTerminalStop(message),
+          ),
+        );
+        textParts.length = 0;
+      }
+      if (thinkingParts.length > 0) {
+        rows.push({kind: 'thinking', timestamp, text: thinkingParts.join('\n\n')});
+        thinkingParts.length = 0;
+      }
+      rows.push(toolCallRow(timestamp, block));
+      continue;
+    }
+
+    if (isThinkingBlock(block)) {
+      const text = blockText(block);
+      if (text) thinkingParts.push(text);
+      continue;
+    }
+
+    const text = blockText(block);
+    if (text) textParts.push(text);
+  }
+
+  if (textParts.length > 0) {
+    rows.push(
+      messageRow(
+        timestamp,
+        'assistant',
+        assistantLabel(message),
+        textParts.join('\n\n'),
+        isTerminalStop(message),
+      ),
+    );
+  }
+  if (thinkingParts.length > 0)
+    rows.push({kind: 'thinking', timestamp, text: thinkingParts.join('\n\n')});
+  if (rows.length === 0)
+    rows.push(
+      messageRow(
+        timestamp,
+        'assistant',
+        assistantLabel(message),
+        toJson(message),
+        isTerminalStop(message),
+      ),
+    );
+
+  return rows;
+}
+
+function messageRow(
+  timestamp: number,
+  role: string,
+  label: string,
+  text: string,
+  terminalFailure: boolean,
+): AgentMessageRow {
+  return {kind: 'message', timestamp, role, label, text, terminalFailure};
+}
+
+function lifecycleRow(
+  timestamp: number,
+  label: string,
+  detail: string | null,
+  tone: AgentLifecycleRow['tone'],
+  terminalFailure: boolean,
+): AgentLifecycleRow {
+  return {kind: 'lifecycle', timestamp, label, detail, tone, terminalFailure};
+}
+
+function toolCallRow(timestamp: number, block: ContentBlock): AgentToolCallRow {
+  const id = stringField(block, 'id') ?? stringField(block, 'toolCallId') ?? null;
+  const name = stringField(block, 'name') ?? stringField(block, 'toolName') ?? 'tool';
+  const args = field(block, 'arguments') ?? field(block, 'input') ?? field(block, 'args') ?? {};
+
+  return {kind: 'tool-call', timestamp, id, name, input: stringifyValue(args)};
+}
+
+function toolResultRow(timestamp: number, message: AgentMessage): AgentToolResultRow {
+  return {
+    kind: 'tool-result',
+    timestamp,
+    toolCallId: message.toolCallId ?? null,
+    toolName: message.toolName ?? 'tool',
+    output: stringifyValue(message.content ?? ''),
+    isError: message.isError === true,
+  };
+}
+
+function isToolResultMessage(message: AgentMessage): boolean {
+  return typeof message.toolCallId === 'string' || normalizeRole(message) === 'tool';
+}
+
+function isToolCallBlock(block: ContentBlock): boolean {
+  const type = stringField(block, 'type');
+  return type === 'toolCall' || type === 'tool_call' || type === 'tool-call';
+}
+
+function isThinkingBlock(block: ContentBlock): boolean {
+  const type = stringField(block, 'type');
+  return type === 'thinking' || type === 'thought' || type === 'reasoning';
+}
+
+function blockText(block: ContentBlock): string {
+  return (
+    stringField(block, 'text') ??
+    stringField(block, 'content') ??
+    stringField(block, 'thinking') ??
+    ''
+  );
+}
+
+function messageText(message: AgentMessage): string {
+  if (typeof message.content === 'string') return message.content;
+
+  const blocks = asContentBlocks(message.content);
+  if (blocks.length > 0) {
+    return blocks
+      .map((block) => blockText(block))
+      .filter(Boolean)
+      .join('\n\n');
+  }
+
+  return '';
+}
+
+function normalizeRole(message: AgentMessage): string {
+  const raw = message.role ?? message.type ?? 'message';
+  return raw.replace(MESSAGE_SUFFIX, '').replace(CAMEL_CASE_BOUNDARY, '$1-$2').toLowerCase();
+}
+
+function roleLabel(role: string): string {
+  if (role === 'user') return 'user';
+  if (role === 'assistant') return 'assistant';
+  return role.replaceAll('-', ' ');
+}
+
+function assistantLabel(message: AgentMessage): string {
+  const parts = ['assistant'];
+  if (message.model) parts.push(message.model);
+  if (message.provider) parts.push(message.provider);
+  return parts.join(' · ');
+}
+
+function isTerminalStop(message: AgentMessage): boolean {
+  return (
+    message.errorMessage != null ||
+    message.stopReason === 'error' ||
+    message.stopReason === 'aborted'
+  );
+}
+
+function terminalStopDetail(message: AgentMessage): string | null {
+  if (message.errorMessage) return message.errorMessage;
+  if (message.stopReason === 'error') return 'Assistant stopped with an error.';
+  if (message.stopReason === 'aborted') return 'Assistant run was aborted.';
+  return null;
+}
+
+function sessionDetail(entry: SessionEntry): string | null {
+  const id = stringField(entry, 'id') ?? stringField(entry, 'sessionId');
+  const cwd = stringField(entry, 'cwd');
+  return [id, cwd].filter(Boolean).join(' · ') || entryDetail(entry);
+}
+
+function modelChangeDetail(entry: SessionEntry): string | null {
+  const model =
+    stringField(entry, 'model') ?? stringField(entry, 'to') ?? stringField(entry, 'modelId');
+  const provider = stringField(entry, 'provider');
+  return [model, provider].filter(Boolean).join(' · ') || entryDetail(entry);
+}
+
+function entryDetail(entry: SessionEntry): string | null {
+  const detail =
+    stringField(entry, 'message') ??
+    stringField(entry, 'text') ??
+    stringField(entry, 'summary') ??
+    stringField(entry, 'label') ??
+    stringField(entry, 'level') ??
+    stringField(entry, 'reason');
+  if (detail) return detail;
+
+  const value = field(entry, 'data') ?? field(entry, 'payload');
+  if (value === undefined) return null;
+  return stringifyValue(value);
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const object = asLooseObject(value);
+  const fieldValue = object?.[key];
+  return typeof fieldValue === 'string' && fieldValue.length > 0 ? fieldValue : undefined;
+}
+
+function field(value: unknown, key: string): unknown {
+  const object = asLooseObject(value);
+  return object?.[key];
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  return toJson(value);
+}
+
+function toJson(value: unknown): string {
+  return JSON.stringify(value, null, 2) ?? String(value);
+}

--- a/libs/client/logs/src/core/agent-session/selector.ts
+++ b/libs/client/logs/src/core/agent-session/selector.ts
@@ -258,6 +258,8 @@ function expandAssistantMessage(
   message: AgentMessage,
 ): readonly AgentSessionRow[] {
   const blocks = asContentBlocks(message.content);
+  const terminalFailure = isTerminalStop(message);
+  const meta = assistantMeta(message);
   if (blocks.length === 0) {
     const text = messageText(message);
     return [
@@ -266,8 +268,8 @@ function expandAssistantMessage(
         'assistant',
         'assistant',
         text || terminalStopDetail(message) || toJson(message),
-        isTerminalStop(message),
-        assistantMeta(message),
+        terminalFailure,
+        meta,
       ),
     ];
   }
@@ -275,64 +277,63 @@ function expandAssistantMessage(
   const rows: AgentSessionRow[] = [];
   const textParts: string[] = [];
   const thinkingParts: string[] = [];
-
-  for (const block of blocks) {
-    if (isToolCallBlock(block)) {
-      if (textParts.length > 0) {
-        rows.push(
-          messageRow(
-            timestamp,
-            'assistant',
-            'assistant',
-            textParts.join('\n\n'),
-            isTerminalStop(message),
-            assistantMeta(message),
-          ),
-        );
-        textParts.length = 0;
-      }
-      if (thinkingParts.length > 0) {
-        rows.push({kind: 'thinking', timestamp, text: thinkingParts.join('\n\n')});
-        thinkingParts.length = 0;
-      }
-      rows.push(toolCallRow(timestamp, block));
-      continue;
-    }
-
-    if (isThinkingBlock(block)) {
-      const text = blockText(block);
-      if (text) thinkingParts.push(text);
-      continue;
-    }
-
-    const text = blockText(block);
-    if (text) textParts.push(text);
-  }
-
-  if (textParts.length > 0) {
+  const pushTextParts = () => {
+    if (textParts.length === 0) return;
     rows.push(
       messageRow(
         timestamp,
         'assistant',
         'assistant',
         textParts.join('\n\n'),
-        isTerminalStop(message),
-        assistantMeta(message),
+        terminalFailure,
+        meta,
       ),
     );
-  }
-  if (thinkingParts.length > 0)
+    textParts.length = 0;
+  };
+  const pushThinkingParts = () => {
+    if (thinkingParts.length === 0) return;
     rows.push({kind: 'thinking', timestamp, text: thinkingParts.join('\n\n')});
-  if (rows.length === 0)
+    thinkingParts.length = 0;
+  };
+
+  for (const block of blocks) {
+    if (isToolCallBlock(block)) {
+      pushTextParts();
+      pushThinkingParts();
+      rows.push(toolCallRow(timestamp, block));
+      continue;
+    }
+
+    if (isThinkingBlock(block)) {
+      pushTextParts();
+      const text = blockText(block);
+      if (text) thinkingParts.push(text);
+      continue;
+    }
+
+    pushThinkingParts();
+    const text = blockText(block);
+    if (text) textParts.push(text);
+  }
+
+  pushTextParts();
+  pushThinkingParts();
+  if (terminalFailure && !rows.some((row) => row.kind === 'message' && row.terminalFailure)) {
     rows.push(
       messageRow(
         timestamp,
         'assistant',
         'assistant',
-        toJson(message),
-        isTerminalStop(message),
-        assistantMeta(message),
+        terminalStopDetail(message) || toJson(message),
+        true,
+        meta,
       ),
+    );
+  }
+  if (rows.length === 0)
+    rows.push(
+      messageRow(timestamp, 'assistant', 'assistant', toJson(message), terminalFailure, meta),
     );
 
   return rows;

--- a/libs/client/logs/src/core/agent-session/selector.ts
+++ b/libs/client/logs/src/core/agent-session/selector.ts
@@ -107,30 +107,41 @@ function expandSessionRecordUncached(record: AgentSessionLogRecord): readonly Ag
     case 'model_change':
       return [lifecycleRow(record.ts, 'Model changed', modelChangeDetail(entry), 'default', false)];
     case 'compaction':
-      return [lifecycleRow(record.ts, 'Context compacted', entryDetail(entry), 'default', false)];
+      return [
+        lifecycleRow(record.ts, 'Context compacted', compactionDetail(entry), 'default', false),
+      ];
     case 'branch_summary':
       return [
         messageRow(
           record.ts,
           'system',
           'branch summary',
-          entryDetail(entry) ?? toJson(entry),
+          branchSummaryDetail(entry) ?? toJson(entry),
           false,
         ),
       ];
     case 'custom':
+      return [
+        messageRow(
+          record.ts,
+          'custom',
+          customEntryLabel(entry, 'custom'),
+          customEntryText(entry) ?? toJson(entry),
+          false,
+        ),
+      ];
     case 'custom_message':
       return [
         messageRow(
           record.ts,
           'custom',
-          entry.type.replace('_', ' '),
-          entryDetail(entry) ?? toJson(entry),
+          customEntryLabel(entry, 'custom message'),
+          customEntryText(entry) ?? toJson(entry),
           false,
         ),
       ];
     case 'label':
-      return [lifecycleRow(record.ts, 'Label', entryDetail(entry), 'default', false)];
+      return [lifecycleRow(record.ts, 'Label', labelDetail(entry), 'default', false)];
     default:
       return [
         {
@@ -159,6 +170,51 @@ function expandMessageEntry(
   if (isToolResultMessage(message)) return [toolResultRow(timestamp, message)];
 
   if (role === 'assistant') return expandAssistantMessage(timestamp, message);
+
+  if (role === 'bash-execution') {
+    return [
+      messageRow(
+        timestamp,
+        role,
+        'bash execution',
+        bashExecutionText(message),
+        isTerminalStop(message),
+      ),
+    ];
+  }
+  if (role === 'branch-summary') {
+    return [
+      messageRow(
+        timestamp,
+        role,
+        'branch summary',
+        branchSummaryDetail(message) ?? toJson(message),
+        isTerminalStop(message),
+      ),
+    ];
+  }
+  if (role === 'compaction-summary') {
+    return [
+      messageRow(
+        timestamp,
+        role,
+        'compaction summary',
+        compactionDetail(message) ?? toJson(message),
+        isTerminalStop(message),
+      ),
+    ];
+  }
+  if (role === 'custom') {
+    return [
+      messageRow(
+        timestamp,
+        role,
+        customEntryLabel(message, 'custom'),
+        customEntryText(message) ?? toJson(message),
+        isTerminalStop(message),
+      ),
+    ];
+  }
 
   const text = messageText(message);
   return [
@@ -289,7 +345,8 @@ function toolResultRow(timestamp: number, message: AgentMessage): AgentToolResul
 }
 
 function isToolResultMessage(message: AgentMessage): boolean {
-  return typeof message.toolCallId === 'string' || normalizeRole(message) === 'tool';
+  const role = normalizeRole(message);
+  return typeof message.toolCallId === 'string' || role === 'tool' || role === 'tool-result';
 }
 
 function isToolCallBlock(block: ContentBlock): boolean {
@@ -303,6 +360,8 @@ function isThinkingBlock(block: ContentBlock): boolean {
 }
 
 function blockText(block: ContentBlock): string {
+  if (stringField(block, 'type') === 'image') return imagePlaceholder(block);
+
   return (
     stringField(block, 'text') ??
     stringField(block, 'content') ??
@@ -359,9 +418,13 @@ function terminalStopDetail(message: AgentMessage): string | null {
 }
 
 function sessionDetail(entry: SessionEntry): string | null {
+  const version = numberField(entry, 'version');
   const id = stringField(entry, 'id') ?? stringField(entry, 'sessionId');
   const cwd = stringField(entry, 'cwd');
-  return [id, cwd].filter(Boolean).join(' · ') || entryDetail(entry);
+  return (
+    [version == null ? null : `v${version}`, id, cwd].filter(Boolean).join(' · ') ||
+    entryDetail(entry)
+  );
 }
 
 function modelChangeDetail(entry: SessionEntry): string | null {
@@ -371,10 +434,73 @@ function modelChangeDetail(entry: SessionEntry): string | null {
   return [model, provider].filter(Boolean).join(' · ') || entryDetail(entry);
 }
 
-function entryDetail(entry: SessionEntry): string | null {
+function compactionDetail(entry: SessionEntry | AgentMessage): string | null {
+  const summary = stringField(entry, 'summary') ?? stringField(entry, 'message');
+  const tokensBefore = numberField(entry, 'tokensBefore');
+  const tokenDetail = tokensBefore == null ? null : `${tokensBefore} tokens summarized`;
+  return [summary, tokenDetail].filter(Boolean).join(' · ') || entryDetail(entry);
+}
+
+function branchSummaryDetail(entry: SessionEntry | AgentMessage): string | null {
+  const summary = stringField(entry, 'summary') ?? stringField(entry, 'message');
+  const fromId = stringField(entry, 'fromId');
+  const branchDetail = fromId == null ? null : `from ${fromId}`;
+  return [summary, branchDetail].filter(Boolean).join(' · ') || entryDetail(entry);
+}
+
+function customEntryLabel(entry: SessionEntry | AgentMessage, fallback: string): string {
+  const customType = stringField(entry, 'customType');
+  return [fallback, customType].filter(Boolean).join(' · ');
+}
+
+function customEntryText(entry: SessionEntry | AgentMessage): string | null {
+  const text = messageText(entry);
+  if (text) return text;
+
+  const data = field(entry, 'data') ?? field(entry, 'details');
+  return data === undefined ? entryDetail(entry) : stringifyValue(data);
+}
+
+function labelDetail(entry: SessionEntry): string | null {
+  const label = stringField(entry, 'label');
+  const targetId = stringField(entry, 'targetId');
+  return (
+    [label, targetId == null ? null : `target ${targetId}`].filter(Boolean).join(' · ') ||
+    entryDetail(entry)
+  );
+}
+
+function bashExecutionText(message: AgentMessage): string {
+  const command = stringField(message, 'command');
+  const output = stringField(message, 'output');
+  const exitCode = field(message, 'exitCode');
+  const cancelled = booleanField(message, 'cancelled');
+  const truncated = booleanField(message, 'truncated');
+  const fullOutputPath = stringField(message, 'fullOutputPath');
+  const status = [
+    typeof exitCode === 'number' ? `exit ${exitCode}` : null,
+    cancelled ? 'cancelled' : null,
+    truncated ? 'truncated' : null,
+    fullOutputPath == null ? null : `full output: ${fullOutputPath}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    [`$ ${command ?? ''}`.trim(), output, status].filter(Boolean).join('\n') || toJson(message)
+  );
+}
+
+function imagePlaceholder(block: ContentBlock): string {
+  const mimeType = stringField(block, 'mimeType');
+  return mimeType == null ? '[image]' : `[${mimeType} image]`;
+}
+
+function entryDetail(entry: SessionEntry | AgentMessage): string | null {
   const detail =
     stringField(entry, 'message') ??
     stringField(entry, 'text') ??
+    stringField(entry, 'content') ??
     stringField(entry, 'summary') ??
     stringField(entry, 'label') ??
     stringField(entry, 'thinkingLevel') ??
@@ -396,6 +522,15 @@ function stringField(value: unknown, key: string): string | undefined {
 function field(value: unknown, key: string): unknown {
   const object = asLooseObject(value);
   return object?.[key];
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  const fieldValue = field(value, key);
+  return typeof fieldValue === 'number' && Number.isFinite(fieldValue) ? fieldValue : undefined;
+}
+
+function booleanField(value: unknown, key: string): boolean {
+  return field(value, key) === true;
 }
 
 function stringifyValue(value: unknown): string {

--- a/libs/client/logs/src/core/agent-session/selector.ts
+++ b/libs/client/logs/src/core/agent-session/selector.ts
@@ -26,10 +26,17 @@ export interface AgentSessionRowBase {
   timestamp: number;
 }
 
+export interface AgentRowMeta {
+  label: string;
+  value: string;
+  inline?: boolean;
+}
+
 export interface AgentMessageRow extends AgentSessionRowBase {
   kind: 'message';
   role: string;
   label: string;
+  meta: readonly AgentRowMeta[];
   text: string;
   terminalFailure: boolean;
 }
@@ -58,6 +65,7 @@ export interface AgentLifecycleRow extends AgentSessionRowBase {
   kind: 'lifecycle';
   label: string;
   detail: string | null;
+  meta: readonly AgentRowMeta[];
   tone: 'default' | 'warning' | 'error';
   terminalFailure: boolean;
 }
@@ -108,7 +116,14 @@ function expandSessionRecordUncached(record: AgentSessionLogRecord): readonly Ag
       return [lifecycleRow(record.ts, 'Model changed', modelChangeDetail(entry), 'default', false)];
     case 'compaction':
       return [
-        lifecycleRow(record.ts, 'Context compacted', compactionDetail(entry), 'default', false),
+        lifecycleRow(
+          record.ts,
+          'Context compacted',
+          compactionDetail(entry),
+          'default',
+          false,
+          compactionMeta(entry),
+        ),
       ];
     case 'branch_summary':
       return [
@@ -118,6 +133,7 @@ function expandSessionRecordUncached(record: AgentSessionLogRecord): readonly Ag
           'branch summary',
           branchSummaryDetail(entry) ?? toJson(entry),
           false,
+          branchSummaryMeta(entry),
         ),
       ];
     case 'custom':
@@ -125,9 +141,10 @@ function expandSessionRecordUncached(record: AgentSessionLogRecord): readonly Ag
         messageRow(
           record.ts,
           'custom',
-          customEntryLabel(entry, 'custom'),
+          customEntryLabel('custom'),
           customEntryText(entry) ?? toJson(entry),
           false,
+          customEntryMeta(entry),
         ),
       ];
     case 'custom_message':
@@ -135,13 +152,16 @@ function expandSessionRecordUncached(record: AgentSessionLogRecord): readonly Ag
         messageRow(
           record.ts,
           'custom',
-          customEntryLabel(entry, 'custom message'),
+          customEntryLabel('custom message'),
           customEntryText(entry) ?? toJson(entry),
           false,
+          customEntryMeta(entry),
         ),
       ];
     case 'label':
-      return [lifecycleRow(record.ts, 'Label', labelDetail(entry), 'default', false)];
+      return [
+        lifecycleRow(record.ts, 'Label', labelDetail(entry), 'default', false, labelMeta(entry)),
+      ];
     default:
       return [
         {
@@ -179,6 +199,7 @@ function expandMessageEntry(
         'bash execution',
         bashExecutionText(message),
         isTerminalStop(message),
+        bashExecutionMeta(message),
       ),
     ];
   }
@@ -190,6 +211,7 @@ function expandMessageEntry(
         'branch summary',
         branchSummaryDetail(message) ?? toJson(message),
         isTerminalStop(message),
+        branchSummaryMeta(message),
       ),
     ];
   }
@@ -201,6 +223,7 @@ function expandMessageEntry(
         'compaction summary',
         compactionDetail(message) ?? toJson(message),
         isTerminalStop(message),
+        compactionMeta(message),
       ),
     ];
   }
@@ -209,16 +232,24 @@ function expandMessageEntry(
       messageRow(
         timestamp,
         role,
-        customEntryLabel(message, 'custom'),
+        customEntryLabel('custom'),
         customEntryText(message) ?? toJson(message),
         isTerminalStop(message),
+        customEntryMeta(message),
       ),
     ];
   }
 
   const text = messageText(message);
   return [
-    messageRow(timestamp, role, roleLabel(role), text || toJson(message), isTerminalStop(message)),
+    messageRow(
+      timestamp,
+      role,
+      roleLabel(role),
+      text || toJson(message),
+      isTerminalStop(message),
+      messageMeta(message),
+    ),
   ];
 }
 
@@ -233,9 +264,10 @@ function expandAssistantMessage(
       messageRow(
         timestamp,
         'assistant',
-        assistantLabel(message),
+        'assistant',
         text || terminalStopDetail(message) || toJson(message),
         isTerminalStop(message),
+        assistantMeta(message),
       ),
     ];
   }
@@ -251,9 +283,10 @@ function expandAssistantMessage(
           messageRow(
             timestamp,
             'assistant',
-            assistantLabel(message),
+            'assistant',
             textParts.join('\n\n'),
             isTerminalStop(message),
+            assistantMeta(message),
           ),
         );
         textParts.length = 0;
@@ -281,9 +314,10 @@ function expandAssistantMessage(
       messageRow(
         timestamp,
         'assistant',
-        assistantLabel(message),
+        'assistant',
         textParts.join('\n\n'),
         isTerminalStop(message),
+        assistantMeta(message),
       ),
     );
   }
@@ -294,9 +328,10 @@ function expandAssistantMessage(
       messageRow(
         timestamp,
         'assistant',
-        assistantLabel(message),
+        'assistant',
         toJson(message),
         isTerminalStop(message),
+        assistantMeta(message),
       ),
     );
 
@@ -309,8 +344,9 @@ function messageRow(
   label: string,
   text: string,
   terminalFailure: boolean,
+  meta: readonly AgentRowMeta[] = [],
 ): AgentMessageRow {
-  return {kind: 'message', timestamp, role, label, text, terminalFailure};
+  return {kind: 'message', timestamp, role, label, meta, text, terminalFailure};
 }
 
 function lifecycleRow(
@@ -319,8 +355,9 @@ function lifecycleRow(
   detail: string | null,
   tone: AgentLifecycleRow['tone'],
   terminalFailure: boolean,
+  meta: readonly AgentRowMeta[] = [],
 ): AgentLifecycleRow {
-  return {kind: 'lifecycle', timestamp, label, detail, tone, terminalFailure};
+  return {kind: 'lifecycle', timestamp, label, detail, meta, tone, terminalFailure};
 }
 
 function toolCallRow(timestamp: number, block: ContentBlock): AgentToolCallRow {
@@ -395,11 +432,18 @@ function roleLabel(role: string): string {
   return role.replaceAll('-', ' ');
 }
 
-function assistantLabel(message: AgentMessage): string {
-  const parts = ['assistant'];
-  if (message.model) parts.push(message.model);
-  if (message.provider) parts.push(message.provider);
-  return parts.join(' · ');
+function assistantMeta(message: AgentMessage): readonly AgentRowMeta[] {
+  return [
+    providerModelMeta(message),
+    metaItem('api', stringField(message, 'api'), false),
+    usageMeta(message),
+    costMeta(message),
+    stopReasonMeta(message),
+  ].filter(isMeta);
+}
+
+function messageMeta(message: AgentMessage): readonly AgentRowMeta[] {
+  return [stopReasonMeta(message)].filter(isMeta);
 }
 
 function isTerminalStop(message: AgentMessage): boolean {
@@ -435,22 +479,35 @@ function modelChangeDetail(entry: SessionEntry): string | null {
 }
 
 function compactionDetail(entry: SessionEntry | AgentMessage): string | null {
-  const summary = stringField(entry, 'summary') ?? stringField(entry, 'message');
+  return stringField(entry, 'summary') ?? stringField(entry, 'message') ?? entryDetail(entry);
+}
+
+function compactionMeta(entry: SessionEntry | AgentMessage): readonly AgentRowMeta[] {
   const tokensBefore = numberField(entry, 'tokensBefore');
-  const tokenDetail = tokensBefore == null ? null : `${tokensBefore} tokens summarized`;
-  return [summary, tokenDetail].filter(Boolean).join(' · ') || entryDetail(entry);
+  return [
+    tokensBefore == null ? null : metaItem('tokens before', formatCount(tokensBefore, 'token')),
+  ].filter(isMeta);
 }
 
 function branchSummaryDetail(entry: SessionEntry | AgentMessage): string | null {
-  const summary = stringField(entry, 'summary') ?? stringField(entry, 'message');
-  const fromId = stringField(entry, 'fromId');
-  const branchDetail = fromId == null ? null : `from ${fromId}`;
-  return [summary, branchDetail].filter(Boolean).join(' · ') || entryDetail(entry);
+  return stringField(entry, 'summary') ?? stringField(entry, 'message') ?? entryDetail(entry);
 }
 
-function customEntryLabel(entry: SessionEntry | AgentMessage, fallback: string): string {
-  const customType = stringField(entry, 'customType');
-  return [fallback, customType].filter(Boolean).join(' · ');
+function branchSummaryMeta(entry: SessionEntry | AgentMessage): readonly AgentRowMeta[] {
+  const fromId = stringField(entry, 'fromId');
+  return [fromId == null ? null : metaItem('from', fromId)].filter(isMeta);
+}
+
+function customEntryLabel(fallback: string): string {
+  return fallback;
+}
+
+function customEntryMeta(entry: SessionEntry | AgentMessage): readonly AgentRowMeta[] {
+  const display = field(entry, 'display');
+  return [
+    metaItem('type', stringField(entry, 'customType')),
+    typeof display === 'boolean' ? metaItem('display', display ? 'on' : 'off') : null,
+  ].filter(isMeta);
 }
 
 function customEntryText(entry: SessionEntry | AgentMessage): string | null {
@@ -461,34 +518,73 @@ function customEntryText(entry: SessionEntry | AgentMessage): string | null {
   return data === undefined ? entryDetail(entry) : stringifyValue(data);
 }
 
+function bashExecutionMeta(message: AgentMessage): readonly AgentRowMeta[] {
+  const exitCode = field(message, 'exitCode');
+  return [
+    typeof exitCode === 'number' ? metaItem('exit', String(exitCode)) : null,
+    booleanField(message, 'cancelled') ? metaItem('cancelled', 'yes') : null,
+    booleanField(message, 'truncated') ? metaItem('truncated', 'yes') : null,
+    booleanField(message, 'excludeFromContext') ? metaItem('context', 'excluded') : null,
+    metaItem('full output', stringField(message, 'fullOutputPath'), false),
+  ].filter(isMeta);
+}
+
 function labelDetail(entry: SessionEntry): string | null {
-  const label = stringField(entry, 'label');
+  return stringField(entry, 'label') ?? entryDetail(entry);
+}
+
+function labelMeta(entry: SessionEntry): readonly AgentRowMeta[] {
   const targetId = stringField(entry, 'targetId');
-  return (
-    [label, targetId == null ? null : `target ${targetId}`].filter(Boolean).join(' · ') ||
-    entryDetail(entry)
-  );
+  return [targetId == null ? null : metaItem('target', targetId, false)].filter(isMeta);
 }
 
 function bashExecutionText(message: AgentMessage): string {
   const command = stringField(message, 'command');
   const output = stringField(message, 'output');
-  const exitCode = field(message, 'exitCode');
-  const cancelled = booleanField(message, 'cancelled');
-  const truncated = booleanField(message, 'truncated');
-  const fullOutputPath = stringField(message, 'fullOutputPath');
-  const status = [
-    typeof exitCode === 'number' ? `exit ${exitCode}` : null,
-    cancelled ? 'cancelled' : null,
-    truncated ? 'truncated' : null,
-    fullOutputPath == null ? null : `full output: ${fullOutputPath}`,
-  ]
-    .filter(Boolean)
-    .join(' · ');
 
-  return (
-    [`$ ${command ?? ''}`.trim(), output, status].filter(Boolean).join('\n') || toJson(message)
-  );
+  return [`$ ${command ?? ''}`.trim(), output].filter(Boolean).join('\n') || toJson(message);
+}
+
+function providerModelMeta(message: AgentMessage): AgentRowMeta | null {
+  const model = stringField(message, 'model') ?? stringField(message, 'modelId');
+  const provider = stringField(message, 'provider');
+  const value = [provider, model].filter(Boolean).join('/');
+  return value ? metaItem('model', value) : null;
+}
+
+function usageMeta(message: AgentMessage): AgentRowMeta | null {
+  const usage = asLooseObject(field(message, 'usage'));
+  const totalTokens = numberField(usage, 'totalTokens');
+  return totalTokens == null ? null : metaItem('tokens', formatCount(totalTokens, 'token'));
+}
+
+function costMeta(message: AgentMessage): AgentRowMeta | null {
+  const usage = asLooseObject(field(message, 'usage'));
+  const cost = asLooseObject(field(usage, 'cost'));
+  const total = numberField(cost, 'total');
+  return total == null ? null : metaItem('cost', `$${total.toFixed(total < 0.01 ? 4 : 2)}`);
+}
+
+function stopReasonMeta(message: AgentMessage): AgentRowMeta | null {
+  const stopReason = stringField(message, 'stopReason');
+  return stopReason == null ? null : metaItem('stop', stopReason);
+}
+
+function formatCount(value: number, unit: string): string {
+  return `${new Intl.NumberFormat('en-US', {maximumFractionDigits: 1, notation: value >= 10000 ? 'compact' : 'standard'}).format(value)} ${unit}${value === 1 ? '' : 's'}`;
+}
+
+function metaItem(
+  label: string,
+  value: string | null | undefined,
+  inline = true,
+): AgentRowMeta | null {
+  if (value == null || value.length === 0) return null;
+  return inline ? {label, value} : {label, value, inline};
+}
+
+function isMeta(value: AgentRowMeta | null | undefined): value is AgentRowMeta {
+  return value != null;
 }
 
 function imagePlaceholder(block: ContentBlock): string {

--- a/libs/client/logs/src/core/agent-session/selector.ts
+++ b/libs/client/logs/src/core/agent-session/selector.ts
@@ -276,12 +276,14 @@ function toolCallRow(timestamp: number, block: ContentBlock): AgentToolCallRow {
 }
 
 function toolResultRow(timestamp: number, message: AgentMessage): AgentToolResultRow {
+  const output = messageText(message) || stringifyValue(message.content ?? '');
+
   return {
     kind: 'tool-result',
     timestamp,
     toolCallId: message.toolCallId ?? null,
     toolName: message.toolName ?? 'tool',
-    output: stringifyValue(message.content ?? ''),
+    output,
     isError: message.isError === true,
   };
 }
@@ -375,6 +377,7 @@ function entryDetail(entry: SessionEntry): string | null {
     stringField(entry, 'text') ??
     stringField(entry, 'summary') ??
     stringField(entry, 'label') ??
+    stringField(entry, 'thinkingLevel') ??
     stringField(entry, 'level') ??
     stringField(entry, 'reason');
   if (detail) return detail;

--- a/libs/client/logs/src/core/log-tree.test.ts
+++ b/libs/client/logs/src/core/log-tree.test.ts
@@ -74,10 +74,10 @@ describe('buildLogTree', () => {
     expect(empty.lineCount).toBe(0);
   });
 
-  test('anchors originTs on the first render-relevant record, skipping a leading agent_session', () => {
+  test('anchors originTs on the first agent_session record', () => {
     const tree = buildLogTree([agentSession('entry', 5), out('a', 'stdout', 9)]);
 
-    expect(tree.originTs).toBe(9);
+    expect(tree.originTs).toBe(5);
   });
 
   test('nests output inside a closed group', () => {
@@ -250,13 +250,37 @@ describe('buildLogTree', () => {
     expect(seqs).toEqual([0, 1, 2, 3]);
   });
 
-  test('skips agent_session without consuming a line number', () => {
+  test('emits agent_session nodes without consuming a line number', () => {
     const records = [out('a'), agentSession('{"role":"assistant"}'), out('b')];
 
     const tree = buildLogTree(records);
 
-    expect(tree.nodes).toHaveLength(2);
-    expect(tree.nodes.map((n) => (n.kind === 'output' ? n.lineNumber : null))).toEqual([1, 2]);
+    expect(tree.nodes.map((node) => node.kind)).toEqual(['output', 'session', 'output']);
+    expect(tree.nodes.flatMap((n) => (n.kind === 'output' ? [n.lineNumber] : []))).toEqual([1, 2]);
+  });
+
+  test('keeps stdout between a tool call and tool result in stream order', () => {
+    const toolCall = agentSession(
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{type: 'toolCall', id: 'call-1', name: 'edit_file', arguments: {}}],
+        },
+      }),
+      1,
+    );
+    const toolResult = agentSession(
+      JSON.stringify({
+        type: 'message',
+        message: {toolCallId: 'call-1', toolName: 'edit_file', content: 'done'},
+      }),
+      3,
+    );
+
+    const tree = buildLogTree([toolCall, out('interleaved\n', 'stdout', 2), toolResult]);
+
+    expect(tree.nodes.map((node) => node.kind)).toEqual(['session', 'output', 'session']);
   });
 
   test.each([

--- a/libs/client/logs/src/core/log-tree.ts
+++ b/libs/client/logs/src/core/log-tree.ts
@@ -19,6 +19,7 @@ export type EndLogRecord = Extract<LogRecord, {type: 'end'}>;
 export type GapLogRecord = Extract<LogRecord, {type: 'gap'}>;
 export type CappedLogRecord = Extract<LogRecord, {type: 'capped'}>;
 export type RunnerLostLogRecord = Extract<LogRecord, {type: 'runner_lost'}>;
+export type AgentSessionLogRecord = Extract<LogRecord, {type: 'agent_session'}>;
 export type MarkerLogRecord = EndLogRecord | GapLogRecord | CappedLogRecord | RunnerLostLogRecord;
 
 /**
@@ -56,7 +57,12 @@ export interface GroupLogNode extends LogNodeBase {
   children: LogNode[];
 }
 
-export type LogNode = OutputLogNode | MarkerLogNode | GroupLogNode;
+export interface SessionLogNode extends LogNodeBase {
+  kind: 'session';
+  record: AgentSessionLogRecord;
+}
+
+export type LogNode = OutputLogNode | MarkerLogNode | GroupLogNode | SessionLogNode;
 
 export interface LogTree {
   nodes: LogNode[];
@@ -86,8 +92,6 @@ export function buildLogTree(records: readonly LogRecord[]): LogTree {
   let lineNumber = 0;
   let lineCount = 0;
   let terminated = false;
-  // Anchor relative timestamps on the first render-relevant record, skipping a leading
-  // agent_session (rendered elsewhere) so the first visible row reads as the baseline.
   let originTs: number | null = null;
 
   const childrenOf = (): LogNode[] => stack[stack.length - 1]?.children ?? nodes;
@@ -99,7 +103,7 @@ export function buildLogTree(records: readonly LogRecord[]): LogTree {
   };
 
   for (const record of records) {
-    if (originTs === null && record.type !== 'agent_session') originTs = record.ts;
+    if (originTs === null) originTs = record.ts;
     switch (record.type) {
       case 'output': {
         lineNumber += 1;
@@ -180,7 +184,7 @@ export function buildLogTree(records: readonly LogRecord[]): LogTree {
         break;
       }
       case 'agent_session':
-        // Rendered by the agent-session surface, not this package.
+        childrenOf().push({kind: 'session', seq: seq++, record});
         break;
       default:
         assertNever(record);

--- a/libs/client/logs/src/index.ts
+++ b/libs/client/logs/src/index.ts
@@ -6,6 +6,7 @@ export {
   type LogTree,
   type MarkerLogNode,
   type OutputLogNode,
+  type SessionLogNode,
 } from '#core/log-tree.js';
 export * from './components/index.js';
 export {

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.test.tsx
@@ -66,6 +66,7 @@ describe('StepAttemptLogPanel', () => {
     cleanup();
     vi.useRealTimers();
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     configureApiClient({baseUrl: '', fetchImpl: undefined});
   });
 
@@ -145,7 +146,7 @@ describe('StepAttemptLogPanel', () => {
 
     expect(await screen.findByText('Step produced no output')).toBeInTheDocument();
     expect(
-      screen.getByText('This log stream closed without stdout or stderr.'),
+      screen.getByText('This log stream closed without session entries or process output.'),
     ).toBeInTheDocument();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.getByRole('log')).toBeInTheDocument();
@@ -197,5 +198,46 @@ describe('StepAttemptLogPanel', () => {
 
     await waitFor(() => expect(screen.getByText('second')).toBeInTheDocument());
     expect(logRows.scrollTop).toBe(320);
+  });
+
+  test('passes failure anchoring for failed attempts', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi.fn(async () =>
+        jsonResponse(
+          inlineLogBody(
+            JSON.stringify({
+              v: 1,
+              ts: 1,
+              type: 'agent_session',
+              data: JSON.stringify({
+                type: 'message',
+                message: {
+                  role: 'assistant',
+                  content: [{type: 'text', text: 'I cannot continue.'}],
+                  stopReason: 'error',
+                },
+              }),
+            }),
+            1,
+          ),
+        ),
+      ),
+    });
+
+    renderPanel({attemptStatus: 'failed'});
+
+    expect(await screen.findByText('I cannot continue.')).toBeInTheDocument();
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalledWith({block: 'center'}));
   });
 });

--- a/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/step-attempt-log-panel.tsx
@@ -37,6 +37,7 @@ export function StepAttemptLogPanel({
   });
   const records = query.data?.records ?? [];
   const recordCount = records.length;
+  const anchorToFailure = attemptStatus === 'failed';
   const missingActiveStream =
     retryMissingStream && query.data === undefined && isMissingStepLogStreamError(query.error);
   const initialError = query.isError && query.data === undefined && !missingActiveStream;
@@ -44,6 +45,7 @@ export function StepAttemptLogPanel({
 
   useEffect(() => {
     if (recordCount === 0) return undefined;
+    if (anchorToFailure) return undefined;
     if (!shouldFollowTailRef.current) return undefined;
 
     const frame = scheduleAnimationFrame(() => {
@@ -55,7 +57,7 @@ export function StepAttemptLogPanel({
     return () => {
       cancelScheduledFrame(frame);
     };
-  }, [recordCount]);
+  }, [anchorToFailure, recordCount]);
 
   function handleLogScroll(event: UIEvent<HTMLDivElement>) {
     const element = event.currentTarget;
@@ -96,6 +98,7 @@ export function StepAttemptLogPanel({
       <LogView
         records={records}
         emptyState={query.data?.complete ? 'complete' : 'pending'}
+        anchorToFailure={anchorToFailure}
         className={logSurfaceClasses}
         onScroll={handleLogScroll}
       />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2462,6 +2462,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@argos-ci/cli':
         specifier: ^5.0.0


### PR DESCRIPTION
Render agent session records directly inside the existing log viewer.

Agent steps were unreadable because the backend served `agent_session` log records verbatim but the client log tree dropped them. This keeps the backend format-agnostic and parses the rendered subset in `@shipfox/client-logs`, preserving stream order with stdout/stderr while showing prompts, assistant messages, thinking, tool calls/results, lifecycle rows, unknown-entry fallbacks, and terminal failure anchors.

The workflows package only passes the failed-attempt anchor flag into `LogView`; step-level error copy stays on the step row.

Closes ENG-502

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render agent session logs inline in `@shipfox/client-logs`, interleaving `agent_session` entries with stdout/stderr so agent steps read clearly. Addresses ENG-502 with full session coverage, clearer metadata, and failure anchoring.

- **New Features**
  - Parse and render session entries with process output: messages (user/assistant), collapsible thinking with a bounded word-count summary, tool calls/results with “awaiting result”, lifecycle rows, and unknown-entry fallback.
  - Support documented shapes and extended roles: `thinking_level_change`, `model_change`, `compaction`/`compactionSummary`, `branch_summary`/`branchSummary`, `label`, `session_info`, `custom`/`custom_message`, and `bashExecution`; show image blocks as compact placeholders.
  - Clarify message metadata: show simple values inline; move detailed key/value pairs into a tooltip.
  - Normalize runner shapes and UX: preserve assistant block order; parse tool-result text blocks; mark terminal assistant errors and add a failure row for thinking-only errors; scroll to failures when `anchorToFailure` is set; update empty-state copy to include session entries; “show more/less” now exposes `aria-expanded`.
  - Add Storybook stories covering all agent entry types, failure anchoring, unknown entries, and large payloads.

- **Dependencies**
  - Add `zod` to validate and normalize session entries.

<sup>Written for commit 951fd3f99afe8a32e7b9bf7f4ba55eded69e1f46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

