### PR TITLE
Add env declarations for workflow run steps

### DIFF
--- a/.changeset/crisp-envs-flow.md
+++ b/.changeset/crisp-envs-flow.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": minor
+---
+
+Adds workflow, job, and run-step env declarations for non-secret run-step configuration.

--- a/libs/api/definitions/src/core/entities/workflow-model.ts
+++ b/libs/api/definitions/src/core/entities/workflow-model.ts
@@ -4,6 +4,7 @@ import type {AgentThinking} from '@shipfox/workflow-document';
 export interface WorkflowModel {
   readonly kind: 'workflow';
   readonly name: string;
+  readonly env?: Readonly<Record<string, string>>;
   readonly triggers: readonly WorkflowModelTrigger[];
   readonly jobs: readonly WorkflowModelJob[];
   readonly dependencies: readonly WorkflowModelDependency[];
@@ -22,6 +23,7 @@ export interface WorkflowModelJob {
   readonly id: string;
   readonly sourceName: string;
   readonly runner: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
   readonly dependencies: readonly string[];
   readonly steps: readonly WorkflowModelStep[];
 }
@@ -38,6 +40,7 @@ interface WorkflowModelStepBase {
 export interface WorkflowModelRunStep extends WorkflowModelStepBase {
   readonly kind: 'run';
   readonly command: WorkflowModelRunCommand;
+  readonly env?: Readonly<Record<string, string>>;
 }
 
 export interface WorkflowModelAgentStep extends WorkflowModelStepBase {

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -354,6 +354,47 @@ describe('normalizeWorkflowDocument', () => {
     expect(model.jobs).toMatchObject([{id: 'build', runner: ['ubuntu-latest']}]);
   });
 
+  it('stringifies env at workflow, job, and run-step scope', () => {
+    const document: WorkflowDocument = {
+      name: 'env build',
+      env: {NODE_ENV: 'test', PORT: 3000, CI: true},
+      jobs: {
+        build: {
+          env: {JOB_SCOPE: 'build'},
+          steps: [{run: 'npm test', env: {STEP_SCOPE: 'test', DEBUG: false}}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.env).toEqual({NODE_ENV: 'test', PORT: '3000', CI: 'true'});
+    expect(model.jobs[0]?.env).toEqual({JOB_SCOPE: 'build'});
+    expect(model.jobs[0]?.steps[0]).toMatchObject({
+      kind: 'run',
+      env: {STEP_SCOPE: 'test', DEBUG: 'false'},
+    });
+  });
+
+  it('omits empty env maps and does not attach inherited env to agent steps', () => {
+    const document: WorkflowDocument = {
+      name: 'agent env',
+      env: {},
+      jobs: {
+        fix: {
+          env: {JOB_SCOPE: 'fix'},
+          steps: [{model: 'claude-opus-4-8', prompt: 'Fix it.'}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model).not.toHaveProperty('env');
+    expect(model.jobs[0]?.env).toEqual({JOB_SCOPE: 'fix'});
+    expect(model.jobs[0]?.steps[0]).not.toHaveProperty('env');
+  });
+
   it('expands needs into job dependencies and explicit graph edges', () => {
     const document: WorkflowDocument = {
       name: 'graph',

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.ts
@@ -66,6 +66,7 @@ export function normalizeWorkflowDocument(
   return {
     kind: 'workflow',
     name: document.name,
+    ...optionalEnv(document.env),
     triggers,
     jobs,
     dependencies,
@@ -213,7 +214,12 @@ function normalizeJobs(
       };
 
       if (step.run !== undefined) {
-        return {...stepBase, kind: 'run', command: {kind: 'shell', value: step.run}};
+        return {
+          ...stepBase,
+          kind: 'run',
+          command: {kind: 'shell', value: step.run},
+          ...optionalEnv(step.env),
+        };
       }
 
       if (step.model !== undefined && step.prompt !== undefined) {
@@ -239,6 +245,7 @@ function normalizeJobs(
         id,
         sourceName,
         runner,
+        ...optionalEnv(job.env),
         dependencies,
         steps,
       },
@@ -482,6 +489,16 @@ function normalizeNeeds(value: string | readonly string[] | undefined): readonly
 function normalizeStringArray(value: string | readonly string[] | undefined): readonly string[] {
   if (value === undefined) return [];
   return typeof value === 'string' ? [value] : value;
+}
+
+function optionalEnv(
+  env: Readonly<Record<string, string | number | boolean>> | undefined,
+): {env: Readonly<Record<string, string>>} | Record<string, never> {
+  if (env === undefined || Object.keys(env).length === 0) return {};
+
+  return {
+    env: Object.fromEntries(Object.entries(env).map(([key, value]) => [key, String(value)])),
+  };
 }
 
 function uniqueStrings(values: readonly string[]): readonly string[] {

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -167,6 +167,60 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('materializes merged env for run steps only', () => {
+    const model = workflowModel({
+      env: {SHARED: 'workflow', WORKFLOW_ONLY: 'yes'},
+      jobs: {
+        build: {
+          env: {SHARED: 'job', JOB_ONLY: 'yes'},
+          steps: [
+            {name: 'run', run: 'npm test', env: {SHARED: 'step', STEP_ONLY: 'yes'}},
+            {
+              name: 'agent',
+              model: 'claude-opus-4-8',
+              provider: 'anthropic',
+              thinking: 'high',
+              prompt: 'Fix it.',
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel(model);
+
+    expect(rows[0]?.steps[0]?.config).toEqual({});
+    expect(rows[0]?.steps[1]?.config).toEqual({
+      run: 'npm test',
+      env: {
+        SHARED: 'step',
+        WORKFLOW_ONLY: 'yes',
+        JOB_ONLY: 'yes',
+        STEP_ONLY: 'yes',
+      },
+    });
+    expect(rows[0]?.steps[2]?.config).toEqual({
+      model: 'claude-opus-4-8',
+      provider: 'anthropic',
+      thinking: 'high',
+      prompt: 'Fix it.',
+    });
+  });
+
+  it('omits env from run-step config when the merge is empty', () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [{run: 'npm test'}],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel(model);
+
+    expect(rows[0]?.steps[1]?.config).toEqual({run: 'npm test'});
+  });
+
   it('gives a job with no user steps just the synthetic setup step', () => {
     const model = workflowModel({jobs: {noop: {steps: []}}});
 

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -56,7 +56,7 @@ export function materializeWorkflowModel(model: WorkflowModel): readonly Materia
         sourceLocation: step.sourceLocation ?? null,
         status: 'pending' as const,
         type: step.kind,
-        config: stepConfig(step),
+        config: stepConfig(step, model.env, job.env),
         position: stepPosition + 1,
       })),
     ],
@@ -91,10 +91,15 @@ function firstLine(value: string): string {
   return value.split(FIRST_LINE_PATTERN, 1)[0]?.trim() || value.trim();
 }
 
-function stepConfig(step: WorkflowModelStep): Record<string, unknown> {
+function stepConfig(
+  step: WorkflowModelStep,
+  workflowEnv: WorkflowModel['env'],
+  jobEnv: WorkflowModelJob['env'],
+): Record<string, unknown> {
   const gate = step.gate === undefined ? {} : {gate: stepGateConfig(step.gate)};
+  const env = step.kind === 'run' ? mergedEnv(workflowEnv, jobEnv, step.env) : {};
   return step.kind === 'run'
-    ? {run: step.command.value, ...gate}
+    ? {run: step.command.value, ...env, ...gate}
     : {
         model: step.model,
         provider: step.provider,
@@ -102,6 +107,15 @@ function stepConfig(step: WorkflowModelStep): Record<string, unknown> {
         prompt: step.prompt,
         ...gate,
       };
+}
+
+function mergedEnv(
+  workflowEnv: WorkflowModel['env'],
+  jobEnv: WorkflowModelJob['env'],
+  stepEnv: Extract<WorkflowModelStep, {kind: 'run'}>['env'],
+): {env: Readonly<Record<string, string>>} | Record<string, never> {
+  const env = {...workflowEnv, ...jobEnv, ...stepEnv};
+  return Object.keys(env).length === 0 ? {} : {env};
 }
 
 function assertNever(value: never): never {

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -49,7 +49,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
       id: jobId,
       sourceName,
       runner: normalizeStringArray(job.runner ?? input.runner),
-      ...(job.env === undefined ? {} : {env: job.env}),
+      ...optionalEnv(job.env),
       dependencies: normalizeStringArray(job.needs).map(stableId),
       steps: job.steps.map((step, stepIndex) => normalizeStep(step, jobId, stepIndex)),
     };
@@ -58,7 +58,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
   return {
     kind: 'workflow',
     name: input.name ?? 'Test Workflow',
-    ...(input.env === undefined ? {} : {env: input.env}),
+    ...optionalEnv(input.env),
     triggers: [],
     jobs: modelJobs,
     dependencies: modelJobs.flatMap((job) =>
@@ -74,7 +74,7 @@ function normalizeStep(step: TestWorkflowStep, jobId: string, stepIndex: number)
         ...base,
         kind: 'run',
         command: {kind: 'shell', value: step.run},
-        ...(step.env === undefined ? {} : {env: step.env}),
+        ...optionalEnv(step.env),
       }
     : {
         ...base,
@@ -101,6 +101,13 @@ function stepBase(step: TestWorkflowStep, jobId: string, stepIndex: number) {
 function normalizeStringArray(value: string | readonly string[] | undefined): readonly string[] {
   if (value === undefined) return [];
   return typeof value === 'string' ? [value] : value;
+}
+
+function optionalEnv(
+  env: WorkflowModel['env'] | undefined,
+): {env: NonNullable<WorkflowModel['env']>} | Record<string, never> {
+  if (env === undefined || Object.keys(env).length === 0) return {};
+  return {env};
 }
 
 function stableId(sourceName: string): string {

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -11,6 +11,7 @@ interface TestWorkflowStepBase {
 
 interface TestRunStep extends TestWorkflowStepBase {
   readonly run: string;
+  readonly env?: WorkflowModel['env'] | undefined;
 }
 
 interface TestAgentStep extends TestWorkflowStepBase {
@@ -25,12 +26,14 @@ type TestWorkflowStep = TestRunStep | TestAgentStep;
 interface TestWorkflowJob {
   readonly needs?: string | readonly string[] | undefined;
   readonly runner?: string | readonly string[] | undefined;
+  readonly env?: WorkflowModel['env'] | undefined;
   readonly steps: readonly TestWorkflowStep[];
 }
 
 interface TestWorkflowModelInput {
   readonly name?: string | undefined;
   readonly runner?: string | readonly string[] | undefined;
+  readonly env?: WorkflowModel['env'] | undefined;
   readonly jobs?: Readonly<Record<string, TestWorkflowJob>> | undefined;
 }
 
@@ -46,6 +49,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
       id: jobId,
       sourceName,
       runner: normalizeStringArray(job.runner ?? input.runner),
+      ...(job.env === undefined ? {} : {env: job.env}),
       dependencies: normalizeStringArray(job.needs).map(stableId),
       steps: job.steps.map((step, stepIndex) => normalizeStep(step, jobId, stepIndex)),
     };
@@ -54,6 +58,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
   return {
     kind: 'workflow',
     name: input.name ?? 'Test Workflow',
+    ...(input.env === undefined ? {} : {env: input.env}),
     triggers: [],
     jobs: modelJobs,
     dependencies: modelJobs.flatMap((job) =>
@@ -65,7 +70,12 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
 function normalizeStep(step: TestWorkflowStep, jobId: string, stepIndex: number): ModelStep {
   const base = stepBase(step, jobId, stepIndex);
   return 'run' in step
-    ? {...base, kind: 'run', command: {kind: 'shell', value: step.run}}
+    ? {
+        ...base,
+        kind: 'run',
+        command: {kind: 'shell', value: step.run},
+        ...(step.env === undefined ? {} : {env: step.env}),
+      }
     : {
         ...base,
         kind: 'agent',

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -2,6 +2,7 @@ import {mkdtemp, rm} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import {type CommandStartMetadata, executeRunStep, type OutputSink} from '#core/run-step.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
@@ -22,7 +23,16 @@ function collectOutput(): {sink: OutputSink; text: () => string; sources: () => 
   };
 }
 
+function nodeEnvDumpCommand(keys: readonly string[]): string {
+  const script = `const keys = ${JSON.stringify(keys)}; process.stdout.write(JSON.stringify(Object.fromEntries(keys.map((key) => [key, process.env[key] ?? null]))));`;
+  return `node -e ${JSON.stringify(script)}`;
+}
+
 describe('executeRunStep', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('succeeds with exit code 0', async () => {
     const step = buildStep({config: {run: 'echo hello'}});
     const output = collectOutput();
@@ -32,6 +42,89 @@ describe('executeRunStep', () => {
     expect(result.success).toBe(true);
     expect(output.text()).toContain('hello');
     expect(result.exit_code).toBe(0);
+  });
+
+  it('passes step env to the spawned process with precedence over inherited env', async () => {
+    const previous = process.env.SHIPFOX_ENV_TEST_EXISTING;
+    process.env.SHIPFOX_ENV_TEST_EXISTING = 'inherited';
+    try {
+      const step = buildStep({
+        config: {
+          run: nodeEnvDumpCommand(['SHIPFOX_ENV_TEST_CUSTOM', 'SHIPFOX_ENV_TEST_EXISTING']),
+          env: {
+            SHIPFOX_ENV_TEST_CUSTOM: 'custom',
+            SHIPFOX_ENV_TEST_EXISTING: 'step',
+          },
+        },
+      });
+      const output = collectOutput();
+
+      const result = await executeRunStep(step, {onOutput: output.sink});
+
+      expect(result.success).toBe(true);
+      expect(JSON.parse(output.text())).toEqual({
+        SHIPFOX_ENV_TEST_CUSTOM: 'custom',
+        SHIPFOX_ENV_TEST_EXISTING: 'step',
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.SHIPFOX_ENV_TEST_EXISTING;
+      } else {
+        process.env.SHIPFOX_ENV_TEST_EXISTING = previous;
+      }
+    }
+  });
+
+  it('inherits process env when step env is absent', async () => {
+    const previous = process.env.SHIPFOX_ENV_TEST_INHERITED;
+    process.env.SHIPFOX_ENV_TEST_INHERITED = 'inherited';
+    try {
+      const step = buildStep({
+        config: {run: nodeEnvDumpCommand(['SHIPFOX_ENV_TEST_INHERITED'])},
+      });
+      const output = collectOutput();
+
+      const result = await executeRunStep(step, {onOutput: output.sink});
+
+      expect(result.success).toBe(true);
+      expect(JSON.parse(output.text())).toEqual({SHIPFOX_ENV_TEST_INHERITED: 'inherited'});
+    } finally {
+      if (previous === undefined) {
+        delete process.env.SHIPFOX_ENV_TEST_INHERITED;
+      } else {
+        process.env.SHIPFOX_ENV_TEST_INHERITED = previous;
+      }
+    }
+  });
+
+  it('skips non-string step env values and warns without failing the step', async () => {
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const step = buildStep({
+      config: {
+        run: nodeEnvDumpCommand(['SHIPFOX_ENV_TEST_GOOD', 'SHIPFOX_ENV_TEST_BAD']),
+        env: {
+          SHIPFOX_ENV_TEST_GOOD: 'good',
+          SHIPFOX_ENV_TEST_BAD: 123,
+        },
+      },
+    });
+    const output = collectOutput();
+
+    const result = await executeRunStep(step, {onOutput: output.sink});
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(output.text())).toEqual({
+      SHIPFOX_ENV_TEST_GOOD: 'good',
+      SHIPFOX_ENV_TEST_BAD: null,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      {
+        stepId: step.id,
+        key: 'SHIPFOX_ENV_TEST_BAD',
+        valueType: 'number',
+      },
+      'Skipping non-string step env value',
+    );
   });
 
   it('fails with non-zero exit code and reports it on result.error', async () => {

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -55,17 +55,21 @@ export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Pro
     });
   }
 
-  return runShellCommand(command, options);
+  return runShellCommand(command, readStepEnv(step), options);
 }
 
-async function runShellCommand(command: string, options: RunStepOptions): Promise<StepResult> {
+async function runShellCommand(
+  command: string,
+  stepEnv: Readonly<Record<string, string>>,
+  options: RunStepOptions,
+): Promise<StepResult> {
   const scriptPath = join(tmpdir(), `shipfox-runner-${randomUUID()}.sh`);
   const metadata = commandStartMetadata({command, scriptPath, cwd: options.cwd});
   notifyCommandStart(options.onCommandStart, cloneCommandStartMetadata(metadata));
 
   try {
     await writeFile(scriptPath, command, {mode: 0o700});
-    return await spawnAndCapture(metadata, options);
+    return await spawnAndCapture(metadata, stepEnv, options);
   } finally {
     await unlink(scriptPath).catch(() => undefined);
   }
@@ -73,6 +77,7 @@ async function runShellCommand(command: string, options: RunStepOptions): Promis
 
 function spawnAndCapture(
   metadata: CommandStartMetadata,
+  stepEnv: Readonly<Record<string, string>>,
   options: RunStepOptions,
 ): Promise<StepResult> {
   return new Promise((resolve) => {
@@ -85,6 +90,7 @@ function spawnAndCapture(
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
       cwd: options.cwd,
+      env: {...process.env, ...stepEnv},
     });
 
     // stdout and stderr are two separate pipes, so the sink sees them merged by
@@ -177,6 +183,32 @@ function spawnAndCapture(
       });
     });
   });
+}
+
+function readStepEnv(step: StepDto): Readonly<Record<string, string>> {
+  const rawEnv = step.config.env;
+  if (
+    rawEnv === undefined ||
+    rawEnv === null ||
+    typeof rawEnv !== 'object' ||
+    Array.isArray(rawEnv)
+  ) {
+    return {};
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawEnv)) {
+    if (typeof value === 'string') {
+      env[key] = value;
+      continue;
+    }
+
+    logger().warn(
+      {stepId: step.id, key, valueType: value === null ? 'null' : typeof value},
+      'Skipping non-string step env value',
+    );
+  }
+  return env;
 }
 
 function findShell(): string {

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -43,8 +43,9 @@ try {
     },
     jobs: {
       build: {
+        env: {NODE_ENV: 'test'},
         runner: 'ubuntu-latest',
-        steps: [{run: 'npm run build', gate: {success_if: 'exit_code == 0'}}],
+        steps: [{run: 'npm run build', env: {CI: true}, gate: {success_if: 'exit_code == 0'}}],
       },
     },
   });
@@ -98,6 +99,21 @@ parseWorkflowDocument({
   time and fails later at runtime. The `high` and `anthropic` defaults are
   applied later in the model layer, not here. The `agent` key is reserved for a
   future step kind and is rejected today.
+- `env` can be declared on the workflow, a job, or a run step. Values may be
+  strings, numbers, or booleans; the model layer stringifies numbers and
+  booleans before a run is saved. Values are literal. Expression interpolation
+  such as `${{ ... }}` is not evaluated.
+- `env` applies only to run steps. Declaring `env` directly on an agent step is
+  rejected. Workflow-level and job-level `env` is not applied to agent steps.
+- Run-step env is plaintext, non-secret configuration. Values are stored in the
+  committed workflow file and in the saved step config, and they are not masked.
+  Do not put secrets in `env`.
+- Env precedence is workflow, then job, then step; the nearest scope wins. A run
+  step inherits the runner process environment, and workflow env can override
+  names such as `PATH` for that subprocess. This is within the run-step trust
+  boundary because the workflow author already controls the shell script.
+- There is no unset syntax. `env: {}` does not remove inherited variables, and
+  `FOO: ""` sets `FOO` to an empty string.
 - Rules that need a project, user, runner, database row, or saved state belong
   outside this package.
 

--- a/libs/shared/workflow/document/src/document/index.ts
+++ b/libs/shared/workflow/document/src/document/index.ts
@@ -6,10 +6,12 @@ export {
 } from './step-enums.js';
 export {
   type WorkflowDocument,
+  type WorkflowDocumentEnv,
   type WorkflowDocumentJob,
   type WorkflowDocumentRunStepGate,
   type WorkflowDocumentStep,
   type WorkflowDocumentTrigger,
+  workflowDocumentEnvSchema,
   workflowDocumentJobSchema,
   workflowDocumentSchema,
   workflowDocumentStepSchema,

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -100,10 +100,10 @@ describe('workflowDocumentSchema', () => {
   });
 
   it.each([
-    ['starts with a digit', {env: {'1PORT': '3000'}}],
-    ['contains a dash', {env: {'NODE-ENV': 'test'}}],
-    ['contains a dot', {env: {'node.env': 'test'}}],
-    ['has a null byte string value', {env: {NODE_ENV: 'test\u0000prod'}}],
+    ['has a key that starts with a digit', {env: {'1PORT': '3000'}}],
+    ['has a key containing a dash', {env: {'NODE-ENV': 'test'}}],
+    ['has a key containing a dot', {env: {'node.env': 'test'}}],
+    ['has a string value containing a null byte', {env: {NODE_ENV: 'test\u0000prod'}}],
     ['has a null value', {env: {NODE_ENV: null}}],
     ['has an object value', {env: {NODE_ENV: {value: 'test'}}}],
   ])('rejects env that %s', (_label, override) => {

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -82,6 +82,59 @@ describe('workflowDocumentSchema', () => {
     expect(result.triggers?.main_push?.filter).toBe('event.ref == "refs/heads/main"');
   });
 
+  it('accepts env maps at workflow, job, and run-step scope', () => {
+    const workflowDocument = {
+      name: 'env build',
+      env: {NODE_ENV: 'test', PORT: 3000, CI: true},
+      jobs: {
+        build: {
+          env: {JOB_SCOPE: 'build'},
+          steps: [{run: 'npm test', env: {STEP_SCOPE: 'test'}}],
+        },
+      },
+    };
+
+    const result = workflowDocumentSchema.safeParse(workflowDocument);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    ['starts with a digit', {env: {'1PORT': '3000'}}],
+    ['contains a dash', {env: {'NODE-ENV': 'test'}}],
+    ['contains a dot', {env: {'node.env': 'test'}}],
+    ['has a null byte string value', {env: {NODE_ENV: 'test\u0000prod'}}],
+    ['has a null value', {env: {NODE_ENV: null}}],
+    ['has an object value', {env: {NODE_ENV: {value: 'test'}}}],
+  ])('rejects env that %s', (_label, override) => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'env build',
+      jobs: {
+        build: {
+          steps: [{run: 'npm test', ...override}],
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('reports a clear message for env on an agent step', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'agent build',
+      jobs: {
+        fix: {
+          steps: [{model: 'claude-opus-4-8', prompt: 'Fix it.', env: {NODE_ENV: 'test'}}],
+        },
+      },
+    });
+
+    const envIssue = result.success
+      ? undefined
+      : result.error.issues.find((issue) => issue.path.includes('env'));
+    expect(envIssue?.message).toBe('"env" is supported only on run steps.');
+  });
+
   it('accepts a step gate with success_if and on_failure', () => {
     const workflowDocument = {
       name: 'review loop',

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -7,6 +7,17 @@ const nonEmptyRecordSchema = <ValueSchema extends z.ZodType>(valueSchema: ValueS
     .record(z.string().min(1), valueSchema)
     .refine((value) => Object.keys(value).length > 0, {message: 'Expected at least one entry'});
 
+// Runner shell steps execute on Unix shells, so workflow env names follow the
+// portable POSIX-style variable shape.
+const envNameSchema = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
+const envStringValueSchema = z.string().refine((value) => !value.includes('\u0000'), {
+  message: 'Env string values cannot contain null bytes',
+});
+export const workflowDocumentEnvSchema = z.record(
+  envNameSchema,
+  z.union([envStringValueSchema, z.number(), z.boolean()]),
+);
+
 const workflowDocumentTriggerBaseSchema = {
   source: z.string().min(1),
   with: z.record(z.string(), z.unknown()).optional(),
@@ -48,6 +59,7 @@ export const workflowDocumentStepSchema = z
     provider: z.string().min(1).optional(),
     agent: z.unknown().optional(),
     gate: workflowDocumentStepGateSchema.optional(),
+    env: workflowDocumentEnvSchema.optional(),
   })
   .superRefine((step, ctx) => {
     if (step.agent !== undefined) {
@@ -80,6 +92,13 @@ export const workflowDocumentStepSchema = z
     }
 
     if (isAgent) {
+      if (step.env !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['env'],
+          message: '"env" is supported only on run steps.',
+        });
+      }
       if (step.model === undefined) {
         ctx.addIssue({code: 'custom', path: ['model'], message: 'An agent step requires "model".'});
       }
@@ -107,17 +126,20 @@ export const workflowDocumentStepSchema = z
 export const workflowDocumentJobSchema = z.strictObject({
   needs: stringOrStringArraySchema.optional(),
   runner: stringOrStringArraySchema.optional(),
+  env: workflowDocumentEnvSchema.optional(),
   steps: z.array(workflowDocumentStepSchema).min(1),
 });
 
 export const workflowDocumentSchema = z.strictObject({
   name: z.string().min(1),
   runner: stringOrStringArraySchema.optional(),
+  env: workflowDocumentEnvSchema.optional(),
   triggers: nonEmptyRecordSchema(workflowDocumentTriggerSchema).optional(),
   jobs: nonEmptyRecordSchema(workflowDocumentJobSchema),
 });
 
 export type WorkflowDocument = z.infer<typeof workflowDocumentSchema>;
+export type WorkflowDocumentEnv = z.infer<typeof workflowDocumentEnvSchema>;
 export type WorkflowDocumentJob = z.infer<typeof workflowDocumentJobSchema>;
 export type WorkflowDocumentRunStepGate = z.infer<typeof workflowDocumentStepGateSchema>;
 export type WorkflowDocumentStep = z.infer<typeof workflowDocumentStepSchema>;

--- a/libs/shared/workflow/document/src/index.ts
+++ b/libs/shared/workflow/document/src/index.ts
@@ -7,10 +7,12 @@ export {
   invalidWorkflowDocumentErrorCode,
   parseWorkflowDocument,
   type WorkflowDocument,
+  type WorkflowDocumentEnv,
   type WorkflowDocumentJob,
   type WorkflowDocumentRunStepGate,
   type WorkflowDocumentStep,
   type WorkflowDocumentTrigger,
+  workflowDocumentEnvSchema,
   workflowDocumentSchema,
   workflowDocumentStepSchema,
 } from '#document/index.js';


### PR DESCRIPTION
Add `env` declarations at workflow, job, and run-step scope so workflow authors can pass non-secret configuration into shell steps.

Workflow documents now accept POSIX-style env names with string, number, or boolean values. The model layer stringifies scalar values once, materialization snapshots the merged workflow < job < step env into each run-step config, and the runner injects that config into the spawned shell process with step env overriding inherited process env. Agent steps and the synthetic setup step intentionally remain env-free.

The README documents the plaintext/non-secret contract, literal-value behavior, precedence, PATH override semantics, and no-unset limitation. The changeset bumps `@shipfox/workflow-document` as the only public package touched.

Follow-up hardening was split out after review:

Refs ENG-626
Refs ENG-627

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add env maps to workflows, jobs, and run steps so authors can pass non-secret config into shell steps. The runner injects the merged env into the spawned shell, with step values overriding inherited process env; agent steps remain env‑free. Addresses ENG-626 and ENG-627.

- **New Features**
  - Schema: allow `env` on workflow, job, and run steps; POSIX-style keys; string/number/boolean values (stringified in the model). Reject `env` on agent steps with a clear error; disallow null bytes. Export `workflowDocumentEnvSchema` and `WorkflowDocumentEnv`.
  - Model/Materialization: merge env with precedence workflow < job < step; apply only to run steps; omit `env` from run-step config when the merge is empty.
  - Runner: pass merged env to the shell while preserving the parent env; step env wins on conflicts. Skip non-string `config.env` values and warn instead of failing.

- **Dependencies**
  - Bump `@shipfox/workflow-document` (minor).

<sup>Written for commit 28465b7a7e67af713b43475a9e597a6fa5dc929f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

