### PR TITLE
Add workflow run cancellation

### DIFF
--- a/.changeset/calm-runs-cancel.md
+++ b/.changeset/calm-runs-cancel.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-runners": minor
+"@shipfox/api-workflows": minor
+"@shipfox/api-workflows-dto": minor
+"@shipfox/client-workflows": minor
+---
+
+Adds workflow-run cancellation across the API, orchestration queue cleanup, event contract, and run-page cancel action.

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -4,6 +4,7 @@ import {fileURLToPath} from 'node:url';
 export {closeDb, db, schema} from './db.js';
 export type {ClaimedJob, EnqueueJobParams} from './jobs.js';
 export {
+  cancelRunnerJobs,
   claimPendingJob,
   enqueueJob,
   expireStuckJobs,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -9,6 +9,7 @@ import {claimJob, detectAndExpireStuckJobs} from '#core/jobs.js';
 import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
 import {db} from './db.js';
 import {
+  cancelRunnerJobs,
   claimPendingJob,
   enqueueJob,
   expireStuckJobs,
@@ -480,6 +481,53 @@ describe('requestJobCancellation', () => {
 
   it('is a no-op when the job is missing (does not throw)', async () => {
     await expect(requestJobCancellation({jobId: crypto.randomUUID()})).resolves.toBeUndefined();
+  });
+});
+
+describe('cancelRunnerJobs', () => {
+  let workspaceId: string;
+  let runnerTokenId: string;
+
+  beforeEach(async () => {
+    await db().execute(
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+    );
+    workspaceId = crypto.randomUUID();
+    const runnerToken = await runnerTokenFactory.create({workspaceId});
+    runnerTokenId = runnerToken.id;
+  });
+
+  it('deletes queued jobs and requests cancellation for running jobs', async () => {
+    const running = await pendingJobFactory.create({workspaceId});
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const queued = await pendingJobFactory.create({workspaceId});
+
+    await cancelRunnerJobs({jobIds: [queued.jobId, claimed?.jobId as string]});
+
+    expect(await db().select().from(pendingJobs)).toHaveLength(0);
+    const rows = await db().select().from(runningJobs);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.jobId).toBe(running.jobId);
+    expect(rows[0]?.cancellationRequestedAt).not.toBeNull();
+  });
+
+  it('is idempotent and no-ops for absent jobs', async () => {
+    const queued = await pendingJobFactory.create({workspaceId});
+
+    await cancelRunnerJobs({jobIds: [queued.jobId, crypto.randomUUID()]});
+    await cancelRunnerJobs({jobIds: [queued.jobId, crypto.randomUUID()]});
+
+    expect(await db().select().from(pendingJobs)).toHaveLength(0);
+    expect(await db().select().from(runningJobs)).toHaveLength(0);
+  });
+
+  it('prevents a cancelled queued job from being claimed', async () => {
+    const queued = await pendingJobFactory.create({workspaceId});
+
+    await cancelRunnerJobs({jobIds: [queued.jobId]});
+
+    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    expect(claimed).toBeNull();
   });
 });
 

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -236,3 +236,17 @@ export async function requestJobCancellation(params: {jobId: string}): Promise<v
     })
     .where(eq(runningJobs.jobId, params.jobId));
 }
+
+export async function cancelRunnerJobs(params: {jobIds: string[]}): Promise<void> {
+  if (params.jobIds.length === 0) return;
+
+  await db().transaction(async (tx) => {
+    await tx.delete(pendingJobs).where(inArray(pendingJobs.jobId, params.jobIds));
+    await tx
+      .update(runningJobs)
+      .set({
+        cancellationRequestedAt: sql`COALESCE(${runningJobs.cancellationRequestedAt}, now())`,
+      })
+      .where(inArray(runningJobs.jobId, params.jobIds));
+  });
+}

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -9,7 +9,7 @@ import {createRunnerTokenAuthMethod, onWorkflowsJobTimedOut, routes} from '#pres
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
 import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
-export {type EnqueueJobParams, enqueueJob, releaseJob} from '#db/index.js';
+export {cancelRunnerJobs, type EnqueueJobParams, enqueueJob, releaseJob} from '#db/index.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -4,6 +4,7 @@ import {
   WORKFLOWS_JOB_TIMED_OUT,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
+  WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   workflowsEventSchemas,
@@ -12,6 +13,7 @@ import {
   workflowsJobTimedOutSchema,
   workflowsStepAttemptTerminatedSchema,
   workflowsStepRestartEnqueuedSchema,
+  workflowsWorkflowRunCancelledSchema,
   workflowsWorkflowRunCreatedSchema,
   workflowsWorkflowRunTerminatedSchema,
 } from './events.js';
@@ -34,6 +36,11 @@ const validRunTerminated = {
   runId: 'run-1',
   projectId: 'proj-1',
   status: 'failed',
+};
+
+const validRunCancelled = {
+  runId: 'run-1',
+  projectId: 'proj-1',
 };
 
 const validJobTimedOut = {
@@ -157,6 +164,12 @@ describe.each([
     validRunCreated,
     'runId',
   ],
+  [
+    'workflowsWorkflowRunCancelledSchema',
+    workflowsWorkflowRunCancelledSchema,
+    validRunCancelled,
+    'projectId',
+  ],
   ['workflowsJobTimedOutSchema', workflowsJobTimedOutSchema, validJobTimedOut, 'jobId'],
   [
     'workflowsJobStepsSettledSchema',
@@ -202,6 +215,7 @@ describe('workflowsEventSchemas', () => {
       [
         WORKFLOWS_WORKFLOW_RUN_CREATED,
         WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+        WORKFLOWS_WORKFLOW_RUN_CANCELLED,
         WORKFLOWS_JOB_TIMED_OUT,
         WORKFLOWS_JOB_TERMINATED,
         WORKFLOWS_JOB_STEPS_SETTLED,

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -7,6 +7,8 @@ const nonEmptyStringSchema = z.string().nonempty();
 export const WORKFLOWS_WORKFLOW_RUN_CREATED = 'workflows.workflow_run.created' as const;
 // Terminal fact for a workflow run, written in the same transaction as the status flip.
 export const WORKFLOWS_WORKFLOW_RUN_TERMINATED = 'workflows.workflow_run.terminated' as const;
+// Intent fact for cooperative run cancellation. Consumers use this to stop orchestration.
+export const WORKFLOWS_WORKFLOW_RUN_CANCELLED = 'workflows.workflow_run.cancelled' as const;
 export const WORKFLOWS_JOB_TIMED_OUT = 'workflows.job.timed_out' as const;
 // Terminal fact for a job: the single reliable "this job is over" signal, written in
 // the same transaction as the status flip, on every terminal path.
@@ -43,6 +45,14 @@ export const workflowsWorkflowRunTerminatedSchema = z.object({
 });
 export type WorkflowsWorkflowRunTerminatedEvent = z.infer<
   typeof workflowsWorkflowRunTerminatedSchema
+>;
+
+export const workflowsWorkflowRunCancelledSchema = z.object({
+  runId: nonEmptyStringSchema,
+  projectId: nonEmptyStringSchema,
+});
+export type WorkflowsWorkflowRunCancelledEvent = z.infer<
+  typeof workflowsWorkflowRunCancelledSchema
 >;
 
 export const workflowsJobTimedOutSchema = z.object({
@@ -94,6 +104,7 @@ export type WorkflowsStepAttemptTerminatedEvent = z.infer<
 export interface WorkflowsEventMap {
   [WORKFLOWS_WORKFLOW_RUN_CREATED]: WorkflowsWorkflowRunCreatedEvent;
   [WORKFLOWS_WORKFLOW_RUN_TERMINATED]: WorkflowsWorkflowRunTerminatedEvent;
+  [WORKFLOWS_WORKFLOW_RUN_CANCELLED]: WorkflowsWorkflowRunCancelledEvent;
   [WORKFLOWS_JOB_TIMED_OUT]: WorkflowsJobTimedOutEvent;
   [WORKFLOWS_JOB_TERMINATED]: WorkflowsJobTerminatedEvent;
   [WORKFLOWS_JOB_STEPS_SETTLED]: WorkflowsJobStepsSettledEvent;
@@ -104,6 +115,7 @@ export interface WorkflowsEventMap {
 export const workflowsEventSchemas = {
   [WORKFLOWS_WORKFLOW_RUN_CREATED]: workflowsWorkflowRunCreatedSchema,
   [WORKFLOWS_WORKFLOW_RUN_TERMINATED]: workflowsWorkflowRunTerminatedSchema,
+  [WORKFLOWS_WORKFLOW_RUN_CANCELLED]: workflowsWorkflowRunCancelledSchema,
   [WORKFLOWS_JOB_TIMED_OUT]: workflowsJobTimedOutSchema,
   [WORKFLOWS_JOB_TERMINATED]: workflowsJobTerminatedSchema,
   [WORKFLOWS_JOB_STEPS_SETTLED]: workflowsJobStepsSettledSchema,

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -64,6 +64,7 @@ export {
   WORKFLOWS_JOB_TIMED_OUT,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
+  WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMap,
@@ -72,6 +73,7 @@ export {
   type WorkflowsJobTimedOutEvent,
   type WorkflowsStepAttemptTerminatedEvent,
   type WorkflowsStepRestartEnqueuedEvent,
+  type WorkflowsWorkflowRunCancelledEvent,
   type WorkflowsWorkflowRunCreatedEvent,
   type WorkflowsWorkflowRunTerminatedEvent,
   workflowRunTerminalStatusSchema,
@@ -81,6 +83,7 @@ export {
   workflowsJobTimedOutSchema,
   workflowsStepAttemptTerminatedSchema,
   workflowsStepRestartEnqueuedSchema,
+  workflowsWorkflowRunCancelledSchema,
   workflowsWorkflowRunCreatedSchema,
   workflowsWorkflowRunTerminatedSchema,
 } from './events.js';

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -1,4 +1,5 @@
 import type {JobStatus} from './entities/job.js';
+import type {WorkflowRunStatus} from './entities/workflow-run.js';
 
 export class DefinitionNotFoundError extends Error {
   constructor(definitionId: string) {
@@ -49,6 +50,16 @@ export class WorkflowRunNotFoundError extends Error {
   constructor(runId: string) {
     super(`Workflow run not found: ${runId}`);
     this.name = 'WorkflowRunNotFoundError';
+  }
+}
+
+export class WorkflowRunNotCancellableError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly status: WorkflowRunStatus,
+  ) {
+    super(`Workflow run ${runId} is ${status} and cannot be cancelled`);
+    this.name = 'WorkflowRunNotCancellableError';
   }
 }
 

--- a/libs/api/workflows/src/core/index.ts
+++ b/libs/api/workflows/src/core/index.ts
@@ -19,6 +19,7 @@ export {
   ProjectMismatchError,
   StepNotFoundError,
   StepNotRunningError,
+  WorkflowRunNotCancellableError,
 } from './errors.js';
 export type {NextStep, RecordStepResultOutcome, RecordStepResultParams} from './job-execution.js';
 export {nextStepForJob, recordStepResult} from './job-execution.js';

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -5,6 +5,7 @@ export {closeDb, db, schema} from './db.js';
 export {workflowsOutbox} from './schema/outbox.js';
 export type {
   BulkUpdateStepStatusesParams,
+  CancelWorkflowRunParams,
   CreateWorkflowRunParams,
   FailJobAsTimedOutParams,
   ListWorkflowRunsParams,
@@ -19,6 +20,7 @@ export type {
 } from './workflow-runs.js';
 export {
   bulkUpdateStepStatuses,
+  cancelWorkflowRun,
   createWorkflowRun,
   failJobAsTimedOut,
   getJobById,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -2,11 +2,12 @@ import {
   WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
+  WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
 } from '@shipfox/api-workflows-dto';
 import {and, eq, sql} from 'drizzle-orm';
-import {JobNotFoundError} from '#core/errors.js';
+import {JobNotFoundError, WorkflowRunNotCancellableError} from '#core/errors.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
@@ -16,6 +17,7 @@ import {workflowsOutbox} from './schema/outbox.js';
 import {steps as stepsTable} from './schema/steps.js';
 import {
   bulkUpdateStepStatuses,
+  cancelWorkflowRun,
   createWorkflowRun,
   failJobAsTimedOut,
   getJobsByRunId,
@@ -82,6 +84,19 @@ async function runTerminatedEvents(runId: string) {
       ),
     );
   return rows.map((row) => row.payload as {runId: string; projectId: string; status: string});
+}
+
+async function runCancelledEvents(runId: string) {
+  const rows = await db()
+    .select({payload: workflowsOutbox.payload})
+    .from(workflowsOutbox)
+    .where(
+      and(
+        eq(workflowsOutbox.eventType, WORKFLOWS_WORKFLOW_RUN_CANCELLED),
+        sql`${workflowsOutbox.payload}->>'runId' = ${runId}`,
+      ),
+    );
+  return rows.map((row) => row.payload as {runId: string; projectId: string});
 }
 
 async function stepAttemptTerminatedEvents(jobId: string) {
@@ -758,7 +773,7 @@ jobs:
       expect(updated.version).toBe(2);
     });
 
-    test('persists terminal status reason and clears it on a later non-reasoned transition', async () => {
+    test('preserves terminal status reason when a later transition is ignored', async () => {
       const run = await createWorkflowRun({
         workspaceId,
         projectId,
@@ -779,14 +794,15 @@ jobs:
         expectedVersion: 1,
         statusReason: 'dependency_not_completed',
       });
-      const running = await updateJobStatus({
+      const retry = await updateJobStatus({
         jobId: job?.id as string,
         status: 'running',
         expectedVersion: 2,
       });
 
       expect(skipped.statusReason).toBe('dependency_not_completed');
-      expect(running.statusReason).toBeNull();
+      expect(retry.status).toBe('skipped');
+      expect(retry.statusReason).toBe('dependency_not_completed');
     });
 
     test('throws on version mismatch', async () => {
@@ -856,6 +872,137 @@ jobs:
 
       expect(retry.version).toBe(first.version);
       expect(await runTerminatedEvents(run.id)).toHaveLength(1);
+    });
+
+    test('terminal-tolerant mismatch: existing terminal run returns without re-emitting', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const cancelled = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'cancelled',
+        expectedVersion: 1,
+      });
+
+      const retry = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'running',
+        expectedVersion: 1,
+      });
+
+      expect(retry.status).toBe('cancelled');
+      expect(retry.version).toBe(cancelled.version);
+      expect(await runTerminatedEvents(run.id)).toHaveLength(1);
+    });
+
+    test('terminal-tolerant match: existing terminal run cannot be revived at the current version', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const cancelled = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'cancelled',
+        expectedVersion: 1,
+      });
+
+      const retry = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'running',
+        expectedVersion: cancelled.version,
+      });
+
+      expect(retry.status).toBe('cancelled');
+      expect(retry.version).toBe(cancelled.version);
+      expect(await getWorkflowRunById(run.id)).toMatchObject({
+        status: 'cancelled',
+        version: cancelled.version,
+      });
+      expect(await runTerminatedEvents(run.id)).toHaveLength(1);
+    });
+  });
+
+  describe('cancelWorkflowRun', () => {
+    test('cancels the run, non-terminal jobs, and only their non-terminal steps', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            running: {steps: [{run: 'a'}, {run: 'b'}]},
+            succeeded: {steps: [{run: 'ok'}]},
+            skipped: {steps: [{run: 'skip'}]},
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      await updateWorkflowRunStatus({runId: run.id, status: 'running', expectedVersion: 1});
+      const [runningJob, succeededJob, skippedJob] = await getJobsByRunId(run.id);
+      if (!runningJob || !succeededJob || !skippedJob) throw new Error('Expected jobs');
+      await updateJobStatus({jobId: runningJob.id, status: 'running', expectedVersion: 1});
+      await nextStepForJob(runningJob.id);
+      await updateJobStatus({jobId: succeededJob.id, status: 'succeeded', expectedVersion: 1});
+      await updateJobStatus({
+        jobId: skippedJob.id,
+        status: 'skipped',
+        expectedVersion: 1,
+        statusReason: 'dependency_not_completed',
+      });
+
+      const cancelled = await cancelWorkflowRun({runId: run.id});
+
+      expect(cancelled.status).toBe('cancelled');
+      expect(cancelled.finishedAt).not.toBeNull();
+      const [finalRunning, finalSucceeded, finalSkipped] = await getJobsByRunId(run.id);
+      expect(finalRunning).toMatchObject({status: 'cancelled', statusReason: 'run_cancelled'});
+      expect(finalSucceeded).toMatchObject({status: 'succeeded', statusReason: null});
+      expect(finalSkipped).toMatchObject({
+        status: 'skipped',
+        statusReason: 'dependency_not_completed',
+      });
+      expect((await getStepsByJobId(runningJob.id)).map((step) => step.status)).toEqual([
+        'cancelled',
+        'cancelled',
+        'cancelled',
+      ]);
+      expect(
+        (await getStepsByJobId(skippedJob.id)).every((step) => step.status === 'pending'),
+      ).toBe(true);
+      expect(await runTerminatedEvents(run.id)).toEqual([
+        {runId: run.id, projectId, status: 'cancelled'},
+      ]);
+      expect(await runCancelledEvents(run.id)).toEqual([{runId: run.id, projectId}]);
+      expect(await jobTerminatedEvents(runningJob.id)).toEqual([
+        {
+          jobId: runningJob.id,
+          runId: run.id,
+          status: 'cancelled',
+          statusReason: 'run_cancelled',
+        },
+      ]);
+      expect(await stepAttemptTerminatedEvents(runningJob.id)).toHaveLength(1);
+      expect(await jobTerminatedEvents(succeededJob.id)).toHaveLength(1);
+      expect(await jobTerminatedEvents(skippedJob.id)).toHaveLength(1);
+    });
+
+    test('throws without changing an already-terminal run', async () => {
+      const run = await createTestRun({workspaceId, projectId, definitionId});
+      const finished = await updateWorkflowRunStatus({
+        runId: run.id,
+        status: 'succeeded',
+        expectedVersion: 1,
+      });
+
+      await expect(cancelWorkflowRun({runId: run.id})).rejects.toBeInstanceOf(
+        WorkflowRunNotCancellableError,
+      );
+
+      expect(await getWorkflowRunById(run.id)).toMatchObject({
+        status: 'succeeded',
+        version: finished.version,
+      });
+      expect(await runCancelledEvents(run.id)).toHaveLength(0);
     });
   });
 
@@ -962,6 +1109,72 @@ jobs:
 
       expect(retry.status).toBe('running');
       expect(retry.version).toBe(first.version);
+    });
+
+    test('terminal-tolerant mismatch: existing terminal job returns without re-emitting', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel(),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const job = (await getJobsByRunId(run.id))[0];
+      const cancelled = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'cancelled',
+        expectedVersion: 1,
+      });
+
+      const retry = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'running',
+        expectedVersion: 1,
+      });
+
+      expect(retry.status).toBe('cancelled');
+      expect(retry.version).toBe(cancelled.version);
+      expect(await jobTerminatedEvents(job?.id as string)).toHaveLength(1);
+    });
+
+    test('terminal-tolerant match: existing terminal job cannot be revived at the current version', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel(),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const job = (await getJobsByRunId(run.id))[0];
+      const cancelled = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'cancelled',
+        expectedVersion: 1,
+      });
+
+      const retry = await updateJobStatus({
+        jobId: job?.id as string,
+        status: 'running',
+        expectedVersion: cancelled.version,
+      });
+
+      expect(retry.status).toBe('cancelled');
+      expect(retry.version).toBe(cancelled.version);
+      expect((await getJobsByRunId(run.id))[0]).toMatchObject({
+        status: 'cancelled',
+        version: cancelled.version,
+      });
+      expect(await jobTerminatedEvents(job?.id as string)).toHaveLength(1);
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -6,6 +6,7 @@ import {
   WORKFLOWS_JOB_TIMED_OUT,
   WORKFLOWS_STEP_ATTEMPT_TERMINATED,
   WORKFLOWS_STEP_RESTART_ENQUEUED,
+  WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMap,
@@ -16,7 +17,20 @@ import {
   timestampIdCursorWhere,
 } from '@shipfox/node-drizzle';
 import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
-import {and, asc, count, desc, eq, gte, inArray, isNull, lte, type SQL, sql} from 'drizzle-orm';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  notInArray,
+  type SQL,
+  sql,
+} from 'drizzle-orm';
 import {isJobTerminal, type Job, type JobStatus, type JobStatusReason} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import type {Step, StepAttempt, StepAttemptStatus, StepStatus} from '#core/entities/step.js';
@@ -27,7 +41,11 @@ import {
   type WorkflowRunStatus,
   type WorkflowSourceSnapshot,
 } from '#core/entities/workflow-run.js';
-import {JobNotFoundError} from '#core/errors.js';
+import {
+  JobNotFoundError,
+  WorkflowRunNotCancellableError,
+  WorkflowRunNotFoundError,
+} from '#core/errors.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import {materializeWorkflowModel} from '#core/workflow-runtime/index.js';
 import {
@@ -45,6 +63,9 @@ import {workflowsOutbox} from './schema/outbox.js';
 import {stepAttempts, toStepAttempt} from './schema/step-attempts.js';
 import {steps, toStep} from './schema/steps.js';
 import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
+
+const TERMINAL_WORKFLOW_RUN_STATUSES: WorkflowRunStatus[] = ['succeeded', 'failed', 'cancelled'];
+const TERMINAL_JOB_STATUSES: JobStatus[] = ['succeeded', 'failed', 'cancelled', 'skipped'];
 
 export interface CreateWorkflowRunParams {
   workspaceId: string;
@@ -397,6 +418,96 @@ export async function getStepsByJobIds(jobIds: string[]): Promise<Step[]> {
   return rows.map(toStep);
 }
 
+export interface CancelWorkflowRunParams {
+  runId: string;
+}
+
+export async function cancelWorkflowRun(params: CancelWorkflowRunParams): Promise<WorkflowRun> {
+  const result = await db().transaction(async (tx) => {
+    const runJobIds = tx.select({id: jobs.id}).from(jobs).where(eq(jobs.runId, params.runId));
+
+    await tx
+      .select({id: steps.id})
+      .from(steps)
+      .where(inArray(steps.jobId, runJobIds))
+      .orderBy(asc(steps.jobId), asc(steps.position))
+      .for('update');
+
+    const jobRows = await tx
+      .select()
+      .from(jobs)
+      .where(eq(jobs.runId, params.runId))
+      .orderBy(asc(jobs.position), asc(jobs.id))
+      .for('update');
+
+    const [lockedRun] = await tx
+      .select()
+      .from(workflowRuns)
+      .where(eq(workflowRuns.id, params.runId))
+      .limit(1)
+      .for('update');
+
+    if (!lockedRun) {
+      throw new WorkflowRunNotFoundError(params.runId);
+    }
+    if (isWorkflowRunTerminal(lockedRun.status)) {
+      throw new WorkflowRunNotCancellableError(lockedRun.id, lockedRun.status);
+    }
+
+    const cancelledJobs: Job[] = [];
+    for (const jobRow of jobRows) {
+      if (isJobTerminal(jobRow.status)) continue;
+
+      const updated = await updateJobStatusAtVersion(tx, {
+        jobId: jobRow.id,
+        status: 'cancelled',
+        expectedVersion: jobRow.version,
+        statusReason: 'run_cancelled',
+      });
+      if (updated?.changed) cancelledJobs.push(updated.job);
+      await bulkUpdateStepStatuses({jobId: jobRow.id, status: 'cancelled'}, tx);
+    }
+
+    const [cancelledRunRow] = await tx
+      .update(workflowRuns)
+      .set({
+        status: 'cancelled',
+        version: sql`${workflowRuns.version} + 1`,
+        updatedAt: new Date(),
+        finishedAt: sql`now()`,
+      })
+      .where(and(eq(workflowRuns.id, lockedRun.id), eq(workflowRuns.version, lockedRun.version)))
+      .returning();
+
+    if (!cancelledRunRow) {
+      throw new Error(`Optimistic lock failure: run ${lockedRun.id} version ${lockedRun.version}`);
+    }
+
+    const cancelledRun = toWorkflowRun(cancelledRunRow);
+    await writeOutboxEvents<WorkflowsEventMap>(tx, workflowsOutbox, [
+      {
+        type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
+        payload: {
+          runId: cancelledRun.id,
+          projectId: cancelledRun.projectId,
+          status: 'cancelled',
+        },
+      },
+      {
+        type: WORKFLOWS_WORKFLOW_RUN_CANCELLED,
+        payload: {runId: cancelledRun.id, projectId: cancelledRun.projectId},
+      },
+    ]);
+
+    return {run: cancelledRun, cancelledJobs};
+  });
+
+  recordWorkflowRunStatusChanged(result.run.status);
+  for (const job of result.cancelledJobs) recordWorkflowJobStatusChanged(job.status);
+
+  return result.run;
+}
+
 export interface UpdateWorkflowRunStatusParams {
   runId: string;
   status: WorkflowRunStatus;
@@ -423,7 +534,11 @@ export async function updateWorkflowRunStatus(
         ...(isWorkflowRunTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
       })
       .where(
-        and(eq(workflowRuns.id, params.runId), eq(workflowRuns.version, params.expectedVersion)),
+        and(
+          eq(workflowRuns.id, params.runId),
+          eq(workflowRuns.version, params.expectedVersion),
+          notInArray(workflowRuns.status, TERMINAL_WORKFLOW_RUN_STATUSES),
+        ),
       )
       .returning();
 
@@ -439,7 +554,10 @@ export async function updateWorkflowRunStatus(
         .where(eq(workflowRuns.id, params.runId))
         .limit(1);
       const existingRow = existing[0];
-      if (existingRow && existingRow.status === params.status) {
+      if (
+        existingRow &&
+        (existingRow.status === params.status || isWorkflowRunTerminal(existingRow.status))
+      ) {
         return {run: toWorkflowRun(existingRow), changed: false};
       }
       throw new Error(
@@ -490,7 +608,13 @@ async function updateJobStatusAtVersion(
       // DB clock so finished_at shares the runner-sourced queued_at/started_at clock.
       ...(isJobTerminal(params.status) ? {finishedAt: sql`now()`} : {}),
     })
-    .where(and(eq(jobs.id, params.jobId), eq(jobs.version, params.expectedVersion)))
+    .where(
+      and(
+        eq(jobs.id, params.jobId),
+        eq(jobs.version, params.expectedVersion),
+        notInArray(jobs.status, TERMINAL_JOB_STATUSES),
+      ),
+    )
     .returning();
 
   const row = rows[0];
@@ -540,7 +664,11 @@ export async function updateJobStatus(params: UpdateJobStatusParams): Promise<Jo
     // instead of throwing an optimistic-lock error that would wedge the workflow.
     const existing = await tx.select().from(jobs).where(eq(jobs.id, params.jobId)).limit(1);
     const row = existing[0];
-    if (row && row.status === params.status && row.statusReason === statusReason) {
+    if (
+      row &&
+      ((row.status === params.status && row.statusReason === statusReason) ||
+        isJobTerminal(row.status))
+    ) {
       return {job: toJob(row), changed: false};
     }
     throw new Error(

--- a/libs/api/workflows/src/index.ts
+++ b/libs/api/workflows/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@shipfox/api-runners-dto';
 import {
   WORKFLOWS_JOB_STEPS_SETTLED,
+  WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_CREATED,
   type WorkflowsEventMap,
   workflowsEventSchemas,
@@ -20,6 +21,7 @@ import {
   onRunnerJobClaimed,
   onRunnerJobLeaseExpired,
   onRunnerJobQueued,
+  onWorkflowRunCancelled,
   onWorkflowRunCreated,
   routes,
 } from '#presentation/index.js';
@@ -38,6 +40,7 @@ export {
   isPermanentRunWorkflowError,
   ProjectMismatchError,
   runWorkflow,
+  WorkflowRunNotCancellableError,
 } from '#core/index.js';
 export {setSourceControl} from '#core/source-control.js';
 export {
@@ -65,6 +68,7 @@ export const workflowsModule: ShipfoxModule = {
   ],
   subscribers: [
     subscriber(WORKFLOWS_WORKFLOW_RUN_CREATED, onWorkflowRunCreated),
+    subscriber(WORKFLOWS_WORKFLOW_RUN_CANCELLED, onWorkflowRunCancelled),
     subscriber(WORKFLOWS_JOB_STEPS_SETTLED, onJobStepsSettled),
     subscriber(RUNNER_JOB_LEASE_EXPIRED, onRunnerJobLeaseExpired),
     subscriber(RUNNER_JOB_QUEUED, onRunnerJobQueued),

--- a/libs/api/workflows/src/presentation/index.ts
+++ b/libs/api/workflows/src/presentation/index.ts
@@ -4,5 +4,6 @@ export {
   onRunnerJobClaimed,
   onRunnerJobLeaseExpired,
   onRunnerJobQueued,
+  onWorkflowRunCancelled,
   onWorkflowRunCreated,
 } from './subscribers/index.js';

--- a/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.test.ts
@@ -1,0 +1,156 @@
+import {buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {requireProjectAccess} from '@shipfox/api-projects';
+import {ClientError} from '@shipfox/node-fastify';
+import type {FastifyInstance} from 'fastify';
+import Fastify from 'fastify';
+import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
+import {WorkflowRunNotFoundError} from '#core/errors.js';
+import {getJobsByRunId, getWorkflowRunById, updateWorkflowRunStatus} from '#db/index.js';
+import {createWorkflowRun} from '#db/workflow-runs.js';
+import {workflowModel} from '#test/index.js';
+import {cancelRunRoute} from './cancel-run.js';
+
+const projectAccessState = vi.hoisted(() => ({workspaceId: ''}));
+
+vi.mock('@shipfox/api-projects', () => ({
+  requireProjectAccess: vi.fn(({projectId}) =>
+    Promise.resolve({
+      project: {id: projectId, workspaceId: projectAccessState.workspaceId},
+      workspaceId: projectAccessState.workspaceId,
+    }),
+  ),
+}));
+
+const mockRequireProjectAccess = vi.mocked(requireProjectAccess);
+
+describe('POST /api/workflows/runs/:id/cancel', () => {
+  let app: FastifyInstance;
+  let workspaceId: string;
+  let projectId: string;
+  let definitionId: string;
+
+  beforeAll(async () => {
+    app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.addHook('onRequest', (request, _reply, done) => {
+      setUserContext(
+        request,
+        buildUserContext({
+          userId: crypto.randomUUID(),
+          email: 'user@example.com',
+          memberships: [{workspaceId, role: 'admin'}],
+        }),
+      );
+      done();
+    });
+    app.post('/api/workflows/runs/:id/cancel', cancelRunRoute);
+    await app.ready();
+  });
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+    projectId = crypto.randomUUID();
+    definitionId = crypto.randomUUID();
+    projectAccessState.workspaceId = workspaceId;
+    mockRequireProjectAccess.mockImplementation(({projectId: requestedProjectId}) =>
+      Promise.resolve({
+        project: {
+          id: requestedProjectId,
+          workspaceId,
+          sourceConnectionId: crypto.randomUUID(),
+          sourceExternalRepositoryId: `repo:${crypto.randomUUID()}`,
+          name: 'Project',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        workspaceId,
+      }),
+    );
+  });
+
+  test('returns 200 and cancels a running run', async () => {
+    const run = await createRun();
+    await updateWorkflowRunStatus({runId: run.id, status: 'running', expectedVersion: 1});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${run.id}/cancel`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({id: run.id, status: 'cancelled'});
+    expect(await getWorkflowRunById(run.id)).toMatchObject({status: 'cancelled'});
+    const [job] = await getJobsByRunId(run.id);
+    expect(job).toMatchObject({status: 'cancelled', statusReason: 'run_cancelled'});
+  });
+
+  test('returns 404 for an unknown run', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${crypto.randomUUID()}/cancel`,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('not-found');
+  });
+
+  test('maps a run disappearing during cancellation to 404', () => {
+    let mapped: unknown;
+    const errorHandler = cancelRunRoute.errorHandler as (error: Error) => void;
+
+    try {
+      errorHandler(new WorkflowRunNotFoundError(crypto.randomUUID()));
+    } catch (error) {
+      mapped = error;
+    }
+
+    expect(mapped).toBeInstanceOf(ClientError);
+    expect(mapped).toMatchObject({status: 404, code: 'not-found'});
+  });
+
+  test('returns 404 when project access is denied', async () => {
+    const run = await createRun();
+    mockRequireProjectAccess.mockRejectedValueOnce(
+      new ClientError('Forbidden', 'forbidden', {status: 403}),
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${run.id}/cancel`,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('not-found');
+    expect(await getWorkflowRunById(run.id)).toMatchObject({status: 'pending'});
+  });
+
+  test('returns 409 for a terminal run', async () => {
+    const run = await createRun();
+    await updateWorkflowRunStatus({runId: run.id, status: 'succeeded', expectedVersion: 1});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/workflows/runs/${run.id}/cancel`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('run-already-finished');
+    expect(await getWorkflowRunById(run.id)).toMatchObject({status: 'succeeded'});
+  });
+
+  function createRun() {
+    return createWorkflowRun({
+      workspaceId,
+      projectId,
+      definitionId,
+      model: workflowModel({name: 'Deploy'}),
+      triggerPayload: {
+        source: 'manual',
+        event: 'fire',
+        subscriptionId: crypto.randomUUID(),
+        userId: crypto.randomUUID(),
+      },
+    });
+  }
+});

--- a/libs/api/workflows/src/presentation/routes/cancel-run.ts
+++ b/libs/api/workflows/src/presentation/routes/cancel-run.ts
@@ -1,0 +1,48 @@
+import {requireProjectAccess} from '@shipfox/api-projects';
+import {runDtoSchema} from '@shipfox/api-workflows-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {z} from 'zod';
+import {WorkflowRunNotCancellableError, WorkflowRunNotFoundError} from '#core/errors.js';
+import {cancelWorkflowRun, getWorkflowRunById} from '#db/index.js';
+import {toRunDto} from '#presentation/dto/index.js';
+
+export const cancelRunRoute = defineRoute({
+  method: 'POST',
+  path: '/:id/cancel',
+  description: 'Cancel an in-progress workflow run',
+  schema: {
+    params: z.object({
+      id: z.string().uuid(),
+    }),
+    response: {
+      200: runDtoSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof WorkflowRunNotCancellableError) {
+      throw new ClientError(error.message, 'run-already-finished', {status: 409});
+    }
+    if (error instanceof WorkflowRunNotFoundError) {
+      throw new ClientError('Run not found', 'not-found', {status: 404});
+    }
+    throw error;
+  },
+  handler: async (request) => {
+    const {id} = request.params;
+
+    const run = await getWorkflowRunById(id);
+    if (!run) {
+      throw new ClientError('Run not found', 'not-found', {status: 404});
+    }
+
+    await requireProjectAccess({request, projectId: run.projectId}).catch((err: unknown) => {
+      if (err instanceof ClientError && (err.status === 403 || err.status === 404)) {
+        throw new ClientError('Run not found', 'not-found', {status: 404});
+      }
+      throw err;
+    });
+
+    const cancelled = await cancelWorkflowRun({runId: run.id});
+    return toRunDto(cancelled);
+  },
+});

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -1,5 +1,6 @@
 import {AUTH_LEASED_JOB, AUTH_USER} from '@shipfox/api-auth-context';
 import type {RouteGroup} from '@shipfox/node-fastify';
+import {cancelRunRoute} from './cancel-run.js';
 import {checkoutTokenRoute} from './checkout-token.js';
 import {getRunRoute} from './get-run.js';
 import {getRunAggregatesRoute} from './get-run-aggregates.js';
@@ -18,7 +19,7 @@ export const workflowRoutes: RouteGroup[] = [
   {
     prefix: '/workflows/runs',
     auth: AUTH_USER,
-    routes: [listRunsRoute, getRunAggregatesRoute, getRunRoute],
+    routes: [listRunsRoute, getRunAggregatesRoute, getRunRoute, cancelRunRoute],
   },
   leaseTokenRouteGroup,
 ];

--- a/libs/api/workflows/src/presentation/subscribers/index.ts
+++ b/libs/api/workflows/src/presentation/subscribers/index.ts
@@ -2,4 +2,5 @@ export {onJobStepsSettled} from './on-job-steps-settled.js';
 export {onRunnerJobClaimed} from './on-runner-job-claimed.js';
 export {onRunnerJobLeaseExpired} from './on-runner-job-lease-expired.js';
 export {onRunnerJobQueued} from './on-runner-job-queued.js';
+export {onWorkflowRunCancelled} from './on-workflow-run-cancelled.js';
 export {onWorkflowRunCreated} from './on-workflow-run-created.js';

--- a/libs/api/workflows/src/presentation/subscribers/on-workflow-run-cancelled.test.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-workflow-run-cancelled.test.ts
@@ -1,0 +1,52 @@
+import type {WorkflowsWorkflowRunCancelledEvent} from '@shipfox/api-workflows-dto';
+import {onWorkflowRunCancelled} from './on-workflow-run-cancelled.js';
+
+const signalMock = vi.fn();
+const getHandleMock = vi.fn(() => ({signal: signalMock}));
+
+vi.mock('@shipfox/node-temporal', () => ({
+  temporalClient: () => ({workflow: {getHandle: getHandleMock}}),
+}));
+
+function buildPayload(
+  overrides: Partial<WorkflowsWorkflowRunCancelledEvent> = {},
+): WorkflowsWorkflowRunCancelledEvent {
+  return {runId: crypto.randomUUID(), projectId: crypto.randomUUID(), ...overrides};
+}
+
+describe('onWorkflowRunCancelled', () => {
+  beforeEach(() => {
+    getHandleMock.mockClear();
+    signalMock.mockReset();
+    signalMock.mockResolvedValue(undefined);
+  });
+
+  it('signals the run workflow that cancellation was requested', async () => {
+    const payload = buildPayload();
+
+    await onWorkflowRunCancelled(payload);
+
+    expect(getHandleMock).toHaveBeenCalledWith(`run:${payload.runId}`);
+    expect(signalMock).toHaveBeenCalledWith('run-cancel');
+  });
+
+  it('discards a late event when the run workflow already terminated', async () => {
+    const notFound = new Error('gone');
+    notFound.name = 'WorkflowNotFoundError';
+    signalMock.mockRejectedValueOnce(notFound);
+
+    const result = onWorkflowRunCancelled(buildPayload());
+
+    await expect(result).resolves.toBeUndefined();
+    expect(signalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows a non-terminal signal failure', async () => {
+    const failure = new Error('temporal unavailable');
+    signalMock.mockRejectedValueOnce(failure);
+
+    const result = onWorkflowRunCancelled(buildPayload());
+
+    await expect(result).rejects.toBe(failure);
+  });
+});

--- a/libs/api/workflows/src/presentation/subscribers/on-workflow-run-cancelled.ts
+++ b/libs/api/workflows/src/presentation/subscribers/on-workflow-run-cancelled.ts
@@ -1,0 +1,24 @@
+import type {WorkflowsWorkflowRunCancelledEvent} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import {temporalClient} from '@shipfox/node-temporal';
+import {RUN_CANCEL_SIGNAL} from '#temporal/constants.js';
+import {isWorkflowNotFound} from '#temporal/workflow-not-found.js';
+
+export async function onWorkflowRunCancelled(
+  payload: WorkflowsWorkflowRunCancelledEvent,
+): Promise<void> {
+  logger().info({runId: payload.runId}, 'Signaling run orchestration cancellation');
+  const handle = temporalClient().workflow.getHandle(`run:${payload.runId}`);
+  try {
+    await handle.signal(RUN_CANCEL_SIGNAL);
+  } catch (err) {
+    if (isWorkflowNotFound(err)) {
+      logger().debug(
+        {runId: payload.runId},
+        'Run workflow already terminated; cancel event discarded',
+      );
+      return;
+    }
+    throw err;
+  }
+}

--- a/libs/api/workflows/src/temporal/activities/index.ts
+++ b/libs/api/workflows/src/temporal/activities/index.ts
@@ -1,5 +1,6 @@
 import {
   bulkSetStepStatuses,
+  cancelRunnerJobsActivity,
   enqueueJobForRunner,
   failJobAsTimedOutActivity,
   loadRunDag,
@@ -15,6 +16,7 @@ export function createOrchestrationActivities() {
     setRunStatus,
     setJobStatus,
     bulkSetStepStatuses,
+    cancelRunnerJobsActivity,
     enqueueJobForRunner,
     failJobAsTimedOutActivity,
     resolveLeaseExpiredJobActivity,

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -1,4 +1,4 @@
-import {enqueueJob, releaseJob} from '@shipfox/api-runners';
+import {cancelRunnerJobs, enqueueJob, releaseJob} from '@shipfox/api-runners';
 import {ApplicationFailure} from '@temporalio/common';
 import type {JobStatus, JobStatusReason} from '#core/entities/job.js';
 import type {RuntimeCompletionStatus, RuntimeDagJob} from '#core/entities/runtime-dag.js';
@@ -80,13 +80,13 @@ export async function setRunStatus(params: {
   runId: string;
   status: WorkflowRunStatus;
   version: number;
-}): Promise<{newVersion: number}> {
+}): Promise<{newVersion: number; status: WorkflowRunStatus}> {
   const updated = await updateWorkflowRunStatus({
     runId: params.runId,
     status: params.status,
     expectedVersion: params.version,
   });
-  return {newVersion: updated.version};
+  return {newVersion: updated.version, status: updated.status};
 }
 
 export async function setJobStatus(params: {
@@ -94,14 +94,14 @@ export async function setJobStatus(params: {
   status: JobStatus;
   version: number;
   statusReason?: JobStatusReason | null | undefined;
-}): Promise<{newVersion: number}> {
+}): Promise<{newVersion: number; status: JobStatus}> {
   const updated = await updateJobStatus({
     jobId: params.jobId,
     status: params.status,
     expectedVersion: params.version,
     statusReason: params.statusReason,
   });
-  return {newVersion: updated.version};
+  return {newVersion: updated.version, status: updated.status};
 }
 
 export async function bulkSetStepStatuses(params: {
@@ -150,6 +150,10 @@ export async function enqueueJobForRunner(params: {
     runId: params.runId,
     projectId: params.projectId,
   });
+}
+
+export async function cancelRunnerJobsActivity(params: {jobIds: string[]}): Promise<void> {
+  await cancelRunnerJobs({jobIds: params.jobIds});
 }
 
 export async function failJobAsTimedOutActivity(params: {

--- a/libs/api/workflows/src/temporal/constants.ts
+++ b/libs/api/workflows/src/temporal/constants.ts
@@ -1,3 +1,4 @@
 export const WORKFLOWS_TASK_QUEUE = 'workflows-orchestrator';
+export const RUN_CANCEL_SIGNAL = 'run-cancel';
 export const JOB_FINISHED_SIGNAL = 'job-finished';
 export const JOB_LEASE_EXPIRED_SIGNAL = 'job-lease-expired';

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
@@ -149,6 +149,20 @@ describe('jobOrchestration', () => {
     expect(finalStatusesFor('job-dup').filter((s) => s !== 'running')).toEqual(['succeeded']);
   });
 
+  test('already-terminal job is not enqueued', async () => {
+    setCfg({
+      dag: makeDag([]),
+      jobResults: new Map(),
+      runningJobStatus: 'cancelled',
+    });
+
+    const result = await executeJob({...defaultJobInput, jobId: 'job-cancelled'});
+
+    expect(result).toMatchObject({status: 'failed'});
+    expect(callsNamed('enqueueJobForRunner')).toHaveLength(0);
+    expect(callsNamed('releaseLeaseActivity')).toHaveLength(0);
+  });
+
   test('releaseLease failure does not block the result (best-effort)', async () => {
     setCfg({
       dag: makeDag([]),

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
@@ -72,12 +72,27 @@ async function releaseLeaseBestEffort(jobId: string): Promise<void> {
   }
 }
 
-async function markJobRunningAndEnqueue(input: JobOrchestrationInput): Promise<number> {
-  const {newVersion: runningVersion} = await setJobStatus({
+function runtimeStatusForTerminalJob(status: string): RuntimeCompletionStatus {
+  return status === 'succeeded' ? 'succeeded' : 'failed';
+}
+
+async function markJobRunningAndEnqueue(
+  input: JobOrchestrationInput,
+): Promise<
+  {kind: 'running'; runningVersion: number} | {kind: 'terminal'; result: JobOrchestrationResult}
+> {
+  const {newVersion: runningVersion, status} = await setJobStatus({
     jobId: input.jobId,
     status: 'running',
     version: input.jobVersion,
   });
+
+  if (status !== undefined && status !== 'pending' && status !== 'running') {
+    return {
+      kind: 'terminal',
+      result: {status: runtimeStatusForTerminalJob(status), jobVersion: runningVersion},
+    };
+  }
 
   await enqueueJobForRunner({
     workspaceId: input.workspaceId,
@@ -86,7 +101,7 @@ async function markJobRunningAndEnqueue(input: JobOrchestrationInput): Promise<n
     projectId: input.projectId,
   });
 
-  return runningVersion;
+  return {kind: 'running', runningVersion};
 }
 
 interface JobOutcomeSignals {
@@ -169,7 +184,9 @@ async function resolveTimedOutJob({
 export async function jobOrchestration(
   input: JobOrchestrationInput,
 ): Promise<JobOrchestrationResult> {
-  const runningVersion = await markJobRunningAndEnqueue(input);
+  const running = await markJobRunningAndEnqueue(input);
+  if (running.kind === 'terminal') return running.result;
+  const {runningVersion} = running;
 
   const {finished, leaseExpired} = await awaitJobOutcome();
 

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
@@ -38,6 +38,14 @@ async function executeRun(): Promise<void> {
   });
 }
 
+async function waitForActivity(name: string): Promise<void> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (callsNamed(name).length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${name}`);
+}
+
 describe('runOrchestration', () => {
   test('linear DAG, all succeed', async () => {
     const jobs = [
@@ -149,6 +157,42 @@ describe('runOrchestration', () => {
     // The final setRunStatus should use the version returned by the first setRunStatus
     const finalRunStatus = setRunStatusCalls().at(-1);
     expect(finalRunStatus?.params.version).toBeGreaterThan(0);
+  });
+
+  test('cancel signal stops scheduling and fans out runner cancellation', async () => {
+    const jobs = [dagJob('j1', 'build'), dagJob('j2', 'deploy', ['build'])];
+    setCfg({dag: makeDag(jobs, 'r-cancel'), jobResults: new Map(), skipSignal: true});
+
+    const handle = await testEnv.client.workflow.start('runOrchestration', {
+      taskQueue: TASK_QUEUE,
+      workflowId: `run:${runId}`,
+      args: [{runId, workspaceId}],
+    });
+    await waitForActivity('enqueueJobForRunner');
+
+    await handle.signal('run-cancel');
+    await handle.result();
+
+    expect(setRunStatusCalls().map((c) => c.params.status)).toEqual(['running']);
+    expect(callsNamed('enqueueJobForRunner')).toHaveLength(1);
+    expect(callsNamed('cancelRunnerJobsActivity')).toEqual([
+      {name: 'cancelRunnerJobsActivity', params: {jobIds: ['j1', 'j2']}},
+    ]);
+  });
+
+  test('aborts early when the initial running write reports an already-terminal run', async () => {
+    const jobs = [dagJob('j1', 'build')];
+    setCfg({
+      dag: makeDag(jobs, 'r-terminal'),
+      jobResults: new Map(),
+      initialRunStatus: 'cancelled',
+    });
+
+    await executeRun();
+
+    expect(setRunStatusCalls().map((c) => c.params.status)).toEqual(['running']);
+    expect(callsNamed('enqueueJobForRunner')).toHaveLength(0);
+    expect(callsNamed('cancelRunnerJobsActivity')).toHaveLength(0);
   });
 
   test('diamond DAG with partial failure', async () => {

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -1,17 +1,27 @@
-import {executeChild, proxyActivities} from '@temporalio/workflow';
+import {
+  condition,
+  defineSignal,
+  executeChild,
+  ParentClosePolicy,
+  proxyActivities,
+  setHandler,
+} from '@temporalio/workflow';
 
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
 import {scheduleRuntimeDag} from '#core/workflow-runtime/index.js';
 
 import type {createOrchestrationActivities} from '../activities/index.js';
 import type {DagJob, RunDag} from '../activities/orchestration-activities.js';
+import {RUN_CANCEL_SIGNAL} from '../constants.js';
 import {jobOrchestration} from './job-orchestration.js';
 
-const {loadRunDag, setRunStatus, setJobStatus} = proxyActivities<
+const {loadRunDag, setRunStatus, setJobStatus, cancelRunnerJobsActivity} = proxyActivities<
   ReturnType<typeof createOrchestrationActivities>
 >({
   startToCloseTimeout: '30s',
 });
+
+export const runCancelSignal = defineSignal<[]>(RUN_CANCEL_SIGNAL);
 
 export interface RunOrchestrationInput {
   runId: string;
@@ -19,15 +29,21 @@ export interface RunOrchestrationInput {
 }
 
 export async function runOrchestration(input: RunOrchestrationInput): Promise<void> {
+  let cancelRequested = false;
+  setHandler(runCancelSignal, () => {
+    cancelRequested = true;
+  });
+
   const dag = await loadRunDag(input.runId);
 
   let runVersion = dag.runVersion;
-  const {newVersion} = await setRunStatus({
+  const {newVersion, status} = await setRunStatus({
     runId: input.runId,
     status: 'running',
     version: runVersion,
   });
   runVersion = newVersion;
+  if (status !== undefined && status !== 'pending' && status !== 'running') return;
 
   const completed = new Map<string, RuntimeCompletionStatus>();
   const jobVersions = new Map<string, number>();
@@ -36,6 +52,11 @@ export async function runOrchestration(input: RunOrchestrationInput): Promise<vo
   }
 
   while (true) {
+    if (cancelRequested) {
+      await cancelNonCompletedRunnerJobs(dag, completed);
+      return;
+    }
+
     const commands = scheduleRuntimeDag({jobs: dag.jobs, completed});
     const completeRun = commands.find((command) => command.kind === 'complete-run');
 
@@ -47,7 +68,17 @@ export async function runOrchestration(input: RunOrchestrationInput): Promise<vo
     const jobsToStart = commands.flatMap((command) =>
       command.kind === 'start-job' ? [command.job] : [],
     );
-    const results = await launchJobs(jobsToStart, dag, jobVersions);
+    const outcome = await launchJobsUntilCancel(
+      jobsToStart,
+      dag,
+      jobVersions,
+      () => cancelRequested,
+    );
+    if (outcome.kind === 'cancelled') {
+      await cancelNonCompletedRunnerJobs(dag, completed);
+      return;
+    }
+    const results = outcome.results;
     for (const [job, result] of jobsToStart.map((j, i) => [j, results[i]] as const)) {
       if (!result) continue;
       completed.set(job.name, result.status);
@@ -104,8 +135,32 @@ function launchJobs(
             jobVersion: jobVersions.get(job.id) ?? job.version,
           },
         ],
+        parentClosePolicy: ParentClosePolicy.TERMINATE,
       });
       return {status: result.status, jobVersion: result.jobVersion};
     }),
   );
+}
+
+async function launchJobsUntilCancel(
+  jobs: DagJob[],
+  run: RunDag,
+  jobVersions: Map<string, number>,
+  isCancelRequested: () => boolean,
+): Promise<{kind: 'completed'; results: LaunchResult[]} | {kind: 'cancelled'}> {
+  if (jobs.length === 0) return {kind: 'completed', results: []};
+  const results = launchJobs(jobs, run, jobVersions);
+  const cancel = condition(isCancelRequested).then(() => ({kind: 'cancelled' as const}));
+  return await Promise.race([
+    results.then((value) => ({kind: 'completed' as const, results: value})),
+    cancel,
+  ]);
+}
+
+async function cancelNonCompletedRunnerJobs(
+  dag: RunDag,
+  completed: Map<string, RuntimeCompletionStatus>,
+): Promise<void> {
+  const jobIds = dag.jobs.filter((job) => !completed.has(job.name)).map((job) => job.id);
+  await cancelRunnerJobsActivity({jobIds});
 }

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -35,6 +35,10 @@ export interface TestConfig {
   releaseLeaseError?: string;
   /** If set, failJobAsTimedOutActivity throws (for timeout error-path testing) */
   failJobAsTimedOutError?: string;
+  /** Effective status returned by the initial running setRunStatus call */
+  initialRunStatus?: string;
+  /** Effective status returned by a running setJobStatus call */
+  runningJobStatus?: string;
 }
 
 export let cfg: TestConfig;
@@ -139,7 +143,9 @@ function createMockActivities() {
 
     setRunStatus: (params: {runId: string; status: string; version: number}) => {
       calls.push({name: 'setRunStatus', params});
-      return {newVersion: nextVersion()};
+      const status =
+        params.status === 'running' && cfg.initialRunStatus ? cfg.initialRunStatus : params.status;
+      return {newVersion: nextVersion(), status};
     },
 
     setJobStatus: (params: {
@@ -149,11 +155,17 @@ function createMockActivities() {
       statusReason?: string | null;
     }) => {
       calls.push({name: 'setJobStatus', params});
-      return {newVersion: nextVersion()};
+      const status =
+        params.status === 'running' && cfg.runningJobStatus ? cfg.runningJobStatus : params.status;
+      return {newVersion: nextVersion(), status};
     },
 
     bulkSetStepStatuses: (params: {jobId: string; status: string}) => {
       calls.push({name: 'bulkSetStepStatuses', params});
+    },
+
+    cancelRunnerJobsActivity: (params: {jobIds: string[]}) => {
+      calls.push({name: 'cancelRunnerJobsActivity', params});
     },
 
     // Scheduling is step-less. The mock runner reports the job outcome by signalling

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -57,6 +57,21 @@ export const SourceOpen: Story = {
   },
 };
 
+export const Cancellable: Story = {
+  args: {
+    run: workflowRun({status: 'running'}),
+    canCancel: true,
+  },
+};
+
+export const Cancelling: Story = {
+  args: {
+    run: workflowRun({status: 'running'}),
+    canCancel: true,
+    cancelling: true,
+  },
+};
+
 const ALL_STATUSES: WorkflowRunStatus[] = [
   'pending',
   'running',

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -158,6 +158,32 @@ describe('WorkflowRunSummary', () => {
 
     expect(screen.queryByRole('button', {name: 'Source'})).not.toBeInTheDocument();
   });
+
+  test('shows the cancel action when the run can be cancelled', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderSummary({}, {canCancel: true, onCancel});
+
+    await user.click(await screen.findByRole('button', {name: 'Cancel workflow'}));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('omits the cancel action when the run cannot be cancelled', async () => {
+    renderSummary({status: 'succeeded'}, {canCancel: false});
+
+    await screen.findByRole('region', {name: 'deploy-web'});
+
+    expect(screen.queryByRole('button', {name: 'Cancel workflow'})).not.toBeInTheDocument();
+  });
+
+  test('disables the cancel action while cancellation is pending', async () => {
+    renderSummary({}, {canCancel: true, cancelling: true, onCancel: vi.fn()});
+
+    const button = await screen.findByRole('button', {name: 'Cancel workflow'});
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
 });
 
 function renderSummary(

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -29,6 +29,9 @@ export interface WorkflowRunSummaryProps {
   sourcePanelId?: string | undefined;
   sourceButtonRef?: Ref<HTMLButtonElement> | undefined;
   onSourceToggle?: (() => void) | undefined;
+  canCancel?: boolean | undefined;
+  cancelling?: boolean | undefined;
+  onCancel?: (() => void) | undefined;
 }
 
 export function WorkflowRunSummary({
@@ -38,6 +41,9 @@ export function WorkflowRunSummary({
   sourcePanelId,
   sourceButtonRef,
   onSourceToggle,
+  canCancel = false,
+  cancelling = false,
+  onCancel,
 }: WorkflowRunSummaryProps) {
   const headingId = useId();
   const status = getWorkflowStatusVisual(run.status);
@@ -75,23 +81,40 @@ export function WorkflowRunSummary({
           </Tooltip>
         </div>
 
-        {sourceAvailable ? (
-          <Button
-            ref={sourceButtonRef}
-            type="button"
-            variant="transparentMuted"
-            size="xs"
-            iconLeft="fileCodeLine"
-            aria-controls={sourcePanelId}
-            aria-expanded={sourceOpen}
-            className={cn(
-              'col-start-2 row-start-1 justify-self-end text-foreground-neutral-subtle',
-              sourceOpen && 'bg-background-components-hover text-foreground-neutral-base',
-            )}
-            onClick={onSourceToggle}
-          >
-            Source
-          </Button>
+        {sourceAvailable || canCancel ? (
+          <div className="col-start-2 row-start-1 flex items-center gap-8 justify-self-end">
+            {canCancel ? (
+              <Button
+                type="button"
+                variant="danger"
+                size="xs"
+                iconLeft="close"
+                isLoading={cancelling}
+                disabled={cancelling || !onCancel}
+                onClick={onCancel}
+              >
+                Cancel workflow
+              </Button>
+            ) : null}
+            {sourceAvailable ? (
+              <Button
+                ref={sourceButtonRef}
+                type="button"
+                variant="transparentMuted"
+                size="xs"
+                iconLeft="fileCodeLine"
+                aria-controls={sourcePanelId}
+                aria-expanded={sourceOpen}
+                className={cn(
+                  'text-foreground-neutral-subtle',
+                  sourceOpen && 'bg-background-components-hover text-foreground-neutral-base',
+                )}
+                onClick={onSourceToggle}
+              >
+                Source
+              </Button>
+            ) : null}
+          </div>
         ) : null}
 
         <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-8 overflow-hidden text-foreground-neutral-muted">

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,10 +1,10 @@
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {RelativeTimeProvider} from '@shipfox/react-ui';
+import {RelativeTimeProvider, toast} from '@shipfox/react-ui';
 import {useEffect, useId, useRef, useState} from 'react';
-import type {WorkflowJob} from '#core/workflow-run.js';
+import {isWorkflowRunTerminal, type WorkflowJob} from '#core/workflow-run.js';
 import type {WorkflowRunSelectionInput} from '#core/workflow-run-url-state.js';
-import {useWorkflowRunQuery} from '#hooks/api/workflow-runs.js';
+import {useCancelWorkflowRunMutation, useWorkflowRunQuery} from '#hooks/api/workflow-runs.js';
 import {WorkflowJobsGraph} from '../workflow-jobs-graph/index.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
 import {WorkflowSourcePanel} from '../workflow-source-panel/index.js';
@@ -60,6 +60,7 @@ function RunViewContent({
   const selectionControlled = selection !== undefined;
   const sourceAvailable =
     query.data?.sourceSnapshot !== null && query.data?.sourceSnapshot !== undefined;
+  const cancelMutation = useCancelWorkflowRunMutation(query.data);
 
   useEffect(() => {
     if (!sourceAvailable) setSourcePanelOpen(false);
@@ -125,6 +126,14 @@ function RunViewContent({
     }, 0);
   }
 
+  function cancelRun() {
+    cancelMutation.mutate(undefined, {
+      onError: (error) => {
+        toast.error(cancelErrorMessage(error));
+      },
+    });
+  }
+
   return (
     <>
       <div className="flex min-w-0 flex-1 flex-col">
@@ -135,6 +144,9 @@ function RunViewContent({
           sourcePanelId={sourcePanelId}
           sourceButtonRef={sourceButtonRef}
           onSourceToggle={() => setSourcePanelOpen((open) => !open)}
+          canCancel={!isWorkflowRunTerminal(query.data.status)}
+          cancelling={cancelMutation.isPending}
+          onCancel={cancelRun}
         />
         {query.isError ? <WorkflowRunStaleError query={query} /> : null}
         <div className="min-h-0 flex-1 overflow-auto bg-background-neutral-base p-16">
@@ -173,6 +185,13 @@ function RunViewContent({
       />
     </>
   );
+}
+
+function cancelErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.code === 'run-already-finished') {
+    return 'This workflow run has already finished.';
+  }
+  return 'Could not cancel workflow run.';
 }
 
 function emptyStateForJob(job: WorkflowJob): WorkflowStepListEmptyState | undefined {

--- a/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.test.tsx
@@ -1,8 +1,9 @@
 import type {RunDetailResponseDto, RunListResponseDto} from '@shipfox/api-workflows-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {type InfiniteData, QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {cleanup, renderHook, waitFor} from '@testing-library/react';
+import {act, cleanup, renderHook, waitFor} from '@testing-library/react';
 import type {ReactNode} from 'react';
+import {toWorkflowRun} from '#core/workflow-run.js';
 import {
   workflowJobDto,
   workflowRunDetailDto,
@@ -10,6 +11,7 @@ import {
   workflowRunListResponseDto,
 } from '#test/fixtures/workflow-run.js';
 import {
+  useCancelWorkflowRunMutation,
   useWorkflowRunQuery,
   useWorkflowRunsInfiniteQuery,
   workflowRunsQueryKeys,
@@ -117,5 +119,32 @@ describe('workflow run API hooks', () => {
       jobs: [{name: 'build', run_id: RUN_ID}],
     });
     expect(cached).not.toHaveProperty('triggerSource');
+  });
+
+  test('cancels a workflow run and invalidates detail and list queries', async () => {
+    const body = workflowRunDto({id: RUN_ID, project_id: PROJECT_ID, status: 'cancelled'});
+    const fetchImpl = vi.fn(async () => jsonResponse(body));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+    const run = workflowRunDto({id: RUN_ID, project_id: PROJECT_ID, status: 'running'});
+    const {result, queryClient} = renderWithQueryClient(() =>
+      useCancelWorkflowRunMutation(toWorkflowRun(run)),
+    );
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    let cancelled: Awaited<ReturnType<typeof result.current.mutateAsync>> | undefined;
+    await act(async () => {
+      cancelled = await result.current.mutateAsync();
+    });
+
+    const calls = fetchImpl.mock.calls as unknown as Array<[Request]>;
+    const request = calls[0]?.[0];
+    if (!request) throw new Error('Expected cancel request');
+    expect(request.url).toBe(
+      'https://api.example.test/workflows/runs/66666666-6666-4666-8666-666666666666/cancel',
+    );
+    expect(request.method).toBe('POST');
+    expect(cancelled?.status).toBe('cancelled');
+    expect(invalidateSpy).toHaveBeenCalledWith({queryKey: workflowRunsQueryKeys.detail(RUN_ID)});
+    expect(invalidateSpy).toHaveBeenCalledWith({queryKey: workflowRunsQueryKeys.lists(PROJECT_ID)});
   });
 });

--- a/libs/client/workflows/src/hooks/api/workflow-runs.ts
+++ b/libs/client/workflows/src/hooks/api/workflow-runs.ts
@@ -1,15 +1,19 @@
-import type {RunDetailResponseDto, RunListResponseDto} from '@shipfox/api-workflows-dto';
+import type {RunDetailResponseDto, RunDto, RunListResponseDto} from '@shipfox/api-workflows-dto';
 import {apiRequest} from '@shipfox/client-api';
 import {
   type InfiniteData,
   keepPreviousData,
   useInfiniteQuery,
+  useMutation,
   useQuery,
+  useQueryClient,
 } from '@tanstack/react-query';
 import {
   isWorkflowRunTerminal,
+  toWorkflowRun,
   toWorkflowRunDetail,
   toWorkflowRunListPage,
+  type WorkflowRun,
   type WorkflowRunDetail,
   type WorkflowRunListPage,
   type WorkflowRunStatus,
@@ -125,6 +129,10 @@ async function getWorkflowRunDto({runId, signal}: {runId: string; signal?: Abort
   return await apiRequest<RunDetailResponseDto>(`/workflows/runs/${runId}`, {signal});
 }
 
+async function cancelWorkflowRunDto({runId}: {runId: string}) {
+  return await apiRequest<RunDto>(`/workflows/runs/${runId}/cancel`, {method: 'POST'});
+}
+
 export function useWorkflowRunQuery(runId: string | undefined) {
   // Poll a non-terminal run so the open run detail stays live (same cadence as the run
   // list); stop once the run is terminal.
@@ -143,5 +151,22 @@ export function useWorkflowRunQuery(runId: string | undefined) {
       return isWorkflowRunTerminal(status) ? false : ACTIVE_POLL_MS;
     },
     refetchIntervalInBackground: false,
+  });
+}
+
+export function useCancelWorkflowRunMutation(run: WorkflowRun | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      if (!run) throw new Error('Workflow run is not loaded');
+      return toWorkflowRun(await cancelWorkflowRunDto({runId: run.id}));
+    },
+    onSuccess: async () => {
+      if (!run) return;
+      await Promise.all([
+        queryClient.invalidateQueries({queryKey: workflowRunsQueryKeys.detail(run.id)}),
+        queryClient.invalidateQueries({queryKey: workflowRunsQueryKeys.lists(run.projectId)}),
+      ]);
+    },
   });
 }

--- a/libs/client/workflows/src/index.ts
+++ b/libs/client/workflows/src/index.ts
@@ -25,6 +25,7 @@ export {
   workflowRunTriggerLabel,
 } from '#core/workflow-run.js';
 export {
+  useCancelWorkflowRunMutation,
   useWorkflowRunQuery,
   useWorkflowRunsInfiniteQuery,
   type WorkflowRunFilters,


### PR DESCRIPTION
Add workflow-run cancellation for pending and running runs.

Workflow runs could previously stay pending or running without an operator escape hatch. This adds the API route, DTO event, outbox subscriber, Temporal cancellation signal, runner queue cleanup, and run-page action needed to cancel a run and converge its non-terminal jobs and steps to cancelled.

The status writers now treat terminal run and job states as immovable, so a late or replayed orchestration write cannot revive a cancelled run or enqueue a cancelled job. The runner-side cleanup also deletes pending queue rows and marks active leases for heartbeat cancellation.

Reviewers should pay close attention to the guarded status-update semantics in `libs/api/workflows/src/db/workflow-runs.ts` and the Temporal cancellation path in `run-orchestration.ts`, since those are the race-sensitive parts of the change.

Closes ENG-628

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end cancellation for pending or running workflow runs, including an API route, orchestration stop signal, runner queue cleanup, and a “Cancel workflow” action in the run UI. Fulfills ENG-628 by giving operators a reliable escape hatch and making cancelled work stay cancelled.

- **New Features**
  - API: POST `/workflows/runs/:id/cancel` in `@shipfox/api-workflows` cancels the run plus non-terminal jobs and steps; returns 404 for unknown/unauthorized and 409 for finished runs.
  - Events/Control: Added `WORKFLOWS_WORKFLOW_RUN_CANCELLED` in `@shipfox/api-workflows-dto`; `@shipfox/api-workflows` subscriber signals Temporal `run-cancel` to stop scheduling and calls runner cleanup.
  - Runners/UI: `cancelRunnerJobs` in `@shipfox/api-runners` deletes queued jobs and requests cancellation for running leases; `@shipfox/client-workflows` adds a “Cancel workflow” button and `useCancelWorkflowRunMutation`.

- **Refactors**
  - Status updates in `@shipfox/api-workflows` now treat terminal run/job states as final, preventing late/replayed writes from reviving cancelled work.
  - Orchestration updates make run workflows abort on cancel and skip enqueueing already-terminal jobs.

<sup>Written for commit f41238e18826ddd1ed01d16d1d92915369a8096c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

