### PR TITLE
[api-workflows] Align test runner label defaults

### DIFF
--- a/libs/api/workflows/test/factories/workflow-model.test.ts
+++ b/libs/api/workflows/test/factories/workflow-model.test.ts
@@ -1,0 +1,26 @@
+import {workflowModel} from './workflow-model.js';
+
+describe('workflowModel', () => {
+  it('defaults jobs to a non-empty canonical runner label set', () => {
+    const model = workflowModel();
+
+    expect(model.jobs[0]?.runner).toEqual(['ubuntu-latest']);
+  });
+
+  it('uses workflow and job runner overrides', () => {
+    const model = workflowModel({
+      runner: 'ubuntu-22',
+      jobs: {
+        build: {
+          steps: [{run: 'pnpm build'}],
+        },
+        test: {
+          runner: ['ubuntu-22', 'node-22'],
+          steps: [{run: 'pnpm test'}],
+        },
+      },
+    });
+
+    expect(model.jobs.map((job) => job.runner)).toEqual([['ubuntu-22'], ['ubuntu-22', 'node-22']]);
+  });
+});

--- a/libs/api/workflows/test/factories/workflow-model.ts
+++ b/libs/api/workflows/test/factories/workflow-model.ts
@@ -23,6 +23,8 @@ interface TestAgentStep extends TestWorkflowStepBase {
 
 type TestWorkflowStep = TestRunStep | TestAgentStep;
 
+const DEFAULT_RUNNER_LABELS = ['ubuntu-latest'] as const;
+
 interface TestWorkflowJob {
   readonly needs?: string | readonly string[] | undefined;
   readonly runner?: string | readonly string[] | undefined;
@@ -48,7 +50,7 @@ export function workflowModel(input: TestWorkflowModelInput = {}): WorkflowModel
     return {
       id: jobId,
       sourceName,
-      runner: normalizeStringArray(job.runner ?? input.runner),
+      runner: normalizeStringArray(job.runner ?? input.runner ?? DEFAULT_RUNNER_LABELS),
       ...optionalEnv(job.env),
       dependencies: normalizeStringArray(job.needs).map(stableId),
       steps: job.steps.map((step, stepIndex) => normalizeStep(step, jobId, stepIndex)),


### PR DESCRIPTION
Align workflow model test fixtures with the required runner-label invariant.

The workflow test factory previously produced jobs with an empty runner label set whenever callers omitted `runner`. Real workflow definitions now resolve every job to a non-empty canonical label set, and queue work depends on that baseline. This changes the factory default to `ubuntu-latest` and adds focused coverage for defaulting plus workflow/job overrides.

No changeset is included because `@shipfox/api-workflows` is private.

Closes ENG-620

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default workflow model test jobs to ['ubuntu-latest'] so runner labels are never empty and match the scheduling invariant. Adds tests for defaulting and workflow/job overrides in `@shipfox/api-workflows`. Closes ENG-620.

<sup>Written for commit 3cdb51c29b72a0a1f918579a0787f1a725e4881d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

