### PR TITLE
[api-agent] Add backend agent provider storage

### DIFF
--- a/.changeset/brave-agents-store.md
+++ b/.changeset/brave-agents-store.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-agent": minor
+---
+
+Adds backend agent provider storage with workspace defaults and Pi catalog registry validation.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-agent": "workspace:*",
     "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-definitions": "workspace:*",
     "@shipfox/api-dispatcher": "workspace:*",

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -1,3 +1,4 @@
+import {agentModule} from '@shipfox/api-agent';
 import {authModule} from '@shipfox/api-auth';
 import {createDefinitionsModule} from '@shipfox/api-definitions';
 import {dispatcherModule} from '@shipfox/api-dispatcher';
@@ -36,6 +37,7 @@ export async function run(): Promise<void> {
   const modules = [
     authModule,
     workspacesModule,
+    agentModule,
     integrations.module,
     projectsModule,
     definitionsModule,

--- a/libs/api/agent/drizzle.config.ts
+++ b/libs/api/agent/drizzle.config.ts
@@ -1,0 +1,7 @@
+import {defineConfig} from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema/*.ts',
+  out: './drizzle',
+  dialect: 'postgresql',
+});

--- a/libs/api/agent/drizzle/0000_daffy_leopardon.sql
+++ b/libs/api/agent/drizzle/0000_daffy_leopardon.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "agent_provider_configs" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"provider_id" text NOT NULL,
+	"encrypted_credentials" jsonb NOT NULL,
+	"key_fingerprints" jsonb NOT NULL,
+	"default_model" text NOT NULL,
+	"default_thinking" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "agent_workspace_settings" (
+	"workspace_id" uuid PRIMARY KEY NOT NULL,
+	"default_provider_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "agent_provider_configs_workspace_provider_unique" ON "agent_provider_configs" USING btree ("workspace_id","provider_id");--> statement-breakpoint
+CREATE INDEX "agent_provider_configs_workspace_idx" ON "agent_provider_configs" USING btree ("workspace_id");

--- a/libs/api/agent/drizzle/0000_daffy_leopardon.sql
+++ b/libs/api/agent/drizzle/0000_daffy_leopardon.sql
@@ -17,5 +17,4 @@ CREATE TABLE "agent_workspace_settings" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX "agent_provider_configs_workspace_provider_unique" ON "agent_provider_configs" USING btree ("workspace_id","provider_id");--> statement-breakpoint
-CREATE INDEX "agent_provider_configs_workspace_idx" ON "agent_provider_configs" USING btree ("workspace_id");
+CREATE UNIQUE INDEX "agent_provider_configs_workspace_provider_unique" ON "agent_provider_configs" USING btree ("workspace_id","provider_id");

--- a/libs/api/agent/drizzle/meta/0000_snapshot.json
+++ b/libs/api/agent/drizzle/meta/0000_snapshot.json
@@ -87,21 +87,6 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "agent_provider_configs_workspace_idx": {
-          "name": "agent_provider_configs_workspace_idx",
-          "columns": [
-            {
-              "expression": "workspace_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {},

--- a/libs/api/agent/drizzle/meta/0000_snapshot.json
+++ b/libs/api/agent/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,165 @@
+{
+  "id": "9e6949f6-d9ef-4c8a-8b22-42ffd11a7e59",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent_provider_configs": {
+      "name": "agent_provider_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_credentials": {
+          "name": "encrypted_credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_fingerprints": {
+          "name": "key_fingerprints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_model": {
+          "name": "default_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_thinking": {
+          "name": "default_thinking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_provider_configs_workspace_provider_unique": {
+          "name": "agent_provider_configs_workspace_provider_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_provider_configs_workspace_idx": {
+          "name": "agent_provider_configs_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_workspace_settings": {
+      "name": "agent_workspace_settings",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "default_provider_id": {
+          "name": "default_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/agent/drizzle/meta/_journal.json
+++ b/libs/api/agent/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1782630453879,
+      "tag": "0000_daffy_leopardon",
+      "breakpoints": true
+    }
+  ]
+}

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@shipfox/api-agent",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/agent"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@earendil-works/pi-ai": "0.79.9",
+    "@opentelemetry/api": "1.9.1",
+    "@shipfox/api-agent-dto": "workspace:*",
+    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*",
+    "drizzle-orm": "^0.45.2",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*",
+    "@types/pg": "^8.15.5",
+    "drizzle-kit": "^0.31.10"
+  }
+}

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -37,17 +37,14 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@earendil-works/pi-ai": "0.79.9",
-    "@opentelemetry/api": "1.9.1",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-module": "workspace:*",
-    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
-    "drizzle-orm": "^0.45.2",
-    "zod": "^4.4.3"
+    "drizzle-orm": "^0.45.2"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.79.9",
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",

--- a/libs/api/agent/src/core/catalog-registry.test.ts
+++ b/libs/api/agent/src/core/catalog-registry.test.ts
@@ -1,0 +1,33 @@
+import {getModels, getProviders, type KnownProvider} from '@earendil-works/pi-ai';
+import {
+  AGENT_PROVIDER_CATALOG_SEED,
+  AGENT_PROVIDER_IDS,
+  type AgentProviderId,
+} from '@shipfox/api-agent-dto';
+
+describe('agent provider catalog registry', () => {
+  it('keeps catalog provider ids synced with the pinned Pi provider registry', () => {
+    const catalogProviderIds = [...AGENT_PROVIDER_IDS].sort();
+    const piProviderIds = getProviders().sort();
+
+    expect(catalogProviderIds).toEqual(piProviderIds);
+  });
+
+  it('keeps supported catalog default models present in the pinned Pi model registry', () => {
+    const supportedEntries = AGENT_PROVIDER_CATALOG_SEED.filter(
+      (entry) => entry.support_status === 'supported',
+    );
+
+    const missingDefaults = supportedEntries.flatMap((entry) => {
+      const piModels = getModels(entry.id as KnownProvider);
+      const defaultExists = piModels.some((model) => model.id === entry.default_model);
+      return defaultExists ? [] : [formatMissingDefault(entry.id, entry.default_model)];
+    });
+
+    expect(missingDefaults).toEqual([]);
+  });
+});
+
+function formatMissingDefault(providerId: AgentProviderId, defaultModel: string | null): string {
+  return `${providerId}:${defaultModel ?? '<null>'}`;
+}

--- a/libs/api/agent/src/core/entities/agent-provider-config.ts
+++ b/libs/api/agent/src/core/entities/agent-provider-config.ts
@@ -1,0 +1,13 @@
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+
+export interface AgentProviderConfig {
+  id: string;
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  encryptedCredentials: Record<string, string>;
+  keyFingerprints: Record<string, string>;
+  defaultModel: string;
+  defaultThinking: AgentThinking;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/agent/src/core/entities/agent-workspace-settings.ts
+++ b/libs/api/agent/src/core/entities/agent-workspace-settings.ts
@@ -1,0 +1,8 @@
+import type {SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+
+export interface AgentWorkspaceSettings {
+  workspaceId: string;
+  defaultProviderId: SupportedAgentProviderId | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/agent/src/core/errors.ts
+++ b/libs/api/agent/src/core/errors.ts
@@ -1,0 +1,11 @@
+import type {SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+
+export class AgentProviderConfigNotFoundError extends Error {
+  constructor(
+    public readonly workspaceId: string,
+    public readonly providerId: SupportedAgentProviderId,
+  ) {
+    super(`Agent provider config not found: ${workspaceId}/${providerId}`);
+    this.name = 'AgentProviderConfigNotFoundError';
+  }
+}

--- a/libs/api/agent/src/core/index.ts
+++ b/libs/api/agent/src/core/index.ts
@@ -1,2 +1,3 @@
 export type {AgentProviderConfig} from './entities/agent-provider-config.js';
 export type {AgentWorkspaceSettings} from './entities/agent-workspace-settings.js';
+export {AgentProviderConfigNotFoundError} from './errors.js';

--- a/libs/api/agent/src/core/index.ts
+++ b/libs/api/agent/src/core/index.ts
@@ -1,0 +1,2 @@
+export type {AgentProviderConfig} from './entities/agent-provider-config.js';
+export type {AgentWorkspaceSettings} from './entities/agent-workspace-settings.js';

--- a/libs/api/agent/src/db/agent-provider-configs.test.ts
+++ b/libs/api/agent/src/db/agent-provider-configs.test.ts
@@ -1,0 +1,146 @@
+import crypto from 'node:crypto';
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {
+  deleteAgentProviderConfig,
+  getAgentProviderConfig,
+  getAgentWorkspaceSettings,
+  listAgentProviderConfigs,
+  setDefaultAgentProvider,
+  type UpsertAgentProviderConfigParams,
+  upsertAgentProviderConfig,
+} from '#db/index.js';
+
+describe('agent provider configs', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('persists a provider config for a workspace provider pair', async () => {
+    const params = createProviderConfigParams({workspaceId, providerId: 'anthropic'});
+
+    const created = await upsertAgentProviderConfig(params);
+
+    const found = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(found).toEqual(created);
+    expect(found).toMatchObject({
+      workspaceId,
+      providerId: 'anthropic',
+      encryptedCredentials: {api_key: 'encrypted-anthropic-key'},
+      keyFingerprints: {api_key: 'sk-ant-...abcd'},
+      defaultModel: 'claude-opus-4-8',
+      defaultThinking: 'high',
+    });
+    expect(found?.createdAt).toBeInstanceOf(Date);
+    expect(found?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('updates the existing config for the same workspace provider pair', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'openai'}),
+    );
+
+    const updated = await upsertAgentProviderConfig(
+      createProviderConfigParams({
+        workspaceId,
+        providerId: 'openai',
+        encryptedCredentials: {api_key: 'encrypted-rotated-key'},
+        keyFingerprints: {api_key: 'sk-openai-...wxyz'},
+        defaultModel: 'gpt-5.5-pro',
+        defaultThinking: 'medium',
+      }),
+    );
+
+    const configs = await listAgentProviderConfigs(workspaceId);
+    expect(configs).toHaveLength(1);
+    expect(configs[0]).toEqual(updated);
+    expect(configs[0]).toMatchObject({
+      encryptedCredentials: {api_key: 'encrypted-rotated-key'},
+      keyFingerprints: {api_key: 'sk-openai-...wxyz'},
+      defaultThinking: 'medium',
+    });
+  });
+
+  it('lists only configs for the requested workspace', async () => {
+    const otherWorkspaceId = crypto.randomUUID();
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'openai'}),
+    );
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId: otherWorkspaceId, providerId: 'google'}),
+    );
+
+    const configs = await listAgentProviderConfigs(workspaceId);
+
+    expect(configs.map((config) => config.providerId)).toEqual(['anthropic', 'openai']);
+  });
+
+  it('hard-deletes a provider config', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
+
+    const deleted = await deleteAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+
+    const found = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(deleted).toBe(true);
+    expect(found).toBeUndefined();
+  });
+
+  it('returns false when deleting a missing provider config', async () => {
+    const deleted = await deleteAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+
+    expect(deleted).toBe(false);
+  });
+
+  it('clears the workspace default when the default provider config is deleted', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
+    await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
+
+    await deleteAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+
+    const settings = await getAgentWorkspaceSettings(workspaceId);
+    expect(settings?.defaultProviderId).toBeNull();
+  });
+
+  it('keeps the workspace default when a non-default provider config is deleted', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'openai'}),
+    );
+    await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
+
+    await deleteAgentProviderConfig({workspaceId, providerId: 'openai'});
+
+    const settings = await getAgentWorkspaceSettings(workspaceId);
+    expect(settings?.defaultProviderId).toBe('anthropic');
+  });
+});
+
+function createProviderConfigParams(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  encryptedCredentials?: Record<string, string> | undefined;
+  keyFingerprints?: Record<string, string> | undefined;
+  defaultModel?: string | undefined;
+  defaultThinking?: AgentThinking | undefined;
+}): UpsertAgentProviderConfigParams {
+  return {
+    workspaceId: params.workspaceId,
+    providerId: params.providerId,
+    encryptedCredentials: params.encryptedCredentials ?? {
+      api_key: `encrypted-${params.providerId}-key`,
+    },
+    keyFingerprints: params.keyFingerprints ?? {api_key: 'sk-ant-...abcd'},
+    defaultModel: params.defaultModel ?? 'claude-opus-4-8',
+    defaultThinking: params.defaultThinking ?? 'high',
+  };
+}

--- a/libs/api/agent/src/db/agent-provider-configs.ts
+++ b/libs/api/agent/src/db/agent-provider-configs.ts
@@ -1,0 +1,108 @@
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {and, eq, sql} from 'drizzle-orm';
+import type {AgentProviderConfig} from '#core/entities/agent-provider-config.js';
+import {db} from './db.js';
+import {agentProviderConfigs, toAgentProviderConfig} from './schema/agent-provider-configs.js';
+import {agentWorkspaceSettings} from './schema/agent-workspace-settings.js';
+
+export interface UpsertAgentProviderConfigParams {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  encryptedCredentials: Record<string, string>;
+  keyFingerprints: Record<string, string>;
+  defaultModel: string;
+  defaultThinking: AgentThinking;
+}
+
+export async function upsertAgentProviderConfig(
+  params: UpsertAgentProviderConfigParams,
+): Promise<AgentProviderConfig> {
+  const rows = await db()
+    .insert(agentProviderConfigs)
+    .values({
+      workspaceId: params.workspaceId,
+      providerId: params.providerId,
+      encryptedCredentials: params.encryptedCredentials,
+      keyFingerprints: params.keyFingerprints,
+      defaultModel: params.defaultModel,
+      defaultThinking: params.defaultThinking,
+    })
+    .onConflictDoUpdate({
+      target: [agentProviderConfigs.workspaceId, agentProviderConfigs.providerId],
+      set: {
+        encryptedCredentials: params.encryptedCredentials,
+        keyFingerprints: params.keyFingerprints,
+        defaultModel: params.defaultModel,
+        defaultThinking: params.defaultThinking,
+        updatedAt: sql`NOW()`,
+      },
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) throw new Error('Upsert returned no rows');
+  return toAgentProviderConfig(row);
+}
+
+export async function getAgentProviderConfig(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+}): Promise<AgentProviderConfig | undefined> {
+  const rows = await db()
+    .select()
+    .from(agentProviderConfigs)
+    .where(
+      and(
+        eq(agentProviderConfigs.workspaceId, params.workspaceId),
+        eq(agentProviderConfigs.providerId, params.providerId),
+      ),
+    )
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toAgentProviderConfig(row);
+}
+
+export async function listAgentProviderConfigs(
+  workspaceId: string,
+): Promise<AgentProviderConfig[]> {
+  const rows = await db()
+    .select()
+    .from(agentProviderConfigs)
+    .where(eq(agentProviderConfigs.workspaceId, workspaceId))
+    .orderBy(agentProviderConfigs.providerId);
+
+  return rows.map(toAgentProviderConfig);
+}
+
+export async function deleteAgentProviderConfig(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+}): Promise<boolean> {
+  return await db().transaction(async (tx) => {
+    const deleted = await tx
+      .delete(agentProviderConfigs)
+      .where(
+        and(
+          eq(agentProviderConfigs.workspaceId, params.workspaceId),
+          eq(agentProviderConfigs.providerId, params.providerId),
+        ),
+      )
+      .returning({id: agentProviderConfigs.id});
+
+    if (deleted.length === 0) return false;
+
+    await tx
+      .update(agentWorkspaceSettings)
+      .set({defaultProviderId: null, updatedAt: sql`NOW()`})
+      .where(
+        and(
+          eq(agentWorkspaceSettings.workspaceId, params.workspaceId),
+          eq(agentWorkspaceSettings.defaultProviderId, params.providerId),
+        ),
+      );
+
+    return true;
+  });
+}

--- a/libs/api/agent/src/db/agent-workspace-settings.test.ts
+++ b/libs/api/agent/src/db/agent-workspace-settings.test.ts
@@ -1,5 +1,11 @@
 import crypto from 'node:crypto';
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {AgentProviderConfigNotFoundError} from '#core/index.js';
 import {getAgentWorkspaceSettings, setDefaultAgentProvider} from '#db/index.js';
+import {
+  type UpsertAgentProviderConfigParams,
+  upsertAgentProviderConfig,
+} from './agent-provider-configs.js';
 
 describe('agent workspace settings', () => {
   let workspaceId: string;
@@ -9,6 +15,10 @@ describe('agent workspace settings', () => {
   });
 
   it('persists the workspace default provider', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
+
     const settings = await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
 
     const found = await getAgentWorkspaceSettings(workspaceId);
@@ -22,6 +32,12 @@ describe('agent workspace settings', () => {
   });
 
   it('updates the workspace default provider', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'openai'}),
+    );
     await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
 
     const updated = await setDefaultAgentProvider({workspaceId, providerId: 'openai'});
@@ -32,6 +48,9 @@ describe('agent workspace settings', () => {
   });
 
   it('clears the workspace default provider', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({workspaceId, providerId: 'anthropic'}),
+    );
     await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
 
     await setDefaultAgentProvider({workspaceId, providerId: null});
@@ -45,4 +64,25 @@ describe('agent workspace settings', () => {
 
     expect(found).toBeUndefined();
   });
+
+  it('rejects a default provider without a matching config', async () => {
+    const result = setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
+
+    await expect(result).rejects.toBeInstanceOf(AgentProviderConfigNotFoundError);
+  });
 });
+
+function createProviderConfigParams(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  defaultThinking?: AgentThinking | undefined;
+}): UpsertAgentProviderConfigParams {
+  return {
+    workspaceId: params.workspaceId,
+    providerId: params.providerId,
+    encryptedCredentials: {api_key: `encrypted-${params.providerId}-key`},
+    keyFingerprints: {api_key: 'sk-ant-...abcd'},
+    defaultModel: 'claude-opus-4-8',
+    defaultThinking: params.defaultThinking ?? 'high',
+  };
+}

--- a/libs/api/agent/src/db/agent-workspace-settings.test.ts
+++ b/libs/api/agent/src/db/agent-workspace-settings.test.ts
@@ -1,0 +1,48 @@
+import crypto from 'node:crypto';
+import {getAgentWorkspaceSettings, setDefaultAgentProvider} from '#db/index.js';
+
+describe('agent workspace settings', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('persists the workspace default provider', async () => {
+    const settings = await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
+
+    const found = await getAgentWorkspaceSettings(workspaceId);
+    expect(found).toEqual(settings);
+    expect(found).toMatchObject({
+      workspaceId,
+      defaultProviderId: 'anthropic',
+    });
+    expect(found?.createdAt).toBeInstanceOf(Date);
+    expect(found?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  it('updates the workspace default provider', async () => {
+    await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
+
+    const updated = await setDefaultAgentProvider({workspaceId, providerId: 'openai'});
+
+    const found = await getAgentWorkspaceSettings(workspaceId);
+    expect(found).toEqual(updated);
+    expect(found?.defaultProviderId).toBe('openai');
+  });
+
+  it('clears the workspace default provider', async () => {
+    await setDefaultAgentProvider({workspaceId, providerId: 'anthropic'});
+
+    await setDefaultAgentProvider({workspaceId, providerId: null});
+
+    const found = await getAgentWorkspaceSettings(workspaceId);
+    expect(found?.defaultProviderId).toBeNull();
+  });
+
+  it('returns undefined for a workspace without settings', async () => {
+    const found = await getAgentWorkspaceSettings(workspaceId);
+
+    expect(found).toBeUndefined();
+  });
+});

--- a/libs/api/agent/src/db/agent-workspace-settings.ts
+++ b/libs/api/agent/src/db/agent-workspace-settings.ts
@@ -1,0 +1,46 @@
+import type {SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {eq, sql} from 'drizzle-orm';
+import type {AgentWorkspaceSettings} from '#core/entities/agent-workspace-settings.js';
+import {db} from './db.js';
+import {
+  agentWorkspaceSettings,
+  toAgentWorkspaceSettings,
+} from './schema/agent-workspace-settings.js';
+
+export async function getAgentWorkspaceSettings(
+  workspaceId: string,
+): Promise<AgentWorkspaceSettings | undefined> {
+  const rows = await db()
+    .select()
+    .from(agentWorkspaceSettings)
+    .where(eq(agentWorkspaceSettings.workspaceId, workspaceId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toAgentWorkspaceSettings(row);
+}
+
+export async function setDefaultAgentProvider(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId | null;
+}): Promise<AgentWorkspaceSettings> {
+  const rows = await db()
+    .insert(agentWorkspaceSettings)
+    .values({
+      workspaceId: params.workspaceId,
+      defaultProviderId: params.providerId,
+    })
+    .onConflictDoUpdate({
+      target: agentWorkspaceSettings.workspaceId,
+      set: {
+        defaultProviderId: params.providerId,
+        updatedAt: sql`NOW()`,
+      },
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) throw new Error('Upsert returned no rows');
+  return toAgentWorkspaceSettings(row);
+}

--- a/libs/api/agent/src/db/agent-workspace-settings.ts
+++ b/libs/api/agent/src/db/agent-workspace-settings.ts
@@ -1,7 +1,9 @@
 import type {SupportedAgentProviderId} from '@shipfox/api-agent-dto';
-import {eq, sql} from 'drizzle-orm';
+import {and, eq, sql} from 'drizzle-orm';
 import type {AgentWorkspaceSettings} from '#core/entities/agent-workspace-settings.js';
+import {AgentProviderConfigNotFoundError} from '#core/errors.js';
 import {db} from './db.js';
+import {agentProviderConfigs} from './schema/agent-provider-configs.js';
 import {
   agentWorkspaceSettings,
   toAgentWorkspaceSettings,
@@ -25,22 +27,42 @@ export async function setDefaultAgentProvider(params: {
   workspaceId: string;
   providerId: SupportedAgentProviderId | null;
 }): Promise<AgentWorkspaceSettings> {
-  const rows = await db()
-    .insert(agentWorkspaceSettings)
-    .values({
-      workspaceId: params.workspaceId,
-      defaultProviderId: params.providerId,
-    })
-    .onConflictDoUpdate({
-      target: agentWorkspaceSettings.workspaceId,
-      set: {
-        defaultProviderId: params.providerId,
-        updatedAt: sql`NOW()`,
-      },
-    })
-    .returning();
+  return await db().transaction(async (tx) => {
+    if (params.providerId !== null) {
+      const existingRows = await tx
+        .select({id: agentProviderConfigs.id})
+        .from(agentProviderConfigs)
+        .where(
+          and(
+            eq(agentProviderConfigs.workspaceId, params.workspaceId),
+            eq(agentProviderConfigs.providerId, params.providerId),
+          ),
+        )
+        .limit(1)
+        .for('update');
 
-  const row = rows[0];
-  if (!row) throw new Error('Upsert returned no rows');
-  return toAgentWorkspaceSettings(row);
+      if (!existingRows[0]) {
+        throw new AgentProviderConfigNotFoundError(params.workspaceId, params.providerId);
+      }
+    }
+
+    const rows = await tx
+      .insert(agentWorkspaceSettings)
+      .values({
+        workspaceId: params.workspaceId,
+        defaultProviderId: params.providerId,
+      })
+      .onConflictDoUpdate({
+        target: agentWorkspaceSettings.workspaceId,
+        set: {
+          defaultProviderId: params.providerId,
+          updatedAt: sql`NOW()`,
+        },
+      })
+      .returning();
+
+    const row = rows[0];
+    if (!row) throw new Error('Upsert returned no rows');
+    return toAgentWorkspaceSettings(row);
+  });
 }

--- a/libs/api/agent/src/db/db.ts
+++ b/libs/api/agent/src/db/db.ts
@@ -1,0 +1,20 @@
+import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
+import {pgClient} from '@shipfox/node-postgres';
+import {agentProviderConfigs} from './schema/agent-provider-configs.js';
+import {agentWorkspaceSettings} from './schema/agent-workspace-settings.js';
+
+export const schema = {
+  agentProviderConfigs,
+  agentWorkspaceSettings,
+};
+
+let _db: NodePgDatabase<typeof schema> | undefined;
+
+export function db() {
+  if (!_db) _db = drizzle(pgClient(), {schema});
+  return _db;
+}
+
+export function closeDb(): void {
+  _db = undefined;
+}

--- a/libs/api/agent/src/db/index.ts
+++ b/libs/api/agent/src/db/index.ts
@@ -1,0 +1,19 @@
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export type {UpsertAgentProviderConfigParams} from './agent-provider-configs.js';
+export {
+  deleteAgentProviderConfig,
+  getAgentProviderConfig,
+  listAgentProviderConfigs,
+  upsertAgentProviderConfig,
+} from './agent-provider-configs.js';
+export {
+  getAgentWorkspaceSettings,
+  setDefaultAgentProvider,
+} from './agent-workspace-settings.js';
+export {closeDb, db, schema} from './db.js';
+export {agentProviderConfigs} from './schema/agent-provider-configs.js';
+export {agentWorkspaceSettings} from './schema/agent-workspace-settings.js';
+
+export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/agent/src/db/schema/agent-provider-configs.ts
+++ b/libs/api/agent/src/db/schema/agent-provider-configs.ts
@@ -1,0 +1,44 @@
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import type {AgentProviderConfig} from '#core/entities/agent-provider-config.js';
+import {pgTable} from './common.js';
+
+export const agentProviderConfigs = pgTable(
+  'provider_configs',
+  {
+    id: uuidv7PrimaryKey(),
+    workspaceId: uuid('workspace_id').notNull(),
+    providerId: text('provider_id').notNull(),
+    encryptedCredentials: jsonb('encrypted_credentials').$type<Record<string, string>>().notNull(),
+    keyFingerprints: jsonb('key_fingerprints').$type<Record<string, string>>().notNull(),
+    defaultModel: text('default_model').notNull(),
+    defaultThinking: text('default_thinking').notNull(),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('agent_provider_configs_workspace_provider_unique').on(
+      table.workspaceId,
+      table.providerId,
+    ),
+    index('agent_provider_configs_workspace_idx').on(table.workspaceId),
+  ],
+);
+
+export type AgentProviderConfigDb = typeof agentProviderConfigs.$inferSelect;
+export type AgentProviderConfigCreateDb = typeof agentProviderConfigs.$inferInsert;
+
+export function toAgentProviderConfig(row: AgentProviderConfigDb): AgentProviderConfig {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    providerId: row.providerId as SupportedAgentProviderId,
+    encryptedCredentials: row.encryptedCredentials,
+    keyFingerprints: row.keyFingerprints,
+    defaultModel: row.defaultModel,
+    defaultThinking: row.defaultThinking as AgentThinking,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/agent/src/db/schema/agent-provider-configs.ts
+++ b/libs/api/agent/src/db/schema/agent-provider-configs.ts
@@ -1,6 +1,6 @@
 import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {jsonb, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {AgentProviderConfig} from '#core/entities/agent-provider-config.js';
 import {pgTable} from './common.js';
 
@@ -22,7 +22,6 @@ export const agentProviderConfigs = pgTable(
       table.workspaceId,
       table.providerId,
     ),
-    index('agent_provider_configs_workspace_idx').on(table.workspaceId),
   ],
 );
 

--- a/libs/api/agent/src/db/schema/agent-workspace-settings.ts
+++ b/libs/api/agent/src/db/schema/agent-workspace-settings.ts
@@ -1,0 +1,23 @@
+import type {SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import type {AgentWorkspaceSettings} from '#core/entities/agent-workspace-settings.js';
+import {pgTable} from './common.js';
+
+export const agentWorkspaceSettings = pgTable('workspace_settings', {
+  workspaceId: uuid('workspace_id').primaryKey(),
+  defaultProviderId: text('default_provider_id'),
+  createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+});
+
+export type AgentWorkspaceSettingsDb = typeof agentWorkspaceSettings.$inferSelect;
+export type AgentWorkspaceSettingsCreateDb = typeof agentWorkspaceSettings.$inferInsert;
+
+export function toAgentWorkspaceSettings(row: AgentWorkspaceSettingsDb): AgentWorkspaceSettings {
+  return {
+    workspaceId: row.workspaceId,
+    defaultProviderId: row.defaultProviderId as SupportedAgentProviderId | null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/agent/src/db/schema/common.ts
+++ b/libs/api/agent/src/db/schema/common.ts
@@ -1,0 +1,3 @@
+import {pgTableCreator} from 'drizzle-orm/pg-core';
+
+export const pgTable = pgTableCreator((name) => `agent_${name}`);

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -1,0 +1,19 @@
+import type {ShipfoxModule} from '@shipfox/node-module';
+import {db, migrationsPath} from '#db/index.js';
+
+export type {AgentProviderConfig, AgentWorkspaceSettings} from '#core/index.js';
+export {
+  db,
+  deleteAgentProviderConfig,
+  getAgentProviderConfig,
+  getAgentWorkspaceSettings,
+  listAgentProviderConfigs,
+  migrationsPath,
+  setDefaultAgentProvider,
+  upsertAgentProviderConfig,
+} from '#db/index.js';
+
+export const agentModule: ShipfoxModule = {
+  name: 'agent',
+  database: {db, migrationsPath},
+};

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -1,14 +1,16 @@
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath} from '#db/index.js';
 
-export type {AgentProviderConfig, AgentWorkspaceSettings} from '#core/index.js';
 export {
-  db,
+  type AgentProviderConfig,
+  AgentProviderConfigNotFoundError,
+  type AgentWorkspaceSettings,
+} from '#core/index.js';
+export {
   deleteAgentProviderConfig,
   getAgentProviderConfig,
   getAgentWorkspaceSettings,
   listAgentProviderConfigs,
-  migrationsPath,
   setDefaultAgentProvider,
   upsertAgentProviderConfig,
 } from '#db/index.js';

--- a/libs/api/agent/test/env.ts
+++ b/libs/api/agent/test/env.ts
@@ -1,0 +1,7 @@
+process.env.POSTGRES_HOST = 'localhost';
+process.env.POSTGRES_PORT = '5432';
+process.env.POSTGRES_USERNAME = 'shipfox';
+process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_DATABASE = 'api_test';
+process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.TZ = 'UTC';

--- a/libs/api/agent/test/globalSetup.ts
+++ b/libs/api/agent/test/globalSetup.ts
@@ -1,0 +1,16 @@
+import './env.js';
+import {runMigrations} from '@shipfox/node-drizzle';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {sql} from 'drizzle-orm';
+import {closeDb, db, migrationsPath} from '#db/index.js';
+
+export async function setup() {
+  createPostgresClient();
+
+  await runMigrations(db(), migrationsPath, '__drizzle_migrations_agent');
+  await db().execute(sql`TRUNCATE agent_provider_configs CASCADE`);
+  await db().execute(sql`TRUNCATE agent_workspace_settings CASCADE`);
+
+  closeDb();
+  await closePostgresClient();
+}

--- a/libs/api/agent/test/setup.ts
+++ b/libs/api/agent/test/setup.ts
@@ -1,0 +1,17 @@
+import './env.js';
+import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
+import {afterAll, afterEach, beforeAll, vi} from '@shipfox/vitest/vi';
+import {closeDb} from '#db/index.js';
+
+beforeAll(() => {
+  createPostgresClient();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterAll(async () => {
+  closeDb();
+  await closePostgresClient();
+});

--- a/libs/api/agent/tsconfig.build.json
+++ b/libs/api/agent/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/agent/tsconfig.json
+++ b/libs/api/agent/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/agent/tsconfig.test.json
+++ b/libs/api/agent/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/agent/vitest.config.ts
+++ b/libs/api/agent/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      globalSetup: ['test/globalSetup.ts'],
+      setupFiles: ['test/setup.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,12 +437,6 @@ importers:
 
   libs/api/agent:
     dependencies:
-      '@earendil-works/pi-ai':
-        specifier: 0.79.9
-        version: 0.79.9(ws@8.21.0)(zod@4.4.3)
-      '@opentelemetry/api':
-        specifier: 1.9.1
-        version: 1.9.1
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../agent-dto
@@ -452,19 +446,16 @@ importers:
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
-      '@shipfox/node-opentelemetry':
-        specifier: workspace:*
-        version: link:../../shared/node/opentelemetry
       '@shipfox/node-postgres':
         specifier: workspace:*
         version: link:../../shared/node/postgres
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.79.9
+        version: 0.79.9(ws@8.21.0)(zod@4.4.3)
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@shipfox/api-agent':
+        specifier: workspace:*
+        version: link:../../libs/api/agent
       '@shipfox/api-auth':
         specifier: workspace:*
         version: link:../../libs/api/auth
@@ -431,6 +434,58 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+
+  libs/api/agent:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.79.9
+        version: 0.79.9(ws@8.21.0)(zod@4.4.3)
+      '@opentelemetry/api':
+        specifier: 1.9.1
+        version: 1.9.1
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../agent-dto
+      '@shipfox/node-drizzle':
+        specifier: workspace:*
+        version: link:../../shared/node/drizzle
+      '@shipfox/node-module':
+        specifier: workspace:*
+        version: link:../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../shared/node/postgres
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
 
   libs/api/agent-dto:
     dependencies:
@@ -3236,7 +3291,7 @@ importers:
     dependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.79.6
-        version: 0.79.6(ws@8.21.0)(zod@4.4.3)
+        version: 0.79.6
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../api/workflows-dto
@@ -12330,7 +12385,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
@@ -12430,7 +12485,7 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/signature-v4-multi-region': 3.996.35
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.7
@@ -12806,7 +12861,7 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.79.9(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.9':
     dependencies:
       '@earendil-works/pi-ai': 0.79.9(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
@@ -12841,9 +12896,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.6(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.6':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.9(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core': 0.79.9
       '@earendil-works/pi-ai': 0.79.9(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.79.9
       '@silvia-odwyer/photon-node': 0.3.4
@@ -16102,7 +16157,7 @@ snapshots:
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -16111,7 +16166,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
 
   '@types/deep-eql@4.0.2': {}
 
@@ -16135,7 +16190,7 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
 
   '@types/mjml-core@5.0.0': {}
 
@@ -16145,7 +16200,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
 
   '@types/node@12.20.55': {}
 
@@ -16167,7 +16222,7 @@ snapshots:
 
   '@types/oracledb@6.5.2':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -16175,13 +16230,13 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 26.0.0
+      '@types/node': 25.9.3
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
@@ -16201,7 +16256,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
 
   '@types/unist@3.0.3': {}
 
@@ -19303,7 +19358,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
       long: 5.3.2
 
   protobufjs@7.6.4:
@@ -19317,7 +19372,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 24.13.2
+      '@types/node': 25.9.3
       long: 5.3.2
 
   pump@3.0.4:


### PR DESCRIPTION
Adds the backend `@shipfox/api-agent` module that owns workspace agent provider storage.

This gives follow-on agent provider routes, validation, and runtime resolution a module-owned database surface for provider configs and workspace default provider settings. Provider configs are unique per workspace/provider pair, can be hard-deleted, and deleting one clears the workspace default when it points at the removed provider.

The package also validates the shared provider catalog against the pinned Pi registry so catalog provider IDs and default models stay aligned with runtime provider data.

Closes ENG-596

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the backend `@shipfox/api-agent` module to store workspace agent provider configs and defaults, with Pi catalog validation. Integrates with `apps/api` and enforces that workspace defaults must reference an existing provider config, fulfilling ENG-596.

- **New Features**
  - Drizzle tables for provider configs and workspace settings with per-(workspace, provider) uniqueness.
  - Upsert/get/list/delete provider configs; deleting a defaulted config clears the workspace default.
  - Set or clear workspace default provider; setting requires a matching provider config or it fails.
  - Catalog tests keep `@shipfox/api-agent-dto` provider IDs and default models aligned with `@earendil-works/pi-ai`.
  - Wired into `apps/api` via `agentModule`, exposing DB and migrations.

- **Migration**
  - Run database migrations to create `agent_provider_configs` and `agent_workspace_settings` before deploy.

<sup>Written for commit 4eb62de8461debc931ba87a63e40758b49b16eef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

