### PR TITLE
[api/auth] Extract shared bearer token auth helper

### DIFF
--- a/libs/api/auth/src/presentation/auth/bearer-token-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/bearer-token-auth.test.ts
@@ -1,0 +1,99 @@
+import {errorHandler} from '@shipfox/node-fastify';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import Fastify from 'fastify';
+import {serializerCompiler, validatorCompiler} from 'fastify-type-provider-zod';
+import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
+
+const CONTEXT_KEY = 'testContext';
+
+interface TestClaims {
+  subject: string;
+}
+
+describe('bearer-token-auth', () => {
+  let app: FastifyInstance;
+  let verifyToken: ReturnType<typeof vi.fn<(token: string) => Promise<TestClaims | null>>>;
+
+  beforeEach(async () => {
+    verifyToken = vi.fn<(token: string) => Promise<TestClaims | null>>();
+    app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+    app.setErrorHandler(errorHandler);
+
+    const authMethod = createBearerTokenAuthMethod({
+      name: 'test-bearer',
+      verifyToken,
+      invalidTokenError: {message: 'Invalid test bearer token', code: 'invalid-test-token'},
+      setContext: (request, claims) => {
+        (request as FastifyRequest & Record<typeof CONTEXT_KEY, typeof claims>)[CONTEXT_KEY] =
+          claims;
+      },
+    });
+
+    app.addHook('onRequest', async (request, reply) => {
+      await authMethod.authenticate(request, reply);
+    });
+
+    app.get('/protected', (request) => {
+      return {
+        context: (request as FastifyRequest & Record<typeof CONTEXT_KEY, unknown>)[CONTEXT_KEY],
+      };
+    });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  test('valid bearer token sets context on the request', async () => {
+    verifyToken.mockResolvedValue({subject: 'runner-1'});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {authorization: 'Bearer valid-token'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(verifyToken).toHaveBeenCalledWith('valid-token');
+    expect(res.json().context).toEqual({subject: 'runner-1'});
+  });
+
+  test('missing bearer token returns the shared unauthorized response', async () => {
+    const res = await app.inject({method: 'GET', url: '/protected'});
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({code: 'unauthorized'});
+    expect(verifyToken).not.toHaveBeenCalled();
+  });
+
+  test('invalid bearer token returns the configured unauthorized response', async () => {
+    verifyToken.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {authorization: 'Bearer invalid-token'},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({code: 'invalid-test-token'});
+    expect(verifyToken).toHaveBeenCalledWith('invalid-token');
+  });
+
+  test('thrown verifier errors return the configured unauthorized response', async () => {
+    verifyToken.mockRejectedValue(new Error('bad signature'));
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {authorization: 'Bearer invalid-token'},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toEqual({code: 'invalid-test-token'});
+    expect(verifyToken).toHaveBeenCalledWith('invalid-token');
+  });
+});

--- a/libs/api/auth/src/presentation/auth/bearer-token-auth.ts
+++ b/libs/api/auth/src/presentation/auth/bearer-token-auth.ts
@@ -1,0 +1,51 @@
+import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
+import type {FastifyRequest} from 'fastify';
+
+interface UnauthorizedErrorParams {
+  message: string;
+  code: string;
+}
+
+interface BearerTokenAuthMethodOptions<TClaims> {
+  name: string;
+  verifyToken: (token: string) => Promise<TClaims | null>;
+  invalidTokenError: UnauthorizedErrorParams;
+  setContext: (request: FastifyRequest, claims: TClaims) => void;
+}
+
+const missingBearerError: UnauthorizedErrorParams = {
+  message: 'Missing or invalid Authorization header',
+  code: 'unauthorized',
+};
+
+export function createBearerTokenAuthMethod<TClaims>(
+  options: BearerTokenAuthMethodOptions<TClaims>,
+): AuthMethod {
+  return {
+    name: options.name,
+    authenticate: async (request) => {
+      const token = extractBearerToken(request.headers.authorization);
+      if (!token) throwUnauthorized(missingBearerError);
+
+      const claims = await verifyBearerToken(token, options.verifyToken);
+      if (!claims) throwUnauthorized(options.invalidTokenError);
+
+      options.setContext(request, claims);
+    },
+  };
+}
+
+async function verifyBearerToken<TClaims>(
+  token: string,
+  verifyToken: (token: string) => Promise<TClaims | null>,
+): Promise<TClaims | null> {
+  try {
+    return await verifyToken(token);
+  } catch {
+    return null;
+  }
+}
+
+function throwUnauthorized(error: UnauthorizedErrorParams): never {
+  throw new ClientError(error.message, error.code, {status: 401});
+}

--- a/libs/api/auth/src/presentation/auth/jwt-auth.ts
+++ b/libs/api/auth/src/presentation/auth/jwt-auth.ts
@@ -5,10 +5,11 @@ import {
   setUserContext,
   type UserContext,
 } from '@shipfox/api-auth-context';
-import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
+import type {AuthMethod} from '@shipfox/node-fastify';
 import type {FastifyRequest} from 'fastify';
 import {config} from '#config.js';
 import {verifyUserToken} from '#core/jwt.js';
+import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
 export type ClientContext = UserContext;
 
@@ -21,28 +22,18 @@ export function getClientContext(request: FastifyRequest): ClientContext | null 
 }
 
 export function createJwtAuthMethod(): AuthMethod {
-  return {
+  return createBearerTokenAuthMethod({
     name: AUTH_USER,
-    authenticate: async (request) => {
-      const token = extractBearerToken(request.headers.authorization);
-      if (!token) {
-        throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {
-          status: 401,
-        });
-      }
-
-      const claims = await verifyUserToken({token, secret: config.AUTH_JWT_SECRET}).catch(() => {
-        throw new ClientError('Invalid or expired token', 'unauthorized', {status: 401});
-      });
-
+    verifyToken: (token) => verifyUserToken({token, secret: config.AUTH_JWT_SECRET}),
+    invalidTokenError: {message: 'Invalid or expired token', code: 'unauthorized'},
+    setContext: (request, claims) => {
       const clientContext: ClientContext = buildUserContext({
         userId: claims.sub,
         email: claims.email,
         name: claims.name ?? null,
         memberships: claims.memberships,
       });
-
       setUserContext(request, clientContext);
     },
-  };
+  });
 }

--- a/libs/api/auth/src/presentation/auth/lease-token-auth.ts
+++ b/libs/api/auth/src/presentation/auth/lease-token-auth.ts
@@ -1,6 +1,7 @@
 import {AUTH_LEASED_JOB, setLeasedJobContext} from '@shipfox/api-auth-context';
-import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
+import type {AuthMethod} from '@shipfox/node-fastify';
 import {verifyJobLeaseToken} from '#core/job-lease-token.js';
+import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
 /**
  * Trust boundary: the signed token is the sole authority — `claims.jobId` scopes
@@ -15,22 +16,10 @@ import {verifyJobLeaseToken} from '#core/job-lease-token.js';
  * "Security model" section in the package README for the full rationale.
  */
 export function createLeaseTokenAuthMethod(): AuthMethod {
-  return {
+  return createBearerTokenAuthMethod({
     name: AUTH_LEASED_JOB,
-    authenticate: async (request) => {
-      const token = extractBearerToken(request.headers.authorization);
-      if (!token) {
-        throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {
-          status: 401,
-        });
-      }
-
-      const claims = await verifyJobLeaseToken(token);
-      if (!claims) {
-        throw new ClientError('Invalid or expired job lease token', 'unauthorized', {status: 401});
-      }
-
-      setLeasedJobContext(request, claims);
-    },
-  };
+    verifyToken: verifyJobLeaseToken,
+    invalidTokenError: {message: 'Invalid or expired job lease token', code: 'unauthorized'},
+    setContext: setLeasedJobContext,
+  });
 }

--- a/libs/api/auth/src/presentation/auth/runner-session-auth.ts
+++ b/libs/api/auth/src/presentation/auth/runner-session-auth.ts
@@ -1,26 +1,13 @@
 import {AUTH_RUNNER_SESSION, setRunnerSessionContext} from '@shipfox/api-auth-context';
-import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
+import type {AuthMethod} from '@shipfox/node-fastify';
 import {verifyRunnerSessionToken} from '#core/runner-session-token.js';
+import {createBearerTokenAuthMethod} from './bearer-token-auth.js';
 
 export function createRunnerSessionAuthMethod(): AuthMethod {
-  return {
+  return createBearerTokenAuthMethod({
     name: AUTH_RUNNER_SESSION,
-    authenticate: async (request) => {
-      const token = extractBearerToken(request.headers.authorization);
-      if (!token) {
-        throw new ClientError('Missing or invalid Authorization header', 'unauthorized', {
-          status: 401,
-        });
-      }
-
-      const claims = await verifyRunnerSessionToken(token);
-      if (!claims) {
-        throw new ClientError('Invalid or expired runner session token', 'unauthorized', {
-          status: 401,
-        });
-      }
-
-      setRunnerSessionContext(request, claims);
-    },
-  };
+    verifyToken: verifyRunnerSessionToken,
+    invalidTokenError: {message: 'Invalid or expired runner session token', code: 'unauthorized'},
+    setContext: setRunnerSessionContext,
+  });
 }


### PR DESCRIPTION
Extract shared bearer-token auth handling for stateless API auth methods.

The runner-session auth method intentionally duplicated the existing JWT and job-lease bearer flow during ENG-609 to keep the live auth blast radius narrow. This follow-up moves the common bearer extraction, verifier invocation, `401` translation, and request-context setting into an internal helper while keeping each token type's verifier, error code/message, and context mapper owned by its existing auth method.

The helper test uses the production Fastify error handler so negative-path assertions match the deployed `ClientError` response shape. A stale `api-runners` cancellation test was also updated from runner-token setup to runner-session setup so the changed surface matches the ENG-609 `claimPendingJob` contract.

Local validation is green for focused `@shipfox/api-auth` and `@shipfox/api-runners` checks, plus changed-surface build, type, check, and test against `origin/main`.

Closes ENG-621