### PR TITLE
[api-runners] Fix runner cancellation test setup

### DIFF
--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -486,20 +486,20 @@ describe('requestJobCancellation', () => {
 
 describe('cancelRunnerJobs', () => {
   let workspaceId: string;
-  let runnerTokenId: string;
+  let runnerSessionId: string;
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
-    const runnerToken = await runnerTokenFactory.create({workspaceId});
-    runnerTokenId = runnerToken.id;
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    runnerSessionId = runnerSession.id;
   });
 
   it('deletes queued jobs and requests cancellation for running jobs', async () => {
     const running = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     const queued = await pendingJobFactory.create({workspaceId});
 
     await cancelRunnerJobs({jobIds: [queued.jobId, claimed?.jobId as string]});
@@ -526,7 +526,7 @@ describe('cancelRunnerJobs', () => {
 
     await cancelRunnerJobs({jobIds: [queued.jobId]});
 
-    const claimed = await claimPendingJob({workspaceId, runnerTokenId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
     expect(claimed).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes the runner cancellation database tests to create a runner session before claiming a pending job.

The failing tests were setting up a runner token id and passing it into `claimPendingJob`, even though that database helper records a runner session id on the running job row. That also left the test block referencing an unimported `runnerTokenFactory`, which made the suite fail before exercising cancellation behavior.

No changeset is included because `@shipfox/api-runners` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runner cancellation database tests by creating a runner session and passing its id to `claimPendingJob`, matching the helper that records `runner_session_id`.
Also truncates `runners_runner_sessions` in setup and swaps to `runnerSessionFactory` to avoid setup errors and properly exercise cancellation behavior.

<sup>Written for commit 2958d5891ffbb7fd0cb422eb43148c10b15410c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

