### PR TITLE
[runners] Add label-aware job claiming

### DIFF
--- a/.changeset/label-aware-runners-claim.md
+++ b/.changeset/label-aware-runners-claim.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-runners": patch
+"@shipfox/api-runners-dto": patch
+"@shipfox/api-workflows": patch
+---
+
+Adds label-aware runner job claiming with shared runner-label validation and required-label orchestration.

--- a/libs/api/runners-dto/package.json
+++ b/libs/api/runners-dto/package.json
@@ -38,6 +38,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/runner-labels": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/libs/api/runners-dto/src/labels.ts
+++ b/libs/api/runners-dto/src/labels.ts
@@ -1,10 +1,5 @@
+import {canonicalizeLabels} from '@shipfox/runner-labels';
+
 export function canonicalizeRunnerLabels(labels: string[]): string[] {
-  const canonical = new Set<string>();
-
-  for (const label of labels) {
-    const value = label.trim().toLowerCase();
-    if (value.length > 0) canonical.add(value);
-  }
-
-  return [...canonical].sort();
+  return [...canonicalizeLabels(labels)];
 }

--- a/libs/api/runners-dto/src/schemas/register.ts
+++ b/libs/api/runners-dto/src/schemas/register.ts
@@ -1,13 +1,18 @@
+import {
+  MAX_RUNNER_LABEL_LENGTH,
+  MAX_RUNNER_LABELS,
+  RUNNER_LABEL_PATTERN,
+} from '@shipfox/runner-labels';
 import {z} from 'zod';
 
 export const runnerLabelSchema = z
   .string()
   .min(1)
-  .max(63)
-  .regex(/^[a-z0-9][a-z0-9._-]*$/i);
+  .max(MAX_RUNNER_LABEL_LENGTH)
+  .regex(new RegExp(RUNNER_LABEL_PATTERN.source, 'i'));
 
 export const registerRunnerBodySchema = z.object({
-  labels: z.array(runnerLabelSchema).min(1).max(50),
+  labels: z.array(runnerLabelSchema).min(1).max(MAX_RUNNER_LABELS),
 });
 
 export const registerRunnerResponseSchema = z.object({

--- a/libs/api/runners/drizzle/0002_flippant_manta.sql
+++ b/libs/api/runners/drizzle/0002_flippant_manta.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "runners_pending_jobs" ADD COLUMN "required_labels" text[] DEFAULT '{}'::text[] NOT NULL;--> statement-breakpoint
+ALTER TABLE "runners_pending_jobs" ALTER COLUMN "required_labels" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ADD COLUMN "required_labels" text[] DEFAULT '{}'::text[] NOT NULL;--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ALTER COLUMN "required_labels" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_labels" text[] DEFAULT '{}'::text[] NOT NULL;--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ALTER COLUMN "runner_labels" DROP DEFAULT;

--- a/libs/api/runners/drizzle/meta/0002_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,539 @@
+{
+  "id": "eb235830-25e1-4cf0-bcf8-c0c333b77b46",
+  "prevId": "fff3e821-10b9-41e7-971c-701202da0b7b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.runners_outbox": {
+      "name": "runners_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_outbox_pending_idx": {
+          "name": "runners_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_outbox_dispatched_retention_idx": {
+          "name": "runners_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_pending_jobs": {
+      "name": "runners_pending_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_pending_jobs_created_idx": {
+          "name": "runners_pending_jobs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_pending_jobs_workspace_created_idx": {
+          "name": "runners_pending_jobs_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_pending_jobs_job_id_unique": {
+          "name": "runners_pending_jobs_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_tokens": {
+      "name": "runners_runner_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_tokens_hashed_token_unique": {
+          "name": "runners_runner_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_tokens_workspace_id_idx": {
+          "name": "runners_runner_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_tokens_active_lookup_idx": {
+          "name": "runners_runner_tokens_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_running_jobs": {
+      "name": "runners_running_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_running_jobs_last_heartbeat_at_idx": {
+          "name": "runners_running_jobs_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_running_jobs_job_id_unique": {
+          "name": "runners_running_jobs_job_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.runners_runner_session_scope": {
+      "name": "runners_runner_session_scope",
+      "schema": "public",
+      "values": ["workspace"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/runners/drizzle/meta/_journal.json
+++ b/libs/api/runners/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777291200000,
       "tag": "0001_runner_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777377600000,
+      "tag": "0002_flippant_manta",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/runners/src/core/errors.ts
+++ b/libs/api/runners/src/core/errors.ts
@@ -18,3 +18,10 @@ export class EmptyRunnerLabelsError extends Error {
     this.name = 'EmptyRunnerLabelsError';
   }
 }
+
+export class EmptyRequiredLabelsError extends Error {
+  constructor() {
+    super('Required labels cannot be empty');
+    this.name = 'EmptyRequiredLabelsError';
+  }
+}

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -11,6 +11,7 @@ export interface ClaimJobResult {
 export async function claimJob(params: {
   workspaceId: string;
   runnerSessionId: string;
+  sessionLabels: string[];
 }): Promise<ClaimJobResult | null> {
   const claimed = await claimPendingJob(params);
   if (!claimed) {

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -5,12 +5,13 @@ import {
   RUNNER_JOB_QUEUED,
 } from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
+import {EmptyRequiredLabelsError} from '#core/errors.js';
 import {claimJob, detectAndExpireStuckJobs} from '#core/jobs.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {db} from './db.js';
 import {
   cancelRunnerJobs,
-  claimPendingJob,
+  claimPendingJob as claimPendingJobDb,
   enqueueJob,
   expireStuckJobs,
   getJobQueueDepth,
@@ -21,6 +22,16 @@ import {
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
 import {runningJobs} from './schema/running-jobs.js';
+
+const sessionLabels = ['linux', 'x64'];
+
+function claimPendingJob(
+  params: Omit<Parameters<typeof claimPendingJobDb>[0], 'sessionLabels'> & {
+    sessionLabels?: string[];
+  },
+) {
+  return claimPendingJobDb({...params, sessionLabels: params.sessionLabels ?? sessionLabels});
+}
 
 describe('enqueueJob', () => {
   beforeEach(async () => {
@@ -35,7 +46,7 @@ describe('enqueueJob', () => {
     const workspaceId = crypto.randomUUID();
     const projectId = crypto.randomUUID();
 
-    await enqueueJob({workspaceId, jobId, runId, projectId});
+    await enqueueJob({workspaceId, jobId, runId, projectId, requiredLabels: ['linux']});
 
     const rows = await db().select().from(pendingJobs);
     expect(rows).toHaveLength(1);
@@ -43,7 +54,35 @@ describe('enqueueJob', () => {
     expect(rows[0]?.runId).toBe(runId);
     expect(rows[0]?.projectId).toBe(projectId);
     expect(rows[0]?.workspaceId).toBe(workspaceId);
+    expect(rows[0]?.requiredLabels).toEqual(['linux']);
     expect(rows[0]).not.toHaveProperty('payload');
+  });
+
+  it('stores canonical required labels', async () => {
+    const jobId = crypto.randomUUID();
+
+    await enqueueJob({
+      workspaceId: crypto.randomUUID(),
+      jobId,
+      runId: crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      requiredLabels: ['Ubuntu22', ' ubuntu22 ', 'LINUX'],
+    });
+
+    const rows = await db().select().from(pendingJobs).where(eq(pendingJobs.jobId, jobId));
+    expect(rows[0]?.requiredLabels).toEqual(['linux', 'ubuntu22']);
+  });
+
+  it('rejects empty required labels', async () => {
+    await expect(
+      enqueueJob({
+        workspaceId: crypto.randomUUID(),
+        jobId: crypto.randomUUID(),
+        runId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        requiredLabels: [],
+      }),
+    ).rejects.toBeInstanceOf(EmptyRequiredLabelsError);
   });
 
   it('is idempotent: scheduling the same jobId twice is a no-op', async () => {
@@ -53,6 +92,7 @@ describe('enqueueJob', () => {
       runId: crypto.randomUUID(),
       projectId: crypto.randomUUID(),
       jobId,
+      requiredLabels: ['linux'],
     };
 
     await enqueueJob(params);
@@ -71,6 +111,7 @@ describe('enqueueJob', () => {
       jobId,
       runId,
       projectId: crypto.randomUUID(),
+      requiredLabels: ['linux'],
     });
 
     const [pending] = await db().select().from(pendingJobs);
@@ -89,6 +130,7 @@ describe('enqueueJob', () => {
       runId: crypto.randomUUID(),
       projectId: crypto.randomUUID(),
       jobId: crypto.randomUUID(),
+      requiredLabels: ['linux'],
     };
 
     await enqueueJob(params);
@@ -152,6 +194,7 @@ describe('claimPendingJob', () => {
       jobId: created.jobId,
       runId: created.runId,
       projectId: created.projectId,
+      requiredLabels: created.requiredLabels,
     });
     // Clear the initial claim's events so this assertion only covers the orphan claim.
     await db().delete(runnersOutbox);
@@ -212,6 +255,77 @@ describe('claimPendingJob', () => {
     expect(running).toHaveLength(1);
     expect(running[0]?.runnerSessionId).toBe(runnerSessionId);
     expect(running[0]?.projectId).toBe(created.projectId);
+    expect(running[0]?.requiredLabels).toEqual(created.requiredLabels);
+    expect(running[0]?.runnerLabels).toEqual(sessionLabels);
+  });
+
+  it('claims a job whose required labels are a subset of the session labels', async () => {
+    const created = await pendingJobFactory.create({
+      workspaceId,
+      requiredLabels: ['linux'],
+    });
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+
+    expect(claimed?.jobId).toBe(created.jobId);
+  });
+
+  it('claims a job whose required labels exactly match the session labels', async () => {
+    const created = await pendingJobFactory.create({
+      workspaceId,
+      requiredLabels: ['linux', 'x64'],
+    });
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+
+    expect(claimed?.jobId).toBe(created.jobId);
+  });
+
+  it('skips an older incompatible job and claims the oldest compatible job', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['macos']});
+    const compatible = await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+
+    expect(claimed?.jobId).toBe(compatible.jobId);
+  });
+
+  it('claims the older matching job before newer matching jobs', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['macos']});
+    const olderMatching = await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['x64']});
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+
+    expect(claimed?.jobId).toBe(olderMatching.jobId);
+  });
+
+  it('returns null when no compatible job is pending', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['macos']});
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+
+    expect(claimed).toBeNull();
+  });
+
+  it('returns null for an empty session label set', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, sessionLabels: []});
+
+    expect(claimed).toBeNull();
+  });
+
+  it('claims the compatible row from a mixed-label queue', async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await pendingJobFactory.create({workspaceId, requiredLabels: [`gpu-${index}`]});
+    }
+    const compatible = await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
+
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+
+    expect(claimed?.jobId).toBe(compatible.jobId);
   });
 
   it('does not claim jobs from another workspace', async () => {
@@ -233,6 +347,7 @@ describe('claimPendingJob', () => {
       jobId: created.jobId,
       runId: created.runId,
       projectId: created.projectId,
+      requiredLabels: created.requiredLabels,
     });
 
     const second = await claimPendingJob({workspaceId, runnerSessionId});
@@ -242,6 +357,30 @@ describe('claimPendingJob', () => {
     const running = await db().select().from(runningJobs);
     expect(running).toHaveLength(1);
     expect(running[0]?.jobId).toBe(created.jobId);
+  });
+
+  it('leaves a non-matching orphan unclaimed until release sweeps it', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+    const first = await claimPendingJob({workspaceId, runnerSessionId});
+    expect(first?.jobId).toBe(created.jobId);
+    await db().insert(pendingJobs).values({
+      workspaceId,
+      jobId: created.jobId,
+      runId: created.runId,
+      projectId: created.projectId,
+      requiredLabels: created.requiredLabels,
+    });
+
+    const second = await claimPendingJob({
+      workspaceId,
+      runnerSessionId,
+      sessionLabels: ['macos'],
+    });
+    await releaseJob({jobId: created.jobId});
+
+    expect(second).toBeNull();
+    expect(await db().select().from(runningJobs)).toHaveLength(0);
+    expect(await db().select().from(pendingJobs)).toHaveLength(0);
   });
 
   it('claims a real pending job ahead of a newer orphan', async () => {
@@ -255,6 +394,7 @@ describe('claimPendingJob', () => {
       jobId: alreadyRunning.jobId,
       runId: alreadyRunning.runId,
       projectId: alreadyRunning.projectId,
+      requiredLabels: alreadyRunning.requiredLabels,
     });
 
     const claimed = await claimPendingJob({workspaceId, runnerSessionId});
@@ -279,7 +419,7 @@ describe('claimJob', () => {
   it('mints a lease token whose claims match the claimed job', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimJob({workspaceId, runnerSessionId});
+    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels});
 
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
@@ -297,7 +437,7 @@ describe('claimJob', () => {
   });
 
   it('returns null and mints no token when the queue is empty', async () => {
-    const claimed = await claimJob({workspaceId, runnerSessionId});
+    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels});
 
     expect(claimed).toBeNull();
   });
@@ -352,6 +492,7 @@ describe('releaseJob', () => {
         jobId: claimed?.jobId as string,
         runId: claimed?.runId as string,
         projectId: claimed?.projectId as string,
+        requiredLabels: ['linux'],
       });
 
     await releaseJob({jobId: claimed?.jobId as string});
@@ -649,7 +790,15 @@ describe('detectAndExpireStuckJobs', () => {
     const {jobId, runId, projectId} = await makeStaleJob(600);
     // A post-claim enqueue retry left a pending row whose job is already running;
     // without this sweep it would stay re-claimable for an already-finished job.
-    await db().insert(pendingJobs).values({workspaceId, jobId, runId, projectId});
+    await db()
+      .insert(pendingJobs)
+      .values({
+        workspaceId,
+        jobId,
+        runId,
+        projectId,
+        requiredLabels: ['linux'],
+      });
 
     await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
@@ -661,7 +810,15 @@ describe('detectAndExpireStuckJobs', () => {
 
   it('leaves the orphan pending row alone when the running row is not stale enough to reap', async () => {
     const {jobId, runId, projectId} = await makeStaleJob(60);
-    await db().insert(pendingJobs).values({workspaceId, jobId, runId, projectId});
+    await db()
+      .insert(pendingJobs)
+      .values({
+        workspaceId,
+        jobId,
+        runId,
+        projectId,
+        requiredLabels: ['linux'],
+      });
 
     await detectAndExpireStuckJobs({thresholdSeconds: 180});
 
@@ -709,7 +866,15 @@ describe('detectAndExpireStuckJobs', () => {
   it('a reaper tick and a concurrent claim of the same orphan-pending job leave consistent state', async () => {
     const {jobId, runId, projectId} = await makeStaleJob(600);
     // Orphan pending row from a post-claim enqueue retry for an already-running job.
-    await db().insert(pendingJobs).values({workspaceId, jobId, runId, projectId});
+    await db()
+      .insert(pendingJobs)
+      .values({
+        workspaceId,
+        jobId,
+        runId,
+        projectId,
+        requiredLabels: ['linux'],
+      });
 
     // The reaper locks running-then-pending while the claim locks pending-then-running;
     // a deadlock loser rolls back, so either side may settle as rejected.

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -1,12 +1,13 @@
 import {
+  canonicalizeRunnerLabels,
   RUNNER_JOB_CLAIMED,
   RUNNER_JOB_LEASE_EXPIRED,
   RUNNER_JOB_QUEUED,
   type RunnersEventMap,
 } from '@shipfox/api-runners-dto';
 import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
-import {and, asc, count, eq, inArray, lt, sql} from 'drizzle-orm';
-import {RunningJobNotFoundError} from '#core/errors.js';
+import {and, arrayContained, asc, count, eq, inArray, lt, sql} from 'drizzle-orm';
+import {EmptyRequiredLabelsError, RunningJobNotFoundError} from '#core/errors.js';
 import {jobEnqueuedCount, jobLeaseExpiredCount} from '#metrics/instance.js';
 import {db} from './db.js';
 import {runnersOutbox} from './schema/outbox.js';
@@ -18,6 +19,7 @@ export interface EnqueueJobParams {
   jobId: string;
   runId: string;
   projectId: string;
+  requiredLabels: string[];
 }
 
 // Idempotent while the job is still pending: a duplicate jobId already in
@@ -28,6 +30,9 @@ export interface EnqueueJobParams {
 // can reinsert an orphan pending row, which a later `claimPendingJob` drops
 // via the running-job unique constraint (onConflictDoNothing) instead of failing.
 export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
+  const requiredLabels = canonicalizeRunnerLabels(params.requiredLabels);
+  if (requiredLabels.length === 0) throw new EmptyRequiredLabelsError();
+
   const enqueued = await db().transaction(async (tx) => {
     const [inserted] = await tx
       .insert(pendingJobs)
@@ -36,6 +41,7 @@ export async function enqueueJob(params: EnqueueJobParams): Promise<void> {
         jobId: params.jobId,
         runId: params.runId,
         projectId: params.projectId,
+        requiredLabels,
       })
       .onConflictDoNothing({target: pendingJobs.jobId})
       .returning({createdAt: pendingJobs.createdAt});
@@ -68,14 +74,22 @@ export interface ClaimedJob {
 export async function claimPendingJob(params: {
   workspaceId: string;
   runnerSessionId: string;
+  sessionLabels: string[];
 }): Promise<ClaimedJob | null> {
+  if (params.sessionLabels.length === 0) return null;
+
   return await db().transaction(async (tx) => {
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
     // for rows sharing a created_at within a batch.
     const [row] = await tx
       .select()
       .from(pendingJobs)
-      .where(eq(pendingJobs.workspaceId, params.workspaceId))
+      .where(
+        and(
+          eq(pendingJobs.workspaceId, params.workspaceId),
+          arrayContained(pendingJobs.requiredLabels, params.sessionLabels),
+        ),
+      )
       .orderBy(asc(pendingJobs.createdAt), asc(pendingJobs.id))
       .limit(1)
       .for('update', {skipLocked: true});
@@ -98,6 +112,8 @@ export async function claimPendingJob(params: {
         runId: row.runId,
         projectId: row.projectId,
         runnerSessionId: params.runnerSessionId,
+        requiredLabels: row.requiredLabels,
+        runnerLabels: params.sessionLabels,
       })
       .onConflictDoNothing({target: runningJobs.jobId})
       .returning({claimedAt: runningJobs.startedAt});

--- a/libs/api/runners/src/db/schema/pending-jobs.ts
+++ b/libs/api/runners/src/db/schema/pending-jobs.ts
@@ -1,5 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {index, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 
 export const pendingJobs = pgTable(
@@ -10,6 +10,7 @@ export const pendingJobs = pgTable(
     jobId: uuid('job_id').notNull().unique(),
     runId: uuid('run_id').notNull(),
     projectId: uuid('project_id').notNull(),
+    requiredLabels: text('required_labels').array().notNull(),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
   },
   (table) => [

--- a/libs/api/runners/src/db/schema/running-jobs.ts
+++ b/libs/api/runners/src/db/schema/running-jobs.ts
@@ -1,5 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {index, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 
 export const runningJobs = pgTable(
@@ -11,6 +11,8 @@ export const runningJobs = pgTable(
     runId: uuid('run_id').notNull(),
     projectId: uuid('project_id').notNull(),
     runnerSessionId: uuid('runner_session_id').notNull(),
+    requiredLabels: text('required_labels').array().notNull(),
+    runnerLabels: text('runner_labels').array().notNull(),
     startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
     lastHeartbeatAt: timestamp('last_heartbeat_at', {withTimezone: true}).notNull().defaultNow(),
     cancellationRequestedAt: timestamp('cancellation_requested_at', {withTimezone: true}),

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -54,7 +54,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
 
   async function claimAvailableJob(): Promise<{jobId: string; leaseToken: string}> {
     const pending = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerSessionId});
+    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels: ['linux', 'x64']});
     expect(claimed).not.toBeNull();
     return {jobId: pending.jobId, leaseToken: claimed?.leaseToken as string};
   }

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -140,8 +140,8 @@ describe('POST /runners/register', () => {
   });
 
   it.each([
-    ['too many labels', {labels: Array.from({length: 51}, (_, index) => `label-${index}`)}],
-    ['too long label', {labels: ['a'.repeat(64)]}],
+    ['too many labels', {labels: Array.from({length: 21}, (_, index) => `label-${index}`)}],
+    ['too long label', {labels: ['a'.repeat(129)]}],
     ['bad charset', {labels: ['linux/amd64']}],
   ])('returns 400 for %s', async (_case, payload) => {
     const res = await app.inject({
@@ -152,5 +152,19 @@ describe('POST /runners/register', () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  it.each([
+    ['20 labels', {labels: Array.from({length: 20}, (_, index) => `label-${index}`)}],
+    ['128-character label', {labels: ['a'.repeat(128)]}],
+  ])('accepts %s', async (_case, payload) => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${rawToken}`},
+      payload,
+    });
+
+    expect(res.statusCode).toBe(200);
   });
 });

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -129,6 +129,18 @@ describe('POST /runners/jobs/request', () => {
     expect(res.statusCode).toBe(204);
   });
 
+  it('returns 204 when no pending job matches the session labels', async () => {
+    await pendingJobFactory.create({workspaceId, requiredLabels: ['macos']});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/jobs/request',
+      headers: {authorization: `Bearer ${sessionToken}`},
+    });
+
+    expect(res.statusCode).toBe(204);
+  });
+
   it('claims multiple jobs from one manual session', async () => {
     const first = await pendingJobFactory.create({workspaceId});
     const second = await pendingJobFactory.create({workspaceId});

--- a/libs/api/runners/src/presentation/routes/request-job.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.ts
@@ -18,6 +18,7 @@ export const requestJobRoute = defineRoute({
     const job = await claimJob({
       workspaceId: runner.workspaceId,
       runnerSessionId: runner.runnerSessionId,
+      sessionLabels: runner.labels,
     });
 
     if (!job) {

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
@@ -22,7 +22,11 @@ describe('onWorkflowsJobTimedOut', () => {
 
   it('sets cancellation_requested_at on the matching running_jobs row', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({
+      workspaceId,
+      runnerSessionId,
+      sessionLabels: ['linux', 'x64'],
+    });
     expect(claimed).not.toBeNull();
 
     await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
@@ -36,7 +40,11 @@ describe('onWorkflowsJobTimedOut', () => {
 
   it('idempotent under double delivery: second call preserves the first timestamp', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({
+      workspaceId,
+      runnerSessionId,
+      sessionLabels: ['linux', 'x64'],
+    });
 
     await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));
     const after1 = await db()

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -19,7 +19,11 @@ describe('detectAndExpireStuckJobsActivity', () => {
 
   it('delegates to detectAndExpireStuckJobs and returns the expired count', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({
+      workspaceId,
+      runnerSessionId,
+      sessionLabels: ['linux', 'x64'],
+    });
     await db()
       .update(runningJobs)
       .set({lastHeartbeatAt: sql`now() - interval '10 minutes'`})

--- a/libs/api/runners/test/factories/pending-job.ts
+++ b/libs/api/runners/test/factories/pending-job.ts
@@ -6,6 +6,7 @@ interface PendingJobAttrs {
   jobId: string;
   runId: string;
   projectId: string;
+  requiredLabels: string[];
 }
 
 export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) => {
@@ -20,6 +21,7 @@ export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) =>
       jobId: attrs.jobId,
       runId: attrs.runId,
       projectId: attrs.projectId,
+      requiredLabels: attrs.requiredLabels,
     });
     return attrs;
   });
@@ -29,5 +31,6 @@ export const pendingJobFactory = Factory.define<PendingJobAttrs>(({onCreate}) =>
     jobId,
     runId,
     projectId,
+    requiredLabels: ['linux'],
   };
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.test.ts
@@ -67,7 +67,7 @@ describe('loadRunDag', () => {
       workspaceId,
       projectId,
       definitionId: crypto.randomUUID(),
-      model: workflowModel({jobs: {build: {steps: [{run: 'step1'}]}}}),
+      model: workflowModel({jobs: {build: {runner: ['ubuntu22'], steps: [{run: 'step1'}]}}}),
       triggerPayload: {
         source: 'manual',
         event: 'fire',
@@ -81,5 +81,6 @@ describe('loadRunDag', () => {
     expect(dag.runId).toBe(run.id);
     expect(dag.workspaceId).toBe(workspaceId);
     expect(dag.projectId).toBe(projectId);
+    expect(dag.jobs[0]?.runner).toEqual(['ubuntu22']);
   });
 });

--- a/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
+++ b/libs/api/workflows/src/temporal/activities/orchestration-activities.ts
@@ -21,6 +21,7 @@ export interface DagJob extends RuntimeDagJob {
   name: string;
   status: string;
   dependencies: string[];
+  runner: string[];
   version: number;
   steps: Array<{
     id: string;
@@ -64,6 +65,7 @@ export async function loadRunDag(runId: string): Promise<RunDag> {
       name: job.name,
       status: job.status,
       dependencies: job.dependencies,
+      runner: job.runner ?? [],
       version: job.version,
       steps: (stepsByJobId.get(job.id) ?? []).map((s) => ({
         id: s.id,
@@ -143,13 +145,22 @@ export async function enqueueJobForRunner(params: {
   jobId: string;
   runId: string;
   projectId: string;
+  requiredLabels: string[];
 }): Promise<void> {
-  await enqueueJob({
-    workspaceId: params.workspaceId,
-    jobId: params.jobId,
-    runId: params.runId,
-    projectId: params.projectId,
-  });
+  try {
+    await enqueueJob({
+      workspaceId: params.workspaceId,
+      jobId: params.jobId,
+      runId: params.runId,
+      projectId: params.projectId,
+      requiredLabels: params.requiredLabels,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'EmptyRequiredLabelsError') {
+      throw ApplicationFailure.nonRetryable(err.message, err.name);
+    }
+    throw err;
+  }
 }
 
 export async function cancelRunnerJobsActivity(params: {jobIds: string[]}): Promise<void> {

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration-timeout.test.ts
@@ -100,6 +100,7 @@ const defaultJobInput = {
   runId: 'run-1',
   projectId: 'project-1',
   jobVersion: 1,
+  requiredLabels: ['ubuntu22'],
 };
 
 function executeJob(input: typeof defaultJobInput): Promise<{status: string; jobVersion: number}> {

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
@@ -52,6 +52,24 @@ function terminalSetJobCall(jobId: string) {
   );
 }
 
+async function expectEmptyRequiredLabelsFailure(input: typeof defaultJobInput): Promise<void> {
+  let error: unknown;
+
+  try {
+    await executeJob(input);
+  } catch (err) {
+    error = err;
+  }
+
+  expect(error).toMatchObject({
+    cause: expect.objectContaining({
+      message: `Job ${input.jobId} has no required runner labels`,
+      nonRetryable: true,
+      type: 'EmptyRequiredLabelsError',
+    }),
+  });
+}
+
 describe('jobOrchestration', () => {
   test('finished signal (succeeded) flips status and releases the lease', async () => {
     setCfg({
@@ -74,9 +92,11 @@ describe('jobOrchestration', () => {
       jobResults: new Map([['job-empty-labels', 'succeeded']]),
     });
 
-    await expect(
-      executeJob({...defaultJobInput, jobId: 'job-empty-labels', requiredLabels: []}),
-    ).rejects.toThrow();
+    await expectEmptyRequiredLabelsFailure({
+      ...defaultJobInput,
+      jobId: 'job-empty-labels',
+      requiredLabels: [],
+    });
 
     expect(setJobStatusCalls()).toHaveLength(0);
     expect(callsNamed('enqueueJobForRunner')).toHaveLength(0);
@@ -88,9 +108,11 @@ describe('jobOrchestration', () => {
       jobResults: new Map([['job-blank-labels', 'succeeded']]),
     });
 
-    await expect(
-      executeJob({...defaultJobInput, jobId: 'job-blank-labels', requiredLabels: ['  ']}),
-    ).rejects.toThrow();
+    await expectEmptyRequiredLabelsFailure({
+      ...defaultJobInput,
+      jobId: 'job-blank-labels',
+      requiredLabels: ['  '],
+    });
 
     expect(setJobStatusCalls()).toHaveLength(0);
     expect(callsNamed('enqueueJobForRunner')).toHaveLength(0);

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.test.ts
@@ -29,6 +29,7 @@ const defaultJobInput = {
   runId: 'run-1',
   projectId: 'project-1',
   jobVersion: 1,
+  requiredLabels: ['ubuntu22'],
 };
 
 function executeJob(input: typeof defaultJobInput): Promise<{status: string; jobVersion: number}> {
@@ -65,6 +66,34 @@ describe('jobOrchestration', () => {
     expect(callsNamed('releaseLeaseActivity')).toHaveLength(1);
     expect(callsNamed('resolveLeaseExpiredJobActivity')).toHaveLength(0);
     expect(callsNamed('bulkSetStepStatuses')).toHaveLength(0);
+  });
+
+  test('empty required labels fail before the job is marked running', async () => {
+    setCfg({
+      dag: makeDag([dagJob('job-empty-labels', 'build')]),
+      jobResults: new Map([['job-empty-labels', 'succeeded']]),
+    });
+
+    await expect(
+      executeJob({...defaultJobInput, jobId: 'job-empty-labels', requiredLabels: []}),
+    ).rejects.toThrow();
+
+    expect(setJobStatusCalls()).toHaveLength(0);
+    expect(callsNamed('enqueueJobForRunner')).toHaveLength(0);
+  });
+
+  test('whitespace-only required labels fail before the job is marked running', async () => {
+    setCfg({
+      dag: makeDag([dagJob('job-blank-labels', 'build')]),
+      jobResults: new Map([['job-blank-labels', 'succeeded']]),
+    });
+
+    await expect(
+      executeJob({...defaultJobInput, jobId: 'job-blank-labels', requiredLabels: ['  ']}),
+    ).rejects.toThrow();
+
+    expect(setJobStatusCalls()).toHaveLength(0);
+    expect(callsNamed('enqueueJobForRunner')).toHaveLength(0);
   });
 
   test('finished signal (failed) flips status without sweeping steps', async () => {

--- a/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-orchestration.ts
@@ -1,3 +1,4 @@
+import {ApplicationFailure} from '@temporalio/common';
 import {condition, defineSignal, log, proxyActivities, setHandler} from '@temporalio/workflow';
 
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
@@ -54,6 +55,7 @@ export interface JobOrchestrationInput {
   runId: string;
   projectId: string;
   jobVersion: number;
+  requiredLabels: string[];
 }
 
 export interface JobOrchestrationResult {
@@ -81,6 +83,13 @@ async function markJobRunningAndEnqueue(
 ): Promise<
   {kind: 'running'; runningVersion: number} | {kind: 'terminal'; result: JobOrchestrationResult}
 > {
+  if (input.requiredLabels.every((label) => label.trim().length === 0)) {
+    throw ApplicationFailure.nonRetryable(
+      `Job ${input.jobId} has no required runner labels`,
+      'EmptyRequiredLabelsError',
+    );
+  }
+
   const {newVersion: runningVersion, status} = await setJobStatus({
     jobId: input.jobId,
     status: 'running',
@@ -99,6 +108,7 @@ async function markJobRunningAndEnqueue(
     jobId: input.jobId,
     runId: input.runId,
     projectId: input.projectId,
+    requiredLabels: input.requiredLabels,
   });
 
   return {kind: 'running', runningVersion};

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.test.ts
@@ -67,6 +67,7 @@ describe('runOrchestration', () => {
         workspaceId: 'workspace-1',
         projectId: 'project-1',
         runId: 'r1',
+        requiredLabels: ['ubuntu22'],
       });
     }
   });

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -133,6 +133,7 @@ function launchJobs(
             jobId: job.id,
             runId: run.runId,
             jobVersion: jobVersions.get(job.id) ?? job.version,
+            requiredLabels: job.runner,
           },
         ],
         parentClosePolicy: ParentClosePolicy.TERMINATE,

--- a/libs/api/workflows/src/temporal/workflows/test-env.ts
+++ b/libs/api/workflows/src/temporal/workflows/test-env.ts
@@ -93,6 +93,7 @@ export function dagJob(id: string, name: string, deps: string[] = []): RunDag['j
     name,
     status: 'pending',
     dependencies: deps,
+    runner: ['ubuntu22'],
     version: 1,
     steps: [{id: `${id}-step`, name: null, type: 'run', config: {cmd: 'echo'}, position: 0}],
   };
@@ -176,6 +177,7 @@ function createMockActivities() {
       jobId: string;
       runId: string;
       projectId: string;
+      requiredLabels: string[];
     }) => {
       calls.push({name: 'enqueueJobForRunner', params});
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1803,6 +1803,9 @@ importers:
 
   libs/api/runners-dto:
     dependencies:
+      '@shipfox/runner-labels':
+        specifier: workspace:*
+        version: link:../../shared/common/runner-labels
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Adds label-aware runner queue claiming so a runner only receives jobs whose required labels are satisfied by its session labels.

Workflow jobs now carry required labels from the workflow `runner` field into the runner queue. The runners API stores required labels on pending and running jobs, stores the claiming runner labels for audit/debugging, and filters claims with Postgres array containment. Runner label validation now delegates to the shared `@shipfox/runner-labels` package so registration and enqueue paths canonicalize labels consistently.

This also keeps the branch current with the workflow cancellation work from `main` and uses a deploy-safe migration shape for the new non-null array columns: backfill through a temporary default, then drop the default so application writes stay explicit.

Closes ENG-608

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds label-aware job claiming so runners only receive jobs whose required labels are satisfied by their session labels, per ENG-608. Required and runner labels are stored for audit, and claims are filtered in Postgres for accuracy.

- **New Features**
  - Propagate workflow `runner` labels into the queue as required labels; canonicalize and validate via `@shipfox/runner-labels` (empty sets fail non-retryably in Temporal).
  - Filter claims with Postgres array containment so only sessions whose labels cover a job’s required labels can claim; empty session labels return no job.
  - Persist `required_labels` on pending/running jobs and `runner_labels` on running jobs for debugging/audit.
  - API updates: `claimJob`/`claimPendingJob` accept `sessionLabels`; the request-job route passes runner labels; DAG now includes `runner`. Tests assert the specific non-retryable `EmptyRequiredLabelsError`.

- **Migration**
  - Add `required_labels` (pending/running) and `runner_labels` (running) as text[] with a deploy-safe default-then-drop approach.

<sup>Written for commit 834527a30fab8e62c87c5d1e406ba712dd18afff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

