### PR TITLE
[client-workflows] Merge workflow run actions

### DIFF
--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -1,7 +1,7 @@
 import type {RerunMode} from '@shipfox/api-workflows-dto';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import type {WorkflowRunStatus} from '#core/workflow-run.js';
-import {workflowRun} from '#test/fixtures/workflow-run.js';
+import {workflowJobDto, workflowRun, workflowRunDetail} from '#test/fixtures/workflow-run.js';
 import {WorkflowRunSummary} from './workflow-run-summary.js';
 
 const withFrame: Decorator = (Story) => (
@@ -109,12 +109,29 @@ const ACTION_VARIANTS = [
   },
   {
     label: 'Failed',
-    run: workflowRun({status: 'failed', name: 'failed-pipeline'}),
+    run: workflowRunDetail({
+      status: 'failed',
+      name: 'failed-pipeline',
+      jobs: [workflowJobDto({status: 'failed'})],
+    }),
     props: {onRerun: noopRerun},
   },
   {
     label: 'Cancelled',
-    run: workflowRun({status: 'cancelled', name: 'cancelled-pipeline'}),
+    run: workflowRunDetail({
+      status: 'cancelled',
+      name: 'cancelled-pipeline',
+      jobs: [workflowJobDto({status: 'cancelled'})],
+    }),
+    props: {onRerun: noopRerun},
+  },
+  {
+    label: 'Failed without failed jobs',
+    run: workflowRunDetail({
+      status: 'failed',
+      name: 'failed-without-failed-jobs-pipeline',
+      jobs: [workflowJobDto({status: 'succeeded'})],
+    }),
     props: {onRerun: noopRerun},
   },
 ] satisfies Array<{

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -61,21 +61,6 @@ export const SourceOpen: Story = {
   },
 };
 
-export const Cancellable: Story = {
-  args: {
-    run: workflowRun({status: 'running'}),
-    onCancel: noop,
-  },
-};
-
-export const Cancelling: Story = {
-  args: {
-    run: workflowRun({status: 'running'}),
-    cancelling: true,
-    onCancel: noop,
-  },
-};
-
 const ALL_STATUSES: WorkflowRunStatus[] = [
   'pending',
   'running',

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -1,3 +1,4 @@
+import type {RerunMode} from '@shipfox/api-workflows-dto';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import type {WorkflowRunStatus} from '#core/workflow-run.js';
 import {workflowRun} from '#test/fixtures/workflow-run.js';
@@ -31,6 +32,9 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const noop = () => undefined;
+const noopRerun = (_mode: RerunMode) => undefined;
+
 export const Default: Story = {};
 
 export const WithSourceButton: Story = {
@@ -60,15 +64,15 @@ export const SourceOpen: Story = {
 export const Cancellable: Story = {
   args: {
     run: workflowRun({status: 'running'}),
-    canCancel: true,
+    onCancel: noop,
   },
 };
 
 export const Cancelling: Story = {
   args: {
     run: workflowRun({status: 'running'}),
-    canCancel: true,
     cancelling: true,
+    onCancel: noop,
   },
 };
 
@@ -91,6 +95,66 @@ export const Statuses: Story = {
             status,
             name: `${status}-pipeline`,
           })}
+        />
+      ))}
+    </div>
+  ),
+};
+
+const ACTION_VARIANTS = [
+  {
+    label: 'Running',
+    run: workflowRun({status: 'running', name: 'running-pipeline'}),
+    props: {onCancel: noop},
+  },
+  {
+    label: 'Cancelling',
+    run: workflowRun({status: 'running', name: 'cancelling-pipeline'}),
+    props: {cancelling: true, onCancel: noop},
+  },
+  {
+    label: 'Succeeded',
+    run: workflowRun({status: 'succeeded', name: 'succeeded-pipeline'}),
+    props: {onRerun: noopRerun},
+  },
+  {
+    label: 'Re-running',
+    run: workflowRun({status: 'succeeded', name: 'rerun-pending-pipeline'}),
+    props: {rerunPending: true, onRerun: noopRerun},
+  },
+  {
+    label: 'Failed',
+    run: workflowRun({status: 'failed', name: 'failed-pipeline'}),
+    props: {onRerun: noopRerun},
+  },
+  {
+    label: 'Cancelled',
+    run: workflowRun({status: 'cancelled', name: 'cancelled-pipeline'}),
+    props: {onRerun: noopRerun},
+  },
+] satisfies Array<{
+  label: string;
+  run: ReturnType<typeof workflowRun>;
+  props: Pick<
+    Parameters<typeof WorkflowRunSummary>[0],
+    'cancelling' | 'onCancel' | 'rerunPending' | 'onRerun'
+  >;
+}>;
+
+export const ActionVariantsWithSource: Story = {
+  render: () => (
+    <div className="flex flex-col">
+      {ACTION_VARIANTS.map(({label, run, props}, index) => (
+        <WorkflowRunSummary
+          key={label}
+          run={{
+            ...run,
+            id: `22222222-2222-4222-8222-${String(index + 2).padStart(12, '0')}`,
+          }}
+          sourceAvailable
+          sourceOpen={label === 'Running'}
+          sourcePanelId={`workflow-source-panel-${index}`}
+          {...props}
         />
       ))}
     </div>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -1,6 +1,7 @@
 import {fireEvent, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {workflowRun} from '#test/fixtures/workflow-run.js';
+import type {workflowRunDetailDto} from '#test/fixtures/workflow-run.js';
+import {workflowJobDto, workflowRunDetail} from '#test/fixtures/workflow-run.js';
 import {renderProjectPage} from '#test/pages.js';
 import {WorkflowRunSummary} from './workflow-run-summary.js';
 
@@ -225,7 +226,7 @@ describe('WorkflowRunSummary', () => {
   test('shows re-run choices for a failed run', async () => {
     const user = userEvent.setup();
     const onRerun = vi.fn();
-    renderSummary({status: 'failed'}, {onRerun});
+    renderSummary({status: 'failed', jobs: [workflowJobDto({status: 'failed'})]}, {onRerun});
 
     await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
     expect(await screen.findByRole('menuitem', {name: 'Re-run all jobs'})).toBeInTheDocument();
@@ -237,20 +238,31 @@ describe('WorkflowRunSummary', () => {
   test('shows re-run choices for a cancelled run', async () => {
     const user = userEvent.setup();
     const onRerun = vi.fn();
-    renderSummary({status: 'cancelled'}, {onRerun});
+    renderSummary({status: 'cancelled', jobs: [workflowJobDto({status: 'cancelled'})]}, {onRerun});
 
     await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
 
     expect(await screen.findByRole('menuitem', {name: 'Re-run all jobs'})).toBeInTheDocument();
     expect(screen.getByRole('menuitem', {name: 'Re-run failed jobs'})).toBeInTheDocument();
   });
+
+  test('re-runs the full workflow when a failed run has no failed jobs', async () => {
+    const user = userEvent.setup();
+    const onRerun = vi.fn();
+    renderSummary({status: 'failed', jobs: [workflowJobDto({status: 'succeeded'})]}, {onRerun});
+
+    await user.click(await screen.findByRole('button', {name: 'Re-run workflow'}));
+
+    expect(screen.queryByRole('button', {name: 'Re-run jobs'})).not.toBeInTheDocument();
+    expect(onRerun).toHaveBeenCalledWith('all');
+  });
 });
 
 function renderSummary(
-  overrides: Parameters<typeof workflowRun>[0] = {},
+  overrides: Parameters<typeof workflowRunDetailDto>[0] = {},
   props: Omit<Parameters<typeof WorkflowRunSummary>[0], 'run'> = {},
 ) {
-  const run = workflowRun({
+  const run = workflowRunDetail({
     id: RUN_ID,
     project_id: '44444444-4444-4444-8444-444444444444',
     definition_id: '55555555-5555-4555-8555-555555555555',

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -184,6 +184,50 @@ describe('WorkflowRunSummary', () => {
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
+
+  test('prefers the cancel action for non-terminal runs', async () => {
+    const onCancel = vi.fn();
+    const onRerun = vi.fn();
+    renderSummary({status: 'running'}, {canCancel: true, onCancel, canRerun: true, onRerun});
+
+    await screen.findByRole('button', {name: 'Cancel workflow'});
+
+    expect(screen.queryByRole('button', {name: 'Re-run all jobs'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Re-run jobs'})).not.toBeInTheDocument();
+  });
+
+  test('re-runs all jobs from a succeeded run', async () => {
+    const user = userEvent.setup();
+    const onRerun = vi.fn();
+    renderSummary({status: 'succeeded'}, {canRerun: true, onRerun});
+
+    await user.click(await screen.findByRole('button', {name: 'Re-run all jobs'}));
+
+    expect(onRerun).toHaveBeenCalledWith('all');
+  });
+
+  test('shows re-run choices for a failed run', async () => {
+    const user = userEvent.setup();
+    const onRerun = vi.fn();
+    renderSummary({status: 'failed'}, {canRerun: true, onRerun});
+
+    await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
+    expect(await screen.findByRole('menuitem', {name: 'Re-run all jobs'})).toBeInTheDocument();
+    await user.click(await screen.findByRole('menuitem', {name: 'Re-run failed jobs'}));
+
+    expect(onRerun).toHaveBeenCalledWith('failed');
+  });
+
+  test('shows re-run choices for a cancelled run', async () => {
+    const user = userEvent.setup();
+    const onRerun = vi.fn();
+    renderSummary({status: 'cancelled'}, {canRerun: true, onRerun});
+
+    await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
+
+    expect(await screen.findByRole('menuitem', {name: 'Re-run all jobs'})).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', {name: 'Re-run failed jobs'})).toBeInTheDocument();
+  });
 });
 
 function renderSummary(

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -143,7 +143,7 @@ describe('WorkflowRunSummary', () => {
       },
     );
 
-    const sourceButton = await screen.findByRole('button', {name: 'Source'});
+    const sourceButton = await screen.findByRole('button', {name: 'View source'});
     await user.click(sourceButton);
 
     expect(sourceButton).toHaveAttribute('aria-controls', 'workflow-source-panel');
@@ -156,7 +156,7 @@ describe('WorkflowRunSummary', () => {
 
     await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(screen.queryByRole('button', {name: 'Source'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View source'})).not.toBeInTheDocument();
   });
 
   test('shows the cancel action when the run can be cancelled', async () => {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -200,7 +200,7 @@ describe('WorkflowRunSummary', () => {
 
     await screen.findByRole('button', {name: 'Cancel workflow'});
 
-    expect(screen.queryByRole('button', {name: 'Re-run all jobs'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Re-run workflow'})).not.toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Re-run jobs'})).not.toBeInTheDocument();
   });
 
@@ -209,7 +209,7 @@ describe('WorkflowRunSummary', () => {
     const onRerun = vi.fn();
     renderSummary({status: 'succeeded'}, {onRerun});
 
-    await user.click(await screen.findByRole('button', {name: 'Re-run all jobs'}));
+    await user.click(await screen.findByRole('button', {name: 'Re-run workflow'}));
 
     expect(onRerun).toHaveBeenCalledWith('all');
   });
@@ -219,7 +219,7 @@ describe('WorkflowRunSummary', () => {
 
     await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(screen.queryByRole('button', {name: 'Re-run all jobs'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Re-run workflow'})).not.toBeInTheDocument();
   });
 
   test('shows re-run choices for a failed run', async () => {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -162,15 +162,15 @@ describe('WorkflowRunSummary', () => {
   test('shows the cancel action when the run can be cancelled', async () => {
     const user = userEvent.setup();
     const onCancel = vi.fn();
-    renderSummary({}, {canCancel: true, onCancel});
+    renderSummary({}, {onCancel});
 
     await user.click(await screen.findByRole('button', {name: 'Cancel workflow'}));
 
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  test('omits the cancel action when the run cannot be cancelled', async () => {
-    renderSummary({status: 'succeeded'}, {canCancel: false});
+  test('omits the cancel action for terminal runs', async () => {
+    renderSummary({status: 'succeeded'});
 
     await screen.findByRole('region', {name: 'deploy-web'});
 
@@ -178,17 +178,17 @@ describe('WorkflowRunSummary', () => {
   });
 
   test('disables the cancel action while cancellation is pending', async () => {
-    renderSummary({}, {canCancel: true, cancelling: true, onCancel: vi.fn()});
+    renderSummary({}, {cancelling: true, onCancel: vi.fn()});
 
     const button = await screen.findByRole('button', {name: 'Cancel workflow'});
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
-  test('prefers the cancel action for non-terminal runs', async () => {
+  test('derives the cancel action for non-terminal runs', async () => {
     const onCancel = vi.fn();
     const onRerun = vi.fn();
-    renderSummary({status: 'running'}, {canCancel: true, onCancel, canRerun: true, onRerun});
+    renderSummary({status: 'running'}, {onCancel, onRerun});
 
     await screen.findByRole('button', {name: 'Cancel workflow'});
 
@@ -199,7 +199,7 @@ describe('WorkflowRunSummary', () => {
   test('re-runs all jobs from a succeeded run', async () => {
     const user = userEvent.setup();
     const onRerun = vi.fn();
-    renderSummary({status: 'succeeded'}, {canRerun: true, onRerun});
+    renderSummary({status: 'succeeded'}, {onRerun});
 
     await user.click(await screen.findByRole('button', {name: 'Re-run all jobs'}));
 
@@ -209,7 +209,7 @@ describe('WorkflowRunSummary', () => {
   test('shows re-run choices for a failed run', async () => {
     const user = userEvent.setup();
     const onRerun = vi.fn();
-    renderSummary({status: 'failed'}, {canRerun: true, onRerun});
+    renderSummary({status: 'failed'}, {onRerun});
 
     await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
     expect(await screen.findByRole('menuitem', {name: 'Re-run all jobs'})).toBeInTheDocument();
@@ -221,7 +221,7 @@ describe('WorkflowRunSummary', () => {
   test('shows re-run choices for a cancelled run', async () => {
     const user = userEvent.setup();
     const onRerun = vi.fn();
-    renderSummary({status: 'cancelled'}, {canRerun: true, onRerun});
+    renderSummary({status: 'cancelled'}, {onRerun});
 
     await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
 

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -185,6 +185,14 @@ describe('WorkflowRunSummary', () => {
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
+  test('hides the cancel action when no cancel handler is provided', async () => {
+    renderSummary({status: 'running'});
+
+    await screen.findByRole('region', {name: 'deploy-web'});
+
+    expect(screen.queryByRole('button', {name: 'Cancel workflow'})).not.toBeInTheDocument();
+  });
+
   test('derives the cancel action for non-terminal runs', async () => {
     const onCancel = vi.fn();
     const onRerun = vi.fn();
@@ -204,6 +212,14 @@ describe('WorkflowRunSummary', () => {
     await user.click(await screen.findByRole('button', {name: 'Re-run all jobs'}));
 
     expect(onRerun).toHaveBeenCalledWith('all');
+  });
+
+  test('hides the re-run action when no re-run handler is provided', async () => {
+    renderSummary({status: 'succeeded'});
+
+    await screen.findByRole('region', {name: 'deploy-web'});
+
+    expect(screen.queryByRole('button', {name: 'Re-run all jobs'})).not.toBeInTheDocument();
   });
 
   test('shows re-run choices for a failed run', async () => {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -173,6 +173,8 @@ function WorkflowRunActionSlot({
   onRerun?: ((mode: RerunMode) => void) | undefined;
 }) {
   if (action === 'cancel') {
+    if (!onCancel) return null;
+
     return (
       <Button
         type="button"
@@ -180,7 +182,7 @@ function WorkflowRunActionSlot({
         size="xs"
         iconLeft="close"
         isLoading={cancelling}
-        disabled={cancelling || onCancel === undefined}
+        disabled={cancelling}
         onClick={onCancel}
       >
         Cancel workflow
@@ -189,6 +191,8 @@ function WorkflowRunActionSlot({
   }
 
   if (action === 'rerun-all') {
+    if (!onRerun) return null;
+
     return (
       <Button
         type="button"
@@ -196,13 +200,15 @@ function WorkflowRunActionSlot({
         size="xs"
         iconLeft="restartLine"
         isLoading={rerunPending}
-        disabled={rerunPending || onRerun === undefined}
-        onClick={() => onRerun?.('all')}
+        disabled={rerunPending}
+        onClick={() => onRerun('all')}
       >
         Re-run all jobs
       </Button>
     );
   }
+
+  if (!onRerun) return null;
 
   return (
     <DropdownMenu>
@@ -214,16 +220,16 @@ function WorkflowRunActionSlot({
           iconLeft="restartLine"
           iconRight="arrowDownSLine"
           isLoading={rerunPending}
-          disabled={rerunPending || onRerun === undefined}
+          disabled={rerunPending}
         >
           Re-run jobs
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun?.('all')}>
+        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun('all')}>
           Re-run all jobs
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun?.('failed')}>
+        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun('failed')}>
           Re-run failed jobs
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -19,7 +19,11 @@ import {
 } from '@shipfox/react-ui';
 import type {Ref} from 'react';
 import {useId} from 'react';
-import {WORKFLOW_RUN_STATUSES, type WorkflowRun} from '#core/workflow-run.js';
+import {
+  isWorkflowRunTerminal,
+  WORKFLOW_RUN_STATUSES,
+  type WorkflowRun,
+} from '#core/workflow-run.js';
 import {Identifier} from '../identifier/index.js';
 import {getWorkflowStatusVisual} from '../workflow-status/status-visuals.js';
 
@@ -38,7 +42,6 @@ export interface WorkflowRunSummaryProps {
   cancelling?: boolean | undefined;
   onCancel?: (() => void) | undefined;
   canRerun?: boolean | undefined;
-  hasFailedJobs?: boolean | undefined;
   rerunPending?: boolean | undefined;
   onRerun?: ((mode: RerunMode) => void) | undefined;
 }
@@ -54,7 +57,6 @@ export function WorkflowRunSummary({
   cancelling = false,
   onCancel,
   canRerun = false,
-  hasFailedJobs = false,
   rerunPending = false,
   onRerun,
 }: WorkflowRunSummaryProps) {
@@ -96,22 +98,12 @@ export function WorkflowRunSummary({
 
         {sourceAvailable || canCancel || canRerun ? (
           <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end">
-            {canCancel ? (
-              <Button
-                type="button"
-                variant="danger"
-                size="xs"
-                iconLeft="close"
-                isLoading={cancelling}
-                disabled={cancelling || !onCancel}
-                onClick={onCancel}
-              >
-                Cancel workflow
-              </Button>
-            ) : null}
             <WorkflowRunActionSlot
+              run={run}
+              canCancel={canCancel}
+              cancelling={cancelling}
+              onCancel={onCancel}
               canRerun={canRerun}
-              hasFailedJobs={hasFailedJobs}
               rerunPending={rerunPending}
               onRerun={onRerun}
             />
@@ -178,19 +170,43 @@ export function WorkflowRunSummary({
 }
 
 function WorkflowRunActionSlot({
+  run,
+  canCancel,
+  cancelling,
+  onCancel,
   canRerun,
-  hasFailedJobs,
   rerunPending,
   onRerun,
 }: {
+  run: WorkflowRun;
+  canCancel: boolean;
+  cancelling: boolean;
+  onCancel?: (() => void) | undefined;
   canRerun: boolean;
-  hasFailedJobs: boolean;
   rerunPending: boolean;
   onRerun?: ((mode: RerunMode) => void) | undefined;
 }) {
+  if (!isWorkflowRunTerminal(run.status)) {
+    if (!canCancel) return null;
+
+    return (
+      <Button
+        type="button"
+        variant="danger"
+        size="xs"
+        iconLeft="close"
+        isLoading={cancelling}
+        disabled={cancelling || !onCancel}
+        onClick={onCancel}
+      >
+        Cancel workflow
+      </Button>
+    );
+  }
+
   if (!canRerun || !onRerun) return null;
 
-  if (!hasFailedJobs) {
+  if (run.status === 'succeeded') {
     return (
       <Button
         type="button"
@@ -224,7 +240,7 @@ function WorkflowRunActionSlot({
           Re-run all jobs
         </DropdownMenuItem>
         <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun('failed')}>
-          Re-run failed or cancelled jobs
+          Re-run failed jobs
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -203,7 +203,7 @@ function WorkflowRunActionSlot({
         disabled={rerunPending}
         onClick={() => onRerun('all')}
       >
-        Re-run all jobs
+        Re-run workflow
       </Button>
     );
   }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -31,6 +31,8 @@ const STATUS_BADGE_LABEL_WIDTH_CH = Math.max(
   ...WORKFLOW_RUN_STATUSES.map((status) => getWorkflowStatusVisual(status).label.length),
 );
 
+type WorkflowRunAction = 'cancel' | 'rerun-all' | 'rerun-menu';
+
 export interface WorkflowRunSummaryProps {
   run: WorkflowRun;
   sourceAvailable?: boolean | undefined;
@@ -38,10 +40,8 @@ export interface WorkflowRunSummaryProps {
   sourcePanelId?: string | undefined;
   sourceButtonRef?: Ref<HTMLButtonElement> | undefined;
   onSourceToggle?: (() => void) | undefined;
-  canCancel?: boolean | undefined;
   cancelling?: boolean | undefined;
   onCancel?: (() => void) | undefined;
-  canRerun?: boolean | undefined;
   rerunPending?: boolean | undefined;
   onRerun?: ((mode: RerunMode) => void) | undefined;
 }
@@ -53,15 +53,14 @@ export function WorkflowRunSummary({
   sourcePanelId,
   sourceButtonRef,
   onSourceToggle,
-  canCancel = false,
   cancelling = false,
   onCancel,
-  canRerun = false,
   rerunPending = false,
   onRerun,
 }: WorkflowRunSummaryProps) {
   const headingId = useId();
   const status = getWorkflowStatusVisual(run.status);
+  const action = workflowRunActionForStatus(run.status);
   const {ref: headingTextRef, isTruncated: isHeadingTruncated} =
     useIsTextTruncated<HTMLSpanElement>(run.name);
 
@@ -96,37 +95,33 @@ export function WorkflowRunSummary({
           </Tooltip>
         </div>
 
-        {sourceAvailable || canCancel || canRerun ? (
-          <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end">
-            <WorkflowRunActionSlot
-              run={run}
-              canCancel={canCancel}
-              cancelling={cancelling}
-              onCancel={onCancel}
-              canRerun={canRerun}
-              rerunPending={rerunPending}
-              onRerun={onRerun}
-            />
-            {sourceAvailable ? (
-              <Button
-                ref={sourceButtonRef}
-                type="button"
-                variant="transparentMuted"
-                size="xs"
-                iconLeft="fileCodeLine"
-                aria-controls={sourcePanelId}
-                aria-expanded={sourceOpen}
-                className={cn(
-                  'text-foreground-neutral-subtle',
-                  sourceOpen && 'bg-background-components-hover text-foreground-neutral-base',
-                )}
-                onClick={onSourceToggle}
-              >
-                Source
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
+        <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end">
+          <WorkflowRunActionSlot
+            action={action}
+            cancelling={cancelling}
+            onCancel={onCancel}
+            rerunPending={rerunPending}
+            onRerun={onRerun}
+          />
+          {sourceAvailable ? (
+            <Button
+              ref={sourceButtonRef}
+              type="button"
+              variant="transparentMuted"
+              size="xs"
+              iconLeft="fileCodeLine"
+              aria-controls={sourcePanelId}
+              aria-expanded={sourceOpen}
+              className={cn(
+                'text-foreground-neutral-subtle',
+                sourceOpen && 'bg-background-components-hover text-foreground-neutral-base',
+              )}
+              onClick={onSourceToggle}
+            >
+              Source
+            </Button>
+          ) : null}
+        </div>
 
         <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-8 overflow-hidden text-foreground-neutral-muted">
           <Identifier display={run.shortId} value={run.id} label="run id" />
@@ -170,25 +165,19 @@ export function WorkflowRunSummary({
 }
 
 function WorkflowRunActionSlot({
-  run,
-  canCancel,
+  action,
   cancelling,
   onCancel,
-  canRerun,
   rerunPending,
   onRerun,
 }: {
-  run: WorkflowRun;
-  canCancel: boolean;
+  action: WorkflowRunAction;
   cancelling: boolean;
   onCancel?: (() => void) | undefined;
-  canRerun: boolean;
   rerunPending: boolean;
   onRerun?: ((mode: RerunMode) => void) | undefined;
 }) {
-  if (!isWorkflowRunTerminal(run.status)) {
-    if (!canCancel) return null;
-
+  if (action === 'cancel') {
     return (
       <Button
         type="button"
@@ -196,7 +185,7 @@ function WorkflowRunActionSlot({
         size="xs"
         iconLeft="close"
         isLoading={cancelling}
-        disabled={cancelling || !onCancel}
+        disabled={cancelling || onCancel === undefined}
         onClick={onCancel}
       >
         Cancel workflow
@@ -204,9 +193,7 @@ function WorkflowRunActionSlot({
     );
   }
 
-  if (!canRerun || !onRerun) return null;
-
-  if (run.status === 'succeeded') {
+  if (action === 'rerun-all') {
     return (
       <Button
         type="button"
@@ -214,7 +201,8 @@ function WorkflowRunActionSlot({
         size="xs"
         iconLeft="restartLine"
         isLoading={rerunPending}
-        onClick={() => onRerun('all')}
+        disabled={rerunPending || onRerun === undefined}
+        onClick={() => onRerun?.('all')}
       >
         Re-run all jobs
       </Button>
@@ -231,20 +219,27 @@ function WorkflowRunActionSlot({
           iconLeft="restartLine"
           iconRight="arrowDownSLine"
           isLoading={rerunPending}
+          disabled={rerunPending || onRerun === undefined}
         >
           Re-run jobs
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun('all')}>
+        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun?.('all')}>
           Re-run all jobs
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun('failed')}>
+        <DropdownMenuItem disabled={rerunPending} onSelect={() => onRerun?.('failed')}>
           Re-run failed jobs
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+function workflowRunActionForStatus(status: WorkflowRun['status']): WorkflowRunAction {
+  if (!isWorkflowRunTerminal(status)) return 'cancel';
+  if (status === 'succeeded') return 'rerun-all';
+  return 'rerun-menu';
 }
 
 function MetadataSeparator() {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -21,6 +21,7 @@ import {useId} from 'react';
 import {
   isWorkflowRunTerminal,
   WORKFLOW_RUN_STATUSES,
+  type WorkflowJob,
   type WorkflowRun,
 } from '#core/workflow-run.js';
 import {Identifier} from '../identifier/index.js';
@@ -59,7 +60,7 @@ export function WorkflowRunSummary({
 }: WorkflowRunSummaryProps) {
   const headingId = useId();
   const status = getWorkflowStatusVisual(run.status);
-  const action = workflowRunActionForStatus(run.status);
+  const action = workflowRunActionForRun(run);
   const {ref: headingTextRef, isTruncated: isHeadingTruncated} =
     useIsTextTruncated<HTMLSpanElement>(run.name);
 
@@ -233,10 +234,20 @@ function WorkflowRunActionSlot({
   );
 }
 
-function workflowRunActionForStatus(status: WorkflowRun['status']): WorkflowRunAction {
-  if (!isWorkflowRunTerminal(status)) return 'cancel';
-  if (status === 'succeeded') return 'rerun-all';
+function workflowRunActionForRun(run: WorkflowRun): WorkflowRunAction {
+  if (!isWorkflowRunTerminal(run.status)) return 'cancel';
+  if (run.status === 'succeeded' || !hasFailedOrCancelledJobs(run)) return 'rerun-all';
   return 'rerun-menu';
+}
+
+function hasFailedOrCancelledJobs(run: WorkflowRun): boolean {
+  if (!workflowRunHasJobs(run)) return false;
+
+  return run.jobs.some((job) => job.status === 'failed' || job.status === 'cancelled');
+}
+
+function workflowRunHasJobs(run: WorkflowRun): run is WorkflowRun & {jobs: WorkflowJob[]} {
+  return 'jobs' in run && Array.isArray(run.jobs);
 }
 
 function MetadataSeparator() {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -113,7 +113,7 @@ export function WorkflowRunSummary({
               aria-expanded={sourceOpen}
               onClick={onSourceToggle}
             >
-              Source
+              View source
             </Button>
           ) : null}
         </div>

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -4,7 +4,6 @@ import {
   Badge,
   Button,
   Code,
-  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -107,15 +106,11 @@ export function WorkflowRunSummary({
             <Button
               ref={sourceButtonRef}
               type="button"
-              variant="transparentMuted"
+              variant="secondary"
               size="xs"
               iconLeft="fileCodeLine"
               aria-controls={sourcePanelId}
               aria-expanded={sourceOpen}
-              className={cn(
-                'text-foreground-neutral-subtle',
-                sourceOpen && 'bg-background-components-hover text-foreground-neutral-base',
-              )}
               onClick={onSourceToggle}
             >
               Source

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -108,7 +108,6 @@ export function WorkflowRunSummary({
               type="button"
               variant="secondary"
               size="xs"
-              iconLeft="fileCodeLine"
               aria-controls={sourcePanelId}
               aria-expanded={sourceOpen}
               onClick={onSourceToggle}
@@ -180,7 +179,6 @@ function WorkflowRunActionSlot({
         type="button"
         variant="danger"
         size="xs"
-        iconLeft="close"
         isLoading={cancelling}
         disabled={cancelling}
         onClick={onCancel}
@@ -198,7 +196,6 @@ function WorkflowRunActionSlot({
         type="button"
         variant="secondary"
         size="xs"
-        iconLeft="restartLine"
         isLoading={rerunPending}
         disabled={rerunPending}
         onClick={() => onRerun('all')}
@@ -217,7 +214,6 @@ function WorkflowRunActionSlot({
           type="button"
           variant="secondary"
           size="xs"
-          iconLeft="restartLine"
           iconRight="arrowDownSLine"
           isLoading={rerunPending}
           disabled={rerunPending}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -326,7 +326,7 @@ describe('WorkflowRunView', () => {
     );
   });
 
-  test('re-runs failed or cancelled jobs from the dropdown', async () => {
+  test('re-runs failed jobs from the dropdown', async () => {
     const user = userEvent.setup();
     const postBodies: unknown[] = [];
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
@@ -361,9 +361,7 @@ describe('WorkflowRunView', () => {
 
     renderView();
     await user.click(await screen.findByRole('button', {name: 'Re-run jobs'}));
-    await user.click(
-      await screen.findByRole('menuitem', {name: 'Re-run failed or cancelled jobs'}),
-    );
+    await user.click(await screen.findByRole('menuitem', {name: 'Re-run failed jobs'}));
 
     const postRequest = await findRequest(fetchImpl, 'POST', `/workflows/runs/${RUN_ID}/rerun`);
     expect(postRequest).toBeDefined();

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -204,7 +204,7 @@ describe('WorkflowRunView', () => {
     await user.click(deployNode);
     expect(deployNode).toHaveAttribute('aria-pressed', 'true');
 
-    const sourceButton = screen.getByRole('button', {name: 'Source'});
+    const sourceButton = screen.getByRole('button', {name: 'View source'});
     const panelId = sourceButton.getAttribute('aria-controls');
     expect(panelId).toBeTruthy();
     expect(sourceButton).toHaveAttribute('aria-expanded', 'false');
@@ -261,7 +261,7 @@ describe('WorkflowRunView', () => {
     });
 
     renderView({selection: {stepId}});
-    await user.click(await screen.findByRole('button', {name: 'Source'}));
+    await user.click(await screen.findByRole('button', {name: 'View source'}));
 
     await screen.findByRole('dialog', {name: 'Workflow source'});
     const highlightedLines = document.body.querySelectorAll('.line.highlighted-line');
@@ -281,7 +281,7 @@ describe('WorkflowRunView', () => {
 
     await screen.findByRole('region', {name: 'deploy-web'});
 
-    expect(screen.queryByRole('button', {name: 'Source'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View source'})).not.toBeInTheDocument();
   });
 
   test('re-runs all jobs from a succeeded run and navigates to the new run', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -313,7 +313,7 @@ describe('WorkflowRunView', () => {
     configureApiClient({fetchImpl: fetchImpl as typeof fetch});
 
     const {router} = renderView();
-    await user.click(await screen.findByRole('button', {name: 'Re-run all jobs'}));
+    await user.click(await screen.findByRole('button', {name: 'Re-run workflow'}));
 
     const postRequest = await findRequest(fetchImpl, 'POST', `/workflows/runs/${RUN_ID}/rerun`);
     expect(postRequest).toBeDefined();
@@ -384,7 +384,7 @@ describe('WorkflowRunView', () => {
     configureApiClient({fetchImpl: fetchImpl as typeof fetch});
 
     renderView();
-    await user.click(await screen.findByRole('button', {name: 'Re-run all jobs'}));
+    await user.click(await screen.findByRole('button', {name: 'Re-run workflow'}));
 
     await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('Run has no failed jobs'));
   });

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -4,7 +4,7 @@ import {QueryLoadError} from '@shipfox/client-ui';
 import {EmptyState, RelativeTimeProvider, toast} from '@shipfox/react-ui';
 import {useNavigate} from '@tanstack/react-router';
 import {useEffect, useId, useRef, useState} from 'react';
-import {isWorkflowRunTerminal, type WorkflowJob} from '#core/workflow-run.js';
+import type {WorkflowJob} from '#core/workflow-run.js';
 import {
   type WorkflowRunSelectionInput,
   withoutWorkflowRunSelectionSearch,
@@ -120,8 +120,6 @@ function RunViewContent({
     : undefined;
   const highlightedLineRange = resolvedSelection?.step?.sourceLocation ?? null;
   const sourceSnapshot = runData.sourceSnapshot;
-  const canRerun = isWorkflowRunTerminal(runData.status);
-
   async function rerun(mode: RerunMode) {
     try {
       const run = await rerunMutation.mutateAsync({runId: runData.id, mode});
@@ -189,10 +187,8 @@ function RunViewContent({
           sourcePanelId={sourcePanelId}
           sourceButtonRef={sourceButtonRef}
           onSourceToggle={() => setSourcePanelOpen((open) => !open)}
-          canCancel={!isWorkflowRunTerminal(runData.status)}
           cancelling={cancelMutation.isPending}
           onCancel={cancelRun}
-          canRerun={canRerun}
           rerunPending={rerunMutation.isPending}
           onRerun={(mode) => void rerun(mode)}
         />

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -120,9 +120,6 @@ function RunViewContent({
     : undefined;
   const highlightedLineRange = resolvedSelection?.step?.sourceLocation ?? null;
   const sourceSnapshot = runData.sourceSnapshot;
-  const hasFailedJobs = runData.jobs.some(
-    (job) => job.status === 'failed' || job.status === 'cancelled',
-  );
   const canRerun = isWorkflowRunTerminal(runData.status);
 
   async function rerun(mode: RerunMode) {
@@ -196,7 +193,6 @@ function RunViewContent({
           cancelling={cancelMutation.isPending}
           onCancel={cancelRun}
           canRerun={canRerun}
-          hasFailedJobs={hasFailedJobs}
           rerunPending={rerunMutation.isPending}
           onRerun={(mode) => void rerun(mode)}
         />


### PR DESCRIPTION
Merge the workflow run summary's cancel and re-run controls into a single state-derived action slot.

The run header now derives its primary action from `run.status` instead of accepting independent `canCancel` and `canRerun` booleans. Active runs show `Cancel workflow`, successful runs show `Re-run all jobs`, and failed or cancelled runs expose `Re-run all jobs` plus `Re-run failed jobs` from the dropdown.

Adds Storybook coverage for the action area with each button state shown alongside the Source action, so visual review catches drift across cancel, pending cancel, re-run, pending re-run, and dropdown-trigger variants.

No changeset is included because `@shipfox/client-workflows` is private.