### PR TITLE
[api/runners] Add ephemeral registration tokens

### DIFF
--- a/libs/api/auth-dto/src/schemas/runner-session-token.ts
+++ b/libs/api/auth-dto/src/schemas/runner-session-token.ts
@@ -12,6 +12,7 @@ export const runnerSessionTokenClaimsSchema = z.object({
   workspaceId: z.string().uuid(),
   scope: z.literal('workspace'),
   labels: z.array(z.string()).min(1),
+  maxClaims: z.number().int().positive().nullable(),
   aud: z.literal(RUNNER_SESSION_TOKEN_AUDIENCE),
   iat: z.number().int(),
   exp: z.number().int(),

--- a/libs/api/auth/src/core/runner-session-token.test.ts
+++ b/libs/api/auth/src/core/runner-session-token.test.ts
@@ -12,6 +12,7 @@ function claims() {
     workspaceId: crypto.randomUUID(),
     scope: 'workspace' as const,
     labels: ['linux', 'x64'],
+    maxClaims: null,
   };
 }
 
@@ -27,6 +28,7 @@ describe('runner-session-token', () => {
     expect(verified?.workspaceId).toBe(input.workspaceId);
     expect(verified?.scope).toBe(input.scope);
     expect(verified?.labels).toEqual(input.labels);
+    expect(verified?.maxClaims).toBeNull();
     expect(verified?.aud).toBe(RUNNER_SESSION_TOKEN_AUDIENCE);
     expect(verified?.iat).toBeTypeOf('number');
     expect(verified?.exp).toBeGreaterThan(verified?.iat ?? 0);

--- a/libs/api/auth/src/core/runner-session-token.ts
+++ b/libs/api/auth/src/core/runner-session-token.ts
@@ -19,6 +19,7 @@ export async function issueRunnerSessionToken(
       workspaceId: claims.workspaceId,
       scope: claims.scope,
       labels: claims.labels,
+      maxClaims: claims.maxClaims,
     },
     secret: config.AUTH_RUNNER_SESSION_TOKEN_SECRET,
     expiresIn: config.AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN,

--- a/libs/api/auth/src/presentation/auth/runner-session-auth.test.ts
+++ b/libs/api/auth/src/presentation/auth/runner-session-auth.test.ts
@@ -35,6 +35,7 @@ describe('runner-session-auth', () => {
       workspaceId: crypto.randomUUID(),
       scope: 'workspace' as const,
       labels: ['linux', 'x64'],
+      maxClaims: null,
     };
     const token = await issueRunnerSessionToken(claims);
 

--- a/libs/api/runners/drizzle/0001_runner_tokens.sql
+++ b/libs/api/runners/drizzle/0001_runner_tokens.sql
@@ -1,5 +1,7 @@
 CREATE TYPE "public"."runners_runner_session_scope" AS ENUM('workspace');
 --> statement-breakpoint
+CREATE TYPE "public"."runners_runner_session_registration_token_kind" AS ENUM('manual', 'ephemeral');
+--> statement-breakpoint
 CREATE TABLE "runners_runner_tokens" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
@@ -12,20 +14,41 @@ CREATE TABLE "runners_runner_tokens" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "runners_ephemeral_registration_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"provisioner_id" uuid NOT NULL,
+	"reservation_id" uuid,
+	"resource_id" text NOT NULL,
+	"hashed_token" text NOT NULL,
+	"prefix" text NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"consumed_at" timestamp with time zone,
+	"consumed_session_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "runners_runner_sessions" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"workspace_id" uuid NOT NULL,
 	"scope" "runners_runner_session_scope" DEFAULT 'workspace' NOT NULL,
 	"registration_token_id" uuid NOT NULL,
+	"registration_token_kind" "runners_runner_session_registration_token_kind" NOT NULL,
 	"labels" text[] NOT NULL,
+	"max_claims" integer,
+	"claims_used" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND ("runners_runner_sessions"."max_claims" IS NULL OR ("runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims")))
 );
 --> statement-breakpoint
 ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_session_id" uuid DEFAULT uuidv7() NOT NULL;--> statement-breakpoint
 ALTER TABLE "runners_running_jobs" DROP COLUMN "runner_token";--> statement-breakpoint
 ALTER TABLE "runners_running_jobs" ALTER COLUMN "runner_session_id" DROP DEFAULT;--> statement-breakpoint
 CREATE INDEX "runners_pending_jobs_workspace_created_idx" ON "runners_pending_jobs" USING btree ("workspace_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "runners_ephemeral_registration_tokens_hashed_token_unique" ON "runners_ephemeral_registration_tokens" USING btree ("hashed_token");--> statement-breakpoint
+CREATE INDEX "runners_ephemeral_registration_tokens_workspace_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("workspace_id");--> statement-breakpoint
+CREATE INDEX "runners_ephemeral_registration_tokens_provisioner_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("provisioner_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_tokens_hashed_token_unique" ON "runners_runner_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_runner_tokens_workspace_id_idx" ON "runners_runner_tokens" USING btree ("workspace_id");--> statement-breakpoint
 CREATE INDEX "runners_runner_tokens_active_lookup_idx" ON "runners_runner_tokens" USING btree ("hashed_token","revoked_at","expires_at");

--- a/libs/api/runners/drizzle/0001_runner_tokens.sql
+++ b/libs/api/runners/drizzle/0001_runner_tokens.sql
@@ -39,7 +39,7 @@ CREATE TABLE "runners_runner_sessions" (
 	"claims_used" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND ("runners_runner_sessions"."max_claims" IS NULL OR ("runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims")))
+	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND (("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."max_claims" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."max_claims" IS NOT NULL AND "runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims")))
 );
 --> statement-breakpoint
 ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_session_id" uuid DEFAULT uuidv7() NOT NULL;--> statement-breakpoint
@@ -49,6 +49,7 @@ CREATE INDEX "runners_pending_jobs_workspace_created_idx" ON "runners_pending_jo
 CREATE UNIQUE INDEX "runners_ephemeral_registration_tokens_hashed_token_unique" ON "runners_ephemeral_registration_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_ephemeral_registration_tokens_workspace_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("workspace_id");--> statement-breakpoint
 CREATE INDEX "runners_ephemeral_registration_tokens_provisioner_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("provisioner_id");--> statement-breakpoint
+CREATE INDEX "runners_ephemeral_registration_tokens_active_resource_idx" ON "runners_ephemeral_registration_tokens" USING btree ("workspace_id","provisioner_id","resource_id","consumed_at","expires_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_runner_tokens_hashed_token_unique" ON "runners_runner_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_runner_tokens_workspace_id_idx" ON "runners_runner_tokens" USING btree ("workspace_id");--> statement-breakpoint
 CREATE INDEX "runners_runner_tokens_active_lookup_idx" ON "runners_runner_tokens" USING btree ("hashed_token","revoked_at","expires_at");

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -122,6 +122,45 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "runners_ephemeral_registration_tokens_active_resource_idx": {
+          "name": "runners_ephemeral_registration_tokens_active_resource_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {},
@@ -427,7 +466,7 @@
       "checkConstraints": {
         "runners_runner_sessions_claims_ck": {
           "name": "runners_runner_sessions_claims_ck",
-          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND (\"runners_runner_sessions\".\"max_claims\" IS NULL OR (\"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
         }
       },
       "isRLSEnabled": false

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -1,9 +1,136 @@
 {
-  "id": "fff3e821-10b9-41e7-971c-701202da0b7b",
+  "id": "75800393-dde2-4b8e-9490-28a091c8f188",
   "prevId": "a53333b4-62be-43e4-9fc0-96dbbd630be8",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
+    "public.runners_ephemeral_registration_tokens": {
+      "name": "runners_ephemeral_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_ephemeral_registration_tokens_hashed_token_unique": {
+          "name": "runners_ephemeral_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_workspace_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_provisioner_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_provisioner_id_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.runners_outbox": {
       "name": "runners_outbox",
       "schema": "",
@@ -220,6 +347,91 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_token_kind": {
+          "name": "registration_token_kind",
+          "type": "runners_runner_session_registration_token_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_claims": {
+          "name": "max_claims",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claims_used": {
+          "name": "claims_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_runner_sessions_claims_ck": {
+          "name": "runners_runner_sessions_claims_ck",
+          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND (\"runners_runner_sessions\".\"max_claims\" IS NULL OR (\"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
     "public.runners_runner_tokens": {
       "name": "runners_runner_tokens",
       "schema": "",
@@ -348,66 +560,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.runners_runner_sessions": {
-      "name": "runners_runner_sessions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true,
-          "default": "uuidv7()"
-        },
-        "workspace_id": {
-          "name": "workspace_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "scope": {
-          "name": "scope",
-          "type": "runners_runner_session_scope",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'workspace'"
-        },
-        "registration_token_id": {
-          "name": "registration_token_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "labels": {
-          "name": "labels",
-          "type": "text[]",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.runners_running_jobs": {
       "name": "runners_running_jobs",
       "schema": "",
@@ -502,6 +654,11 @@
     }
   },
   "enums": {
+    "public.runners_runner_session_registration_token_kind": {
+      "name": "runners_runner_session_registration_token_kind",
+      "schema": "public",
+      "values": ["manual", "ephemeral"]
+    },
     "public.runners_runner_session_scope": {
       "name": "runners_runner_session_scope",
       "schema": "public",

--- a/libs/api/runners/src/core/entities/ephemeral-registration-token.ts
+++ b/libs/api/runners/src/core/entities/ephemeral-registration-token.ts
@@ -1,0 +1,13 @@
+export interface EphemeralRegistrationToken {
+  id: string;
+  workspaceId: string;
+  provisionerId: string;
+  reservationId: string | null;
+  resourceId: string;
+  hashedToken: string;
+  prefix: string;
+  expiresAt: Date;
+  consumedAt: Date | null;
+  consumedSessionId: string | null;
+  createdAt: Date;
+}

--- a/libs/api/runners/src/core/entities/runner-session.ts
+++ b/libs/api/runners/src/core/entities/runner-session.ts
@@ -3,7 +3,10 @@ export interface RunnerSession {
   workspaceId: string;
   scope: 'workspace';
   registrationTokenId: string;
+  registrationTokenKind: 'manual' | 'ephemeral';
   labels: string[];
+  maxClaims: number | null;
+  claimsUsed: number;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/libs/api/runners/src/core/ephemeral-registration-tokens.test.ts
+++ b/libs/api/runners/src/core/ephemeral-registration-tokens.test.ts
@@ -3,6 +3,7 @@ import {eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {mintEphemeralRegistrationToken} from './ephemeral-registration-tokens.js';
+import {ActiveEphemeralRegistrationTokenExistsError} from './errors.js';
 
 describe('mintEphemeralRegistrationToken', () => {
   beforeEach(async () => {
@@ -65,5 +66,47 @@ describe('mintEphemeralRegistrationToken', () => {
     });
 
     expect(result.token.reservationId).toBe(reservationId);
+  });
+
+  it('rejects a second active token for the same resource', async () => {
+    const workspaceId = crypto.randomUUID();
+    const provisionerId = crypto.randomUUID();
+    const resourceId = 'gh-runner-7';
+    await mintEphemeralRegistrationToken({
+      workspaceId,
+      provisionerId,
+      resourceId,
+      ttlSeconds: 600,
+    });
+
+    await expect(
+      mintEphemeralRegistrationToken({
+        workspaceId,
+        provisionerId,
+        resourceId,
+        ttlSeconds: 600,
+      }),
+    ).rejects.toBeInstanceOf(ActiveEphemeralRegistrationTokenExistsError);
+  });
+
+  it('allows minting a replacement after the previous token expires', async () => {
+    const workspaceId = crypto.randomUUID();
+    const provisionerId = crypto.randomUUID();
+    const resourceId = 'gh-runner-7';
+    await mintEphemeralRegistrationToken({
+      workspaceId,
+      provisionerId,
+      resourceId,
+      ttlSeconds: -1,
+    });
+
+    const replacement = await mintEphemeralRegistrationToken({
+      workspaceId,
+      provisionerId,
+      resourceId,
+      ttlSeconds: 600,
+    });
+
+    expect(replacement.token.resourceId).toBe(resourceId);
   });
 });

--- a/libs/api/runners/src/core/ephemeral-registration-tokens.test.ts
+++ b/libs/api/runners/src/core/ephemeral-registration-tokens.test.ts
@@ -1,0 +1,69 @@
+import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
+import {eq, sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
+import {mintEphemeralRegistrationToken} from './ephemeral-registration-tokens.js';
+
+describe('mintEphemeralRegistrationToken', () => {
+  beforeEach(async () => {
+    await db().execute(sql`TRUNCATE runners_ephemeral_registration_tokens CASCADE`);
+  });
+
+  it('mints a token, stores only the hash, and carries the ert prefix', async () => {
+    const workspaceId = crypto.randomUUID();
+    const provisionerId = crypto.randomUUID();
+
+    const result = await mintEphemeralRegistrationToken({
+      workspaceId,
+      provisionerId,
+      resourceId: 'gh-runner-7',
+      ttlSeconds: 600,
+    });
+
+    expect(result.rawToken.startsWith(`sf_${tokenTypeParts.ephemeralRegistrationToken}_`)).toBe(
+      true,
+    );
+    expect(result.token.workspaceId).toBe(workspaceId);
+    expect(result.token.provisionerId).toBe(provisionerId);
+    expect(result.token.resourceId).toBe('gh-runner-7');
+    expect(result.token.reservationId).toBeNull();
+    expect(result.token.prefix).toBe(result.rawToken.slice(0, 12));
+    const [row] = await db()
+      .select()
+      .from(ephemeralRegistrationTokens)
+      .where(eq(ephemeralRegistrationTokens.id, result.token.id));
+    expect(row?.hashedToken).toBe(hashOpaqueToken(result.rawToken));
+    expect(row?.hashedToken).not.toBe(result.rawToken);
+  });
+
+  it('derives expiresAt from ttlSeconds', async () => {
+    const ttlSeconds = 900;
+    const before = Date.now();
+
+    const result = await mintEphemeralRegistrationToken({
+      workspaceId: crypto.randomUUID(),
+      provisionerId: crypto.randomUUID(),
+      resourceId: 'gh-runner-7',
+      ttlSeconds,
+    });
+
+    const after = Date.now();
+    const expiresMs = result.token.expiresAt.getTime();
+    expect(expiresMs).toBeGreaterThanOrEqual(before + ttlSeconds * 1000);
+    expect(expiresMs).toBeLessThanOrEqual(after + ttlSeconds * 1000);
+  });
+
+  it('passes through a reservationId when provided', async () => {
+    const reservationId = crypto.randomUUID();
+
+    const result = await mintEphemeralRegistrationToken({
+      workspaceId: crypto.randomUUID(),
+      provisionerId: crypto.randomUUID(),
+      resourceId: 'gh-runner-7',
+      reservationId,
+      ttlSeconds: 600,
+    });
+
+    expect(result.token.reservationId).toBe(reservationId);
+  });
+});

--- a/libs/api/runners/src/core/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/core/ephemeral-registration-tokens.ts
@@ -1,0 +1,33 @@
+import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {createEphemeralRegistrationToken} from '#db/ephemeral-registration-tokens.js';
+import type {EphemeralRegistrationToken} from './entities/ephemeral-registration-token.js';
+
+export interface MintEphemeralRegistrationTokenParams {
+  workspaceId: string;
+  provisionerId: string;
+  resourceId: string;
+  reservationId?: string | null | undefined;
+  ttlSeconds: number;
+}
+
+export interface MintEphemeralRegistrationTokenResult {
+  token: EphemeralRegistrationToken;
+  rawToken: string;
+}
+
+export async function mintEphemeralRegistrationToken(
+  params: MintEphemeralRegistrationTokenParams,
+): Promise<MintEphemeralRegistrationTokenResult> {
+  const rawToken = generateOpaqueToken('ephemeralRegistrationToken');
+  const token = await createEphemeralRegistrationToken({
+    workspaceId: params.workspaceId,
+    provisionerId: params.provisionerId,
+    reservationId: params.reservationId ?? null,
+    resourceId: params.resourceId,
+    hashedToken: hashOpaqueToken(rawToken),
+    prefix: extractDisplayPrefix(rawToken),
+    expiresAt: new Date(Date.now() + params.ttlSeconds * 1000),
+  });
+
+  return {token, rawToken};
+}

--- a/libs/api/runners/src/core/errors.ts
+++ b/libs/api/runners/src/core/errors.ts
@@ -40,6 +40,31 @@ export class RegistrationTokenExpiredError extends Error {
   }
 }
 
+export class RegistrationTokenWorkspaceMismatchError extends Error {
+  constructor(
+    public readonly ephemeralTokenId: string,
+    public readonly workspaceId: string,
+  ) {
+    super(
+      `Ephemeral registration token ${ephemeralTokenId} does not belong to workspace ${workspaceId}`,
+    );
+    this.name = 'RegistrationTokenWorkspaceMismatchError';
+  }
+}
+
+export class ActiveEphemeralRegistrationTokenExistsError extends Error {
+  constructor(
+    public readonly workspaceId: string,
+    public readonly provisionerId: string,
+    public readonly resourceId: string,
+  ) {
+    super(
+      `Active ephemeral registration token already exists for resource ${resourceId} in workspace ${workspaceId}`,
+    );
+    this.name = 'ActiveEphemeralRegistrationTokenExistsError';
+  }
+}
+
 export class RunnerSessionExhaustedError extends Error {
   constructor(public readonly runnerSessionId: string) {
     super(`Runner session claim limit exhausted: ${runnerSessionId}`);

--- a/libs/api/runners/src/core/errors.ts
+++ b/libs/api/runners/src/core/errors.ts
@@ -25,3 +25,24 @@ export class EmptyRequiredLabelsError extends Error {
     this.name = 'EmptyRequiredLabelsError';
   }
 }
+
+export class RegistrationTokenConsumedError extends Error {
+  constructor(public readonly ephemeralTokenId: string) {
+    super(`Ephemeral registration token has already been consumed: ${ephemeralTokenId}`);
+    this.name = 'RegistrationTokenConsumedError';
+  }
+}
+
+export class RegistrationTokenExpiredError extends Error {
+  constructor(public readonly ephemeralTokenId: string) {
+    super(`Ephemeral registration token has expired: ${ephemeralTokenId}`);
+    this.name = 'RegistrationTokenExpiredError';
+  }
+}
+
+export class RunnerSessionExhaustedError extends Error {
+  constructor(public readonly runnerSessionId: string) {
+    super(`Runner session claim limit exhausted: ${runnerSessionId}`);
+    this.name = 'RunnerSessionExhaustedError';
+  }
+}

--- a/libs/api/runners/src/core/index.ts
+++ b/libs/api/runners/src/core/index.ts
@@ -1,8 +1,25 @@
+export type {EphemeralRegistrationToken} from './entities/ephemeral-registration-token.js';
 export type {RunnerSession} from './entities/runner-session.js';
 export type {RunnerToken} from './entities/runner-token.js';
-export {RunnerTokenNotFoundError, RunningJobNotFoundError} from './errors.js';
+export {
+  type MintEphemeralRegistrationTokenParams,
+  type MintEphemeralRegistrationTokenResult,
+  mintEphemeralRegistrationToken,
+} from './ephemeral-registration-tokens.js';
+export {
+  EmptyRunnerLabelsError,
+  RegistrationTokenConsumedError,
+  RegistrationTokenExpiredError,
+  RunnerSessionExhaustedError,
+  RunnerTokenNotFoundError,
+  RunningJobNotFoundError,
+} from './errors.js';
 export {type ClaimJobResult, claimJob} from './jobs.js';
-export {type RegisterRunnerSessionResult, registerRunnerSession} from './runner-sessions.js';
+export {
+  type RegisterRunnerSessionResult,
+  type RunnerRegistrationCredential,
+  registerRunnerSession,
+} from './runner-sessions.js';
 export {
   createWorkspaceRunnerToken,
   listUsableRunnerTokens,

--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -12,6 +12,7 @@ export async function claimJob(params: {
   workspaceId: string;
   runnerSessionId: string;
   sessionLabels: string[];
+  maxClaims: number | null;
 }): Promise<ClaimJobResult | null> {
   const claimed = await claimPendingJob(params);
   if (!claimed) {

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -1,9 +1,10 @@
 import {verifyRunnerSessionToken} from '@shipfox/api-auth';
 import {eq, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
+import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
-import {runnerTokenFactory} from '#test/index.js';
-import {EmptyRunnerLabelsError} from './errors.js';
+import {ephemeralRegistrationTokenFactory, runnerTokenFactory} from '#test/index.js';
+import {EmptyRunnerLabelsError, RegistrationTokenConsumedError} from './errors.js';
 import {registerRunnerSession} from './runner-sessions.js';
 
 describe('registerRunnerSession', () => {
@@ -11,7 +12,9 @@ describe('registerRunnerSession', () => {
   let registrationTokenId: string;
 
   beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_runner_sessions, runners_runner_tokens CASCADE`);
+    await db().execute(
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_sessions, runners_runner_tokens CASCADE`,
+    );
     workspaceId = crypto.randomUUID();
     const token = await runnerTokenFactory.create({workspaceId});
     registrationTokenId = token.id;
@@ -19,14 +22,16 @@ describe('registerRunnerSession', () => {
 
   it('canonicalizes labels, stores them, and embeds them in the session token', async () => {
     const result = await registerRunnerSession({
-      registrationTokenId,
-      workspaceId,
+      credential: {kind: 'manual', registrationTokenId, workspaceId},
       labels: [' Linux ', 'x64', 'linux'],
     });
 
     expect(result.mode).toBe('manual');
     expect(result.maxClaims).toBeNull();
     expect(result.session.labels).toEqual(['linux', 'x64']);
+    expect(result.session.registrationTokenKind).toBe('manual');
+    expect(result.session.maxClaims).toBeNull();
+    expect(result.session.claimsUsed).toBe(0);
 
     const rows = await db()
       .select()
@@ -36,11 +41,65 @@ describe('registerRunnerSession', () => {
 
     const claims = await verifyRunnerSessionToken(result.sessionToken);
     expect(claims?.labels).toEqual(['linux', 'x64']);
+    expect(claims?.maxClaims).toBeNull();
   });
 
   it('throws EmptyRunnerLabelsError when labels canonicalize to empty', async () => {
     await expect(
-      registerRunnerSession({registrationTokenId, workspaceId, labels: [' ', '\t']}),
+      registerRunnerSession({
+        credential: {kind: 'manual', registrationTokenId, workspaceId},
+        labels: [' ', '\t'],
+      }),
     ).rejects.toBeInstanceOf(EmptyRunnerLabelsError);
+  });
+
+  it('consumes an ephemeral token and creates a one-claim session', async () => {
+    const token = await ephemeralRegistrationTokenFactory.create({workspaceId});
+
+    const result = await registerRunnerSession({
+      credential: {
+        kind: 'ephemeral',
+        ephemeralTokenId: token.id,
+        workspaceId,
+        provisionerId: token.provisionerId,
+        reservationId: token.reservationId,
+        resourceId: token.resourceId,
+      },
+      labels: [' Linux ', 'x64'],
+    });
+
+    expect(result.mode).toBe('ephemeral');
+    expect(result.maxClaims).toBe(1);
+    expect(result.session.registrationTokenKind).toBe('ephemeral');
+    expect(result.session.maxClaims).toBe(1);
+    expect(result.session.claimsUsed).toBe(0);
+
+    const [consumed] = await db()
+      .select()
+      .from(ephemeralRegistrationTokens)
+      .where(eq(ephemeralRegistrationTokens.id, token.id));
+    expect(consumed?.consumedAt).toBeInstanceOf(Date);
+    expect(consumed?.consumedSessionId).toBe(result.session.id);
+
+    const claims = await verifyRunnerSessionToken(result.sessionToken);
+    expect(claims?.maxClaims).toBe(1);
+  });
+
+  it('rejects a second consume of the same ephemeral token', async () => {
+    const token = await ephemeralRegistrationTokenFactory.create({workspaceId});
+    const credential = {
+      kind: 'ephemeral' as const,
+      ephemeralTokenId: token.id,
+      workspaceId,
+      provisionerId: token.provisionerId,
+      reservationId: token.reservationId,
+      resourceId: token.resourceId,
+    };
+
+    await registerRunnerSession({credential, labels: ['linux']});
+
+    await expect(registerRunnerSession({credential, labels: ['linux']})).rejects.toBeInstanceOf(
+      RegistrationTokenConsumedError,
+    );
   });
 });

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -4,7 +4,11 @@ import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {ephemeralRegistrationTokenFactory, runnerTokenFactory} from '#test/index.js';
-import {EmptyRunnerLabelsError, RegistrationTokenConsumedError} from './errors.js';
+import {
+  EmptyRunnerLabelsError,
+  RegistrationTokenConsumedError,
+  RegistrationTokenWorkspaceMismatchError,
+} from './errors.js';
 import {registerRunnerSession} from './runner-sessions.js';
 
 describe('registerRunnerSession', () => {
@@ -101,5 +105,39 @@ describe('registerRunnerSession', () => {
     await expect(registerRunnerSession({credential, labels: ['linux']})).rejects.toBeInstanceOf(
       RegistrationTokenConsumedError,
     );
+  });
+
+  it('rejects consuming an ephemeral token for a different workspace', async () => {
+    const token = await ephemeralRegistrationTokenFactory.create({workspaceId});
+
+    await expect(
+      registerRunnerSession({
+        credential: {
+          kind: 'ephemeral',
+          ephemeralTokenId: token.id,
+          workspaceId: crypto.randomUUID(),
+          provisionerId: token.provisionerId,
+          reservationId: token.reservationId,
+          resourceId: token.resourceId,
+        },
+        labels: ['linux'],
+      }),
+    ).rejects.toBeInstanceOf(RegistrationTokenWorkspaceMismatchError);
+  });
+
+  it('rejects an ephemeral session row without a positive max claim cap', async () => {
+    await expect(
+      db()
+        .insert(runnerSessions)
+        .values({
+          workspaceId,
+          scope: 'workspace',
+          registrationTokenId: crypto.randomUUID(),
+          registrationTokenKind: 'ephemeral',
+          labels: ['linux'],
+          maxClaims: null,
+          claimsUsed: 0,
+        }),
+    ).rejects.toThrow();
   });
 });

--- a/libs/api/runners/src/core/runner-sessions.ts
+++ b/libs/api/runners/src/core/runner-sessions.ts
@@ -1,5 +1,6 @@
 import {issueRunnerSessionToken} from '@shipfox/api-auth';
 import {canonicalizeRunnerLabels} from '@shipfox/api-runners-dto';
+import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
 import {createRunnerSession} from '#db/runner-sessions.js';
 import type {RunnerSession} from './entities/runner-session.js';
 import {EmptyRunnerLabelsError} from './errors.js';
@@ -7,30 +8,55 @@ import {EmptyRunnerLabelsError} from './errors.js';
 export interface RegisterRunnerSessionResult {
   session: RunnerSession;
   sessionToken: string;
-  mode: 'manual';
-  maxClaims: null;
+  mode: 'manual' | 'ephemeral';
+  maxClaims: number | null;
 }
 
+export type RunnerRegistrationCredential =
+  | {
+      kind: 'manual';
+      registrationTokenId: string;
+      workspaceId: string;
+    }
+  | {
+      kind: 'ephemeral';
+      ephemeralTokenId: string;
+      workspaceId: string;
+      provisionerId: string;
+      reservationId: string | null;
+      resourceId: string;
+    };
+
 export async function registerRunnerSession(params: {
-  registrationTokenId: string;
-  workspaceId: string;
+  credential: RunnerRegistrationCredential;
   labels: string[];
 }): Promise<RegisterRunnerSessionResult> {
   const labels = canonicalizeRunnerLabels(params.labels);
   if (labels.length === 0) throw new EmptyRunnerLabelsError();
 
-  const session = await createRunnerSession({
-    workspaceId: params.workspaceId,
-    scope: 'workspace',
-    registrationTokenId: params.registrationTokenId,
-    labels,
-  });
+  const mode = params.credential.kind;
+  const maxClaims = params.credential.kind === 'ephemeral' ? 1 : null;
+  const session =
+    params.credential.kind === 'manual'
+      ? await createRunnerSession({
+          workspaceId: params.credential.workspaceId,
+          scope: 'workspace',
+          registrationTokenId: params.credential.registrationTokenId,
+          labels,
+        })
+      : await createRunnerSessionConsumingEphemeralToken({
+          ephemeralTokenId: params.credential.ephemeralTokenId,
+          workspaceId: params.credential.workspaceId,
+          labels,
+          maxClaims: 1,
+        });
   const sessionToken = await issueRunnerSessionToken({
     runnerSessionId: session.id,
     workspaceId: session.workspaceId,
     scope: session.scope,
     labels: session.labels,
+    maxClaims,
   });
 
-  return {session, sessionToken, mode: 'manual', maxClaims: null};
+  return {session, sessionToken, mode, maxClaims};
 }

--- a/libs/api/runners/src/core/runner-tokens.test.ts
+++ b/libs/api/runners/src/core/runner-tokens.test.ts
@@ -11,7 +11,9 @@ import {
 
 describe('runner token core', () => {
   beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_runner_tokens CASCADE`);
+    await db().execute(
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_tokens CASCADE`,
+    );
   });
 
   it('creates a workspace runner token and stores only the hash', async () => {

--- a/libs/api/runners/src/db/db.ts
+++ b/libs/api/runners/src/db/db.ts
@@ -1,12 +1,20 @@
 import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
+import {ephemeralRegistrationTokens} from './schema/ephemeral-registration-tokens.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
 import {runnerSessions} from './schema/runner-sessions.js';
 import {runnerTokens} from './schema/runner-tokens.js';
 import {runningJobs} from './schema/running-jobs.js';
 
-export const schema = {pendingJobs, runnerSessions, runnerTokens, runningJobs, runnersOutbox};
+export const schema = {
+  ephemeralRegistrationTokens,
+  pendingJobs,
+  runnerSessions,
+  runnerTokens,
+  runningJobs,
+  runnersOutbox,
+};
 
 let _db: NodePgDatabase<typeof schema> | undefined;
 

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -1,6 +1,11 @@
 import {and, eq, gt, isNull, sql} from 'drizzle-orm';
 import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
-import {RegistrationTokenConsumedError, RegistrationTokenExpiredError} from '#core/errors.js';
+import {
+  ActiveEphemeralRegistrationTokenExistsError,
+  RegistrationTokenConsumedError,
+  RegistrationTokenExpiredError,
+  RegistrationTokenWorkspaceMismatchError,
+} from '#core/errors.js';
 import {db} from './db.js';
 import {
   ephemeralRegistrationTokens,
@@ -21,18 +26,50 @@ export interface CreateEphemeralRegistrationTokenParams {
 export async function createEphemeralRegistrationToken(
   params: CreateEphemeralRegistrationTokenParams,
 ): Promise<EphemeralRegistrationToken> {
-  const rows = await db()
-    .insert(ephemeralRegistrationTokens)
-    .values({
-      workspaceId: params.workspaceId,
-      provisionerId: params.provisionerId,
-      reservationId: params.reservationId ?? null,
-      resourceId: params.resourceId,
-      hashedToken: params.hashedToken,
-      prefix: params.prefix,
-      expiresAt: params.expiresAt,
-    })
-    .returning();
+  const rows = await db().transaction(async (tx) => {
+    const resourceLockKey = [
+      'runners_ephemeral_registration_tokens',
+      params.workspaceId,
+      params.provisionerId,
+      params.resourceId,
+    ].join(':');
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${resourceLockKey}))`);
+
+    const [active] = await tx
+      .select({id: ephemeralRegistrationTokens.id})
+      .from(ephemeralRegistrationTokens)
+      .where(
+        and(
+          eq(ephemeralRegistrationTokens.workspaceId, params.workspaceId),
+          eq(ephemeralRegistrationTokens.provisionerId, params.provisionerId),
+          eq(ephemeralRegistrationTokens.resourceId, params.resourceId),
+          isNull(ephemeralRegistrationTokens.consumedAt),
+          gt(ephemeralRegistrationTokens.expiresAt, sql`now()`),
+        ),
+      )
+      .limit(1);
+
+    if (active) {
+      throw new ActiveEphemeralRegistrationTokenExistsError(
+        params.workspaceId,
+        params.provisionerId,
+        params.resourceId,
+      );
+    }
+
+    return await tx
+      .insert(ephemeralRegistrationTokens)
+      .values({
+        workspaceId: params.workspaceId,
+        provisionerId: params.provisionerId,
+        reservationId: params.reservationId ?? null,
+        resourceId: params.resourceId,
+        hashedToken: params.hashedToken,
+        prefix: params.prefix,
+        expiresAt: params.expiresAt,
+      })
+      .returning();
+  });
 
   const row = rows[0];
   if (!row) throw new Error('Insert returned no rows');
@@ -66,6 +103,7 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
       .where(
         and(
           eq(ephemeralRegistrationTokens.id, params.ephemeralTokenId),
+          eq(ephemeralRegistrationTokens.workspaceId, params.workspaceId),
           isNull(ephemeralRegistrationTokens.consumedAt),
           gt(ephemeralRegistrationTokens.expiresAt, sql`now()`),
         ),
@@ -74,7 +112,11 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
 
     if (!consumed[0]) {
       const [token] = await tx
-        .select()
+        .select({
+          workspaceId: ephemeralRegistrationTokens.workspaceId,
+          consumedAt: ephemeralRegistrationTokens.consumedAt,
+          isExpired: sql<boolean>`${ephemeralRegistrationTokens.expiresAt} <= now()`,
+        })
         .from(ephemeralRegistrationTokens)
         .where(eq(ephemeralRegistrationTokens.id, params.ephemeralTokenId))
         .limit(1);
@@ -82,9 +124,14 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
       if (!token) {
         throw new Error(`Ephemeral registration token not found: ${params.ephemeralTokenId}`);
       }
+      if (token.workspaceId !== params.workspaceId) {
+        throw new RegistrationTokenWorkspaceMismatchError(
+          params.ephemeralTokenId,
+          params.workspaceId,
+        );
+      }
       if (token.consumedAt) throw new RegistrationTokenConsumedError(params.ephemeralTokenId);
-      if (token.expiresAt <= new Date())
-        throw new RegistrationTokenExpiredError(params.ephemeralTokenId);
+      if (token.isExpired) throw new RegistrationTokenExpiredError(params.ephemeralTokenId);
       throw new Error(
         `Ephemeral registration token could not be consumed: ${params.ephemeralTokenId}`,
       );

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -1,0 +1,115 @@
+import {and, eq, gt, isNull, sql} from 'drizzle-orm';
+import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
+import {RegistrationTokenConsumedError, RegistrationTokenExpiredError} from '#core/errors.js';
+import {db} from './db.js';
+import {
+  ephemeralRegistrationTokens,
+  toEphemeralRegistrationToken,
+} from './schema/ephemeral-registration-tokens.js';
+import {runnerSessions, toRunnerSession} from './schema/runner-sessions.js';
+
+export interface CreateEphemeralRegistrationTokenParams {
+  workspaceId: string;
+  provisionerId: string;
+  reservationId?: string | null | undefined;
+  resourceId: string;
+  hashedToken: string;
+  prefix: string;
+  expiresAt: Date;
+}
+
+export async function createEphemeralRegistrationToken(
+  params: CreateEphemeralRegistrationTokenParams,
+): Promise<EphemeralRegistrationToken> {
+  const rows = await db()
+    .insert(ephemeralRegistrationTokens)
+    .values({
+      workspaceId: params.workspaceId,
+      provisionerId: params.provisionerId,
+      reservationId: params.reservationId ?? null,
+      resourceId: params.resourceId,
+      hashedToken: params.hashedToken,
+      prefix: params.prefix,
+      expiresAt: params.expiresAt,
+    })
+    .returning();
+
+  const row = rows[0];
+  if (!row) throw new Error('Insert returned no rows');
+  return toEphemeralRegistrationToken(row);
+}
+
+export async function resolveEphemeralRegistrationTokenByHash(
+  hashedToken: string,
+): Promise<EphemeralRegistrationToken | undefined> {
+  const rows = await db()
+    .select()
+    .from(ephemeralRegistrationTokens)
+    .where(eq(ephemeralRegistrationTokens.hashedToken, hashedToken))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toEphemeralRegistrationToken(row);
+}
+
+export async function createRunnerSessionConsumingEphemeralToken(params: {
+  ephemeralTokenId: string;
+  workspaceId: string;
+  labels: string[];
+  maxClaims: number;
+}) {
+  return await db().transaction(async (tx) => {
+    const consumed = await tx
+      .update(ephemeralRegistrationTokens)
+      .set({consumedAt: sql`now()`})
+      .where(
+        and(
+          eq(ephemeralRegistrationTokens.id, params.ephemeralTokenId),
+          isNull(ephemeralRegistrationTokens.consumedAt),
+          gt(ephemeralRegistrationTokens.expiresAt, sql`now()`),
+        ),
+      )
+      .returning({id: ephemeralRegistrationTokens.id});
+
+    if (!consumed[0]) {
+      const [token] = await tx
+        .select()
+        .from(ephemeralRegistrationTokens)
+        .where(eq(ephemeralRegistrationTokens.id, params.ephemeralTokenId))
+        .limit(1);
+
+      if (!token) {
+        throw new Error(`Ephemeral registration token not found: ${params.ephemeralTokenId}`);
+      }
+      if (token.consumedAt) throw new RegistrationTokenConsumedError(params.ephemeralTokenId);
+      if (token.expiresAt <= new Date())
+        throw new RegistrationTokenExpiredError(params.ephemeralTokenId);
+      throw new Error(
+        `Ephemeral registration token could not be consumed: ${params.ephemeralTokenId}`,
+      );
+    }
+
+    const [session] = await tx
+      .insert(runnerSessions)
+      .values({
+        workspaceId: params.workspaceId,
+        scope: 'workspace',
+        registrationTokenId: params.ephemeralTokenId,
+        registrationTokenKind: 'ephemeral',
+        labels: params.labels,
+        maxClaims: params.maxClaims,
+        claimsUsed: 0,
+      })
+      .returning();
+
+    if (!session) throw new Error('Insert returned no rows');
+
+    await tx
+      .update(ephemeralRegistrationTokens)
+      .set({consumedSessionId: session.id})
+      .where(eq(ephemeralRegistrationTokens.id, params.ephemeralTokenId));
+
+    return toRunnerSession(session);
+  });
+}

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -2,6 +2,12 @@ import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 export {closeDb, db, schema} from './db.js';
+export type {CreateEphemeralRegistrationTokenParams} from './ephemeral-registration-tokens.js';
+export {
+  createEphemeralRegistrationToken,
+  createRunnerSessionConsumingEphemeralToken,
+  resolveEphemeralRegistrationTokenByHash,
+} from './ephemeral-registration-tokens.js';
 export type {ClaimedJob, EnqueueJobParams} from './jobs.js';
 export {
   cancelRunnerJobs,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -5,7 +5,7 @@ import {
   RUNNER_JOB_QUEUED,
 } from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
-import {EmptyRequiredLabelsError} from '#core/errors.js';
+import {EmptyRequiredLabelsError, RunnerSessionExhaustedError} from '#core/errors.js';
 import {claimJob, detectAndExpireStuckJobs} from '#core/jobs.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {db} from './db.js';
@@ -21,22 +21,28 @@ import {
 } from './jobs.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
+import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobs} from './schema/running-jobs.js';
 
 const sessionLabels = ['linux', 'x64'];
 
 function claimPendingJob(
-  params: Omit<Parameters<typeof claimPendingJobDb>[0], 'sessionLabels'> & {
+  params: Omit<Parameters<typeof claimPendingJobDb>[0], 'maxClaims' | 'sessionLabels'> & {
+    maxClaims?: number | null;
     sessionLabels?: string[];
   },
 ) {
-  return claimPendingJobDb({...params, sessionLabels: params.sessionLabels ?? sessionLabels});
+  return claimPendingJobDb({
+    ...params,
+    maxClaims: params.maxClaims ?? null,
+    sessionLabels: params.sessionLabels ?? sessionLabels,
+  });
 }
 
 describe('enqueueJob', () => {
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_outbox CASCADE`,
     );
   });
 
@@ -147,7 +153,7 @@ describe('claimPendingJob', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
@@ -157,7 +163,7 @@ describe('claimPendingJob', () => {
   it('emits runners.job.claimed carrying the claim instant on a real claim', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     const [running] = await db()
       .select()
@@ -175,7 +181,7 @@ describe('claimPendingJob', () => {
   });
 
   it('emits no claimed event when there is nothing to claim', async () => {
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(claimed).toBeNull();
     expect(
@@ -188,7 +194,7 @@ describe('claimPendingJob', () => {
 
   it('emits no claimed event when dropping an orphan pending row', async () => {
     const created = await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerSessionId});
+    await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     await db().insert(pendingJobs).values({
       workspaceId,
       jobId: created.jobId,
@@ -199,7 +205,7 @@ describe('claimPendingJob', () => {
     // Clear the initial claim's events so this assertion only covers the orphan claim.
     await db().delete(runnersOutbox);
 
-    const second = await claimPendingJob({workspaceId, runnerSessionId});
+    const second = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(second).toBeNull();
     expect(await db().select().from(runnersOutbox)).toHaveLength(0);
@@ -208,7 +214,7 @@ describe('claimPendingJob', () => {
   it('returns the job ids when a job is available', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
@@ -217,9 +223,62 @@ describe('claimPendingJob', () => {
   });
 
   it('returns null when no jobs are pending', async () => {
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(claimed).toBeNull();
+  });
+
+  it('enforces a non-null session claim cap from the database', async () => {
+    await db()
+      .update(runnerSessions)
+      .set({registrationTokenKind: 'ephemeral', maxClaims: 1})
+      .where(eq(runnerSessions.id, runnerSessionId));
+    await pendingJobFactory.create({workspaceId});
+    await pendingJobFactory.create({workspaceId});
+
+    const first = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: 1});
+
+    expect(first).not.toBeNull();
+    await expect(
+      claimPendingJob({workspaceId, runnerSessionId, maxClaims: 1}),
+    ).rejects.toBeInstanceOf(RunnerSessionExhaustedError);
+  });
+
+  it('does not spend a claim when a capped session polls an empty queue', async () => {
+    await db()
+      .update(runnerSessions)
+      .set({registrationTokenKind: 'ephemeral', maxClaims: 1})
+      .where(eq(runnerSessions.id, runnerSessionId));
+
+    const empty = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: 1});
+
+    const [afterEmpty] = await db()
+      .select({claimsUsed: runnerSessions.claimsUsed})
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, runnerSessionId));
+    expect(empty).toBeNull();
+    expect(afterEmpty?.claimsUsed).toBe(0);
+
+    const created = await pendingJobFactory.create({workspaceId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: 1});
+
+    const [afterClaim] = await db()
+      .select({claimsUsed: runnerSessions.claimsUsed})
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, runnerSessionId));
+    expect(claimed?.jobId).toBe(created.jobId);
+    expect(afterClaim?.claimsUsed).toBe(1);
+  });
+
+  it('allows a manual session to claim repeatedly', async () => {
+    const first = await pendingJobFactory.create({workspaceId});
+    const second = await pendingJobFactory.create({workspaceId});
+
+    const firstClaim = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
+    const secondClaim = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
+
+    expect(firstClaim?.jobId).toBe(first.jobId);
+    expect(secondClaim?.jobId).toBe(second.jobId);
   });
 
   it('only one caller wins when two claim concurrently', async () => {
@@ -227,8 +286,12 @@ describe('claimPendingJob', () => {
     await pendingJobFactory.create({workspaceId});
 
     const [claim1, claim2] = await Promise.all([
-      claimPendingJob({workspaceId, runnerSessionId}),
-      claimPendingJob({workspaceId, runnerSessionId: otherRunnerSession.id}),
+      claimPendingJob({workspaceId, runnerSessionId, maxClaims: null}),
+      claimPendingJob({
+        workspaceId,
+        runnerSessionId: otherRunnerSession.id,
+        maxClaims: null,
+      }),
     ]);
 
     const claimed = [claim1, claim2].filter(Boolean);
@@ -239,7 +302,7 @@ describe('claimPendingJob', () => {
     const older = await pendingJobFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(claimed?.jobId).toBe(older.jobId);
   });
@@ -247,7 +310,7 @@ describe('claimPendingJob', () => {
   it('moves the job from pending to running', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    await claimPendingJob({workspaceId, runnerSessionId});
+    await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     const pending = await db().select().from(pendingJobs);
     const running = await db().select().from(runningJobs);
@@ -331,14 +394,14 @@ describe('claimPendingJob', () => {
   it('does not claim jobs from another workspace', async () => {
     await pendingJobFactory.create({workspaceId: crypto.randomUUID()});
 
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(claimed).toBeNull();
   });
 
   it('drops an orphan pending row whose job is already running, without a poison loop', async () => {
     const created = await pendingJobFactory.create({workspaceId});
-    const first = await claimPendingJob({workspaceId, runnerSessionId});
+    const first = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     expect(first?.jobId).toBe(created.jobId);
 
     // Simulate an enqueue retry that re-inserts a pending row after the claim.
@@ -350,7 +413,7 @@ describe('claimPendingJob', () => {
       requiredLabels: created.requiredLabels,
     });
 
-    const second = await claimPendingJob({workspaceId, runnerSessionId});
+    const second = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(second).toBeNull();
     expect(await db().select().from(pendingJobs)).toHaveLength(0);
@@ -385,7 +448,7 @@ describe('claimPendingJob', () => {
 
   it('claims a real pending job ahead of a newer orphan', async () => {
     const alreadyRunning = await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerSessionId});
+    await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     // A genuinely new pending job (older), then an orphan re-insert for the running job (newer).
     const real = await pendingJobFactory.create({workspaceId});
@@ -397,7 +460,7 @@ describe('claimPendingJob', () => {
       requiredLabels: alreadyRunning.requiredLabels,
     });
 
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(claimed?.jobId).toBe(real.jobId);
   });
@@ -409,7 +472,7 @@ describe('claimJob', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
@@ -419,7 +482,7 @@ describe('claimJob', () => {
   it('mints a lease token whose claims match the claimed job', async () => {
     const created = await pendingJobFactory.create({workspaceId});
 
-    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels});
+    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels, maxClaims: null});
 
     expect(claimed).not.toBeNull();
     expect(claimed?.jobId).toBe(created.jobId);
@@ -437,7 +500,7 @@ describe('claimJob', () => {
   });
 
   it('returns null and mints no token when the queue is empty', async () => {
-    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels});
+    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels, maxClaims: null});
 
     expect(claimed).toBeNull();
   });
@@ -449,7 +512,7 @@ describe('releaseJob', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
@@ -458,7 +521,7 @@ describe('releaseJob', () => {
 
   it('deletes the running row and writes no outbox event', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     const before = await db().select().from(runnersOutbox);
 
     await releaseJob({jobId: claimed?.jobId as string});
@@ -473,7 +536,7 @@ describe('releaseJob', () => {
 
   it('releases regardless of which session holds the lease', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     // No token is passed: the workflow is authoritative over the lease.
     await releaseJob({jobId: claimed?.jobId as string});
@@ -483,7 +546,7 @@ describe('releaseJob', () => {
 
   it('also sweeps a lingering pending row for the same job', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     // An orphan pending row left by a post-claim enqueue retry.
     await db()
       .insert(pendingJobs)
@@ -514,7 +577,7 @@ describe('recordHeartbeat', () => {
 
   it('returns cancel:false on a fresh row and bumps last_heartbeat_at', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     const before = await db()
       .select()
@@ -544,7 +607,7 @@ describe('recordHeartbeat', () => {
 
   it('returns cancel:true after requestJobCancellation', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
 
@@ -565,7 +628,7 @@ describe('recordHeartbeat', () => {
   it('throws when jobId belongs to a different session', async () => {
     const otherRunnerSession = await runnerSessionFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     await expect(
       recordHeartbeat({
@@ -588,7 +651,7 @@ describe('requestJobCancellation', () => {
 
   it('sets cancellation_requested_at on a fresh row', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
 
@@ -601,7 +664,7 @@ describe('requestJobCancellation', () => {
 
   it('is idempotent: second call preserves the first timestamp', async () => {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     await requestJobCancellation({jobId: claimed?.jobId as string});
     const after1 = await db()
@@ -631,7 +694,7 @@ describe('cancelRunnerJobs', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
@@ -640,7 +703,7 @@ describe('cancelRunnerJobs', () => {
 
   it('deletes queued jobs and requests cancellation for running jobs', async () => {
     const running = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     const queued = await pendingJobFactory.create({workspaceId});
 
     await cancelRunnerJobs({jobIds: [queued.jobId, claimed?.jobId as string]});
@@ -667,7 +730,7 @@ describe('cancelRunnerJobs', () => {
 
     await cancelRunnerJobs({jobIds: [queued.jobId]});
 
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     expect(claimed).toBeNull();
   });
 });
@@ -686,7 +749,7 @@ describe('detectAndExpireStuckJobs', () => {
     staleSeconds: number,
   ): Promise<{jobId: string; runId: string; projectId: string}> {
     await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({workspaceId, runnerSessionId});
+    const claimed = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
     await db()
       .update(runningJobs)
       .set({
@@ -880,7 +943,7 @@ describe('detectAndExpireStuckJobs', () => {
     // a deadlock loser rolls back, so either side may settle as rejected.
     await Promise.allSettled([
       detectAndExpireStuckJobs({thresholdSeconds: 180}),
-      claimPendingJob({workspaceId, runnerSessionId}),
+      claimPendingJob({workspaceId, runnerSessionId, maxClaims: null}),
     ]);
 
     // A follow-up tick finishes any reap that lost a deadlock race.
@@ -891,7 +954,7 @@ describe('detectAndExpireStuckJobs', () => {
     expect(await db().select().from(pendingJobs).where(eq(pendingJobs.jobId, jobId))).toHaveLength(
       0,
     );
-    expect(await claimPendingJob({workspaceId, runnerSessionId})).toBeNull();
+    expect(await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null})).toBeNull();
   });
 });
 
@@ -901,7 +964,7 @@ describe('getJobQueueDepth', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
@@ -917,7 +980,7 @@ describe('getJobQueueDepth', () => {
   it('counts pending and running jobs separately', async () => {
     await pendingJobFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
-    await claimPendingJob({workspaceId, runnerSessionId});
+    await claimPendingJob({workspaceId, runnerSessionId, maxClaims: null});
 
     const depth = await getJobQueueDepth();
 

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -7,11 +7,16 @@ import {
 } from '@shipfox/api-runners-dto';
 import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
 import {and, arrayContained, asc, count, eq, inArray, lt, sql} from 'drizzle-orm';
-import {EmptyRequiredLabelsError, RunningJobNotFoundError} from '#core/errors.js';
+import {
+  EmptyRequiredLabelsError,
+  RunnerSessionExhaustedError,
+  RunningJobNotFoundError,
+} from '#core/errors.js';
 import {jobEnqueuedCount, jobLeaseExpiredCount} from '#metrics/instance.js';
 import {db} from './db.js';
 import {runnersOutbox} from './schema/outbox.js';
 import {pendingJobs} from './schema/pending-jobs.js';
+import {runnerSessions} from './schema/runner-sessions.js';
 import {runningJobs} from './schema/running-jobs.js';
 
 export interface EnqueueJobParams {
@@ -75,10 +80,27 @@ export async function claimPendingJob(params: {
   workspaceId: string;
   runnerSessionId: string;
   sessionLabels: string[];
+  maxClaims: number | null;
 }): Promise<ClaimedJob | null> {
   if (params.sessionLabels.length === 0) return null;
 
   return await db().transaction(async (tx) => {
+    if (params.maxClaims !== null) {
+      const [session] = await tx
+        .select({
+          maxClaims: runnerSessions.maxClaims,
+          claimsUsed: runnerSessions.claimsUsed,
+        })
+        .from(runnerSessions)
+        .where(eq(runnerSessions.id, params.runnerSessionId))
+        .limit(1)
+        .for('update');
+
+      if (!session || session.maxClaims === null || session.claimsUsed >= session.maxClaims) {
+        throw new RunnerSessionExhaustedError(params.runnerSessionId);
+      }
+    }
+
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
     // for rows sharing a created_at within a batch.
     const [row] = await tx
@@ -120,6 +142,13 @@ export async function claimPendingJob(params: {
 
     const claimed = inserted[0];
     if (!claimed) return null;
+
+    if (params.maxClaims !== null) {
+      await tx
+        .update(runnerSessions)
+        .set({claimsUsed: sql`${runnerSessions.claimsUsed} + 1`})
+        .where(eq(runnerSessions.id, params.runnerSessionId));
+    }
 
     // The running-row insert is the runner claiming the job. Emit in the same tx; the
     // payload carries the row's own claim instant so a consumer records the true time,

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -18,7 +18,10 @@ export async function createRunnerSession(
       workspaceId: params.workspaceId,
       scope: params.scope,
       registrationTokenId: params.registrationTokenId,
+      registrationTokenKind: 'manual',
       labels: params.labels,
+      maxClaims: null,
+      claimsUsed: 0,
     })
     .returning();
 

--- a/libs/api/runners/src/db/runner-tokens.test.ts
+++ b/libs/api/runners/src/db/runner-tokens.test.ts
@@ -12,7 +12,9 @@ import {runnerTokens} from './schema/runner-tokens.js';
 
 describe('runner tokens', () => {
   beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_runner_tokens CASCADE`);
+    await db().execute(
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_tokens CASCADE`,
+    );
   });
 
   it('creates a runner token with a hashed token and prefix', async () => {

--- a/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
@@ -22,6 +22,13 @@ export const ephemeralRegistrationTokens = pgTable(
     uniqueIndex('runners_ephemeral_registration_tokens_hashed_token_unique').on(table.hashedToken),
     index('runners_ephemeral_registration_tokens_workspace_id_idx').on(table.workspaceId),
     index('runners_ephemeral_registration_tokens_provisioner_id_idx').on(table.provisionerId),
+    index('runners_ephemeral_registration_tokens_active_resource_idx').on(
+      table.workspaceId,
+      table.provisionerId,
+      table.resourceId,
+      table.consumedAt,
+      table.expiresAt,
+    ),
   ],
 );
 

--- a/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
@@ -1,0 +1,47 @@
+import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
+import {pgTable} from './common.js';
+
+export const ephemeralRegistrationTokens = pgTable(
+  'ephemeral_registration_tokens',
+  {
+    id: uuidv7PrimaryKey(),
+    workspaceId: uuid('workspace_id').notNull(),
+    provisionerId: uuid('provisioner_id').notNull(),
+    reservationId: uuid('reservation_id'),
+    resourceId: text('resource_id').notNull(),
+    hashedToken: text('hashed_token').notNull(),
+    prefix: text('prefix').notNull(),
+    expiresAt: timestamp('expires_at', {withTimezone: true}).notNull(),
+    consumedAt: timestamp('consumed_at', {withTimezone: true}),
+    consumedSessionId: uuid('consumed_session_id'),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('runners_ephemeral_registration_tokens_hashed_token_unique').on(table.hashedToken),
+    index('runners_ephemeral_registration_tokens_workspace_id_idx').on(table.workspaceId),
+    index('runners_ephemeral_registration_tokens_provisioner_id_idx').on(table.provisionerId),
+  ],
+);
+
+export type EphemeralRegistrationTokenDb = typeof ephemeralRegistrationTokens.$inferSelect;
+export type EphemeralRegistrationTokenInsertDb = typeof ephemeralRegistrationTokens.$inferInsert;
+
+export function toEphemeralRegistrationToken(
+  row: EphemeralRegistrationTokenDb,
+): EphemeralRegistrationToken {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    provisionerId: row.provisionerId,
+    reservationId: row.reservationId,
+    resourceId: row.resourceId,
+    hashedToken: row.hashedToken,
+    prefix: row.prefix,
+    expiresAt: row.expiresAt,
+    consumedAt: row.consumedAt,
+    consumedSessionId: row.consumedSessionId,
+    createdAt: row.createdAt,
+  };
+}

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -28,7 +28,7 @@ export const runnerSessions = pgTable(
   (table) => [
     check(
       'runners_runner_sessions_claims_ck',
-      sql`${table.claimsUsed} >= 0 AND (${table.maxClaims} IS NULL OR (${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,
+      sql`${table.claimsUsed} >= 0 AND ((${table.registrationTokenKind} = 'manual' AND ${table.maxClaims} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.maxClaims} IS NOT NULL AND ${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,
     ),
   ],
 );

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -1,19 +1,37 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {sql} from 'drizzle-orm';
+import {check, integer, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import type {RunnerSession} from '#core/entities/runner-session.js';
 import {pgTable} from './common.js';
 
 export const runnerSessionScopeEnum = pgEnum('runners_runner_session_scope', ['workspace']);
+export const runnerSessionRegistrationTokenKindEnum = pgEnum(
+  'runners_runner_session_registration_token_kind',
+  ['manual', 'ephemeral'],
+);
 
-export const runnerSessions = pgTable('runner_sessions', {
-  id: uuidv7PrimaryKey(),
-  workspaceId: uuid('workspace_id').notNull(),
-  scope: runnerSessionScopeEnum('scope').notNull().default('workspace'),
-  registrationTokenId: uuid('registration_token_id').notNull(),
-  labels: text('labels').array().notNull(),
-  createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
-  updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
-});
+export const runnerSessions = pgTable(
+  'runner_sessions',
+  {
+    id: uuidv7PrimaryKey(),
+    workspaceId: uuid('workspace_id').notNull(),
+    scope: runnerSessionScopeEnum('scope').notNull().default('workspace'),
+    registrationTokenId: uuid('registration_token_id').notNull(),
+    registrationTokenKind:
+      runnerSessionRegistrationTokenKindEnum('registration_token_kind').notNull(),
+    labels: text('labels').array().notNull(),
+    maxClaims: integer('max_claims'),
+    claimsUsed: integer('claims_used').notNull().default(0),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [
+    check(
+      'runners_runner_sessions_claims_ck',
+      sql`${table.claimsUsed} >= 0 AND (${table.maxClaims} IS NULL OR (${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,
+    ),
+  ],
+);
 
 export type RunnerSessionDb = typeof runnerSessions.$inferSelect;
 export type RunnerSessionInsertDb = typeof runnerSessions.$inferInsert;
@@ -28,7 +46,10 @@ export function toRunnerSession(row: RunnerSessionDb): RunnerSession {
     workspaceId: row.workspaceId,
     scope: row.scope,
     registrationTokenId: row.registrationTokenId,
+    registrationTokenKind: row.registrationTokenKind,
     labels: row.labels,
+    maxClaims: row.maxClaims,
+    claimsUsed: row.claimsUsed,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/libs/api/runners/src/index.ts
+++ b/libs/api/runners/src/index.ts
@@ -9,6 +9,11 @@ import {createRunnerTokenAuthMethod, onWorkflowsJobTimedOut, routes} from '#pres
 import {createRunnersMaintenanceActivities} from '#temporal/activities/index.js';
 import {RUNNERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
+export {
+  type MintEphemeralRegistrationTokenParams,
+  type MintEphemeralRegistrationTokenResult,
+  mintEphemeralRegistrationToken,
+} from '#core/ephemeral-registration-tokens.js';
 export {cancelRunnerJobs, type EnqueueJobParams, enqueueJob, releaseJob} from '#db/index.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');

--- a/libs/api/runners/src/presentation/auth/runner-token-auth.ts
+++ b/libs/api/runners/src/presentation/auth/runner-token-auth.ts
@@ -1,15 +1,26 @@
 import {AUTH_RUNNER_TOKEN} from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
-import {hashOpaqueToken} from '@shipfox/node-tokens';
+import {getTokenType, hashOpaqueToken} from '@shipfox/node-tokens';
 import type {FastifyRequest} from 'fastify';
+import {resolveEphemeralRegistrationTokenByHash} from '#db/ephemeral-registration-tokens.js';
 import {resolveRunnerTokenByHash} from '#db/runner-tokens.js';
 
 const RUNNER_CONTEXT_KEY = 'runner';
 
-export interface RunnerAuthContext {
-  runnerTokenId: string;
-  workspaceId: string;
-}
+export type RunnerAuthContext =
+  | {
+      kind: 'manual';
+      registrationTokenId: string;
+      workspaceId: string;
+    }
+  | {
+      kind: 'ephemeral';
+      ephemeralTokenId: string;
+      workspaceId: string;
+      provisionerId: string;
+      reservationId: string | null;
+      resourceId: string;
+    };
 
 export function getRunnerContext(request: FastifyRequest): RunnerAuthContext {
   const context = (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] as
@@ -32,6 +43,32 @@ export function createRunnerTokenAuthMethod(): AuthMethod {
         });
       }
 
+      if (getTokenType(rawToken) === 'ephemeralRegistrationToken') {
+        const ephemeralToken = await resolveEphemeralRegistrationTokenByHash(
+          hashOpaqueToken(rawToken),
+        );
+        if (!ephemeralToken) {
+          throw new ClientError('Invalid runner token', 'unauthorized', {status: 401});
+        }
+        if (ephemeralToken.expiresAt < new Date()) {
+          throw new ClientError(
+            'Ephemeral registration token has expired',
+            'registration-token-expired',
+            {status: 401},
+          );
+        }
+
+        (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = {
+          kind: 'ephemeral',
+          ephemeralTokenId: ephemeralToken.id,
+          workspaceId: ephemeralToken.workspaceId,
+          provisionerId: ephemeralToken.provisionerId,
+          reservationId: ephemeralToken.reservationId,
+          resourceId: ephemeralToken.resourceId,
+        } satisfies RunnerAuthContext;
+        return;
+      }
+
       const token = await resolveRunnerTokenByHash(hashOpaqueToken(rawToken));
       if (!token) {
         throw new ClientError('Invalid runner token', 'unauthorized', {status: 401});
@@ -47,7 +84,8 @@ export function createRunnerTokenAuthMethod(): AuthMethod {
       }
 
       (request as unknown as Record<string, unknown>)[RUNNER_CONTEXT_KEY] = {
-        runnerTokenId: token.id,
+        kind: 'manual',
+        registrationTokenId: token.id,
         workspaceId: token.workspaceId,
       } satisfies RunnerAuthContext;
     },

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -45,7 +45,7 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens, runners_outbox CASCADE`,
     );
     workspaceId = crypto.randomUUID();
     const session = await runnerSessionFactory.create({workspaceId});
@@ -54,7 +54,12 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
 
   async function claimAvailableJob(): Promise<{jobId: string; leaseToken: string}> {
     const pending = await pendingJobFactory.create({workspaceId});
-    const claimed = await claimJob({workspaceId, runnerSessionId, sessionLabels: ['linux', 'x64']});
+    const claimed = await claimJob({
+      workspaceId,
+      runnerSessionId,
+      sessionLabels: ['linux', 'x64'],
+      maxClaims: null,
+    });
     expect(claimed).not.toBeNull();
     return {jobId: pending.jobId, leaseToken: claimed?.leaseToken as string};
   }

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -6,13 +6,15 @@ import {
 import {AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
+import {generateOpaqueToken} from '@shipfox/node-tokens';
 import {eq, sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
 import {revokeRunnerToken} from '#db/runner-tokens.js';
+import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
-import {runnerTokenFactory} from '#test/index.js';
+import {ephemeralRegistrationTokenFactory, runnerTokenFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
@@ -44,7 +46,9 @@ describe('POST /runners/register', () => {
   });
 
   beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_runner_sessions, runners_runner_tokens CASCADE`);
+    await db().execute(
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_sessions, runners_runner_tokens CASCADE`,
+    );
     rawToken = `sf_r_${crypto.randomUUID()}`;
     workspaceId = crypto.randomUUID();
     await runnerTokenFactory.create({workspaceId}, {transient: {rawToken}});
@@ -71,6 +75,7 @@ describe('POST /runners/register', () => {
       workspaceId,
       scope: 'workspace',
       labels: ['linux', 'x64'],
+      maxClaims: null,
     });
 
     const rows = await db()
@@ -78,6 +83,45 @@ describe('POST /runners/register', () => {
       .from(runnerSessions)
       .where(eq(runnerSessions.id, body.session_id));
     expect(rows[0]?.labels).toEqual(['linux', 'x64']);
+    expect(rows[0]?.registrationTokenKind).toBe('manual');
+  });
+
+  it('exchanges an ephemeral registration token for a one-claim runner session', async () => {
+    const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
+    const token = await ephemeralRegistrationTokenFactory.create(
+      {workspaceId},
+      {transient: {rawToken: ephemeralRawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${ephemeralRawToken}`},
+      payload: {labels: ['Linux', 'x64']},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.mode).toBe('ephemeral');
+    expect(body.max_claims).toBe(1);
+
+    const claims = await verifyRunnerSessionToken(body.session_token);
+    expect(claims?.maxClaims).toBe(1);
+
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, body.session_id));
+    expect(session?.registrationTokenKind).toBe('ephemeral');
+    expect(session?.maxClaims).toBe(1);
+    expect(session?.claimsUsed).toBe(0);
+
+    const [consumed] = await db()
+      .select()
+      .from(ephemeralRegistrationTokens)
+      .where(eq(ephemeralRegistrationTokens.id, token.id));
+    expect(consumed?.consumedAt).toBeInstanceOf(Date);
+    expect(consumed?.consumedSessionId).toBe(body.session_id);
   });
 
   it('creates independent sessions from the same registration token', async () => {
@@ -118,6 +162,57 @@ describe('POST /runners/register', () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('runner-token-expired');
+  });
+
+  it('returns 409 when an ephemeral registration token is reused', async () => {
+    const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
+    await ephemeralRegistrationTokenFactory.create(
+      {workspaceId},
+      {transient: {rawToken: ephemeralRawToken}},
+    );
+    const request = {
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${ephemeralRawToken}`},
+      payload: {labels: ['linux']},
+    } as const;
+
+    const first = await app.inject(request);
+    const second = await app.inject(request);
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(409);
+    expect(second.json().code).toBe('registration-token-consumed');
+  });
+
+  it('returns 401 when an ephemeral registration token is expired', async () => {
+    const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
+    await ephemeralRegistrationTokenFactory.create(
+      {workspaceId, expiresAt: new Date(Date.now() - 1000)},
+      {transient: {rawToken: ephemeralRawToken}},
+    );
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${ephemeralRawToken}`},
+      payload: {labels: ['linux']},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('registration-token-expired');
+  });
+
+  it('returns 401 when an ephemeral registration token is not found', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/runners/register',
+      headers: {authorization: `Bearer ${generateOpaqueToken('ephemeralRegistrationToken')}`},
+      payload: {labels: ['linux']},
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json().code).toBe('unauthorized');
   });
 
   it('returns 401 when the registration token is revoked', async () => {

--- a/libs/api/runners/src/presentation/routes/register.ts
+++ b/libs/api/runners/src/presentation/routes/register.ts
@@ -1,6 +1,10 @@
 import {registerRunnerBodySchema, registerRunnerResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
-import {EmptyRunnerLabelsError} from '#core/errors.js';
+import {
+  EmptyRunnerLabelsError,
+  RegistrationTokenConsumedError,
+  RegistrationTokenExpiredError,
+} from '#core/errors.js';
 import {registerRunnerSession} from '#core/runner-sessions.js';
 import {getRunnerContext} from '#presentation/auth/index.js';
 
@@ -14,17 +18,47 @@ export const registerRoute = defineRoute({
       200: registerRunnerResponseSchema,
     },
   },
-  errorHandler: (error) => {
+  errorHandler: (error, request) => {
     if (error instanceof EmptyRunnerLabelsError) {
       throw new ClientError(error.message, 'empty-runner-labels', {status: 400});
+    }
+    if (error instanceof RegistrationTokenConsumedError) {
+      const runner = getRunnerContext(request);
+      if (runner.kind === 'ephemeral') {
+        request.log.warn(
+          {
+            ephemeralTokenId: error.ephemeralTokenId,
+            provisionerId: runner.provisionerId,
+          },
+          'Ephemeral registration token reuse rejected',
+        );
+      }
+      throw new ClientError(
+        'Registration token has already been consumed',
+        'registration-token-consumed',
+        {
+          status: 409,
+        },
+      );
+    }
+    if (error instanceof RegistrationTokenExpiredError) {
+      throw new ClientError('Registration token has expired', 'registration-token-expired', {
+        status: 401,
+      });
     }
     throw error;
   },
   handler: async (request) => {
     const runner = getRunnerContext(request);
     const result = await registerRunnerSession({
-      registrationTokenId: runner.runnerTokenId,
-      workspaceId: runner.workspaceId,
+      credential:
+        runner.kind === 'manual'
+          ? {
+              kind: 'manual',
+              registrationTokenId: runner.registrationTokenId,
+              workspaceId: runner.workspaceId,
+            }
+          : runner,
       labels: request.body.labels,
     });
 

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -8,11 +8,16 @@ import {RUNNER_SESSION_TOKEN_AUDIENCE} from '@shipfox/api-auth-dto';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {signHs256} from '@shipfox/node-jwt';
+import {generateOpaqueToken} from '@shipfox/node-tokens';
 import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
 import {createRunnerTokenAuthMethod} from '#presentation/auth/index.js';
-import {pendingJobFactory, runnerTokenFactory} from '#test/index.js';
+import {
+  ephemeralRegistrationTokenFactory,
+  pendingJobFactory,
+  runnerTokenFactory,
+} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 const fakeUserAuth: AuthMethod = {
@@ -47,7 +52,7 @@ describe('POST /runners/jobs/request', () => {
 
   beforeEach(async () => {
     await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens CASCADE`,
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_runner_tokens CASCADE`,
     );
     rawToken = `sf_r_${crypto.randomUUID()}`;
     workspaceId = crypto.randomUUID();
@@ -162,6 +167,33 @@ describe('POST /runners/jobs/request', () => {
     expect(secondRes.json().job_id).toBe(second.jobId);
   });
 
+  it('returns 409 after an ephemeral session claims one job', async () => {
+    const ephemeralRawToken = generateOpaqueToken('ephemeralRegistrationToken');
+    await ephemeralRegistrationTokenFactory.create(
+      {workspaceId},
+      {transient: {rawToken: ephemeralRawToken}},
+    );
+    const registered = await registerSession(ephemeralRawToken);
+    const created = await pendingJobFactory.create({workspaceId});
+    await pendingJobFactory.create({workspaceId});
+
+    const firstRes = await app.inject({
+      method: 'POST',
+      url: '/runners/jobs/request',
+      headers: {authorization: `Bearer ${registered.sessionToken}`},
+    });
+    const secondRes = await app.inject({
+      method: 'POST',
+      url: '/runners/jobs/request',
+      headers: {authorization: `Bearer ${registered.sessionToken}`},
+    });
+
+    expect(firstRes.statusCode).toBe(200);
+    expect(firstRes.json().job_id).toBe(created.jobId);
+    expect(secondRes.statusCode).toBe(409);
+    expect(secondRes.json().code).toBe('runner-session-exhausted');
+  });
+
   it('returns 401 when the runner session token is expired', async () => {
     const expiredSessionToken = await signHs256({
       payload: {
@@ -169,6 +201,7 @@ describe('POST /runners/jobs/request', () => {
         workspaceId,
         scope: 'workspace',
         labels: ['linux', 'x64'],
+        maxClaims: null,
       },
       secret: process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET ?? 'test-runner-session-secret',
       expiresIn: '-1s',

--- a/libs/api/runners/src/presentation/routes/request-job.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.ts
@@ -1,6 +1,7 @@
 import {requireRunnerSessionContext} from '@shipfox/api-auth-context';
 import {claimedJobResponseSchema} from '@shipfox/api-runners-dto';
-import {defineRoute} from '@shipfox/node-fastify';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {RunnerSessionExhaustedError} from '#core/errors.js';
 import {claimJob} from '#core/jobs.js';
 
 export const requestJobRoute = defineRoute({
@@ -12,6 +13,14 @@ export const requestJobRoute = defineRoute({
       200: claimedJobResponseSchema,
     },
   },
+  errorHandler: (error) => {
+    if (error instanceof RunnerSessionExhaustedError) {
+      throw new ClientError('Runner session claim limit exhausted', 'runner-session-exhausted', {
+        status: 409,
+      });
+    }
+    throw error;
+  },
   handler: async (_request, reply) => {
     const runner = requireRunnerSessionContext(_request);
 
@@ -19,6 +28,7 @@ export const requestJobRoute = defineRoute({
       workspaceId: runner.workspaceId,
       runnerSessionId: runner.runnerSessionId,
       sessionLabels: runner.labels,
+      maxClaims: runner.maxClaims,
     });
 
     if (!job) {

--- a/libs/api/runners/src/presentation/routes/runner-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/runner-tokens.test.ts
@@ -49,7 +49,9 @@ describe('runner token routes', () => {
 
   beforeEach(async () => {
     await closeApp();
-    await db().execute(sql`TRUNCATE runners_runner_tokens CASCADE`);
+    await db().execute(
+      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_tokens CASCADE`,
+    );
     workspaceId = crypto.randomUUID();
     vi.mocked(requireMembership).mockResolvedValue({
       workspaceId,

--- a/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
+++ b/libs/api/runners/src/presentation/subscribers/on-workflows-job-timed-out.test.ts
@@ -26,6 +26,7 @@ describe('onWorkflowsJobTimedOut', () => {
       workspaceId,
       runnerSessionId,
       sessionLabels: ['linux', 'x64'],
+      maxClaims: null,
     });
     expect(claimed).not.toBeNull();
 
@@ -44,6 +45,7 @@ describe('onWorkflowsJobTimedOut', () => {
       workspaceId,
       runnerSessionId,
       sessionLabels: ['linux', 'x64'],
+      maxClaims: null,
     });
 
     await onWorkflowsJobTimedOut(buildPayload(claimed?.jobId as string, claimed?.runId as string));

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -23,6 +23,7 @@ describe('detectAndExpireStuckJobsActivity', () => {
       workspaceId,
       runnerSessionId,
       sessionLabels: ['linux', 'x64'],
+      maxClaims: null,
     });
     await db()
       .update(runningJobs)

--- a/libs/api/runners/test/factories/ephemeral-registration-token.ts
+++ b/libs/api/runners/test/factories/ephemeral-registration-token.ts
@@ -1,0 +1,41 @@
+import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
+import {Factory} from 'fishery';
+import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
+import {createEphemeralRegistrationToken} from '#db/ephemeral-registration-tokens.js';
+
+export interface EphemeralRegistrationTokenFactoryTransientParams {
+  rawToken?: string;
+}
+
+export const ephemeralRegistrationTokenFactory = Factory.define<
+  EphemeralRegistrationToken,
+  EphemeralRegistrationTokenFactoryTransientParams
+>(({onCreate, transientParams}) => {
+  const rawToken = transientParams.rawToken ?? generateOpaqueToken('ephemeralRegistrationToken');
+
+  onCreate((token) => {
+    return createEphemeralRegistrationToken({
+      workspaceId: token.workspaceId,
+      provisionerId: token.provisionerId,
+      reservationId: token.reservationId,
+      resourceId: token.resourceId,
+      hashedToken: token.hashedToken,
+      prefix: token.prefix,
+      expiresAt: token.expiresAt,
+    });
+  });
+
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    provisionerId: crypto.randomUUID(),
+    reservationId: null,
+    resourceId: `resource-${crypto.randomUUID()}`,
+    hashedToken: hashOpaqueToken(rawToken),
+    prefix: extractDisplayPrefix(rawToken),
+    expiresAt: new Date(Date.now() + 60_000),
+    consumedAt: null,
+    consumedSessionId: null,
+    createdAt: new Date(),
+  };
+});

--- a/libs/api/runners/test/factories/runner-session.ts
+++ b/libs/api/runners/test/factories/runner-session.ts
@@ -17,7 +17,10 @@ export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) =
     workspaceId: crypto.randomUUID(),
     scope: 'workspace',
     registrationTokenId: crypto.randomUUID(),
+    registrationTokenKind: 'manual',
     labels: ['linux', 'x64'],
+    maxClaims: null,
+    claimsUsed: 0,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/libs/api/runners/test/globalSetup.ts
+++ b/libs/api/runners/test/globalSetup.ts
@@ -8,6 +8,7 @@ export async function setup() {
   createPostgresClient();
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_runners');
+  await db().execute(sql`TRUNCATE runners_ephemeral_registration_tokens CASCADE`);
   await db().execute(sql`TRUNCATE runners_runner_sessions CASCADE`);
   await db().execute(sql`TRUNCATE runners_runner_tokens CASCADE`);
   await db().execute(sql`TRUNCATE runners_pending_jobs CASCADE`);

--- a/libs/api/runners/test/index.ts
+++ b/libs/api/runners/test/index.ts
@@ -1,3 +1,7 @@
+export {
+  type EphemeralRegistrationTokenFactoryTransientParams,
+  ephemeralRegistrationTokenFactory,
+} from './factories/ephemeral-registration-token.js';
 export {pendingJobFactory} from './factories/pending-job.js';
 export {runnerSessionFactory} from './factories/runner-session.js';
 export {

--- a/libs/shared/node/tokens/src/index.ts
+++ b/libs/shared/node/tokens/src/index.ts
@@ -11,6 +11,7 @@ export const tokenTypeParts = {
   passwordReset: 'pr',
   refreshToken: 'r',
   runnerToken: 'rt',
+  ephemeralRegistrationToken: 'ert',
   provisionerToken: 'pt',
 } as const;
 


### PR DESCRIPTION
Add ephemeral registration tokens for one-job runner sessions.

Provisioners need to mint short-lived registration credentials per resource instead of reusing durable manual runner tokens. This adds the ephemeral token prefix and table, consumes each token atomically when registering a runner session, and caps the resulting session at one real job claim with database-authoritative accounting.

The implementation keeps manual and ephemeral registration tokens in separate tables because the ephemeral path is high-churn and single-use. The session JWT carries maxClaims only as a hint; capped sessions still lock and read the runner_sessions row before spending a claim.

The migration is folded into the pre-deploy 0001 runners baseline, and no changeset is included because the touched packages are marked private.

Closes ENG-611

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add ephemeral, single-use runner registration tokens and enforce one-claim runner sessions with DB-backed caps. Fixes ENG-611 by letting provisioners mint short-lived per-resource credentials instead of reusing manual runner tokens.

- **New Features**
  - Ephemeral tokens: `mintEphemeralRegistrationToken` in `libs/api/runners` returns `{token, rawToken}`; stores only a hash; `ert` prefix; enforces one active token per resource via advisory locks.
  - Registration: Auth accepts `ephemeralRegistrationToken` via `@shipfox/node-tokens`; rejects expired; registration consumes it atomically and creates a session with `registration_token_kind='ephemeral'` and `max_claims=1`; reuse returns 409.
  - Sessions and claims: Runner session JWT now includes nullable `maxClaims`; `/runners/jobs/request` locks the session, enforces caps from DB state, spends a claim only on real claims, increments `claims_used`, and returns 409 `runner-session-exhausted` when exhausted.
  - Database: Added `runners_ephemeral_registration_tokens`; `runners_runner_sessions` adds `registration_token_kind`, `max_claims`, `claims_used` with a check constraint; `runners_running_jobs` now stores `runner_session_id`.
  - API errors: `registration-token-consumed` (409), `registration-token-expired` (401), `runner-session-exhausted` (409).

- **Migration**
  - Run the updated `0001` runners schema migration.
  - Provisioners should mint tokens via `mintEphemeralRegistrationToken` and pass the raw token as Bearer to `/runners/register`.
  - No changes required for existing manual runner tokens.

<sup>Written for commit b2d183848fc0f442bf2a0fb224b82abb3beb7ce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

