### PR TITLE
[api-provisioners] Stop clearing workspaces in tests

### DIFF
--- a/libs/api/provisioners/src/db/provisioner-tokens.test.ts
+++ b/libs/api/provisioners/src/db/provisioner-tokens.test.ts
@@ -12,7 +12,6 @@ import {provisionerTokenFactory} from '#test/index.js';
 describe('provisioner token db', () => {
   beforeEach(async () => {
     await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
-    await db().execute(sql`TRUNCATE workspaces CASCADE`);
   });
 
   it('creates and resolves a token', async () => {

--- a/libs/api/provisioners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/provisioners/src/presentation/routes/provisioner-me.test.ts
@@ -40,7 +40,6 @@ describe('provisioner me route', () => {
   beforeEach(async () => {
     await closeApp();
     await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
-    await db().execute(sql`TRUNCATE workspaces CASCADE`);
     mocks.logger.warn.mockReset();
     app = await createApp({
       auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],

--- a/libs/api/provisioners/test/globalSetup.ts
+++ b/libs/api/provisioners/test/globalSetup.ts
@@ -11,7 +11,6 @@ export async function setup() {
   await runMigrations(db(), workspacesMigrationsPath, '__drizzle_migrations_workspaces');
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_provisioners');
   await db().execute(sql`TRUNCATE provisioners_provisioner_tokens CASCADE`);
-  await db().execute(sql`TRUNCATE workspaces CASCADE`);
 
   closeDb();
   await closePostgresClient();


### PR DESCRIPTION
[api-provisioners] Stop clearing workspaces in tests

Provisioner tests were truncating the shared `workspaces` table even though the provisioner token table does not have a foreign key to it. When Turbo runs API package tests concurrently, that cleanup can delete rows created by `@shipfox/api-workspaces` between insert and lookup, producing flaky create-then-read assertions.

This keeps provisioner test isolation scoped to `provisioners_provisioner_tokens`; route tests that need a real workspace still create one explicitly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope provisioner test cleanup to the `provisioners_provisioner_tokens` table and stop truncating the shared `workspaces` table. This prevents cross-package test races when Turbo runs `@shipfox/api-workspaces` and provisioner tests concurrently, fixing flaky create-then-read assertions.

<sup>Written for commit 31ae19565520664829ff17dbd9d0c82ab87167ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

