### PR TITLE
[expression] Document CEL map access behavior

### DIFF
--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -78,4 +78,61 @@ describe('evaluateWorkflowExpression', () => {
 
     expect(act).toThrow(WorkflowExpressionEvaluationError);
   });
+
+  it('reads dotted properties from syntax-checked plain objects', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.pull_request.title',
+      check: {mode: 'syntax'},
+    });
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {
+        pull_request: {
+          title: 'Fix auth',
+        },
+      },
+    });
+
+    expect(result).toBe('Fix auth');
+  });
+
+  it('returns heterogeneous nested values from syntax-checked plain objects', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.pull_request',
+      check: {mode: 'syntax'},
+    });
+    const pullRequest = {
+      title: 'Fix auth',
+      labels: [{name: 'bug'}],
+      number: 42,
+      draft: false,
+      review: {score: 0.95},
+    };
+
+    const result = evaluateWorkflowExpression(expression, {
+      event: {
+        pull_request: pullRequest,
+      },
+    });
+
+    expect(result).toEqual(pullRequest);
+  });
+
+  it('wraps missing paths from syntax-checked plain objects as evaluation errors', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.nope.deep',
+      check: {mode: 'syntax'},
+    });
+
+    const act = () =>
+      evaluateWorkflowExpression(expression, {
+        event: {
+          pull_request: {
+            title: 'Fix auth',
+          },
+        },
+      });
+
+    expect(act).toThrow(WorkflowExpressionEvaluationError);
+  });
 });


### PR DESCRIPTION
Document the CEL runtime behavior that the workflow interpolation resolver depends on when evaluating syntax-checked expressions over untyped webhook/input maps.

The spike found that `@gresb/cel-javascript` supports dotted access over plain JS objects, including returning heterogeneous nested object values. Missing paths are not native-lenient though: `event.nope.deep` throws and is wrapped as `WorkflowExpressionEvaluationError`, so the resolver should include a wrapper/preprocessing layer if v1 keeps missing path -> null -> empty string + diagnostic semantics.

The findings and wrapper-needed decision are also recorded on ENG-631 and the interpolation spec document in Linear.

Closes ENG-631

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests that document CEL dotted map access in the workflow expression evaluator over plain JS objects. Confirms nested values resolve correctly and that missing paths throw WorkflowExpressionEvaluationError, guiding the interpolation resolver’s wrapper semantics for ENG-631.

<sup>Written for commit 8f117d4371bfcd981e89e6bb97c7b96d951189cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

