### PR TITLE
Move workspace setup gating into route hooks

### DIFF
--- a/.changeset/quiet-routes-guard.md
+++ b/.changeset/quiet-routes-guard.md
@@ -6,4 +6,4 @@
 "@shipfox/client-router": patch
 ---
 
-Adds a workspace setup guard that keeps VCS onboarding and first project creation out of the completed-workspace navigation.
+Moves workspace setup gating into route hooks so VCS onboarding and first project creation resolve before protected workspace content renders.

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -26,6 +26,7 @@
     "@shipfox/client-router": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",
+    "@tanstack/react-query": "^5.101.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "zod": "^4.4.3"

--- a/apps/client/src/main.tsx
+++ b/apps/client/src/main.tsx
@@ -7,9 +7,12 @@ import {AuthProvider, useAuthState} from '@shipfox/client-auth';
 import {ConfigErrorScreen, setLoadedConfig} from '@shipfox/client-config';
 import {RouterProvider, router} from '@shipfox/client-router';
 import {ThemeProvider, Toaster, TooltipProvider} from '@shipfox/react-ui';
+import {QueryClient} from '@tanstack/react-query';
 import {StrictMode, useEffect} from 'react';
 import {createRoot} from 'react-dom/client';
 import {loadAppConfig} from './config.js';
+
+const queryClient = new QueryClient();
 
 function RoutedApp() {
   const auth = useAuthState();
@@ -23,7 +26,7 @@ function RoutedApp() {
     }
   }, [auth.isLoading]);
 
-  return <RouterProvider router={router} context={{auth}} />;
+  return <RouterProvider router={router} context={{auth, queryClient}} />;
 }
 
 const element = document.getElementById('app');
@@ -51,7 +54,7 @@ if (!configResult.ok) {
     <StrictMode>
       <ThemeProvider>
         <TooltipProvider>
-          <AuthProvider>
+          <AuthProvider queryClient={queryClient}>
             <RoutedApp />
             <Toaster />
           </AuthProvider>

--- a/libs/client/auth/src/components/auth-provider.tsx
+++ b/libs/client/auth/src/components/auth-provider.tsx
@@ -7,11 +7,16 @@ import {authStateAtom} from '#state/auth.js';
 
 const REFRESH_RETRY_DELAY_MS = 60_000;
 
-export function AuthProvider({children}: PropsWithChildren) {
-  const [queryClient] = useState(() => new QueryClient());
+export interface AuthProviderProps extends PropsWithChildren {
+  queryClient?: QueryClient;
+}
+
+export function AuthProvider({children, queryClient}: AuthProviderProps) {
+  const [fallbackQueryClient] = useState(() => new QueryClient());
+  const client = queryClient ?? fallbackQueryClient;
 
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={client}>
       <JotaiProvider>
         <AuthProviderContent>{children}</AuthProviderContent>
       </JotaiProvider>

--- a/libs/client/integrations/src/pages/debug-install-page.tsx
+++ b/libs/client/integrations/src/pages/debug-install-page.tsx
@@ -23,9 +23,9 @@ export function DebugInstallPage() {
       .then(async () => {
         await queryClient.invalidateQueries({
           queryKey: integrationsQueryKeys.sourceConnections(workspaceId),
-          // WorkspaceSetupGuard is the next active observer, not this page, so the
-          // default 'active' refetch would no-op and leave the cache stale
-          // until after the guard's first render redirects back here.
+          // The workspace setup runs in the route's beforeLoad via fetchQuery,
+          // not a mounted observer, so the default 'active' refetch would no-op
+          // and leave the cache stale until the next navigation reads it.
           refetchType: 'all',
         });
         toast.success('Debug source control connected.');

--- a/libs/client/projects/src/components/workspace-setup-guard.test.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.test.tsx
@@ -13,11 +13,12 @@ import {
   RouterProvider,
   useRouteContext,
 } from '@tanstack/react-router';
-import {render, screen, waitFor} from '@testing-library/react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {projectsQueryKeys} from '#hooks/api/projects.js';
 import {
   loadWorkspaceSetupRoute,
   WorkspaceSetupErrorRoute,
+  WorkspaceSetupPending,
   type WorkspaceSetupState,
 } from './workspace-setup-guard.js';
 
@@ -120,7 +121,7 @@ function renderSetupRoute(
 
   configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-  return render(<RouterProvider router={router} context={{queryClient}} />);
+  return {router, ...render(<RouterProvider router={router} context={{queryClient}} />)};
 }
 
 function GuardedRoute({label}: {label: string}) {
@@ -183,6 +184,9 @@ describe('workspace setup route hook', () => {
           projects: [projectStub()],
           next_cursor: null,
         });
+        // Existence is cached with an infinite staleTime, so only an explicit
+        // invalidation forces the refetch whose failure exercises the fallback.
+        void queryClient.invalidateQueries({queryKey: projectsQueryKeys.exists(WORKSPACE_ID)});
       },
     });
 
@@ -263,4 +267,77 @@ describe('workspace setup route hook', () => {
     expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
     expect(screen.queryByText('Workspace home')).not.toBeInTheDocument();
   });
+
+  test('recovers workspace content when Retry re-runs the route load', async () => {
+    let projectAttempts = 0;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes('/projects?')) {
+        projectAttempts += 1;
+        if (projectAttempts === 1)
+          return Promise.resolve(jsonResponse({code: 'server-error'}, {status: 500}));
+        return Promise.resolve(jsonResponse({projects: [projectStub()], next_cursor: null}));
+      }
+      return Promise.resolve(jsonResponse({}, {status: 404}));
+    });
+
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
+
+    fireEvent.click(await screen.findByRole('button', {name: 'Retry'}));
+
+    expect(await screen.findByText('Workspace home')).toBeInTheDocument();
+    expect(screen.queryByText('Could not load workspace setup')).not.toBeInTheDocument();
+  });
+
+  test('re-evaluates the guard on navigation between children without refetching existence', async () => {
+    const fetchImpl = setupFetch({projects: [projectStub()]});
+    const {router} = renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
+
+    expect(await screen.findByText('Workspace home')).toBeInTheDocument();
+
+    await act(async () => {
+      await router.navigate({
+        to: '/workspaces/$wid/integrations',
+        params: {wid: WORKSPACE_ID},
+      });
+    });
+
+    expect(await screen.findByText('Settings integrations')).toBeInTheDocument();
+    expect(calledUrls(fetchImpl).filter((url) => url.includes('/projects?'))).toHaveLength(1);
+  });
+
+  test('shows the pending loader while setup state is unresolved (auth-loading parity)', async () => {
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+    const rootRoute = createRootRouteWithContext<{queryClient: QueryClient}>()({
+      component: Outlet,
+    });
+    const layoutRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/workspaces/$wid',
+      beforeLoad: () => undefined,
+      component: WorkspaceLayoutParity,
+    });
+    const router = createRouter({
+      defaultPendingMs: 0,
+      history: createMemoryHistory({initialEntries: [`/workspaces/${WORKSPACE_ID}`]}),
+      routeTree: rootRoute.addChildren([layoutRoute]),
+      context: {queryClient},
+    });
+
+    render(<RouterProvider router={router} context={{queryClient}} />);
+
+    expect(await screen.findByRole('status', {name: 'Loading'})).toBeInTheDocument();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
 });
+
+// Mirrors the _layout route component: while auth is loading, beforeLoad returns
+// undefined, so the route context carries no setup state and the layout shows a
+// loader instead of protected content. Guards the TanStack contract (undefined
+// beforeLoad leaves the key absent) that the production sentinel depends on.
+function WorkspaceLayoutParity() {
+  const setupState = useRouteContext({strict: false}) as Partial<WorkspaceSetupState>;
+  if (setupState.hideProjectNavigation === undefined) return <WorkspaceSetupPending />;
+
+  return <main>Protected content</main>;
+}

--- a/libs/client/projects/src/components/workspace-setup-guard.test.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.test.tsx
@@ -121,7 +121,11 @@ function renderSetupRoute(
 
   configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-  return {router, ...render(<RouterProvider router={router} context={{queryClient}} />)};
+  return {
+    queryClient,
+    router,
+    ...render(<RouterProvider router={router} context={{queryClient}} />),
+  };
 }
 
 function GuardedRoute({label}: {label: string}) {
@@ -184,8 +188,8 @@ describe('workspace setup route hook', () => {
           projects: [projectStub()],
           next_cursor: null,
         });
-        // Existence is cached with an infinite staleTime, so only an explicit
-        // invalidation forces the refetch whose failure exercises the fallback.
+        // Existence has a freshness window, so explicit invalidation forces the
+        // refetch whose failure exercises the cached fallback.
         void queryClient.invalidateQueries({queryKey: projectsQueryKeys.exists(WORKSPACE_ID)});
       },
     });
@@ -289,7 +293,7 @@ describe('workspace setup route hook', () => {
     expect(screen.queryByText('Could not load workspace setup')).not.toBeInTheDocument();
   });
 
-  test('re-evaluates the guard on navigation between children without refetching existence', async () => {
+  test('re-evaluates the guard on navigation between children without refetching fresh existence', async () => {
     const fetchImpl = setupFetch({projects: [projectStub()]});
     const {router} = renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
 
@@ -304,6 +308,65 @@ describe('workspace setup route hook', () => {
 
     expect(await screen.findByText('Settings integrations')).toBeInTheDocument();
     expect(calledUrls(fetchImpl).filter((url) => url.includes('/projects?'))).toHaveLength(1);
+  });
+
+  test('refetches stale project existence so external project creation can complete setup', async () => {
+    let projects = [] as unknown[];
+    const fetchImpl = setupFetch({connections: [sourceConnection()]});
+    fetchImpl.mockImplementation((input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.includes('/projects?')) {
+        return Promise.resolve(jsonResponse({projects, next_cursor: null}));
+      }
+      if (url.includes('/integration-connections?')) {
+        return Promise.resolve(jsonResponse({connections: [sourceConnection()]}));
+      }
+      return Promise.resolve(jsonResponse({}, {status: 404}));
+    });
+    const {queryClient, router} = renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
+
+    expect(await screen.findByText('Create project')).toBeInTheDocument();
+    projects = [projectStub()];
+    queryClient.setQueryData(
+      projectsQueryKeys.exists(WORKSPACE_ID),
+      {projects: [], next_cursor: null},
+      {updatedAt: Date.now() - 31_000},
+    );
+
+    await act(async () => {
+      await router.navigate({
+        to: '/workspaces/$wid',
+        params: {wid: WORKSPACE_ID},
+      });
+    });
+
+    expect(await screen.findByText('Workspace home')).toBeInTheDocument();
+    expect(calledUrls(fetchImpl).filter((url) => url.includes('/projects?'))).toHaveLength(2);
+  });
+
+  test('uses a generic workspace error for descendant route failures', async () => {
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+    const rootRoute = createRootRouteWithContext<{queryClient: QueryClient}>()({
+      component: Outlet,
+    });
+    const throwingRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/workspaces/$wid',
+      beforeLoad: () => ({hideProjectNavigation: false}),
+      errorComponent: WorkspaceSetupErrorRoute,
+      component: ThrowingWorkspaceRoute,
+    });
+    const router = createRouter({
+      defaultPendingMs: 0,
+      history: createMemoryHistory({initialEntries: [`/workspaces/${WORKSPACE_ID}`]}),
+      routeTree: rootRoute.addChildren([throwingRoute]),
+      context: {queryClient},
+    });
+
+    render(<RouterProvider router={router} context={{queryClient}} />);
+
+    expect(await screen.findByText('Could not load workspace')).toBeInTheDocument();
+    expect(screen.queryByText('Could not load workspace setup')).not.toBeInTheDocument();
   });
 
   test('shows the pending loader while setup state is unresolved (auth-loading parity)', async () => {
@@ -340,4 +403,8 @@ function WorkspaceLayoutParity() {
   if (setupState.hideProjectNavigation === undefined) return <WorkspaceSetupPending />;
 
   return <main>Protected content</main>;
+}
+
+function ThrowingWorkspaceRoute(): never {
+  throw new Error('Descendant route failed');
 }

--- a/libs/client/projects/src/components/workspace-setup-guard.test.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.test.tsx
@@ -17,7 +17,7 @@ import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {projectsQueryKeys} from '#hooks/api/projects.js';
 import {
   loadWorkspaceSetupRoute,
-  WorkspaceSetupErrorRoute,
+  WorkspaceLayoutErrorRoute,
   WorkspaceSetupPending,
   type WorkspaceSetupState,
 } from './workspace-setup-guard.js';
@@ -102,7 +102,7 @@ function renderSetupRoute(
           pathname: location.pathname,
         }),
       pendingComponent: FullPageLoader,
-      errorComponent: WorkspaceSetupErrorRoute,
+      errorComponent: WorkspaceLayoutErrorRoute,
       component: () => <GuardedRoute label={label} />,
     });
   const routeTree = rootRoute.addChildren([
@@ -353,7 +353,7 @@ describe('workspace setup route hook', () => {
       getParentRoute: () => rootRoute,
       path: '/workspaces/$wid',
       beforeLoad: () => ({hideProjectNavigation: false}),
-      errorComponent: WorkspaceSetupErrorRoute,
+      errorComponent: WorkspaceLayoutErrorRoute,
       component: ThrowingWorkspaceRoute,
     });
     const router = createRouter({

--- a/libs/client/projects/src/components/workspace-setup-guard.test.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.test.tsx
@@ -1,39 +1,27 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import {configureApiClient} from '@shipfox/client-api';
-import {type AuthState, authStateAtom} from '@shipfox/client-auth';
 import {integrationsQueryKeys} from '@shipfox/client-integrations';
-import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {FullPageLoader} from '@shipfox/react-ui';
+import {QueryClient} from '@tanstack/react-query';
 import {
   createMemoryHistory,
-  createRootRoute,
+  createRootRouteWithContext,
   createRoute,
   createRouter,
   Outlet,
   RouterProvider,
+  useRouteContext,
 } from '@tanstack/react-router';
 import {render, screen, waitFor} from '@testing-library/react';
-import {Provider as JotaiProvider, useSetAtom} from 'jotai';
-import {useEffect} from 'react';
 import {projectsQueryKeys} from '#hooks/api/projects.js';
-import {WorkspaceSetupGuard} from './workspace-setup-guard.js';
+import {
+  loadWorkspaceSetupRoute,
+  WorkspaceSetupErrorRoute,
+  type WorkspaceSetupState,
+} from './workspace-setup-guard.js';
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
-
-const authState: AuthState = {
-  status: 'authenticated',
-  token: 'token',
-  user: {
-    id: '22222222-2222-4222-8222-222222222222',
-    email: 'user@example.com',
-    name: null,
-    email_verified_at: new Date().toISOString(),
-    status: 'active',
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-  },
-  workspaces: [{id: WORKSPACE_ID, name: 'Acme', membershipId: 'm-1'}],
-};
 
 function jsonResponse(body: unknown, init: ResponseInit = {}) {
   return new Response(JSON.stringify(body), {
@@ -91,18 +79,29 @@ function setupFetch(options: SetupFetchOptions = {}) {
   });
 }
 
-function renderGuardPage(
+function renderSetupRoute(
   path: string,
   fetchImpl: ReturnType<typeof setupFetch>,
   options: {seedQueryClient?: (queryClient: QueryClient) => void} = {},
 ) {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
   options.seedQueryClient?.(queryClient);
-  const rootRoute = createRootRoute({component: Outlet});
+
+  const rootRoute = createRootRouteWithContext<{queryClient: QueryClient}>()({
+    component: Outlet,
+  });
   const guardedRoute = (routePath: string, label: string) =>
     createRoute({
       getParentRoute: () => rootRoute,
       path: routePath,
+      beforeLoad: ({context, location, params}) =>
+        loadWorkspaceSetupRoute({
+          queryClient: context.queryClient,
+          workspaceId: (params as {wid: string}).wid,
+          pathname: location.pathname,
+        }),
+      pendingComponent: FullPageLoader,
+      errorComponent: WorkspaceSetupErrorRoute,
       component: () => <GuardedRoute label={label} />,
     });
   const routeTree = rootRoute.addChildren([
@@ -113,43 +112,28 @@ function renderGuardPage(
     guardedRoute('/workspaces/$wid/settings/integrations', 'Settings integrations'),
   ]);
   const router = createRouter({
+    defaultPendingMs: 0,
     history: createMemoryHistory({initialEntries: [path]}),
     routeTree,
+    context: {queryClient},
   });
 
   configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
 
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <JotaiProvider>
-        <AuthSeed />
-        <RouterProvider router={router} />
-      </JotaiProvider>
-    </QueryClientProvider>,
-  );
+  return render(<RouterProvider router={router} context={{queryClient}} />);
 }
 
 function GuardedRoute({label}: {label: string}) {
+  const setupState = useRouteContext({strict: false}) as WorkspaceSetupState;
+
   return (
-    <WorkspaceSetupGuard>
-      {({hideProjectNavigation}) => (
-        <>
-          <div data-testid="project-navigation">{hideProjectNavigation ? 'hidden' : 'visible'}</div>
-          <main>{label}</main>
-        </>
-      )}
-    </WorkspaceSetupGuard>
+    <>
+      <div data-testid="project-navigation">
+        {setupState.hideProjectNavigation ? 'hidden' : 'visible'}
+      </div>
+      <main>{label}</main>
+    </>
   );
-}
-
-function AuthSeed() {
-  const setAuth = useSetAtom(authStateAtom);
-
-  useEffect(() => {
-    setAuth(authState);
-  }, [setAuth]);
-
-  return null;
 }
 
 function projectStub() {
@@ -162,16 +146,16 @@ function calledUrls(fetchImpl: ReturnType<typeof setupFetch>) {
   );
 }
 
-describe('WorkspaceSetupGuard', () => {
+describe('workspace setup route hook', () => {
   test('renders a loader while the project existence query is pending', async () => {
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, setupFetch({projectsPending: true}));
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, setupFetch({projectsPending: true}));
 
     expect(await screen.findByRole('status', {name: 'Loading'})).toBeInTheDocument();
     expect(screen.queryByText('Workspace home')).not.toBeInTheDocument();
   });
 
   test('renders a retryable setup-status error when the project query fails', async () => {
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, setupFetch({projectsFail: true}));
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, setupFetch({projectsFail: true}));
 
     expect(await screen.findByText('Could not load workspace setup')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();
@@ -181,7 +165,7 @@ describe('WorkspaceSetupGuard', () => {
   test('allows normal workspace content and skips source connections when a project exists', async () => {
     const fetchImpl = setupFetch({projects: [projectStub()]});
 
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
 
     expect(await screen.findByText('Workspace home')).toBeInTheDocument();
     expect(screen.getByTestId('project-navigation')).toHaveTextContent('visible');
@@ -193,7 +177,7 @@ describe('WorkspaceSetupGuard', () => {
   test('keeps cached completed-workspace state when the project refetch fails', async () => {
     const fetchImpl = setupFetch({projectsFail: true});
 
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, fetchImpl, {
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl, {
       seedQueryClient: (queryClient) => {
         queryClient.setQueryData(projectsQueryKeys.exists(WORKSPACE_ID), {
           projects: [projectStub()],
@@ -215,14 +199,14 @@ describe('WorkspaceSetupGuard', () => {
       connections: [sourceConnection({lifecycle_status: 'disabled'})],
     });
 
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl);
 
     expect(await screen.findByText('VCS onboarding')).toBeInTheDocument();
     expect(screen.getByTestId('project-navigation')).toHaveTextContent('hidden');
   });
 
   test('sends a workspace with active VCS and no project to project creation', async () => {
-    renderGuardPage(
+    renderSetupRoute(
       `/workspaces/${WORKSPACE_ID}/integrations`,
       setupFetch({connections: [sourceConnection()]}),
     );
@@ -234,7 +218,7 @@ describe('WorkspaceSetupGuard', () => {
   test('keeps cached source-connection state when the source refetch fails', async () => {
     const fetchImpl = setupFetch({connectionsFail: true});
 
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, fetchImpl, {
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, fetchImpl, {
       seedQueryClient: (queryClient) => {
         queryClient.setQueryData(integrationsQueryKeys.sourceConnections(WORKSPACE_ID), {
           connections: [sourceConnection()],
@@ -253,7 +237,7 @@ describe('WorkspaceSetupGuard', () => {
   });
 
   test('redirects the completed workspace integrations index to settings integrations', async () => {
-    renderGuardPage(
+    renderSetupRoute(
       `/workspaces/${WORKSPACE_ID}/integrations`,
       setupFetch({projects: [projectStub()]}),
     );
@@ -263,7 +247,7 @@ describe('WorkspaceSetupGuard', () => {
   });
 
   test('keeps completed workspace integration install routes available', async () => {
-    renderGuardPage(
+    renderSetupRoute(
       `/workspaces/${WORKSPACE_ID}/integrations/debug`,
       setupFetch({projects: [projectStub()]}),
     );
@@ -273,7 +257,7 @@ describe('WorkspaceSetupGuard', () => {
   });
 
   test('renders a retryable setup-status error when the source connection query fails', async () => {
-    renderGuardPage(`/workspaces/${WORKSPACE_ID}`, setupFetch({connectionsFail: true}));
+    renderSetupRoute(`/workspaces/${WORKSPACE_ID}`, setupFetch({connectionsFail: true}));
 
     expect(await screen.findByText('Could not load workspace setup')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Retry'})).toBeInTheDocument();

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -1,10 +1,11 @@
+import type {ListIntegrationConnectionsResponseDto} from '@shipfox/api-integration-core-dto';
+import type {ListProjectsResponseDto} from '@shipfox/api-projects-dto';
 import {ApiError} from '@shipfox/client-api';
-import {useMaybeActiveWorkspace} from '@shipfox/client-auth';
-import {useSourceConnectionsQuery} from '@shipfox/client-integrations';
+import {integrationsQueryKeys, listSourceConnections} from '@shipfox/client-integrations';
 import {Alert, Button, FullPageLoader, Header, Text} from '@shipfox/react-ui';
-import {Navigate, useLocation} from '@tanstack/react-router';
-import type {ReactNode} from 'react';
-import {useWorkspaceProjectExistenceQuery} from '#hooks/api/projects.js';
+import type {QueryClient} from '@tanstack/react-query';
+import {type ErrorComponentProps, redirect, useRouter} from '@tanstack/react-router';
+import {listProjects, projectsQueryKeys} from '#hooks/api/projects.js';
 
 const TRAILING_SLASHES_RE = /\/+$/u;
 
@@ -12,81 +13,75 @@ export interface WorkspaceSetupState {
   hideProjectNavigation: boolean;
 }
 
-export interface WorkspaceSetupGuardProps {
-  children: ReactNode | ((state: WorkspaceSetupState) => ReactNode);
+export interface WorkspaceSetupRouteOptions {
+  queryClient: QueryClient;
+  workspaceId: string;
+  pathname: string;
 }
 
-export function WorkspaceSetupGuard({children}: WorkspaceSetupGuardProps) {
-  const workspace = useMaybeActiveWorkspace();
-  const location = useLocation();
-  const projectQuery = useWorkspaceProjectExistenceQuery(workspace?.id);
-  const hasProject = (projectQuery.data?.projects.length ?? 0) > 0;
-  const projectQueryInitialError = projectQuery.isError && projectQuery.data === undefined;
-  const sourceConnectionsQuery = useSourceConnectionsQuery(
-    workspace && !projectQuery.isPending && !projectQueryInitialError && !hasProject
-      ? workspace.id
-      : undefined,
-  );
-
-  if (!workspace || projectQuery.isPending) return <FullPageLoader />;
-
-  if (projectQueryInitialError) {
-    return (
-      <WorkspaceSetupError
-        message={setupErrorMessage(projectQuery.error)}
-        onRetry={() => {
-          void projectQuery.refetch();
-        }}
-      />
-    );
-  }
-
-  const pathname = normalizePath(location.pathname);
+export async function loadWorkspaceSetupRoute({
+  queryClient,
+  workspaceId,
+  pathname,
+}: WorkspaceSetupRouteOptions): Promise<WorkspaceSetupState> {
+  const projects = await fetchWorkspaceProjectExistence(queryClient, workspaceId);
+  const normalizedPathname = normalizePath(pathname);
+  const hasProject = projects.projects.length > 0;
 
   if (hasProject) {
-    if (isIntegrationsIndexPath(pathname, workspace.id)) {
-      return (
-        <Navigate
-          to="/workspaces/$wid/settings/integrations"
-          params={{wid: workspace.id}}
-          replace
-        />
-      );
+    if (isIntegrationsIndexPath(normalizedPathname, workspaceId)) {
+      throw redirect({
+        to: '/workspaces/$wid/settings/integrations',
+        params: {wid: workspaceId},
+        replace: true,
+      });
     }
 
-    return renderChildren(children, {hideProjectNavigation: false});
+    return {hideProjectNavigation: false};
   }
 
-  if (sourceConnectionsQuery.isPending) return <FullPageLoader />;
-
-  if (sourceConnectionsQuery.isError && sourceConnectionsQuery.data === undefined) {
-    return (
-      <WorkspaceSetupError
-        message={setupErrorMessage(sourceConnectionsQuery.error)}
-        onRetry={() => {
-          void sourceConnectionsQuery.refetch();
-        }}
-      />
-    );
-  }
-
-  if (sourceConnectionsQuery.data === undefined) return <FullPageLoader />;
-
-  const hasSourceConnection = sourceConnectionsQuery.data.connections.length > 0;
+  const sourceConnections = await fetchWorkspaceSourceConnections(queryClient, workspaceId);
+  const hasSourceConnection = sourceConnections.connections.length > 0;
 
   if (!hasSourceConnection) {
-    if (isIntegrationsPath(pathname, workspace.id)) {
-      return renderChildren(children, {hideProjectNavigation: true});
+    if (isIntegrationsPath(normalizedPathname, workspaceId)) {
+      return {hideProjectNavigation: true};
     }
 
-    return <Navigate to="/workspaces/$wid/integrations" params={{wid: workspace.id}} replace />;
+    throw redirect({
+      to: '/workspaces/$wid/integrations',
+      params: {wid: workspaceId},
+      replace: true,
+    });
   }
 
-  if (isProjectCreationPath(pathname, workspace.id)) {
-    return renderChildren(children, {hideProjectNavigation: true});
+  if (isProjectCreationPath(normalizedPathname, workspaceId)) {
+    return {hideProjectNavigation: true};
   }
 
-  return <Navigate to="/workspaces/$wid/projects/new" params={{wid: workspace.id}} replace />;
+  throw redirect({
+    to: '/workspaces/$wid/projects/new',
+    params: {wid: workspaceId},
+    replace: true,
+  });
+}
+
+export function WorkspaceSetupPending() {
+  return <FullPageLoader />;
+}
+
+export function WorkspaceSetupErrorRoute({error, reset}: ErrorComponentProps) {
+  const router = useRouter();
+
+  return (
+    <WorkspaceSetupError
+      message={setupErrorMessage(error)}
+      onRetry={() => {
+        reset();
+        void router.invalidate();
+      }}
+    />
+  );
 }
 
 function WorkspaceSetupError({message, onRetry}: {message: string; onRetry: () => void}) {
@@ -110,16 +105,39 @@ function WorkspaceSetupError({message, onRetry}: {message: string; onRetry: () =
   );
 }
 
-function renderChildren(
-  children: WorkspaceSetupGuardProps['children'],
-  state: WorkspaceSetupState,
-) {
-  return typeof children === 'function' ? children(state) : children;
-}
-
 function setupErrorMessage(error: unknown) {
   if (error instanceof ApiError) return error.message;
   return 'Try again in a moment.';
+}
+
+async function fetchWorkspaceProjectExistence(queryClient: QueryClient, workspaceId: string) {
+  const queryKey = projectsQueryKeys.exists(workspaceId);
+
+  try {
+    return await queryClient.fetchQuery({
+      queryKey,
+      queryFn: ({signal}) => listProjects({workspaceId, limit: 1, signal}),
+    });
+  } catch (error) {
+    const cached = queryClient.getQueryData<ListProjectsResponseDto>(queryKey);
+    if (cached !== undefined) return cached;
+    throw error;
+  }
+}
+
+async function fetchWorkspaceSourceConnections(queryClient: QueryClient, workspaceId: string) {
+  const queryKey = integrationsQueryKeys.sourceConnections(workspaceId);
+
+  try {
+    return await queryClient.fetchQuery({
+      queryKey,
+      queryFn: ({signal}) => listSourceConnections({workspaceId, signal}),
+    });
+  } catch (error) {
+    const cached = queryClient.getQueryData<ListIntegrationConnectionsResponseDto>(queryKey);
+    if (cached !== undefined) return cached;
+    throw error;
+  }
 }
 
 function normalizePath(pathname: string) {

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -78,7 +78,7 @@ export function WorkspaceSetupPending() {
   return <FullPageLoader />;
 }
 
-export function WorkspaceSetupErrorRoute({error, reset}: ErrorComponentProps) {
+export function WorkspaceLayoutErrorRoute({error, reset}: ErrorComponentProps) {
   const router = useRouter();
   const onRetry = () => {
     reset();

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -117,6 +117,11 @@ async function fetchWorkspaceProjectExistence(queryClient: QueryClient, workspac
     return await queryClient.fetchQuery({
       queryKey,
       queryFn: ({signal}) => listProjects({workspaceId, limit: 1, signal}),
+      // This runs in beforeLoad on every in-workspace navigation. Project
+      // existence never reverts within a session (there is no client delete
+      // flow) and creation seeds this key, so serve from cache instead of
+      // blocking each navigation on a round-trip. Invalidation still refetches.
+      staleTime: Number.POSITIVE_INFINITY,
     });
   } catch (error) {
     const cached = queryClient.getQueryData<ListProjectsResponseDto>(queryKey);
@@ -129,6 +134,9 @@ async function fetchWorkspaceSourceConnections(queryClient: QueryClient, workspa
   const queryKey = integrationsQueryKeys.sourceConnections(workspaceId);
 
   try {
+    // Onboarding-only path: kept fresh (no staleTime) because some install
+    // flows connect a source without invalidating this key, and a stale
+    // "no connection" read would trap the user in the onboarding redirect.
     return await queryClient.fetchQuery({
       queryKey,
       queryFn: ({signal}) => listSourceConnections({workspaceId, signal}),

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -21,7 +21,7 @@ export interface WorkspaceSetupRouteOptions {
 }
 
 export class WorkspaceSetupLoadError extends Error {
-  constructor(public readonly cause: unknown) {
+  constructor(public override readonly cause: unknown) {
     super(cause instanceof Error ? cause.message : 'Workspace setup load failed');
     this.name = 'WorkspaceSetupLoadError';
   }

--- a/libs/client/projects/src/components/workspace-setup-guard.tsx
+++ b/libs/client/projects/src/components/workspace-setup-guard.tsx
@@ -8,6 +8,7 @@ import {type ErrorComponentProps, redirect, useRouter} from '@tanstack/react-rou
 import {listProjects, projectsQueryKeys} from '#hooks/api/projects.js';
 
 const TRAILING_SLASHES_RE = /\/+$/u;
+const PROJECT_EXISTENCE_STALE_TIME_MS = 30_000;
 
 export interface WorkspaceSetupState {
   hideProjectNavigation: boolean;
@@ -17,6 +18,13 @@ export interface WorkspaceSetupRouteOptions {
   queryClient: QueryClient;
   workspaceId: string;
   pathname: string;
+}
+
+export class WorkspaceSetupLoadError extends Error {
+  constructor(public readonly cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Workspace setup load failed');
+    this.name = 'WorkspaceSetupLoadError';
+  }
 }
 
 export async function loadWorkspaceSetupRoute({
@@ -72,16 +80,16 @@ export function WorkspaceSetupPending() {
 
 export function WorkspaceSetupErrorRoute({error, reset}: ErrorComponentProps) {
   const router = useRouter();
+  const onRetry = () => {
+    reset();
+    void router.invalidate();
+  };
 
-  return (
-    <WorkspaceSetupError
-      message={setupErrorMessage(error)}
-      onRetry={() => {
-        reset();
-        void router.invalidate();
-      }}
-    />
-  );
+  if (!(error instanceof WorkspaceSetupLoadError)) {
+    return <WorkspaceRouteError message={routeErrorMessage(error)} onRetry={onRetry} />;
+  }
+
+  return <WorkspaceSetupError message={setupErrorMessage(error)} onRetry={onRetry} />;
 }
 
 function WorkspaceSetupError({message, onRetry}: {message: string; onRetry: () => void}) {
@@ -106,6 +114,33 @@ function WorkspaceSetupError({message, onRetry}: {message: string; onRetry: () =
 }
 
 function setupErrorMessage(error: unknown) {
+  const cause = error instanceof WorkspaceSetupLoadError ? error.cause : error;
+  if (cause instanceof ApiError) return cause.message;
+  return 'Try again in a moment.';
+}
+
+function WorkspaceRouteError({message, onRetry}: {message: string; onRetry: () => void}) {
+  return (
+    <main className="min-h-screen bg-background-subtle-base px-24 py-32 max-[520px]:px-16">
+      <div className="mx-auto flex w-full max-w-[640px] flex-col gap-24">
+        <Header variant="h1">Workspace</Header>
+        <Alert variant="error">
+          <div className="flex flex-col gap-8">
+            <Text size="sm" bold>
+              Could not load workspace
+            </Text>
+            <Text size="sm">{message}</Text>
+            <Button size="sm" variant="secondary" onClick={onRetry} className="w-fit">
+              Retry
+            </Button>
+          </div>
+        </Alert>
+      </div>
+    </main>
+  );
+}
+
+function routeErrorMessage(error: unknown) {
   if (error instanceof ApiError) return error.message;
   return 'Try again in a moment.';
 }
@@ -117,16 +152,15 @@ async function fetchWorkspaceProjectExistence(queryClient: QueryClient, workspac
     return await queryClient.fetchQuery({
       queryKey,
       queryFn: ({signal}) => listProjects({workspaceId, limit: 1, signal}),
-      // This runs in beforeLoad on every in-workspace navigation. Project
-      // existence never reverts within a session (there is no client delete
-      // flow) and creation seeds this key, so serve from cache instead of
-      // blocking each navigation on a round-trip. Invalidation still refetches.
-      staleTime: Number.POSITIVE_INFINITY,
+      // beforeLoad runs for every in-workspace navigation. Use a short
+      // freshness window to avoid hot-path refetches while still detecting
+      // project creation from another tab or actor.
+      staleTime: PROJECT_EXISTENCE_STALE_TIME_MS,
     });
   } catch (error) {
     const cached = queryClient.getQueryData<ListProjectsResponseDto>(queryKey);
     if (cached !== undefined) return cached;
-    throw error;
+    throw new WorkspaceSetupLoadError(error);
   }
 }
 
@@ -144,7 +178,7 @@ async function fetchWorkspaceSourceConnections(queryClient: QueryClient, workspa
   } catch (error) {
     const cached = queryClient.getQueryData<ListIntegrationConnectionsResponseDto>(queryKey);
     if (cached !== undefined) return cached;
-    throw error;
+    throw new WorkspaceSetupLoadError(error);
   }
 }
 

--- a/libs/client/projects/src/hooks/api/projects.ts
+++ b/libs/client/projects/src/hooks/api/projects.ts
@@ -11,7 +11,6 @@ export const projectsQueryKeys = {
   list: (workspaceId: string, search?: string) =>
     [...projectsQueryKeys.all, 'list', workspaceId, search ?? ''] as const,
   exists: (workspaceId: string) => [...projectsQueryKeys.all, 'exists', workspaceId] as const,
-  existsDisabled: () => [...projectsQueryKeys.all, 'exists', 'disabled'] as const,
   detail: (projectId: string) => [...projectsQueryKeys.all, 'detail', projectId] as const,
 };
 
@@ -58,16 +57,6 @@ export function useProjectsInfiniteQuery(
       listProjects({workspaceId: workspaceId ?? '', limit, cursor: pageParam, search, signal}),
     getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
     placeholderData: keepPreviousData,
-  });
-}
-
-export function useWorkspaceProjectExistenceQuery(workspaceId: string | undefined) {
-  return useQuery({
-    queryKey: workspaceId
-      ? projectsQueryKeys.exists(workspaceId)
-      : projectsQueryKeys.existsDisabled(),
-    enabled: Boolean(workspaceId),
-    queryFn: ({signal}) => listProjects({workspaceId: workspaceId ?? '', limit: 1, signal}),
   });
 }
 

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -2,7 +2,7 @@ export {ProjectCrumb, type ProjectCrumbProps} from './components/project-crumb.j
 export {ProjectSwitcher, type ProjectSwitcherProps} from './components/project-switcher.js';
 export {
   loadWorkspaceSetupRoute,
-  WorkspaceSetupErrorRoute,
+  WorkspaceLayoutErrorRoute,
   WorkspaceSetupPending,
   type WorkspaceSetupRouteOptions,
   type WorkspaceSetupState,

--- a/libs/client/projects/src/index.ts
+++ b/libs/client/projects/src/index.ts
@@ -1,8 +1,10 @@
 export {ProjectCrumb, type ProjectCrumbProps} from './components/project-crumb.js';
 export {ProjectSwitcher, type ProjectSwitcherProps} from './components/project-switcher.js';
 export {
-  WorkspaceSetupGuard,
-  type WorkspaceSetupGuardProps,
+  loadWorkspaceSetupRoute,
+  WorkspaceSetupErrorRoute,
+  WorkspaceSetupPending,
+  type WorkspaceSetupRouteOptions,
   type WorkspaceSetupState,
 } from './components/workspace-setup-guard.js';
 export * from './hooks/api/definitions.js';

--- a/libs/client/router/src/router.tsx
+++ b/libs/client/router/src/router.tsx
@@ -1,4 +1,5 @@
 import type {AuthStateValue} from '@shipfox/client-auth';
+import type {QueryClient} from '@tanstack/react-query';
 import {createRouter, type RouteIds} from '@tanstack/react-router';
 import {routeTree} from './routeTree.gen.js';
 
@@ -10,12 +11,13 @@ export interface RouterContext {
    * `auth.status === 'loading'` so the route waits for auth before deciding.
    */
   auth: AuthStateValue | undefined;
+  queryClient: QueryClient | undefined;
 }
 
 export const router = createRouter({
   routeTree,
   scrollRestoration: true,
-  context: {auth: undefined} satisfies RouterContext,
+  context: {auth: undefined, queryClient: undefined} satisfies RouterContext,
 });
 
 export type RouterType = typeof router;

--- a/libs/client/router/src/routes/workspaces/$wid/_layout.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout.tsx
@@ -1,13 +1,17 @@
 import {MainLayout} from '@shipfox/client-app-shell';
 import {rememberLastWorkspaceId} from '@shipfox/client-auth';
-import {WorkspaceSetupGuard} from '@shipfox/client-projects';
+import {
+  loadWorkspaceSetupRoute,
+  WorkspaceSetupErrorRoute,
+  WorkspaceSetupPending,
+} from '@shipfox/client-projects';
 import {ShipfoxLoader} from '@shipfox/react-ui';
 import {createFileRoute, redirect} from '@tanstack/react-router';
 
 export const Route = createFileRoute('/workspaces/$wid/_layout')({
-  beforeLoad: ({context, params, location}) => {
+  beforeLoad: async ({context, params, location}) => {
     const auth = context.auth;
-    if (!auth || auth.isLoading) return;
+    if (!auth || auth.isLoading || !context.queryClient) return;
     if (!auth.isAuthenticated) {
       throw redirect({to: '/auth/login', search: {redirect: location.href}});
     }
@@ -19,19 +23,24 @@ export const Route = createFileRoute('/workspaces/$wid/_layout')({
     } catch {
       // localStorage may throw in private browsing or quota-exceeded; routing is still URL-driven.
     }
+    return await loadWorkspaceSetupRoute({
+      queryClient: context.queryClient,
+      workspaceId: params.wid,
+      pathname: location.pathname,
+    });
   },
   pendingComponent: () => (
     <div className="flex h-screen items-center justify-center">
       <ShipfoxLoader size={64} animation="circular" color="orange" background="dark" />
     </div>
   ),
+  errorComponent: WorkspaceSetupErrorRoute,
   component: WorkspaceLayoutRoute,
 });
 
 function WorkspaceLayoutRoute() {
-  return (
-    <WorkspaceSetupGuard>
-      {({hideProjectNavigation}) => <MainLayout hideProjectNavigation={hideProjectNavigation} />}
-    </WorkspaceSetupGuard>
-  );
+  const setupState = Route.useRouteContext();
+  if (setupState.hideProjectNavigation === undefined) return <WorkspaceSetupPending />;
+
+  return <MainLayout hideProjectNavigation={setupState.hideProjectNavigation} />;
 }

--- a/libs/client/router/src/routes/workspaces/$wid/_layout.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout.tsx
@@ -2,7 +2,7 @@ import {MainLayout} from '@shipfox/client-app-shell';
 import {rememberLastWorkspaceId} from '@shipfox/client-auth';
 import {
   loadWorkspaceSetupRoute,
-  WorkspaceSetupErrorRoute,
+  WorkspaceLayoutErrorRoute,
   WorkspaceSetupPending,
 } from '@shipfox/client-projects';
 import {ShipfoxLoader} from '@shipfox/react-ui';
@@ -34,7 +34,7 @@ export const Route = createFileRoute('/workspaces/$wid/_layout')({
       <ShipfoxLoader size={64} animation="circular" color="orange" background="dark" />
     </div>
   ),
-  errorComponent: WorkspaceSetupErrorRoute,
+  errorComponent: WorkspaceLayoutErrorRoute,
   component: WorkspaceLayoutRoute,
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.17
         version: 0.5.23
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
       react:
         specifier: ^19.1.1
         version: 19.2.7


### PR DESCRIPTION
Move workspace setup redirects from a rendered React guard into TanStack Router `beforeLoad`.

The workspace layout previously rendered a guard component that fetched project existence and active source-control connections before deciding whether to show onboarding, project creation, or normal workspace content. That left setup gating as render-time behavior. This makes the gating part of route loading instead, so protected workspace content waits for setup state before it can render.

The app now shares a single React Query client between `AuthProvider` and router context so route hooks and page components read the same setup cache. Cached setup state is still used as a fallback when a refetch fails, matching the previous guard behavior.

Validation:
- `mise exec -- pnpm --filter=@shipfox/client-projects test -- --run src/components/workspace-setup-guard.test.tsx`
- `mise exec -- turbo type --filter=@shipfox/client-router...`
- `mise exec -- turbo check --filter=@shipfox/client-router...`
- `git diff --check`
- `mise exec -- turbo build --filter '...[origin/main]'`
- `mise exec -- turbo test --filter '...[origin/main]'`
- `mise exec -- turbo check --filter '...[origin/main]'`

Closes ENG-606

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved workspace setup gating into TanStack Router `beforeLoad` so workspace routes wait for project/VCS state, redirect during load, and show a pending loader. Clarified the workspace layout error boundary to show setup-specific retry copy for setup-load failures and a generic workspace error for descendant route failures. Addresses ENG-606.

- **New Features**
  - Added `loadWorkspaceSetupRoute` returning `WorkspaceSetupState` for the layout; shows `WorkspaceSetupPending` while unresolved.
  - Added `WorkspaceLayoutErrorRoute`: setup-load errors get setup-specific copy with Retry; other route errors use a generic workspace error.
  - Redirects during load: no VCS → integrations onboarding; completed workspace integrations index → settings integrations; install routes stay accessible.

- **Refactors**
  - Replaced render-time `WorkspaceSetupGuard` with route `beforeLoad` on `/workspaces/$wid/_layout`; layout reads setup from route context.
  - Router context now provides a shared `queryClient`; `AuthProvider` accepts an external client and the app passes the same instance to both.
  - Caching: project existence uses `fetchQuery` with a 30s `staleTime` and cached fallback on errors; source connections stay fresh with the same fallback. Removed `useWorkspaceProjectExistenceQuery`. Tests cover retry, child-route navigation without extra refetches, stale-to-fresh project completion, and pending-loader parity.
  - Added `@tanstack/react-query` to `apps/client`.
  - Introduced `WorkspaceSetupLoadError` to mark setup-load failures; typed its `.cause` for strict TypeScript.

<sup>Written for commit 5018907e02a19ddfdac4f5774e7222145b578bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

