### PR TITLE
[react-ui] Add shared search components

### DIFF
--- a/.changeset/steady-searches-open.md
+++ b/.changeset/steady-searches-open.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds shared search components for inline search fields and modal command-search surfaces.

--- a/libs/shared/react/ui/src/components/index.ts
+++ b/libs/shared/react/ui/src/components/index.ts
@@ -29,6 +29,7 @@ export * from './popover/index.js';
 export * from './radio-group/index.js';
 export * from './relative-time/index.js';
 export * from './scroll-area/index.js';
+export * from './search/index.js';
 export * from './select/index.js';
 export * from './sheet/index.js';
 export * from './shiny-text/index.js';

--- a/libs/shared/react/ui/src/components/search/index.ts
+++ b/libs/shared/react/ui/src/components/search/index.ts
@@ -1,0 +1,26 @@
+export {Search, type SearchProps} from './search.js';
+export {useSearchContext} from './search-context.js';
+export {SearchInline, type SearchInlineProps} from './search-inline.js';
+export {
+  SearchContent,
+  type SearchContentProps,
+  SearchEmpty,
+  type SearchEmptyProps,
+  SearchFooter,
+  type SearchFooterProps,
+  SearchGroup,
+  type SearchGroupProps,
+  SearchInput,
+  type SearchInputProps,
+  SearchItem,
+  type SearchItemProps,
+  SearchList,
+  type SearchListProps,
+  SearchSeparator,
+  type SearchSeparatorProps,
+} from './search-modal.js';
+export {SearchTrigger, type SearchTriggerProps} from './search-trigger.js';
+export {
+  searchInputVariants,
+  searchTriggerVariants,
+} from './search-variants.js';

--- a/libs/shared/react/ui/src/components/search/search-context.tsx
+++ b/libs/shared/react/ui/src/components/search/search-context.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import {createContext, useCallback, useContext, useEffect, useState} from 'react';
+
+const shortcutKeyRegex = /^(meta\+|cmd\+|ctrl\+|⌘\+?)/i;
+
+export type SearchContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  searchValue: string;
+  setSearchValue: (value: string) => void;
+  shortcutKey: string | undefined;
+};
+
+export const SearchContext = createContext<SearchContextValue | null>(null);
+
+export function useSearchContext() {
+  const context = useContext(SearchContext);
+  if (!context) {
+    throw new Error('Search components must be used within a Search component');
+  }
+  return context;
+}
+
+export function useControllableState<T>(
+  controlledValue: T | undefined,
+  defaultValue: T,
+  onChange?: (value: T) => void,
+): [T, (value: T) => void] {
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : internalValue;
+
+  const setValue = useCallback(
+    (newValue: T) => {
+      if (!isControlled) {
+        setInternalValue(newValue);
+      }
+      onChange?.(newValue);
+    },
+    [isControlled, onChange],
+  );
+
+  return [value, setValue];
+}
+
+export function useKeyboardShortcut(shortcutKey: string | undefined, onTrigger: () => void) {
+  useEffect(() => {
+    if (!shortcutKey) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = shortcutKey.toLowerCase();
+      const isMetaKey = key.startsWith('meta+') || key.startsWith('cmd+') || key.startsWith('⌘');
+      const isCtrlKey = key.startsWith('ctrl+');
+      const targetKey = key.replace(shortcutKeyRegex, '');
+
+      const shouldTrigger =
+        (isMetaKey && event.metaKey && event.key.toLowerCase() === targetKey) ||
+        (isCtrlKey && event.ctrlKey && event.key.toLowerCase() === targetKey) ||
+        (!isMetaKey &&
+          !isCtrlKey &&
+          event.key.toLowerCase() === targetKey &&
+          !event.metaKey &&
+          !event.ctrlKey);
+
+      if (!shouldTrigger) return;
+
+      if (!isMetaKey && !isCtrlKey) {
+        const target = event.target as HTMLElement;
+        if (
+          target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+
+      event.preventDefault();
+      onTrigger();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [shortcutKey, onTrigger]);
+}

--- a/libs/shared/react/ui/src/components/search/search-inline.tsx
+++ b/libs/shared/react/ui/src/components/search/search-inline.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import type {VariantProps} from 'class-variance-authority';
+import type {ChangeEvent, ComponentProps, KeyboardEvent} from 'react';
+import {useCallback, useRef, useState} from 'react';
+import {cn} from '#utils/cn.js';
+import {Icon} from '../icon/index.js';
+import {searchInputVariants} from './search-variants.js';
+
+export type SearchInlineProps = Omit<ComponentProps<'input'>, 'size'> &
+  VariantProps<typeof searchInputVariants> & {
+    showClearButton?: boolean;
+    onClear?: () => void;
+  };
+
+export function SearchInline({
+  className,
+  variant,
+  size,
+  radius,
+  value,
+  defaultValue,
+  onChange,
+  onKeyDown,
+  onClear,
+  disabled,
+  readOnly,
+  showClearButton = true,
+  'aria-label': ariaLabel,
+  ...props
+}: SearchInlineProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [internalValue, setInternalValue] = useState<SearchInlineProps['value']>(
+    defaultValue ?? '',
+  );
+  const isControlled = value !== undefined;
+  const inputValue = isControlled ? value : internalValue;
+  const hasValue = Boolean(inputValue);
+  const isSmall = size === 'small';
+  const canEdit = !disabled && !readOnly;
+  const canShowClearButton = showClearButton && hasValue && canEdit;
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (!isControlled) {
+        setInternalValue(event.target.value);
+      }
+      onChange?.(event);
+    },
+    [isControlled, onChange],
+  );
+
+  const handleClear = useCallback(() => {
+    if (!isControlled) {
+      setInternalValue('');
+    }
+
+    if (onChange && inputRef.current) {
+      inputRef.current.value = '';
+      const syntheticEvent = {
+        target: inputRef.current,
+        currentTarget: inputRef.current,
+      } as ChangeEvent<HTMLInputElement>;
+      onChange(syntheticEvent);
+    }
+    onClear?.();
+    inputRef.current?.focus();
+  }, [isControlled, onChange, onClear]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Escape' && hasValue && canEdit) {
+        event.preventDefault();
+        handleClear();
+      }
+      onKeyDown?.(event);
+    },
+    [canEdit, hasValue, handleClear, onKeyDown],
+  );
+
+  return (
+    <div
+      data-slot="search-inline"
+      className={cn(searchInputVariants({variant, size, radius}), className)}
+    >
+      <Icon
+        name="searchLine"
+        className={cn('shrink-0 text-foreground-neutral-muted', isSmall ? 'size-14' : 'size-16')}
+      />
+      <input
+        ref={inputRef}
+        type="text"
+        value={inputValue}
+        disabled={disabled}
+        readOnly={readOnly}
+        aria-label={ariaLabel ?? 'Search'}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          'min-w-0 flex-1 bg-transparent outline-none',
+          'text-base md:text-sm',
+          'text-foreground-neutral-base',
+          'placeholder:text-foreground-neutral-muted',
+          'disabled:cursor-not-allowed disabled:text-foreground-neutral-disabled',
+        )}
+        {...props}
+      />
+      {canShowClearButton && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className={cn(
+            '-mx-2 shrink-0 cursor-pointer rounded-4 p-2',
+            'text-foreground-neutral-muted transition-colors hover:text-foreground-neutral-subtle',
+          )}
+          aria-label="Clear search"
+        >
+          <Icon name="closeLine" className="size-16" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/libs/shared/react/ui/src/components/search/search-modal.tsx
+++ b/libs/shared/react/ui/src/components/search/search-modal.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import {Command as CommandPrimitive} from 'cmdk';
+import type {ComponentProps, ReactNode} from 'react';
+import {useCallback} from 'react';
+import {cn} from '#utils/cn.js';
+import {
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '../command/index.js';
+import {Icon} from '../icon/index.js';
+import {Kbd} from '../kbd/index.js';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  type ModalContentProps,
+  ModalTitle,
+} from '../modal/index.js';
+import {useSearchContext} from './search-context.js';
+
+export type SearchContentProps = {
+  breakpoint?: string;
+} & Omit<ModalContentProps, 'open' | 'onOpenChange'>;
+
+export function SearchContent({
+  breakpoint = '(min-width: 768px)',
+  className,
+  children,
+  overlayClassName,
+  onEscapeKeyDown,
+  ...props
+}: SearchContentProps) {
+  const {open, setOpen, searchValue, setSearchValue} = useSearchContext();
+
+  const handleEscapeKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (searchValue) {
+        event.preventDefault();
+        setSearchValue('');
+      } else {
+        onEscapeKeyDown?.(event);
+      }
+    },
+    [searchValue, setSearchValue, onEscapeKeyDown],
+  );
+
+  return (
+    <Modal open={open} onOpenChange={setOpen} breakpoint={breakpoint}>
+      <ModalContent
+        data-slot="search-content"
+        className={cn('md:top-[15%]! md:translate-y-0!', className)}
+        overlayClassName={cn('backdrop-blur-sm', overlayClassName)}
+        onEscapeKeyDown={handleEscapeKeyDown}
+        {...props}
+      >
+        <ModalTitle className="sr-only">Search</ModalTitle>
+        <ModalBody className="flex min-h-0 flex-col overflow-hidden p-0 md:overflow-clip">
+          {children}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export type SearchInputProps = Omit<
+  ComponentProps<typeof CommandPrimitive.Input>,
+  'value' | 'onValueChange'
+>;
+
+export function SearchInput({className, ...props}: SearchInputProps) {
+  const {open, searchValue, setSearchValue} = useSearchContext();
+
+  return (
+    <div className="flex w-full shrink-0 items-center gap-8 border-b border-border-neutral-strong px-16 py-12">
+      <Icon name="searchLine" className="size-16 shrink-0 text-foreground-neutral-muted" />
+      <CommandPrimitive.Input
+        data-slot="search-input"
+        autoFocus={open}
+        value={searchValue}
+        onValueChange={setSearchValue}
+        className={cn(
+          'flex-1 bg-transparent text-base leading-20 outline-none md:text-sm',
+          'placeholder:text-foreground-neutral-muted',
+          'disabled:cursor-not-allowed disabled:text-foreground-neutral-disabled',
+          className,
+        )}
+        {...props}
+      />
+      <Kbd aria-hidden="true">Esc</Kbd>
+    </div>
+  );
+}
+
+export type SearchListProps = ComponentProps<typeof CommandList>;
+
+export function SearchList({className, ...props}: SearchListProps) {
+  return (
+    <CommandList
+      data-slot="search-list"
+      className={cn('max-h-none min-h-0 w-full flex-1 px-8 py-4', 'md:max-h-400', className)}
+      {...props}
+    />
+  );
+}
+
+export type SearchEmptyProps = ComponentProps<typeof CommandEmpty>;
+
+export function SearchEmpty({className, ...props}: SearchEmptyProps) {
+  return (
+    <CommandEmpty
+      data-slot="search-empty"
+      className={cn('py-32 text-center text-sm text-foreground-neutral-muted', className)}
+      {...props}
+    />
+  );
+}
+
+export type SearchGroupProps = ComponentProps<typeof CommandGroup>;
+
+export function SearchGroup({className, ...props}: SearchGroupProps) {
+  return <CommandGroup data-slot="search-group" className={className} {...props} />;
+}
+
+export type SearchItemProps = ComponentProps<typeof CommandItem> & {
+  icon?: ReactNode;
+  description?: string;
+};
+
+export function SearchItem({className, children, icon, description, ...props}: SearchItemProps) {
+  return (
+    <CommandItem
+      data-slot="search-item"
+      className={cn('gap-12 rounded-8 p-8', className)}
+      {...props}
+    >
+      {icon && <span className="shrink-0 text-foreground-neutral-muted">{icon}</span>}
+      <div className="min-w-0 flex-1">
+        <div className="truncate">{children}</div>
+        {description && (
+          <div className="truncate text-xs text-foreground-neutral-muted">{description}</div>
+        )}
+      </div>
+    </CommandItem>
+  );
+}
+
+export type SearchSeparatorProps = ComponentProps<typeof CommandSeparator>;
+
+export function SearchSeparator({className, ...props}: SearchSeparatorProps) {
+  return (
+    <CommandSeparator
+      data-slot="search-separator"
+      className={cn('mx-0 my-8 bg-border-neutral-base after:hidden', className)}
+      {...props}
+    />
+  );
+}
+
+export type SearchFooterProps = ComponentProps<'div'>;
+
+export function SearchFooter({className, ...props}: SearchFooterProps) {
+  return (
+    <div
+      data-slot="search-footer"
+      className={cn(
+        'flex w-full shrink-0 items-center justify-end gap-12 px-16 py-12',
+        'border-t border-border-neutral-strong',
+        'bg-background-components-base',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex items-center gap-8">
+        <span className="text-xs font-medium text-foreground-neutral-subtle">Navigation</span>
+        <div className="flex items-center gap-4">
+          <Kbd aria-hidden="true">Down</Kbd>
+          <Kbd aria-hidden="true">Up</Kbd>
+        </div>
+      </div>
+      <div className="h-12 w-px bg-border-neutral-strong" />
+      <div className="flex items-center gap-8">
+        <span className="text-xs font-medium text-foreground-neutral-subtle">Open result</span>
+        <Kbd aria-hidden="true">Enter</Kbd>
+      </div>
+    </div>
+  );
+}

--- a/libs/shared/react/ui/src/components/search/search-trigger.tsx
+++ b/libs/shared/react/ui/src/components/search/search-trigger.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type {VariantProps} from 'class-variance-authority';
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+import {Icon} from '../icon/index.js';
+import {Kbd} from '../kbd/index.js';
+import {useSearchContext} from './search-context.js';
+import {searchTriggerVariants} from './search-variants.js';
+
+const metaShortcutRegex = /^meta\+/i;
+const cmdShortcutRegex = /^cmd\+/i;
+const ctrlShortcutRegex = /^ctrl\+/i;
+const commandGlyphShortcutRegex = /^⌘\+?/i;
+const whitespaceRegex = /\s+/;
+const lastCharacterRegex = /.$/;
+
+export type SearchTriggerProps = ComponentProps<'button'> &
+  VariantProps<typeof searchTriggerVariants> & {
+    placeholder?: string;
+    shortcut?: string;
+  };
+
+export function SearchTrigger({
+  className,
+  variant,
+  size,
+  radius,
+  placeholder = 'Search',
+  shortcut,
+  onClick,
+  ...props
+}: SearchTriggerProps) {
+  const {setOpen, shortcutKey} = useSearchContext();
+  const isSmall = size === 'small';
+  const shortcutLabel = shortcut ?? formatShortcutKey(shortcutKey);
+
+  return (
+    <button
+      type="button"
+      data-slot="search-trigger"
+      onClick={(event) => {
+        setOpen(true);
+        onClick?.(event);
+      }}
+      className={cn(searchTriggerVariants({variant, size, radius}), className)}
+      {...props}
+    >
+      <Icon name="searchLine" className={cn('shrink-0', isSmall ? 'size-14' : 'size-16')} />
+      <span className="flex-1 truncate text-left">{placeholder}</span>
+      {shortcutLabel && (
+        <Kbd
+          aria-hidden="true"
+          className={cn(
+            isSmall && 'h-16 min-w-16 px-4 text-[10px]',
+            radius === 'rounded' && 'rounded-full',
+          )}
+        >
+          {shortcutLabel}
+        </Kbd>
+      )}
+    </button>
+  );
+}
+
+function formatShortcutKey(shortcutKey: string | undefined) {
+  if (!shortcutKey) return undefined;
+
+  return shortcutKey
+    .replace(metaShortcutRegex, 'Cmd ')
+    .replace(cmdShortcutRegex, 'Cmd ')
+    .replace(ctrlShortcutRegex, 'Ctrl ')
+    .replace(commandGlyphShortcutRegex, 'Cmd ')
+    .replace(whitespaceRegex, ' ')
+    .trim()
+    .replace(lastCharacterRegex, (key) => key.toUpperCase());
+}

--- a/libs/shared/react/ui/src/components/search/search-variants.ts
+++ b/libs/shared/react/ui/src/components/search/search-variants.ts
@@ -1,0 +1,79 @@
+import {cva} from 'class-variance-authority';
+
+const sharedInputStyles = [
+  'inline-flex items-center gap-8',
+  'text-sm leading-20',
+  'transition-[color,box-shadow,background-color] outline-none',
+];
+
+const variantStyles = {
+  primary: {
+    base: ['bg-background-field-base', 'shadow-button-neutral'],
+    focus: 'focus-within:shadow-border-interactive-with-active',
+    hover: 'hover:bg-background-field-hover',
+    focusVisible: 'focus-visible:shadow-border-interactive-with-active',
+  },
+  secondary: {
+    base: ['bg-background-field-component', 'border border-border-neutral-strong'],
+    focus: 'focus-within:shadow-border-interactive-with-active',
+    hover: 'hover:bg-background-field-component-hover',
+    focusVisible: 'focus-visible:shadow-border-interactive-with-active',
+  },
+};
+
+const sizeStyles = {
+  base: 'h-32 px-8 py-6',
+  small: 'h-28 px-8 py-4',
+};
+
+const radiusStyles = {
+  rounded: 'rounded-full',
+  squared: 'rounded-6',
+};
+
+export const searchInputVariants = cva(sharedInputStyles, {
+  variants: {
+    variant: {
+      primary: [...variantStyles.primary.base, variantStyles.primary.focus],
+      secondary: [...variantStyles.secondary.base, variantStyles.secondary.focus],
+    },
+    size: sizeStyles,
+    radius: radiusStyles,
+  },
+  defaultVariants: {
+    variant: 'primary',
+    size: 'base',
+    radius: 'squared',
+  },
+});
+
+export const searchTriggerVariants = cva(
+  [
+    ...sharedInputStyles,
+    'cursor-pointer text-foreground-neutral-muted',
+    'disabled:pointer-events-none disabled:cursor-not-allowed disabled:text-foreground-neutral-disabled',
+  ],
+  {
+    variants: {
+      variant: {
+        primary: [
+          ...variantStyles.primary.base,
+          variantStyles.primary.hover,
+          variantStyles.primary.focusVisible,
+        ],
+        secondary: [
+          ...variantStyles.secondary.base,
+          variantStyles.secondary.hover,
+          variantStyles.secondary.focusVisible,
+        ],
+      },
+      size: sizeStyles,
+      radius: radiusStyles,
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'base',
+      radius: 'squared',
+    },
+  },
+);

--- a/libs/shared/react/ui/src/components/search/search.stories.tsx
+++ b/libs/shared/react/ui/src/components/search/search.stories.tsx
@@ -1,0 +1,201 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {Icon} from '../icon/index.js';
+import {
+  Search,
+  SearchContent,
+  SearchEmpty,
+  SearchFooter,
+  SearchGroup,
+  SearchInline,
+  SearchInput,
+  SearchItem,
+  SearchList,
+  SearchSeparator,
+  SearchTrigger,
+} from './index.js';
+
+const meta: Meta = {
+  title: 'Components/Search',
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Inline: Story = {
+  render: () => {
+    function InlineDemo() {
+      const [value, setValue] = useState('');
+
+      return (
+        <div className="flex max-w-400 flex-col gap-16">
+          <SearchInline
+            placeholder="Search..."
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onClear={() => setValue('')}
+          />
+          {value && <p className="text-sm text-foreground-neutral-muted">Searching for: {value}</p>}
+        </div>
+      );
+    }
+
+    return <InlineDemo />;
+  },
+};
+
+export const InlineVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      <div className="flex flex-col gap-8">
+        <span className="text-xs text-foreground-neutral-muted">Primary</span>
+        <div className="flex gap-8">
+          <SearchInline
+            variant="primary"
+            radius="squared"
+            placeholder="Search..."
+            className="w-200"
+          />
+          <SearchInline
+            variant="primary"
+            radius="rounded"
+            placeholder="Search..."
+            className="w-200"
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-8">
+        <span className="text-xs text-foreground-neutral-muted">Secondary</span>
+        <div className="flex gap-8">
+          <SearchInline
+            variant="secondary"
+            radius="squared"
+            placeholder="Search..."
+            className="w-200"
+          />
+          <SearchInline
+            variant="secondary"
+            radius="rounded"
+            placeholder="Search..."
+            className="w-200"
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const InlineSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      <SearchInline size="base" placeholder="Search..." className="w-200" />
+      <SearchInline size="small" placeholder="Search..." className="w-200" />
+    </div>
+  ),
+};
+
+function ModalSearchDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Search open={open} onOpenChange={setOpen} shortcutKey="meta+k">
+      <SearchTrigger placeholder="Find..." className="w-full max-w-280" />
+      <SearchContent aria-describedby={undefined}>
+        <SearchInput placeholder="Search for anything..." />
+        <SearchList>
+          <SearchEmpty>No results found.</SearchEmpty>
+          <SearchGroup heading="Recent">
+            <SearchItem
+              icon={
+                <Icon name="gitBranchLine" className="size-16 text-foreground-neutral-subtle" />
+              }
+              description="workflow-platform"
+            >
+              feat/data-processing
+            </SearchItem>
+            <SearchItem
+              icon={
+                <Icon name="gitBranchLine" className="size-16 text-foreground-neutral-subtle" />
+              }
+              description="workflow-platform"
+            >
+              fix/retry-window
+            </SearchItem>
+          </SearchGroup>
+          <SearchSeparator />
+          <SearchGroup heading="Team">
+            <SearchItem
+              icon={<Icon name="rocketLine" className="size-16 text-foreground-neutral-subtle" />}
+              description="Team"
+            >
+              Deployments
+            </SearchItem>
+            <SearchItem
+              icon={<Icon name="linksLine" className="size-16 text-foreground-neutral-subtle" />}
+              description="Team"
+            >
+              Integrations
+            </SearchItem>
+          </SearchGroup>
+        </SearchList>
+        <SearchFooter />
+      </SearchContent>
+    </Search>
+  );
+}
+
+export const Modal: Story = {
+  render: () => <ModalSearchDemo />,
+};
+
+function TriggerPreview({
+  variant,
+  size,
+  radius,
+  className,
+}: {
+  variant?: 'primary' | 'secondary';
+  size?: 'base' | 'small';
+  radius?: 'squared' | 'rounded';
+  className?: string;
+}) {
+  return (
+    <Search>
+      <SearchTrigger variant={variant} size={size} radius={radius} className={className} />
+    </Search>
+  );
+}
+
+export const ModalTriggerVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      <div className="flex flex-col gap-8">
+        <span className="text-xs text-foreground-neutral-muted">Primary</span>
+        <div className="flex gap-8">
+          <TriggerPreview variant="primary" radius="squared" className="w-200" />
+          <TriggerPreview variant="primary" radius="rounded" className="w-200" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-8">
+        <span className="text-xs text-foreground-neutral-muted">Secondary</span>
+        <div className="flex gap-8">
+          <TriggerPreview variant="secondary" radius="squared" className="w-200" />
+          <TriggerPreview variant="secondary" radius="rounded" className="w-200" />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const ModalTriggerSizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      <TriggerPreview size="base" variant="primary" className="w-200" />
+      <TriggerPreview size="small" variant="primary" className="w-200" />
+      <TriggerPreview size="base" variant="secondary" className="w-200" />
+      <TriggerPreview size="small" variant="secondary" className="w-200" />
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/search/search.test.tsx
+++ b/libs/shared/react/ui/src/components/search/search.test.tsx
@@ -1,0 +1,140 @@
+import {fireEvent, render, screen} from '@testing-library/react';
+import {useState} from 'react';
+import {Search} from './search.js';
+import {useKeyboardShortcut, useSearchContext} from './search-context.js';
+import {SearchInline} from './search-inline.js';
+import {SearchTrigger} from './search-trigger.js';
+
+describe('SearchInline', () => {
+  test('provides a default search label and clears with Escape', () => {
+    render(<SearchInlineHost />);
+
+    const input = screen.getByLabelText<HTMLInputElement>('Search');
+    fireEvent.change(input, {target: {value: 'deploy'}});
+    expect(input.value).toBe('deploy');
+
+    fireEvent.keyDown(input, {key: 'Escape'});
+
+    expect(input.value).toBe('');
+    expect(document.activeElement).toBe(input);
+  });
+
+  test('uses defaultValue for uncontrolled input state', () => {
+    render(<SearchInline defaultValue="deploy" />);
+
+    expect(screen.getByLabelText<HTMLInputElement>('Search').value).toBe('deploy');
+  });
+
+  test('composes consumer key handlers with Escape clear behavior', () => {
+    const onKeyDown = vi.fn();
+    render(<SearchInline defaultValue="deploy" onKeyDown={onKeyDown} />);
+
+    const input = screen.getByLabelText<HTMLInputElement>('Search');
+    fireEvent.keyDown(input, {key: 'Escape'});
+
+    expect(input.value).toBe('');
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not render the clear button for immutable inputs', () => {
+    const {rerender} = render(<SearchInline defaultValue="deploy" readOnly />);
+    expect(screen.queryByLabelText('Clear search')).toBeNull();
+
+    rerender(<SearchInline defaultValue="deploy" disabled />);
+    expect(screen.queryByLabelText('Clear search')).toBeNull();
+  });
+
+  test('does not clear immutable inputs with Escape', () => {
+    render(<SearchInline defaultValue="deploy" readOnly />);
+
+    const input = screen.getByLabelText<HTMLInputElement>('Search');
+    fireEvent.keyDown(input, {key: 'Escape'});
+
+    expect(input.value).toBe('deploy');
+  });
+});
+
+describe('useKeyboardShortcut', () => {
+  test('opens from meta shortcuts written with the command glyph', () => {
+    const onTrigger = vi.fn();
+    render(<ShortcutProbe shortcutKey="⌘k" onTrigger={onTrigger} />);
+
+    fireEvent.keyDown(document, {key: 'k', metaKey: true});
+
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores plain-key shortcuts while typing in editable fields', () => {
+    const onTrigger = vi.fn();
+    render(
+      <>
+        <ShortcutProbe shortcutKey="k" onTrigger={onTrigger} />
+        <input aria-label="Editable field" />
+        <div contentEditable data-testid="editable-region" />
+      </>,
+    );
+
+    const editableRegion = screen.getByTestId('editable-region');
+    Object.defineProperty(editableRegion, 'isContentEditable', {
+      configurable: true,
+      value: true,
+    });
+
+    fireEvent.keyDown(screen.getByLabelText('Editable field'), {key: 'k'});
+    fireEvent.keyDown(editableRegion, {key: 'k'});
+    fireEvent.keyDown(document, {key: 'k'});
+
+    expect(onTrigger).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SearchTrigger', () => {
+  test('only shows a shortcut hint when one is configured', () => {
+    const {rerender} = render(
+      <Search>
+        <SearchTrigger />
+      </Search>,
+    );
+
+    expect(screen.queryByText('Cmd K')).toBeNull();
+
+    rerender(
+      <Search shortcutKey="meta+k">
+        <SearchTrigger />
+      </Search>,
+    );
+
+    expect(screen.getByText('Cmd K')).toBeDefined();
+  });
+
+  test('composes consumer click handlers with opening the search', () => {
+    const onClick = vi.fn();
+    render(
+      <Search>
+        <SearchTrigger onClick={onClick} />
+        <SearchOpenProbe />
+      </Search>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('search-open-probe').dataset.open).toBe('true');
+  });
+});
+
+function SearchInlineHost() {
+  const [value, setValue] = useState('');
+
+  return <SearchInline value={value} onChange={(event) => setValue(event.target.value)} />;
+}
+
+function ShortcutProbe({shortcutKey, onTrigger}: {shortcutKey: string; onTrigger: () => void}) {
+  useKeyboardShortcut(shortcutKey, onTrigger);
+  return null;
+}
+
+function SearchOpenProbe() {
+  const {open} = useSearchContext();
+  return <div data-testid="search-open-probe" data-open={open} />;
+}

--- a/libs/shared/react/ui/src/components/search/search.tsx
+++ b/libs/shared/react/ui/src/components/search/search.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import {Command as CommandPrimitive} from 'cmdk';
+import type {ReactNode} from 'react';
+import {useCallback, useState} from 'react';
+import {SearchContext, useControllableState, useKeyboardShortcut} from './search-context.js';
+
+export type SearchProps = {
+  children: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  defaultOpen?: boolean;
+  shortcutKey?: string;
+  shouldFilter?: boolean;
+};
+
+export function Search({
+  children,
+  open: controlledOpen,
+  onOpenChange,
+  defaultOpen = false,
+  shortcutKey,
+  shouldFilter = true,
+}: SearchProps) {
+  const [open, setOpen] = useControllableState(controlledOpen, defaultOpen, onOpenChange);
+  const [searchValue, setSearchValue] = useState('');
+
+  const handleOpen = useCallback(() => setOpen(true), [setOpen]);
+
+  useKeyboardShortcut(shortcutKey, handleOpen);
+
+  const handleSetOpen = useCallback(
+    (newOpen: boolean) => {
+      if (!newOpen) {
+        setSearchValue('');
+      }
+      setOpen(newOpen);
+    },
+    [setOpen],
+  );
+
+  return (
+    <SearchContext.Provider
+      value={{open, setOpen: handleSetOpen, searchValue, setSearchValue, shortcutKey}}
+    >
+      <CommandPrimitive data-slot="search" shouldFilter={shouldFilter}>
+        {children}
+      </CommandPrimitive>
+    </SearchContext.Provider>
+  );
+}


### PR DESCRIPTION
Adds shared search components to `@shipfox/react-ui`, covering inline search fields and modal command-search surfaces.

This gives downstream client packages a standard search primitive that uses the existing Shipfox field, modal, keyboard, icon, and Storybook conventions instead of each surface rebuilding the same interaction.

The port adapts the source component to this workspace's import aliases, exported component structure, keyboard labels, design tokens, and changeset flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared search components to `@shipfox/react-ui` for inline fields and a modal command palette, giving apps a consistent, keyboard-friendly search experience.

- **New Features**
  - `Search` provider with `open`, `onOpenChange`, `defaultOpen`, `shortcutKey`, and `shouldFilter`; clears query on close. In the modal, Esc clears the input first, then closes.
  - Inline search: `SearchInline` with optional clear button, Esc-to-clear, default aria-label “Search”, and readOnly/disabled-aware behavior.
  - Modal suite using `cmdk`: `SearchTrigger` (placeholder, shows formatted shortcut hint from `shortcutKey` or `shortcut` prop), `SearchContent` (responsive `breakpoint`, blurred overlay), `SearchInput`, `SearchList`, `SearchGroup`, `SearchItem` (icon/description), `SearchEmpty`, `SearchSeparator`, `SearchFooter` (keyboard hints).
  - Keyboard shortcuts support Cmd/Ctrl and plain keys; plain-key shortcuts are ignored in inputs and contentEditable fields.
  - Variants and sizes: primary/secondary, base/small, rounded/squared via `searchInputVariants` and `searchTriggerVariants`. Exports added to `components/index.ts`; Storybook stories and tests included; changeset for a minor release.

<sup>Written for commit ea306346f65ee38fac11a334646e34bc777b4cb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

