### PR TITLE
[api/workflows] Resolve agent defaults at run creation

### DIFF
--- a/.changeset/eager-agents-resolve.md
+++ b/.changeset/eager-agents-resolve.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-agent": patch
+"@shipfox/api-workflows": patch
+---
+
+Resolves agent provider, model, and thinking defaults at workflow run creation using workspace and instance configuration.

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -25,6 +25,36 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./core/errors": {
+      "development": {
+        "types": "./src/core/errors.ts",
+        "default": "./src/core/errors.ts"
+      },
+      "default": {
+        "types": "./dist/core/errors.d.ts",
+        "default": "./dist/core/errors.js"
+      }
+    },
+    "./core/resolve-agent-config": {
+      "development": {
+        "types": "./src/core/resolve-agent-config.ts",
+        "default": "./src/core/resolve-agent-config.ts"
+      },
+      "default": {
+        "types": "./dist/core/resolve-agent-config.d.ts",
+        "default": "./dist/core/resolve-agent-config.js"
+      }
+    },
+    "./core/workspace-agent-defaults-resolver": {
+      "development": {
+        "types": "./src/core/workspace-agent-defaults-resolver.ts",
+        "default": "./src/core/workspace-agent-defaults-resolver.ts"
+      },
+      "default": {
+        "types": "./dist/core/workspace-agent-defaults-resolver.d.ts",
+        "default": "./dist/core/workspace-agent-defaults-resolver.js"
+      }
     }
   },
   "scripts": {

--- a/libs/api/agent/src/config.ts
+++ b/libs/api/agent/src/config.ts
@@ -17,7 +17,7 @@ export const config = createConfig({
     default: undefined,
   }),
   AGENT_DEFAULT_PROVIDER_THINKING: str({
-    desc: 'Instance-wide default thinking effort used when the resolved provider matches AGENT_DEFAULT_PROVIDER and no workflow or workspace thinking effort is set. Optional. Accepted values are low, medium, and high.',
+    desc: 'Instance-wide default thinking effort used when the resolved provider matches AGENT_DEFAULT_PROVIDER and no workflow or workspace thinking effort is set. Optional. Accepted values are off, minimal, low, medium, high, and xhigh.',
     choices: AGENT_THINKING_CHOICES,
     default: undefined,
   }),

--- a/libs/api/agent/src/config.ts
+++ b/libs/api/agent/src/config.ts
@@ -1,8 +1,25 @@
+import {agentThinkingSchema, SUPPORTED_AGENT_PROVIDER_IDS} from '@shipfox/api-agent-dto';
 import {createConfig, num, str} from '@shipfox/config';
+
+const AGENT_THINKING_CHOICES = agentThinkingSchema.options;
 
 export const config = createConfig({
   AGENT_CREDENTIALS_ENCRYPTION_KEY: str({
     desc: 'Base64-encoded 32-byte key used to encrypt saved agent provider credentials. Required. Generate one with openssl rand -base64 32.',
+  }),
+  AGENT_DEFAULT_PROVIDER: str({
+    desc: 'Instance-wide default agent provider ID used when a workflow and workspace do not choose one. Optional. Use one of the supported provider IDs from the agent provider catalog.',
+    choices: SUPPORTED_AGENT_PROVIDER_IDS,
+    default: undefined,
+  }),
+  AGENT_DEFAULT_PROVIDER_MODEL: str({
+    desc: 'Instance-wide default model ID used when the resolved provider matches AGENT_DEFAULT_PROVIDER and no workflow or workspace model is set. Optional. Use a model ID supported by that provider.',
+    default: undefined,
+  }),
+  AGENT_DEFAULT_PROVIDER_THINKING: str({
+    desc: 'Instance-wide default thinking effort used when the resolved provider matches AGENT_DEFAULT_PROVIDER and no workflow or workspace thinking effort is set. Optional. Accepted values are low, medium, and high.',
+    choices: AGENT_THINKING_CHOICES,
+    default: undefined,
   }),
   AGENT_PROVIDER_VALIDATION_TIMEOUT_MS: num({
     desc: 'Maximum time in milliseconds to wait for the live provider test request when saving credentials.',

--- a/libs/api/agent/src/core/index.ts
+++ b/libs/api/agent/src/core/index.ts
@@ -17,7 +17,7 @@ export {
   type AgentDefaultsResolver,
   type ContextualAgentConfig,
   catalogDefaultAgentResolver,
-  createWorkspaceAgentDefaultsResolver,
   type ResolvedAgentConfig,
   resolveAgentConfig,
 } from './resolve-agent-config.js';
+export {createWorkspaceAgentDefaultsResolver} from './workspace-agent-defaults-resolver.js';

--- a/libs/api/agent/src/core/index.ts
+++ b/libs/api/agent/src/core/index.ts
@@ -12,3 +12,12 @@ export {
 } from './errors.js';
 export {buildAgentProviderCatalog} from './provider-catalog.js';
 export {testAndSaveProviderConfig} from './provider-config-service.js';
+export {
+  type AgentConfigResolutionContext,
+  type AgentDefaultsResolver,
+  type ContextualAgentConfig,
+  catalogDefaultAgentResolver,
+  createWorkspaceAgentDefaultsResolver,
+  type ResolvedAgentConfig,
+  resolveAgentConfig,
+} from './resolve-agent-config.js';

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -1,0 +1,188 @@
+import crypto from 'node:crypto';
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {
+  getAgentWorkspaceSettings,
+  setDefaultAgentProvider,
+  type UpsertAgentProviderConfigParams,
+  upsertAgentProviderConfig,
+} from '#db/index.js';
+import {InvalidAgentModelError, UnsupportedAgentProviderError} from './errors.js';
+import {
+  catalogDefaultAgentResolver,
+  createWorkspaceAgentDefaultsResolver,
+  resolveAgentConfig,
+} from './resolve-agent-config.js';
+
+describe('resolveAgentConfig', () => {
+  test('resolves provider from explicit step, workspace, instance, then catalog default', () => {
+    const workspaceProviderConfigs = new Map([
+      ['openai' as const, {defaultModel: 'gpt-5.5-pro', defaultThinking: 'medium' as const}],
+      [
+        'google' as const,
+        {defaultModel: 'gemini-3.1-pro-preview', defaultThinking: 'low' as const},
+      ],
+    ]);
+
+    const explicit = resolveAgentConfig(
+      {provider: 'google'},
+      {
+        workspaceDefaultProviderId: 'openai',
+        workspaceProviderConfigs,
+        instanceDefaultProvider: 'anthropic',
+      },
+    );
+    const workspace = resolveAgentConfig(
+      {},
+      {workspaceDefaultProviderId: 'openai', workspaceProviderConfigs},
+    );
+    const instance = resolveAgentConfig({}, {instanceDefaultProvider: 'anthropic'});
+    const catalog = resolveAgentConfig({});
+
+    expect(explicit.provider).toBe('google');
+    expect(workspace.provider).toBe('openai');
+    expect(instance.provider).toBe('anthropic');
+    expect(catalog.provider).toBe('anthropic');
+  });
+
+  test('resolves model from explicit step, workspace, instance match, then catalog default', () => {
+    const workspaceProviderConfigs = new Map([
+      ['openai' as const, {defaultModel: 'gpt-5.5-pro', defaultThinking: 'medium' as const}],
+    ]);
+
+    const explicit = resolveAgentConfig(
+      {provider: 'openai', model: 'gpt-5.5-pro'},
+      {workspaceProviderConfigs},
+    );
+    const workspace = resolveAgentConfig({provider: 'openai'}, {workspaceProviderConfigs});
+    const instance = resolveAgentConfig(
+      {},
+      {
+        instanceDefaultProvider: 'anthropic',
+        instanceDefaultProviderModel: 'claude-opus-4-8',
+      },
+    );
+    const catalog = resolveAgentConfig({provider: 'deepseek'});
+
+    expect(explicit.model).toBe('gpt-5.5-pro');
+    expect(workspace.model).toBe('gpt-5.5-pro');
+    expect(instance.model).toBe('claude-opus-4-8');
+    expect(catalog.model).toBe('deepseek-v4-pro');
+  });
+
+  test('uses instance model and thinking only for the resolved instance provider', () => {
+    const resolved = resolveAgentConfig(
+      {provider: 'openai'},
+      {
+        instanceDefaultProvider: 'anthropic',
+        instanceDefaultProviderModel: 'claude-opus-4-8',
+        instanceDefaultProviderThinking: 'low',
+      },
+    );
+
+    expect(resolved).toEqual({
+      provider: 'openai',
+      model: 'gpt-5.5-pro',
+      thinking: 'high',
+    });
+  });
+
+  test('resolves thinking from explicit step, workspace, instance match, then default', () => {
+    const workspaceProviderConfigs = new Map([
+      ['openai' as const, {defaultModel: 'gpt-5.5-pro', defaultThinking: 'medium' as const}],
+    ]);
+
+    const explicit = resolveAgentConfig(
+      {provider: 'openai', thinking: 'low'},
+      {workspaceProviderConfigs},
+    );
+    const workspace = resolveAgentConfig({provider: 'openai'}, {workspaceProviderConfigs});
+    const instance = resolveAgentConfig(
+      {},
+      {instanceDefaultProvider: 'anthropic', instanceDefaultProviderThinking: 'medium'},
+    );
+    const fallback = resolveAgentConfig({provider: 'deepseek'});
+
+    expect(explicit.thinking).toBe('low');
+    expect(workspace.thinking).toBe('medium');
+    expect(instance.thinking).toBe('medium');
+    expect(fallback.thinking).toBe('high');
+  });
+
+  test('throws for unsupported providers and unavailable models', () => {
+    expect(() => resolveAgentConfig({provider: 'amazon-bedrock'})).toThrow(
+      UnsupportedAgentProviderError,
+    );
+    expect(() => resolveAgentConfig({provider: 'anthropic', model: 'not-a-model'})).toThrow(
+      InvalidAgentModelError,
+    );
+  });
+
+  test('catalogDefaultAgentResolver uses catalog-only defaults', () => {
+    const resolved = catalogDefaultAgentResolver({provider: 'openai'});
+
+    expect(resolved).toEqual({
+      provider: 'openai',
+      model: 'gpt-5.5-pro',
+      thinking: 'high',
+    });
+  });
+});
+
+describe('createWorkspaceAgentDefaultsResolver', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  test('preloads workspace settings and provider configs for resolution', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({
+        workspaceId,
+        providerId: 'openai',
+        defaultModel: 'gpt-5.5-pro',
+        defaultThinking: 'medium',
+      }),
+    );
+    await setDefaultAgentProvider({workspaceId, providerId: 'openai'});
+
+    const resolver = await createWorkspaceAgentDefaultsResolver(workspaceId);
+    const resolved = resolver({});
+    const settings = await getAgentWorkspaceSettings(workspaceId);
+
+    expect(settings?.defaultProviderId).toBe('openai');
+    expect(resolved).toEqual({
+      provider: 'openai',
+      model: 'gpt-5.5-pro',
+      thinking: 'medium',
+    });
+  });
+
+  test('falls back to catalog defaults when no workspace settings exist', async () => {
+    const resolver = await createWorkspaceAgentDefaultsResolver(workspaceId);
+
+    const resolved = resolver({});
+
+    expect(resolved).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+    });
+  });
+});
+
+function createProviderConfigParams(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  defaultModel: string;
+  defaultThinking: AgentThinking;
+}): UpsertAgentProviderConfigParams {
+  return {
+    workspaceId: params.workspaceId,
+    providerId: params.providerId,
+    encryptedCredentials: {api_key: `encrypted-${params.providerId}-key`},
+    keyFingerprints: {api_key: 'sk-test...abcd'},
+    defaultModel: params.defaultModel,
+    defaultThinking: params.defaultThinking,
+  };
+}

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -117,6 +117,35 @@ describe('resolveAgentConfig', () => {
     );
   });
 
+  test('falls through to the instance default when the workspace default provider is null', () => {
+    const resolved = resolveAgentConfig(
+      {},
+      {workspaceDefaultProviderId: null, instanceDefaultProvider: 'anthropic'},
+    );
+
+    expect(resolved.provider).toBe('anthropic');
+  });
+
+  test('throws when a stored workspace default provider is no longer supported', () => {
+    const resolve = () =>
+      resolveAgentConfig(
+        {},
+        {workspaceDefaultProviderId: 'amazon-bedrock' as SupportedAgentProviderId},
+      );
+
+    expect(resolve).toThrow(UnsupportedAgentProviderError);
+  });
+
+  test('validates the instance default model and rejects an unknown one', () => {
+    const resolve = () =>
+      resolveAgentConfig(
+        {},
+        {instanceDefaultProvider: 'anthropic', instanceDefaultProviderModel: 'not-a-model'},
+      );
+
+    expect(resolve).toThrow(InvalidAgentModelError);
+  });
+
   test('catalogDefaultAgentResolver uses catalog-only defaults', () => {
     const resolved = catalogDefaultAgentResolver({provider: 'openai'});
 

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -7,11 +7,8 @@ import {
   upsertAgentProviderConfig,
 } from '#db/index.js';
 import {InvalidAgentModelError, UnsupportedAgentProviderError} from './errors.js';
-import {
-  catalogDefaultAgentResolver,
-  createWorkspaceAgentDefaultsResolver,
-  resolveAgentConfig,
-} from './resolve-agent-config.js';
+import {catalogDefaultAgentResolver, resolveAgentConfig} from './resolve-agent-config.js';
+import {createWorkspaceAgentDefaultsResolver} from './workspace-agent-defaults-resolver.js';
 
 describe('resolveAgentConfig', () => {
   test('resolves provider from explicit step, workspace, instance, then catalog default', () => {
@@ -196,6 +193,26 @@ describe('createWorkspaceAgentDefaultsResolver', () => {
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       thinking: 'high',
+    });
+  });
+
+  test('uses workspace provider config defaults when settings row does not exist', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({
+        workspaceId,
+        providerId: 'openai',
+        defaultModel: 'gpt-5.5-pro',
+        defaultThinking: 'medium',
+      }),
+    );
+
+    const resolver = await createWorkspaceAgentDefaultsResolver(workspaceId);
+    const resolved = resolver({provider: 'openai'});
+
+    expect(resolved).toEqual({
+      provider: 'openai',
+      model: 'gpt-5.5-pro',
+      thinking: 'medium',
     });
   });
 });

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -1,0 +1,137 @@
+import {getModels, type KnownProvider} from '@earendil-works/pi-ai';
+import {
+  type AgentThinking,
+  DEFAULT_AGENT_PROVIDER,
+  DEFAULT_AGENT_THINKING,
+  getAgentProviderEntry,
+  type SupportedAgentProviderId,
+} from '@shipfox/api-agent-dto';
+import {config} from '#config.js';
+import {getAgentWorkspaceSettings, listAgentProviderConfigs} from '#db/index.js';
+import {InvalidAgentModelError, UnsupportedAgentProviderError} from './errors.js';
+
+export interface ContextualAgentConfig {
+  readonly provider?: string | undefined;
+  readonly model?: string | undefined;
+  readonly thinking?: AgentThinking | undefined;
+}
+
+export interface ResolvedAgentConfig {
+  readonly provider: SupportedAgentProviderId;
+  readonly model: string;
+  readonly thinking: AgentThinking;
+}
+
+export type AgentDefaultsResolver = (step: ContextualAgentConfig) => ResolvedAgentConfig;
+
+export interface AgentConfigResolutionContext {
+  readonly workspaceDefaultProviderId?: SupportedAgentProviderId | null | undefined;
+  readonly workspaceProviderConfigs?: ReadonlyMap<
+    SupportedAgentProviderId,
+    WorkspaceProviderDefaults
+  >;
+  readonly instanceDefaultProvider?: SupportedAgentProviderId | undefined;
+  readonly instanceDefaultProviderModel?: string | undefined;
+  readonly instanceDefaultProviderThinking?: AgentThinking | undefined;
+}
+
+interface WorkspaceProviderDefaults {
+  readonly defaultModel: string;
+  readonly defaultThinking: AgentThinking;
+}
+
+export function resolveAgentConfig(
+  step: ContextualAgentConfig,
+  ctx: AgentConfigResolutionContext = {},
+): ResolvedAgentConfig {
+  const provider = resolveProvider(step, ctx);
+  const workspaceProviderConfig = ctx.workspaceProviderConfigs?.get(provider);
+  const model =
+    step.model ??
+    workspaceProviderConfig?.defaultModel ??
+    instanceDefaultModel(provider, ctx) ??
+    catalogDefaultModel(provider);
+  const thinking =
+    step.thinking ??
+    workspaceProviderConfig?.defaultThinking ??
+    instanceDefaultThinking(provider, ctx) ??
+    DEFAULT_AGENT_THINKING;
+
+  validateModel(provider, model);
+  return {provider, model, thinking};
+}
+
+export async function createWorkspaceAgentDefaultsResolver(
+  workspaceId: string,
+): Promise<AgentDefaultsResolver> {
+  const [settings, providerConfigs] = await Promise.all([
+    getAgentWorkspaceSettings(workspaceId),
+    listAgentProviderConfigs(workspaceId),
+  ]);
+  const workspaceProviderConfigs = new Map(
+    providerConfigs.map((providerConfig) => [
+      providerConfig.providerId,
+      {
+        defaultModel: providerConfig.defaultModel,
+        defaultThinking: providerConfig.defaultThinking,
+      },
+    ]),
+  );
+  const ctx: AgentConfigResolutionContext = {
+    workspaceDefaultProviderId: settings?.defaultProviderId,
+    workspaceProviderConfigs,
+    instanceDefaultProvider: config.AGENT_DEFAULT_PROVIDER as SupportedAgentProviderId | undefined,
+    instanceDefaultProviderModel: config.AGENT_DEFAULT_PROVIDER_MODEL,
+    instanceDefaultProviderThinking: config.AGENT_DEFAULT_PROVIDER_THINKING as
+      | AgentThinking
+      | undefined,
+  };
+
+  return (step) => resolveAgentConfig(step, ctx);
+}
+
+export const catalogDefaultAgentResolver: AgentDefaultsResolver = (step) =>
+  resolveAgentConfig(step);
+
+function resolveProvider(
+  step: ContextualAgentConfig,
+  ctx: AgentConfigResolutionContext,
+): SupportedAgentProviderId {
+  const provider =
+    step.provider ??
+    ctx.workspaceDefaultProviderId ??
+    ctx.instanceDefaultProvider ??
+    DEFAULT_AGENT_PROVIDER;
+  const entry = getAgentProviderEntry(provider);
+  if (entry === undefined || entry.support_status !== 'supported') {
+    throw new UnsupportedAgentProviderError(provider);
+  }
+  return provider as SupportedAgentProviderId;
+}
+
+function catalogDefaultModel(provider: SupportedAgentProviderId): string {
+  const entry = getAgentProviderEntry(provider);
+  if (entry === undefined || entry.support_status !== 'supported' || entry.default_model === null) {
+    throw new UnsupportedAgentProviderError(provider);
+  }
+  return entry.default_model;
+}
+
+function instanceDefaultModel(
+  provider: SupportedAgentProviderId,
+  ctx: AgentConfigResolutionContext,
+): string | undefined {
+  return provider === ctx.instanceDefaultProvider ? ctx.instanceDefaultProviderModel : undefined;
+}
+
+function instanceDefaultThinking(
+  provider: SupportedAgentProviderId,
+  ctx: AgentConfigResolutionContext,
+): AgentThinking | undefined {
+  return provider === ctx.instanceDefaultProvider ? ctx.instanceDefaultProviderThinking : undefined;
+}
+
+function validateModel(provider: SupportedAgentProviderId, model: string): void {
+  const found = getModels(provider as KnownProvider).some((candidate) => candidate.id === model);
+  if (!found) throw new InvalidAgentModelError(provider, model);
+}

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -6,8 +6,6 @@ import {
   getAgentProviderEntry,
   type SupportedAgentProviderId,
 } from '@shipfox/api-agent-dto';
-import {config} from '#config.js';
-import {getAgentWorkspaceSettings, listAgentProviderConfigs} from '#db/index.js';
 import {InvalidAgentModelError, UnsupportedAgentProviderError} from './errors.js';
 
 export interface ContextualAgentConfig {
@@ -59,35 +57,6 @@ export function resolveAgentConfig(
 
   validateModel(provider, model);
   return {provider, model, thinking};
-}
-
-export async function createWorkspaceAgentDefaultsResolver(
-  workspaceId: string,
-): Promise<AgentDefaultsResolver> {
-  const [settings, providerConfigs] = await Promise.all([
-    getAgentWorkspaceSettings(workspaceId),
-    listAgentProviderConfigs(workspaceId),
-  ]);
-  const workspaceProviderConfigs = new Map(
-    providerConfigs.map((providerConfig) => [
-      providerConfig.providerId,
-      {
-        defaultModel: providerConfig.defaultModel,
-        defaultThinking: providerConfig.defaultThinking,
-      },
-    ]),
-  );
-  const ctx: AgentConfigResolutionContext = {
-    workspaceDefaultProviderId: settings?.defaultProviderId,
-    workspaceProviderConfigs,
-    instanceDefaultProvider: config.AGENT_DEFAULT_PROVIDER as SupportedAgentProviderId | undefined,
-    instanceDefaultProviderModel: config.AGENT_DEFAULT_PROVIDER_MODEL,
-    instanceDefaultProviderThinking: config.AGENT_DEFAULT_PROVIDER_THINKING as
-      | AgentThinking
-      | undefined,
-  };
-
-  return (step) => resolveAgentConfig(step, ctx);
 }
 
 export const catalogDefaultAgentResolver: AgentDefaultsResolver = (step) =>

--- a/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
+++ b/libs/api/agent/src/core/workspace-agent-defaults-resolver.ts
@@ -1,0 +1,31 @@
+import type {AgentThinking, SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {config} from '#config.js';
+import {getAgentWorkspaceDefaultsSnapshot} from '#db/index.js';
+import type {AgentConfigResolutionContext, AgentDefaultsResolver} from './resolve-agent-config.js';
+import {resolveAgentConfig} from './resolve-agent-config.js';
+
+export async function createWorkspaceAgentDefaultsResolver(
+  workspaceId: string,
+): Promise<AgentDefaultsResolver> {
+  const snapshot = await getAgentWorkspaceDefaultsSnapshot(workspaceId);
+  const workspaceProviderConfigs = new Map(
+    snapshot.providerConfigs.map((providerConfig) => [
+      providerConfig.providerId,
+      {
+        defaultModel: providerConfig.defaultModel,
+        defaultThinking: providerConfig.defaultThinking,
+      },
+    ]),
+  );
+  const ctx: AgentConfigResolutionContext = {
+    workspaceDefaultProviderId: snapshot.defaultProviderId,
+    workspaceProviderConfigs,
+    instanceDefaultProvider: config.AGENT_DEFAULT_PROVIDER as SupportedAgentProviderId | undefined,
+    instanceDefaultProviderModel: config.AGENT_DEFAULT_PROVIDER_MODEL,
+    instanceDefaultProviderThinking: config.AGENT_DEFAULT_PROVIDER_THINKING as
+      | AgentThinking
+      | undefined,
+  };
+
+  return (step) => resolveAgentConfig(step, ctx);
+}

--- a/libs/api/agent/src/db/agent-defaults-snapshot.ts
+++ b/libs/api/agent/src/db/agent-defaults-snapshot.ts
@@ -1,0 +1,45 @@
+import type {SupportedAgentProviderId} from '@shipfox/api-agent-dto';
+import {eq, or} from 'drizzle-orm';
+import type {AgentProviderConfig} from '#core/entities/agent-provider-config.js';
+import {db} from './db.js';
+import {agentProviderConfigs, toAgentProviderConfig} from './schema/agent-provider-configs.js';
+import {agentWorkspaceSettings} from './schema/agent-workspace-settings.js';
+
+export interface AgentWorkspaceDefaultsSnapshot {
+  readonly defaultProviderId?: SupportedAgentProviderId | null | undefined;
+  readonly providerConfigs: AgentProviderConfig[];
+}
+
+export async function getAgentWorkspaceDefaultsSnapshot(
+  workspaceId: string,
+): Promise<AgentWorkspaceDefaultsSnapshot> {
+  const rows = await db()
+    .select({
+      settingsWorkspaceId: agentWorkspaceSettings.workspaceId,
+      workspaceDefaultProviderId: agentWorkspaceSettings.defaultProviderId,
+      providerConfig: agentProviderConfigs,
+    })
+    .from(agentWorkspaceSettings)
+    .fullJoin(
+      agentProviderConfigs,
+      eq(agentProviderConfigs.workspaceId, agentWorkspaceSettings.workspaceId),
+    )
+    .where(
+      or(
+        eq(agentWorkspaceSettings.workspaceId, workspaceId),
+        eq(agentProviderConfigs.workspaceId, workspaceId),
+      ),
+    )
+    .orderBy(agentProviderConfigs.providerId);
+
+  const settingsRow = rows.find((row) => row.settingsWorkspaceId !== null);
+  return {
+    defaultProviderId: settingsRow?.workspaceDefaultProviderId as
+      | SupportedAgentProviderId
+      | null
+      | undefined,
+    providerConfigs: rows.flatMap((row) =>
+      row.providerConfig === null ? [] : [toAgentProviderConfig(row.providerConfig)],
+    ),
+  };
+}

--- a/libs/api/agent/src/db/index.ts
+++ b/libs/api/agent/src/db/index.ts
@@ -1,6 +1,10 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
+export {
+  type AgentWorkspaceDefaultsSnapshot,
+  getAgentWorkspaceDefaultsSnapshot,
+} from './agent-defaults-snapshot.js';
 export type {UpsertAgentProviderConfigParams} from './agent-provider-configs.js';
 export {
   deleteAgentProviderConfig,

--- a/libs/api/agent/src/index.ts
+++ b/libs/api/agent/src/index.ts
@@ -3,16 +3,23 @@ import {db, migrationsPath} from '#db/index.js';
 import {routes} from '#presentation/index.js';
 
 export {
+  type AgentConfigResolutionContext,
+  type AgentDefaultsResolver,
   type AgentProviderConfig,
   AgentProviderConfigNotFoundError,
   AgentProviderValidationError,
   type AgentWorkspaceSettings,
   buildAgentProviderCatalog,
+  type ContextualAgentConfig,
   CredentialDecryptionError,
+  catalogDefaultAgentResolver,
+  createWorkspaceAgentDefaultsResolver,
   decryptCredentials,
   InvalidAgentModelError,
   InvalidCredentialFieldsError,
   ProviderValidationUnavailableError,
+  type ResolvedAgentConfig,
+  resolveAgentConfig,
   testAndSaveProviderConfig,
   UnsupportedAgentProviderError,
 } from '#core/index.js';

--- a/libs/api/logs/test/env.ts
+++ b/libs/api/logs/test/env.ts
@@ -7,6 +7,7 @@ process.env.POSTGRES_MAX_CONNECTIONS = '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
+process.env.AGENT_CREDENTIALS_ENCRYPTION_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 
 // Small accrual budget so cap/budget tests use tiny payloads: base 100 bytes,
 // rate 60 bytes/min (1 byte/second).

--- a/libs/api/triggers/test/env.ts
+++ b/libs/api/triggers/test/env.ts
@@ -4,4 +4,5 @@ process.env.POSTGRES_USERNAME = 'shipfox';
 process.env.POSTGRES_PASSWORD = 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
 process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.AGENT_CREDENTIALS_ENCRYPTION_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 process.env.TZ = 'UTC';

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-agent": "workspace:*",
     "@shipfox/api-auth": "workspace:*",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",

--- a/libs/api/workflows/src/core/errors.test.ts
+++ b/libs/api/workflows/src/core/errors.test.ts
@@ -1,4 +1,5 @@
 import {
+  AgentConfigUnresolvableError,
   DefinitionNotFoundError,
   isPermanentRunWorkflowError,
   ProjectMismatchError,
@@ -13,6 +14,12 @@ describe('isPermanentRunWorkflowError', () => {
 
   test('is true for a project mismatch', () => {
     const result = isPermanentRunWorkflowError(new ProjectMismatchError('proj-a', 'proj-b'));
+
+    expect(result).toBe(true);
+  });
+
+  test('is true for unresolvable agent configuration', () => {
+    const result = isPermanentRunWorkflowError(new AgentConfigUnresolvableError('def-1'));
 
     expect(result).toBe(true);
   });

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -17,6 +17,16 @@ export class ProjectMismatchError extends Error {
   }
 }
 
+export class AgentConfigUnresolvableError extends Error {
+  constructor(
+    readonly definitionId: string,
+    options?: ErrorOptions | undefined,
+  ) {
+    super(`Agent configuration cannot be resolved for definition ${definitionId}`, options);
+    this.name = 'AgentConfigUnresolvableError';
+  }
+}
+
 /**
  * True when a `runWorkflow` failure can never succeed on retry: the definition is gone or
  * the subscription points at the wrong project. Callers (e.g. the trigger dispatcher) use this
@@ -24,7 +34,11 @@ export class ProjectMismatchError extends Error {
  * treated as transient so at-least-once delivery can converge.
  */
 export function isPermanentRunWorkflowError(error: unknown): boolean {
-  return error instanceof DefinitionNotFoundError || error instanceof ProjectMismatchError;
+  return (
+    error instanceof DefinitionNotFoundError ||
+    error instanceof ProjectMismatchError ||
+    error instanceof AgentConfigUnresolvableError
+  );
 }
 
 export class JobNotFoundError extends Error {

--- a/libs/api/workflows/src/core/index.ts
+++ b/libs/api/workflows/src/core/index.ts
@@ -13,6 +13,7 @@ export type {
   WorkflowSourceSnapshot,
 } from './entities/workflow-run.js';
 export {
+  AgentConfigUnresolvableError,
   DefinitionNotFoundError,
   isPermanentRunWorkflowError,
   JobNotFoundError,
@@ -32,6 +33,7 @@ export {
   type MaterializedWorkflowJob,
   type MaterializedWorkflowStep,
   materializeWorkflowModel,
+  modelHasAgentStep,
   type ScheduleRuntimeDagInput,
   scheduleRuntimeDag,
 } from './workflow-runtime/index.js';

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -17,18 +17,19 @@ vi.mock('@shipfox/api-definitions', () => ({
   getDefinitionById: vi.fn(),
 }));
 
-vi.mock('@shipfox/api-agent', () => {
-  class UnsupportedAgentProviderError extends Error {}
-  class InvalidAgentModelError extends Error {}
+vi.mock('@shipfox/api-agent/core/resolve-agent-config', () => {
   return {
     catalogDefaultAgentResolver: vi.fn().mockReturnValue({
       provider: 'anthropic',
       model: 'claude-opus-4-8',
       thinking: 'high',
     }),
+  };
+});
+
+vi.mock('@shipfox/api-agent/core/workspace-agent-defaults-resolver', () => {
+  return {
     createWorkspaceAgentDefaultsResolver: mockCreateWorkspaceAgentDefaultsResolver,
-    UnsupportedAgentProviderError,
-    InvalidAgentModelError,
   };
 });
 

--- a/libs/api/workflows/src/core/run-workflow.test.ts
+++ b/libs/api/workflows/src/core/run-workflow.test.ts
@@ -4,9 +4,33 @@ import type {TriggerPayload} from './entities/workflow-run.js';
 import {DefinitionNotFoundError, ProjectMismatchError} from './errors.js';
 import {runWorkflow} from './run-workflow.js';
 
+const mockCreateWorkspaceAgentDefaultsResolver = vi.hoisted(() => vi.fn());
+const mockWorkspaceAgentDefaultsResolver = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    provider: 'openai',
+    model: 'gpt-5.5-pro',
+    thinking: 'medium',
+  }),
+);
+
 vi.mock('@shipfox/api-definitions', () => ({
   getDefinitionById: vi.fn(),
 }));
+
+vi.mock('@shipfox/api-agent', () => {
+  class UnsupportedAgentProviderError extends Error {}
+  class InvalidAgentModelError extends Error {}
+  return {
+    catalogDefaultAgentResolver: vi.fn().mockReturnValue({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+    }),
+    createWorkspaceAgentDefaultsResolver: mockCreateWorkspaceAgentDefaultsResolver,
+    UnsupportedAgentProviderError,
+    InvalidAgentModelError,
+  };
+});
 
 import {getDefinitionById} from '@shipfox/api-definitions';
 
@@ -57,6 +81,9 @@ describe('runWorkflow', () => {
   beforeEach(() => {
     workspaceId = crypto.randomUUID();
     projectId = crypto.randomUUID();
+    mockCreateWorkspaceAgentDefaultsResolver.mockClear();
+    mockCreateWorkspaceAgentDefaultsResolver.mockResolvedValue(mockWorkspaceAgentDefaultsResolver);
+    mockWorkspaceAgentDefaultsResolver.mockClear();
   });
 
   test('creates a run from a valid definition with the provided manual trigger payload', async () => {
@@ -79,6 +106,32 @@ describe('runWorkflow', () => {
     expect(run.triggerSource).toBe('manual');
     expect(run.triggerEvent).toBe('fire');
     expect(run.triggerPayload).toEqual(triggerPayload);
+    expect(mockCreateWorkspaceAgentDefaultsResolver).not.toHaveBeenCalled();
+  });
+
+  test('builds the workspace agent resolver only when the definition has an agent step', async () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+      },
+    });
+    const definition = buildDefinition({projectId, model});
+    mockGetDefinitionById.mockResolvedValue(definition);
+
+    const run = await runWorkflow({
+      workspaceId,
+      projectId,
+      definitionId: definition.id,
+      triggerPayload: manualPayload(),
+    });
+
+    expect(run.id).toBeDefined();
+    expect(mockCreateWorkspaceAgentDefaultsResolver).toHaveBeenCalledWith(workspaceId);
+    expect(mockWorkspaceAgentDefaultsResolver).toHaveBeenCalledWith({
+      provider: undefined,
+      model: undefined,
+      thinking: undefined,
+    });
   });
 
   test('persists an integration trigger payload intact', async () => {

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -1,7 +1,12 @@
+import {
+  catalogDefaultAgentResolver,
+  createWorkspaceAgentDefaultsResolver,
+} from '@shipfox/api-agent';
 import {getDefinitionById} from '@shipfox/api-definitions';
 import {createWorkflowRun} from '#db/workflow-runs.js';
 import type {TriggerPayload, WorkflowRun} from './entities/workflow-run.js';
 import {DefinitionNotFoundError, ProjectMismatchError} from './errors.js';
+import {modelHasAgentStep} from './workflow-runtime/index.js';
 
 export interface RunWorkflowParams {
   workspaceId: string;
@@ -19,6 +24,9 @@ export async function runWorkflow(params: RunWorkflowParams): Promise<WorkflowRu
   if (definition.projectId !== params.projectId) {
     throw new ProjectMismatchError(definition.projectId, params.projectId);
   }
+  const resolveAgentDefaults = modelHasAgentStep(definition.model)
+    ? await createWorkspaceAgentDefaultsResolver(params.workspaceId)
+    : catalogDefaultAgentResolver;
 
   return createWorkflowRun({
     workspaceId: params.workspaceId,
@@ -30,5 +38,6 @@ export async function runWorkflow(params: RunWorkflowParams): Promise<WorkflowRu
     inputs: params.inputs,
     sourceSnapshot: definition.sourceSnapshot,
     triggerIdempotencyKey: params.triggerIdempotencyKey,
+    resolveAgentDefaults,
   });
 }

--- a/libs/api/workflows/src/core/run-workflow.ts
+++ b/libs/api/workflows/src/core/run-workflow.ts
@@ -1,7 +1,5 @@
-import {
-  catalogDefaultAgentResolver,
-  createWorkspaceAgentDefaultsResolver,
-} from '@shipfox/api-agent';
+import {catalogDefaultAgentResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import {createWorkspaceAgentDefaultsResolver} from '@shipfox/api-agent/core/workspace-agent-defaults-resolver';
 import {getDefinitionById} from '@shipfox/api-definitions';
 import {createWorkflowRun} from '#db/workflow-runs.js';
 import type {TriggerPayload, WorkflowRun} from './entities/workflow-run.js';

--- a/libs/api/workflows/src/core/workflow-runtime/README.md
+++ b/libs/api/workflows/src/core/workflow-runtime/README.md
@@ -12,7 +12,7 @@ Pure scheduling decisions for workflow run orchestration.
 ## Usage
 
 ```ts
-import {scheduleRuntimeDag} from '#core/workflow-runtime/index.js';
+import {scheduleRuntimeDag} from '#core/workflow-runtime/schedule-runtime-dag.js';
 
 const commands = scheduleRuntimeDag({
   jobs: [

--- a/libs/api/workflows/src/core/workflow-runtime/index.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/index.ts
@@ -2,6 +2,7 @@ export {
   type MaterializedWorkflowJob,
   type MaterializedWorkflowStep,
   materializeWorkflowModel,
+  modelHasAgentStep,
 } from './materialize-workflow-model.js';
 export {
   type ScheduleRuntimeDagInput,

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -1,6 +1,12 @@
+import {
+  type AgentDefaultsResolver,
+  InvalidAgentModelError,
+  UnsupportedAgentProviderError,
+} from '@shipfox/api-agent';
 import type {WorkflowModel} from '@shipfox/api-definitions';
+import {AgentConfigUnresolvableError} from '#core/errors.js';
 import {workflowModel} from '#test/index.js';
-import {materializeWorkflowModel} from './materialize-workflow-model.js';
+import {materializeWorkflowModel, modelHasAgentStep} from './materialize-workflow-model.js';
 
 type TestWorkflowExpression = NonNullable<
   NonNullable<WorkflowModel['jobs'][number]['steps'][number]['gate']>['successIf']
@@ -213,6 +219,73 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('routes agent steps through the provided resolver', () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {
+          steps: [{provider: 'anthropic', prompt: 'Fix the failing tests.'}],
+        },
+      },
+    });
+    const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
+      provider: 'openai',
+      model: 'gpt-5.5-pro',
+      thinking: 'medium',
+    });
+
+    const rows = materializeWorkflowModel(model, resolveAgentDefaults, 'def-1');
+
+    expect(resolveAgentDefaults).toHaveBeenCalledWith({
+      provider: 'anthropic',
+      model: undefined,
+      thinking: undefined,
+    });
+    expect(rows[0]?.steps[1]).toMatchObject({
+      displayName: 'Fix the failing tests.',
+      config: {
+        model: 'gpt-5.5-pro',
+        provider: 'openai',
+        thinking: 'medium',
+        prompt: 'Fix the failing tests.',
+      },
+    });
+  });
+
+  it.each([
+    new UnsupportedAgentProviderError('unknown-provider'),
+    new InvalidAgentModelError('anthropic', 'missing-model'),
+  ])('wraps known resolver errors as permanent agent config errors', (cause) => {
+    const model = workflowModel({
+      jobs: {
+        fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+      },
+    });
+    const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockImplementation(() => {
+      throw cause;
+    });
+
+    const materialize = () => materializeWorkflowModel(model, resolveAgentDefaults, 'def-1');
+
+    expect(materialize).toThrow(AgentConfigUnresolvableError);
+    expect(materialize).toThrow('Agent configuration cannot be resolved for definition def-1');
+  });
+
+  it('re-throws unknown resolver errors unchanged', () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+      },
+    });
+    const error = new Error('database unavailable');
+    const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockImplementation(() => {
+      throw error;
+    });
+
+    const materialize = () => materializeWorkflowModel(model, resolveAgentDefaults, 'def-1');
+
+    expect(materialize).toThrow(error);
+  });
+
   it('materializes merged env for run steps only', () => {
     const model = workflowModel({
       env: {SHARED: 'workflow', WORKFLOW_ONLY: 'yes'},
@@ -303,5 +376,17 @@ describe('materializeWorkflowModel', () => {
     expect(() => materializeWorkflowModel(model)).toThrow(
       'Unresolved workflow model dependency "missing" for job "test"',
     );
+  });
+
+  it('detects whether a workflow model contains agent steps', () => {
+    const runOnly = workflowModel();
+    const withAgent = workflowModel({
+      jobs: {
+        fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+      },
+    });
+
+    expect(modelHasAgentStep(runOnly)).toBe(false);
+    expect(modelHasAgentStep(withAgent)).toBe(true);
   });
 });

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -1,8 +1,8 @@
 import {
-  type AgentDefaultsResolver,
   InvalidAgentModelError,
   UnsupportedAgentProviderError,
-} from '@shipfox/api-agent';
+} from '@shipfox/api-agent/core/errors';
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {AgentConfigUnresolvableError} from '#core/errors.js';
 import {workflowModel} from '#test/index.js';

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -1,9 +1,11 @@
 import {
-  DEFAULT_AGENT_PROVIDER,
-  DEFAULT_AGENT_THINKING,
-  getAgentProviderEntry,
-} from '@shipfox/api-agent-dto';
+  type AgentDefaultsResolver,
+  catalogDefaultAgentResolver,
+  InvalidAgentModelError,
+  UnsupportedAgentProviderError,
+} from '@shipfox/api-agent';
 import type {WorkflowModel} from '@shipfox/api-definitions';
+import {AgentConfigUnresolvableError} from '#core/errors.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
 type WorkflowModelStep = WorkflowModelJob['steps'][number];
@@ -42,7 +44,11 @@ const SETUP_STEP: MaterializedWorkflowStep = {
   position: 0,
 };
 
-export function materializeWorkflowModel(model: WorkflowModel): readonly MaterializedWorkflowJob[] {
+export function materializeWorkflowModel(
+  model: WorkflowModel,
+  resolveAgentDefaults: AgentDefaultsResolver = catalogDefaultAgentResolver,
+  definitionId = model.name,
+): readonly MaterializedWorkflowJob[] {
   const jobsById = new Map(model.jobs.map((job) => [job.id, job]));
 
   return model.jobs.map((job, position) => ({
@@ -60,11 +66,15 @@ export function materializeWorkflowModel(model: WorkflowModel): readonly Materia
         sourceLocation: step.sourceLocation ?? null,
         status: 'pending' as const,
         type: step.kind,
-        config: stepConfig(step, model.env, job.env),
+        config: stepConfig(step, model.env, job.env, resolveAgentDefaults, definitionId),
         position: stepPosition + 1,
       })),
     ],
   }));
+}
+
+export function modelHasAgentStep(model: WorkflowModel): boolean {
+  return model.jobs.some((job) => job.steps.some((step) => step.kind === 'agent'));
 }
 
 function dependencySourceNames(
@@ -101,32 +111,39 @@ function stepConfig(
   step: WorkflowModelStep,
   workflowEnv: WorkflowModel['env'],
   jobEnv: WorkflowModelJob['env'],
+  resolveAgentDefaults: AgentDefaultsResolver,
+  definitionId: string,
 ): Record<string, unknown> {
   const gate = step.gate === undefined ? {} : {gate: stepGateConfig(step.gate)};
   const env = step.kind === 'run' ? mergedEnv(workflowEnv, jobEnv, step.env) : {};
   return step.kind === 'run'
     ? {run: step.command.value, ...env, ...gate}
-    : {...agentStepConfig(step), ...gate};
+    : {...agentStepConfig(step, resolveAgentDefaults, definitionId), ...gate};
 }
 
-function agentStepConfig(step: Extract<WorkflowModelStep, {kind: 'agent'}>): {
+function agentStepConfig(
+  step: Extract<WorkflowModelStep, {kind: 'agent'}>,
+  resolveAgentDefaults: AgentDefaultsResolver,
+  definitionId: string,
+): {
   model: string;
   provider: string;
   thinking: string;
   prompt: string;
 } {
-  const provider = step.provider ?? DEFAULT_AGENT_PROVIDER;
-  const model = step.model ?? defaultModelForProvider(provider);
-  const thinking = step.thinking ?? DEFAULT_AGENT_THINKING;
-  return {model, provider, thinking, prompt: step.prompt};
-}
-
-function defaultModelForProvider(provider: string): string {
-  const entry = getAgentProviderEntry(provider);
-  if (entry === undefined || entry.support_status !== 'supported' || entry.default_model === null) {
-    throw new Error(`No default agent model is cataloged for provider "${provider}"`);
+  try {
+    const resolved = resolveAgentDefaults({
+      provider: step.provider,
+      model: step.model,
+      thinking: step.thinking,
+    });
+    return {...resolved, prompt: step.prompt};
+  } catch (error) {
+    if (error instanceof UnsupportedAgentProviderError || error instanceof InvalidAgentModelError) {
+      throw new AgentConfigUnresolvableError(definitionId, {cause: error});
+    }
+    throw error;
   }
-  return entry.default_model;
 }
 
 function mergedEnv(

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -1,9 +1,11 @@
 import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
   InvalidAgentModelError,
   UnsupportedAgentProviderError,
-} from '@shipfox/api-agent';
+} from '@shipfox/api-agent/core/errors';
+import {
+  type AgentDefaultsResolver,
+  catalogDefaultAgentResolver,
+} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {AgentConfigUnresolvableError} from '#core/errors.js';
 

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1,4 +1,4 @@
-import type {AgentDefaultsResolver} from '@shipfox/api-agent';
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import {
   WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1,3 +1,4 @@
+import type {AgentDefaultsResolver} from '@shipfox/api-agent';
 import {
   WORKFLOWS_JOB_TERMINATED,
   WORKFLOWS_JOB_TIMED_OUT,
@@ -326,6 +327,47 @@ describe('workflow run queries', () => {
       });
     });
 
+    test('stores agent step config resolved by the injected resolver', async () => {
+      const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
+        provider: 'openai',
+        model: 'gpt-5.5-pro',
+        thinking: 'medium',
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        resolveAgentDefaults,
+      });
+
+      const runJobs = await getJobsByRunId(run.id);
+      const jobSteps = await getStepsByJobId(runJobs[0]?.id as string);
+      const agentStep = jobSteps.find((step) => step.type === 'agent');
+      expect(resolveAgentDefaults).toHaveBeenCalledWith({
+        provider: undefined,
+        model: undefined,
+        thinking: undefined,
+      });
+      expect(agentStep?.config).toEqual({
+        model: 'gpt-5.5-pro',
+        provider: 'openai',
+        thinking: 'medium',
+        prompt: 'Fix the failing tests.',
+      });
+    });
+
     test('handles multi-job definitions with correct positions', async () => {
       const run = await createWorkflowRun({
         workspaceId,
@@ -608,6 +650,61 @@ jobs:
       expect(outboxRows).toHaveLength(1);
     });
 
+    test('duplicate triggerIdempotencyKey with an agent step re-resolves before returning the existing run', async () => {
+      const subscriptionId = crypto.randomUUID();
+      const eventId = crypto.randomUUID();
+      const idempotencyKey = `${subscriptionId}:${eventId}`;
+      const model = buildModel({
+        jobs: {
+          fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+        },
+      });
+      const firstResolver = vi.fn<AgentDefaultsResolver>().mockReturnValue({
+        provider: 'openai',
+        model: 'gpt-5.5-pro',
+        thinking: 'medium',
+      });
+      const secondResolver = vi.fn<AgentDefaultsResolver>().mockImplementation(() => {
+        throw new Error('agent defaults unavailable');
+      });
+      const first = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId,
+          userId: crypto.randomUUID(),
+        },
+        triggerIdempotencyKey: idempotencyKey,
+        resolveAgentDefaults: firstResolver,
+      });
+
+      const replay = createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId,
+          userId: crypto.randomUUID(),
+        },
+        triggerIdempotencyKey: idempotencyKey,
+        resolveAgentDefaults: secondResolver,
+      });
+
+      await expect(replay).rejects.toThrow('agent defaults unavailable');
+      expect(firstResolver).toHaveBeenCalledTimes(1);
+      expect(secondResolver).toHaveBeenCalledTimes(1);
+
+      const allJobs = await getJobsByRunId(first.id);
+      expect(allJobs).toHaveLength(1);
+    });
+
     test('null triggerIdempotencyKey allows independent inserts', async () => {
       const a = await createWorkflowRun({
         workspaceId,
@@ -724,6 +821,51 @@ jobs:
         expect(jobSteps.every((step) => step.status === 'pending')).toBe(true);
         expect(jobSteps.every((step) => step.output === null && step.error === null)).toBe(true);
       }
+    });
+
+    test('reruns preserve the original resolved agent step config', async () => {
+      const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockReturnValue({
+        provider: 'openai',
+        model: 'gpt-5.5-pro',
+        thinking: 'medium',
+      });
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            fix: {steps: [{prompt: 'Fix the failing tests.'}]},
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        resolveAgentDefaults,
+      });
+      const sourceJobs = await getJobsByRunId(source.id);
+      await markJob(sourceJobs, 'fix', 'failed');
+      await updateWorkflowRunStatus({runId: source.id, status: 'failed', expectedVersion: 1});
+
+      const rerun = await createRerunWorkflowRun({
+        sourceRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const rerunJobs = await getJobsByRunId(rerun.id);
+      const rerunSteps = await getStepsByJobId(rerunJobs[0]?.id as string);
+      const agentStep = rerunSteps.find((step) => step.type === 'agent');
+      expect(resolveAgentDefaults).toHaveBeenCalledTimes(1);
+      expect(agentStep?.config).toEqual({
+        model: 'gpt-5.5-pro',
+        provider: 'openai',
+        thinking: 'medium',
+        prompt: 'Fix the failing tests.',
+      });
     });
 
     test('writes one workflow_run.created outbox event for the rerun', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1,3 +1,4 @@
+import {type AgentDefaultsResolver, catalogDefaultAgentResolver} from '@shipfox/api-agent';
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {
   type LogOutcomeDto,
@@ -82,10 +83,15 @@ export interface CreateWorkflowRunParams {
   inputs?: Record<string, unknown> | undefined;
   sourceSnapshot?: WorkflowSourceSnapshot | null | undefined;
   triggerIdempotencyKey?: string | undefined;
+  resolveAgentDefaults?: AgentDefaultsResolver | undefined;
 }
 
 export async function createWorkflowRun(params: CreateWorkflowRunParams): Promise<WorkflowRun> {
-  const materializedJobs = materializeWorkflowModel(params.model);
+  const materializedJobs = materializeWorkflowModel(
+    params.model,
+    params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
+    params.definitionId,
+  );
 
   const result = await db().transaction(async (tx) => {
     const insertResult = await tx

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1,4 +1,7 @@
-import {type AgentDefaultsResolver, catalogDefaultAgentResolver} from '@shipfox/api-agent';
+import {
+  type AgentDefaultsResolver,
+  catalogDefaultAgentResolver,
+} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {
   type LogOutcomeDto,

--- a/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/run-orchestration.ts
@@ -8,7 +8,7 @@ import {
 } from '@temporalio/workflow';
 
 import type {RuntimeCompletionStatus} from '#core/entities/runtime-dag.js';
-import {scheduleRuntimeDag} from '#core/workflow-runtime/index.js';
+import {scheduleRuntimeDag} from '#core/workflow-runtime/schedule-runtime-dag.js';
 
 import type {createOrchestrationActivities} from '../activities/index.js';
 import type {DagJob, RunDag} from '../activities/orchestration-activities.js';

--- a/libs/api/workflows/test/env.ts
+++ b/libs/api/workflows/test/env.ts
@@ -7,4 +7,5 @@ process.env.POSTGRES_MAX_CONNECTIONS = '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
+process.env.AGENT_CREDENTIALS_ENCRYPTION_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 process.env.TZ = 'UTC';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2032,6 +2032,9 @@ importers:
 
   libs/api/workflows:
     dependencies:
+      '@shipfox/api-agent':
+        specifier: workspace:*
+        version: link:../agent
       '@shipfox/api-agent-dto':
         specifier: workspace:*
         version: link:../agent-dto


### PR DESCRIPTION
Resolve agent provider, model, and thinking defaults when workflow runs are created.

Agent steps can now omit runtime configuration while preserving deterministic run records: workflows load workspace agent settings only when a definition contains an agent step, materialize the resolved config into step rows, and classify unsupported providers or unavailable models as permanent run-creation failures. Reruns continue to clone the original resolved step config instead of re-resolving.

This keeps future workspace or instance setting changes scoped to future runs and avoids agent DB work for agent-free workflows. The Temporal workflow import path was tightened so deterministic workflow bundles do not pull in API-only agent modules.

Closes ENG-599

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves agent provider, model, and thinking defaults at workflow run creation, preferring workspace settings, then instance, then catalog. Builds the workspace resolver only when the model has agent steps; reruns clone the resolved config; unsupported providers or invalid models are permanent failures; closes ENG-599.

- **New Features**
  - Default resolution order: workspace > instance > catalog.
  - Instance defaults via `AGENT_DEFAULT_PROVIDER`, `AGENT_DEFAULT_PROVIDER_MODEL`, `AGENT_DEFAULT_PROVIDER_THINKING` with validation and clear thinking options.
  - Determinism: reruns keep the original resolved agent config.
  - Handles null/unsupported workspace defaults; invalid instance models and unsupported providers raise AgentConfigUnresolvableError and are permanent.

- **Refactors**
  - Isolated resolver imports under `@shipfox/api-agent/core/*` to keep workflow runtime pure and avoid agent DB modules.
  - Workspace defaults load with one joined snapshot query of settings and provider configs.

<sup>Written for commit ac44c4d61436b416c22ec5125292a92f8b21a029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

