### PR TITLE
[react-ui] Sync README and DESIGN.md component inventory

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -260,11 +260,11 @@ Buttons are `rounded-6`. Status pills are `rounded-4` or `rounded-full`. Cards a
 
 ## 8. Components
 
-The system ships with batteries — use them. Inventory in this workspace:
+The system ships with batteries — use them. The `@shipfox/react-ui` package in this workspace exports the full inventory below. Reach for these before building anything new.
 
-`alert`, `badge`, `button`, `card`, `icon`, `input`, `label`, `loader`, `radio-group`, `skeleton`, `theme`, `toast`, `tooltip`, `typography`.
+`accordion`, `alert`, `avatar`, `badge`, `button`, `calendar`, `card`, `code-block`, `collapsible`, `combobox`, `command`, `date-picker`, `date-range-picker`, `dot`, `dropdown-menu`, `empty-state`, `form-field`, `icon`, `inline-tips`, `input`, `kbd`, `label`, `load-error-state`, `loader`, `log`, `logo`, `modal`, `popover`, `radio-group`, `relative-time`, `scroll-area`, `search`, `select`, `sheet`, `shiny-text`, `skeleton`, `table`, `tabs`, `theme`, `toast`, `tooltip`, `typography`.
 
-The broader `@shipfox/react-ui` catalog adds: `avatar`, `button-group`, `calendar`, `checkbox`, `code-block`, `combobox`, `command`, `confetti`, `count-up`, `dashboard`, `date-picker`, `date-range-picker`, `dot-grid`, `dropdown-menu`, `dynamic-item`, `empty-state`, `form`, `inline-tips`, `interval-selector`, `item`, `kbd`, `modal`, `moving-border`, `popover`, `scroll-area`, `search`, `select`, `sheet`, `shiny-text`, `shipql-editor`, `slider`, `switch`, `table`, `tabs`, `textarea`. When a surface needs one of these, copy it over from the broader catalog rather than rebuilding.
+Still absent from this package and living only in the broader external catalog: `button-group`, `checkbox`, `confetti`, `count-up`, `dashboard`, `dot-grid`, `dynamic-item`, `form`, `interval-selector`, `item`, `moving-border`, `shipql-editor`, `slider`, `switch`, `textarea`. When a surface needs one of these, copy it over from the broader catalog rather than rebuilding.
 
 ### Buttons (the one most people get wrong)
 

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -1,13 +1,14 @@
 # Shipfox React UI
 
-Shared React component library for Shipfox apps. It provides design tokens, Tailwind CSS setup, common components, icons, theme state, and small UI utilities.
+Shared React component library for Shipfox apps. It provides design tokens, Tailwind CSS setup, common components, icons, theme state, hooks, and small UI utilities.
 
 ## What it does
 
-- **Components**: Alert, Badge, Button, Card, Icon, Input, Label, Loader, Skeleton, ThemeProvider, Toast, Tooltip, and Typography.
+- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, InlineTips, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Modal, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Table, Tabs, ThemeProvider, Toast, Tooltip, and Typography.
 - **Theme helpers**: `ThemeProvider`, `useTheme()`, and `useResolvedTheme()`.
+- **Hooks**: `useCopyToClipboard`, `useIsTextTruncated`, `useShikiHighlight`, `useShikiStyleInjection`, plus the theme hooks above.
+- **Utilities**: `cn()` for class name merging, `copyTextToClipboard`, `formatBytes`, `formatDate`/`formatTimestamp`, `formatDuration`/`humanDuration`, `formatRelative`, `debounce`, and avatar helpers (`getInitial`, `getPlaceholderImageUrl`).
 - **Icons**: Custom Shipfox icons plus the icon registry used by the `Icon` component.
-- **Utilities**: `cn()` for class name merging.
 - **CSS entry**: `@shipfox/react-ui/index.css` for fonts, Tailwind, animation utilities, and design tokens.
 
 ## Setup
@@ -60,6 +61,26 @@ export function EmptyState() {
 }
 ```
 
+`FormField` wires up label, input, error, and description with the correct `id`, `aria-invalid`, and `aria-describedby` plumbing. Render the input through `FormFieldInput` to inherit those props automatically:
+
+```tsx
+import {FormField, FormFieldInput} from '@shipfox/react-ui';
+
+<FormField label="Email" id="email" error={error}>
+  <FormFieldInput type="email" value={value} onChange={...} />
+</FormField>
+```
+
+## Storybook
+
+Components are documented in Storybook stories under `src/**/*.stories.tsx`:
+
+```sh
+pnpm --filter=@shipfox/react-ui storybook
+```
+
+Stories are also captured by Argos for visual regression under `turbo test` (light + dark).
+
 ## Build
 
 The package builds JavaScript with SWC and CSS with Vite:
@@ -76,6 +97,7 @@ The CSS build writes `dist/styles.css`. The package also exports `./index.css` f
 turbo check --filter=@shipfox/react-ui
 turbo type --filter=@shipfox/react-ui
 turbo build --filter=@shipfox/react-ui
+turbo test --filter=@shipfox/react-ui
 ```
 
 ## License


### PR DESCRIPTION
The README listed 12 components while the package actually exports 42, and DESIGN.md §8 split components into "this workspace" vs "broader catalog adds", implying 21 listed components hadn't been imported yet — 21 of them had been ported long ago.

- `libs/shared/react/ui/README.md`: expanded the components list to the actual 42 exports; added Hooks, Utilities, Storybook, and a `FormField` usage example.
- `DESIGN.md` §8: replaced the stale two-list split with one accurate list of the 42 exported components, plus a corrected list of the 15 still living only in the external catalog (`button-group`, `checkbox`, `confetti`, `count-up`, `dashboard`, `dot-grid`, `dynamic-item`, `form`, `interval-selector`, `item`, `moving-border`, `shipql-editor`, `slider`, `switch`, `textarea`). Also added the 8 components DESIGN.md never mentioned: `accordion`, `collapsible`, `dot`, `form-field`, `load-error-state`, `log`, `logo`, `relative-time`.

Documentation-only change; no code, types, or exports modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced docs with the real `@shipfox/react-ui` inventory: README now lists all 42 exports, and DESIGN.md mirrors that plus the 15 still only in the external catalog. Added hooks and utilities lists, Storybook notes, and a `FormField` example; docs-only, no code or exports changed.

<sup>Written for commit f1e60faf3ae1a062b7d037f65b75a5faeab5455e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

