### PR TITLE
[api/logs] Gate test suite on Garage bucket readiness

### DIFF
--- a/libs/api/logs/test/globalSetup.ts
+++ b/libs/api/logs/test/globalSetup.ts
@@ -2,7 +2,29 @@ import './env.js';
 import {runMigrations} from '@shipfox/node-drizzle';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {sql} from 'drizzle-orm';
+import {checkBucketReachable, closeS3Client} from '#api/object-storage.js';
 import {closeDb, db, migrationsPath} from '#db/index.js';
+
+const BUCKET_READY_TIMEOUT_MS = 30_000;
+const BUCKET_READY_POLL_INTERVAL_MS = 500;
+
+// `garage-init` exits 0 once it has posted the key/bucket ACLs, but Garage does not guarantee
+// those are immediately usable for S3 uploads. Poll HeadBucket so the suite never starts before
+// the store will accept the configured credentials — without this, the compaction tests race the
+// ACL propagation and fail with `AccessDenied: No such key`.
+async function waitForBucketReachable(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await checkBucketReachable()) return;
+    await new Promise((resolve) => setTimeout(resolve, BUCKET_READY_POLL_INTERVAL_MS));
+  }
+  if (!(await checkBucketReachable())) {
+    throw new Error(
+      `Garage bucket not reachable after ${timeoutMs / 1000}s; ` +
+        'check that the garage + garage-init compose services are up and the access key is provisioned.',
+    );
+  }
+}
 
 export async function setup() {
   createPostgresClient();
@@ -15,4 +37,7 @@ export async function setup() {
 
   closeDb();
   await closePostgresClient();
+
+  await waitForBucketReachable(BUCKET_READY_TIMEOUT_MS);
+  closeS3Client();
 }


### PR DESCRIPTION
The `@shipfox/api-logs` compaction tests upload to and read back from live Garage, but the suite started as soon as `garage-init` exited 0. Garage does not guarantee the imported access key is immediately usable for S3 requests at that point, so the suite raced ACL propagation and intermittently failed with `AccessDenied: No such key` (observed on `compact-stream.test.ts:176`).

`garage-init` has no healthcheck of its own — `docker compose up --wait` only confirms the container exited 0, not that Garage will accept uploads. Postgres and Temporal are already gated; the S3 store was the missing one.

Polls `checkBucketReachable()` (HeadBucket) in `globalSetup` for up to 30s before any test runs, throwing a clear error if the bucket never becomes reachable. Extracted the polling loop into `waitForBucketReachable` for readability.

Test-only change; no runtime behavior affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the `@shipfox/api-logs` test suite on Garage S3 bucket readiness to eliminate flaky compaction tests. Tests now wait until `HeadBucket` succeeds before starting.

- **Bug Fixes**
  - Poll `HeadBucket` in `globalSetup` for up to 30s with 500ms intervals; fail fast with a clear error if unreachable.
  - Added `waitForBucketReachable()` and `closeS3Client()`; test-only change, no runtime impact.

<sup>Written for commit 9d23f7a075a135aee58c5c2bba1323b43206ccf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

