### PR TITLE
[react-ui] Add  helper for TanStack Form fields

### DIFF
--- a/.changeset/calm-ferrets-jump.md
+++ b/.changeset/calm-ferrets-jump.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds a `fieldError` helper to the form-field module that extracts the first error message from a TanStack Form field's validation state.

--- a/libs/shared/react/ui/src/components/form-field/form-field.test.ts
+++ b/libs/shared/react/ui/src/components/form-field/form-field.test.ts
@@ -1,0 +1,71 @@
+import {fieldError} from './form-field.js';
+
+function makeField(errors: unknown[], isBlurred: boolean) {
+  return {state: {meta: {errors, isBlurred}}};
+}
+
+describe('fieldError', () => {
+  test('returns undefined when there are no errors and the field is not blurred', () => {
+    const field = makeField([], false);
+
+    const result = fieldError(field);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when blurred with no errors', () => {
+    const field = makeField([], true);
+
+    const result = fieldError(field);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns a string error after blur', () => {
+    const field = makeField(['Too short'], true);
+
+    const result = fieldError(field);
+
+    expect(result).toBe('Too short');
+  });
+
+  test('returns a string error from submit validation before blur', () => {
+    const field = makeField(['Required'], false);
+
+    const result = fieldError(field);
+
+    expect(result).toBe('Required');
+  });
+
+  test('extracts the message from a Zod-style error object', () => {
+    const field = makeField([{message: 'Invalid email', code: 'invalid_string'}], true);
+
+    const result = fieldError(field);
+
+    expect(result).toBe('Invalid email');
+  });
+
+  test('returns undefined for an object error without a message property', () => {
+    const field = makeField([{code: 'unknown'}], true);
+
+    const result = fieldError(field);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns undefined when the first error is null', () => {
+    const field = makeField([null], true);
+
+    const result = fieldError(field);
+
+    expect(result).toBeUndefined();
+  });
+
+  test('returns only the first error when multiple are present', () => {
+    const field = makeField(['First', 'Second'], true);
+
+    const result = fieldError(field);
+
+    expect(result).toBe('First');
+  });
+});

--- a/libs/shared/react/ui/src/components/form-field/form-field.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.tsx
@@ -97,3 +97,23 @@ export const FormFieldInput = forwardRef<HTMLInputElement, ComponentProps<typeof
 );
 
 FormFieldInput.displayName = 'FormFieldInput';
+
+interface FieldLike {
+  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
+}
+
+/**
+ * Extracts the first error message from a TanStack Form field's validation
+ * state. Returns `undefined` when there are no errors to display. Pass the
+ * result directly to `<FormField error={fieldError(field)}>`.
+ */
+export function fieldError(field: FieldLike): string | undefined {
+  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
+  const first = field.state.meta.errors[0];
+  if (!first) return undefined;
+  if (typeof first === 'string') return first;
+  if (typeof first === 'object' && first !== null && 'message' in first) {
+    return String((first as {message: unknown}).message);
+  }
+  return undefined;
+}


### PR DESCRIPTION
The same `fieldError` helper — extracting the first error message from a TanStack Form field's validation state — was copy-pasted identically across 8 client package files (5 packages). Each site defined its own `FieldLike` interface and `fieldError` function, byte-for-byte identical.

This centralizes the helper in `@shipfox/react-ui`'s existing `form-field` module, exported alongside `FormField` and `FormFieldInput`. It is structurally typed against a `FieldLike` interface, so the UI library stays dependency-free — no `@tanstack/react-form` needed. TanStack's `FieldApi` satisfies the shape automatically.

Considered importing the source tooling repo's composable `Form` module (FormItem/FormLabel/FormControl/FormDescription/FormMessage), but that would have added `react-hook-form` as a competing form library and collided with the existing `FormField` export. The additive approach keeps one declarative form pattern repo-wide.

A follow-up issue (ENG-648) tracks removing the 8 duplicated copies across client packages now that the shared helper is available.

Refs ENG-648

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `fieldError` to `@shipfox/react-ui`’s `form-field` module to return the first validation error from a TanStack Form field. Centralizes the helper across clients without adding `@tanstack/react-form`, and includes a changeset for a minor release. Supports ENG-648.

- **New Features**
  - Export `fieldError(field)` typed to a minimal `FieldLike`, compatible with TanStack `FieldApi` by shape (no `@tanstack/react-form` needed).
  - Added unit tests covering blur behavior, submit-time errors, Zod-style objects, and first-error selection.

<sup>Written for commit dd60232d38b9c377df38f607fa216df2047f028c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

