### PR TITLE
Add workspace agent provider settings

### DIFF
--- a/.changeset/bright-cameras-configure.md
+++ b/.changeset/bright-cameras-configure.md
@@ -1,0 +1,9 @@
+---
+"@shipfox/api-agent": minor
+"@shipfox/api-agent-dto": minor
+"@shipfox/client-agent": minor
+"@shipfox/client-workspace-settings": minor
+"@shipfox/client-router": minor
+---
+
+Adds workspace agent provider settings for configuring, testing, defaulting, and deleting provider credentials.

--- a/libs/api/agent-dto/src/index.ts
+++ b/libs/api/agent-dto/src/index.ts
@@ -38,5 +38,7 @@ export {
   supportedAgentProviderIdSchema,
   UNSUPPORTED_AGENT_PROVIDER_IDS,
   type UpdateAgentProviderConfigBodyDto,
+  type UpdateAgentProviderDefaultModelBodyDto,
   updateAgentProviderConfigBodySchema,
+  updateAgentProviderDefaultModelBodySchema,
 } from '#schemas/index.js';

--- a/libs/api/agent-dto/src/schemas/index.ts
+++ b/libs/api/agent-dto/src/schemas/index.ts
@@ -31,7 +31,9 @@ export {
   setDefaultAgentProviderBodySchema,
   setDefaultAgentProviderResponseSchema,
   type UpdateAgentProviderConfigBodyDto,
+  type UpdateAgentProviderDefaultModelBodyDto,
   updateAgentProviderConfigBodySchema,
+  updateAgentProviderDefaultModelBodySchema,
 } from './provider-config.js';
 export {
   AGENT_PROVIDER_IDS,

--- a/libs/api/agent-dto/src/schemas/provider-config.test.ts
+++ b/libs/api/agent-dto/src/schemas/provider-config.test.ts
@@ -6,14 +6,27 @@ import {
   setDefaultAgentProviderBodySchema,
   setDefaultAgentProviderResponseSchema,
   updateAgentProviderConfigBodySchema,
+  updateAgentProviderDefaultModelBodySchema,
 } from './provider-config.js';
 
 describe('agent provider config schemas', () => {
   it('parses an update body with non-empty credentials', () => {
     const parsed = updateAgentProviderConfigBodySchema.parse({
+      default_model: 'claude-opus-4-8',
       credentials: {api_key: 'rotated-secret'},
     });
 
+    expect(parsed.default_model).toBe('claude-opus-4-8');
+    expect(parsed.credentials.api_key).toBe('rotated-secret');
+  });
+
+  it('parses an update body with Latest selected', () => {
+    const parsed = updateAgentProviderConfigBodySchema.parse({
+      default_model: null,
+      credentials: {api_key: 'rotated-secret'},
+    });
+
+    expect(parsed.default_model).toBeNull();
     expect(parsed.credentials.api_key).toBe('rotated-secret');
   });
 
@@ -51,6 +64,20 @@ describe('agent provider config schemas', () => {
     expect(keysMatch).toBe(false);
   });
 
+  it('parses a model-only update body with Latest selected', () => {
+    const parsed = updateAgentProviderDefaultModelBodySchema.parse({default_model: null});
+
+    expect(parsed.default_model).toBeNull();
+  });
+
+  it('parses a model-only update body with an explicit model', () => {
+    const parsed = updateAgentProviderDefaultModelBodySchema.parse({
+      default_model: 'claude-haiku-4-5',
+    });
+
+    expect(parsed.default_model).toBe('claude-haiku-4-5');
+  });
+
   it('returns credential keys for route-layer validation', () => {
     const keys = getAgentProviderCredentialKeys('cloudflare-ai-gateway');
 
@@ -78,6 +105,7 @@ describe('agent provider config schemas', () => {
   it('parses config rows and list responses with a nullable default provider', () => {
     const row = {
       provider_id: 'openai',
+      default_model: null,
       key_fingerprints: {api_key: 'sk-...abcd'},
       created_at: '2026-06-27T10:30:00.000Z',
       updated_at: '2026-06-27T10:45:00.000Z',
@@ -90,6 +118,7 @@ describe('agent provider config schemas', () => {
     });
 
     expect(parsedRow.provider_id).toBe('openai');
+    expect(parsedRow.default_model).toBeNull();
     expect(parsedList.default_provider_id).toBeNull();
   });
 
@@ -97,6 +126,7 @@ describe('agent provider config schemas', () => {
     const parse = () =>
       agentProviderConfigDtoSchema.parse({
         provider_id: 'openai',
+        default_model: 'gpt-5.5-pro',
         key_fingerprints: {'': 'sk-...abcd'},
         created_at: '2026-06-27T10:30:00.000Z',
         updated_at: '2026-06-27T10:45:00.000Z',

--- a/libs/api/agent-dto/src/schemas/provider-config.ts
+++ b/libs/api/agent-dto/src/schemas/provider-config.ts
@@ -7,6 +7,7 @@ const credentialRecordSchema = z.record(credentialKeySchema, z.string().min(1));
 
 export const agentProviderConfigDtoSchema = z.object({
   provider_id: supportedAgentProviderIdSchema,
+  default_model: z.string().min(1).nullable(),
   key_fingerprints: z.record(credentialKeySchema, z.string()),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
@@ -24,12 +25,21 @@ export type ListAgentProviderConfigsResponseDto = z.infer<
 >;
 
 export const updateAgentProviderConfigBodySchema = z.object({
+  default_model: z.string().min(1).nullable().optional(),
   credentials: credentialRecordSchema.refine((credentials) => Object.keys(credentials).length > 0, {
     message: 'Credentials must include at least one key.',
   }),
 });
 
 export type UpdateAgentProviderConfigBodyDto = z.infer<typeof updateAgentProviderConfigBodySchema>;
+
+export const updateAgentProviderDefaultModelBodySchema = z.object({
+  default_model: z.string().min(1).nullable(),
+});
+
+export type UpdateAgentProviderDefaultModelBodyDto = z.infer<
+  typeof updateAgentProviderDefaultModelBodySchema
+>;
 
 export const setDefaultAgentProviderBodySchema = z.object({
   provider_id: supportedAgentProviderIdSchema,

--- a/libs/api/agent/drizzle/0000_daffy_leopardon.sql
+++ b/libs/api/agent/drizzle/0000_daffy_leopardon.sql
@@ -4,7 +4,7 @@ CREATE TABLE "agent_provider_configs" (
 	"provider_id" text NOT NULL,
 	"encrypted_credentials" jsonb NOT NULL,
 	"key_fingerprints" jsonb NOT NULL,
-	"default_model" text NOT NULL,
+	"default_model" text,
 	"default_thinking" text NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL

--- a/libs/api/agent/drizzle/meta/0000_snapshot.json
+++ b/libs/api/agent/drizzle/meta/0000_snapshot.json
@@ -43,7 +43,7 @@
           "name": "default_model",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "default_thinking": {
           "name": "default_thinking",

--- a/libs/api/agent/src/core/entities/agent-provider-config.ts
+++ b/libs/api/agent/src/core/entities/agent-provider-config.ts
@@ -6,7 +6,7 @@ export interface AgentProviderConfig {
   providerId: SupportedAgentProviderId;
   encryptedCredentials: Record<string, string>;
   keyFingerprints: Record<string, string>;
-  defaultModel: string;
+  defaultModel: string | null;
   defaultThinking: AgentThinking;
   createdAt: Date;
   updatedAt: Date;

--- a/libs/api/agent/src/core/index.ts
+++ b/libs/api/agent/src/core/index.ts
@@ -11,7 +11,10 @@ export {
   UnsupportedAgentProviderError,
 } from './errors.js';
 export {buildAgentProviderCatalog} from './provider-catalog.js';
-export {testAndSaveProviderConfig} from './provider-config-service.js';
+export {
+  testAndSaveProviderConfig,
+  updateProviderConfigDefaultModel,
+} from './provider-config-service.js';
 export {
   type AgentConfigResolutionContext,
   type AgentDefaultsResolver,

--- a/libs/api/agent/src/core/provider-config-service.test.ts
+++ b/libs/api/agent/src/core/provider-config-service.test.ts
@@ -2,11 +2,15 @@ import crypto from 'node:crypto';
 import {getAgentProviderConfig, upsertAgentProviderConfig} from '#db/index.js';
 import {decryptCredentials} from './credential-encryption.js';
 import {
+  AgentProviderConfigNotFoundError,
   AgentProviderValidationError,
   InvalidAgentModelError,
   InvalidCredentialFieldsError,
 } from './errors.js';
-import {testAndSaveProviderConfig} from './provider-config-service.js';
+import {
+  testAndSaveProviderConfig,
+  updateProviderConfigDefaultModel,
+} from './provider-config-service.js';
 
 describe('testAndSaveProviderConfig', () => {
   let workspaceId: string;
@@ -45,8 +49,95 @@ describe('testAndSaveProviderConfig', () => {
       }),
     ).toEqual(credentials);
     expect(stored?.keyFingerprints).toEqual({api_key: 'sk-ant-s...abcd'});
-    expect(stored?.defaultModel).toBe('claude-opus-4-8');
+    expect(stored?.defaultModel).toBeNull();
     expect(stored?.defaultThinking).toBe('high');
+  });
+
+  it('validates and stores an explicit provider default model', async () => {
+    const credentials = {api_key: 'sk-ant-secret-abcd'};
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const config = await testAndSaveProviderConfig(
+      {
+        workspaceId,
+        providerId: 'anthropic',
+        defaultModel: 'claude-haiku-4-5',
+        credentials,
+      },
+      {probe},
+    );
+
+    const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(probe).toHaveBeenCalledWith({
+      providerId: 'anthropic',
+      model: 'claude-haiku-4-5',
+      credentials,
+    });
+    expect(stored).toEqual(config);
+    expect(stored?.defaultModel).toBe('claude-haiku-4-5');
+  });
+
+  it('preserves an existing default model when rotating credentials without a model selection', async () => {
+    await upsertAgentProviderConfig({
+      workspaceId,
+      providerId: 'anthropic',
+      encryptedCredentials: {api_key: 'already-encrypted'},
+      keyFingerprints: {api_key: 'sk-old...abcd'},
+      defaultModel: 'claude-haiku-4-5',
+      defaultThinking: 'high',
+    });
+    const credentials = {api_key: 'sk-ant-rotated-abcd'};
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const config = await testAndSaveProviderConfig(
+      {
+        workspaceId,
+        providerId: 'anthropic',
+        credentials,
+      },
+      {probe},
+    );
+
+    const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(probe).toHaveBeenCalledWith({
+      providerId: 'anthropic',
+      model: 'claude-haiku-4-5',
+      credentials,
+    });
+    expect(stored).toEqual(config);
+    expect(stored?.defaultModel).toBe('claude-haiku-4-5');
+  });
+
+  it('stores Latest when rotating credentials with a null default model selection', async () => {
+    await upsertAgentProviderConfig({
+      workspaceId,
+      providerId: 'anthropic',
+      encryptedCredentials: {api_key: 'already-encrypted'},
+      keyFingerprints: {api_key: 'sk-old...abcd'},
+      defaultModel: 'claude-haiku-4-5',
+      defaultThinking: 'high',
+    });
+    const credentials = {api_key: 'sk-ant-rotated-abcd'};
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const config = await testAndSaveProviderConfig(
+      {
+        workspaceId,
+        providerId: 'anthropic',
+        defaultModel: null,
+        credentials,
+      },
+      {probe},
+    );
+
+    const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(probe).toHaveBeenCalledWith({
+      providerId: 'anthropic',
+      model: 'claude-opus-4-8',
+      credentials,
+    });
+    expect(stored).toEqual(config);
+    expect(stored?.defaultModel).toBeNull();
   });
 
   it('does not persist when provider validation fails and sanitizes the surfaced error', async () => {
@@ -114,6 +205,97 @@ describe('testAndSaveProviderConfig', () => {
     await expect(save).rejects.toBe(error);
     const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
     expect(stored).toBeUndefined();
+  });
+
+  it('rejects an explicit default model outside the provider catalog', async () => {
+    const probe = vi.fn();
+
+    const save = testAndSaveProviderConfig(
+      {
+        workspaceId,
+        providerId: 'anthropic',
+        defaultModel: 'missing-model',
+        credentials: {api_key: 'sk-ant-secret-abcd'},
+      },
+      {probe},
+    );
+
+    await expect(save).rejects.toThrow(InvalidAgentModelError);
+    expect(probe).not.toHaveBeenCalled();
+    const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(stored).toBeUndefined();
+  });
+
+  it('updates the default model without changing credentials', async () => {
+    const existing = await upsertAgentProviderConfig({
+      workspaceId,
+      providerId: 'anthropic',
+      encryptedCredentials: {api_key: 'already-encrypted'},
+      keyFingerprints: {api_key: 'sk-old...abcd'},
+      defaultModel: null,
+      defaultThinking: 'high',
+    });
+
+    const updated = await updateProviderConfigDefaultModel({
+      workspaceId,
+      providerId: 'anthropic',
+      defaultModel: 'claude-haiku-4-5',
+    });
+
+    expect(updated).toMatchObject({
+      encryptedCredentials: existing.encryptedCredentials,
+      keyFingerprints: existing.keyFingerprints,
+      defaultModel: 'claude-haiku-4-5',
+      defaultThinking: existing.defaultThinking,
+    });
+  });
+
+  it('stores null when the default model is set to Latest', async () => {
+    await upsertAgentProviderConfig({
+      workspaceId,
+      providerId: 'anthropic',
+      encryptedCredentials: {api_key: 'already-encrypted'},
+      keyFingerprints: {api_key: 'sk-old...abcd'},
+      defaultModel: 'claude-haiku-4-5',
+      defaultThinking: 'high',
+    });
+
+    const updated = await updateProviderConfigDefaultModel({
+      workspaceId,
+      providerId: 'anthropic',
+      defaultModel: null,
+    });
+
+    expect(updated.defaultModel).toBeNull();
+  });
+
+  it('rejects a default model update for a missing config', async () => {
+    const update = updateProviderConfigDefaultModel({
+      workspaceId,
+      providerId: 'anthropic',
+      defaultModel: null,
+    });
+
+    await expect(update).rejects.toThrow(AgentProviderConfigNotFoundError);
+  });
+
+  it('rejects a default model update outside the provider catalog', async () => {
+    await upsertAgentProviderConfig({
+      workspaceId,
+      providerId: 'anthropic',
+      encryptedCredentials: {api_key: 'already-encrypted'},
+      keyFingerprints: {api_key: 'sk-old...abcd'},
+      defaultModel: null,
+      defaultThinking: 'high',
+    });
+
+    const update = updateProviderConfigDefaultModel({
+      workspaceId,
+      providerId: 'anthropic',
+      defaultModel: 'missing-model',
+    });
+
+    await expect(update).rejects.toThrow(InvalidAgentModelError);
   });
 
   it('validates and stores Azure provider configs with multi-field credentials', async () => {

--- a/libs/api/agent/src/core/provider-config-service.ts
+++ b/libs/api/agent/src/core/provider-config-service.ts
@@ -4,7 +4,11 @@ import {
   getAgentProviderEntry,
   type SupportedAgentProviderId,
 } from '@shipfox/api-agent-dto';
-import {upsertAgentProviderConfig} from '#db/index.js';
+import {
+  getAgentProviderConfig,
+  updateAgentProviderDefaultModel,
+  upsertAgentProviderConfig,
+} from '#db/index.js';
 import {providerValidationCount} from '#metrics/index.js';
 import {
   encryptCredentials,
@@ -13,21 +17,30 @@ import {
 } from './credential-encryption.js';
 import type {AgentProviderConfig} from './entities/agent-provider-config.js';
 import {
+  AgentProviderConfigNotFoundError,
   AgentProviderValidationError,
   InvalidAgentModelError,
   InvalidCredentialFieldsError,
   UnsupportedAgentProviderError,
 } from './errors.js';
+import {buildAgentProviderCatalog} from './provider-catalog.js';
 import {probeProviderCredentials, sanitizeProviderError} from './provider-validation.js';
 
 export interface TestAndSaveProviderConfigParams {
   workspaceId: string;
   providerId: SupportedAgentProviderId;
+  defaultModel?: string | null | undefined;
   credentials: Record<string, string>;
 }
 
 export interface TestAndSaveProviderConfigOptions {
   probe?: typeof probeProviderCredentials;
+}
+
+export interface UpdateProviderConfigDefaultModelParams {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  defaultModel: string | null;
 }
 
 export async function testAndSaveProviderConfig(
@@ -47,10 +60,19 @@ export async function testAndSaveProviderConfig(
 
   ensureCredentialsEncryptionKeyConfigured();
 
+  const existingConfig = await getAgentProviderConfig({
+    workspaceId: params.workspaceId,
+    providerId: params.providerId,
+  });
+  const modelSelection = resolveDefaultModel(
+    params.providerId,
+    params.defaultModel !== undefined ? params.defaultModel : existingConfig?.defaultModel,
+  );
+
   try {
     await probe({
       providerId: params.providerId,
-      model: entry.default_model,
+      model: modelSelection.probeModel,
       credentials: params.credentials,
     });
   } catch (error) {
@@ -73,7 +95,46 @@ export async function testAndSaveProviderConfig(
       credentials: params.credentials,
     }),
     keyFingerprints: fingerprintCredentials(params.providerId, params.credentials),
-    defaultModel: entry.default_model,
+    defaultModel: modelSelection.storedModel,
     defaultThinking: DEFAULT_AGENT_THINKING,
   });
+}
+
+export async function updateProviderConfigDefaultModel(
+  params: UpdateProviderConfigDefaultModelParams,
+): Promise<AgentProviderConfig> {
+  const entry = getAgentProviderEntry(params.providerId);
+  if (entry === undefined || entry.support_status !== 'supported') {
+    throw new UnsupportedAgentProviderError(params.providerId);
+  }
+  if (entry.default_model === null) throw new UnsupportedAgentProviderError(params.providerId);
+
+  const modelSelection = resolveDefaultModel(params.providerId, params.defaultModel);
+  const config = await updateAgentProviderDefaultModel({
+    workspaceId: params.workspaceId,
+    providerId: params.providerId,
+    defaultModel: modelSelection.storedModel,
+  });
+  if (!config) throw new AgentProviderConfigNotFoundError(params.workspaceId, params.providerId);
+  return config;
+}
+
+function resolveDefaultModel(
+  providerId: SupportedAgentProviderId,
+  requestedModel: string | null | undefined,
+): {probeModel: string; storedModel: string | null} {
+  const catalogEntry = buildAgentProviderCatalog().find((entry) => entry.id === providerId);
+  if (
+    catalogEntry === undefined ||
+    catalogEntry.support_status !== 'supported' ||
+    catalogEntry.default_model === null
+  ) {
+    throw new UnsupportedAgentProviderError(providerId);
+  }
+
+  const model = requestedModel ?? catalogEntry.default_model;
+  if (!catalogEntry.models.some((candidate) => candidate.id === model)) {
+    throw new InvalidAgentModelError(providerId, model);
+  }
+  return {probeModel: model, storedModel: requestedModel ?? null};
 }

--- a/libs/api/agent/src/core/provider-validation.test.ts
+++ b/libs/api/agent/src/core/provider-validation.test.ts
@@ -1,4 +1,4 @@
-import type {Context, ProviderStreamOptions} from '@earendil-works/pi-ai';
+import type {AssistantMessage, Context, ProviderStreamOptions} from '@earendil-works/pi-ai';
 import {InvalidAgentModelError} from './errors.js';
 import {probeProviderCredentials, sanitizeProviderError} from './provider-validation.js';
 
@@ -26,7 +26,7 @@ describe('probeProviderCredentials', () => {
         maxTokens: 32000,
       },
     ]);
-    piAi.complete.mockResolvedValue(undefined);
+    piAi.complete.mockResolvedValue(createAssistantMessage());
   });
 
   it('resolves the catalog model and sends the catalog secret field as apiKey', async () => {
@@ -65,6 +65,20 @@ describe('probeProviderCredentials', () => {
 
     await expect(probe).rejects.toThrow(InvalidAgentModelError);
     expect(piAi.complete).not.toHaveBeenCalled();
+  });
+
+  it('rejects provider error results from Pi complete', async () => {
+    piAi.complete.mockResolvedValue(
+      createAssistantMessage({stopReason: 'error', errorMessage: '401 Unauthorized'}),
+    );
+
+    const probe = probeProviderCredentials({
+      providerId: 'anthropic',
+      model: 'claude-opus-4-8',
+      credentials: {api_key: 'sk-ant-secret'},
+    });
+
+    await expect(probe).rejects.toThrow('401 Unauthorized');
   });
 
   it('passes Azure endpoint credentials as Pi Azure base URL options', async () => {
@@ -182,6 +196,27 @@ describe('probeProviderCredentials', () => {
     });
   });
 });
+
+function createAssistantMessage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    role: 'assistant',
+    content: [{type: 'text', text: 'OK'}],
+    api: 'anthropic-messages',
+    provider: 'anthropic',
+    model: 'claude-opus-4-8',
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0},
+    },
+    stopReason: 'stop',
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
 
 describe('sanitizeProviderError', () => {
   it('redacts literal and derived secret wire forms from provider messages', () => {

--- a/libs/api/agent/src/core/provider-validation.ts
+++ b/libs/api/agent/src/core/provider-validation.ts
@@ -1,4 +1,10 @@
-import {type Context, complete, getModels, type ProviderStreamOptions} from '@earendil-works/pi-ai';
+import {
+  type AssistantMessage,
+  type Context,
+  complete,
+  getModels,
+  type ProviderStreamOptions,
+} from '@earendil-works/pi-ai';
 import {getAgentProviderEntry, type SupportedAgentProviderId} from '@shipfox/api-agent-dto';
 import {redactSecrets, secretWireForms} from '@shipfox/redact';
 import {config} from '#config.js';
@@ -52,7 +58,8 @@ export async function probeProviderCredentials(
     ...(params.signal ? {signal: params.signal} : {}),
   };
 
-  await complete(model, context, options);
+  const result = await complete(model, context, options);
+  rejectProviderErrorResult(result);
 }
 
 export function sanitizeProviderError(error: unknown, secrets: string[]): string {
@@ -96,4 +103,9 @@ function credentialValue(
   const value = params.credentials[key];
   if (value === undefined) throw new InvalidCredentialFieldsError(params.providerId);
   return value;
+}
+
+function rejectProviderErrorResult(result: AssistantMessage): void {
+  if (result.stopReason !== 'error' && result.stopReason !== 'aborted') return;
+  throw new Error(result.errorMessage ?? 'Provider validation failed.');
 }

--- a/libs/api/agent/src/core/resolve-agent-config.test.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.test.ts
@@ -44,6 +44,7 @@ describe('resolveAgentConfig', () => {
   test('resolves model from explicit step, workspace, instance match, then catalog default', () => {
     const workspaceProviderConfigs = new Map([
       ['openai' as const, {defaultModel: 'gpt-5.5-pro', defaultThinking: 'medium' as const}],
+      ['anthropic' as const, {defaultModel: null, defaultThinking: 'low' as const}],
     ]);
 
     const explicit = resolveAgentConfig(
@@ -58,11 +59,13 @@ describe('resolveAgentConfig', () => {
         instanceDefaultProviderModel: 'claude-opus-4-8',
       },
     );
+    const workspaceLatest = resolveAgentConfig({provider: 'anthropic'}, {workspaceProviderConfigs});
     const catalog = resolveAgentConfig({provider: 'deepseek'});
 
     expect(explicit.model).toBe('gpt-5.5-pro');
     expect(workspace.model).toBe('gpt-5.5-pro');
     expect(instance.model).toBe('claude-opus-4-8');
+    expect(workspaceLatest.model).toBe('claude-opus-4-8');
     expect(catalog.model).toBe('deepseek-v4-pro');
   });
 
@@ -215,12 +218,32 @@ describe('createWorkspaceAgentDefaultsResolver', () => {
       thinking: 'medium',
     });
   });
+
+  test('uses catalog model when the workspace provider config keeps latest selected', async () => {
+    await upsertAgentProviderConfig(
+      createProviderConfigParams({
+        workspaceId,
+        providerId: 'openai',
+        defaultModel: null,
+        defaultThinking: 'medium',
+      }),
+    );
+
+    const resolver = await createWorkspaceAgentDefaultsResolver(workspaceId);
+    const resolved = resolver({provider: 'openai'});
+
+    expect(resolved).toEqual({
+      provider: 'openai',
+      model: 'gpt-5.5-pro',
+      thinking: 'medium',
+    });
+  });
 });
 
 function createProviderConfigParams(params: {
   workspaceId: string;
   providerId: SupportedAgentProviderId;
-  defaultModel: string;
+  defaultModel: string | null;
   defaultThinking: AgentThinking;
 }): UpsertAgentProviderConfigParams {
   return {

--- a/libs/api/agent/src/core/resolve-agent-config.ts
+++ b/libs/api/agent/src/core/resolve-agent-config.ts
@@ -34,7 +34,7 @@ export interface AgentConfigResolutionContext {
 }
 
 interface WorkspaceProviderDefaults {
-  readonly defaultModel: string;
+  readonly defaultModel: string | null;
   readonly defaultThinking: AgentThinking;
 }
 

--- a/libs/api/agent/src/db/agent-provider-configs.test.ts
+++ b/libs/api/agent/src/db/agent-provider-configs.test.ts
@@ -7,6 +7,7 @@ import {
   listAgentProviderConfigs,
   setDefaultAgentProvider,
   type UpsertAgentProviderConfigParams,
+  updateAgentProviderDefaultModel,
   upsertAgentProviderConfig,
 } from '#db/index.js';
 
@@ -77,6 +78,39 @@ describe('agent provider configs', () => {
     const configs = await listAgentProviderConfigs(workspaceId);
 
     expect(configs.map((config) => config.providerId)).toEqual(['anthropic', 'openai']);
+  });
+
+  it('updates only the provider default model', async () => {
+    const created = await upsertAgentProviderConfig(
+      createProviderConfigParams({
+        workspaceId,
+        providerId: 'anthropic',
+        defaultModel: 'claude-opus-4-8',
+      }),
+    );
+
+    const updated = await updateAgentProviderDefaultModel({
+      workspaceId,
+      providerId: 'anthropic',
+      defaultModel: 'claude-haiku-4-5',
+    });
+
+    expect(updated).toMatchObject({
+      encryptedCredentials: created.encryptedCredentials,
+      keyFingerprints: created.keyFingerprints,
+      defaultModel: 'claude-haiku-4-5',
+      defaultThinking: created.defaultThinking,
+    });
+  });
+
+  it('returns undefined when updating a missing provider default model', async () => {
+    const updated = await updateAgentProviderDefaultModel({
+      workspaceId,
+      providerId: 'anthropic',
+      defaultModel: null,
+    });
+
+    expect(updated).toBeUndefined();
   });
 
   it('hard-deletes a provider config', async () => {

--- a/libs/api/agent/src/db/agent-provider-configs.ts
+++ b/libs/api/agent/src/db/agent-provider-configs.ts
@@ -10,7 +10,7 @@ export interface UpsertAgentProviderConfigParams {
   providerId: SupportedAgentProviderId;
   encryptedCredentials: Record<string, string>;
   keyFingerprints: Record<string, string>;
-  defaultModel: string;
+  defaultModel: string | null;
   defaultThinking: AgentThinking;
 }
 
@@ -58,6 +58,27 @@ export async function getAgentProviderConfig(params: {
       ),
     )
     .limit(1);
+
+  const row = rows[0];
+  if (!row) return undefined;
+  return toAgentProviderConfig(row);
+}
+
+export async function updateAgentProviderDefaultModel(params: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  defaultModel: string | null;
+}): Promise<AgentProviderConfig | undefined> {
+  const rows = await db()
+    .update(agentProviderConfigs)
+    .set({defaultModel: params.defaultModel, updatedAt: sql`NOW()`})
+    .where(
+      and(
+        eq(agentProviderConfigs.workspaceId, params.workspaceId),
+        eq(agentProviderConfigs.providerId, params.providerId),
+      ),
+    )
+    .returning();
 
   const row = rows[0];
   if (!row) return undefined;

--- a/libs/api/agent/src/db/index.ts
+++ b/libs/api/agent/src/db/index.ts
@@ -10,6 +10,7 @@ export {
   deleteAgentProviderConfig,
   getAgentProviderConfig,
   listAgentProviderConfigs,
+  updateAgentProviderDefaultModel,
   upsertAgentProviderConfig,
 } from './agent-provider-configs.js';
 export {

--- a/libs/api/agent/src/db/schema/agent-provider-configs.ts
+++ b/libs/api/agent/src/db/schema/agent-provider-configs.ts
@@ -12,7 +12,7 @@ export const agentProviderConfigs = pgTable(
     providerId: text('provider_id').notNull(),
     encryptedCredentials: jsonb('encrypted_credentials').$type<Record<string, string>>().notNull(),
     keyFingerprints: jsonb('key_fingerprints').$type<Record<string, string>>().notNull(),
-    defaultModel: text('default_model').notNull(),
+    defaultModel: text('default_model'),
     defaultThinking: text('default_thinking').notNull(),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),

--- a/libs/api/agent/src/presentation/dto/agent-provider-config.ts
+++ b/libs/api/agent/src/presentation/dto/agent-provider-config.ts
@@ -4,6 +4,7 @@ import type {AgentProviderConfig} from '#core/index.js';
 export function toAgentProviderConfigDto(config: AgentProviderConfig): AgentProviderConfigDto {
   return {
     provider_id: config.providerId,
+    default_model: config.defaultModel,
     key_fingerprints: config.keyFingerprints,
     created_at: config.createdAt.toISOString(),
     updated_at: config.updatedAt.toISOString(),

--- a/libs/api/agent/src/presentation/routes/errors.ts
+++ b/libs/api/agent/src/presentation/routes/errors.ts
@@ -3,6 +3,7 @@ import {ClientError} from '@shipfox/node-fastify';
 import {
   AgentProviderConfigNotFoundError,
   AgentProviderValidationError,
+  InvalidAgentModelError,
   InvalidCredentialFieldsError,
   UnsupportedAgentProviderError,
 } from '#core/index.js';
@@ -24,6 +25,16 @@ export function translateAgentProviderRouteError(error: unknown): never {
       details: {
         provider_id: error.providerId,
         expected_keys: getAgentProviderCredentialKeys(error.providerId) ?? [],
+      },
+    });
+  }
+
+  if (error instanceof InvalidAgentModelError) {
+    throw new ClientError('Invalid agent model', 'invalid-agent-model', {
+      status: 422,
+      details: {
+        provider_id: error.providerId,
+        model: error.model,
       },
     });
   }

--- a/libs/api/agent/src/presentation/routes/index.ts
+++ b/libs/api/agent/src/presentation/routes/index.ts
@@ -4,6 +4,7 @@ import {deleteProviderConfigRoute} from './delete-provider-config.js';
 import {listProviderCatalogRoute} from './list-provider-catalog.js';
 import {listProviderConfigsRoute} from './list-provider-configs.js';
 import {setDefaultProviderRoute} from './set-default-provider.js';
+import {updateProviderDefaultModelRoute} from './update-provider-default-model.js';
 import {upsertProviderConfigRoute} from './upsert-provider-config.js';
 
 export const agentRoutes: RouteGroup[] = [
@@ -13,6 +14,7 @@ export const agentRoutes: RouteGroup[] = [
     routes: [
       listProviderConfigsRoute,
       upsertProviderConfigRoute,
+      updateProviderDefaultModelRoute,
       deleteProviderConfigRoute,
       setDefaultProviderRoute,
     ],

--- a/libs/api/agent/src/presentation/routes/provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/provider-config.test.ts
@@ -173,14 +173,68 @@ describe('agent provider config routes', () => {
 
       expect(res.statusCode).toBe(200);
       expect(res.json().provider_id).toBe('anthropic');
+      expect(res.json().default_model).toBeNull();
       expect(res.json().key_fingerprints).toEqual({api_key: 'sk-ant-s...abcd'});
       expect(res.body).not.toContain(secret);
       expect(res.body).not.toContain('encrypted_credentials');
       expect(replace.statusCode).toBe(200);
+      expect(replace.json().default_model).toBeNull();
       expect(replace.json().key_fingerprints).toEqual({api_key: 'sk-ant-r...wxyz'});
       const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
       expect(stored?.encryptedCredentials.api_key).not.toBeUndefined();
       expect(stored?.encryptedCredentials.api_key).not.toContain(secret);
+      expect(stored?.defaultModel).toBeNull();
+    });
+
+    it('saves an explicit default model for a provider config', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic`,
+        headers: {authorization: 'Bearer user'},
+        payload: {
+          default_model: 'claude-haiku-4-5',
+          credentials: {api_key: 'sk-ant-secret-abcd'},
+        },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().default_model).toBe('claude-haiku-4-5');
+      const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+      expect(stored?.defaultModel).toBe('claude-haiku-4-5');
+    });
+
+    it('preserves the existing default model when replacing credentials without default_model', async () => {
+      await seedProviderConfig({providerId: 'anthropic'});
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic`,
+        headers: {authorization: 'Bearer user'},
+        payload: {credentials: {api_key: 'sk-ant-rotated-wxyz'}},
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().default_model).toBe('claude-opus-4-8');
+      expect(res.json().key_fingerprints).toEqual({api_key: 'sk-ant-r...wxyz'});
+      const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+      expect(stored?.defaultModel).toBe('claude-opus-4-8');
+    });
+
+    it('stores Latest when replacing credentials with a null default_model', async () => {
+      await seedProviderConfig({providerId: 'anthropic'});
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic`,
+        headers: {authorization: 'Bearer user'},
+        payload: {default_model: null, credentials: {api_key: 'sk-ant-rotated-wxyz'}},
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().default_model).toBeNull();
+      expect(res.json().key_fingerprints).toEqual({api_key: 'sk-ant-r...wxyz'});
+      const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+      expect(stored?.defaultModel).toBeNull();
     });
 
     it('returns sanitized provider validation errors without leaking the submitted secret', async () => {
@@ -266,6 +320,69 @@ describe('agent provider config routes', () => {
       expect(res.statusCode).toBe(204);
       const settings = await getAgentWorkspaceSettings(workspaceId);
       expect(settings?.defaultProviderId).toBeNull();
+    });
+  });
+
+  describe('PUT /workspaces/:workspaceId/agent/providers/:providerId/default-model', () => {
+    it('updates the provider default model without changing credentials', async () => {
+      await seedProviderConfig({providerId: 'anthropic'});
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic/default-model`,
+        headers: {authorization: 'Bearer user'},
+        payload: {default_model: 'claude-haiku-4-5'},
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().default_model).toBe('claude-haiku-4-5');
+      expect(res.json().key_fingerprints).toEqual({api_key: 'sk-secre...abcd'});
+      const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+      expect(stored?.defaultModel).toBe('claude-haiku-4-5');
+      expect(stored?.encryptedCredentials).toEqual({api_key: 'encrypted-secret'});
+    });
+
+    it('stores Latest as a null provider default model', async () => {
+      await seedProviderConfig({providerId: 'anthropic'});
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic/default-model`,
+        headers: {authorization: 'Bearer user'},
+        payload: {default_model: null},
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().default_model).toBeNull();
+      const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+      expect(stored?.defaultModel).toBeNull();
+    });
+
+    it('returns 422 when updating a default model for a missing provider config', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic/default-model`,
+        headers: {authorization: 'Bearer user'},
+        payload: {default_model: null},
+      });
+
+      expect(res.statusCode).toBe(422);
+      expect(res.json().code).toBe('provider-not-configured');
+    });
+
+    it('returns 422 when the selected default model is unsupported', async () => {
+      await seedProviderConfig({providerId: 'anthropic'});
+
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic/default-model`,
+        headers: {authorization: 'Bearer user'},
+        payload: {default_model: 'missing-model'},
+      });
+
+      expect(res.statusCode).toBe(422);
+      expect(res.json().code).toBe('invalid-agent-model');
+      expect(res.json().details.model).toBe('missing-model');
     });
   });
 

--- a/libs/api/agent/src/presentation/routes/update-provider-default-model.ts
+++ b/libs/api/agent/src/presentation/routes/update-provider-default-model.ts
@@ -1,25 +1,25 @@
 import {
   agentProviderConfigDtoSchema,
   supportedAgentProviderIdSchema,
-  updateAgentProviderConfigBodySchema,
+  updateAgentProviderDefaultModelBodySchema,
 } from '@shipfox/api-agent-dto';
 import {requireMembership} from '@shipfox/api-workspaces';
 import {defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
-import {testAndSaveProviderConfig} from '#core/index.js';
+import {updateProviderConfigDefaultModel} from '#core/index.js';
 import {toAgentProviderConfigDto} from '#presentation/dto/index.js';
 import {translateAgentProviderRouteError} from './errors.js';
 
-export const upsertProviderConfigRoute = defineRoute({
+export const updateProviderDefaultModelRoute = defineRoute({
   method: 'PUT',
-  path: '/providers/:providerId',
-  description: 'Test and save an agent provider configuration for a workspace',
+  path: '/providers/:providerId/default-model',
+  description: 'Update the default model for an existing agent provider configuration',
   schema: {
     params: z.object({
       workspaceId: z.string().uuid(),
       providerId: supportedAgentProviderIdSchema,
     }),
-    body: updateAgentProviderConfigBodySchema,
+    body: updateAgentProviderDefaultModelBodySchema,
     response: {
       200: agentProviderConfigDtoSchema,
     },
@@ -29,11 +29,10 @@ export const upsertProviderConfigRoute = defineRoute({
     const {workspaceId, providerId} = request.params;
     await requireMembership({request, workspaceId});
 
-    const config = await testAndSaveProviderConfig({
+    const config = await updateProviderConfigDefaultModel({
       workspaceId,
       providerId,
-      ...('default_model' in request.body ? {defaultModel: request.body.default_model} : {}),
-      credentials: request.body.credentials,
+      defaultModel: request.body.default_model,
     });
 
     return toAgentProviderConfigDto(config);

--- a/libs/client/agent/package.json
+++ b/libs/client/agent/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@shipfox/client-workspace-settings",
+  "name": "@shipfox/client-agent",
   "license": "MIT",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "libs/client/workspace-settings"
+    "directory": "libs/client/agent"
   },
   "private": true,
   "type": "module",
@@ -37,13 +37,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/api-workspaces-dto": "workspace:*",
-    "@shipfox/client-agent": "workspace:*",
+    "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
-    "@shipfox/client-auth": "workspace:*",
-    "@shipfox/client-integrations": "workspace:*",
-    "@shipfox/client-runners": "workspace:*",
-    "@shipfox/client-triggers": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",
@@ -51,7 +46,6 @@
     "@tanstack/react-query": "^5.101.0"
   },
   "peerDependencies": {
-    "@tanstack/react-router": "^1.170.16",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -60,16 +54,13 @@
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
-    "@shipfox/vite": "workspace:*",
     "@shipfox/vitest": "workspace:*",
-    "@tanstack/react-router": "^1.170.16",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
     "jsdom": "^29.0.0",
-    "jotai": "^2.19.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -1,0 +1,564 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {ReactElement} from 'react';
+import {
+  AGENT_TEST_WORKSPACE_ID,
+  agentProviderCatalogResponse,
+  agentProviderConfig,
+  agentProviderConfigsResponse,
+  agentProviderEntry,
+  unsupportedAgentProviderEntry,
+} from '#test/fixtures/agent-providers.js';
+import {WorkspaceAgentProvidersSection} from './agent-providers-section.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function renderAgentProviders(element: ReactElement) {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {element}
+      <Toaster />
+    </QueryClientProvider>,
+  );
+}
+
+const ANTHROPIC_FINGERPRINT_RE = /sk-ant-s\.\.\.abcd/;
+const OPENAI_FINGERPRINT_RE = /sk-proj\.\.\.abcd/;
+function requestPath(input: RequestInfo | URL): string {
+  return new URL((input as Request).url).pathname;
+}
+
+async function openProviderActions(user: ReturnType<typeof userEvent.setup>, label: string) {
+  await user.click(screen.getByRole('button', {name: `Open ${label} provider actions`}));
+}
+
+describe('WorkspaceAgentProvidersSection', () => {
+  test('renders configured, available, and unsupported providers', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderCatalogResponse([
+              agentProviderEntry(),
+              agentProviderEntry({
+                id: 'openai',
+                label: 'OpenAI',
+                default_model: 'gpt-5.5-pro',
+                models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+              }),
+              unsupportedAgentProviderEntry(),
+            ]),
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse(agentProviderConfigsResponse()));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    expect(await screen.findByText('Configured providers')).toBeVisible();
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    expect(screen.getByText('Default provider')).toHaveClass('sr-only');
+    expect(screen.queryByText(ANTHROPIC_FINGERPRINT_RE)).not.toBeInTheDocument();
+    expect(screen.getByText('Available providers')).toBeVisible();
+    expect(screen.getByText('OpenAI')).toBeVisible();
+    expect(screen.getByText('Unsupported providers')).toBeVisible();
+    expect(screen.getByText('Amazon Bedrock')).toBeVisible();
+    expect(screen.getByText('AWS cloud credentials are not supported yet.')).toBeVisible();
+  });
+
+  test('waits for configured providers before rendering available provider cards', async () => {
+    let resolveConfigs!: (response: Response) => void;
+    const configsResponse = new Promise<Response>((resolve) => {
+      resolveConfigs = resolve;
+    });
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderCatalogResponse([
+              agentProviderEntry({
+                id: 'openai',
+                label: 'OpenAI',
+                default_model: 'gpt-5.5-pro',
+                models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+              }),
+            ]),
+          ),
+        );
+      }
+      return configsResponse;
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    expect(await screen.findByRole('status', {name: 'Loading available providers'})).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'Configure OpenAI'})).not.toBeInTheDocument();
+
+    resolveConfigs(
+      jsonResponse(agentProviderConfigsResponse({configs: [], default_provider_id: null})),
+    );
+
+    expect(await screen.findByRole('button', {name: 'Configure OpenAI'})).toBeVisible();
+  });
+
+  test('configures a provider and moves it to configured after save', async () => {
+    const user = userEvent.setup();
+    let isConfigured = false;
+    let requestBody: unknown;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderCatalogResponse([
+              agentProviderEntry({
+                id: 'openai',
+                label: 'OpenAI',
+                default_model: 'gpt-5.5-pro',
+                models: [
+                  {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'},
+                  {id: 'gpt-5-mini', label: 'GPT-5 Mini'},
+                ],
+              }),
+            ]),
+          ),
+        );
+      }
+      if (request.method === 'PUT') {
+        isConfigured = true;
+        void request
+          .clone()
+          .json()
+          .then((body) => {
+            requestBody = body;
+          });
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderConfig({
+              provider_id: 'openai',
+              default_model: 'gpt-5-mini',
+              key_fingerprints: {api_key: 'sk-proj...abcd'},
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(
+          agentProviderConfigsResponse({
+            configs: isConfigured
+              ? [
+                  agentProviderConfig({
+                    provider_id: 'openai',
+                    default_model: 'gpt-5-mini',
+                    key_fingerprints: {api_key: 'sk-proj...abcd'},
+                  }),
+                ]
+              : [],
+            default_provider_id: null,
+          }),
+        ),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('No providers configured')).toBeVisible();
+    await user.click(screen.getByRole('button', {name: 'Configure OpenAI'}));
+    expect(await screen.findByLabelText('Default model')).toHaveValue('__latest__');
+    expect(screen.getByRole('option', {name: 'Latest'})).toBeVisible();
+    expect(
+      screen.getByText(
+        'Latest follows the provider catalog default. Currently resolves to GPT-5.5 Pro.',
+      ),
+    ).toBeVisible();
+    await user.selectOptions(screen.getByLabelText('Default model'), 'gpt-5-mini');
+    expect(
+      screen.queryByText(
+        'Latest follows the provider catalog default. Currently resolves to GPT-5.5 Pro.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('gpt-5-mini')).toBeVisible();
+    await user.type(await screen.findByLabelText('API key'), 'sk-proj-secret');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(requestBody).toEqual({
+        default_model: 'gpt-5-mini',
+        credentials: {api_key: 'sk-proj-secret'},
+      }),
+    );
+    expect(await screen.findByText('OpenAI')).toBeVisible();
+    expect(screen.queryByText(OPENAI_FINGERPRINT_RE)).not.toBeInTheDocument();
+    expect(screen.queryByText('GPT-5 Mini')).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue('sk-proj-secret')).not.toBeInTheDocument();
+  });
+
+  test('submits null default model when configuring a provider with Latest selected', async () => {
+    const user = userEvent.setup();
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return jsonResponse(
+          agentProviderCatalogResponse([
+            agentProviderEntry({
+              id: 'openai',
+              label: 'OpenAI',
+              default_model: 'gpt-5.5-pro',
+              models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+            }),
+          ]),
+        );
+      }
+      if (request.method === 'PUT') {
+        requestBody = await request.clone().json();
+        return jsonResponse(
+          agentProviderConfig({
+            provider_id: 'openai',
+            default_model: null,
+            key_fingerprints: {api_key: 'sk-proj...abcd'},
+          }),
+        );
+      }
+      return jsonResponse(agentProviderConfigsResponse({configs: [], default_provider_id: null}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    await user.click(await screen.findByRole('button', {name: 'Configure OpenAI'}));
+    await user.type(await screen.findByLabelText('API key'), 'sk-proj-secret');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() =>
+      expect(requestBody).toEqual({
+        default_model: null,
+        credentials: {api_key: 'sk-proj-secret'},
+      }),
+    );
+  });
+
+  test('shows current fingerprints without echoing secret values while editing', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(jsonResponse(agentProviderCatalogResponse()));
+      }
+      return Promise.resolve(jsonResponse(agentProviderConfigsResponse()));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    expect(screen.queryByText(ANTHROPIC_FINGERPRINT_RE)).not.toBeInTheDocument();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'Edit credentials'}));
+
+    await waitFor(() =>
+      expect(screen.getAllByText('Edit credentials for Anthropic').length).toBeGreaterThan(0),
+    );
+    expect(await screen.findByText('Current:')).toBeVisible();
+    expect(screen.queryByLabelText('Default model')).not.toBeInTheDocument();
+    expect(screen.getAllByText(ANTHROPIC_FINGERPRINT_RE).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('API key')).toHaveValue('');
+    expect(screen.queryByDisplayValue('sk-ant-secret')).not.toBeInTheDocument();
+  });
+
+  test('edits credentials without submitting default model fields', async () => {
+    const user = userEvent.setup();
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return jsonResponse(
+          agentProviderCatalogResponse([
+            agentProviderEntry({
+              default_model: 'claude-opus-4-8',
+              models: [
+                {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+                {id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5'},
+              ],
+            }),
+          ]),
+        );
+      }
+      if (requestPath(input).endsWith('/agent/providers/anthropic') && request.method === 'PUT') {
+        requestBody = await request.clone().json();
+        return jsonResponse(agentProviderConfig({default_model: 'claude-haiku-4-5'}));
+      }
+      return jsonResponse(
+        agentProviderConfigsResponse({
+          configs: [agentProviderConfig({default_model: 'claude-haiku-4-5'})],
+          default_provider_id: 'anthropic',
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'Edit credentials'}));
+    await waitFor(() =>
+      expect(screen.getAllByText('Edit credentials for Anthropic').length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByLabelText('Default model')).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText('API key'), 'sk-ant-rotated');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await waitFor(() => expect(requestBody).toEqual({credentials: {api_key: 'sk-ant-rotated'}}));
+  });
+
+  test('surfaces provider validation errors without clearing the form', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(jsonResponse(agentProviderCatalogResponse()));
+      }
+      if (request.method === 'PUT') {
+        return Promise.resolve(
+          jsonResponse(
+            {
+              code: 'provider-validation-failed',
+              message: 'Provider validation failed',
+              details: {provider_id: 'anthropic', message: 'Provider rejected the key.'},
+            },
+            {status: 422},
+          ),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(agentProviderConfigsResponse({configs: [], default_provider_id: null})),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    await screen.findByText('No providers configured');
+    await user.click(screen.getByRole('button', {name: 'Configure Anthropic'}));
+    await user.type(await screen.findByLabelText('API key'), 'sk-ant-secret');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    expect(await screen.findByText('Could not save provider')).toBeVisible();
+    expect(screen.getByText('Provider rejected the key.')).toBeVisible();
+    expect(screen.getByLabelText('API key')).toHaveValue('sk-ant-secret');
+  });
+
+  test('sets a configured provider as the default', async () => {
+    const user = userEvent.setup();
+    let defaultProviderId: 'anthropic' | 'openai' = 'openai';
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return jsonResponse(
+          agentProviderCatalogResponse([
+            agentProviderEntry(),
+            agentProviderEntry({
+              id: 'openai',
+              label: 'OpenAI',
+              default_model: 'gpt-5.5-pro',
+              models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+            }),
+          ]),
+        );
+      }
+      if (requestPath(input).endsWith('/agent/default-provider')) {
+        requestBody = await request.clone().json();
+        defaultProviderId = 'anthropic';
+        return jsonResponse({default_provider_id: 'anthropic'});
+      }
+      return jsonResponse(
+        agentProviderConfigsResponse({
+          configs: [
+            agentProviderConfig(),
+            agentProviderConfig({
+              provider_id: 'openai',
+              key_fingerprints: {api_key: 'sk-proj...abcd'},
+            }),
+          ],
+          default_provider_id: defaultProviderId,
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'Set as default'}));
+
+    await waitFor(() => expect(requestBody).toEqual({provider_id: 'anthropic'}));
+  });
+
+  test('changes a configured provider default model without credentials', async () => {
+    const user = userEvent.setup();
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return jsonResponse(
+          agentProviderCatalogResponse([
+            agentProviderEntry({
+              default_model: 'claude-opus-4-8',
+              models: [
+                {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+                {id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5'},
+              ],
+            }),
+          ]),
+        );
+      }
+      if (requestPath(input).endsWith('/agent/providers/anthropic/default-model')) {
+        requestBody = await request.clone().json();
+        return jsonResponse(agentProviderConfig({default_model: null}));
+      }
+      return jsonResponse(
+        agentProviderConfigsResponse({
+          configs: [agentProviderConfig({default_model: 'claude-haiku-4-5'})],
+          default_provider_id: 'anthropic',
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'Change default model'}));
+    expect(await screen.findByLabelText('Default model')).toHaveValue('claude-haiku-4-5');
+    await user.selectOptions(screen.getByLabelText('Default model'), '__latest__');
+    expect(
+      screen.getByText(
+        'Latest follows the provider catalog default. Currently resolves to Claude Opus 4.8.',
+      ),
+    ).toBeVisible();
+    await user.click(screen.getByRole('button', {name: 'Save model'}));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await waitFor(() => expect(requestBody).toEqual({default_model: null}));
+  });
+
+  test('shows a recoverable set-default error', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderCatalogResponse([
+              agentProviderEntry(),
+              agentProviderEntry({
+                id: 'openai',
+                label: 'OpenAI',
+                default_model: 'gpt-5.5-pro',
+                models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+              }),
+            ]),
+          ),
+        );
+      }
+      if (requestPath(input).endsWith('/agent/default-provider')) {
+        return Promise.resolve(
+          jsonResponse(
+            {code: 'provider-not-configured', message: 'Provider is not configured'},
+            {status: 422},
+          ),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(
+          agentProviderConfigsResponse({
+            configs: [
+              agentProviderConfig(),
+              agentProviderConfig({
+                provider_id: 'openai',
+                key_fingerprints: {api_key: 'sk-proj...abcd'},
+              }),
+            ],
+            default_provider_id: 'openai',
+          }),
+        ),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'Set as default'}));
+
+    expect(
+      await screen.findByText('Configure this provider before setting it as the default.'),
+    ).toBeVisible();
+  });
+
+  test('deletes a configured provider after confirmation', async () => {
+    const user = userEvent.setup();
+    let isDeleted = false;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(jsonResponse(agentProviderCatalogResponse()));
+      }
+      if (request.method === 'DELETE') {
+        isDeleted = true;
+        return Promise.resolve(new Response(null, {status: 204}));
+      }
+      return Promise.resolve(
+        jsonResponse(
+          agentProviderConfigsResponse({
+            configs: isDeleted ? [] : [agentProviderConfig()],
+            default_provider_id: isDeleted ? null : 'anthropic',
+          }),
+        ),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'Delete'}));
+    await user.click(screen.getByRole('button', {name: 'Delete'}));
+
+    expect(await screen.findByText('No providers configured')).toBeVisible();
+  });
+
+  test('disables edit when a configured provider is missing from the catalog', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(jsonResponse(agentProviderCatalogResponse([])));
+      }
+      return Promise.resolve(jsonResponse(agentProviderConfigsResponse()));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    expect(await screen.findByText('anthropic')).toBeVisible();
+    await openProviderActions(user, 'anthropic');
+    expect(screen.getByRole('menuitem', {name: 'Change default model'})).toHaveAttribute(
+      'data-disabled',
+    );
+    expect(screen.getByRole('menuitem', {name: 'Edit credentials'})).toHaveAttribute(
+      'data-disabled',
+    );
+  });
+});

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -1,0 +1,519 @@
+import type {AgentProviderCatalogEntryDto, AgentProviderConfigDto} from '@shipfox/api-agent-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {
+  Alert,
+  Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyState,
+  Header,
+  Icon,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Skeleton,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  toast,
+} from '@shipfox/react-ui';
+import {useMemo, useState} from 'react';
+import {
+  useAgentProviderCatalogQuery,
+  useAgentProviderConfigsQuery,
+  useDeleteAgentProviderConfigMutation,
+  useSetDefaultAgentProviderMutation,
+} from '#hooks/api/agent-providers.js';
+import {ChangeDefaultModelForm} from './change-default-model-form.js';
+import {agentProviderConfigErrorToFormError} from './form-errors.js';
+import {AgentProviderTestAndSaveForm} from './test-and-save-form.js';
+
+const SURFACE_CLASS =
+  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
+
+type ProviderFormState =
+  | {mode: 'configure'; entry: AgentProviderCatalogEntryDto; config?: undefined}
+  | {mode: 'edit'; entry: AgentProviderCatalogEntryDto; config: AgentProviderConfigDto};
+type ModelFormState = {entry: AgentProviderCatalogEntryDto; config: AgentProviderConfigDto};
+
+export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: string}) {
+  const catalogQuery = useAgentProviderCatalogQuery();
+  const configsQuery = useAgentProviderConfigsQuery(workspaceId);
+  const [formState, setFormState] = useState<ProviderFormState | null>(null);
+  const [modelFormState, setModelFormState] = useState<ModelFormState | null>(null);
+
+  const providers = catalogQuery.data?.providers ?? [];
+  const configs = configsQuery.data?.configs ?? [];
+  const configsLoaded = configsQuery.data !== undefined;
+  const defaultProviderId = configsQuery.data?.default_provider_id ?? null;
+  const providerById = useMemo(
+    () => new Map(providers.map((provider) => [provider.id, provider])),
+    [providers],
+  );
+  const configuredIds = useMemo(
+    () => new Set<string>(configs.map((config) => config.provider_id)),
+    [configs],
+  );
+  const availableProviders = configsLoaded
+    ? providers.filter(
+        (provider) => provider.support_status === 'supported' && !configuredIds.has(provider.id),
+      )
+    : [];
+  const unsupportedProviders = providers.filter(
+    (provider) => provider.support_status === 'unsupported',
+  );
+
+  function closeForm() {
+    setFormState(null);
+  }
+
+  function closeModelForm() {
+    setModelFormState(null);
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-32">
+      <section className="flex flex-col gap-16" aria-label="Configured providers">
+        <div className="flex flex-col gap-4">
+          <Header variant="h3">Configured providers</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Workspace credentials available to agent jobs.
+          </Text>
+        </div>
+
+        {configsQuery.isPending ? (
+          <ProviderRowsSkeleton label="Loading configured providers" />
+        ) : null}
+
+        {configsQuery.isError && configsQuery.data === undefined ? (
+          <div className={cn(SURFACE_CLASS, 'px-16')}>
+            <QueryLoadError query={configsQuery} subject="agent provider configs" />
+          </div>
+        ) : null}
+
+        {configsQuery.data !== undefined && configs.length === 0 ? (
+          <div className={cn(SURFACE_CLASS, 'px-16')}>
+            <EmptyState
+              icon="key2Line"
+              title="No providers configured"
+              description="Configure a provider below to run agent jobs with workspace-managed credentials."
+            />
+          </div>
+        ) : null}
+
+        {configs.length > 0 ? (
+          <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
+            {configs.map((config) => {
+              const entry = providerById.get(config.provider_id);
+              return (
+                <ConfiguredProviderRow
+                  key={config.provider_id}
+                  workspaceId={workspaceId}
+                  config={config}
+                  entry={entry}
+                  isDefault={config.provider_id === defaultProviderId}
+                  onEdit={() => {
+                    if (entry) setFormState({mode: 'edit', entry, config});
+                  }}
+                  onChangeDefaultModel={() => {
+                    if (entry) setModelFormState({entry, config});
+                  }}
+                />
+              );
+            })}
+          </ul>
+        ) : null}
+      </section>
+
+      <section className="flex flex-col gap-16" aria-label="Available providers">
+        <div className="flex flex-col gap-4">
+          <Header variant="h3">Available providers</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Supported providers ready for workspace credentials.
+          </Text>
+        </div>
+
+        {catalogQuery.isPending || configsQuery.isPending ? <ProviderGridSkeleton /> : null}
+
+        {catalogQuery.isError && catalogQuery.data === undefined ? (
+          <div className={cn(SURFACE_CLASS, 'px-16')}>
+            <QueryLoadError query={catalogQuery} subject="agent provider catalog" />
+          </div>
+        ) : null}
+
+        {catalogQuery.data !== undefined && configsLoaded && availableProviders.length === 0 ? (
+          <div className={cn(SURFACE_CLASS, 'px-16')}>
+            <EmptyState
+              icon="componentLine"
+              title="No available providers"
+              description="All supported providers are already configured for this workspace."
+            />
+          </div>
+        ) : null}
+
+        {configsLoaded && availableProviders.length > 0 ? (
+          <ul className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1">
+            {availableProviders.map((entry) => (
+              <AvailableProviderCard
+                key={entry.id}
+                entry={entry}
+                onConfigure={() => setFormState({mode: 'configure', entry})}
+              />
+            ))}
+          </ul>
+        ) : null}
+      </section>
+
+      <section className="flex flex-col gap-16" aria-label="Unsupported providers">
+        <div className="flex flex-col gap-4">
+          <Header variant="h3">Unsupported providers</Header>
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Providers that cannot use workspace-managed API keys yet.
+          </Text>
+        </div>
+
+        {catalogQuery.isPending ? (
+          <ProviderRowsSkeleton label="Loading unsupported providers" />
+        ) : null}
+
+        {unsupportedProviders.length > 0 ? (
+          <ul className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}>
+            {unsupportedProviders.map((entry) => (
+              <li key={entry.id} className="flex items-start gap-12 px-16 py-12 opacity-70">
+                <Icon
+                  name="forbid2Line"
+                  className="mt-2 size-18 shrink-0 text-foreground-neutral-muted"
+                  aria-hidden
+                />
+                <div className="flex min-w-0 flex-1 flex-col gap-2">
+                  <Text size="md" bold className="truncate">
+                    {entry.label}
+                  </Text>
+                  <Text size="sm" className="text-foreground-neutral-muted">
+                    {entry.unsupported_reason}
+                  </Text>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </section>
+
+      <Modal open={formState !== null} onOpenChange={(open) => (open ? undefined : closeForm())}>
+        <ModalContent aria-describedby={undefined}>
+          <ModalTitle className="sr-only">{providerFormTitle(formState)}</ModalTitle>
+          <ModalHeader>
+            <Text
+              size="lg"
+              aria-hidden="true"
+              className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+            >
+              {providerFormTitle(formState)}
+            </Text>
+          </ModalHeader>
+          {formState ? (
+            <AgentProviderTestAndSaveForm
+              workspaceId={workspaceId}
+              entry={formState.entry}
+              existingConfig={formState.config}
+              onSaved={() => {
+                toast.success(`${formState.entry.label} saved`);
+                closeForm();
+              }}
+            />
+          ) : null}
+        </ModalContent>
+      </Modal>
+
+      <Modal
+        open={modelFormState !== null}
+        onOpenChange={(open) => (open ? undefined : closeModelForm())}
+      >
+        <ModalContent aria-describedby={undefined}>
+          <ModalTitle className="sr-only">Change default model</ModalTitle>
+          <ModalHeader>
+            <Text
+              size="lg"
+              aria-hidden="true"
+              className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+            >
+              Change default model for {modelFormState?.entry.label}
+            </Text>
+          </ModalHeader>
+          {modelFormState ? (
+            <ChangeDefaultModelForm
+              workspaceId={workspaceId}
+              entry={modelFormState.entry}
+              config={modelFormState.config}
+              onSaved={() => {
+                toast.success(`${modelFormState.entry.label} default model saved`);
+                closeModelForm();
+              }}
+            />
+          ) : null}
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}
+
+function providerFormTitle(formState: ProviderFormState | null): string {
+  if (formState === null) return '';
+  if (formState.mode === 'edit') return `Edit credentials for ${formState.entry.label}`;
+  return `Configure ${formState.entry.label}`;
+}
+
+function ConfiguredProviderRow({
+  workspaceId,
+  config,
+  entry,
+  isDefault,
+  onEdit,
+  onChangeDefaultModel,
+}: {
+  workspaceId: string;
+  config: AgentProviderConfigDto;
+  entry: AgentProviderCatalogEntryDto | undefined;
+  isDefault: boolean;
+  onEdit: () => void;
+  onChangeDefaultModel: () => void;
+}) {
+  const setDefault = useSetDefaultAgentProviderMutation();
+  const deleteConfig = useDeleteAgentProviderConfigMutation();
+  const [defaultError, setDefaultError] = useState<string | undefined>();
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
+  const label = entry?.label ?? config.provider_id;
+
+  async function handleSetDefault() {
+    setDefaultError(undefined);
+    try {
+      await setDefault.mutateAsync({
+        workspaceId,
+        body: {provider_id: config.provider_id},
+      });
+      toast.success(`${label} is now the default provider`);
+    } catch (error) {
+      const mapped = agentProviderConfigErrorToFormError(error);
+      setDefaultError(mapped.message);
+    }
+  }
+
+  async function handleDelete() {
+    setDeleteError(undefined);
+    try {
+      await deleteConfig.mutateAsync({workspaceId, providerId: config.provider_id});
+      toast.success(`${label} deleted`);
+      setDeleteOpen(false);
+    } catch (error) {
+      const mapped = agentProviderConfigErrorToFormError(error);
+      setDeleteError(mapped.message);
+    }
+  }
+
+  function handleDeleteOpenChange(nextOpen: boolean) {
+    setDeleteOpen(nextOpen);
+    if (nextOpen) {
+      setDeleteError(undefined);
+      deleteConfig.reset();
+    }
+  }
+
+  return (
+    <li className="flex flex-col gap-10 px-16 py-12 transition-colors hover:bg-background-components-hover">
+      <div className="flex items-center justify-between gap-12">
+        <div className="flex min-w-0 items-center gap-8">
+          {isDefault ? (
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex size-16 shrink-0 items-center justify-center">
+                    <Icon
+                      name="starLine"
+                      className="size-16 text-foreground-neutral-muted"
+                      aria-hidden
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Default provider</TooltipContent>
+              </Tooltip>
+              <span className="sr-only">Default provider</span>
+            </>
+          ) : null}
+          <Text size="md" bold className="truncate">
+            {label}
+          </Text>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Open ${label} provider actions`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {!isDefault ? (
+              <DropdownMenuItem
+                icon="starLine"
+                disabled={setDefault.isPending}
+                onSelect={() => {
+                  void handleSetDefault();
+                }}
+              >
+                Set as default
+              </DropdownMenuItem>
+            ) : null}
+            <DropdownMenuItem
+              icon="settings3Line"
+              disabled={!entry}
+              onSelect={onChangeDefaultModel}
+            >
+              Change default model
+            </DropdownMenuItem>
+            <DropdownMenuItem icon="editLine" disabled={!entry} onSelect={onEdit}>
+              Edit credentials
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              icon="deleteBinLine"
+              onSelect={() => {
+                setDeleteOpen(true);
+              }}
+            >
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {defaultError ? (
+        <Alert variant="error" animated={false}>
+          <Text size="sm">{defaultError}</Text>
+        </Alert>
+      ) : null}
+      <DeleteProviderDialog
+        open={deleteOpen}
+        onOpenChange={handleDeleteOpenChange}
+        label={label}
+        errorMessage={deleteError}
+        isLoading={deleteConfig.isPending}
+        onDelete={handleDelete}
+      />
+    </li>
+  );
+}
+
+function DeleteProviderDialog({
+  open,
+  onOpenChange,
+  label,
+  errorMessage,
+  isLoading,
+  onDelete,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  label: string;
+  errorMessage: string | undefined;
+  isLoading: boolean;
+  onDelete: () => void;
+}) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent aria-describedby={undefined} className="max-w-[420px]">
+        <ModalTitle className="sr-only">Delete agent provider</ModalTitle>
+        <ModalHeader title="Delete agent provider" />
+        <ModalBody className="gap-16">
+          <Text size="sm" className="text-foreground-neutral-muted">
+            Delete {label} credentials from this workspace? Agent jobs cannot use this provider
+            until it is configured again.
+          </Text>
+          {errorMessage ? (
+            <Alert variant="error" animated={false}>
+              <Text size="sm">{errorMessage}</Text>
+            </Alert>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button size="sm" variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button size="sm" variant="danger" isLoading={isLoading} onClick={onDelete}>
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function AvailableProviderCard({
+  entry,
+  onConfigure,
+}: {
+  entry: AgentProviderCatalogEntryDto;
+  onConfigure: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        className={cn(
+          'block w-full cursor-pointer px-14 py-10 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
+          SURFACE_CLASS,
+        )}
+        aria-label={`Configure ${entry.label}`}
+        onClick={onConfigure}
+      >
+        <div className="min-w-0 flex-1">
+          <Text size="md" bold className="truncate">
+            {entry.label}
+          </Text>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function ProviderRowsSkeleton({label}: {label: string}) {
+  return (
+    <ul
+      role="status"
+      aria-label={label}
+      className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}
+    >
+      {[0, 1, 2].map((row) => (
+        <li key={row} className="flex items-center gap-12 px-16 py-12">
+          <Skeleton className="size-32 shrink-0" />
+          <div className="flex min-w-0 flex-1 flex-col gap-6">
+            <Skeleton className="h-16 w-120" />
+            <Skeleton className="h-14 w-180" />
+          </div>
+          <Skeleton className="h-28 w-96 shrink-0" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ProviderGridSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading available providers"
+      className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1"
+    >
+      {[0, 1, 2, 3].map((card) => (
+        <Skeleton key={card} className="h-136 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/libs/client/agent/src/components/change-default-model-form.tsx
+++ b/libs/client/agent/src/components/change-default-model-form.tsx
@@ -1,0 +1,100 @@
+import type {AgentProviderCatalogEntryDto, AgentProviderConfigDto} from '@shipfox/api-agent-dto';
+import {Alert, Button, ModalBody, ModalFooter, Text} from '@shipfox/react-ui';
+import {useForm} from '@tanstack/react-form';
+import {useState} from 'react';
+import {useUpdateAgentProviderDefaultModelMutation} from '#hooks/api/agent-providers.js';
+import {
+  DefaultModelField,
+  defaultModelFormValue,
+  selectedModelForModelPayload,
+} from './default-model-field.js';
+import {fieldError} from './field-error.js';
+import {agentProviderConfigErrorToFormError} from './form-errors.js';
+
+const CHANGE_DEFAULT_MODEL_FORM_ID = 'agent-provider-change-default-model-form';
+
+export function ChangeDefaultModelForm({
+  workspaceId,
+  entry,
+  config,
+  onSaved,
+}: {
+  workspaceId: string;
+  entry: AgentProviderCatalogEntryDto;
+  config: AgentProviderConfigDto;
+  onSaved: () => void;
+}) {
+  const updateDefaultModel = useUpdateAgentProviderDefaultModelMutation();
+  const [formError, setFormError] = useState<string | undefined>();
+  const form = useForm({
+    defaultValues: {default_model: defaultModelFormValue(config.default_model)},
+    onSubmit: async ({value}) => {
+      setFormError(undefined);
+      try {
+        await updateDefaultModel.mutateAsync({
+          workspaceId,
+          providerId: config.provider_id,
+          body: {default_model: selectedModelForModelPayload(value.default_model)},
+        });
+        onSaved();
+      } catch (error) {
+        const mapped = agentProviderConfigErrorToFormError(error);
+        setFormError(mapped.message);
+      }
+    },
+  });
+
+  return (
+    <>
+      <ModalBody className="gap-16">
+        <form
+          id={CHANGE_DEFAULT_MODEL_FORM_ID}
+          className="flex w-full flex-col gap-14"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="default_model"
+            validators={{
+              onBlur: ({value}) => (value.trim() ? undefined : 'Default model is required.'),
+              onSubmit: ({value}) => (value.trim() ? undefined : 'Default model is required.'),
+            }}
+          >
+            {(field) => (
+              <DefaultModelField
+                entry={entry}
+                value={field.state.value}
+                error={fieldError(field)}
+                onChange={(event) => field.handleChange(event.target.value)}
+                onBlur={field.handleBlur}
+              />
+            )}
+          </form.Field>
+        </form>
+        {formError ? (
+          <Alert variant="error" animated={false}>
+            <div className="flex flex-col gap-8">
+              <Text size="sm" bold>
+                Could not save default model
+              </Text>
+              <Text size="sm">{formError}</Text>
+            </div>
+          </Alert>
+        ) : null}
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          type="submit"
+          form={CHANGE_DEFAULT_MODEL_FORM_ID}
+          isLoading={updateDefaultModel.isPending}
+        >
+          Save model
+        </Button>
+      </ModalFooter>
+    </>
+  );
+}

--- a/libs/client/agent/src/components/default-model-field.tsx
+++ b/libs/client/agent/src/components/default-model-field.tsx
@@ -1,0 +1,84 @@
+import type {AgentProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+import {cn, FormField, useFormField} from '@shipfox/react-ui';
+import type {ComponentProps, ReactNode} from 'react';
+
+export const LATEST_MODEL_VALUE = '__latest__';
+
+export function DefaultModelField({
+  entry,
+  value,
+  error,
+  children,
+  onChange,
+  onBlur,
+}: {
+  entry: AgentProviderCatalogEntryDto;
+  value: string;
+  error: string | undefined;
+  children?: ReactNode;
+  onChange: ComponentProps<'select'>['onChange'];
+  onBlur: ComponentProps<'select'>['onBlur'];
+}) {
+  return (
+    <FormField
+      label="Default model"
+      id={`agent-provider-${entry.id}-default-model`}
+      error={error}
+      description={defaultModelDescription(entry, value)}
+    >
+      <FormFieldSelect value={value} onChange={onChange} onBlur={onBlur}>
+        <option value={LATEST_MODEL_VALUE}>Latest</option>
+        {entry.models.map((model) => (
+          <option key={model.id} value={model.id}>
+            {model.label}
+          </option>
+        ))}
+      </FormFieldSelect>
+      {children}
+    </FormField>
+  );
+}
+
+export function defaultModelFormValue(defaultModel: string | null | undefined): string {
+  return defaultModel ?? LATEST_MODEL_VALUE;
+}
+
+export function selectedModelForCredentialsPayload(selectedModel: string): string | null {
+  return selectedModel === LATEST_MODEL_VALUE ? null : selectedModel.trim();
+}
+
+export function selectedModelForModelPayload(selectedModel: string): string | null {
+  return selectedModel === LATEST_MODEL_VALUE ? null : selectedModel.trim();
+}
+
+function defaultModelLabel(entry: AgentProviderCatalogEntryDto): string {
+  const defaultModel = entry.default_model ?? entry.models[0]?.id ?? '';
+  return entry.models.find((model) => model.id === defaultModel)?.label ?? defaultModel;
+}
+
+function defaultModelDescription(
+  entry: AgentProviderCatalogEntryDto,
+  selectedModel: string | undefined,
+): string | undefined {
+  if (selectedModel === LATEST_MODEL_VALUE) {
+    return `Latest follows the provider catalog default. Currently resolves to ${defaultModelLabel(entry)}.`;
+  }
+  if (!selectedModel) return undefined;
+  return selectedModel;
+}
+
+function FormFieldSelect({className, ...props}: ComponentProps<'select'>) {
+  const wiring = useFormField();
+  return (
+    <select
+      className={cn(
+        'w-full min-w-0 rounded-6 bg-background-field-base px-8 py-6 text-sm leading-20 text-foreground-neutral-base shadow-button-neutral outline-none transition-[color,box-shadow]',
+        'hover:bg-background-field-hover focus-visible:shadow-border-interactive-with-active disabled:cursor-not-allowed disabled:bg-background-neutral-disabled disabled:text-foreground-neutral-disabled',
+        'aria-invalid:shadow-border-error',
+        className,
+      )}
+      {...props}
+      {...wiring}
+    />
+  );
+}

--- a/libs/client/agent/src/components/field-error.ts
+++ b/libs/client/agent/src/components/field-error.ts
@@ -1,0 +1,14 @@
+interface FieldLike {
+  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
+}
+
+export function fieldError(field: FieldLike): string | undefined {
+  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
+  const first = field.state.meta.errors[0];
+  if (!first) return undefined;
+  if (typeof first === 'string') return first;
+  if (typeof first === 'object' && first !== null && 'message' in first) {
+    return String((first as {message: unknown}).message);
+  }
+  return undefined;
+}

--- a/libs/client/agent/src/components/form-errors.test.ts
+++ b/libs/client/agent/src/components/form-errors.test.ts
@@ -1,0 +1,102 @@
+import {ApiError} from '@shipfox/client-api';
+import {agentProviderConfigErrorToFormError} from './form-errors.js';
+
+describe('agentProviderConfigErrorToFormError', () => {
+  test.each([
+    [
+      new ApiError({
+        code: 'provider-validation-failed',
+        message: 'Validation failed',
+        status: 422,
+        details: {provider_id: 'anthropic', message: 'Provider rejected the key.'},
+      }),
+      'Provider rejected the key.',
+    ],
+    [
+      new ApiError({
+        code: 'provider-validation-failed',
+        message: 'Validation failed',
+        status: 422,
+        details: {
+          code: 'provider-validation-failed',
+          message: 'Validation failed',
+          details: {provider_id: 'anthropic', message: 'Provider rejected the key.'},
+        },
+      }),
+      'Provider rejected the key.',
+    ],
+    [
+      new ApiError({
+        code: 'provider-validation-failed',
+        message: 'Validation failed',
+        status: 422,
+      }),
+      'Validation failed',
+    ],
+    [
+      new ApiError({
+        code: 'invalid-credential-fields',
+        message: 'Invalid credentials',
+        status: 422,
+        details: {provider_id: 'azure-openai-responses', expected_keys: ['endpoint', 'api_key']},
+      }),
+      'Credentials must include exactly these fields: endpoint, api_key.',
+    ],
+    [
+      new ApiError({
+        code: 'invalid-credential-fields',
+        message: 'Invalid credentials',
+        status: 422,
+      }),
+      'Credentials do not match the fields required by this provider.',
+    ],
+    [
+      new ApiError({
+        code: 'provider-unsupported',
+        message: 'Unsupported',
+        status: 422,
+        details: {provider_id: 'amazon-bedrock'},
+      }),
+      'This provider is not supported for workspace-managed credentials.',
+    ],
+    [
+      new ApiError({
+        code: 'invalid-agent-model',
+        message: 'Invalid agent model',
+        status: 422,
+        details: {provider_id: 'anthropic', model: 'missing-model'},
+      }),
+      'Choose a model supported by this provider.',
+    ],
+    [
+      new ApiError({
+        code: 'provider-not-configured',
+        message: 'Not configured',
+        status: 422,
+        details: {provider_id: 'openai'},
+      }),
+      'Configure this provider before setting it as the default.',
+    ],
+    [
+      new ApiError({code: 'not-found', message: 'Provider config not found', status: 404}),
+      'Provider config not found',
+    ],
+    [new ApiError({code: 'unknown-code', message: 'Server copy', status: 422}), 'Server copy'],
+  ])('maps ApiError %s to a form-level alert', (error, expectedMessage) => {
+    const result = agentProviderConfigErrorToFormError(error);
+
+    expect(result).toEqual({kind: 'form', message: expectedMessage});
+  });
+
+  test('routes Error to a form-level alert with the error message', () => {
+    const result = agentProviderConfigErrorToFormError(new Error('boom'));
+
+    expect(result).toEqual({kind: 'form', message: 'boom'});
+  });
+
+  test('falls back to generic copy for non-Error throwables', () => {
+    const result = agentProviderConfigErrorToFormError('weird');
+
+    expect(result).toEqual({kind: 'form', message: 'Something went wrong. Try again.'});
+  });
+});

--- a/libs/client/agent/src/components/form-errors.ts
+++ b/libs/client/agent/src/components/form-errors.ts
@@ -1,0 +1,59 @@
+import {ApiError} from '@shipfox/client-api';
+
+export type AgentProviderConfigFormErrorMapping = {kind: 'form'; message: string};
+
+type ProviderErrorDetails = {
+  message?: unknown;
+  provider_id?: unknown;
+  expected_keys?: unknown;
+  details?: unknown;
+};
+
+export function agentProviderConfigErrorToFormError(
+  error: unknown,
+): AgentProviderConfigFormErrorMapping {
+  if (error instanceof ApiError) {
+    return {kind: 'form', message: apiErrorMessage(error)};
+  }
+  if (error instanceof Error) {
+    return {kind: 'form', message: error.message};
+  }
+  return {kind: 'form', message: 'Something went wrong. Try again.'};
+}
+
+function apiErrorMessage(error: ApiError): string {
+  const details = providerErrorDetails(error.details);
+
+  if (error.code === 'provider-validation-failed') {
+    return typeof details.message === 'string' ? details.message : error.message;
+  }
+  if (error.code === 'invalid-credential-fields') {
+    const expectedKeys = Array.isArray(details.expected_keys)
+      ? details.expected_keys.filter((key): key is string => typeof key === 'string')
+      : [];
+    if (expectedKeys.length > 0) {
+      return `Credentials must include exactly these fields: ${expectedKeys.join(', ')}.`;
+    }
+    return 'Credentials do not match the fields required by this provider.';
+  }
+  if (error.code === 'invalid-agent-model') {
+    return 'Choose a model supported by this provider.';
+  }
+  if (error.code === 'provider-unsupported') {
+    return 'This provider is not supported for workspace-managed credentials.';
+  }
+  if (error.code === 'provider-not-configured') {
+    return 'Configure this provider before setting it as the default.';
+  }
+  return error.message;
+}
+
+function providerErrorDetails(rawDetails: unknown): ProviderErrorDetails {
+  if (typeof rawDetails !== 'object' || rawDetails === null) return {};
+
+  const payload = rawDetails as ProviderErrorDetails;
+  if (typeof payload.details === 'object' && payload.details !== null) {
+    return payload.details as ProviderErrorDetails;
+  }
+  return payload;
+}

--- a/libs/client/agent/src/components/test-and-save-form.tsx
+++ b/libs/client/agent/src/components/test-and-save-form.tsx
@@ -1,0 +1,177 @@
+import type {
+  AgentProviderCatalogEntryDto,
+  AgentProviderConfigDto,
+  SupportedAgentProviderId,
+} from '@shipfox/api-agent-dto';
+import {
+  Alert,
+  Button,
+  Code,
+  FormField,
+  FormFieldInput,
+  ModalBody,
+  ModalFooter,
+  Text,
+} from '@shipfox/react-ui';
+import {useForm} from '@tanstack/react-form';
+import {useState} from 'react';
+import {useUpsertAgentProviderConfigMutation} from '#hooks/api/agent-providers.js';
+import {
+  DefaultModelField,
+  defaultModelFormValue,
+  LATEST_MODEL_VALUE,
+  selectedModelForCredentialsPayload,
+} from './default-model-field.js';
+import {fieldError} from './field-error.js';
+import {agentProviderConfigErrorToFormError} from './form-errors.js';
+
+export const AGENT_PROVIDER_TEST_AND_SAVE_FORM_ID = 'agent-provider-test-and-save-form';
+
+export function AgentProviderTestAndSaveForm({
+  workspaceId,
+  entry,
+  existingConfig,
+  onSaved,
+}: {
+  workspaceId: string;
+  entry: AgentProviderCatalogEntryDto;
+  existingConfig?: AgentProviderConfigDto | undefined;
+  onSaved: () => void;
+}) {
+  const upsertConfig = useUpsertAgentProviderConfigMutation();
+  const [formError, setFormError] = useState<string | undefined>();
+  const form = useForm({
+    defaultValues: defaultFormValues(entry, existingConfig),
+    onSubmit: async ({value}) => {
+      setFormError(undefined);
+      const credentials = Object.fromEntries(
+        entry.credential_fields.map((credentialField) => [
+          credentialField.key,
+          value[credentialField.key]?.trim() ?? '',
+        ]),
+      );
+      const selectedModel = value.default_model ?? LATEST_MODEL_VALUE;
+      const defaultModel =
+        existingConfig === undefined
+          ? selectedModelForCredentialsPayload(selectedModel)
+          : undefined;
+
+      try {
+        await upsertConfig.mutateAsync({
+          workspaceId,
+          providerId: entry.id as SupportedAgentProviderId,
+          body: {
+            ...(defaultModel !== undefined ? {default_model: defaultModel} : {}),
+            credentials,
+          },
+        });
+        onSaved();
+      } catch (error) {
+        const mapped = agentProviderConfigErrorToFormError(error);
+        setFormError(mapped.message);
+      }
+    },
+  });
+
+  return (
+    <>
+      <ModalBody className="gap-16">
+        <form
+          id={AGENT_PROVIDER_TEST_AND_SAVE_FORM_ID}
+          className="flex w-full flex-col gap-14"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          {existingConfig === undefined ? (
+            <form.Field
+              name="default_model"
+              validators={{
+                onBlur: ({value}) => (value.trim() ? undefined : 'Default model is required.'),
+                onSubmit: ({value}) => (value.trim() ? undefined : 'Default model is required.'),
+              }}
+            >
+              {(field) => (
+                <DefaultModelField
+                  entry={entry}
+                  value={field.state.value}
+                  error={fieldError(field)}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                  onBlur={field.handleBlur}
+                />
+              )}
+            </form.Field>
+          ) : null}
+          {entry.credential_fields.map((credentialField) => (
+            <form.Field
+              key={credentialField.key}
+              name={credentialField.key}
+              validators={{
+                onBlur: ({value}) =>
+                  value.trim() ? undefined : `${credentialField.label} is required.`,
+                onSubmit: ({value}) =>
+                  value.trim() ? undefined : `${credentialField.label} is required.`,
+              }}
+            >
+              {(field) => (
+                <FormField
+                  label={credentialField.label}
+                  id={`agent-provider-${entry.id}-${credentialField.key}`}
+                  error={fieldError(field)}
+                >
+                  <FormFieldInput
+                    type={credentialField.secret ? 'password' : 'text'}
+                    autoComplete="off"
+                    value={field.state.value}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    onBlur={field.handleBlur}
+                  />
+                  {existingConfig?.key_fingerprints[credentialField.key] ? (
+                    <Text size="sm" className="mt-4 text-foreground-neutral-muted">
+                      Current:{' '}
+                      <Code as="span" variant="label">
+                        {existingConfig.key_fingerprints[credentialField.key]}
+                      </Code>
+                    </Text>
+                  ) : null}
+                </FormField>
+              )}
+            </form.Field>
+          ))}
+        </form>
+        {formError ? (
+          <Alert variant="error" animated={false}>
+            <div className="flex flex-col gap-8">
+              <Text size="sm" bold>
+                Could not save provider
+              </Text>
+              <Text size="sm">{formError}</Text>
+            </div>
+          </Alert>
+        ) : null}
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          type="submit"
+          form={AGENT_PROVIDER_TEST_AND_SAVE_FORM_ID}
+          isLoading={upsertConfig.isPending}
+        >
+          Test & save
+        </Button>
+      </ModalFooter>
+    </>
+  );
+}
+
+function defaultFormValues(
+  entry: AgentProviderCatalogEntryDto,
+  existingConfig: AgentProviderConfigDto | undefined,
+): Record<string, string> {
+  return {
+    default_model: defaultModelFormValue(existingConfig?.default_model),
+    ...Object.fromEntries(entry.credential_fields.map((field) => [field.key, ''])),
+  };
+}

--- a/libs/client/agent/src/hooks/api/agent-providers.test.ts
+++ b/libs/client/agent/src/hooks/api/agent-providers.test.ts
@@ -1,0 +1,143 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {
+  AGENT_TEST_WORKSPACE_ID,
+  agentProviderCatalogResponse,
+  agentProviderConfig,
+  agentProviderConfigsResponse,
+} from '#test/fixtures/agent-providers.js';
+import {
+  deleteAgentProviderConfig,
+  getAgentProviderCatalog,
+  listAgentProviderConfigs,
+  setDefaultAgentProvider,
+  updateAgentProviderDefaultModel,
+  upsertAgentProviderConfig,
+} from './agent-providers.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('agent provider transport', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('fetches the provider catalog', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(agentProviderCatalogResponse()));
+    configureApiClient({fetchImpl});
+
+    const result = await getAgentProviderCatalog();
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.providers[0]?.label).toBe('Anthropic');
+    expect(request.url).toBe('https://api.example.test/agent/provider-catalog');
+    expect(request.method).toBe('GET');
+  });
+
+  test('fetches workspace provider configs', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(agentProviderConfigsResponse()));
+    configureApiClient({fetchImpl});
+
+    const result = await listAgentProviderConfigs({workspaceId: AGENT_TEST_WORKSPACE_ID});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.default_provider_id).toBe('anthropic');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/providers`,
+    );
+    expect(request.method).toBe('GET');
+  });
+
+  test('puts provider credentials', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse(agentProviderConfig(), {status: 201});
+    });
+    configureApiClient({fetchImpl});
+    const body = {default_model: 'claude-haiku-4-5', credentials: {api_key: 'sk-ant-secret'}};
+
+    const result = await upsertAgentProviderConfig({
+      workspaceId: AGENT_TEST_WORKSPACE_ID,
+      providerId: 'anthropic',
+      body,
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.key_fingerprints.api_key).toBe('sk-ant-s...abcd');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/providers/anthropic`,
+    );
+    expect(request.method).toBe('PUT');
+    expect(requestBody).toEqual(body);
+  });
+
+  test('deletes provider credentials', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, {status: 204}));
+    configureApiClient({fetchImpl});
+
+    const result = await deleteAgentProviderConfig({
+      workspaceId: AGENT_TEST_WORKSPACE_ID,
+      providerId: 'anthropic',
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result).toBeUndefined();
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/providers/anthropic`,
+    );
+    expect(request.method).toBe('DELETE');
+  });
+
+  test('puts a provider default model without credentials', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse(agentProviderConfig({default_model: null}));
+    });
+    configureApiClient({fetchImpl});
+    const body = {default_model: null};
+
+    const result = await updateAgentProviderDefaultModel({
+      workspaceId: AGENT_TEST_WORKSPACE_ID,
+      providerId: 'anthropic',
+      body,
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.default_model).toBeNull();
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/providers/anthropic/default-model`,
+    );
+    expect(request.method).toBe('PUT');
+    expect(requestBody).toEqual(body);
+  });
+
+  test('sets the default provider', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({default_provider_id: 'anthropic'});
+    });
+    configureApiClient({fetchImpl});
+    const body = {provider_id: 'anthropic'} as const;
+
+    const result = await setDefaultAgentProvider({
+      workspaceId: AGENT_TEST_WORKSPACE_ID,
+      body,
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.default_provider_id).toBe('anthropic');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${AGENT_TEST_WORKSPACE_ID}/agent/default-provider`,
+    );
+    expect(request.method).toBe('PUT');
+    expect(requestBody).toEqual(body);
+  });
+});

--- a/libs/client/agent/src/hooks/api/agent-providers.ts
+++ b/libs/client/agent/src/hooks/api/agent-providers.ts
@@ -1,0 +1,157 @@
+import type {
+  AgentProviderCatalogResponseDto,
+  AgentProviderConfigDto,
+  ListAgentProviderConfigsResponseDto,
+  SetDefaultAgentProviderBodyDto,
+  SetDefaultAgentProviderResponseDto,
+  SupportedAgentProviderId,
+  UpdateAgentProviderConfigBodyDto,
+  UpdateAgentProviderDefaultModelBodyDto,
+} from '@shipfox/api-agent-dto';
+import {apiRequest} from '@shipfox/client-api';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+export const agentProviderQueryKeys = {
+  all: ['agent-providers'] as const,
+  catalog: () => [...agentProviderQueryKeys.all, 'catalog'] as const,
+  configs: (workspaceId: string) =>
+    [...agentProviderQueryKeys.all, 'configs', workspaceId] as const,
+};
+
+export async function getAgentProviderCatalog({signal}: {signal?: AbortSignal} = {}) {
+  return await apiRequest<AgentProviderCatalogResponseDto>('/agent/provider-catalog', {signal});
+}
+
+export async function listAgentProviderConfigs({
+  workspaceId,
+  signal,
+}: {
+  workspaceId: string;
+  signal?: AbortSignal;
+}) {
+  return await apiRequest<ListAgentProviderConfigsResponseDto>(
+    `/workspaces/${workspaceId}/agent/providers`,
+    {signal},
+  );
+}
+
+export async function upsertAgentProviderConfig({
+  workspaceId,
+  providerId,
+  body,
+}: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  body: UpdateAgentProviderConfigBodyDto;
+}) {
+  return await apiRequest<AgentProviderConfigDto>(
+    `/workspaces/${workspaceId}/agent/providers/${providerId}`,
+    {method: 'PUT', body},
+  );
+}
+
+export async function deleteAgentProviderConfig({
+  workspaceId,
+  providerId,
+}: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+}) {
+  return await apiRequest<void>(`/workspaces/${workspaceId}/agent/providers/${providerId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function updateAgentProviderDefaultModel({
+  workspaceId,
+  providerId,
+  body,
+}: {
+  workspaceId: string;
+  providerId: SupportedAgentProviderId;
+  body: UpdateAgentProviderDefaultModelBodyDto;
+}) {
+  return await apiRequest<AgentProviderConfigDto>(
+    `/workspaces/${workspaceId}/agent/providers/${providerId}/default-model`,
+    {method: 'PUT', body},
+  );
+}
+
+export async function setDefaultAgentProvider({
+  workspaceId,
+  body,
+}: {
+  workspaceId: string;
+  body: SetDefaultAgentProviderBodyDto;
+}) {
+  return await apiRequest<SetDefaultAgentProviderResponseDto>(
+    `/workspaces/${workspaceId}/agent/default-provider`,
+    {method: 'PUT', body},
+  );
+}
+
+export function useAgentProviderCatalogQuery() {
+  return useQuery({
+    queryKey: agentProviderQueryKeys.catalog(),
+    queryFn: ({signal}) => getAgentProviderCatalog({signal}),
+    staleTime: 1000 * 60 * 60,
+  });
+}
+
+export function useAgentProviderConfigsQuery(workspaceId: string | undefined) {
+  return useQuery({
+    queryKey: workspaceId
+      ? agentProviderQueryKeys.configs(workspaceId)
+      : [...agentProviderQueryKeys.all, 'configs'],
+    enabled: Boolean(workspaceId),
+    queryFn: ({signal}) => listAgentProviderConfigs({workspaceId: workspaceId ?? '', signal}),
+  });
+}
+
+export function useUpsertAgentProviderConfigMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: upsertAgentProviderConfig,
+    onSuccess: async (_config, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: agentProviderQueryKeys.configs(variables.workspaceId),
+      });
+    },
+  });
+}
+
+export function useDeleteAgentProviderConfigMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteAgentProviderConfig,
+    onSuccess: async (_config, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: agentProviderQueryKeys.configs(variables.workspaceId),
+      });
+    },
+  });
+}
+
+export function useUpdateAgentProviderDefaultModelMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateAgentProviderDefaultModel,
+    onSuccess: async (_config, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: agentProviderQueryKeys.configs(variables.workspaceId),
+      });
+    },
+  });
+}
+
+export function useSetDefaultAgentProviderMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: setDefaultAgentProvider,
+    onSuccess: async (_config, variables) => {
+      await queryClient.invalidateQueries({
+        queryKey: agentProviderQueryKeys.configs(variables.workspaceId),
+      });
+    },
+  });
+}

--- a/libs/client/agent/src/index.ts
+++ b/libs/client/agent/src/index.ts
@@ -1,0 +1,4 @@
+export * from './components/agent-providers-section.js';
+export * from './components/form-errors.js';
+export * from './components/test-and-save-form.js';
+export * from './hooks/api/agent-providers.js';

--- a/libs/client/agent/test/fixtures/agent-providers.ts
+++ b/libs/client/agent/test/fixtures/agent-providers.ts
@@ -1,0 +1,67 @@
+import type {
+  AgentProviderCatalogEntryDto,
+  AgentProviderCatalogResponseDto,
+  AgentProviderConfigDto,
+  ListAgentProviderConfigsResponseDto,
+} from '@shipfox/api-agent-dto';
+
+export const AGENT_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+export function agentProviderEntry(
+  overrides: Partial<AgentProviderCatalogEntryDto> = {},
+): AgentProviderCatalogEntryDto {
+  return {
+    id: 'anthropic',
+    label: 'Anthropic',
+    support_status: 'supported',
+    default_model: null,
+    credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
+    unsupported_reason: null,
+    models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
+    ...overrides,
+  };
+}
+
+export function unsupportedAgentProviderEntry(
+  overrides: Partial<AgentProviderCatalogEntryDto> = {},
+): AgentProviderCatalogEntryDto {
+  return {
+    id: 'amazon-bedrock',
+    label: 'Amazon Bedrock',
+    support_status: 'unsupported',
+    default_model: null,
+    credential_fields: [],
+    unsupported_reason: 'AWS cloud credentials are not supported yet.',
+    models: [],
+    ...overrides,
+  };
+}
+
+export function agentProviderConfig(
+  overrides: Partial<AgentProviderConfigDto> = {},
+): AgentProviderConfigDto {
+  return {
+    provider_id: 'anthropic',
+    default_model: null,
+    key_fingerprints: {api_key: 'sk-ant-s...abcd'},
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function agentProviderCatalogResponse(
+  providers: AgentProviderCatalogEntryDto[] = [agentProviderEntry()],
+): AgentProviderCatalogResponseDto {
+  return {providers};
+}
+
+export function agentProviderConfigsResponse(
+  overrides: Partial<ListAgentProviderConfigsResponseDto> = {},
+): ListAgentProviderConfigsResponseDto {
+  return {
+    configs: [agentProviderConfig()],
+    default_provider_id: 'anthropic',
+    ...overrides,
+  };
+}

--- a/libs/client/agent/test/setup.ts
+++ b/libs/client/agent/test/setup.ts
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom/vitest';
+
+class ResizeObserverStub {
+  observe(): void {
+    /* no-op */
+  }
+  unobserve(): void {
+    /* no-op */
+  }
+  disconnect(): void {
+    /* no-op */
+  }
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  configurable: true,
+  value: ResizeObserverStub,
+});
+
+Object.defineProperty(window, 'scrollTo', {
+  configurable: true,
+  value: () => undefined,
+});
+
+Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+  configurable: true,
+  value: () => undefined,
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  configurable: true,
+  value: (query: string) => ({
+    addEventListener: () => undefined,
+    addListener: () => undefined,
+    dispatchEvent: () => false,
+    matches: query.includes('min-width'),
+    media: query,
+    onchange: null,
+    removeEventListener: () => undefined,
+    removeListener: () => undefined,
+  }),
+});

--- a/libs/client/agent/tsconfig.build.json
+++ b/libs/client/agent/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/react",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/client/agent/tsconfig.json
+++ b/libs/client/agent/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/client/agent/tsconfig.test.json
+++ b/libs/client/agent/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/client/agent/vitest.config.ts
+++ b/libs/client/agent/vitest.config.ts
@@ -1,0 +1,28 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+      ],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as WorkspacesWidLayoutSettingsRunnersRouteImport } from './routes
 import { Route as WorkspacesWidLayoutSettingsMembersRouteImport } from './routes/workspaces/$wid/_layout/settings/members'
 import { Route as WorkspacesWidLayoutSettingsIntegrationsRouteImport } from './routes/workspaces/$wid/_layout/settings/integrations'
 import { Route as WorkspacesWidLayoutSettingsEventsRouteImport } from './routes/workspaces/$wid/_layout/settings/events'
+import { Route as WorkspacesWidLayoutSettingsAgentProvidersRouteImport } from './routes/workspaces/$wid/_layout/settings/agent-providers'
 import { Route as WorkspacesWidLayoutProjectsNewRouteImport } from './routes/workspaces/$wid/_layout/projects/new'
 import { Route as WorkspacesWidLayoutIntegrationsSentryRouteImport } from './routes/workspaces/$wid/_layout/integrations/sentry'
 import { Route as WorkspacesWidLayoutIntegrationsGithubRouteImport } from './routes/workspaces/$wid/_layout/integrations/github'
@@ -144,6 +145,12 @@ const WorkspacesWidLayoutSettingsEventsRoute =
     path: '/settings/events',
     getParentRoute: () => WorkspacesWidLayoutRoute,
   } as any)
+const WorkspacesWidLayoutSettingsAgentProvidersRoute =
+  WorkspacesWidLayoutSettingsAgentProvidersRouteImport.update({
+    id: '/settings/agent-providers',
+    path: '/settings/agent-providers',
+    getParentRoute: () => WorkspacesWidLayoutRoute,
+  } as any)
 const WorkspacesWidLayoutProjectsNewRoute =
   WorkspacesWidLayoutProjectsNewRouteImport.update({
     id: '/projects/new',
@@ -224,6 +231,7 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/integrations/github': typeof WorkspacesWidLayoutIntegrationsGithubRoute
   '/workspaces/$wid/integrations/sentry': typeof WorkspacesWidLayoutIntegrationsSentryRoute
   '/workspaces/$wid/projects/new': typeof WorkspacesWidLayoutProjectsNewRoute
+  '/workspaces/$wid/settings/agent-providers': typeof WorkspacesWidLayoutSettingsAgentProvidersRoute
   '/workspaces/$wid/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
@@ -254,6 +262,7 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/integrations/github': typeof WorkspacesWidLayoutIntegrationsGithubRoute
   '/workspaces/$wid/integrations/sentry': typeof WorkspacesWidLayoutIntegrationsSentryRoute
   '/workspaces/$wid/projects/new': typeof WorkspacesWidLayoutProjectsNewRoute
+  '/workspaces/$wid/settings/agent-providers': typeof WorkspacesWidLayoutSettingsAgentProvidersRoute
   '/workspaces/$wid/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
@@ -285,6 +294,7 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/integrations/github': typeof WorkspacesWidLayoutIntegrationsGithubRoute
   '/workspaces/$wid/_layout/integrations/sentry': typeof WorkspacesWidLayoutIntegrationsSentryRoute
   '/workspaces/$wid/_layout/projects/new': typeof WorkspacesWidLayoutProjectsNewRoute
+  '/workspaces/$wid/_layout/settings/agent-providers': typeof WorkspacesWidLayoutSettingsAgentProvidersRoute
   '/workspaces/$wid/_layout/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/_layout/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/_layout/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
@@ -318,6 +328,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/integrations/github'
     | '/workspaces/$wid/integrations/sentry'
     | '/workspaces/$wid/projects/new'
+    | '/workspaces/$wid/settings/agent-providers'
     | '/workspaces/$wid/settings/events'
     | '/workspaces/$wid/settings/integrations'
     | '/workspaces/$wid/settings/members'
@@ -348,6 +359,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/integrations/github'
     | '/workspaces/$wid/integrations/sentry'
     | '/workspaces/$wid/projects/new'
+    | '/workspaces/$wid/settings/agent-providers'
     | '/workspaces/$wid/settings/events'
     | '/workspaces/$wid/settings/integrations'
     | '/workspaces/$wid/settings/members'
@@ -378,6 +390,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/integrations/github'
     | '/workspaces/$wid/_layout/integrations/sentry'
     | '/workspaces/$wid/_layout/projects/new'
+    | '/workspaces/$wid/_layout/settings/agent-providers'
     | '/workspaces/$wid/_layout/settings/events'
     | '/workspaces/$wid/_layout/settings/integrations'
     | '/workspaces/$wid/_layout/settings/members'
@@ -540,6 +553,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspacesWidLayoutSettingsEventsRouteImport
       parentRoute: typeof WorkspacesWidLayoutRoute
     }
+    '/workspaces/$wid/_layout/settings/agent-providers': {
+      id: '/workspaces/$wid/_layout/settings/agent-providers'
+      path: '/settings/agent-providers'
+      fullPath: '/workspaces/$wid/settings/agent-providers'
+      preLoaderRoute: typeof WorkspacesWidLayoutSettingsAgentProvidersRouteImport
+      parentRoute: typeof WorkspacesWidLayoutRoute
+    }
     '/workspaces/$wid/_layout/projects/new': {
       id: '/workspaces/$wid/_layout/projects/new'
       path: '/projects/new'
@@ -656,6 +676,7 @@ interface WorkspacesWidLayoutRouteChildren {
   WorkspacesWidLayoutIntegrationsGithubRoute: typeof WorkspacesWidLayoutIntegrationsGithubRoute
   WorkspacesWidLayoutIntegrationsSentryRoute: typeof WorkspacesWidLayoutIntegrationsSentryRoute
   WorkspacesWidLayoutProjectsNewRoute: typeof WorkspacesWidLayoutProjectsNewRoute
+  WorkspacesWidLayoutSettingsAgentProvidersRoute: typeof WorkspacesWidLayoutSettingsAgentProvidersRoute
   WorkspacesWidLayoutSettingsEventsRoute: typeof WorkspacesWidLayoutSettingsEventsRoute
   WorkspacesWidLayoutSettingsIntegrationsRoute: typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   WorkspacesWidLayoutSettingsMembersRoute: typeof WorkspacesWidLayoutSettingsMembersRoute
@@ -676,6 +697,8 @@ const WorkspacesWidLayoutRouteChildren: WorkspacesWidLayoutRouteChildren = {
   WorkspacesWidLayoutIntegrationsSentryRoute:
     WorkspacesWidLayoutIntegrationsSentryRoute,
   WorkspacesWidLayoutProjectsNewRoute: WorkspacesWidLayoutProjectsNewRoute,
+  WorkspacesWidLayoutSettingsAgentProvidersRoute:
+    WorkspacesWidLayoutSettingsAgentProvidersRoute,
   WorkspacesWidLayoutSettingsEventsRoute:
     WorkspacesWidLayoutSettingsEventsRoute,
   WorkspacesWidLayoutSettingsIntegrationsRoute:

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/settings/agent-providers.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/settings/agent-providers.tsx
@@ -1,0 +1,6 @@
+import {AgentProvidersSettingsPage} from '@shipfox/client-workspace-settings';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/settings/agent-providers')({
+  component: AgentProvidersSettingsPage,
+});

--- a/libs/client/workspace-settings/src/components/settings-nav.tsx
+++ b/libs/client/workspace-settings/src/components/settings-nav.tsx
@@ -9,6 +9,9 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
   const isRunnersActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/runners', params: {wid: workspaceId}}),
   );
+  const isAgentProvidersActive = Boolean(
+    matchRoute({to: '/workspaces/$wid/settings/agent-providers', params: {wid: workspaceId}}),
+  );
   const isIntegrationsActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/integrations', params: {wid: workspaceId}}),
   );
@@ -44,6 +47,20 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
         >
           <Icon name="settings3Line" className="size-16" />
           Runners
+        </Link>
+      </Button>
+      <Button
+        asChild
+        variant={isAgentProvidersActive ? 'secondary' : 'transparent'}
+        className="w-full justify-start"
+      >
+        <Link
+          to="/workspaces/$wid/settings/agent-providers"
+          params={{wid: workspaceId}}
+          aria-current={isAgentProvidersActive ? 'page' : undefined}
+        >
+          <Icon name="robot2Line" className="size-16" />
+          Agent providers
         </Link>
       </Button>
       <Button

--- a/libs/client/workspace-settings/src/index.ts
+++ b/libs/client/workspace-settings/src/index.ts
@@ -1,3 +1,4 @@
+export * from './pages/agent-providers-settings-page.js';
 export * from './pages/events-settings-page.js';
 export * from './pages/integrations-settings-page.js';
 export * from './pages/members-settings-page.js';

--- a/libs/client/workspace-settings/src/pages/agent-providers-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/agent-providers-settings-page.test.tsx
@@ -1,0 +1,42 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {screen} from '@testing-library/react';
+import {
+  jsonResponse,
+  renderWorkspaceSettingsPage,
+  WORKSPACE_SETTINGS_TEST_WID,
+} from '#test/pages.js';
+import {AgentProvidersSettingsPage} from './agent-providers-settings-page.js';
+
+describe('AgentProvidersSettingsPage', () => {
+  test('renders the settings shell and agent providers section', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          providers: [
+            {
+              id: 'anthropic',
+              label: 'Anthropic',
+              support_status: 'supported',
+              default_model: 'claude-opus-4-8',
+              credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
+              unsupported_reason: null,
+              models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({configs: [], default_provider_id: null}));
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderWorkspaceSettingsPage(
+      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/agent-providers`,
+      <AgentProvidersSettingsPage />,
+    );
+
+    expect(await screen.findByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+    expect(await screen.findByText('No providers configured')).toBeVisible();
+    expect(screen.getByText('Available providers')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Configure Anthropic'})).toBeVisible();
+  });
+});

--- a/libs/client/workspace-settings/src/pages/agent-providers-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/agent-providers-settings-page.tsx
@@ -1,0 +1,14 @@
+import {WorkspaceAgentProvidersSection} from '@shipfox/client-agent';
+import {WorkspaceSettingsShell} from '#components/workspace-settings-shell.js';
+
+export function AgentProvidersSettingsPage() {
+  return (
+    <WorkspaceSettingsShell>
+      {(workspace) => (
+        <div>
+          <WorkspaceAgentProvidersSection workspaceId={workspace.id} />
+        </div>
+      )}
+    </WorkspaceSettingsShell>
+  );
+}

--- a/libs/client/workspace-settings/test/pages.tsx
+++ b/libs/client/workspace-settings/test/pages.tsx
@@ -46,6 +46,11 @@ function createTestRouter(path: string, element: ReactElement) {
     path: '/workspaces/$wid/settings/runners',
     component: () => element,
   });
+  const agentProvidersRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/settings/agent-providers',
+    component: () => element,
+  });
   const integrationsRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/settings/integrations',
@@ -54,7 +59,7 @@ function createTestRouter(path: string, element: ReactElement) {
 
   return createRouter({
     history: createMemoryHistory({initialEntries: [path]}),
-    routeTree: rootRoute.addChildren([runnersRoute, integrationsRoute]),
+    routeTree: rootRoute.addChildren([runnersRoute, agentProvidersRoute, integrationsRoute]),
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2271,6 +2271,70 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  libs/client/agent:
+    dependencies:
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../../api/agent-dto
+      '@shipfox/client-api':
+        specifier: workspace:*
+        version: link:../api
+      '@shipfox/client-ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@shipfox/react-ui':
+        specifier: workspace:*
+        version: link:../../shared/react/ui
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.23
+      '@tanstack/react-form':
+        specifier: ^1.32.0
+        version: 1.33.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.1.11
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.0.0
+        version: 29.1.1
+      react:
+        specifier: ^19.1.1
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.7(react@19.2.7)
+
   libs/client/api:
     dependencies:
       '@swc/helpers':
@@ -3282,6 +3346,9 @@ importers:
       '@shipfox/api-workspaces-dto':
         specifier: workspace:*
         version: link:../../api/workspaces-dto
+      '@shipfox/client-agent':
+        specifier: workspace:*
+        version: link:../agent
       '@shipfox/client-api':
         specifier: workspace:*
         version: link:../api


### PR DESCRIPTION
Add workspace settings for agent provider credentials.

Agent jobs now use backend-managed workspace provider configuration, but the client had no settings surface for users to configure or rotate those credentials. This adds a reusable @shipfox/client-agent package with provider catalog/config hooks, a test-and-save credentials form, and a gallery section for configured, available, and unsupported providers. The workspace settings app and router now expose the new Agent providers page.

The provider form lives in the shared client-agent package so onboarding can reuse the same credential flow in ENG-603.

Closes ENG-602

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Workspace Settings page for agent providers so teams can configure, test, rotate, set a default provider, change a provider’s default model, and delete credentials. Supports a “Latest” catalog default stored as null; APIs validate model IDs, return `default_model`, and runtime resolves null to the catalog default, satisfying ENG-602 (form is reusable for ENG-603).

- **New Features**
  - Agent Providers page at `/workspaces/$wid/settings/agent-providers` with nav and route.
  - `@shipfox/client-agent` with transport functions, React Query hooks, and UI components.
  - Test & save modal with a default model picker (“Latest” or explicit), required-field validation, precise API error mapping (including `invalid-agent-model`), and fingerprint display without exposing secrets.
  - Change the default model without rotating credentials via modal and API (`PUT /providers/:providerId/default-model`); DTO/DB allow nullable `default_model`; responses include `default_model` (nullable for Latest).
  - Set a default provider with recoverable errors; delete credentials with a confirm modal and success toasts; gallery for configured (with default badge), available, and unsupported providers; loading skeletons and safe edit disabling when a provider is missing from the catalog.

- **Bug Fixes**
  - Provider validation now performs a lightweight `complete` call, rejects provider-error results, and returns clearer error messages.

<sup>Written for commit 5dd281b98bb6e8a7c854d27ebfd94ef059a322c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

