### PR TITLE
Use shared form field error helper

### DIFF
--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -1,5 +1,14 @@
 import {loginBodySchema} from '@shipfox/api-auth-dto';
-import {Alert, Button, ButtonLink, FormField, FormFieldInput, Icon, Text} from '@shipfox/react-ui';
+import {
+  Alert,
+  Button,
+  ButtonLink,
+  FormField,
+  FormFieldInput,
+  fieldError,
+  Icon,
+  Text,
+} from '@shipfox/react-ui';
 import {useForm} from '@tanstack/react-form';
 import {Link, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
@@ -173,19 +182,4 @@ export function LoginPage() {
       </Text>
     </AuthShell>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -2,7 +2,16 @@ import {
   passwordResetConfirmBodySchema,
   passwordResetRequestBodySchema,
 } from '@shipfox/api-auth-dto';
-import {Alert, Button, ButtonLink, FormField, FormFieldInput, Text, toast} from '@shipfox/react-ui';
+import {
+  Alert,
+  Button,
+  ButtonLink,
+  FormField,
+  FormFieldInput,
+  fieldError,
+  Text,
+  toast,
+} from '@shipfox/react-ui';
 import {useForm} from '@tanstack/react-form';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
@@ -207,19 +216,4 @@ function PasswordResetConfirm({token}: {token: string}) {
       </ButtonLink>
     </AuthShell>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -6,6 +6,7 @@ import {
   ButtonLink,
   FormField,
   FormFieldInput,
+  fieldError,
   Icon,
   Text,
   toast,
@@ -347,19 +348,4 @@ export function SignupPage() {
       </Text>
     </AuthShell>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/auth/src/pages/workspace-onboarding-page.tsx
+++ b/libs/client/auth/src/pages/workspace-onboarding-page.tsx
@@ -10,6 +10,7 @@ import {
   CardTitle,
   FormField,
   FormFieldInput,
+  fieldError,
   Icon,
   Text,
   toast,
@@ -213,19 +214,4 @@ function PreviewPanel({title, bars = false}: {title: string; bars?: boolean}) {
       </div>
     </div>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/integrations/src/pages/gitea-install-page.tsx
+++ b/libs/client/integrations/src/pages/gitea-install-page.tsx
@@ -5,6 +5,7 @@ import {
   ButtonLink,
   FormField,
   FormFieldInput,
+  fieldError,
   Header,
   Text,
   toast,
@@ -106,19 +107,4 @@ export function GiteaInstallPage() {
       </form>
     </div>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/projects/src/pages/create-project-page.tsx
+++ b/libs/client/projects/src/pages/create-project-page.tsx
@@ -23,6 +23,7 @@ import {
   FormField,
   FormFieldInput,
   FullPageLoader,
+  fieldError,
   Header,
   Text,
   toast,
@@ -378,19 +379,4 @@ function setWorkspaceProjectExists(
     projects: [project],
     next_cursor: null,
   });
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/runners/src/components/create-runner-token-form.tsx
+++ b/libs/client/runners/src/components/create-runner-token-form.tsx
@@ -5,6 +5,7 @@ import {
   Code,
   FormField,
   FormFieldInput,
+  fieldError,
   InlineTips,
   InlineTipsContent,
   InlineTipsDescription,
@@ -239,19 +240,4 @@ export function CreatedRunnerTokenPanel({token}: {token: CreateRunnerTokenRespon
       </InlineTipsContent>
     </InlineTips>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }

--- a/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
+++ b/libs/client/workspace-settings/src/components/members/workspace-members-section.tsx
@@ -10,6 +10,7 @@ import {
   EmptyState,
   FormField,
   FormFieldInput,
+  fieldError,
   formatDate,
   Header,
   Icon,
@@ -434,21 +435,6 @@ function InviteMemberModal({
       </ModalContent>
     </Modal>
   );
-}
-
-interface FieldLike {
-  state: {meta: {errors: Array<unknown>; isBlurred: boolean}};
-}
-
-function fieldError(field: FieldLike): string | undefined {
-  if (!field.state.meta.isBlurred && field.state.meta.errors.length === 0) return undefined;
-  const first = field.state.meta.errors[0];
-  if (!first) return undefined;
-  if (typeof first === 'string') return first;
-  if (typeof first === 'object' && first !== null && 'message' in first) {
-    return String((first as {message: unknown}).message);
-  }
-  return undefined;
 }
 
 function EmptyInvitations() {


### PR DESCRIPTION
Replace duplicate TanStack form field error extraction in client forms with the shared `fieldError` helper exported by `@shipfox/react-ui`.

The helper had already been added to the form field component, but several forms still carried local copies. Centralizing the usage keeps error display behavior consistent across auth, project creation, runner token creation, workspace invitations, and Gitea connection forms.

The touched client packages are private, so no changeset is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced local form field error helpers with the shared `fieldError` from `@shipfox/react-ui` to standardize validation messages and reduce duplication across client forms. Affects auth, project creation, runner tokens, workspace invitations, and Gitea connection forms; no behavior changes expected.

- **Refactors**
  - Removed bespoke `fieldError` implementations; all updated files now import `fieldError` from `@shipfox/react-ui`.
  - Touched packages are private, so no changeset.

<sup>Written for commit e5cbab5b8e83a4e0fb4a306035a779f2904927c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

