### PR TITLE
[client-workflows] Clarify empty job step copy

### DIFF
--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -131,7 +131,65 @@ describe('WorkflowRunView', () => {
     expect(
       screen.getByText('A required job did not complete, so this job was skipped.'),
     ).toBeInTheDocument();
-    expect(screen.queryByText('No step attempts yet')).not.toBeInTheDocument();
+    expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
+  });
+
+  test('renders pending zero-step jobs as waiting to start', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve(
+          jsonResponse(
+            workflowRunViewDetailDto({
+              jobs: [
+                workflowJobDto({
+                  id: DEPLOY_JOB_ID,
+                  run_id: RUN_ID,
+                  name: 'deploy',
+                  status: 'pending',
+                  steps: [],
+                }),
+              ],
+            }),
+          ),
+        ),
+      ),
+    });
+
+    renderView();
+
+    expect(await screen.findByText('Waiting for this job to start')).toBeInTheDocument();
+    expect(screen.getByText('Steps will appear here once the job starts.')).toBeInTheDocument();
+    expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
+  });
+
+  test('renders running zero-step jobs as waiting for the first step', async () => {
+    configureApiClient({
+      fetchImpl: vi.fn(() =>
+        Promise.resolve(
+          jsonResponse(
+            workflowRunViewDetailDto({
+              jobs: [
+                workflowJobDto({
+                  id: DEPLOY_JOB_ID,
+                  run_id: RUN_ID,
+                  name: 'deploy',
+                  status: 'running',
+                  steps: [],
+                }),
+              ],
+            }),
+          ),
+        ),
+      ),
+    });
+
+    renderView();
+
+    expect(await screen.findByText('Waiting for the first step')).toBeInTheDocument();
+    expect(
+      screen.getByText('This job is running, but no steps have started yet.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No steps recorded')).not.toBeInTheDocument();
   });
 
   test('renders cancelled zero-attempt jobs separately from skipped jobs', async () => {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -254,6 +254,22 @@ function emptyStateForJob(job: WorkflowJob): WorkflowStepListEmptyState | undefi
     };
   }
 
+  if (job.status === 'pending') {
+    return {
+      title: 'Waiting for this job to start',
+      description: 'Steps will appear here once the job starts.',
+      status: 'pending',
+    };
+  }
+
+  if (job.status === 'running') {
+    return {
+      title: 'Waiting for the first step',
+      description: 'This job is running, but no steps have started yet.',
+      status: 'running',
+    };
+  }
+
   if (job.status === 'skipped') {
     return {
       title: 'This job was skipped',

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -349,7 +349,8 @@ describe('WorkflowStepList', () => {
   test('renders an empty state', () => {
     render(<WorkflowStepList job={makeJob({steps: []})} />);
 
-    expect(screen.getByText('No step attempts yet')).toBeInTheDocument();
+    expect(screen.getByText('No steps recorded')).toBeInTheDocument();
+    expect(screen.getByText('This job has not recorded any steps.')).toBeInTheDocument();
   });
 
   test('renders a skipped empty state with a status glyph', () => {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -185,8 +185,8 @@ function WorkflowStepListContent({
 
 function WorkflowStepListEmptyStateView({
   emptyState = {
-    title: 'No step attempts yet',
-    description: 'This job has not recorded step attempts.',
+    title: 'No steps recorded',
+    description: 'This job has not recorded any steps.',
   },
 }: {
   emptyState?: WorkflowStepListEmptyState | undefined;


### PR DESCRIPTION
Clarifies the workflow run empty-state copy shown when a selected job has no recorded steps yet.

The previous message exposed the backend concept of step attempts. This replaces it with user-facing job and step language, with separate copy for pending jobs that have not started and running jobs that have not started their first step.

The fallback copy in the reusable step list now says steps rather than step attempts, and tests cover the pending, running, skipped, and generic empty states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified empty-state copy in workflow runs by replacing “step attempts” with user-facing “steps” and adding clear messages for pending and running jobs with no steps yet. Improves readability and sets expectations in the job details view.

- **New Features**
  - Pending job (0 steps): “Waiting for this job to start” — “Steps will appear here once the job starts.”
  - Running job (0 steps): “Waiting for the first step” — “This job is running, but no steps have started yet.”
  - Default empty state: “No steps recorded” — “This job has not recorded any steps.”

<sup>Written for commit 53de1ef7adeadc8db28ab60ccd019a82d93f62ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

