### PR TITLE
Align workspace provider settings cards

### DIFF
--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -107,7 +107,7 @@ test('settings catalogue shows a connected provider after Debug connect', async 
 
   const installed = page.locator('section[aria-label="Installed integrations"]');
   await expect(installed.getByText('Debug', {exact: true})).toBeVisible();
-  await expect(installed.getByText('Connected')).toBeVisible();
+  await expect(installed.getByText('Connected')).toHaveCount(0);
 
   // `Added <date>` is server-generated, so it would drift the Argos baseline.
   // Pin only that text and keep the rest of the row anchored to the real Debug

--- a/libs/client/agent/.storybook/main.ts
+++ b/libs/client/agent/.storybook/main.ts
@@ -1,0 +1,1 @@
+export {default} from '../../.storybook/main.ts';

--- a/libs/client/agent/.storybook/preview.css
+++ b/libs/client/agent/.storybook/preview.css
@@ -1,0 +1,4 @@
+@import "@shipfox/react-ui/index.css";
+
+@source "../src";
+@source "../../../shared/react/ui/src";

--- a/libs/client/agent/.storybook/preview.tsx
+++ b/libs/client/agent/.storybook/preview.tsx
@@ -1,0 +1,55 @@
+import './preview.css';
+import {ThemeProvider} from '@shipfox/react-ui';
+import type {Decorator, Preview} from '@storybook/react';
+
+if (typeof document !== 'undefined' && document.fonts) {
+  void Promise.all([
+    document.fonts.load("16px 'Inter'"),
+    document.fonts.load("italic 16px 'Inter'"),
+    document.fonts.load("16px 'Commit Mono'"),
+    document.fonts.load("bold 16px 'Commit Mono'"),
+  ]);
+}
+
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-theme-${theme}`}>
+      <Story />
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    argos: {
+      modes: {
+        light: {theme: 'light'},
+        dark: {theme: 'dark'},
+      },
+      fitToContent: false,
+    },
+    options: {
+      storySort: {method: 'alphabetical'},
+    },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {value: 'light', icon: 'sun', title: 'Light'},
+          {value: 'dark', icon: 'moon', title: 'Dark'},
+          {value: 'system', icon: 'info', title: 'System'},
+        ],
+        showName: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/libs/client/agent/package.json
+++ b/libs/client/agent/package.json
@@ -31,6 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "storybook": "storybook dev -p 6010",
+    "storybook:build": "storybook build -o storybook-static",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
@@ -50,18 +52,31 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@argos-ci/cli": "^5.0.0",
+    "@argos-ci/storybook": "^6.0.0",
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@storybook/addon-vitest": "^10.3.6",
+    "@storybook/react": "^10.0.0",
+    "@storybook/react-vite": "^10.0.0",
+    "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/browser-playwright": "^4.1.5",
     "jsdom": "^29.0.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "storybook": "^10.0.0",
+    "storybook-addon-pseudo-states": "^10.0.0",
+    "tailwindcss": "^4.1.13",
+    "vite": "^8.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/libs/client/agent/src/components/agent-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.stories.tsx
@@ -1,0 +1,221 @@
+import type {AgentProviderCatalogEntryDto, AgentProviderConfigDto} from '@shipfox/api-agent-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import {screen, userEvent, within} from 'storybook/test';
+import {WorkspaceAgentProvidersSection} from './agent-providers-section.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+type Scenario =
+  | 'mixed'
+  | 'empty-configured'
+  | 'all-configured'
+  | 'loading'
+  | 'configs-error'
+  | 'catalog-error'
+  | 'long-names';
+
+interface AgentProvidersStoryProps {
+  scenario: Scenario;
+}
+
+const CATALOG: AgentProviderCatalogEntryDto[] = [
+  providerEntry({
+    id: 'anthropic',
+    label: 'Anthropic',
+    default_model: 'claude-opus-4-8',
+    models: [
+      {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+      {id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5'},
+    ],
+  }),
+  providerEntry({
+    id: 'openai',
+    label: 'OpenAI',
+    default_model: 'gpt-5.5-pro',
+    models: [
+      {id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'},
+      {id: 'gpt-5-mini', label: 'GPT-5 Mini'},
+    ],
+  }),
+  providerEntry({
+    id: 'xai',
+    label: 'xAI',
+    default_model: 'grok-code-fast-1',
+    models: [{id: 'grok-code-fast-1', label: 'Grok Code Fast 1'}],
+  }),
+  providerEntry({
+    id: 'amazon-bedrock',
+    label: 'Amazon Bedrock',
+    support_status: 'unsupported',
+    credential_fields: [],
+    unsupported_reason: 'AWS cloud credentials are not supported yet.',
+    models: [],
+  }),
+];
+
+function AgentProvidersStory({scenario}: AgentProvidersStoryProps) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
+        <WorkspaceAgentProvidersSection workspaceId={WORKSPACE_ID} />
+      </div>
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Agent/ProviderSettings',
+  component: AgentProvidersStory,
+  parameters: {layout: 'fullscreen'},
+  args: {scenario: 'mixed'},
+} satisfies Meta<typeof AgentProvidersStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MixedProviderStates: Story = {};
+
+export const EmptyConfigured: Story = {
+  args: {scenario: 'empty-configured'},
+};
+
+export const AllConfigured: Story = {
+  args: {scenario: 'all-configured'},
+};
+
+export const Loading: Story = {
+  args: {scenario: 'loading'},
+};
+
+export const ConfigsError: Story = {
+  args: {scenario: 'configs-error'},
+};
+
+export const CatalogError: Story = {
+  args: {scenario: 'catalog-error'},
+};
+
+export const LongNames: Story = {
+  args: {scenario: 'long-names'},
+};
+
+export const ConfigureModalOpen: Story = {
+  args: {scenario: 'empty-configured'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', {name: 'Configure Anthropic'}));
+    await screen.findByLabelText('API key');
+  },
+};
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return (input) => {
+    const url = requestUrl(input);
+    if (scenario === 'loading') return new Promise<Response>(() => undefined);
+    if (url.pathname.endsWith('/agent/provider-catalog')) {
+      if (scenario === 'catalog-error') return Promise.resolve(errorResponse());
+      return Promise.resolve(jsonResponse({providers: catalogForScenario(scenario)}));
+    }
+    if (url.pathname.endsWith('/agent/providers')) {
+      if (scenario === 'configs-error') return Promise.resolve(errorResponse());
+      return Promise.resolve(jsonResponse(configsForScenario(scenario)));
+    }
+    return Promise.resolve(jsonResponse({}, {status: 404}));
+  };
+}
+
+function catalogForScenario(scenario: Scenario): AgentProviderCatalogEntryDto[] {
+  if (scenario !== 'long-names') return CATALOG;
+  return [
+    providerEntry({
+      id: 'anthropic',
+      label: 'Anthropic Enterprise Production Claude Provider With Long Label',
+      default_model: 'claude-opus-4-8',
+    }),
+    providerEntry({
+      id: 'openai',
+      label: 'OpenAI Platform Shared Workspace Credentials With Long Label',
+      default_model: 'gpt-5.5-pro',
+      models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+    }),
+  ];
+}
+
+function configsForScenario(scenario: Scenario) {
+  if (scenario === 'empty-configured' || scenario === 'configs-error') {
+    return {configs: [], default_provider_id: null};
+  }
+  if (scenario === 'all-configured') {
+    return {
+      configs: [
+        providerConfig({provider_id: 'anthropic'}),
+        providerConfig({provider_id: 'openai', key_fingerprints: {api_key: 'sk-proj...abcd'}}),
+        providerConfig({provider_id: 'xai', key_fingerprints: {api_key: 'xai...abcd'}}),
+      ],
+      default_provider_id: 'anthropic',
+    };
+  }
+  return {
+    configs: [providerConfig({provider_id: 'anthropic'})],
+    default_provider_id: 'anthropic',
+  };
+}
+
+function providerEntry(
+  overrides: Partial<AgentProviderCatalogEntryDto> = {},
+): AgentProviderCatalogEntryDto {
+  return {
+    id: 'anthropic',
+    label: 'Anthropic',
+    support_status: 'supported',
+    default_model: null,
+    credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
+    unsupported_reason: null,
+    models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
+    ...overrides,
+  };
+}
+
+function providerConfig(overrides: Partial<AgentProviderConfigDto> = {}): AgentProviderConfigDto {
+  return {
+    provider_id: 'anthropic',
+    default_model: null,
+    key_fingerprints: {api_key: 'sk-ant-s...abcd'},
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (typeof input === 'string') return new URL(input);
+  if (input instanceof URL) return input;
+  return new URL(input.url);
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function errorResponse() {
+  return jsonResponse({code: 'server-error'}, {status: 500, statusText: 'Server error'});
+}

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -38,6 +38,7 @@ import {AgentProviderTestAndSaveForm} from './test-and-save-form.js';
 
 const SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
+const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-12 max-[760px]:grid-cols-1';
 
 type ProviderFormState =
   | {mode: 'configure'; entry: AgentProviderCatalogEntryDto; config?: undefined}
@@ -160,7 +161,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
 
         {configsLoaded && availableProviders.length > 0 ? (
-          <ul className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1">
+          <ul className={PROVIDER_GRID_CLASS}>
             {availableProviders.map((entry) => (
               <AvailableProviderCard
                 key={entry.id}
@@ -467,16 +468,20 @@ function AvailableProviderCard({
       <button
         type="button"
         className={cn(
-          'block w-full cursor-pointer px-14 py-10 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
+          'group block w-full cursor-pointer p-16 text-left outline-none transition-colors hover:bg-background-components-hover focus-visible:shadow-button-neutral-focus',
           SURFACE_CLASS,
         )}
         aria-label={`Configure ${entry.label}`}
         onClick={onConfigure}
       >
-        <div className="min-w-0 flex-1">
-          <Text size="md" bold className="truncate">
+        <div className="flex min-w-0 items-center justify-between gap-12">
+          <Text size="md" bold className="min-w-0 truncate">
             {entry.label}
           </Text>
+          <div className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
+            <Text size="sm">Connect</Text>
+            <Icon name="chevronRight" className="size-16" />
+          </div>
         </div>
       </button>
     </li>
@@ -506,11 +511,7 @@ function ProviderRowsSkeleton({label}: {label: string}) {
 
 function ProviderGridSkeleton() {
   return (
-    <div
-      role="status"
-      aria-label="Loading available providers"
-      className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1"
-    >
+    <div role="status" aria-label="Loading available providers" className={PROVIDER_GRID_CLASS}>
       {[0, 1, 2, 3].map((card) => (
         <Skeleton key={card} className="h-136 w-full" />
       ))}

--- a/libs/client/agent/vitest.config.ts
+++ b/libs/client/agent/vitest.config.ts
@@ -55,7 +55,11 @@ export default defineConfig(
             browser: {
               enabled: true,
               headless: true,
-              provider: playwright(),
+              provider: playwright({
+                launchOptions: {
+                  args: ['--disable-lcd-text', '--font-render-hinting=none'],
+                },
+              }),
               instances: [{browser: 'chromium'}],
             },
           },

--- a/libs/client/agent/vitest.config.ts
+++ b/libs/client/agent/vitest.config.ts
@@ -1,7 +1,18 @@
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {argosVitestPlugin} from '@argos-ci/storybook/vitest-plugin';
 import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(
   {
+    plugins: [react(), tailwindcss()],
     test: {
       projects: [
         {
@@ -19,6 +30,34 @@ export default defineConfig(
             environment: 'jsdom',
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
+          },
+        },
+        {
+          extends: true,
+          plugins: [
+            storybookTest({configDir: path.join(dirname, '.storybook')}),
+            argosVitestPlugin({
+              uploadToArgos: !!process.env.CI,
+              ...(process.env.ARGOS_TOKEN ? {token: process.env.ARGOS_TOKEN} : {}),
+              buildName: 'client-agent',
+              argosCSS: `
+                *, *::before, *::after {
+                  animation-delay: 0s !important;
+                  animation-duration: 0s !important;
+                  transition-delay: 0s !important;
+                  transition-duration: 0s !important;
+                }
+              `,
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright(),
+              instances: [{browser: 'chromium'}],
+            },
           },
         },
       ],

--- a/libs/client/integrations/.storybook/main.ts
+++ b/libs/client/integrations/.storybook/main.ts
@@ -1,0 +1,1 @@
+export {default} from '../../.storybook/main.ts';

--- a/libs/client/integrations/.storybook/preview.css
+++ b/libs/client/integrations/.storybook/preview.css
@@ -1,0 +1,4 @@
+@import "@shipfox/react-ui/index.css";
+
+@source "../src";
+@source "../../../shared/react/ui/src";

--- a/libs/client/integrations/.storybook/preview.tsx
+++ b/libs/client/integrations/.storybook/preview.tsx
@@ -1,0 +1,55 @@
+import './preview.css';
+import {ThemeProvider} from '@shipfox/react-ui';
+import type {Decorator, Preview} from '@storybook/react';
+
+if (typeof document !== 'undefined' && document.fonts) {
+  void Promise.all([
+    document.fonts.load("16px 'Inter'"),
+    document.fonts.load("italic 16px 'Inter'"),
+    document.fonts.load("16px 'Commit Mono'"),
+    document.fonts.load("bold 16px 'Commit Mono'"),
+  ]);
+}
+
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-theme-${theme}`}>
+      <Story />
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    argos: {
+      modes: {
+        light: {theme: 'light'},
+        dark: {theme: 'dark'},
+      },
+      fitToContent: false,
+    },
+    options: {
+      storySort: {method: 'alphabetical'},
+    },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {value: 'light', icon: 'sun', title: 'Light'},
+          {value: 'dark', icon: 'moon', title: 'Dark'},
+          {value: 'system', icon: 'info', title: 'System'},
+        ],
+        showName: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/libs/client/integrations/package.json
+++ b/libs/client/integrations/package.json
@@ -31,6 +31,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "storybook": "storybook dev -p 6011",
+    "storybook:build": "storybook build -o storybook-static",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
@@ -56,20 +58,33 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@argos-ci/cli": "^5.0.0",
+    "@argos-ci/storybook": "^6.0.0",
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vite": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@storybook/addon-vitest": "^10.3.6",
+    "@storybook/react": "^10.0.0",
+    "@storybook/react-vite": "^10.0.0",
+    "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-router": "^1.170.16",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/browser-playwright": "^4.1.5",
     "jsdom": "^29.0.0",
     "jotai": "^2.19.1",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "storybook": "^10.0.0",
+    "storybook-addon-pseudo-states": "^10.0.0",
+    "tailwindcss": "^4.1.13",
+    "vite": "^8.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -1,0 +1,223 @@
+import type {
+  IntegrationConnectionDto,
+  IntegrationProviderDto,
+} from '@shipfox/api-integration-core-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {authStateAtom} from '@shipfox/client-auth';
+import {Toaster} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {createStore, Provider as JotaiProvider} from 'jotai';
+import {useMemo} from 'react';
+import {IntegrationGallery} from './integration-gallery.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const WORKSPACE_PATH = `/workspaces/${WORKSPACE_ID}/settings/integrations`;
+const SETUP_PATHS = [
+  '/workspaces/$wid/integrations/github',
+  '/workspaces/$wid/integrations/sentry',
+  '/workspaces/$wid/integrations/gitea',
+  '/workspaces/$wid/integrations/debug',
+] as const;
+
+type Scenario =
+  | 'mixed'
+  | 'empty-connections'
+  | 'loading'
+  | 'connections-error'
+  | 'providers-error'
+  | 'no-providers'
+  | 'long-names';
+
+interface IntegrationGalleryStoryProps {
+  scenario: Scenario;
+}
+
+const PROVIDERS: IntegrationProviderDto[] = [
+  {provider: 'github', display_name: 'GitHub', capabilities: ['source_control']},
+  {provider: 'sentry', display_name: 'Sentry', capabilities: []},
+  {provider: 'gitea', display_name: 'Gitea', capabilities: ['source_control']},
+  {provider: 'debug', display_name: 'Debug provider', capabilities: []},
+];
+
+function IntegrationGalleryStory({scenario}: IntegrationGalleryStoryProps) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+  const store = useMemo(() => {
+    const nextStore = createStore();
+    nextStore.set(authStateAtom, {
+      status: 'authenticated',
+      workspaces: [{id: WORKSPACE_ID, name: 'Acme', membershipId: 'membership-1'}],
+    });
+    return nextStore;
+  }, []);
+  const router = useMemo(() => {
+    const rootRoute = createRootRoute({component: Outlet});
+    const galleryRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: '/workspaces/$wid/settings/integrations',
+      component: () => (
+        <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
+          <IntegrationGallery />
+        </div>
+      ),
+    });
+    const setupRoutes = SETUP_PATHS.map((path) =>
+      createRoute({
+        getParentRoute: () => rootRoute,
+        path,
+        component: () => <div />,
+      }),
+    );
+
+    return createRouter({
+      history: createMemoryHistory({initialEntries: [WORKSPACE_PATH]}),
+      routeTree: rootRoute.addChildren([galleryRoute, ...setupRoutes]),
+    });
+  }, []);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider store={store}>
+        <RouterProvider router={router} />
+        <Toaster />
+      </JotaiProvider>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Integrations/Gallery',
+  component: IntegrationGalleryStory,
+  parameters: {layout: 'fullscreen'},
+  args: {scenario: 'mixed'},
+} satisfies Meta<typeof IntegrationGalleryStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MixedLifecycleStates: Story = {};
+
+export const EmptyConnections: Story = {
+  args: {scenario: 'empty-connections'},
+};
+
+export const Loading: Story = {
+  args: {scenario: 'loading'},
+};
+
+export const ConnectionsError: Story = {
+  args: {scenario: 'connections-error'},
+};
+
+export const ProvidersError: Story = {
+  args: {scenario: 'providers-error'},
+};
+
+export const NoProvidersAvailable: Story = {
+  args: {scenario: 'no-providers'},
+};
+
+export const LongNames: Story = {
+  args: {scenario: 'long-names'},
+};
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return (input) => {
+    const url = requestUrl(input);
+    if (scenario === 'loading') return new Promise<Response>(() => undefined);
+    if (url.pathname === '/integration-providers') {
+      if (scenario === 'providers-error') return Promise.resolve(errorResponse());
+      return Promise.resolve(
+        jsonResponse({providers: scenario === 'no-providers' ? [] : PROVIDERS}),
+      );
+    }
+    if (url.pathname === '/integration-connections') {
+      if (scenario === 'connections-error') return Promise.resolve(errorResponse());
+      return Promise.resolve(jsonResponse({connections: connectionsForScenario(scenario)}));
+    }
+    return Promise.resolve(jsonResponse({}, {status: 404}));
+  };
+}
+
+function connectionsForScenario(scenario: Scenario): IntegrationConnectionDto[] {
+  if (scenario === 'empty-connections' || scenario === 'no-providers') return [];
+  if (scenario === 'long-names') {
+    return [
+      connection({
+        display_name: 'acme-production-observability-and-source-control-organization',
+        lifecycle_status: 'active',
+      }),
+      connection({
+        id: '55555555-5555-4555-8555-555555555555',
+        provider: 'sentry',
+        display_name: 'sentry-team-with-a-very-long-connected-account-name',
+        lifecycle_status: 'error',
+      }),
+    ];
+  }
+  return [
+    connection({display_name: 'acme-corp', lifecycle_status: 'active'}),
+    connection({
+      id: '55555555-5555-4555-8555-555555555555',
+      provider: 'gitea',
+      display_name: 'platform-mirror',
+      lifecycle_status: 'disabled',
+    }),
+    connection({
+      id: '66666666-6666-4666-8666-666666666666',
+      provider: 'sentry',
+      display_name: 'sentry-prod',
+      lifecycle_status: 'error',
+    }),
+  ];
+}
+
+function connection(overrides: Partial<IntegrationConnectionDto> = {}): IntegrationConnectionDto {
+  return {
+    id: '44444444-4444-4444-8444-444444444444',
+    workspace_id: WORKSPACE_ID,
+    provider: 'github',
+    external_account_id: 'installation-1',
+    display_name: 'acme-corp',
+    lifecycle_status: 'active',
+    capabilities: ['source_control'],
+    external_url: 'https://github.com/organizations/acme-corp/settings/installations/1',
+    created_at: '2026-03-12T00:00:00.000Z',
+    updated_at: '2026-03-12T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (typeof input === 'string') return new URL(input);
+  if (input instanceof URL) return input;
+  return new URL(input.url);
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function errorResponse() {
+  return jsonResponse({code: 'server-error'}, {status: 500, statusText: 'Server error'});
+}

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -137,7 +137,7 @@ describe('IntegrationGallery — installed section', () => {
     expect(names).toEqual(['acme-early', 'acme-late']);
   });
 
-  test('renders the lifecycle badge label per status', async () => {
+  test('renders lifecycle badges only for states that need attention', async () => {
     renderGallery(
       {},
       {
@@ -163,7 +163,8 @@ describe('IntegrationGallery — installed section', () => {
       },
     );
 
-    expect(await screen.findByText('Connected')).toBeVisible();
+    expect(await screen.findByText('acme-corp')).toBeVisible();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
     expect(screen.getByText('Disabled')).toBeVisible();
     expect(screen.getByText('Error')).toBeVisible();
   });

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -154,21 +154,31 @@ function InstalledRow({
         )}
       />
       <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <Text
-          size="md"
-          bold
-          className={cn('truncate', muted ? 'text-foreground-neutral-disabled' : undefined)}
-        >
-          {connection.display_name}
-        </Text>
+        <div className="flex min-w-0 items-center gap-8">
+          <Text
+            size="md"
+            bold
+            className={cn('truncate', muted ? 'text-foreground-neutral-disabled' : undefined)}
+          >
+            {connection.display_name}
+          </Text>
+          {pill ? (
+            <Badge
+              variant={pill.variant}
+              radius="rounded"
+              className="shrink-0"
+              {...(pill.iconLeft ? {iconLeft: pill.iconLeft} : {})}
+            >
+              {pill.label}
+            </Badge>
+          ) : null}
+        </div>
         {/* Provider is already named by the icon (and the account name), so the
             meta line carries only the date — no third repeat of the provider. */}
         <Text size="sm" className="truncate text-foreground-neutral-muted">
           Added {formatDate(connection.created_at)}
         </Text>
       </div>
-      {/* "Open" sits left of any status pill so non-active states align in a
-          single scannable column. */}
       {connection.external_url ? (
         <Button
           asChild
@@ -186,16 +196,6 @@ function InstalledRow({
             Open
           </a>
         </Button>
-      ) : null}
-      {pill ? (
-        <Badge
-          variant={pill.variant}
-          radius="rounded"
-          className="shrink-0"
-          {...(pill.iconLeft ? {iconLeft: pill.iconLeft} : {})}
-        >
-          {pill.label}
-        </Badge>
       ) : null}
     </li>
   );

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -31,9 +31,9 @@ export interface IntegrationGalleryProps {
 
 const lifecyclePills: Record<
   IntegrationConnectionLifecycleStatusDto,
-  {variant: 'success' | 'neutral' | 'error'; label: string; iconLeft?: IconName}
+  {variant: 'neutral' | 'error'; label: string; iconLeft?: IconName} | undefined
 > = {
-  active: {variant: 'success', label: 'Connected'},
+  active: undefined,
   // Mirrors the webhook-delivery taxonomy (DESIGN.md §9): disabled is quiet
   // neutral with a warning icon, not warning-orange (which means "act now").
   disabled: {variant: 'neutral', label: 'Disabled', iconLeft: 'errorWarningLine'},
@@ -144,7 +144,7 @@ function InstalledRow({
   const muted = connection.lifecycle_status === 'disabled';
 
   return (
-    <li className="flex items-center gap-12 px-16 py-10 transition-colors hover:bg-background-components-hover">
+    <li className="flex items-center gap-12 px-16 py-12 transition-colors hover:bg-background-components-hover">
       <IntegrationIcon
         source={connection.provider}
         aria-hidden
@@ -188,14 +188,16 @@ function InstalledRow({
           </a>
         </Button>
       ) : null}
-      <Badge
-        variant={pill.variant}
-        radius="rounded"
-        className="shrink-0"
-        {...(pill.iconLeft ? {iconLeft: pill.iconLeft} : {})}
-      >
-        {pill.label}
-      </Badge>
+      {pill ? (
+        <Badge
+          variant={pill.variant}
+          radius="rounded"
+          className="shrink-0"
+          {...(pill.iconLeft ? {iconLeft: pill.iconLeft} : {})}
+        >
+          {pill.label}
+        </Badge>
+      ) : null}
     </li>
   );
 }
@@ -208,7 +210,7 @@ function InstalledSkeleton({label}: {label: string}) {
       className={cn('divide-y divide-border-neutral-base', SURFACE_CLASS)}
     >
       {[0, 1, 2].map((row) => (
-        <li key={row} className="flex items-center gap-12 px-16 py-10">
+        <li key={row} className="flex items-center gap-12 px-16 py-12">
           <Skeleton className="size-24 shrink-0" />
           <div className="flex min-w-0 flex-1 flex-col gap-2">
             <Skeleton className="h-16 w-120" />

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -167,9 +167,8 @@ function InstalledRow({
           Added {formatDate(connection.created_at)}
         </Text>
       </div>
-      {/* "Open" sits left of the pill (optional, only when external_url is set)
-          so the status pill stays the rightmost element on every row and the
-          pills align in a single scannable column. */}
+      {/* "Open" sits left of any status pill so non-active states align in a
+          single scannable column. */}
       {connection.external_url ? (
         <Button
           asChild

--- a/libs/client/integrations/src/components/provider-grid.tsx
+++ b/libs/client/integrations/src/components/provider-grid.tsx
@@ -17,8 +17,7 @@ export interface ProviderGridProps {
   errorSubject?: string;
 }
 
-export const PROVIDER_GRID_CLASS =
-  'grid gap-12 [grid-template-columns:repeat(auto-fill,minmax(180px,1fr))]';
+export const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-12 max-[760px]:grid-cols-1';
 
 export const PROVIDER_SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
@@ -83,20 +82,22 @@ function ProviderCard({
       aria-label={`Connect ${provider.display_name}`}
       className="group block h-full rounded-8 focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
     >
-      <Card className="h-full gap-8 p-16 transition-colors hover:bg-background-components-hover">
-        <div className="flex min-w-0 items-center gap-12">
-          <IntegrationIcon
-            source={provider.provider}
-            aria-hidden
-            className="size-24 shrink-0 text-foreground-neutral-base"
-          />
-          <Text size="md" bold className="truncate">
-            {provider.display_name}
-          </Text>
-        </div>
-        <div className="flex items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-          <Text size="sm">Connect</Text>
-          <Icon name="chevronRight" className="size-16" />
+      <Card className="h-full p-16 transition-colors hover:bg-background-components-hover">
+        <div className="flex min-w-0 items-center justify-between gap-12">
+          <div className="flex min-w-0 items-center gap-12">
+            <IntegrationIcon
+              source={provider.provider}
+              aria-hidden
+              className="size-24 shrink-0 text-foreground-neutral-base"
+            />
+            <Text size="md" bold className="truncate">
+              {provider.display_name}
+            </Text>
+          </div>
+          <div className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
+            <Text size="sm">Connect</Text>
+            <Icon name="chevronRight" className="size-16" />
+          </div>
         </div>
       </Card>
     </Link>
@@ -108,12 +109,14 @@ function ProviderGridSkeleton({label}: {label: string}) {
     <ul role="status" aria-label={label} className={PROVIDER_GRID_CLASS}>
       {[0, 1, 2, 3].map((tile) => (
         <li key={tile}>
-          <Card className="h-full gap-8 p-16">
-            <div className="flex items-center gap-12">
-              <Skeleton className="size-24 shrink-0" />
-              <Skeleton className="h-16 w-100" />
+          <Card className="h-full p-16">
+            <div className="flex items-center justify-between gap-12">
+              <div className="flex min-w-0 items-center gap-12">
+                <Skeleton className="size-24 shrink-0" />
+                <Skeleton className="h-16 w-100" />
+              </div>
+              <Skeleton className="h-16 w-64 shrink-0" />
             </div>
-            <Skeleton className="h-16 w-64" />
           </Card>
         </li>
       ))}

--- a/libs/client/integrations/vitest.config.ts
+++ b/libs/client/integrations/vitest.config.ts
@@ -1,10 +1,67 @@
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {argosVitestPlugin} from '@argos-ci/storybook/vitest-plugin';
 import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(
   {
+    plugins: [react(), tailwindcss()],
     test: {
-      environment: 'node',
-      setupFiles: ['test/setup.ts'],
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+        {
+          extends: true,
+          plugins: [
+            storybookTest({configDir: path.join(dirname, '.storybook')}),
+            argosVitestPlugin({
+              uploadToArgos: !!process.env.CI,
+              ...(process.env.ARGOS_TOKEN ? {token: process.env.ARGOS_TOKEN} : {}),
+              buildName: 'client-integrations',
+              argosCSS: `
+                *, *::before, *::after {
+                  animation-delay: 0s !important;
+                  animation-duration: 0s !important;
+                  transition-delay: 0s !important;
+                  transition-duration: 0s !important;
+                }
+              `,
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright(),
+              instances: [{browser: 'chromium'}],
+            },
+          },
+        },
+      ],
     },
   },
   import.meta.url,

--- a/libs/client/integrations/vitest.config.ts
+++ b/libs/client/integrations/vitest.config.ts
@@ -56,7 +56,11 @@ export default defineConfig(
             browser: {
               enabled: true,
               headless: true,
-              provider: playwright(),
+              provider: playwright({
+                launchOptions: {
+                  args: ['--disable-lcd-text', '--font-render-hinting=none'],
+                },
+              }),
               instances: [{browser: 'chromium'}],
             },
           },

--- a/libs/client/workspace-settings/src/pages/integrations-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/integrations-settings-page.test.tsx
@@ -65,8 +65,8 @@ describe('IntegrationsSettingsPage', () => {
     expect(screen.getByRole('link', {name: INTEGRATIONS_LINK_RE})).toBeVisible();
     expect(await screen.findByRole('region', {name: 'Installed integrations'})).toBeInTheDocument();
     expect(screen.getByRole('region', {name: 'Available integrations'})).toBeInTheDocument();
-    expect(await screen.findByText('Connected')).toBeVisible();
-    expect(screen.getByText('acme-corp')).toBeVisible();
+    expect(await screen.findByText('acme-corp')).toBeVisible();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
     expect(screen.getByText(ADDED_META_RE)).toBeVisible();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2295,6 +2295,12 @@ importers:
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
     devDependencies:
+      '@argos-ci/cli':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@argos-ci/storybook':
+        specifier: ^6.0.0
+        version: 6.0.7
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
@@ -2310,6 +2316,18 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      '@storybook/addon-vitest':
+        specifier: ^10.3.6
+        version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9))(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)
+      '@storybook/react':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@tailwindcss/vite':
+        specifier: ^4.1.13
+        version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.9.1
@@ -2325,6 +2343,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       jsdom:
         specifier: ^29.0.0
         version: 29.1.1
@@ -2334,6 +2358,21 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.2.7(react@19.2.7)
+      storybook:
+        specifier: ^10.0.0
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook-addon-pseudo-states:
+        specifier: ^10.0.0
+        version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.3.1
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   libs/client/api:
     dependencies:
@@ -2627,6 +2666,12 @@ importers:
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
     devDependencies:
+      '@argos-ci/cli':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@argos-ci/storybook':
+        specifier: ^6.0.0
+        version: 6.0.7
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
@@ -2645,6 +2690,18 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      '@storybook/addon-vitest':
+        specifier: ^10.3.6
+        version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9))(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)
+      '@storybook/react':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@tailwindcss/vite':
+        specifier: ^4.1.13
+        version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-router':
         specifier: ^1.170.16
         version: 1.170.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2660,6 +2717,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       jotai:
         specifier: ^2.19.1
         version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)
@@ -2672,6 +2735,21 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.2.7(react@19.2.7)
+      storybook:
+        specifier: ^10.0.0
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook-addon-pseudo-states:
+        specifier: ^10.0.0
+        version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.3.1
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   libs/client/invitations:
     dependencies:


### PR DESCRIPTION
Aligns the integrations and agent-provider settings card layouts so available providers use the same two-column rhythm, consistent card padding, and a right-aligned non-truncating Connect action.

The integrations page previously showed active connections as a success state, which added noise for the normal case. This keeps active integrations quiet and reserves lifecycle badges for disabled or error states that need user attention.

Validated with the required changed-package build, test, and check workflow through Turbo before committing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns integrations and agent provider settings to a shared two‑column grid with consistent padding and a right‑aligned “Connect” action. Hides the “Connected” badge and shows lifecycle pills next to the name only for disabled or error; Storybook visual tests are stabilized.

- **Refactors**
  - Share `PROVIDER_GRID_CLASS` across integrations and agent providers; align skeletons in both.
  - Set card padding to `p-16`; right‑align a non‑truncating “Connect” label + chevron.
  - Normalize installed row spacing to `py-12`; move status pills beside the name; keep “Open” at the row end.
  - Remove success pill for active connections; update unit, DOM, and E2E tests to expect no “Connected” badge.
  - Add Storybook stories for provider settings and integrations; stabilize Argos runs with theme controls, font preloading, animation disabling, and Chromium flags; add `storybook` scripts and `vitest` browser projects using `@storybook/addon-vitest`, `@argos-ci/storybook`, and `@vitest/browser-playwright`.

<sup>Written for commit cf2570cf3508e85a4c609e6ca5fc46c84749990a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

