### PR TITLE
[client-projects] Surface source health on projects hub cards

### DIFF
--- a/.changeset/projects-hub-connection-health.md
+++ b/.changeset/projects-hub-connection-health.md
@@ -1,0 +1,11 @@
+---
+"@shipfox/client-projects": patch
+---
+
+Redesign the projects hub cards around source health. Each card now shows the
+integration provider logo before the name, drops the raw external repository id,
+and replaces the always-green "Connected" badge with a warning that only appears
+when the project's source is disconnected (disabled, error, or missing), paired
+with a direct "Reconnect" link to the workspace integration settings. Provider
+and connection status are joined from the workspace's integration connections,
+fetched only when there are projects to annotate.

--- a/.changeset/projects-hub-connection-health.md
+++ b/.changeset/projects-hub-connection-health.md
@@ -1,11 +1,15 @@
 ---
 "@shipfox/client-projects": patch
+"@shipfox/client-integrations": patch
 ---
 
-Redesign the projects hub cards around source health. Each card now shows the
-integration provider logo before the name, drops the raw external repository id,
-and replaces the always-green "Connected" badge with a warning that only appears
-when the project's source is disconnected (disabled, error, or missing), paired
-with a direct "Reconnect" link to the workspace integration settings. Provider
-and connection status are joined from the workspace's integration connections,
-fetched only when there are projects to annotate.
+Redesign the projects hub cards around source health and align them with the
+integration gallery cards. Each card now shows the integration provider logo
+before the name, drops the raw external repository id, and surfaces a status
+pill only when the project's source is not active (Disabled or Error), in the
+same inline location as the gallery. The cards adopt the gallery layout
+(two-column grid, 16px padding, 24px icon) and carry no call to action.
+
+Extract the connection lifecycle pill into a shared `ConnectionStatusBadge` in
+`@shipfox/client-integrations` so the gallery and the projects hub render the
+same taxonomy from one source of truth.

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -1,22 +1,12 @@
 import type {
   IntegrationCapabilityDto,
   IntegrationConnectionDto,
-  IntegrationConnectionLifecycleStatusDto,
   IntegrationProviderDto,
 } from '@shipfox/api-integration-core-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {
-  Badge,
-  Button,
-  cn,
-  EmptyState,
-  formatDate,
-  Header,
-  type IconName,
-  Skeleton,
-  Text,
-} from '@shipfox/react-ui';
+import {Button, cn, EmptyState, formatDate, Header, Skeleton, Text} from '@shipfox/react-ui';
+import {ConnectionStatusBadge} from '#connection-status-badge.js';
 import {
   useIntegrationConnectionsQuery,
   useIntegrationProvidersQuery,
@@ -28,17 +18,6 @@ export interface IntegrationGalleryProps {
   capability?: IntegrationCapabilityDto;
   emptyProvidersMessage?: string;
 }
-
-const lifecyclePills: Record<
-  IntegrationConnectionLifecycleStatusDto,
-  {variant: 'neutral' | 'error'; label: string; iconLeft?: IconName} | undefined
-> = {
-  active: undefined,
-  // Mirrors the webhook-delivery taxonomy (DESIGN.md §9): disabled is quiet
-  // neutral with a warning icon, not warning-orange (which means "act now").
-  disabled: {variant: 'neutral', label: 'Disabled', iconLeft: 'errorWarningLine'},
-  error: {variant: 'error', label: 'Error'},
-};
 
 // Both gallery surfaces use the same card fill so they read as one system on
 // the subtle page canvas, rather than the list blending into the background.
@@ -140,7 +119,6 @@ function InstalledRow({
   connection: IntegrationConnectionDto;
   providerLabel: string;
 }) {
-  const pill = lifecyclePills[connection.lifecycle_status];
   const muted = connection.lifecycle_status === 'disabled';
 
   return (
@@ -162,16 +140,7 @@ function InstalledRow({
           >
             {connection.display_name}
           </Text>
-          {pill ? (
-            <Badge
-              variant={pill.variant}
-              radius="rounded"
-              className="shrink-0"
-              {...(pill.iconLeft ? {iconLeft: pill.iconLeft} : {})}
-            >
-              {pill.label}
-            </Badge>
-          ) : null}
+          <ConnectionStatusBadge status={connection.lifecycle_status} className="shrink-0" />
         </div>
         {/* Provider is already named by the icon (and the account name), so the
             meta line carries only the date — no third repeat of the provider. */}

--- a/libs/client/integrations/src/connection-status-badge.tsx
+++ b/libs/client/integrations/src/connection-status-badge.tsx
@@ -1,0 +1,39 @@
+import type {IntegrationConnectionLifecycleStatusDto} from '@shipfox/api-integration-core-dto';
+import {Badge, type IconName} from '@shipfox/react-ui';
+
+const lifecyclePills: Record<
+  IntegrationConnectionLifecycleStatusDto,
+  {variant: 'neutral' | 'error'; label: string; iconLeft?: IconName} | undefined
+> = {
+  // `active` is the expected state and carries no badge.
+  active: undefined,
+  // Mirrors the webhook-delivery taxonomy (DESIGN.md §9): disabled is quiet
+  // neutral with a warning icon, not warning-orange (which means "act now").
+  disabled: {variant: 'neutral', label: 'Disabled', iconLeft: 'errorWarningLine'},
+  error: {variant: 'error', label: 'Error'},
+};
+
+export interface ConnectionStatusBadgeProps {
+  status: IntegrationConnectionLifecycleStatusDto;
+  className?: string;
+}
+
+/**
+ * Single source of truth for a connection's lifecycle pill, shared by the
+ * integration gallery and any surface that reflects source health. Renders
+ * nothing for the expected `active` state.
+ */
+export function ConnectionStatusBadge({status, className}: ConnectionStatusBadgeProps) {
+  const pill = lifecyclePills[status];
+  if (!pill) return null;
+  return (
+    <Badge
+      variant={pill.variant}
+      radius="rounded"
+      className={className}
+      {...(pill.iconLeft ? {iconLeft: pill.iconLeft} : {})}
+    >
+      {pill.label}
+    </Badge>
+  );
+}

--- a/libs/client/integrations/src/index.ts
+++ b/libs/client/integrations/src/index.ts
@@ -2,6 +2,7 @@ export * from './components/connection-picker.js';
 export * from './components/integration-gallery.js';
 export * from './components/redirect-install-page.js';
 export * from './components/repository-picker.js';
+export * from './connection-status-badge.js';
 export * from './hooks/api/integrations.js';
 export * from './integration-icon.js';
 export * from './pages/debug-install-page.js';

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -61,9 +61,9 @@ describe('ProjectsHubPage', () => {
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
     expect(await screen.findByText('Platform')).toBeInTheDocument();
     const projectLink = screen.getByText('Platform').closest('a');
-    // The card is fully clickable via a stretched link, so the focus ring is
-    // drawn on the link's ::after (which covers the whole card), not the link box.
-    expect(projectLink).toHaveClass('focus-visible:after:shadow-button-neutral-focus');
+    // The whole card is the link, carrying the neutral focus ring (matching the
+    // integration gallery cards).
+    expect(projectLink).toHaveClass('focus-visible:shadow-button-neutral-focus');
     expect(projectLink?.className).not.toContain('shadow-button-secondary');
 
     fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
@@ -84,7 +84,7 @@ describe('ProjectsHubPage', () => {
     expect(screen.getByRole('button', {name: 'Retry loading projects'})).toBeInTheDocument();
   });
 
-  test('shows no status badge or repository id for a connected source', async () => {
+  test('shows no status pill or repository id for a connected source', async () => {
     configureApiClient({
       fetchImpl: createHubFetch({
         projects: jsonResponse({
@@ -114,36 +114,34 @@ describe('ProjectsHubPage', () => {
       expect(card?.querySelector('svg[viewBox="0 0 25 24"]')).toBeNull();
     });
 
-    // "Connected" is the expected state, so it stays unbadged; the raw repository
+    // "active" is the expected state, so it stays unbadged; the raw repository
     // id is dropped because it is meaningless to end users.
     expect(screen.queryByText('Connected')).not.toBeInTheDocument();
-    expect(screen.queryByText('Disconnected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error')).not.toBeInTheDocument();
     expect(screen.queryByText('github:octo/platform')).not.toBeInTheDocument();
   });
 
-  test('flags a disconnected source with a reconnect link to integration settings', async () => {
+  test.each([
+    ['error', 'Error'],
+    ['disabled', 'Disabled'],
+  ] as const)('flags a %s source with the matching status pill', async (lifecycleStatus, label) => {
     configureApiClient({
       fetchImpl: createHubFetch({
         projects: jsonResponse({
           projects: [projectDto({id: 'project-1', name: 'Platform'})],
           next_cursor: null,
         }),
-        connections: jsonResponse(connectionsDto({lifecycleStatus: 'error'})),
+        connections: jsonResponse(connectionsDto({lifecycleStatus})),
       }),
     });
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
 
-    expect(await screen.findByText('Disconnected')).toBeInTheDocument();
-    const reconnectLink = await screen.findByRole('link', {name: 'Reconnect'});
-    expect(reconnectLink).toHaveAttribute(
-      'href',
-      `/workspaces/${PROJECT_TEST_WID}/settings/integrations`,
-    );
-
-    fireEvent.click(reconnectLink);
-
-    expect(await screen.findByText('Integrations settings placeholder')).toBeInTheDocument();
+    expect(await screen.findByText('Platform')).toBeInTheDocument();
+    expect(await screen.findByText(label)).toBeInTheDocument();
+    // The aligned card carries no CTA.
+    expect(screen.queryByRole('link', {name: 'Reconnect'})).not.toBeInTheDocument();
   });
 
   test('keeps cards usable and unflagged when the connections request fails', async () => {
@@ -170,7 +168,8 @@ describe('ProjectsHubPage', () => {
     });
 
     // A failed connections fetch is not mistaken for a disconnected source.
-    expect(screen.queryByText('Disconnected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Error')).not.toBeInTheDocument();
     expect(screen.queryByText('Connected')).not.toBeInTheDocument();
   });
 });

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -5,11 +5,14 @@ import {ProjectsHubPage} from './projects-hub-page.js';
 
 const NEW_PROJECT_REGEX = /New project/i;
 const WORKSPACE_PROJECTS_NEW_HREF = `/workspaces/${PROJECT_TEST_WID}/projects/new`;
+const CONNECTION_ID = '33333333-3333-4333-8333-333333333333';
 
 describe('ProjectsHubPage', () => {
   test('renders Projects H2 + New project button + empty state with create CTA', async () => {
     configureApiClient({
-      fetchImpl: vi.fn().mockResolvedValue(jsonResponse({projects: [], next_cursor: null})),
+      fetchImpl: createHubFetch({
+        projects: jsonResponse({projects: [], next_cursor: null}),
+      }),
     });
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
@@ -30,26 +33,37 @@ describe('ProjectsHubPage', () => {
   });
 
   test('renders projects and loads the next cursor page', async () => {
-    const fetchImpl = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          projects: [projectDto({id: 'project-1', name: 'Platform'})],
-          next_cursor: 'cursor-1',
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          projects: [projectDto({id: 'project-2', name: 'API'})],
-          next_cursor: null,
-        }),
-      );
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(requestInputUrl(input));
+      if (url.pathname === '/integration-connections') {
+        return Promise.resolve(jsonResponse(connectionsDto()));
+      }
+      if (url.pathname === '/projects') {
+        if (url.searchParams.get('cursor') === 'cursor-1') {
+          return Promise.resolve(
+            jsonResponse({
+              projects: [projectDto({id: 'project-2', name: 'API'})],
+              next_cursor: null,
+            }),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse({
+            projects: [projectDto({id: 'project-1', name: 'Platform'})],
+            next_cursor: 'cursor-1',
+          }),
+        );
+      }
+      return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+    });
     configureApiClient({fetchImpl});
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
     expect(await screen.findByText('Platform')).toBeInTheDocument();
     const projectLink = screen.getByText('Platform').closest('a');
-    expect(projectLink).toHaveClass('focus-visible:shadow-button-neutral-focus');
+    // The card is fully clickable via a stretched link, so the focus ring is
+    // drawn on the link's ::after (which covers the whole card), not the link box.
+    expect(projectLink).toHaveClass('focus-visible:after:shadow-button-neutral-focus');
     expect(projectLink?.className).not.toContain('shadow-button-secondary');
 
     fireEvent.click(screen.getByRole('button', {name: 'Load more'}));
@@ -59,7 +73,9 @@ describe('ProjectsHubPage', () => {
 
   test('renders an error alert with retry', async () => {
     configureApiClient({
-      fetchImpl: vi.fn().mockResolvedValue(jsonResponse({code: 'server-error'}, {status: 500})),
+      fetchImpl: createHubFetch({
+        projects: jsonResponse({code: 'server-error'}, {status: 500}),
+      }),
     });
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
@@ -67,18 +83,127 @@ describe('ProjectsHubPage', () => {
     expect(await screen.findByText("Couldn't load projects")).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Retry loading projects'})).toBeInTheDocument();
   });
+
+  test('shows no status badge or repository id for a connected source', async () => {
+    configureApiClient({
+      fetchImpl: createHubFetch({
+        projects: jsonResponse({
+          projects: [
+            projectDto({
+              id: 'project-1',
+              name: 'Platform',
+              externalRepositoryId: 'github:octo/platform',
+            }),
+          ],
+          next_cursor: null,
+        }),
+        connections: jsonResponse(connectionsDto()),
+      }),
+    });
+
+    renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
+
+    expect(await screen.findByText('Platform')).toBeInTheDocument();
+    // "Connected" is the expected state, so it stays unbadged; the raw repository
+    // id is dropped because it is meaningless to end users.
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disconnected')).not.toBeInTheDocument();
+    expect(screen.queryByText('github:octo/platform')).not.toBeInTheDocument();
+  });
+
+  test('flags a disconnected source with a reconnect link to integration settings', async () => {
+    configureApiClient({
+      fetchImpl: createHubFetch({
+        projects: jsonResponse({
+          projects: [projectDto({id: 'project-1', name: 'Platform'})],
+          next_cursor: null,
+        }),
+        connections: jsonResponse(connectionsDto({lifecycleStatus: 'error'})),
+      }),
+    });
+
+    renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
+
+    expect(await screen.findByText('Disconnected')).toBeInTheDocument();
+    const reconnectLink = await screen.findByRole('link', {name: 'Reconnect'});
+    expect(reconnectLink).toHaveAttribute(
+      'href',
+      `/workspaces/${PROJECT_TEST_WID}/settings/integrations`,
+    );
+  });
 });
 
-function projectDto({id, name}: {id: string; name: string}) {
+function createHubFetch({
+  projects = jsonResponse({
+    projects: [projectDto({id: 'project-1', name: 'Platform'})],
+    next_cursor: null,
+  }),
+  connections = jsonResponse(connectionsDto()),
+}: {
+  projects?: Response;
+  connections?: Response;
+} = {}) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = new URL(requestInputUrl(input));
+    if (url.pathname === '/integration-connections') {
+      return Promise.resolve(connections.clone());
+    }
+    if (url.pathname === '/projects') {
+      return Promise.resolve(projects.clone());
+    }
+    return Promise.resolve(jsonResponse({code: 'not-found'}, {status: 404}));
+  });
+}
+
+function requestInputUrl(input: RequestInfo | URL) {
+  if (input instanceof Request) return input.url;
+  return String(input);
+}
+
+function projectDto({
+  id,
+  name,
+  connectionId = CONNECTION_ID,
+  externalRepositoryId = 'github:octo/platform',
+}: {
+  id: string;
+  name: string;
+  connectionId?: string;
+  externalRepositoryId?: string;
+}) {
   return {
     id,
-    workspace_id: '11111111-1111-4111-8111-111111111111',
+    workspace_id: PROJECT_TEST_WID,
     name,
     source: {
-      connection_id: '33333333-3333-4333-8333-333333333333',
-      external_repository_id: name.toLowerCase(),
+      connection_id: connectionId,
+      external_repository_id: externalRepositoryId,
     },
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
+  };
+}
+
+function connectionsDto({
+  lifecycleStatus = 'active',
+  id = CONNECTION_ID,
+}: {
+  lifecycleStatus?: 'active' | 'disabled' | 'error';
+  id?: string;
+} = {}) {
+  return {
+    connections: [
+      {
+        id,
+        workspace_id: PROJECT_TEST_WID,
+        provider: 'github',
+        external_account_id: 'octo',
+        display_name: 'Acme GitHub',
+        lifecycle_status: lifecycleStatus,
+        capabilities: ['source_control'],
+        created_at: '2026-05-07T00:00:00.000Z',
+        updated_at: '2026-05-07T00:00:00.000Z',
+      },
+    ],
   };
 }

--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {fireEvent, screen} from '@testing-library/react';
+import {fireEvent, screen, waitFor} from '@testing-library/react';
 import {jsonResponse, PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
 import {ProjectsHubPage} from './projects-hub-page.js';
 
@@ -104,6 +104,16 @@ describe('ProjectsHubPage', () => {
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
 
     expect(await screen.findByText('Platform')).toBeInTheDocument();
+
+    // The provider logo resolves to a real icon, not the neutral fallback
+    // (componentLine is the only icon with a 25x24 viewBox).
+    await waitFor(() => {
+      const card = screen.getByText('Platform').closest('li');
+      expect(card?.querySelector('[data-slot="skeleton"]')).toBeNull();
+      expect(card?.querySelector('svg')).toBeInTheDocument();
+      expect(card?.querySelector('svg[viewBox="0 0 25 24"]')).toBeNull();
+    });
+
     // "Connected" is the expected state, so it stays unbadged; the raw repository
     // id is dropped because it is meaningless to end users.
     expect(screen.queryByText('Connected')).not.toBeInTheDocument();
@@ -130,6 +140,38 @@ describe('ProjectsHubPage', () => {
       'href',
       `/workspaces/${PROJECT_TEST_WID}/settings/integrations`,
     );
+
+    fireEvent.click(reconnectLink);
+
+    expect(await screen.findByText('Integrations settings placeholder')).toBeInTheDocument();
+  });
+
+  test('keeps cards usable and unflagged when the connections request fails', async () => {
+    configureApiClient({
+      fetchImpl: createHubFetch({
+        projects: jsonResponse({
+          projects: [projectDto({id: 'project-1', name: 'Platform'})],
+          next_cursor: null,
+        }),
+        connections: jsonResponse({code: 'server-error'}, {status: 500}),
+      }),
+    });
+
+    renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
+
+    expect(await screen.findByText('Platform')).toBeInTheDocument();
+
+    // The icon settles to the neutral fallback rather than spinning on the
+    // loading skeleton forever when the connections fetch errors.
+    await waitFor(() => {
+      const card = screen.getByText('Platform').closest('li');
+      expect(card?.querySelector('[data-slot="skeleton"]')).toBeNull();
+      expect(card?.querySelector('svg')).toBeInTheDocument();
+    });
+
+    // A failed connections fetch is not mistaken for a disconnected source.
+    expect(screen.queryByText('Disconnected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
   });
 });
 

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -1,19 +1,21 @@
 import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
-import {IntegrationIcon, useIntegrationConnectionsQuery} from '@shipfox/client-integrations';
+import {
+  ConnectionStatusBadge,
+  IntegrationIcon,
+  useIntegrationConnectionsQuery,
+} from '@shipfox/client-integrations';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {
   Alert,
   Button,
   Card,
-  CardContent,
   EmptyState,
   Header,
   Icon,
   Input,
   Skeleton,
-  StatusBadge,
   Text,
 } from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
@@ -94,7 +96,7 @@ export function ProjectsHubPage() {
 
       {projects.length > 0 ? (
         <section aria-label="Projects list">
-          <ul className="grid gap-16 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          <ul className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1">
             {projects.map((project) => (
               <ProjectCard
                 project={project}
@@ -144,14 +146,14 @@ function ProjectsSkeleton() {
     <ul
       role="status"
       aria-label="Loading projects"
-      className="grid gap-16 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+      className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1"
     >
       {[0, 1, 2, 3, 4, 5].map((row) => (
         <li key={row}>
-          <Card className="p-20 h-full gap-12">
+          <Card className="h-full p-16">
             <div className="flex items-center gap-12">
-              <Skeleton className="size-20 shrink-0 rounded-4" />
-              <Skeleton className="h-20 w-1/2" />
+              <Skeleton className="size-24 shrink-0" />
+              <Skeleton className="h-16 w-1/2" />
             </div>
           </Card>
         </li>
@@ -205,61 +207,40 @@ function ProjectCard({
   connectionsSettled: boolean;
   workspaceId: string;
 }) {
-  // `active` is the expected state and stays unbadged. Once connections have
-  // resolved, any other state (disabled, error, or a connection that no longer
-  // exists) means the project's source needs attention, so flag it and offer a
-  // direct path to reconnect. Gate on resolved (not settled) so a failed
-  // connections fetch never falsely marks every card as disconnected.
-  const isDisconnected = connectionsResolved && connection?.lifecycle_status !== 'active';
+  // On a resolved fetch, `active` carries no badge while a missing connection
+  // reads as an error so a broken source is still flagged. An unresolved or
+  // failed fetch shows nothing, so a fetch failure never flags every card.
+  const status = connectionsResolved ? (connection?.lifecycle_status ?? 'error') : undefined;
 
   return (
-    <li className="relative h-full">
-      <Card className="relative p-20 h-full gap-12 hover:bg-background-components-hover transition-colors">
-        <CardContent className="flex flex-col gap-8 p-0">
-          <div className="flex items-center gap-12">
+    <li>
+      <Link
+        to="/workspaces/$wid/projects/$pid"
+        params={{wid: workspaceId, pid: project.id}}
+        className="block h-full rounded-8 focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
+      >
+        <Card className="h-full p-16 transition-colors hover:bg-background-components-hover">
+          <div className="flex min-w-0 items-center gap-12">
             {/* Settle on success or error: a failed fetch falls back to the
                 neutral provider icon rather than spinning forever. */}
             {connectionsSettled ? (
               <IntegrationIcon
                 source={connection?.provider}
                 aria-hidden
-                className="size-20 shrink-0 text-foreground-neutral-base"
+                className="size-24 shrink-0 text-foreground-neutral-base"
               />
             ) : (
-              <Skeleton className="size-20 shrink-0 rounded-4" />
+              <Skeleton className="size-24 shrink-0" />
             )}
-            {/* Stretched link: the ::after covers the whole card so the card stays
-                fully clickable, while the Reconnect link below opts out with a
-                higher stacking context (no nested anchors). */}
-            <Link
-              to="/workspaces/$wid/projects/$pid"
-              params={{wid: workspaceId, pid: project.id}}
-              className="min-w-0 flex-1 rounded-4 outline-none after:absolute after:inset-0 after:rounded-8 after:content-[''] focus-visible:after:shadow-button-neutral-focus"
-            >
-              <Text size="lg" bold className="truncate">
+            <div className="flex min-w-0 flex-1 items-center gap-8">
+              <Text size="md" bold className="truncate">
                 {project.name}
               </Text>
-            </Link>
-            {isDisconnected ? (
-              <StatusBadge variant="warning" className="shrink-0">
-                Disconnected
-              </StatusBadge>
-            ) : null}
-          </div>
-          {isDisconnected ? (
-            <div className="relative z-10 flex flex-wrap items-center gap-x-12 gap-y-4">
-              <Text size="sm" className="text-foreground-neutral-muted">
-                This project's source is disconnected.
-              </Text>
-              <Button asChild size="sm" variant="secondary" className="shrink-0">
-                <Link to="/workspaces/$wid/settings/integrations" params={{wid: workspaceId}}>
-                  Reconnect
-                </Link>
-              </Button>
+              {status ? <ConnectionStatusBadge status={status} className="shrink-0" /> : null}
             </div>
-          ) : null}
-        </CardContent>
-      </Card>
+          </div>
+        </Card>
+      </Link>
     </li>
   );
 }

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -1,12 +1,13 @@
+import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
 import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
 import {useActiveWorkspace} from '@shipfox/client-auth';
+import {IntegrationIcon, useIntegrationConnectionsQuery} from '@shipfox/client-integrations';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {
   Alert,
   Button,
   Card,
   CardContent,
-  Code,
   EmptyState,
   Header,
   Icon,
@@ -26,6 +27,16 @@ export function ProjectsHubPage() {
   const debouncedSearch = useDebouncedValue(trimmedInput, 250);
   const query = useProjectsInfiniteQuery(workspace.id, debouncedSearch || undefined);
   const projects = query.data?.pages.flatMap((page) => page.projects) ?? [];
+
+  // The provider logo and connection health live on the integration connection,
+  // not the project, so resolve them once for the whole list and index by id.
+  // Skip the fetch when there are no cards to annotate.
+  const connectionsQuery = useIntegrationConnectionsQuery(
+    projects.length > 0 ? workspace.id : undefined,
+  );
+  const connectionsById = new Map(
+    (connectionsQuery.data?.connections ?? []).map((connection) => [connection.id, connection]),
+  );
 
   const isInitialLoading = query.isPending;
   const isDebouncePending = trimmedInput !== debouncedSearch;
@@ -85,7 +96,13 @@ export function ProjectsHubPage() {
         <section aria-label="Projects list">
           <ul className="grid gap-16 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (
-              <ProjectCard project={project} key={project.id} workspaceId={workspace.id} />
+              <ProjectCard
+                project={project}
+                connection={connectionsById.get(project.source.connection_id)}
+                connectionsResolved={connectionsQuery.isSuccess}
+                key={project.id}
+                workspaceId={workspace.id}
+              />
             ))}
           </ul>
           {query.error && query.data ? (
@@ -131,11 +148,10 @@ function ProjectsSkeleton() {
       {[0, 1, 2, 3, 4, 5].map((row) => (
         <li key={row}>
           <Card className="p-20 h-full gap-12">
-            <div className="flex items-center justify-between gap-12">
+            <div className="flex items-center gap-12">
+              <Skeleton className="size-20 shrink-0 rounded-4" />
               <Skeleton className="h-20 w-1/2" />
-              <Skeleton className="h-20 w-72 shrink-0" />
             </div>
-            <Skeleton className="h-16 w-2/3" />
           </Card>
         </li>
       ))}
@@ -175,30 +191,69 @@ function NoSearchResults({search, onClear}: {search: string; onClear: () => void
   );
 }
 
-function ProjectCard({project, workspaceId}: {project: ProjectResponseDto; workspaceId: string}) {
+function ProjectCard({
+  project,
+  connection,
+  connectionsResolved,
+  workspaceId,
+}: {
+  project: ProjectResponseDto;
+  connection: IntegrationConnectionDto | undefined;
+  connectionsResolved: boolean;
+  workspaceId: string;
+}) {
+  // `active` is the expected state and stays unbadged. Once connections have
+  // resolved, any other state (disabled, error, or a connection that no longer
+  // exists) means the project's source needs attention, so flag it and offer a
+  // direct path to reconnect.
+  const isDisconnected = connectionsResolved && connection?.lifecycle_status !== 'active';
+
   return (
-    <li className="contents">
-      <Link
-        to="/workspaces/$wid/projects/$pid"
-        params={{wid: workspaceId, pid: project.id}}
-        className="block h-full rounded-8 focus-visible:outline-none focus-visible:shadow-button-neutral-focus"
-      >
-        <Card className="p-20 h-full gap-12 hover:bg-background-components-hover transition-colors">
-          <CardContent className="flex flex-col gap-8 p-0">
-            <div className="flex items-center justify-between gap-12">
+    <li className="relative h-full">
+      <Card className="relative p-20 h-full gap-12 hover:bg-background-components-hover transition-colors">
+        <CardContent className="flex flex-col gap-8 p-0">
+          <div className="flex items-center gap-12">
+            {connectionsResolved ? (
+              <IntegrationIcon
+                source={connection?.provider}
+                aria-hidden
+                className="size-20 shrink-0 text-foreground-neutral-base"
+              />
+            ) : (
+              <Skeleton className="size-20 shrink-0 rounded-4" />
+            )}
+            {/* Stretched link: the ::after covers the whole card so the card stays
+                fully clickable, while the Reconnect link below opts out with a
+                higher stacking context (no nested anchors). */}
+            <Link
+              to="/workspaces/$wid/projects/$pid"
+              params={{wid: workspaceId, pid: project.id}}
+              className="min-w-0 flex-1 rounded-4 outline-none after:absolute after:inset-0 after:rounded-8 after:content-[''] focus-visible:after:shadow-button-neutral-focus"
+            >
               <Text size="lg" bold className="truncate">
                 {project.name}
               </Text>
-              <StatusBadge variant="success" className="shrink-0">
-                Connected
+            </Link>
+            {isDisconnected ? (
+              <StatusBadge variant="warning" className="shrink-0">
+                Disconnected
               </StatusBadge>
+            ) : null}
+          </div>
+          {isDisconnected ? (
+            <div className="relative z-10 flex flex-wrap items-center gap-x-12 gap-y-4">
+              <Text size="sm" className="text-foreground-neutral-muted">
+                This project's source is disconnected.
+              </Text>
+              <Button asChild size="sm" variant="secondary" className="shrink-0">
+                <Link to="/workspaces/$wid/settings/integrations" params={{wid: workspaceId}}>
+                  Reconnect
+                </Link>
+              </Button>
             </div>
-            <Code variant="paragraph" className="text-foreground-neutral-muted truncate">
-              {project.source.external_repository_id}
-            </Code>
-          </CardContent>
-        </Card>
-      </Link>
+          ) : null}
+        </CardContent>
+      </Card>
     </li>
   );
 }

--- a/libs/client/projects/src/pages/projects-hub-page.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.tsx
@@ -100,6 +100,7 @@ export function ProjectsHubPage() {
                 project={project}
                 connection={connectionsById.get(project.source.connection_id)}
                 connectionsResolved={connectionsQuery.isSuccess}
+                connectionsSettled={connectionsQuery.isSuccess || connectionsQuery.isError}
                 key={project.id}
                 workspaceId={workspace.id}
               />
@@ -195,17 +196,20 @@ function ProjectCard({
   project,
   connection,
   connectionsResolved,
+  connectionsSettled,
   workspaceId,
 }: {
   project: ProjectResponseDto;
   connection: IntegrationConnectionDto | undefined;
   connectionsResolved: boolean;
+  connectionsSettled: boolean;
   workspaceId: string;
 }) {
   // `active` is the expected state and stays unbadged. Once connections have
   // resolved, any other state (disabled, error, or a connection that no longer
   // exists) means the project's source needs attention, so flag it and offer a
-  // direct path to reconnect.
+  // direct path to reconnect. Gate on resolved (not settled) so a failed
+  // connections fetch never falsely marks every card as disconnected.
   const isDisconnected = connectionsResolved && connection?.lifecycle_status !== 'active';
 
   return (
@@ -213,7 +217,9 @@ function ProjectCard({
       <Card className="relative p-20 h-full gap-12 hover:bg-background-components-hover transition-colors">
         <CardContent className="flex flex-col gap-8 p-0">
           <div className="flex items-center gap-12">
-            {connectionsResolved ? (
+            {/* Settle on success or error: a failed fetch falls back to the
+                neutral provider icon rather than spinning forever. */}
+            {connectionsSettled ? (
               <IntegrationIcon
                 source={connection?.provider}
                 aria-hidden

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -85,11 +85,6 @@ function createTestRouter(path: string, element: ReactElement) {
     path: '/workspaces/$wid/integrations',
     component: () => <div>Integrations gallery placeholder</div>,
   });
-  const settingsIntegrationsRoute = createRoute({
-    getParentRoute: () => rootRoute,
-    path: '/workspaces/$wid/settings/integrations',
-    component: () => <div>Integrations settings placeholder</div>,
-  });
   const projectDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/projects/$pid',
@@ -125,7 +120,6 @@ function createTestRouter(path: string, element: ReactElement) {
       workspaceRoute,
       workspaceNewProjectRoute,
       integrationsRoute,
-      settingsIntegrationsRoute,
       projectDetailRoute,
       projectWorkflowsRoute,
     ]),

--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -85,6 +85,11 @@ function createTestRouter(path: string, element: ReactElement) {
     path: '/workspaces/$wid/integrations',
     component: () => <div>Integrations gallery placeholder</div>,
   });
+  const settingsIntegrationsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/settings/integrations',
+    component: () => <div>Integrations settings placeholder</div>,
+  });
   const projectDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/projects/$pid',
@@ -120,6 +125,7 @@ function createTestRouter(path: string, element: ReactElement) {
       workspaceRoute,
       workspaceNewProjectRoute,
       integrationsRoute,
+      settingsIntegrationsRoute,
       projectDetailRoute,
       projectWorkflowsRoute,
     ]),


### PR DESCRIPTION
Reworks the projects hub cards to communicate source health at a glance.

Each card now shows the integration provider logo (GitHub, Gitea, ...) before
the project name, drops the raw `external_repository_id` line (an internal id
that means nothing to end users), and removes the always-green "Connected"
badge since a healthy connection is the expected state and the badge was pure
noise. In its place, a warning badge plus a direct "Reconnect" link appear only
when a project's source is actually disconnected (the connection is disabled,
errored, or no longer exists), giving users a clear path to fix it.

## Why

The previous card hardcoded "Connected" regardless of the real connection state,
so a broken source looked identical to a working one, and the second line showed
an opaque repository id. The redesign makes the abnormal state the one that
draws attention and tells the user how to recover.

## Notes for review

- Provider and connection health are not on `ProjectResponseDto` (it only carries
  `source.connection_id`). They are joined from the workspace's integration
  connections. This deliberately uses `useIntegrationConnectionsQuery` (all
  lifecycle statuses) rather than `useSourceConnectionsQuery`, which filters to
  active-only and would hide the very connections we need to flag.
- The connections query is gated on `projects.length > 0`, so an empty workspace
  makes no extra request (preserved by the existing home-router test).
- The card keeps its fully-clickable behavior via the stretched-link pattern so
  the "Reconnect" anchor can sit independently above the card link without
  nesting anchors.
- Warning-orange is intentional here (a disconnected source needs action), in
  contrast to the settings gallery where "disabled" is a quiet chosen state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the projects hub cards to show source health inline and match the integration gallery. Provider icons now settle even if the connections fetch fails, avoiding false “Disconnected” flags.

- **New Features**
  - Resolve provider and lifecycle from `useIntegrationConnectionsQuery` (all statuses), fetched only when there are projects; show an inline `ConnectionStatusBadge` next to the name; remove the always-green "Connected" badge and the raw repository id; provider logo appears before the project name.
  - Align with the gallery: two-column grid, 16px card padding, 24px provider icon, inline status pill, whole card is the link with a neutral focus ring; cards carry no CTA.
  - Extract `ConnectionStatusBadge` to `@shipfox/client-integrations` and use it in both the gallery and the projects hub for a single source of truth.

- **Bug Fixes**
  - If `/integration-connections` fails, render the neutral provider icon once the query settles; only show a disconnected status when connections resolve successfully.

<sup>Written for commit 8908755997ce54f9a206e01abc6f463b0c1e44a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

