### PR TITLE
[api-runners] Extract runner maintenance core logic

### DIFF
--- a/libs/api/runners/src/core/jobs.ts
+++ b/libs/api/runners/src/core/jobs.ts
@@ -1,5 +1,5 @@
 import {issueJobLeaseToken} from '@shipfox/api-auth';
-import {claimPendingJob, expireStuckJobs} from '#db/jobs.js';
+import {claimPendingJob} from '#db/jobs.js';
 import {jobClaimedCount} from '#metrics/instance.js';
 
 export interface ClaimJobResult {
@@ -30,11 +30,4 @@ export async function claimJob(params: {
   });
 
   return {jobId: claimed.jobId, runId: claimed.runId, leaseToken};
-}
-
-export async function detectAndExpireStuckJobs(params: {
-  thresholdSeconds: number;
-}): Promise<{expired: number}> {
-  const reaped = await expireStuckJobs({thresholdSeconds: params.thresholdSeconds});
-  return {expired: reaped.length};
 }

--- a/libs/api/runners/src/core/maintenance-policy.ts
+++ b/libs/api/runners/src/core/maintenance-policy.ts
@@ -1,0 +1,1 @@
+export const STUCK_JOB_THRESHOLD_SECONDS = 180;

--- a/libs/api/runners/src/core/maintenance.test.ts
+++ b/libs/api/runners/src/core/maintenance.test.ts
@@ -1,0 +1,40 @@
+import {sql} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {reservations} from '#db/schema/reservations.js';
+import {reservationFactory} from '#test/index.js';
+import {deleteExpiredRunnerReservations} from './maintenance.js';
+
+describe('deleteExpiredRunnerReservations', () => {
+  let workspaceId: string;
+  let provisionerId: string;
+
+  beforeEach(async () => {
+    await db().execute(sql`TRUNCATE runners_reservations CASCADE`);
+    workspaceId = crypto.randomUUID();
+    provisionerId = crypto.randomUUID();
+  });
+
+  it('deletes expired reservations and keeps active reservations', async () => {
+    await reservationFactory.create({
+      workspaceId,
+      provisionerId,
+      requiredLabels: ['linux'],
+      count: 1,
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    await reservationFactory.create({
+      workspaceId,
+      provisionerId,
+      requiredLabels: ['linux', 'gpu'],
+      count: 1,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const result = await deleteExpiredRunnerReservations();
+
+    const remaining = await db().select().from(reservations);
+    expect(result.deleted).toBe(1);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.requiredLabels).toEqual(['linux', 'gpu']);
+  });
+});

--- a/libs/api/runners/src/core/maintenance.ts
+++ b/libs/api/runners/src/core/maintenance.ts
@@ -4,7 +4,6 @@ import {STUCK_JOB_THRESHOLD_SECONDS} from './maintenance-policy.js';
 
 export interface DetectAndExpireStuckJobsParams {
   thresholdSeconds?: number;
-  limit?: number;
 }
 
 export async function detectAndExpireStuckJobs(
@@ -12,7 +11,6 @@ export async function detectAndExpireStuckJobs(
 ): Promise<{expired: number}> {
   const reaped = await expireStuckJobs({
     thresholdSeconds: params.thresholdSeconds ?? STUCK_JOB_THRESHOLD_SECONDS,
-    ...(params.limit === undefined ? {} : {limit: params.limit}),
   });
   return {expired: reaped.length};
 }

--- a/libs/api/runners/src/core/maintenance.ts
+++ b/libs/api/runners/src/core/maintenance.ts
@@ -1,0 +1,25 @@
+import {expireStuckJobs} from '#db/jobs.js';
+import {deleteExpiredReservations} from '#db/reservations.js';
+import {STUCK_JOB_THRESHOLD_SECONDS} from './maintenance-policy.js';
+
+export interface DetectAndExpireStuckJobsParams {
+  thresholdSeconds?: number;
+  limit?: number;
+}
+
+export async function detectAndExpireStuckJobs(
+  params: DetectAndExpireStuckJobsParams = {},
+): Promise<{expired: number}> {
+  const reaped = await expireStuckJobs({
+    thresholdSeconds: params.thresholdSeconds ?? STUCK_JOB_THRESHOLD_SECONDS,
+    ...(params.limit === undefined ? {} : {limit: params.limit}),
+  });
+  return {expired: reaped.length};
+}
+
+export async function deleteExpiredRunnerReservations(params?: {
+  limit?: number;
+}): Promise<{deleted: number}> {
+  const deleted = await deleteExpiredReservations(params);
+  return {deleted};
+}

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -6,7 +6,8 @@ import {
 } from '@shipfox/api-runners-dto';
 import {eq, sql} from 'drizzle-orm';
 import {EmptyRequiredLabelsError, RunnerSessionExhaustedError} from '#core/errors.js';
-import {claimJob, detectAndExpireStuckJobs} from '#core/jobs.js';
+import {claimJob} from '#core/jobs.js';
+import {detectAndExpireStuckJobs} from '#core/maintenance.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
 import {db} from './db.js';
 import {

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -1,95 +1,36 @@
-import {RUNNER_JOB_LEASE_EXPIRED} from '@shipfox/api-runners-dto';
-import {eq, sql} from 'drizzle-orm';
-import {db} from '#db/db.js';
-import {claimPendingJob} from '#db/jobs.js';
-import {runnersOutbox} from '#db/schema/outbox.js';
-import {reservations} from '#db/schema/reservations.js';
-import {runningJobs} from '#db/schema/running-jobs.js';
-import {pendingJobFactory, reservationFactory, runnerSessionFactory} from '#test/index.js';
+import {deleteExpiredRunnerReservations, detectAndExpireStuckJobs} from '#core/maintenance.js';
 import {
   deleteExpiredReservationsActivity,
   detectAndExpireStuckJobsActivity,
 } from './maintenance-activities.js';
 
+vi.mock('#core/maintenance.js', () => ({
+  deleteExpiredRunnerReservations: vi.fn(),
+  detectAndExpireStuckJobs: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('detectAndExpireStuckJobsActivity', () => {
-  let workspaceId: string;
-  let runnerSessionId: string;
-
-  beforeEach(async () => {
-    workspaceId = crypto.randomUUID();
-    const runnerSession = await runnerSessionFactory.create({workspaceId});
-    runnerSessionId = runnerSession.id;
-  });
-
-  it('delegates to detectAndExpireStuckJobs and returns the expired count', async () => {
-    await pendingJobFactory.create({workspaceId});
-    const claimed = await claimPendingJob({
-      workspaceId,
-      runnerSessionId,
-      sessionLabels: ['linux', 'x64'],
-      maxClaims: null,
-    });
-    await db()
-      .update(runningJobs)
-      .set({lastHeartbeatAt: sql`now() - interval '10 minutes'`})
-      .where(eq(runningJobs.jobId, claimed?.jobId as string));
+  it('delegates to core maintenance', async () => {
+    vi.mocked(detectAndExpireStuckJobs).mockResolvedValueOnce({expired: 2});
 
     const result = await detectAndExpireStuckJobsActivity({thresholdSeconds: 180});
 
-    expect(result.expired).toBeGreaterThanOrEqual(1);
-
-    const stillRunning = await db()
-      .select()
-      .from(runningJobs)
-      .where(eq(runningJobs.jobId, claimed?.jobId as string));
-    expect(stillRunning).toHaveLength(0);
-
-    const outbox = await db()
-      .select()
-      .from(runnersOutbox)
-      .where(eq(runnersOutbox.eventType, RUNNER_JOB_LEASE_EXPIRED));
-    const matching = outbox.filter(
-      (row) => (row.payload as Record<string, unknown>).jobId === claimed?.jobId,
-    );
-    expect(matching).toHaveLength(1);
-    const payload = matching[0]?.payload as Record<string, unknown>;
-    expect(payload.runId).toBe(claimed?.runId);
-    expect(payload.steps).toBeUndefined();
-    expect(payload.status).toBeUndefined();
+    expect(result).toEqual({expired: 2});
+    expect(detectAndExpireStuckJobs).toHaveBeenCalledWith({thresholdSeconds: 180});
   });
 });
 
 describe('deleteExpiredReservationsActivity', () => {
-  let workspaceId: string;
-  let provisionerId: string;
+  it('delegates to core maintenance', async () => {
+    vi.mocked(deleteExpiredRunnerReservations).mockResolvedValueOnce({deleted: 3});
 
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_reservations CASCADE`);
-    workspaceId = crypto.randomUUID();
-    provisionerId = crypto.randomUUID();
-  });
+    const result = await deleteExpiredReservationsActivity({limit: 50});
 
-  it('deletes expired reservations and keeps active reservations', async () => {
-    await reservationFactory.create({
-      workspaceId,
-      provisionerId,
-      requiredLabels: ['linux'],
-      count: 1,
-      expiresAt: new Date(Date.now() - 60_000),
-    });
-    await reservationFactory.create({
-      workspaceId,
-      provisionerId,
-      requiredLabels: ['linux', 'gpu'],
-      count: 1,
-      expiresAt: new Date(Date.now() + 60_000),
-    });
-
-    const result = await deleteExpiredReservationsActivity();
-
-    const remaining = await db().select().from(reservations);
-    expect(result.deleted).toBe(1);
-    expect(remaining).toHaveLength(1);
-    expect(remaining[0]?.requiredLabels).toEqual(['linux', 'gpu']);
+    expect(result).toEqual({deleted: 3});
+    expect(deleteExpiredRunnerReservations).toHaveBeenCalledWith({limit: 50});
   });
 });

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.ts
@@ -1,13 +1,13 @@
 import {deleteExpiredRunnerReservations, detectAndExpireStuckJobs} from '#core/maintenance.js';
 
-export async function detectAndExpireStuckJobsActivity(params: {
+export function detectAndExpireStuckJobsActivity(params: {
   thresholdSeconds: number;
 }): Promise<{expired: number}> {
-  return await detectAndExpireStuckJobs(params);
+  return detectAndExpireStuckJobs(params);
 }
 
-export async function deleteExpiredReservationsActivity(params?: {
+export function deleteExpiredReservationsActivity(params?: {
   limit?: number;
 }): Promise<{deleted: number}> {
-  return await deleteExpiredRunnerReservations(params);
+  return deleteExpiredRunnerReservations(params);
 }

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.ts
@@ -1,5 +1,4 @@
-import {detectAndExpireStuckJobs} from '#core/jobs.js';
-import {deleteExpiredReservations} from '#db/reservations.js';
+import {deleteExpiredRunnerReservations, detectAndExpireStuckJobs} from '#core/maintenance.js';
 
 export async function detectAndExpireStuckJobsActivity(params: {
   thresholdSeconds: number;
@@ -10,6 +9,5 @@ export async function detectAndExpireStuckJobsActivity(params: {
 export async function deleteExpiredReservationsActivity(params?: {
   limit?: number;
 }): Promise<{deleted: number}> {
-  const deleted = await deleteExpiredReservations(params);
-  return {deleted};
+  return await deleteExpiredRunnerReservations(params);
 }

--- a/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
+++ b/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
@@ -1,4 +1,5 @@
 import {log, proxyActivities} from '@temporalio/workflow';
+import {STUCK_JOB_THRESHOLD_SECONDS} from '#core/maintenance-policy.js';
 
 import type {createRunnersMaintenanceActivities} from '../activities/index.js';
 
@@ -7,8 +8,6 @@ const {deleteExpiredReservationsActivity, detectAndExpireStuckJobsActivity} = pr
 >({
   startToCloseTimeout: '60s',
 });
-
-const STUCK_JOB_THRESHOLD_SECONDS = 180;
 
 export async function stuckJobDetector(): Promise<void> {
   try {


### PR DESCRIPTION
Moves runner maintenance behavior out of Temporal activities and into the runners core layer. The stuck-job detector workflow now keeps Temporal concerns to orchestration and logging, while activities delegate to core maintenance functions for expiring stale leases and cleaning expired reservations.

This makes the business behavior reusable outside Temporal and gives reservation cleanup direct core coverage instead of relying on activity-level database tests. Activity tests are narrowed to adapter coverage so Temporal glue stays thin.

No changeset is included because `@shipfox/api-runners` is private. Build and check passed; `turbo test --filter '...[origin/main]'` was ignored at request after failing in `@shipfox/api-runners` due the local `api_test` schema being partially migrated/out of sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted runner maintenance into the core layer and made Temporal activities thin adapters. Stuck-job detection and reservation cleanup now use reusable core functions with a shared `STUCK_JOB_THRESHOLD_SECONDS` default.

- **Refactors**
  - Added `core/maintenance.ts` with `detectAndExpireStuckJobs` (defaults to `STUCK_JOB_THRESHOLD_SECONDS`) and `deleteExpiredRunnerReservations`, plus `core/maintenance-policy.ts`.
  - Simplified maintenance activities to direct pass-throughs (non-async) that forward params; tests now mock core and assert delegation.
  - Removed `detectAndExpireStuckJobs` from `core/jobs.ts`; updated DB tests to import from core maintenance and added a core test for reservation cleanup.
  - Workflow now imports `STUCK_JOB_THRESHOLD_SECONDS` from the core policy; behavior and return shapes are unchanged.

<sup>Written for commit 7e74d0ee2097ad40bba37e6fabae6295ca905624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

