### PR TITLE
[expression] Add workflow template resolver

### DIFF
--- a/.changeset/steady-templates-resolve.md
+++ b/.changeset/steady-templates-resolve.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds workflow template resolution with string coercion, missing-path diagnostics, and typed evaluation failures.

--- a/libs/shared/expression/src/evaluator/errors.ts
+++ b/libs/shared/expression/src/evaluator/errors.ts
@@ -1,10 +1,19 @@
+import {EvaluationError} from '@marcbachmann/cel-js';
+
 export const workflowExpressionEvaluationErrorCode = 'workflow-expression-evaluation-failed';
+
+export type WorkflowExpressionEvaluationFailureReason = 'missing-path' | 'evaluation-error';
 
 export class WorkflowExpressionEvaluationError extends Error {
   readonly code = workflowExpressionEvaluationErrorCode;
+  readonly reason: WorkflowExpressionEvaluationFailureReason;
 
   constructor(cause: unknown) {
     super('Workflow expression evaluation failed', {cause});
     this.name = 'WorkflowExpressionEvaluationError';
+    this.reason =
+      cause instanceof EvaluationError && cause.code === 'no_such_key'
+        ? 'missing-path'
+        : 'evaluation-error';
   }
 }

--- a/libs/shared/expression/src/evaluator/errors.ts
+++ b/libs/shared/expression/src/evaluator/errors.ts
@@ -12,7 +12,8 @@ export class WorkflowExpressionEvaluationError extends Error {
     super('Workflow expression evaluation failed', {cause});
     this.name = 'WorkflowExpressionEvaluationError';
     this.reason =
-      cause instanceof EvaluationError && cause.code === 'no_such_key'
+      cause instanceof EvaluationError &&
+      (cause.code === 'no_such_key' || cause.code === 'unknown_variable')
         ? 'missing-path'
         : 'evaluation-error';
   }

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -124,7 +124,8 @@ describe('evaluateWorkflowExpression', () => {
       check: {mode: 'syntax'},
     });
 
-    const act = () =>
+    let error: unknown;
+    try {
       evaluateWorkflowExpression(expression, {
         event: {
           pull_request: {
@@ -132,7 +133,28 @@ describe('evaluateWorkflowExpression', () => {
           },
         },
       });
+    } catch (caught) {
+      error = caught;
+    }
 
-    expect(act).toThrow(WorkflowExpressionEvaluationError);
+    expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
+    expect((error as WorkflowExpressionEvaluationError).reason).toBe('missing-path');
+  });
+
+  it('classifies genuine evaluation failures as evaluation errors', () => {
+    const expression = createWorkflowExpression({
+      source: '1 / 0',
+      check: {mode: 'syntax'},
+    });
+
+    let error: unknown;
+    try {
+      evaluateWorkflowExpression(expression, {});
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
+    expect((error as WorkflowExpressionEvaluationError).reason).toBe('evaluation-error');
   });
 });

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -141,6 +141,23 @@ describe('evaluateWorkflowExpression', () => {
     expect((error as WorkflowExpressionEvaluationError).reason).toBe('missing-path');
   });
 
+  it('classifies absent context roots as missing paths', () => {
+    const expression = createWorkflowExpression({
+      source: 'inputs.environment',
+      check: {mode: 'syntax'},
+    });
+
+    let error: unknown;
+    try {
+      evaluateWorkflowExpression(expression, {event: {}});
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(WorkflowExpressionEvaluationError);
+    expect((error as WorkflowExpressionEvaluationError).reason).toBe('missing-path');
+  });
+
   it('classifies genuine evaluation failures as evaluation errors', () => {
     const expression = createWorkflowExpression({
       source: '1 / 0',

--- a/libs/shared/expression/src/evaluator/index.ts
+++ b/libs/shared/expression/src/evaluator/index.ts
@@ -1,5 +1,6 @@
 export {
   WorkflowExpressionEvaluationError,
+  type WorkflowExpressionEvaluationFailureReason,
   workflowExpressionEvaluationErrorCode,
 } from './errors.js';
 export {

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -1,5 +1,6 @@
 export {
   WorkflowExpressionEvaluationError,
+  type WorkflowExpressionEvaluationFailureReason,
   workflowExpressionEvaluationErrorCode,
 } from './evaluator/errors.js';
 export {
@@ -26,6 +27,16 @@ export type {
   WorkflowExpressionCheck,
   WorkflowExpressionCheckOptions,
 } from './expression/workflow-expression.js';
+export {
+  WorkflowTemplateResolutionError,
+  workflowTemplateResolutionErrorCode,
+} from './resolver/errors.js';
+export {
+  resolveWorkflowTemplate,
+  resolveWorkflowTemplateSource,
+  type WorkflowTemplateDiagnostic,
+  type WorkflowTemplateResolution,
+} from './resolver/resolve-workflow-template.js';
 export {
   InvalidWorkflowTemplateError,
   invalidWorkflowTemplateErrorCode,

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -36,6 +36,7 @@ export {
   resolveWorkflowTemplateSource,
   type WorkflowTemplateDiagnostic,
   type WorkflowTemplateResolution,
+  type WorkflowTemplateResolutionOptions,
 } from './resolver/resolve-workflow-template.js';
 export {
   InvalidWorkflowTemplateError,

--- a/libs/shared/expression/src/resolver/coerce-workflow-value-to-string.test.ts
+++ b/libs/shared/expression/src/resolver/coerce-workflow-value-to-string.test.ts
@@ -1,0 +1,28 @@
+import {coerceWorkflowValueToString} from './coerce-workflow-value-to-string.js';
+
+describe('coerceWorkflowValueToString', () => {
+  it.each([
+    ['string', 'deploy main', 'deploy main'],
+    ['bigint int', 42n, '42'],
+    ['double', 3.14, '3.14'],
+    ['boolean true', true, 'true'],
+    ['boolean false', false, 'false'],
+    ['null', null, ''],
+    ['undefined', undefined, ''],
+    ['date', new Date('2026-01-01T00:00:00.000Z'), '2026-01-01T00:00:00.000Z'],
+    ['list', ['bug', 'p1'], '["bug","p1"]'],
+    ['object', {conclusion: 'success', attempts: 2}, '{"conclusion":"success","attempts":2}'],
+    [
+      'nested object',
+      {pull_request: {title: 'Fix auth', labels: ['bug']}},
+      '{"pull_request":{"title":"Fix auth","labels":["bug"]}}',
+    ],
+    ['empty string', '', ''],
+    ['safe bigint in list', [42n], '[42]'],
+    ['unsafe bigint in list', [9007199254740993n], '["9007199254740993"]'],
+  ])('coerces %s', (_name, value, expected) => {
+    const result = coerceWorkflowValueToString(value);
+
+    expect(result).toBe(expected);
+  });
+});

--- a/libs/shared/expression/src/resolver/coerce-workflow-value-to-string.ts
+++ b/libs/shared/expression/src/resolver/coerce-workflow-value-to-string.ts
@@ -1,0 +1,17 @@
+export function coerceWorkflowValueToString(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'bigint' || typeof value === 'number') return String(value);
+  if (value instanceof Date) return value.toISOString();
+
+  const serialized = JSON.stringify(value, stringifyBigint);
+  return serialized ?? '';
+}
+
+function stringifyBigint(_key: string, value: unknown): unknown {
+  if (typeof value !== 'bigint') return value;
+
+  const numberValue = Number(value);
+  return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
+}

--- a/libs/shared/expression/src/resolver/errors.ts
+++ b/libs/shared/expression/src/resolver/errors.ts
@@ -2,11 +2,11 @@ export const workflowTemplateResolutionErrorCode = 'workflow-template-resolution
 
 export class WorkflowTemplateResolutionError extends Error {
   readonly code = workflowTemplateResolutionErrorCode;
-  readonly expression: string;
+  readonly source: string;
 
-  constructor(params: {expression: string; cause: unknown}) {
+  constructor(params: {source: string; cause: unknown}) {
     super('Workflow template resolution failed', {cause: params.cause});
     this.name = 'WorkflowTemplateResolutionError';
-    this.expression = params.expression;
+    this.source = params.source;
   }
 }

--- a/libs/shared/expression/src/resolver/errors.ts
+++ b/libs/shared/expression/src/resolver/errors.ts
@@ -1,0 +1,12 @@
+export const workflowTemplateResolutionErrorCode = 'workflow-template-resolution-failed';
+
+export class WorkflowTemplateResolutionError extends Error {
+  readonly code = workflowTemplateResolutionErrorCode;
+  readonly expression: string;
+
+  constructor(params: {expression: string; cause: unknown}) {
+    super('Workflow template resolution failed', {cause: params.cause});
+    this.name = 'WorkflowTemplateResolutionError';
+    this.expression = params.expression;
+  }
+}

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
@@ -125,7 +125,28 @@ describe('resolveWorkflowTemplate', () => {
     expect(error).toMatchObject({
       code: 'workflow-template-resolution-failed',
       name: 'WorkflowTemplateResolutionError',
-      expression: '1 / 0',
+      source: '1 / 0',
+    });
+    expect((error as WorkflowTemplateResolutionError).cause).toBeInstanceOf(
+      WorkflowExpressionEvaluationError,
+    );
+  });
+
+  it('wraps missing paths for required context roots in resolution errors', () => {
+    const segments = parseWorkflowTemplate(`run-${templateExpression(' run.id ')}`);
+
+    let error: unknown;
+    try {
+      resolveWorkflowTemplate(segments, {run: {}}, {requiredContextRoots: ['run']});
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(WorkflowTemplateResolutionError);
+    expect(error).toMatchObject({
+      code: 'workflow-template-resolution-failed',
+      name: 'WorkflowTemplateResolutionError',
+      source: 'run.id',
     });
     expect((error as WorkflowTemplateResolutionError).cause).toBeInstanceOf(
       WorkflowExpressionEvaluationError,

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
@@ -94,6 +94,23 @@ describe('resolveWorkflowTemplate', () => {
     });
   });
 
+  it('resolves absent context roots to empty strings with diagnostics', () => {
+    const segments = parseWorkflowTemplate(`push-${templateExpression(' inputs.environment ')}`);
+
+    const result = resolveWorkflowTemplate(segments, {event: {}});
+
+    expect(result).toEqual({
+      value: 'push-',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'inputs.environment',
+          contextRoots: ['inputs'],
+        },
+      ],
+    });
+  });
+
   it('wraps genuine evaluation exceptions in resolution errors', () => {
     const segments = parseWorkflowTemplate(templateExpression(' 1 / 0 '));
 

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
@@ -1,0 +1,131 @@
+import {WorkflowExpressionEvaluationError} from '../evaluator/errors.js';
+import {parseWorkflowTemplate} from '../template/parse-workflow-template.js';
+import {WorkflowTemplateResolutionError} from './errors.js';
+import {
+  resolveWorkflowTemplate,
+  resolveWorkflowTemplateSource,
+} from './resolve-workflow-template.js';
+
+const templateOpen = '$' + '{{';
+const templateClose = '}' + '}';
+
+function templateExpression(source: string): string {
+  return `${templateOpen}${source}${templateClose}`;
+}
+
+describe('resolveWorkflowTemplate', () => {
+  it('returns literal-only templates without diagnostics', () => {
+    const segments = parseWorkflowTemplate('deploy main');
+
+    const result = resolveWorkflowTemplate(segments, {});
+
+    expect(result).toEqual({value: 'deploy main', diagnostics: []});
+  });
+
+  it('concatenates mixed literal and expression segments', () => {
+    const segments = parseWorkflowTemplate(
+      `refs/${templateExpression(' event.ref ')}/${templateExpression(' inputs.environment ')}`,
+    );
+
+    const result = resolveWorkflowTemplate(segments, {
+      event: {ref: 'refs/heads/main'},
+      inputs: {environment: 'prod'},
+    });
+
+    expect(result).toEqual({value: 'refs/refs/heads/main/prod', diagnostics: []});
+  });
+
+  it('coerces expression values through the resolver', () => {
+    const source = [
+      templateExpression(' 42 '),
+      ':',
+      templateExpression(' true '),
+      ':',
+      templateExpression(' event.metadata '),
+    ].join('');
+
+    const result = resolveWorkflowTemplateSource(source, {
+      event: {
+        metadata: {runner: 'macos', labels: ['ship']},
+      },
+    });
+
+    expect(result).toEqual({
+      value: '42:true:{"runner":"macos","labels":["ship"]}',
+      diagnostics: [],
+    });
+  });
+
+  it('resolves missing paths to empty strings with diagnostics', () => {
+    const segments = parseWorkflowTemplate(
+      `prefix-${templateExpression(' event.nope.deep ')}-suffix`,
+    );
+
+    const result = resolveWorkflowTemplate(segments, {
+      event: {pull_request: {title: 'Fix auth'}},
+    });
+
+    expect(result).toEqual({
+      value: 'prefix--suffix',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'event.nope.deep',
+          contextRoots: ['event'],
+        },
+      ],
+    });
+  });
+
+  it('resolves null event paths to empty strings with diagnostics', () => {
+    const segments = parseWorkflowTemplate(`manual-${templateExpression(' event.ref ')}`);
+
+    const result = resolveWorkflowTemplate(segments, {event: null});
+
+    expect(result).toEqual({
+      value: 'manual-',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'event.ref',
+          contextRoots: ['event'],
+        },
+      ],
+    });
+  });
+
+  it('wraps genuine evaluation exceptions in resolution errors', () => {
+    const segments = parseWorkflowTemplate(templateExpression(' 1 / 0 '));
+
+    let error: unknown;
+    try {
+      resolveWorkflowTemplate(segments, {});
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(WorkflowTemplateResolutionError);
+    expect(error).toMatchObject({
+      code: 'workflow-template-resolution-failed',
+      name: 'WorkflowTemplateResolutionError',
+      expression: '1 / 0',
+    });
+    expect((error as WorkflowTemplateResolutionError).cause).toBeInstanceOf(
+      WorkflowExpressionEvaluationError,
+    );
+  });
+
+  it('resolves caller-provided context sets without a hard-coded context list', () => {
+    const source = `artifact:${templateExpression(' steps.build.output ')}`;
+
+    const result = resolveWorkflowTemplateSource(source, {
+      steps: {
+        build: {
+          output: 'dist/app.tar.gz',
+        },
+      },
+    });
+
+    expect(result).toEqual({value: 'artifact:dist/app.tar.gz', diagnostics: []});
+  });
+});

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.ts
@@ -19,9 +19,14 @@ export interface WorkflowTemplateResolution {
   readonly diagnostics: readonly WorkflowTemplateDiagnostic[];
 }
 
+export interface WorkflowTemplateResolutionOptions {
+  readonly requiredContextRoots?: readonly string[];
+}
+
 export function resolveWorkflowTemplate(
   segments: readonly WorkflowTemplateSegment[],
   context: WorkflowExpressionEvaluationContext,
+  options: WorkflowTemplateResolutionOptions = {},
 ): WorkflowTemplateResolution {
   let value = '';
   const diagnostics: WorkflowTemplateDiagnostic[] = [];
@@ -36,16 +41,25 @@ export function resolveWorkflowTemplate(
       value += coerceWorkflowValueToString(evaluateWorkflowExpression(segment.expression, context));
     } catch (error) {
       if (error instanceof WorkflowExpressionEvaluationError && error.reason === 'missing-path') {
-        diagnostics.push({
+        const diagnostic = {
           reason: 'missing-path',
           expression: segment.expression.source,
           contextRoots: segment.contextRoots,
-        });
+        } as const satisfies WorkflowTemplateDiagnostic;
+
+        if (missingPathRequiresFailure(diagnostic, options)) {
+          throw new WorkflowTemplateResolutionError({
+            source: segment.expression.source,
+            cause: error,
+          });
+        }
+
+        diagnostics.push(diagnostic);
         continue;
       }
 
       throw new WorkflowTemplateResolutionError({
-        expression: segment.expression.source,
+        source: segment.expression.source,
         cause: error,
       });
     }
@@ -57,6 +71,15 @@ export function resolveWorkflowTemplate(
 export function resolveWorkflowTemplateSource(
   source: string,
   context: WorkflowExpressionEvaluationContext,
+  options?: WorkflowTemplateResolutionOptions,
 ): WorkflowTemplateResolution {
-  return resolveWorkflowTemplate(parseWorkflowTemplate(source), context);
+  return resolveWorkflowTemplate(parseWorkflowTemplate(source), context, options);
+}
+
+function missingPathRequiresFailure(
+  diagnostic: WorkflowTemplateDiagnostic,
+  options: WorkflowTemplateResolutionOptions,
+): boolean {
+  const requiredContextRoots = options.requiredContextRoots ?? [];
+  return diagnostic.contextRoots.some((contextRoot) => requiredContextRoots.includes(contextRoot));
 }

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.ts
@@ -1,0 +1,62 @@
+import {
+  evaluateWorkflowExpression,
+  type WorkflowExpressionEvaluationContext,
+  WorkflowExpressionEvaluationError,
+} from '../evaluator/index.js';
+import {parseWorkflowTemplate} from '../template/parse-workflow-template.js';
+import type {WorkflowTemplateSegment} from '../template/template-segment.js';
+import {coerceWorkflowValueToString} from './coerce-workflow-value-to-string.js';
+import {WorkflowTemplateResolutionError} from './errors.js';
+
+export interface WorkflowTemplateDiagnostic {
+  readonly reason: 'missing-path';
+  readonly expression: string;
+  readonly contextRoots: readonly string[];
+}
+
+export interface WorkflowTemplateResolution {
+  readonly value: string;
+  readonly diagnostics: readonly WorkflowTemplateDiagnostic[];
+}
+
+export function resolveWorkflowTemplate(
+  segments: readonly WorkflowTemplateSegment[],
+  context: WorkflowExpressionEvaluationContext,
+): WorkflowTemplateResolution {
+  let value = '';
+  const diagnostics: WorkflowTemplateDiagnostic[] = [];
+
+  for (const segment of segments) {
+    if (segment.kind === 'literal') {
+      value += segment.text;
+      continue;
+    }
+
+    try {
+      value += coerceWorkflowValueToString(evaluateWorkflowExpression(segment.expression, context));
+    } catch (error) {
+      if (error instanceof WorkflowExpressionEvaluationError && error.reason === 'missing-path') {
+        diagnostics.push({
+          reason: 'missing-path',
+          expression: segment.expression.source,
+          contextRoots: segment.contextRoots,
+        });
+        continue;
+      }
+
+      throw new WorkflowTemplateResolutionError({
+        expression: segment.expression.source,
+        cause: error,
+      });
+    }
+  }
+
+  return {value, diagnostics};
+}
+
+export function resolveWorkflowTemplateSource(
+  source: string,
+  context: WorkflowExpressionEvaluationContext,
+): WorkflowTemplateResolution {
+  return resolveWorkflowTemplate(parseWorkflowTemplate(source), context);
+}


### PR DESCRIPTION
Adds a pure workflow template resolver for `@shipfox/expression` that evaluates parsed `${{ ... }}` segments against a caller-provided context bundle and returns the resolved string plus diagnostics.

Workflow run creation needs interpolation to degrade cleanly when optional paths are missing, while still failing loudly for genuine evaluator errors. This classifies CEL `no_such_key` failures as missing-path diagnostics, coerces CEL values to strings, and wraps other evaluation failures in a typed resolution error for the materialization path to handle.

The resolver takes the context bundle as an argument and does not hard-code the v1 context set, so future dispatch-time contexts like `steps` can use the same core API. A minor changeset is included for the new public resolver exports.

Closes ENG-634

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pure workflow template resolver to `@shipfox/expression` that evaluates `${{ ... }}` against a provided context and returns a resolved string plus diagnostics. Also treats absent context roots as missing paths and allows marking required roots that must fail; addresses ENG-634.

- **New Features**
  - Adds `resolveWorkflowTemplate` and `resolveWorkflowTemplateSource` returning `{ value, diagnostics }`.
  - Coerces values to strings: strings/numbers/bigints/booleans/`Date`/JSON; `null`/`undefined` → ''.
  - Missing paths (nested keys or absent context roots) resolve to '' with diagnostics `reason: 'missing-path'`.
  - New `requiredContextRoots` option: missing paths on these roots throw `WorkflowTemplateResolutionError`; errors include the failing expression `source`.
  - `WorkflowExpressionEvaluationError` classifies `no_such_key`/`unknown_variable` as `'missing-path'`, others as `'evaluation-error'`. New exports include resolver APIs, errors, and `WorkflowExpressionEvaluationFailureReason`.

<sup>Written for commit d34ee1efc58af2ff0d242472058cedeff239ff9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

