### PR TITLE
Clarify settings integration copy

### DIFF
--- a/e2e/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/client/integrations/tests/integration-flows.e2e.ts
@@ -17,11 +17,11 @@ async function expectSetupNavigationHidden(page: Page): Promise<void> {
   await expect(page.getByLabel('Switch workspace')).toBeVisible();
 }
 
-test('connecting Debug from onboarding flows into project creation', async ({page, auth}) => {
+test('installing Debug from onboarding flows into project creation', async ({page, auth}) => {
   const user = await auth.createUser();
   await auth.loginAs(page, user);
 
-  // Reproduces the user-reported flow: a fresh user lands on Connect source
+  // Reproduces the user-reported flow: a fresh user lands on Install source
   // control via the onboarding handoff (so WorkspaceSetupGuard has already
   // populated the projects + source-connections caches with empty data for this
   // workspace), then clicks Debug to create their first connection.
@@ -29,7 +29,7 @@ test('connecting Debug from onboarding flows into project creation', async ({pag
   await page.getByLabel('Workspace name').fill(`E2E Workspace ${randomUUID()}`);
   await page.getByRole('button', {name: 'Create workspace'}).click();
   await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
-  await expect(page.getByRole('heading', {name: 'Connect source control'})).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Install source control'})).toBeVisible();
   await expectSetupNavigationHidden(page);
 
   const wid = new URL(page.url()).pathname.split('/')[2];
@@ -40,7 +40,7 @@ test('connecting Debug from onboarding flows into project creation', async ({pag
   // DebugInstallPage creates the connection on mount, fires the success toast,
   // then navigates back to /workspaces/$wid. The setup guard should see the new
   // connection plus zero projects and forward the user to /projects/new.
-  await expect(page.getByText('Debug source control connected.')).toBeVisible();
+  await expect(page.getByText('Debug source control installed.')).toBeVisible();
   await expect(page).not.toHaveURL(DEBUG_INSTALL_URL_RE);
   await expect(page).not.toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
   await expect(page).toHaveURL(projectsNewUrlRe(wid as string));

--- a/e2e/client/integrations/tests/sentry-callback.e2e.ts
+++ b/e2e/client/integrations/tests/sentry-callback.e2e.ts
@@ -92,18 +92,18 @@ test('Sentry callback shows the workspace picker', async ({page, auth, workspace
 
   await page.goto(CALLBACK_URL);
 
-  await expect(page.getByRole('heading', {name: 'Connect Sentry'})).toBeVisible();
-  await expect(page.getByText('Connect the Sentry org "acme" to a workspace.')).toBeVisible();
-  await expect(page.getByRole('button', {name: 'Connect'})).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Install Sentry'})).toBeVisible();
+  await expect(page.getByText('Install the Sentry org "acme" in a workspace.')).toBeVisible();
+  await expect(page.getByRole('button', {name: 'Install'})).toBeVisible();
 
   await argosScreenshot(page, 'integrations/sentry-callback-pick-workspace');
 });
 
-test('Sentry callback connects to a workspace on success', async ({page, auth, workspaces}) => {
+test('Sentry callback installs to a workspace on success', async ({page, auth, workspaces}) => {
   const user = await auth.createUser();
   const workspace = await workspaces.create({
     userId: user.user.id,
-    name: 'Sentry Connect Workspace',
+    name: 'Sentry Install Workspace',
   });
   await auth.loginAs(page, user);
 
@@ -111,12 +111,12 @@ test('Sentry callback connects to a workspace on success', async ({page, auth, w
   await stubProjectExists(page, workspace.id);
 
   await page.goto(CALLBACK_URL);
-  await expect(page.getByRole('heading', {name: 'Connect Sentry'})).toBeVisible();
-  await page.getByRole('button', {name: 'Connect'}).click();
+  await expect(page.getByRole('heading', {name: 'Install Sentry'})).toBeVisible();
+  await page.getByRole('button', {name: 'Install'}).click();
 
   // The stub never persisted a connection, so we assert only the success toast
   // and the redirect target — not that Sentry appears in the gallery.
-  await expect(page.getByText('Sentry connected.')).toBeVisible();
+  await expect(page.getByText('Sentry installed.')).toBeVisible();
   await expect(page).toHaveURL(
     new RegExp(`/workspaces/${workspace.id}/settings/integrations/?$`, 'u'),
   );
@@ -144,7 +144,7 @@ test('Sentry callback offers Start over on a terminal failure', async ({
   await page.goto(
     '/integrations/sentry/callback?code=spent-code&installation_id=test-install&org_slug=acme',
   );
-  await page.getByRole('button', {name: 'Connect'}).click();
+  await page.getByRole('button', {name: 'Install'}).click();
 
   await expect(
     page.getByText('This Sentry link could not be completed. Start the install again.'),
@@ -167,7 +167,7 @@ test('Sentry callback offers Retry on a retryable failure', async ({page, auth, 
   });
 
   await page.goto(CALLBACK_URL);
-  await page.getByRole('button', {name: 'Connect'}).click();
+  await page.getByRole('button', {name: 'Install'}).click();
 
   await expect(
     page.getByText('Sentry is rate limiting requests. Try again in a moment.'),

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -76,15 +76,15 @@ test('settings catalogue lists available providers with an empty installed state
   await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
 
   await expect(page.getByRole('heading', {name: 'Available integrations'})).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Connect GitHub'})).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Connect Sentry'})).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Connect Debug'})).toBeVisible();
-  await expect(page.getByText('No integrations connected yet')).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Install GitHub'})).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Install Sentry'})).toBeVisible();
+  await expect(page.getByRole('link', {name: 'Install Debug'})).toBeVisible();
+  await expect(page.getByText('No integrations installed yet')).toBeVisible();
 
   await argosScreenshot(page, 'integrations/settings-empty');
 });
 
-test('settings catalogue shows a connected provider after Debug connect', async ({
+test('settings catalogue shows an installed provider after Debug install', async ({
   page,
   auth,
   workspaces,
@@ -97,11 +97,11 @@ test('settings catalogue shows a connected provider after Debug connect', async 
   await auth.loginAs(page, user);
   await stubProjectExists(page, workspace.id);
 
-  // Real Debug connect (no external dependency): the install page creates the
+  // Real Debug install (no external dependency): the install page creates the
   // connection on mount, fires the success toast, then forwards to
   // /workspaces/$wid, so we explicitly return to settings to inspect the row.
   await page.goto(`/workspaces/${workspace.id}/integrations/debug`);
-  await expect(page.getByText('Debug source control connected.')).toBeVisible();
+  await expect(page.getByText('Debug source control installed.')).toBeVisible();
 
   await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
 

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -60,7 +60,7 @@ async function stubProjectsExist(page: Page, workspaceIds: ReadonlyArray<string>
 
 async function completeWorkspaceSetup(page: Page, workspaceId: string): Promise<void> {
   await page.goto(`/workspaces/${workspaceId}/integrations/debug`);
-  await expect(page.getByText('Debug source control connected.')).toBeVisible();
+  await expect(page.getByText('Debug source control installed.')).toBeVisible();
   await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/projects/new/?$`, 'u'));
   await expect(page.getByRole('radio', {name: DEBUG_REPOSITORY_RE})).toBeVisible();
   await expect(page.getByRole('button', {name: 'Create project'})).toBeEnabled();
@@ -111,7 +111,7 @@ test('creates the first workspace via onboarding and persists lastWorkspaceId', 
   await page.getByRole('button', {name: 'Create workspace'}).click();
 
   await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
-  await expect(page.getByRole('heading', {name: 'Connect source control'})).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Install source control'})).toBeVisible();
   await expectSetupNavigationHidden(page);
   const url = new URL(page.url());
   const wid = url.pathname.split('/')[2];
@@ -185,7 +185,7 @@ test('routes setup workspace settings back to source-control onboarding', async 
   await page.goto(`/workspaces/${workspace.id}/settings`);
 
   await expect(page).toHaveURL(new RegExp(`/workspaces/${workspace.id}/integrations/?$`, 'u'));
-  await expect(page.getByRole('heading', {name: 'Connect source control'})).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Install source control'})).toBeVisible();
   await expectSetupNavigationHidden(page);
 });
 

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -74,7 +74,7 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(screen.queryByText(ANTHROPIC_FINGERPRINT_RE)).not.toBeInTheDocument();
     expect(screen.getByText('Available providers')).toBeVisible();
     expect(
-      screen.getByText('Providers that can be configured with workspace-managed API keys.'),
+      screen.getByText('Providers that can be configured for agent jobs in this workspace.'),
     ).toBeVisible();
     expect(screen.getByText('OpenAI')).toBeVisible();
     expect(screen.getByText('Unsupported providers')).toBeVisible();

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -74,7 +74,7 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(screen.queryByText(ANTHROPIC_FINGERPRINT_RE)).not.toBeInTheDocument();
     expect(screen.getByText('Available providers')).toBeVisible();
     expect(
-      screen.getByText('Providers that can be configured for agent jobs in this workspace.'),
+      screen.getByText('Providers that can be configured for agent steps in this workspace.'),
     ).toBeVisible();
     expect(screen.getByText('OpenAI')).toBeVisible();
     expect(screen.getByText('Unsupported providers')).toBeVisible();

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -73,6 +73,9 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(screen.getByText('Default provider')).toHaveClass('sr-only');
     expect(screen.queryByText(ANTHROPIC_FINGERPRINT_RE)).not.toBeInTheDocument();
     expect(screen.getByText('Available providers')).toBeVisible();
+    expect(
+      screen.getByText('Providers that can be configured with workspace-managed API keys.'),
+    ).toBeVisible();
     expect(screen.getByText('OpenAI')).toBeVisible();
     expect(screen.getByText('Unsupported providers')).toBeVisible();
     expect(screen.getByText('Amazon Bedrock')).toBeVisible();

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -138,7 +138,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         <div className="flex flex-col gap-4">
           <Header variant="h3">Available providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Supported providers ready for workspace credentials.
+            Providers that can be configured with workspace-managed API keys.
           </Text>
         </div>
 

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -138,7 +138,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         <div className="flex flex-col gap-4">
           <Header variant="h3">Available providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Providers that can be configured with workspace-managed API keys.
+            Providers that can be configured for agent jobs in this workspace.
           </Text>
         </div>
 
@@ -177,7 +177,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         <div className="flex flex-col gap-4">
           <Header variant="h3">Unsupported providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Providers that cannot use workspace-managed API keys yet.
+            Providers that cannot be configured in this workspace yet.
           </Text>
         </div>
 

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -479,7 +479,7 @@ function AvailableProviderCard({
             {entry.label}
           </Text>
           <div className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-            <Text size="sm">Connect</Text>
+            <Text size="sm">Configure</Text>
             <Icon name="chevronRight" className="size-16" />
           </div>
         </div>

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -86,7 +86,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         <div className="flex flex-col gap-4">
           <Header variant="h3">Configured providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Workspace credentials available to agent jobs.
+            Workspace credentials available to agent steps.
           </Text>
         </div>
 
@@ -105,7 +105,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
             <EmptyState
               icon="key2Line"
               title="No providers configured"
-              description="Configure a provider below to run agent jobs with workspace-managed credentials."
+              description="Configure a provider below to run agent steps with workspace-managed credentials."
             />
           </div>
         ) : null}
@@ -138,7 +138,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         <div className="flex flex-col gap-4">
           <Header variant="h3">Available providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Providers that can be configured for agent jobs in this workspace.
+            Providers that can be configured for agent steps in this workspace.
           </Text>
         </div>
 

--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -105,7 +105,7 @@ describe('IntegrationGallery — installed section', () => {
 
     expect(await screen.findByText('acme-one')).toBeVisible();
     expect(screen.getByText('acme-two')).toBeVisible();
-    expect(screen.getByText('Provider accounts linked to this workspace.')).toBeVisible();
+    expect(screen.getByText('Provider accounts installed in this workspace.')).toBeVisible();
   });
 
   test('sorts stably by provider name then created_at regardless of input order', async () => {
@@ -263,29 +263,29 @@ describe('IntegrationGallery — installed section', () => {
 
     expect(await screen.findByText("Couldn't load integrations")).toBeInTheDocument();
     expect(screen.queryByText("Couldn't load available integrations")).not.toBeInTheDocument();
-    expect(within(availableRegion()).getByRole('link', {name: 'Connect GitHub'})).toBeVisible();
+    expect(within(availableRegion()).getByRole('link', {name: 'Install GitHub'})).toBeVisible();
   });
 
   test('shows the empty state in the settings context', async () => {
     renderGallery({}, {connections: []});
 
-    expect(await screen.findByText('No integrations connected yet')).toBeVisible();
+    expect(await screen.findByText('No integrations installed yet')).toBeVisible();
   });
 });
 
 describe('IntegrationGallery — available section', () => {
-  test('lists every provider with a Connect link, including connected ones', async () => {
+  test('lists every provider with an Install link, including installed ones', async () => {
     renderGallery({}, {connections: [githubConnection]});
 
-    expect(await screen.findByRole('link', {name: 'Connect GitHub'})).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Connect Sentry'})).toBeVisible();
-    expect(screen.getByText('Providers available to connect to this workspace.')).toBeVisible();
+    expect(await screen.findByRole('link', {name: 'Install GitHub'})).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Install Sentry'})).toBeVisible();
+    expect(screen.getByText('Providers available to install in this workspace.')).toBeVisible();
   });
 
   test('exposes each available tile as a single link with no nested button', async () => {
     renderGallery({}, {connections: [githubConnection]});
 
-    const link = await screen.findByRole('link', {name: 'Connect GitHub'});
+    const link = await screen.findByRole('link', {name: 'Install GitHub'});
 
     expect(link).toHaveClass('focus-visible:shadow-button-neutral-focus');
     expect(link.className).not.toContain('shadow-button-secondary');
@@ -310,8 +310,8 @@ describe('IntegrationGallery — available section', () => {
       },
     );
 
-    await screen.findByRole('link', {name: 'Connect GitHub'});
+    await screen.findByRole('link', {name: 'Install GitHub'});
 
-    expect(screen.queryByRole('link', {name: 'Connect Mystery'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', {name: 'Install Mystery'})).not.toBeInTheDocument();
   });
 });

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -80,7 +80,7 @@ export function IntegrationGallery({
         <div className="flex flex-col gap-4">
           <Header variant="h3">Installed integrations</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Provider accounts linked to this workspace.
+            Provider accounts installed in this workspace.
           </Text>
         </div>
 
@@ -96,8 +96,8 @@ export function IntegrationGallery({
           <div className={cn(SURFACE_CLASS, 'px-16')}>
             <EmptyState
               icon="componentLine"
-              title="No integrations connected yet"
-              description="Connect a provider below to get started."
+              title="No integrations installed yet"
+              description="Install a provider below to get started."
             />
           </div>
         ) : null}
@@ -119,7 +119,7 @@ export function IntegrationGallery({
         <div className="flex flex-col gap-4">
           <Header variant="h3">Available integrations</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
-            Providers available to connect to this workspace.
+            Providers available to install in this workspace.
           </Text>
         </div>
 

--- a/libs/client/integrations/src/components/provider-grid.tsx
+++ b/libs/client/integrations/src/components/provider-grid.tsx
@@ -79,7 +79,7 @@ function ProviderCard({
     <Link
       to={catalog.setupPath}
       params={{wid: workspaceId}}
-      aria-label={`Connect ${provider.display_name}`}
+      aria-label={`Install ${provider.display_name}`}
       className="group block h-full rounded-8 focus-visible:shadow-button-neutral-focus focus-visible:outline-none"
     >
       <Card className="h-full p-16 transition-colors hover:bg-background-components-hover">
@@ -95,7 +95,7 @@ function ProviderCard({
             </Text>
           </div>
           <div className="flex shrink-0 items-center gap-4 text-foreground-neutral-muted transition-colors group-hover:text-foreground-highlight-interactive">
-            <Text size="sm">Connect</Text>
+            <Text size="sm">Install</Text>
             <Icon name="chevronRight" className="size-16" />
           </div>
         </div>

--- a/libs/client/integrations/src/pages/debug-install-page.tsx
+++ b/libs/client/integrations/src/pages/debug-install-page.tsx
@@ -28,12 +28,12 @@ export function DebugInstallPage() {
           // and leave the cache stale until the next navigation reads it.
           refetchType: 'all',
         });
-        toast.success('Debug source control connected.');
+        toast.success('Debug source control installed.');
         await navigate({to: '/workspaces/$wid', params: {wid: workspaceId}});
       })
       .catch((error: unknown) => {
         setErrorMessage(
-          error instanceof ApiError ? error.message : 'Could not connect Debug source control.',
+          error instanceof ApiError ? error.message : 'Could not install Debug source control.',
         );
       });
   }, [workspace, createConnection, queryClient, navigate]);

--- a/libs/client/integrations/src/pages/gitea-form-errors.test.ts
+++ b/libs/client/integrations/src/pages/gitea-form-errors.test.ts
@@ -22,7 +22,7 @@ describe('giteaConnectErrorToFormError', () => {
     expect(result).toEqual({
       kind: 'field',
       field: 'org',
-      message: 'That organization is already connected.',
+      message: 'That organization is already installed.',
     });
   });
 

--- a/libs/client/integrations/src/pages/gitea-form-errors.ts
+++ b/libs/client/integrations/src/pages/gitea-form-errors.ts
@@ -17,7 +17,7 @@ export function giteaConnectErrorToFormError(error: unknown): GiteaConnectFormEr
     };
   }
   if (code === 'gitea-org-already-linked') {
-    return {kind: 'field', field: 'org', message: 'That organization is already connected.'};
+    return {kind: 'field', field: 'org', message: 'That organization is already installed.'};
   }
 
   return {kind: 'form', message: giteaConnectErrorMessage(error)};

--- a/libs/client/integrations/src/pages/gitea-install-page.tsx
+++ b/libs/client/integrations/src/pages/gitea-install-page.tsx
@@ -38,7 +38,7 @@ export function GiteaInstallPage() {
           // after the home redirects back here.
           refetchType: 'all',
         });
-        toast.success('Gitea organization connected.');
+        toast.success('Gitea organization installed.');
         await navigate({to: '/workspaces/$wid', params: {wid: workspaceId}});
       } catch (error) {
         const mapped = giteaConnectErrorToFormError(error);
@@ -57,9 +57,9 @@ export function GiteaInstallPage() {
   return (
     <div className="mx-auto flex w-full max-w-[480px] flex-col gap-20">
       <header className="flex flex-col gap-8">
-        <Header variant="h1">Connect Gitea</Header>
+        <Header variant="h1">Install Gitea</Header>
         <Text size="md" className="text-foreground-neutral-muted">
-          Enter the Gitea organization to connect to this workspace.
+          Enter the Gitea organization to install in this workspace.
         </Text>
       </header>
 
@@ -96,7 +96,7 @@ export function GiteaInstallPage() {
         </form.Field>
         <div className="flex items-center gap-12">
           <Button type="submit" isLoading={connect.isPending}>
-            Connect
+            Install
           </Button>
           <ButtonLink asChild variant="muted">
             <Link to="/workspaces/$wid/integrations" params={{wid: workspace.id}}>

--- a/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.test.tsx
@@ -53,11 +53,11 @@ beforeEach(() => {
 });
 
 describe('SentryCallbackPage', () => {
-  test('always asks for confirmation and never auto-connects', async () => {
+  test('always asks for confirmation and never auto-installs', async () => {
     renderCallback({installationId: 'install-confirm', orgSlug: 'acme'});
 
-    expect(await screen.findByText('Connect the Sentry org "acme" to a workspace.')).toBeVisible();
-    expect(screen.getByRole('button', {name: 'Connect'})).toBeVisible();
+    expect(await screen.findByText('Install the Sentry org "acme" in a workspace.')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Install'})).toBeVisible();
     expect(connectSentryMock).not.toHaveBeenCalled();
   });
 
@@ -67,7 +67,7 @@ describe('SentryCallbackPage', () => {
     renderCallback({installationId: 'install-loading', loadingAuth: true});
 
     expect(await screen.findByRole('status', {name: 'Loading'})).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Connect'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Install'})).not.toBeInTheDocument();
     expect(connectSentryMock).not.toHaveBeenCalled();
   });
 
@@ -86,7 +86,7 @@ describe('SentryCallbackPage', () => {
 
     expect(await screen.findByText('Acme')).toBeVisible();
     expect(screen.getByText('Beta')).toBeVisible();
-    expect(screen.getAllByRole('button', {name: 'Connect'})).toHaveLength(2);
+    expect(screen.getAllByRole('button', {name: 'Install'})).toHaveLength(2);
   });
 
   test('renders a terminal state when params are missing', async () => {
@@ -94,15 +94,15 @@ describe('SentryCallbackPage', () => {
 
     // Alert mounts via framer-motion (opacity 0 in jsdom), so assert presence.
     expect(await screen.findByText(MISSING_PARAMS_RE)).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Connect'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Install'})).not.toBeInTheDocument();
     expect(connectSentryMock).not.toHaveBeenCalled();
   });
 
-  test('connects on click and lands on the settings integrations page', async () => {
+  test('installs on click and lands on the settings integrations page', async () => {
     connectSentryMock.mockResolvedValue({});
     renderCallback({installationId: 'install-success'});
 
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
 
     await screen.findByTestId('route:/workspaces/$wid/settings/integrations');
     expect(connectSentryMock).toHaveBeenCalledWith({
@@ -123,7 +123,7 @@ describe('SentryCallbackPage', () => {
       .mockResolvedValueOnce({});
     renderCallback({installationId: 'install-retry'});
 
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
     fireEvent.click(await screen.findByRole('button', {name: 'Retry'}));
 
     await screen.findByTestId('route:/workspaces/$wid/settings/integrations');
@@ -145,12 +145,12 @@ describe('SentryCallbackPage', () => {
     renderCallback({installationId: 'install-lock-recover'});
 
     // First failure is rate-limited, so the lock disables Retry.
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
     await waitFor(() => expect(screen.getByRole('button', {name: 'Retry'})).toBeDisabled());
 
-    // A second attempt (via the still-enabled workspace Connect) fails with no
+    // A second attempt (via the still-enabled workspace Install) fails with no
     // backoff hint — the lock must clear so the user is not stranded.
-    fireEvent.click(screen.getByRole('button', {name: 'Connect'}));
+    fireEvent.click(screen.getByRole('button', {name: 'Install'}));
     await waitFor(() => expect(screen.getByRole('button', {name: 'Retry'})).toBeEnabled());
   });
 
@@ -160,7 +160,7 @@ describe('SentryCallbackPage', () => {
     );
     renderCallback({installationId: 'install-terminal'});
 
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
 
     expect(await screen.findByText('Sentry rejected the code.')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Start over'})).toBeInTheDocument();
@@ -177,10 +177,10 @@ describe('SentryCallbackPage', () => {
     );
     renderCallback({installationId: 'install-409'});
 
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
 
     expect(
-      await screen.findByText('This Sentry org is already connected to another workspace.'),
+      await screen.findByText('This Sentry org is already installed in another workspace.'),
     ).toBeInTheDocument();
     expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
     expect(screen.queryByRole('link', {name: 'Start over'})).not.toBeInTheDocument();
@@ -191,13 +191,13 @@ describe('SentryCallbackPage', () => {
       new ApiError({message: 'down', code: 'timeout', status: 503}),
     );
     const first = renderCallback({installationId: 'install-remount'});
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
     await screen.findByRole('button', {name: 'Retry'});
     first.unmount();
 
     connectSentryMock.mockResolvedValue({});
     renderCallback({installationId: 'install-remount'});
-    fireEvent.click(await screen.findByRole('button', {name: 'Connect'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Install'}));
 
     await screen.findByTestId('route:/workspaces/$wid/settings/integrations');
     await waitFor(() => expect(connectSentryMock).toHaveBeenCalledTimes(2));

--- a/libs/client/integrations/src/pages/sentry-callback-page.tsx
+++ b/libs/client/integrations/src/pages/sentry-callback-page.tsx
@@ -62,7 +62,7 @@ export function SentryCallbackPage() {
   const noWorkspace = !isLoading && preselection.kind === 'none';
   useEffect(() => {
     if (!noWorkspace) return;
-    toast.error('You need a workspace before connecting Sentry.');
+    toast.error('You need a workspace before installing Sentry.');
     navigate({to: '/', replace: true});
   }, [noWorkspace, navigate]);
 
@@ -134,7 +134,7 @@ export function SentryCallbackPage() {
           queryKey: integrationsQueryKeys.connectionsByWorkspace(workspaceId),
         });
         if (disposedRef.current) return;
-        toast.success('Sentry connected.');
+        toast.success('Sentry installed.');
         await navigate({
           to: '/workspaces/$wid/settings/integrations',
           params: {wid: workspaceId},
@@ -166,11 +166,11 @@ export function SentryCallbackPage() {
   return (
     <CallbackColumn>
       <header className="flex flex-col gap-8">
-        <Header variant="h2">Connect Sentry</Header>
+        <Header variant="h2">Install Sentry</Header>
         <Text size="sm" className="text-foreground-neutral-muted">
           {params.orgSlug
-            ? `Connect the Sentry org "${params.orgSlug}" to a workspace.`
-            : 'Connect this Sentry installation to a workspace.'}
+            ? `Install the Sentry org "${params.orgSlug}" in a workspace.`
+            : 'Install this Sentry integration in a workspace.'}
         </Text>
       </header>
 
@@ -213,7 +213,7 @@ export function SentryCallbackPage() {
                 isLoading={connectingId === workspace.id}
                 onClick={() => connect(workspace.id)}
               >
-                Connect
+                Install
               </Button>
             </div>
           </Card>

--- a/libs/client/integrations/src/pages/source-control-onboarding-page.test.tsx
+++ b/libs/client/integrations/src/pages/source-control-onboarding-page.test.tsx
@@ -30,12 +30,12 @@ describe('SourceControlOnboardingPage', () => {
       extraRoutes: ['/workspaces/$wid/integrations/github'],
     });
 
-    expect(await screen.findByRole('heading', {name: 'Connect source control'})).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Connect GitHub'})).toBeVisible();
+    expect(await screen.findByRole('heading', {name: 'Install source control'})).toBeVisible();
+    expect(screen.getByRole('link', {name: 'Install GitHub'})).toBeVisible();
     expect(screen.queryByRole('region', {name: 'Installed integrations'})).not.toBeInTheDocument();
     expect(screen.queryByRole('region', {name: 'Available integrations'})).not.toBeInTheDocument();
     expect(
-      screen.queryByText('Provider accounts linked to this workspace.'),
+      screen.queryByText('Provider accounts installed in this workspace.'),
     ).not.toBeInTheDocument();
 
     const urls = fetchImpl.mock.calls.map(([input]) =>

--- a/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
+++ b/libs/client/integrations/src/pages/source-control-onboarding-page.tsx
@@ -10,7 +10,7 @@ export function SourceControlOnboardingPage() {
   return (
     <div className="mx-auto flex w-full max-w-[640px] flex-col gap-20">
       <header className="flex flex-col gap-8">
-        <Header variant="h1">Connect source control</Header>
+        <Header variant="h1">Install source control</Header>
         <Text size="md" className="text-foreground-neutral-muted">
           Shipfox needs a source control integration to import your repositories.
         </Text>

--- a/libs/client/integrations/src/sentry-callback.test.ts
+++ b/libs/client/integrations/src/sentry-callback.test.ts
@@ -127,7 +127,7 @@ describe('classifySentryConnectError', () => {
 
     expect(result).toEqual({
       kind: 'terminal',
-      message: 'This Sentry org is already connected to another workspace.',
+      message: 'This Sentry org is already installed in another workspace.',
       startOver: false,
     });
   });
@@ -198,13 +198,13 @@ describe('classifySentryConnectError', () => {
   test('5xx ApiError falls back to retryable', () => {
     const result = classifySentryConnectError(apiError({code: 'server-error', status: 500}));
 
-    expect(result).toEqual({kind: 'retryable', message: 'Could not connect Sentry. Try again.'});
+    expect(result).toEqual({kind: 'retryable', message: 'Could not install Sentry. Try again.'});
   });
 
   test('unknown errors fall back to retryable', () => {
     const result = classifySentryConnectError(new Error('network down'));
 
-    expect(result).toEqual({kind: 'retryable', message: 'Could not connect Sentry. Try again.'});
+    expect(result).toEqual({kind: 'retryable', message: 'Could not install Sentry. Try again.'});
   });
 });
 

--- a/libs/client/integrations/src/sentry-callback.ts
+++ b/libs/client/integrations/src/sentry-callback.ts
@@ -60,7 +60,7 @@ export type SentryWorkspacePreselection =
   | {kind: 'none'};
 
 // Sentry's redirect carries no state token, so the callback can never prove it
-// belongs to an install the user started — connecting always requires an
+// belongs to an install the user started — installation always requires an
 // explicit click. The stored id (and a sole workspace) only pre-select.
 export function preselectSentryWorkspace(
   storedId: string | undefined,
@@ -83,7 +83,7 @@ export function classifySentryConnectError(error: unknown): SentryConnectFailure
     if (error.code === 'sentry-installation-already-linked') {
       return {
         kind: 'terminal',
-        message: 'This Sentry org is already connected to another workspace.',
+        message: 'This Sentry org is already installed in another workspace.',
         // Retrying or starting over would fail identically.
         startOver: false,
       };
@@ -123,7 +123,7 @@ export function classifySentryConnectError(error: unknown): SentryConnectFailure
       return {kind: 'terminal', message: error.message, startOver: true};
     }
   }
-  return {kind: 'retryable', message: 'Could not connect Sentry. Try again.'};
+  return {kind: 'retryable', message: 'Could not install Sentry. Try again.'};
 }
 
 function retryAfterSeconds(details: unknown): number | undefined {

--- a/libs/client/router/src/routes/integrations/github/callback.tsx
+++ b/libs/client/router/src/routes/integrations/github/callback.tsx
@@ -60,7 +60,7 @@ function GithubCallbackRoute() {
         if (disposed) return;
         if (!toastedCallbacks.has(key)) {
           toastedCallbacks.add(key);
-          toast.success('GitHub connected.');
+          toast.success('GitHub installed.');
         }
         navigate({to: '/', replace: true});
       })
@@ -124,5 +124,5 @@ function numberParam(value: unknown): number | undefined {
 function githubCallbackErrorMessage(error: unknown): string {
   if (error instanceof ApiError) return error.message;
   if (error instanceof Error) return error.message;
-  return 'Could not connect GitHub.';
+  return 'Could not install GitHub.';
 }

--- a/libs/client/workspace-settings/src/pages/agent-providers-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/agent-providers-settings-page.test.tsx
@@ -38,5 +38,7 @@ describe('AgentProvidersSettingsPage', () => {
     expect(await screen.findByText('No providers configured')).toBeVisible();
     expect(screen.getByText('Available providers')).toBeVisible();
     expect(screen.getByRole('button', {name: 'Configure Anthropic'})).toBeVisible();
+    expect(screen.getByText('Configure')).toBeVisible();
+    expect(screen.queryByText('Connect')).not.toBeInTheDocument();
   });
 });

--- a/libs/client/workspace-settings/src/pages/integrations-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/integrations-settings-page.test.tsx
@@ -67,6 +67,8 @@ describe('IntegrationsSettingsPage', () => {
     expect(screen.getByRole('region', {name: 'Available integrations'})).toBeInTheDocument();
     expect(await screen.findByText('acme-corp')).toBeVisible();
     expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+    expect(screen.queryByText('Connect')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Install GitHub'})).toBeVisible();
     expect(screen.getByText(ADDED_META_RE)).toBeVisible();
   });
 });


### PR DESCRIPTION
Clarify workspace settings copy so integration providers consistently use install/installed language and agent providers consistently use configure/configured language.

The two settings surfaces were mixing connect/connected with their intended product verbs, which made integration installation and agent credential configuration read like the same action. This updates the rendered labels, empty states, install flow toasts/errors, and callback copy to keep those concepts distinct.

The touched client packages are private, so no changeset is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardize settings terminology: integrations now use “Install/Installed,” agent providers use “Configure/Configured,” and copy now says “agent steps” (no API key wording). This clarifies installation vs. credential configuration across settings, onboarding, callbacks, and toasts.

- **Refactors**
  - Replaced “Connect/Connected” with “Install/Installed” across the integration gallery, provider grid, settings catalogue, source control onboarding, and Gitea/Sentry/GitHub callback pages; updated headers, aria-labels, buttons, toasts, empty states, and form/error messages. E2E expectations updated to match.
  - Agent providers now use “Configure/Configured” with “agent steps” terminology; updated section subtitles and empty states to remove API key language. Tests updated; no behavior changes.

<sup>Written for commit cb3c30aa0afe71822a8258c2f73ea2997dc9f8a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

