### PR TITLE
Set up Vercel client previews

### DIFF
--- a/libs/client/integrations/vercel.json
+++ b/libs/client/integrations/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo build && pnpm run storybook:build",
+  "devCommand": "pnpm run storybook",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
+}

--- a/libs/client/runners/.storybook/main.ts
+++ b/libs/client/runners/.storybook/main.ts
@@ -1,0 +1,1 @@
+export {default} from '../../.storybook/main.ts';

--- a/libs/client/runners/.storybook/preview.css
+++ b/libs/client/runners/.storybook/preview.css
@@ -1,0 +1,4 @@
+@import "@shipfox/react-ui/index.css";
+
+@source "../src";
+@source "../../../shared/react/ui/src";

--- a/libs/client/runners/.storybook/preview.tsx
+++ b/libs/client/runners/.storybook/preview.tsx
@@ -1,0 +1,55 @@
+import './preview.css';
+import {ThemeProvider} from '@shipfox/react-ui';
+import type {Decorator, Preview} from '@storybook/react';
+
+if (typeof document !== 'undefined' && document.fonts) {
+  void Promise.all([
+    document.fonts.load("16px 'Inter'"),
+    document.fonts.load("italic 16px 'Inter'"),
+    document.fonts.load("16px 'Commit Mono'"),
+    document.fonts.load("bold 16px 'Commit Mono'"),
+  ]);
+}
+
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-theme-${theme}`}>
+      <Story />
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    argos: {
+      modes: {
+        light: {theme: 'light'},
+        dark: {theme: 'dark'},
+      },
+      fitToContent: false,
+    },
+    options: {
+      storySort: {method: 'alphabetical'},
+    },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {value: 'light', icon: 'sun', title: 'Light'},
+          {value: 'dark', icon: 'moon', title: 'Dark'},
+          {value: 'system', icon: 'info', title: 'System'},
+        ],
+        showName: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/libs/client/runners/package.json
+++ b/libs/client/runners/package.json
@@ -30,6 +30,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "storybook": "storybook dev -p 6012",
+    "storybook:build": "storybook build -o storybook-static",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
@@ -49,18 +51,32 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@argos-ci/cli": "^5.0.0",
+    "@argos-ci/storybook": "^6.0.0",
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
+    "@shipfox/vite": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@storybook/addon-vitest": "^10.3.6",
+    "@storybook/react": "^10.0.0",
+    "@storybook/react-vite": "^10.0.0",
+    "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/browser-playwright": "^4.1.5",
     "jsdom": "^29.0.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "storybook": "^10.0.0",
+    "storybook-addon-pseudo-states": "^10.0.0",
+    "tailwindcss": "^4.1.13",
+    "vite": "^8.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/libs/client/runners/src/components/runner-token-list.stories.tsx
+++ b/libs/client/runners/src/components/runner-token-list.stories.tsx
@@ -1,0 +1,103 @@
+import type {RunnerTokenDto} from '@shipfox/api-runners-dto';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import {EmptyRunnerTokens, RunnerTokenList, RunnerTokenTableSkeleton} from './runner-token-list.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+function RunnerTokenListStory({tokens}: {tokens: RunnerTokenDto[]}) {
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="mx-auto w-full max-w-[860px] bg-background-neutral-background p-24">
+        <RunnerTokenList workspaceId={WORKSPACE_ID} tokens={tokens} />
+      </div>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: 'Runners/Token list',
+  component: RunnerTokenListStory,
+  parameters: {layout: 'fullscreen'},
+  args: {tokens: runnerTokens()},
+} satisfies Meta<typeof RunnerTokenListStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ActiveTokens: Story = {};
+
+export const LongNames: Story = {
+  args: {
+    tokens: [
+      runnerToken({
+        name: 'mac-stadium-prod-runner-with-extra-long-registration-name',
+        prefix: 'sf_rt_very_long_prefix_12',
+      }),
+      runnerToken({
+        id: '22222222-2222-4222-8222-222222222222',
+        name: null,
+        prefix: 'sf_rt_unnamed_19',
+        expires_at: null,
+      }),
+    ],
+  },
+};
+
+export const Empty: Story = {
+  render: () => (
+    <div className="mx-auto w-full max-w-[860px] bg-background-neutral-background p-24">
+      <EmptyRunnerTokens />
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div className="mx-auto w-full max-w-[860px] bg-background-neutral-background p-24">
+      <RunnerTokenTableSkeleton />
+    </div>
+  ),
+};
+
+function runnerTokens(): RunnerTokenDto[] {
+  return [
+    runnerToken({name: 'Production macOS runner', prefix: 'sf_rt_prod_2x'}),
+    runnerToken({
+      id: '22222222-2222-4222-8222-222222222222',
+      name: 'Linux build pool',
+      prefix: 'sf_rt_linux_7q',
+      created_at: '2026-06-20T09:12:00.000Z',
+      updated_at: '2026-06-20T09:12:00.000Z',
+      expires_at: null,
+    }),
+    runnerToken({
+      id: '33333333-3333-4333-8333-333333333333',
+      name: null,
+      prefix: 'sf_rt_shared_4m',
+      created_at: '2026-06-10T16:30:00.000Z',
+      updated_at: '2026-06-10T16:30:00.000Z',
+      expires_at: '2026-07-10T16:30:00.000Z',
+    }),
+  ];
+}
+
+function runnerToken(overrides: Partial<RunnerTokenDto> = {}): RunnerTokenDto {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    workspace_id: WORKSPACE_ID,
+    prefix: 'sf_rt_local_8f',
+    name: 'Local runner',
+    expires_at: '2026-07-01T12:00:00.000Z',
+    revoked_at: null,
+    created_at: '2026-06-18T12:00:00.000Z',
+    updated_at: '2026-06-18T12:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/libs/client/runners/vercel.json
+++ b/libs/client/runners/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo build && pnpm run storybook:build",
+  "devCommand": "pnpm run storybook",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3017,6 +3017,12 @@ importers:
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
     devDependencies:
+      '@argos-ci/cli':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@argos-ci/storybook':
+        specifier: ^6.0.0
+        version: 6.0.7
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome
@@ -3029,9 +3035,24 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+      '@shipfox/vite':
+        specifier: workspace:*
+        version: link:../../../tools/vite
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      '@storybook/addon-vitest':
+        specifier: ^10.3.6
+        version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9))(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)
+      '@storybook/react':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@tailwindcss/vite':
+        specifier: ^4.1.13
+        version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.9.1
@@ -3047,6 +3068,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
       jsdom:
         specifier: ^29.0.0
         version: 29.1.1
@@ -3056,6 +3083,21 @@ importers:
       react-dom:
         specifier: ^19.1.1
         version: 19.2.7(react@19.2.7)
+      storybook:
+        specifier: ^10.0.0
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook-addon-pseudo-states:
+        specifier: ^10.0.0
+        version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.3.1
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   libs/client/triggers:
     dependencies:


### PR DESCRIPTION
Set up Vercel preview deployments for the integrations and runners client packages.

The integrations package already had a Storybook surface but no Vercel project config, while runners needed matching Storybook scaffolding before Vercel could build a useful preview. This adds the same Storybook-backed Vercel config used by the other client packages and gives runners a token-list story so the deployment has a real surface to render.

No changeset is included because both touched package manifests are private and the change is deployment/preview configuration rather than a published package API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up Vercel preview deployments for the integrations and runners clients by building and publishing their Storybooks. Adds Storybook scaffolding and a `RunnerTokenList` story to `libs/client/runners` so previews render a real UI; no runtime or API changes.

- **New Features**
  - Added `vercel.json` for `libs/client/integrations` and `libs/client/runners` to build and serve Storybook previews.
  - Added Storybook setup for `libs/client/runners` (shared `main.ts`, theming, fonts, Argos modes, and base CSS).
  - Added `runner-token-list.stories.tsx` with states: active, long names, empty, and loading.

- **Dependencies**
  - Added Storybook/Vite and Argos dev deps and `storybook`/`storybook:build` scripts in `libs/client/runners/package.json`; updated `pnpm-lock.yaml`.

<sup>Written for commit 92088ccd8ecaf0e8e35362cb3dabe6f2e2c50ba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

