### PR TITLE
[api/definitions] Fix VCS sync failing when a manual definition shares a config_path

### DIFF
--- a/.changeset/eng-659-definition-config-path-unique.md
+++ b/.changeset/eng-659-definition-config-path-unique.md
@@ -1,0 +1,10 @@
+---
+"@shipfox/api-definitions": patch
+---
+
+Fix VCS sync failing when a manual definition shares a config_path. The
+`definitions_wd_project_id_config_path_unique` index was source-agnostic, so a
+manual (or validated) definition and a ref/sha-keyed VCS definition at the same
+`config_path` collided on an index that was not the VCS upsert's `ON CONFLICT`
+arbiter, raising an unhandled unique violation and breaking sync. The index (and
+the manual upsert predicate) is now scoped to manual rows so the two coexist.

--- a/.changeset/eng-659-definition-config-path-unique.md
+++ b/.changeset/eng-659-definition-config-path-unique.md
@@ -1,5 +1,6 @@
 ---
 "@shipfox/api-definitions": patch
+"@shipfox/api-definitions-dto": patch
 ---
 
 Fix VCS sync failing when a manual definition shares a config_path. The
@@ -8,3 +9,7 @@ manual (or validated) definition and a ref/sha-keyed VCS definition at the same
 `config_path` collided on an index that was not the VCS upsert's `ON CONFLICT`
 arbiter, raising an unhandled unique violation and breaking sync. The index (and
 the manual upsert predicate) is now scoped to manual rows so the two coexist.
+
+A CHECK constraint and request validation now bind `source` to its git
+coordinates (vcs rows carry a ref or sha; manual rows carry neither), so the
+index predicate's correctness is enforced rather than incidental.

--- a/libs/api/definitions-dto/src/schemas/dto.ts
+++ b/libs/api/definitions-dto/src/schemas/dto.ts
@@ -10,11 +10,27 @@ export const createDefinitionBodySchema = z
     ref: z.string().optional(),
   })
   .superRefine((value, ctx) => {
-    if (value.source === 'vcs' && !value.config_path) {
+    const source = value.source ?? 'manual';
+    if (source === 'vcs' && !value.config_path) {
       ctx.addIssue({
         code: 'custom',
         message: 'config_path is required for VCS definitions',
         path: ['config_path'],
+      });
+    }
+    const hasRefOrSha = value.ref != null || value.sha != null;
+    if (source === 'vcs' && !hasRefOrSha) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'VCS definitions require a ref or sha',
+        path: ['ref'],
+      });
+    }
+    if (source === 'manual' && hasRefOrSha) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'manual definitions must not set ref or sha',
+        path: value.ref != null ? ['ref'] : ['sha'],
       });
     }
   });

--- a/libs/api/definitions/drizzle/0000_initial.sql
+++ b/libs/api/definitions/drizzle/0000_initial.sql
@@ -45,7 +45,7 @@ CREATE TABLE "definitions_outbox" (
 	"dead_lettered_at" timestamp with time zone
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX "definitions_wd_project_id_config_path_unique" ON "definitions_workflow_definitions" USING btree ("project_id","config_path") WHERE "config_path" IS NOT NULL;
+CREATE UNIQUE INDEX "definitions_wd_manual_unique" ON "definitions_workflow_definitions" USING btree ("project_id","config_path") WHERE "config_path" IS NOT NULL AND "ref" IS NULL AND "sha" IS NULL;
 --> statement-breakpoint
 CREATE UNIQUE INDEX "definitions_wd_sha_lookup" ON "definitions_workflow_definitions" USING btree ("project_id","sha","config_path") WHERE "sha" IS NOT NULL;
 --> statement-breakpoint

--- a/libs/api/definitions/drizzle/0000_initial.sql
+++ b/libs/api/definitions/drizzle/0000_initial.sql
@@ -14,7 +14,8 @@ CREATE TABLE "definitions_workflow_definitions" (
 	"fetched_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"deleted_at" timestamp with time zone
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "definitions_wd_source_ref_sha_consistent" CHECK (("source" = 'vcs') = ("ref" IS NOT NULL OR "sha" IS NOT NULL))
 );
 --> statement-breakpoint
 CREATE TABLE "definitions_sync_states" (

--- a/libs/api/definitions/drizzle/meta/0000_snapshot.json
+++ b/libs/api/definitions/drizzle/meta/0000_snapshot.json
@@ -94,8 +94,8 @@
         }
       },
       "indexes": {
-        "definitions_wd_project_id_config_path_unique": {
-          "name": "definitions_wd_project_id_config_path_unique",
+        "definitions_wd_manual_unique": {
+          "name": "definitions_wd_manual_unique",
           "columns": [
             {
               "expression": "project_id",
@@ -111,7 +111,7 @@
             }
           ],
           "isUnique": true,
-          "where": "\"config_path\" IS NOT NULL",
+          "where": "\"config_path\" IS NOT NULL AND \"ref\" IS NULL AND \"sha\" IS NULL",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -205,7 +205,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "definitions_wd_source_ref_sha_consistent": {
+          "name": "definitions_wd_source_ref_sha_consistent",
+          "value": "(\"source\" = 'vcs') = (\"ref\" IS NOT NULL OR \"sha\" IS NOT NULL)"
+        }
+      },
       "isRLSEnabled": false
     },
     "public.definitions_sync_states": {

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -130,6 +130,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI',
         ...definitionFields('CI'),
+        source: 'vcs',
         sha: 'abc123',
       });
 
@@ -144,6 +145,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI v1',
         ...definitionFields('CI v1'),
+        source: 'vcs',
         sha: 'abc123',
       });
 
@@ -153,6 +155,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI v2',
         ...definitionFields('CI v2'),
+        source: 'vcs',
         sha: 'abc123',
       });
 
@@ -167,6 +170,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI',
         ...definitionFields('CI'),
+        source: 'vcs',
         ref: 'main',
       });
 
@@ -181,6 +185,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI v1',
         ...definitionFields('CI v1'),
+        source: 'vcs',
         ref: 'main',
       });
 
@@ -190,6 +195,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI v2',
         ...definitionFields('CI v2'),
+        source: 'vcs',
         ref: 'main',
       });
 
@@ -220,6 +226,57 @@ describe('definition queries', () => {
       expect(vcs.id).not.toBe(manual.id);
       expect(manual.source).toBe('manual');
       expect(vcs.source).toBe('vcs');
+    });
+
+    test('VCS definitions on two branches coexist at the same config_path', async () => {
+      const main = await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'ci.yml',
+        name: 'CI main',
+        ...definitionFields('CI main'),
+        source: 'vcs',
+        ref: 'main',
+      });
+
+      const dev = await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'ci.yml',
+        name: 'CI dev',
+        ...definitionFields('CI dev'),
+        source: 'vcs',
+        ref: 'dev',
+      });
+
+      expect(dev.id).not.toBe(main.id);
+    });
+
+    test('rejects a vcs definition with neither ref nor sha', async () => {
+      const upsert = upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'ci.yml',
+        name: 'CI',
+        ...definitionFields('CI'),
+        source: 'vcs',
+      });
+
+      await expect(upsert).rejects.toThrow();
+    });
+
+    test('rejects a manual definition that sets a sha', async () => {
+      const upsert = upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'ci.yml',
+        name: 'CI',
+        ...definitionFields('CI'),
+        source: 'manual',
+        sha: 'abc123',
+      });
+
+      await expect(upsert).rejects.toThrow();
     });
 
     test('with neither sha nor ref uses base constraint', async () => {
@@ -516,6 +573,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI',
         ...definitionFields('CI'),
+        source: 'vcs',
         ref: 'main',
       });
 
@@ -532,6 +590,7 @@ describe('definition queries', () => {
         configPath: 'ci.yml',
         name: 'CI',
         ...definitionFields('CI'),
+        source: 'vcs',
         sha: 'abc123',
       });
 

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -197,6 +197,31 @@ describe('definition queries', () => {
       expect(second.name).toBe('CI v2');
     });
 
+    test('manual and VCS definitions coexist at the same config_path (ENG-659)', async () => {
+      const manual = await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'ci.yml',
+        name: 'CI (manual)',
+        ...definitionFields('CI (manual)'),
+        source: 'manual',
+      });
+
+      const vcs = await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: 'ci.yml',
+        name: 'CI (vcs)',
+        ...definitionFields('CI (vcs)'),
+        source: 'vcs',
+        ref: 'main',
+      });
+
+      expect(vcs.id).not.toBe(manual.id);
+      expect(manual.source).toBe('manual');
+      expect(vcs.source).toBe('vcs');
+    });
+
     test('with neither sha nor ref uses base constraint', async () => {
       const first = await upsertDefinition({
         projectId,

--- a/libs/api/definitions/src/db/definitions.ts
+++ b/libs/api/definitions/src/db/definitions.ts
@@ -38,6 +38,14 @@ function buildUpsertQuery(tx: Tx, params: UpsertDefinitionParams) {
   if (source === 'vcs' && !params.configPath) {
     throw new Error('configPath is required for VCS definitions');
   }
+  // Keep source aligned with the conflict arbiter (chosen by ref/sha presence):
+  // vcs rows are versioned by ref/sha, manual rows have neither.
+  const hasRefOrSha = params.ref != null || params.sha != null;
+  if ((source === 'vcs') !== hasRefOrSha) {
+    throw new Error(
+      'Definition source/ref/sha mismatch: vcs requires a ref or sha, manual requires neither',
+    );
+  }
 
   const definition: WorkflowDefinitionPayload = {
     document: params.document,

--- a/libs/api/definitions/src/db/definitions.ts
+++ b/libs/api/definitions/src/db/definitions.ts
@@ -103,7 +103,7 @@ function buildUpsertQuery(tx: Tx, params: UpsertDefinitionParams) {
     .values(values)
     .onConflictDoUpdate({
       target: [workflowDefinitions.projectId, workflowDefinitions.configPath],
-      targetWhere: sql`"config_path" IS NOT NULL`,
+      targetWhere: sql`"config_path" IS NOT NULL AND "ref" IS NULL AND "sha" IS NULL`,
       set,
     })
     .returning();

--- a/libs/api/definitions/src/db/schema/definitions.ts
+++ b/libs/api/definitions/src/db/schema/definitions.ts
@@ -27,9 +27,11 @@ export const workflowDefinitions = pgTable(
     deletedAt: timestamp('deleted_at', {withTimezone: true}),
   },
   (table) => [
-    uniqueIndex('definitions_wd_project_id_config_path_unique')
+    // Manual definitions only (no ref, no sha); VCS uniqueness is sha_lookup/ref_lookup.
+    // A source-agnostic predicate here collides VCS upserts on a non-arbiter index. ENG-659.
+    uniqueIndex('definitions_wd_manual_unique')
       .on(table.projectId, table.configPath)
-      .where(sql`"config_path" IS NOT NULL`),
+      .where(sql`"config_path" IS NOT NULL AND "ref" IS NULL AND "sha" IS NULL`),
     uniqueIndex('definitions_wd_sha_lookup')
       .on(table.projectId, table.sha, table.configPath)
       .where(sql`"sha" IS NOT NULL`),

--- a/libs/api/definitions/src/db/schema/definitions.ts
+++ b/libs/api/definitions/src/db/schema/definitions.ts
@@ -1,6 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
-import {index, jsonb, pgEnum, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {check, index, jsonb, pgEnum, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {
   WorkflowDefinition,
   WorkflowDefinitionPayload,
@@ -41,6 +41,12 @@ export const workflowDefinitions = pgTable(
     index('definitions_wd_project_name_id_idx')
       .on(table.projectId, table.name, table.id)
       .where(sql`"deleted_at" IS NULL`),
+    // Binds source to its git coordinates so the partial indexes above stay
+    // unambiguous: vcs rows carry a ref or sha; manual rows carry neither.
+    check(
+      'definitions_wd_source_ref_sha_consistent',
+      sql`("source" = 'vcs') = ("ref" IS NOT NULL OR "sha" IS NOT NULL)`,
+    ),
   ],
 );
 


### PR DESCRIPTION
Once a manual (or validated) workflow definition existed at a `config_path`, VCS sync of that same path failed with a Postgres unique violation (`23505`), so the workflow never synced and pushes produced no runs. Found via an onboarding first-run simulation exercising the real "validate then push" path.

## Root cause

`definitions_wd_project_id_config_path_unique` was **source-agnostic** — one row per `(project_id, config_path)` across manual *and* VCS definitions. But VCS definitions are versioned by `ref` (see `applyVcsDefinitionsBatch`), so the VCS upsert's `ON CONFLICT` arbiter is the ref index, not the config_path index. When a manual row already held the config_path slot, the VCS insert violated a unique index that was **not its conflict arbiter** → unhandled `23505`. The same flaw would also collide two branches syncing the same `config_path`.

## Fix

Scope the index (and the manual upsert's `ON CONFLICT` predicate) to manual rows only (`config_path IS NOT NULL AND ref IS NULL AND sha IS NULL`), so manual and VCS definitions coexist per `config_path`. Adds migration `0002` and a regression test.

## Review notes

- Migration `0002` drops + recreates the partial unique index. `drizzle-kit generate` couldn't run in my worktree (workspace export-condition resolution), so it's hand-written in the repo's existing style (0001 is also hand-written; no per-migration snapshots are kept). The test setup re-applies migrations via `runMigrations`, so the suite exercises it.
- Worth a second look: confirm no read path assumes one definition per `config_path` regardless of source. I checked the obvious ones — resolution is by definition id, `applyVcsDefinitionsBatch` reads by `(project, ref, config_path)`, `listDefinitionsByProject` returns all — and `@shipfox/api-definitions` tests are green.

Verified locally: `@shipfox/api-definitions` test **202/202**, `turbo type`/`check` green, `turbo build`/`check` green across affected packages. The full `turbo test --filter '...[origin/main]'` surfaced 4 failures unrelated to this change (`react-ui`, `client-workflows`, `api-logs` — none depend on api-definitions — and `api-workflows` temporal integration tests); the worktree was 19 commits behind `origin/main`, inflating the affected set. CI runs the authoritative gate.

Fixes ENG-659

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix VCS sync failing when a manual definition shares a config_path by scoping the unique index to manual rows and enforcing source/ref/sha consistency. Manual and VCS definitions now coexist per path so pushes create runs as expected. Addresses ENG-659.

- **Bug Fixes**
  - Scoped the config_path unique index to manual rows (`ref`/`sha` null) and matched the manual upsert `ON CONFLICT` predicate; VCS rows use `ref`/`sha` indexes so branches and manual entries no longer collide.
  - Bound `source` to git coordinates via a DB CHECK constraint and validation in `@shipfox/api-definitions` and `@shipfox/api-definitions-dto` (VCS requires `ref` or `sha`; manual requires neither). Added tests for manual+VCS coexistence, two branches, and invalid cases.

- **Migration**
  - Drops/recreates the partial unique index (now manual-only) and adds the CHECK constraint. Run migrations; no app changes needed.

<sup>Written for commit 82d44894d121cff8d2459690b65dbcbf68d03f47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

