### PR TITLE
[client-workflows] Let workflow steps scroll with the page

### DIFF
--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -206,7 +206,6 @@ function RunViewContent({
             {selectedJob ? (
               <WorkflowStepList
                 job={selectedJob}
-                className="max-h-[50vh]"
                 selectedAttemptId={selectedJob.carriedOver ? undefined : selectedAttemptId}
                 onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
                 autoSelectActiveAttempt

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -137,13 +137,7 @@ function WorkflowStepListContent({
       {model.entries.length === 0 ? (
         <WorkflowStepListEmptyStateView emptyState={emptyState} />
       ) : (
-        <Accordion
-          type="multiple"
-          value={selectedAttemptIds}
-          onValueChange={selectAttempt}
-          className="min-h-0 overflow-auto"
-          asChild
-        >
+        <Accordion type="multiple" value={selectedAttemptIds} onValueChange={selectAttempt} asChild>
           <ol>
             {model.entries.map((entry) => {
               const selected = selectedAttemptIds.includes(entry.id);


### PR DESCRIPTION
Let workflow step lists expand to their full content height inside the run detail page.

The run view previously capped the step list at half the viewport and the list accordion owned its own scroll region. That made the step area scroll independently from the surrounding run page. This removes the height cap and nested accordion overflow so the existing run detail page scroller handles long step lists.

No changeset is included because @shipfox/client-workflows is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make workflow step lists scroll with the run page instead of inside a nested scroller. Removes the height cap and internal overflow so long lists use the main page scroll.

- **Refactors**
  - Removed `max-h-[50vh]` from `WorkflowStepList` in the run view.
  - Dropped `overflow-auto` and `min-h-0` from the step list `Accordion`.

<sup>Written for commit b49becbf70f837c7dc5fc1fc8a69a18806d38f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

