### PR TITLE
[client-workflows] Use static timer for waiting step empty state

### DIFF
--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -238,6 +238,17 @@ export const SkippedBeforeStart: Story = {
   },
 };
 
+export const RunningBeforeFirstStep: Story = {
+  args: {
+    job: makeJob({status: 'running', steps: []}),
+    emptyState: {
+      title: 'Waiting for the first step',
+      description: 'This job is running, but no steps have started yet.',
+      status: 'running',
+    },
+  },
+};
+
 export const MultipleAttempts: Story = {
   args: {
     job: makeJob({

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -353,6 +353,25 @@ describe('WorkflowStepList', () => {
     expect(screen.getByText('This job has not recorded any steps.')).toBeInTheDocument();
   });
 
+  test('renders a running empty state without the animated status glyph', () => {
+    render(
+      <WorkflowStepList
+        job={makeJob({status: 'running', steps: []})}
+        emptyState={{
+          title: 'Waiting for the first step',
+          description: 'This job is running, but no steps have started yet.',
+          status: 'running',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Waiting for the first step')).toBeInTheDocument();
+    expect(
+      screen.getByText('This job is running, but no steps have started yet.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('img', {name: 'Running'})).not.toBeInTheDocument();
+  });
+
   test('renders a skipped empty state with a status glyph', () => {
     render(
       <WorkflowStepList

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -205,9 +205,7 @@ function WorkflowStepListEmptyStateView({
 
   return (
     <div className="flex min-h-120 flex-col items-center justify-center gap-10 px-16 py-20">
-      <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8">
-        <WorkflowStatusIcon status={emptyState.status} size={20} tooltip={false} />
-      </div>
+      <WorkflowStepListEmptyStateIcon status={emptyState.status} />
       <div className="text-center">
         <Text size="sm" className="text-foreground-neutral-subtle">
           {emptyState.title}
@@ -216,6 +214,22 @@ function WorkflowStepListEmptyStateView({
           {emptyState.description}
         </Text>
       </div>
+    </div>
+  );
+}
+
+function WorkflowStepListEmptyStateIcon({status}: {status: WorkflowJob['status']}) {
+  if (status !== 'running') {
+    return (
+      <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8">
+        <WorkflowStatusIcon status={status} size={20} tooltip={false} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex size-32 items-center justify-center rounded-6 border border-border-neutral-strong bg-background-neutral-base p-8 text-foreground-neutral-muted">
+      <Icon name="timerLine" size={18} aria-hidden="true" />
     </div>
   );
 }


### PR DESCRIPTION
Use a static timer icon for the running zero-step workflow empty state instead of the animated running status glyph.

The empty state communicates that the job is waiting for its first step, so the pulsing running indicator made the panel read as actively executing. Pending and terminal empty states continue to use the existing status icon treatment.

No changeset is included because `@shipfox/client-workflows` is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the animated running glyph with a static timer icon for the running empty state in WorkflowStepList so it reads as waiting for the first step. Other empty states keep their icons, and tests plus a new Storybook story cover this case.

<sup>Written for commit 56f73c24faba08645c72395ae8accb1b8c401b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

