### PR TITLE
[client-workflows] Fix workflow step multi-panel expansion

### DIFF
--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.test.tsx
@@ -2,6 +2,7 @@ import type {RunJobDetailDto, RunStepDetailDto, StepAttemptDto} from '@shipfox/a
 import {Text} from '@shipfox/react-ui';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {useState} from 'react';
 import type {WorkflowJob} from '#core/workflow-run.js';
 import {workflowJob, workflowStepAttemptDto, workflowStepDto} from '#test/fixtures/workflow-run.js';
 import {WorkflowStepList} from './workflow-step-list.js';
@@ -93,6 +94,40 @@ describe('WorkflowStepList', () => {
     expect(screen.getByText(`logs for ${deployAttempt.id}`)).toBeInTheDocument();
   });
 
+  test('keeps multiple expanded rows open when external attempt selection is singular', async () => {
+    const user = userEvent.setup();
+    const buildAttempt = makeAttempt({status: 'succeeded'});
+    const deployAttempt = makeAttempt({status: 'running'});
+    const build = makeStep({name: 'build', attempts: [buildAttempt]});
+    const deploy = makeStep({name: 'deploy', position: 1, attempts: [deployAttempt]});
+    const job = makeJob({steps: [build, deploy]});
+
+    function ControlledStepList() {
+      const [selectedAttemptId, setSelectedAttemptId] = useState<string | null>(null);
+
+      return (
+        <WorkflowStepList
+          job={job}
+          selectedAttemptId={selectedAttemptId}
+          onSelectedAttemptChange={(attemptId) => setSelectedAttemptId(attemptId ?? null)}
+          renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
+        />
+      );
+    }
+
+    render(<ControlledStepList />);
+    const buildRow = screen.getByRole('button', {name: 'build, Succeeded, attempt 1'});
+    const deployRow = screen.getByRole('button', {name: 'deploy, Running, attempt 1'});
+
+    await user.click(buildRow);
+    await user.click(deployRow);
+
+    expect(buildRow).toHaveAttribute('aria-expanded', 'true');
+    expect(deployRow).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText(`logs for ${buildAttempt.id}`)).toBeInTheDocument();
+    expect(screen.getByText(`logs for ${deployAttempt.id}`)).toBeInTheDocument();
+  });
+
   test('reports selection changes including collapse', async () => {
     const user = userEvent.setup();
     const onSelectedAttemptChange = vi.fn();
@@ -148,7 +183,7 @@ describe('WorkflowStepList', () => {
     expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
   });
 
-  test('respects a controlled empty selected attempt', async () => {
+  test('starts collapsed for a controlled empty selected attempt', async () => {
     const user = userEvent.setup();
     const onSelectedAttemptChange = vi.fn();
     const attempt = makeAttempt();
@@ -175,9 +210,11 @@ describe('WorkflowStepList', () => {
         renderExpandedStep={({attemptId}) => <Text size="sm">logs for {attemptId}</Text>}
       />,
     );
+    expect(screen.queryByText(`logs for ${attempt.id}`)).not.toBeInTheDocument();
+
     await user.click(deploy);
 
-    expect(screen.queryByText(`logs for ${attempt.id}`)).not.toBeInTheDocument();
+    expect(screen.getByText(`logs for ${attempt.id}`)).toBeInTheDocument();
     expect(onSelectedAttemptChange).toHaveBeenCalledWith(attempt.id);
   });
 

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -15,7 +15,7 @@ import {
   TooltipTrigger,
 } from '@shipfox/react-ui';
 import type {ReactNode} from 'react';
-import {useEffect, useId, useMemo, useState} from 'react';
+import {useEffect, useId, useMemo, useRef, useState} from 'react';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import {isWorkflowStatus, type WorkflowJob} from '#core/workflow-run.js';
 import {
@@ -89,34 +89,56 @@ function WorkflowStepListContent({
   className,
 }: Omit<WorkflowStepListProps, 'job'> & {model: WorkflowStepListModel}) {
   const titleId = useId();
-  const [localSelectedAttemptIds, setLocalSelectedAttemptIds] = useState<string[]>(
-    defaultSelectedAttemptId ? [defaultSelectedAttemptId] : [],
+  const [localSelectedAttemptIds, setLocalSelectedAttemptIds] = useState<string[]>(() =>
+    selectedAttemptId
+      ? [selectedAttemptId]
+      : defaultSelectedAttemptId
+        ? [defaultSelectedAttemptId]
+        : [],
   );
   const [userSelectedAttempt, setUserSelectedAttempt] = useState(false);
+  const lastNotifiedSelectedAttemptId = useRef<string | null>(null);
+  const shouldUseControlledCollapsedState =
+    selectedAttemptId === null && lastNotifiedSelectedAttemptId.current === null;
   const autoSelectedAttemptIds =
-    autoSelectActiveAttempt && !userSelectedAttempt && model.activeEntryId
+    selectedAttemptId === undefined &&
+    autoSelectActiveAttempt &&
+    !userSelectedAttempt &&
+    model.activeEntryId
       ? [model.activeEntryId]
       : [];
-  // `undefined` leaves selection uncontrolled; `null` is a controlled collapsed state.
-  const selectedAttemptIds =
-    selectedAttemptId !== undefined
-      ? selectedAttemptId
-        ? [selectedAttemptId]
-        : []
-      : localSelectedAttemptIds.length > 0
-        ? localSelectedAttemptIds
-        : autoSelectedAttemptIds;
+  const selectedAttemptIds = shouldUseControlledCollapsedState
+    ? []
+    : localSelectedAttemptIds.length > 0
+      ? localSelectedAttemptIds
+      : autoSelectedAttemptIds;
   const hasExpandedContent = renderExpandedStep !== undefined;
 
   useEffect(() => {
+    if (selectedAttemptId !== undefined) return;
+
     setLocalSelectedAttemptIds(defaultSelectedAttemptId ? [defaultSelectedAttemptId] : []);
     setUserSelectedAttempt(false);
-  }, [defaultSelectedAttemptId]);
+  }, [defaultSelectedAttemptId, selectedAttemptId]);
+
+  useEffect(() => {
+    if (selectedAttemptId === undefined) return;
+
+    const nextSelectedAttemptId = selectedAttemptId ?? null;
+    if (lastNotifiedSelectedAttemptId.current === nextSelectedAttemptId) {
+      lastNotifiedSelectedAttemptId.current = null;
+      return;
+    }
+
+    setLocalSelectedAttemptIds(selectedAttemptId ? [selectedAttemptId] : []);
+    setUserSelectedAttempt(true);
+  }, [selectedAttemptId]);
 
   function selectAttempt(nextAttemptIds: string[]) {
     const nextAttemptId = nextSelectedAttemptId(selectedAttemptIds, nextAttemptIds);
     setUserSelectedAttempt(true);
     setLocalSelectedAttemptIds(nextAttemptIds);
+    lastNotifiedSelectedAttemptId.current = nextAttemptId ?? null;
     onSelectedAttemptChange?.(nextAttemptId);
   }
 


### PR DESCRIPTION
Fix workflow step rows so multiple expanded panels can stay open while the run view still tracks one active selected attempt.

The step list used Radix multiple accordion mode, but the controlled `selectedAttemptId` prop from the run URL collapsed the rendered value back to a single row after each click. This keeps expanded-row state local to the list and treats `selectedAttemptId` as the singular active selection used for logs, URL state, and source highlighting.

The source panel continues to highlight the active selected step only; opening additional panels does not introduce multi-range source highlighting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workflow step list so multiple panels can stay open while the run still tracks one active attempt for logs, URL state, and source highlighting.

- **Bug Fixes**
  - Decoupled expanded-row state from `selectedAttemptId` to allow multiple open panels.
  - Kept `selectedAttemptId` as the single active selection only; no multi-range source highlighting.
  - Respected a controlled empty `selectedAttemptId` (starts collapsed) and only auto-selects when uncontrolled.
  - Added tests for multi-panel expansion and controlled empty selection behavior.

<sup>Written for commit 13795815c05e1eb73ddf1890195eb0da26117970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

