### PR TITLE
Use OpenRouter Llama in agent seed

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/agent.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent.yml
@@ -11,5 +11,6 @@ triggers:
 jobs:
   greet:
     steps:
-      - model: claude-opus-4-8
+      - provider: openrouter
+        model: meta-llama/llama-3.1-8b-instruct
         prompt: Say hello


### PR DESCRIPTION
Update the seeded Gitea demo agent workflow to run through OpenRouter with Meta's Llama 3.1 8B Instruct model.

The seed repo should exercise the provider-specific agent configuration path instead of relying on the default Anthropic model. This keeps the local agent seed aligned with the intended OpenRouter setup for the demo workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the seeded Gitea demo agent workflow to OpenRouter with `meta-llama/llama-3.1-8b-instruct`. This uses provider-specific config instead of the default Anthropic model and aligns the demo with the intended OpenRouter setup.

<sup>Written for commit b869495bb99f2e7b638a9850527dde60b127ce79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

