### PR TITLE
[api-runners] Persist provisioned runner links

### DIFF
--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -28,10 +28,13 @@ CREATE TABLE "runners_running_jobs" (
 	"run_id" uuid NOT NULL,
 	"project_id" uuid NOT NULL,
 	"runner_token" text NOT NULL,
+	"provisioner_id" uuid,
+	"provisioned_runner_id" text,
 	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"last_heartbeat_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"cancellation_requested_at" timestamp with time zone,
-	CONSTRAINT "runners_running_jobs_job_id_unique" UNIQUE("job_id")
+	CONSTRAINT "runners_running_jobs_job_id_unique" UNIQUE("job_id"),
+	CONSTRAINT "runners_running_jobs_link_ck" CHECK (("runners_running_jobs"."provisioner_id" IS NULL) = ("runners_running_jobs"."provisioned_runner_id" IS NULL))
 );
 --> statement-breakpoint
 CREATE INDEX "runners_outbox_pending_idx" ON "runners_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;

--- a/libs/api/runners/drizzle/0001_runner_tokens.sql
+++ b/libs/api/runners/drizzle/0001_runner_tokens.sql
@@ -34,12 +34,15 @@ CREATE TABLE "runners_runner_sessions" (
 	"scope" "runners_runner_session_scope" DEFAULT 'workspace' NOT NULL,
 	"registration_token_id" uuid NOT NULL,
 	"registration_token_kind" "runners_runner_session_registration_token_kind" NOT NULL,
+	"provisioner_id" uuid,
+	"provisioned_runner_id" text,
 	"labels" text[] NOT NULL,
 	"max_claims" integer,
 	"claims_used" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND (("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."max_claims" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."max_claims" IS NOT NULL AND "runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims")))
+	CONSTRAINT "runners_runner_sessions_claims_ck" CHECK ("runners_runner_sessions"."claims_used" >= 0 AND (("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."max_claims" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."max_claims" IS NOT NULL AND "runners_runner_sessions"."max_claims" > 0 AND "runners_runner_sessions"."claims_used" <= "runners_runner_sessions"."max_claims"))),
+	CONSTRAINT "runners_runner_sessions_link_ck" CHECK (("runners_runner_sessions"."registration_token_kind" = 'manual' AND "runners_runner_sessions"."provisioner_id" IS NULL AND "runners_runner_sessions"."provisioned_runner_id" IS NULL) OR ("runners_runner_sessions"."registration_token_kind" = 'ephemeral' AND "runners_runner_sessions"."provisioner_id" IS NOT NULL AND "runners_runner_sessions"."provisioned_runner_id" IS NOT NULL))
 );
 --> statement-breakpoint
 ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_session_id" uuid DEFAULT uuidv7() NOT NULL;--> statement-breakpoint

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -240,6 +240,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "started_at": {
           "name": "started_at",
           "type": "timestamp with time zone",
@@ -288,7 +300,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provisioned_runner_id\" IS NULL)"
+        }
+      },
       "isRLSEnabled": false
     }
   },

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -424,6 +424,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "labels": {
           "name": "labels",
           "type": "text[]",
@@ -467,6 +479,10 @@
         "runners_runner_sessions_claims_ck": {
           "name": "runners_runner_sessions_claims_ck",
           "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NOT NULL))"
         }
       },
       "isRLSEnabled": false
@@ -640,6 +656,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "started_at": {
           "name": "started_at",
           "type": "timestamp with time zone",
@@ -688,7 +716,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provisioned_runner_id\" IS NULL)"
+        }
+      },
       "isRLSEnabled": false
     }
   },

--- a/libs/api/runners/drizzle/meta/0002_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0002_snapshot.json
@@ -455,6 +455,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "required_labels": {
           "name": "required_labels",
           "type": "text[]",
@@ -515,7 +527,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provisioned_runner_id\" IS NULL)"
+        }
+      },
       "isRLSEnabled": false
     }
   },

--- a/libs/api/runners/drizzle/meta/0003_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0003_snapshot.json
@@ -529,6 +529,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "labels": {
           "name": "labels",
           "type": "text[]",
@@ -572,6 +584,10 @@
         "runners_runner_sessions_claims_ck": {
           "name": "runners_runner_sessions_claims_ck",
           "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NOT NULL))"
         }
       },
       "isRLSEnabled": false
@@ -745,6 +761,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "required_labels": {
           "name": "required_labels",
           "type": "text[]",
@@ -805,7 +833,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provisioned_runner_id\" IS NULL)"
+        }
+      },
       "isRLSEnabled": false
     }
   },

--- a/libs/api/runners/drizzle/meta/0004_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0004_snapshot.json
@@ -882,6 +882,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "labels": {
           "name": "labels",
           "type": "text[]",
@@ -925,6 +937,10 @@
         "runners_runner_sessions_claims_ck": {
           "name": "runners_runner_sessions_claims_ck",
           "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NOT NULL))"
         }
       },
       "isRLSEnabled": false
@@ -1098,6 +1114,18 @@
           "primaryKey": false,
           "notNull": true
         },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "required_labels": {
           "name": "required_labels",
           "type": "text[]",
@@ -1158,7 +1186,12 @@
         }
       },
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provisioned_runner_id\" IS NULL)"
+        }
+      },
       "isRLSEnabled": false
     }
   },

--- a/libs/api/runners/src/core/entities/runner-session.ts
+++ b/libs/api/runners/src/core/entities/runner-session.ts
@@ -4,6 +4,8 @@ export interface RunnerSession {
   scope: 'workspace';
   registrationTokenId: string;
   registrationTokenKind: 'manual' | 'ephemeral';
+  provisionerId: string | null;
+  provisionedRunnerId: string | null;
   labels: string[];
   maxClaims: number | null;
   claimsUsed: number;

--- a/libs/api/runners/src/core/provisioned-runners.ts
+++ b/libs/api/runners/src/core/provisioned-runners.ts
@@ -70,25 +70,41 @@ function mergeActiveRunners(
   jobs: ActiveRunningJob[],
 ): ActiveRunner[] {
   const jobsByRunnerSessionId = new Map<string, ActiveRunningJob[]>();
+  const jobsByProvisionedRunnerId = new Map<string, ActiveRunningJob[]>();
   for (const job of jobs) {
     const runnerJobs = jobsByRunnerSessionId.get(job.runnerSessionId) ?? [];
     runnerJobs.push(job);
     jobsByRunnerSessionId.set(job.runnerSessionId, runnerJobs);
+
+    if (job.provisionerId && job.provisionedRunnerId) {
+      const key = provisionedRunnerKey(job.provisionerId, job.provisionedRunnerId);
+      const provisionedRunnerJobs = jobsByProvisionedRunnerId.get(key) ?? [];
+      provisionedRunnerJobs.push(job);
+      jobsByProvisionedRunnerId.set(key, provisionedRunnerJobs);
+    }
   }
 
   const merged: ActiveRunner[] = [];
   const usedJobIds = new Set<string>();
 
   for (const provisionedRunner of provisionedRunners) {
-    const provisionedRunnerJobs = provisionedRunner.runnerSessionId
-      ? jobsByRunnerSessionId.get(provisionedRunner.runnerSessionId)
-      : undefined;
+    const provisionedRunnerJobs =
+      jobsByProvisionedRunnerId.get(
+        provisionedRunnerKey(
+          provisionedRunner.provisionerId,
+          provisionedRunner.provisionedRunnerId,
+        ),
+      ) ??
+      (provisionedRunner.runnerSessionId
+        ? jobsByRunnerSessionId.get(provisionedRunner.runnerSessionId)
+        : undefined);
     if (!provisionedRunnerJobs || provisionedRunnerJobs.length === 0) {
       merged.push(toActiveRunner(provisionedRunner, undefined));
       continue;
     }
 
     for (const job of provisionedRunnerJobs) {
+      if (usedJobIds.has(job.jobId)) continue;
       usedJobIds.add(job.jobId);
       merged.push(toActiveRunner(provisionedRunner, job));
     }
@@ -102,14 +118,18 @@ function mergeActiveRunners(
   return merged.sort(compareActiveRunners);
 }
 
+function provisionedRunnerKey(provisionerId: string, provisionedRunnerId: string): string {
+  return `${provisionerId}:${provisionedRunnerId}`;
+}
+
 function toActiveRunner(
   provisionedRunner: ProvisionedRunner | undefined,
   job: ActiveRunningJob | undefined,
 ): ActiveRunner {
   return {
     runnerSessionId: provisionedRunner?.runnerSessionId ?? job?.runnerSessionId ?? null,
-    provisionedRunnerId: provisionedRunner?.provisionedRunnerId ?? null,
-    provisionerId: provisionedRunner?.provisionerId ?? null,
+    provisionedRunnerId: provisionedRunner?.provisionedRunnerId ?? job?.provisionedRunnerId ?? null,
+    provisionerId: provisionedRunner?.provisionerId ?? job?.provisionerId ?? null,
     state: job ? 'busy' : toActiveRunnerState(provisionedRunner?.state ?? 'running'),
     labels: provisionedRunner?.labels ?? job?.runnerLabels ?? [],
     templateKey: provisionedRunner?.templateKey ?? null,

--- a/libs/api/runners/src/core/provisioned-runners.ts
+++ b/libs/api/runners/src/core/provisioned-runners.ts
@@ -103,11 +103,14 @@ function mergeActiveRunners(
       continue;
     }
 
+    let emitted = false;
     for (const job of provisionedRunnerJobs) {
       if (usedJobIds.has(job.jobId)) continue;
       usedJobIds.add(job.jobId);
       merged.push(toActiveRunner(provisionedRunner, job));
+      emitted = true;
     }
+    if (!emitted) merged.push(toActiveRunner(provisionedRunner, undefined));
   }
 
   for (const job of jobs) {

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -34,6 +34,8 @@ describe('registerRunnerSession', () => {
     expect(result.maxClaims).toBeNull();
     expect(result.session.labels).toEqual(['linux', 'x64']);
     expect(result.session.registrationTokenKind).toBe('manual');
+    expect(result.session.provisionerId).toBeNull();
+    expect(result.session.provisionedRunnerId).toBeNull();
     expect(result.session.maxClaims).toBeNull();
     expect(result.session.claimsUsed).toBe(0);
 
@@ -75,6 +77,8 @@ describe('registerRunnerSession', () => {
     expect(result.mode).toBe('ephemeral');
     expect(result.maxClaims).toBe(1);
     expect(result.session.registrationTokenKind).toBe('ephemeral');
+    expect(result.session.provisionerId).toBe(token.provisionerId);
+    expect(result.session.provisionedRunnerId).toBe(token.provisionedRunnerId);
     expect(result.session.maxClaims).toBe(1);
     expect(result.session.claimsUsed).toBe(0);
 
@@ -84,6 +88,13 @@ describe('registerRunnerSession', () => {
       .where(eq(ephemeralRegistrationTokens.id, token.id));
     expect(consumed?.consumedAt).toBeInstanceOf(Date);
     expect(consumed?.consumedSessionId).toBe(result.session.id);
+
+    const [session] = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.id, result.session.id));
+    expect(session?.provisionerId).toBe(token.provisionerId);
+    expect(session?.provisionedRunnerId).toBe(token.provisionedRunnerId);
 
     const claims = await verifyRunnerSessionToken(result.sessionToken);
     expect(claims?.maxClaims).toBe(1);
@@ -134,8 +145,26 @@ describe('registerRunnerSession', () => {
           scope: 'workspace',
           registrationTokenId: crypto.randomUUID(),
           registrationTokenKind: 'ephemeral',
+          provisionerId: crypto.randomUUID(),
+          provisionedRunnerId: `provisioned-runner-${crypto.randomUUID()}`,
           labels: ['linux'],
           maxClaims: null,
+          claimsUsed: 0,
+        }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects an ephemeral session row without a provisioned-runner link', async () => {
+    await expect(
+      db()
+        .insert(runnerSessions)
+        .values({
+          workspaceId,
+          scope: 'workspace',
+          registrationTokenId: crypto.randomUUID(),
+          registrationTokenKind: 'ephemeral',
+          labels: ['linux'],
+          maxClaims: 1,
           claimsUsed: 0,
         }),
     ).rejects.toThrow();

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -212,7 +212,11 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
           gt(ephemeralRegistrationTokens.expiresAt, sql`now()`),
         ),
       )
-      .returning({id: ephemeralRegistrationTokens.id});
+      .returning({
+        id: ephemeralRegistrationTokens.id,
+        provisionerId: ephemeralRegistrationTokens.provisionerId,
+        provisionedRunnerId: ephemeralRegistrationTokens.provisionedRunnerId,
+      });
 
     if (!consumed[0]) {
       const [token] = await tx
@@ -248,6 +252,8 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
         scope: 'workspace',
         registrationTokenId: params.ephemeralTokenId,
         registrationTokenKind: 'ephemeral',
+        provisionerId: consumed[0].provisionerId,
+        provisionedRunnerId: consumed[0].provisionedRunnerId,
         labels: params.labels,
         maxClaims: params.maxClaims,
         claimsUsed: 0,

--- a/libs/api/runners/src/db/jobs.test.ts
+++ b/libs/api/runners/src/db/jobs.test.ts
@@ -246,9 +246,11 @@ describe('claimPendingJob', () => {
   });
 
   it('enforces a non-null session claim cap from the database', async () => {
+    const provisionerId = crypto.randomUUID();
+    const provisionedRunnerId = `provisioned-runner-${crypto.randomUUID()}`;
     await db()
       .update(runnerSessions)
-      .set({registrationTokenKind: 'ephemeral', maxClaims: 1})
+      .set({registrationTokenKind: 'ephemeral', maxClaims: 1, provisionerId, provisionedRunnerId})
       .where(eq(runnerSessions.id, runnerSessionId));
     await pendingJobFactory.create({workspaceId});
     await pendingJobFactory.create({workspaceId});
@@ -262,9 +264,11 @@ describe('claimPendingJob', () => {
   });
 
   it('does not spend a claim when a capped session polls an empty queue', async () => {
+    const provisionerId = crypto.randomUUID();
+    const provisionedRunnerId = `provisioned-runner-${crypto.randomUUID()}`;
     await db()
       .update(runnerSessions)
-      .set({registrationTokenKind: 'ephemeral', maxClaims: 1})
+      .set({registrationTokenKind: 'ephemeral', maxClaims: 1, provisionerId, provisionedRunnerId})
       .where(eq(runnerSessions.id, runnerSessionId));
 
     const empty = await claimPendingJob({workspaceId, runnerSessionId, maxClaims: 1});
@@ -337,6 +341,44 @@ describe('claimPendingJob', () => {
     expect(running[0]?.projectId).toBe(created.projectId);
     expect(running[0]?.requiredLabels).toEqual(created.requiredLabels);
     expect(running[0]?.runnerLabels).toEqual(sessionLabels);
+    expect(running[0]?.provisionerId).toBeNull();
+    expect(running[0]?.provisionedRunnerId).toBeNull();
+  });
+
+  it('copies an ephemeral session provisioned-runner link onto the running job', async () => {
+    const provisionerId = crypto.randomUUID();
+    const provisionedRunnerId = `provisioned-runner-${crypto.randomUUID()}`;
+    await db()
+      .update(runnerSessions)
+      .set({registrationTokenKind: 'ephemeral', maxClaims: 1, provisionerId, provisionedRunnerId})
+      .where(eq(runnerSessions.id, runnerSessionId));
+    const created = await pendingJobFactory.create({workspaceId});
+
+    await claimPendingJob({workspaceId, runnerSessionId, maxClaims: 1});
+
+    const [running] = await db()
+      .select()
+      .from(runningJobs)
+      .where(eq(runningJobs.jobId, created.jobId));
+    expect(running?.provisionerId).toBe(provisionerId);
+    expect(running?.provisionedRunnerId).toBe(provisionedRunnerId);
+  });
+
+  it('rejects a running job row with a partial provisioned-runner link', async () => {
+    const created = await pendingJobFactory.create({workspaceId});
+
+    await expect(
+      db().insert(runningJobs).values({
+        workspaceId,
+        jobId: created.jobId,
+        runId: created.runId,
+        projectId: created.projectId,
+        runnerSessionId,
+        provisionerId: crypto.randomUUID(),
+        requiredLabels: created.requiredLabels,
+        runnerLabels: sessionLabels,
+      }),
+    ).rejects.toThrow();
   });
 
   it('claims a job whose required labels are a subset of the session labels', async () => {

--- a/libs/api/runners/src/db/jobs.ts
+++ b/libs/api/runners/src/db/jobs.ts
@@ -81,6 +81,8 @@ export interface ActiveRunningJob {
   runId: string;
   projectId: string;
   runnerSessionId: string;
+  provisionerId: string | null;
+  provisionedRunnerId: string | null;
   requiredLabels: string[];
   runnerLabels: string[];
   startedAt: Date;
@@ -96,11 +98,16 @@ export async function claimPendingJob(params: {
   if (params.sessionLabels.length === 0) return null;
 
   return await db().transaction(async (tx) => {
+    let provisionerId: string | null = null;
+    let provisionedRunnerId: string | null = null;
+
     if (params.maxClaims !== null) {
       const [session] = await tx
         .select({
           maxClaims: runnerSessions.maxClaims,
           claimsUsed: runnerSessions.claimsUsed,
+          provisionerId: runnerSessions.provisionerId,
+          provisionedRunnerId: runnerSessions.provisionedRunnerId,
         })
         .from(runnerSessions)
         .where(eq(runnerSessions.id, params.runnerSessionId))
@@ -110,6 +117,11 @@ export async function claimPendingJob(params: {
       if (!session || session.maxClaims === null || session.claimsUsed >= session.maxClaims) {
         throw new RunnerSessionExhaustedError(params.runnerSessionId);
       }
+
+      // Ephemeral sessions are the only capped sessions, and the DB check keeps
+      // their provisioned-runner link present as a pair.
+      provisionerId = session.provisionerId;
+      provisionedRunnerId = session.provisionedRunnerId;
     }
 
     // `id` is a uuidv7 (time-ordered), so it is a deterministic FIFO tiebreaker
@@ -145,6 +157,8 @@ export async function claimPendingJob(params: {
         runId: row.runId,
         projectId: row.projectId,
         runnerSessionId: params.runnerSessionId,
+        provisionerId,
+        provisionedRunnerId,
         requiredLabels: row.requiredLabels,
         runnerLabels: params.sessionLabels,
       })
@@ -276,6 +290,8 @@ export async function listActiveRunningJobs(params: {
       runId: runningJobs.runId,
       projectId: runningJobs.projectId,
       runnerSessionId: runningJobs.runnerSessionId,
+      provisionerId: runningJobs.provisionerId,
+      provisionedRunnerId: runningJobs.provisionedRunnerId,
       requiredLabels: runningJobs.requiredLabels,
       runnerLabels: runningJobs.runnerLabels,
       startedAt: runningJobs.startedAt,

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -19,6 +19,8 @@ export const runnerSessions = pgTable(
     registrationTokenId: uuid('registration_token_id').notNull(),
     registrationTokenKind:
       runnerSessionRegistrationTokenKindEnum('registration_token_kind').notNull(),
+    provisionerId: uuid('provisioner_id'),
+    provisionedRunnerId: text('provisioned_runner_id'),
     labels: text('labels').array().notNull(),
     maxClaims: integer('max_claims'),
     claimsUsed: integer('claims_used').notNull().default(0),
@@ -29,6 +31,10 @@ export const runnerSessions = pgTable(
     check(
       'runners_runner_sessions_claims_ck',
       sql`${table.claimsUsed} >= 0 AND ((${table.registrationTokenKind} = 'manual' AND ${table.maxClaims} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.maxClaims} IS NOT NULL AND ${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,
+    ),
+    check(
+      'runners_runner_sessions_link_ck',
+      sql`((${table.registrationTokenKind} = 'manual' AND ${table.provisionerId} IS NULL AND ${table.provisionedRunnerId} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.provisionerId} IS NOT NULL AND ${table.provisionedRunnerId} IS NOT NULL))`,
     ),
   ],
 );
@@ -47,6 +53,8 @@ export function toRunnerSession(row: RunnerSessionDb): RunnerSession {
     scope: row.scope,
     registrationTokenId: row.registrationTokenId,
     registrationTokenKind: row.registrationTokenKind,
+    provisionerId: row.provisionerId,
+    provisionedRunnerId: row.provisionedRunnerId,
     labels: row.labels,
     maxClaims: row.maxClaims,
     claimsUsed: row.claimsUsed,

--- a/libs/api/runners/src/db/schema/running-jobs.ts
+++ b/libs/api/runners/src/db/schema/running-jobs.ts
@@ -1,5 +1,6 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {index, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import {sql} from 'drizzle-orm';
+import {check, index, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
 
 export const runningJobs = pgTable(
@@ -11,17 +12,21 @@ export const runningJobs = pgTable(
     runId: uuid('run_id').notNull(),
     projectId: uuid('project_id').notNull(),
     runnerSessionId: uuid('runner_session_id').notNull(),
+    provisionerId: uuid('provisioner_id'),
+    provisionedRunnerId: text('provisioned_runner_id'),
     requiredLabels: text('required_labels').array().notNull(),
     runnerLabels: text('runner_labels').array().notNull(),
     startedAt: timestamp('started_at', {withTimezone: true}).notNull().defaultNow(),
     lastHeartbeatAt: timestamp('last_heartbeat_at', {withTimezone: true}).notNull().defaultNow(),
     cancellationRequestedAt: timestamp('cancellation_requested_at', {withTimezone: true}),
   },
-  (table) => ({
-    lastHeartbeatAtIdx: index('runners_running_jobs_last_heartbeat_at_idx').on(
-      table.lastHeartbeatAt,
+  (table) => [
+    index('runners_running_jobs_last_heartbeat_at_idx').on(table.lastHeartbeatAt),
+    check(
+      'runners_running_jobs_link_ck',
+      sql`(${table.provisionerId} IS NULL) = (${table.provisionedRunnerId} IS NULL)`,
     ),
-  }),
+  ],
 );
 
 export type RunningJobDb = typeof runningJobs.$inferSelect;

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -193,6 +193,90 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
     );
   });
 
+  it('merges active jobs by provisioned-runner link when the session id is not reported', async () => {
+    const provisionerId = crypto.randomUUID();
+    const runnerSessionId = crypto.randomUUID();
+    const jobId = crypto.randomUUID();
+    await db()
+      .insert(provisionedRunners)
+      .values({
+        workspaceId,
+        provisionerId,
+        provisionedRunnerId: 'provisioned-runner-1',
+        labels: ['linux'],
+        state: 'running',
+        runnerSessionId: null,
+        providerKind: 'docker',
+        reportedAt: new Date(),
+      });
+    await db()
+      .insert(runningJobs)
+      .values({
+        workspaceId,
+        jobId,
+        runId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        runnerSessionId,
+        provisionerId,
+        provisionedRunnerId: 'provisioned-runner-1',
+        requiredLabels: ['linux'],
+        runnerLabels: ['linux'],
+      });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/runners/active`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().runners).toEqual([
+      expect.objectContaining({
+        runner_session_id: runnerSessionId,
+        provisioned_runner_id: 'provisioned-runner-1',
+        provisioner_id: provisionerId,
+        state: 'busy',
+        job_id: jobId,
+      }),
+    ]);
+  });
+
+  it('surfaces the job link for a busy runner without an active provisioned-runner row', async () => {
+    const provisionerId = crypto.randomUUID();
+    const runnerSessionId = crypto.randomUUID();
+    const jobId = crypto.randomUUID();
+    await db()
+      .insert(runningJobs)
+      .values({
+        workspaceId,
+        jobId,
+        runId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        runnerSessionId,
+        provisionerId,
+        provisionedRunnerId: 'provisioned-runner-1',
+        requiredLabels: ['linux'],
+        runnerLabels: ['linux'],
+      });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/runners/active`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().runners).toEqual([
+      expect.objectContaining({
+        runner_session_id: runnerSessionId,
+        provisioned_runner_id: 'provisioned-runner-1',
+        provisioner_id: provisionerId,
+        state: 'busy',
+        job_id: jobId,
+      }),
+    ]);
+  });
+
   it('returns 403 when the user is not a workspace member', async () => {
     vi.mocked(requireMembership).mockRejectedValueOnce(
       new ClientError('Not a member of this workspace', 'forbidden', {status: 403}),

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -277,6 +277,79 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
     ]);
   });
 
+  it('keeps a provisioned runner visible when its session fallback job was already merged', async () => {
+    const provisionerId = crypto.randomUUID();
+    const runnerSessionId = crypto.randomUUID();
+    const jobId = crypto.randomUUID();
+    const older = new Date(Date.now() - 1000);
+    const newer = new Date();
+    await db()
+      .insert(provisionedRunners)
+      .values([
+        {
+          workspaceId,
+          provisionerId,
+          provisionedRunnerId: 'provisioned-runner-b',
+          labels: ['linux'],
+          state: 'running',
+          runnerSessionId,
+          providerKind: 'docker',
+          reportedAt: older,
+          updatedAt: older,
+        },
+        {
+          workspaceId,
+          provisionerId,
+          provisionedRunnerId: 'provisioned-runner-a',
+          labels: ['linux'],
+          state: 'running',
+          runnerSessionId: null,
+          providerKind: 'docker',
+          reportedAt: newer,
+          updatedAt: newer,
+        },
+      ]);
+    await db()
+      .insert(runningJobs)
+      .values({
+        workspaceId,
+        jobId,
+        runId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        runnerSessionId,
+        provisionerId,
+        provisionedRunnerId: 'provisioned-runner-a',
+        requiredLabels: ['linux'],
+        runnerLabels: ['linux'],
+      });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/runners/active`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    const body = res.json();
+    expect(res.statusCode).toBe(200);
+    expect(body.runners).toHaveLength(2);
+    expect(body.runners).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          runner_session_id: runnerSessionId,
+          provisioned_runner_id: 'provisioned-runner-a',
+          state: 'busy',
+          job_id: jobId,
+        }),
+        expect.objectContaining({
+          runner_session_id: runnerSessionId,
+          provisioned_runner_id: 'provisioned-runner-b',
+          state: 'running',
+          job_id: null,
+        }),
+      ]),
+    );
+  });
+
   it('returns 403 when the user is not a workspace member', async () => {
     vi.mocked(requireMembership).mockRejectedValueOnce(
       new ClientError('Not a member of this workspace', 'forbidden', {status: 403}),

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -90,6 +90,8 @@ describe('POST /runners/register', () => {
       .where(eq(runnerSessions.id, body.session_id));
     expect(rows[0]?.labels).toEqual(['linux', 'x64']);
     expect(rows[0]?.registrationTokenKind).toBe('manual');
+    expect(rows[0]?.provisionerId).toBeNull();
+    expect(rows[0]?.provisionedRunnerId).toBeNull();
   });
 
   it('exchanges an ephemeral registration token for a one-claim runner session', async () => {
@@ -119,6 +121,8 @@ describe('POST /runners/register', () => {
       .from(runnerSessions)
       .where(eq(runnerSessions.id, body.session_id));
     expect(session?.registrationTokenKind).toBe('ephemeral');
+    expect(session?.provisionerId).toBe(token.provisionerId);
+    expect(session?.provisionedRunnerId).toBe(token.provisionedRunnerId);
     expect(session?.maxClaims).toBe(1);
     expect(session?.claimsUsed).toBe(0);
 

--- a/libs/api/runners/test/factories/runner-session.ts
+++ b/libs/api/runners/test/factories/runner-session.ts
@@ -18,6 +18,8 @@ export const runnerSessionFactory = Factory.define<RunnerSession>(({onCreate}) =
     scope: 'workspace',
     registrationTokenId: crypto.randomUUID(),
     registrationTokenKind: 'manual',
+    provisionerId: null,
+    provisionedRunnerId: null,
     labels: ['linux', 'x64'],
     maxClaims: null,
     claimsUsed: 0,


### PR DESCRIPTION
Persist provisioned-runner bindings from ephemeral registration tokens onto runner sessions and running jobs.

The control plane already binds each ephemeral registration token to a provisioner and provisioned runner, but that link was dropped after registration. Keeping it server-side lets the active-runner view, reconcile work, and cancellation intent paths resolve a busy provisioned runner through `runner_sessions` and `running_jobs` without exposing the provisioned runner id in runner-owned tokens.

This uses the consumed token row as the source of truth at registration, copies the link during capped ephemeral job claims, and updates active-runner merging to prefer the composite `(provisioner_id, provisioned_runner_id)` before falling back to `runner_session_id`. The migrations are edited in place because the runners schema is still pre-deploy.

Closes ENG-660

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted the provisioned-runner link from ephemeral registration tokens onto runner sessions and running jobs to reliably resolve busy runners without exposing runner IDs. Also keeps active runners visible when session IDs are missing or deduped; aligns with ENG-660.

- **New Features**
  - On registration, copy the link from the consumed ephemeral token into runner sessions; manual tokens keep it null.
  - When a capped ephemeral session claims a job, copy the link into running jobs.
  - Active-runner merging prefers the composite (provisioner_id, provisioned_runner_id) and falls back to runner_session_id; preserves a provisioned-runner row when a session-id fallback job was already merged.
  - DB checks require both link fields together (or neither), and require the link for ephemeral sessions.

<sup>Written for commit 02a57a2f2300632181c8186fb474267939f9df9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

