### PR TITLE
[runner] Honor backend agent runtime config

### DIFF
--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -63,7 +63,7 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_POLL_MAX_DURATION_MS` | `300000` | Maximum time to poll without claiming a job. Set to `0` to poll forever for manual or self-hosted runners. |
 | `SHIPFOX_HEARTBEAT_INTERVAL_MS` | `10000` | Heartbeat tick interval for an in-flight job. |
 | `SHIPFOX_HEARTBEAT_MAX_STALE_MS` | `10000` | Max time a single heartbeat may stay outstanding before it is aborted. |
-| `ANTHROPIC_API_KEY` | none | Anthropic API key the embedded pi harness uses to run agent steps against Anthropic models. Read from the process environment. Unset or empty disables agent steps, which then fail at invocation; other step types are unaffected. |
+| `AGENT_DEFAULT_PROVIDER_API_KEY` | none | Default provider API key configured on the API for agent steps when a workspace has no provider-specific key. Agent-step credentials come from workspace provider settings or this API-side default and are sent to the runner as short-lived runtime config. |
 | `SHIPFOX_LOG_FLUSH_INTERVAL_MS` | `2000` | How often buffered step logs are uploaded. Bounds how much recent output is lost if the runner dies mid-step. |
 | `SHIPFOX_LOG_FLUSH_BYTES` | `262144` | Backlog size that triggers an early log upload before the interval elapses, so bursts do not wait for the timer. |
 | `SHIPFOX_LOG_SPOOL_MAX_BYTES` | `67108864` | Max not-yet-acknowledged log bytes kept on disk per step attempt. Beyond this, output is dropped and a gap marker is recorded. |

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -63,7 +63,6 @@ configured root is empty, the filesystem root (`/`), or a home directory.
 | `SHIPFOX_POLL_MAX_DURATION_MS` | `300000` | Maximum time to poll without claiming a job. Set to `0` to poll forever for manual or self-hosted runners. |
 | `SHIPFOX_HEARTBEAT_INTERVAL_MS` | `10000` | Heartbeat tick interval for an in-flight job. |
 | `SHIPFOX_HEARTBEAT_MAX_STALE_MS` | `10000` | Max time a single heartbeat may stay outstanding before it is aborted. |
-| `AGENT_DEFAULT_PROVIDER_API_KEY` | none | Default provider API key configured on the API for agent steps when a workspace has no provider-specific key. Agent-step credentials come from workspace provider settings or this API-side default and are sent to the runner as short-lived runtime config. |
 | `SHIPFOX_LOG_FLUSH_INTERVAL_MS` | `2000` | How often buffered step logs are uploaded. Bounds how much recent output is lost if the runner dies mid-step. |
 | `SHIPFOX_LOG_FLUSH_BYTES` | `262144` | Backlog size that triggers an early log upload before the interval elapses, so bursts do not wait for the timer. |
 | `SHIPFOX_LOG_SPOOL_MAX_BYTES` | `67108864` | Max not-yet-acknowledged log bytes kept on disk per step attempt. Beyond this, output is dropped and a gap marker is recorded. |

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -1,8 +1,9 @@
 /**
  * A user-fixable agent-step configuration failure: an unknown provider, a
- * provider/model pair pi does not know, or no credentials on the runner for the
- * requested provider. The step layer translates this to the `agent_config_invalid`
- * reason, distinct from a genuine provider/API failure (`agent_invocation_failed`).
+ * provider/model pair pi does not know, or workspace provider credentials that
+ * are missing or incomplete. The step layer translates this to the
+ * `agent_config_invalid` reason, distinct from a genuine provider/API failure
+ * (`agent_invocation_failed`).
  */
 export class AgentConfigError extends Error {
   constructor(message: string) {

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -38,6 +38,7 @@ function invocation(overrides: Partial<AgentInvocation> = {}): AgentInvocation {
     provider: 'anthropic',
     thinking: 'high',
     prompt: 'Fix it.',
+    credentials: {api_key: 'sk-runtime-secret'},
     signal: new AbortController().signal,
     ...overrides,
   };
@@ -68,6 +69,7 @@ describe('runAgent', () => {
   });
 
   afterEach(() => {
+    expect(authStorageCreateMock).not.toHaveBeenCalled();
     if (sessionDir) rmSync(sessionDir, {recursive: true, force: true});
     sessionDir = undefined;
   });
@@ -249,14 +251,14 @@ describe('runAgent', () => {
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
-  it('throws an AgentConfigError when the provider has no credentials on the runner', async () => {
+  it('throws an AgentConfigError when the provider has no configured workspace credentials', async () => {
     findMock.mockReturnValue({provider: 'openai', id: 'gpt-5.1'});
     hasConfiguredAuthMock.mockReturnValue(false);
 
     await expect(runAgent(invocation({provider: 'openai', model: 'gpt-5.1'}))).rejects.toThrow(
       new AgentConfigError(
-        'No credentials configured for provider "openai" on this runner. ' +
-          "Set the provider's API key in the runner environment.",
+        'No credentials configured for provider "openai". ' +
+          'Verify the provider is configured for this workspace.',
       ),
     );
     expect(createAgentSessionMock).not.toHaveBeenCalled();

--- a/libs/runner/agent/src/core/run-agent.ts
+++ b/libs/runner/agent/src/core/run-agent.ts
@@ -21,7 +21,7 @@ export interface AgentInvocation {
   readonly provider: string;
   readonly thinking: string;
   readonly prompt: string;
-  readonly credentials?: Record<string, string> | undefined;
+  readonly credentials: Record<string, string>;
   readonly signal: AbortSignal;
   /**
    * Forwards each verbatim pi session entry line as it is persisted, in order. Best-effort
@@ -57,19 +57,18 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
   // session exists so a mid-creation abort still stops pi.
   if (signal.aborted) throw new Error('Agent step aborted before the pi session started');
 
-  const authStorage =
-    credentials === undefined
-      ? AuthStorage.create()
-      : AuthStorage.inMemory({[provider]: toPiRuntimeCredential(provider, credentials)});
+  const authStorage = AuthStorage.inMemory({
+    [provider]: toPiRuntimeCredential(provider, credentials),
+  });
   const modelRegistry = ModelRegistry.create(authStorage);
   const model = resolveModel(modelRegistry, provider, modelId);
 
   // Surface a missing key up front as a config error: otherwise it fails deep inside the
-  // provider call as an opaque invocation failure, hiding that the fix is on the runner.
+  // provider call as an opaque invocation failure, hiding that the fix is workspace config.
   if (!modelRegistry.hasConfiguredAuth(model)) {
     throw new AgentConfigError(
-      `No credentials configured for provider "${provider}" on this runner. ` +
-        "Set the provider's API key in the runner environment.",
+      `No credentials configured for provider "${provider}". ` +
+        'Verify the provider is configured for this workspace.',
     );
   }
 

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -7,6 +7,13 @@ import {AgentConfigError} from '#core/errors.js';
 import type {AgentInvocation} from '#core/run-agent.js';
 import {executeAgentStep} from '#core/step.js';
 
+const RUNTIME = {
+  provider: 'anthropic',
+  model: 'claude-opus-4-8',
+  thinking: 'high',
+  credentials: {api_key: 'sk-runtime-secret'},
+};
+
 function buildAgentStep(overrides: Partial<StepDto> = {}): StepDto {
   const displayName =
     overrides.display_name ??
@@ -37,7 +44,7 @@ describe('executeAgentStep', () => {
   it('runs the agent and reports process-success with exit_code 0', async () => {
     runAgentMock.mockResolvedValue({summary: 'done'});
 
-    const result = await executeAgentStep(buildAgentStep(), {cwd: '/work'});
+    const result = await executeAgentStep(buildAgentStep(), {cwd: '/work', runtime: RUNTIME});
 
     expect(result).toEqual({success: true, output: 'done', error: null, exit_code: 0});
     expect(runAgentMock).toHaveBeenCalledWith(
@@ -50,41 +57,54 @@ describe('executeAgentStep', () => {
     );
   });
 
-  it('defaults thinking to high and provider to anthropic when the config omits them', async () => {
+  it('forwards runtime provider, model, and thinking to the agent invocation', async () => {
     runAgentMock.mockResolvedValue({});
 
-    await executeAgentStep(buildAgentStep({config: {model: 'm', prompt: 'p'}}), {});
+    await executeAgentStep(buildAgentStep({config: {prompt: 'p'}}), {
+      runtime: {
+        provider: 'openai',
+        model: 'gpt-5.1',
+        thinking: 'medium',
+        credentials: {api_key: 'sk-openai'},
+      },
+    });
 
     expect(runAgentMock).toHaveBeenCalledWith(
-      expect.objectContaining({thinking: 'high', provider: 'anthropic'}),
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.1',
+        thinking: 'medium',
+        credentials: {api_key: 'sk-openai'},
+      }),
     );
   });
 
-  it('forwards an explicit provider from the config', async () => {
+  it('ignores stale provider, model, and thinking values in step config', async () => {
     runAgentMock.mockResolvedValue({});
 
     await executeAgentStep(
-      buildAgentStep({config: {model: 'gpt-5.1', prompt: 'p', provider: 'openai'}}),
-      {},
+      buildAgentStep({
+        config: {provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high', prompt: 'p'},
+      }),
+      {
+        runtime: {
+          provider: 'openai',
+          model: 'gpt-5.1',
+          thinking: 'low',
+          credentials: {api_key: 'sk-openai'},
+        },
+      },
     );
 
-    expect(runAgentMock).toHaveBeenCalledWith(expect.objectContaining({provider: 'openai'}));
-  });
-
-  it('forwards runtime credentials to the agent invocation', async () => {
-    runAgentMock.mockResolvedValue({});
-
-    await executeAgentStep(buildAgentStep(), {credentials: {api_key: 'sk-runtime-secret'}});
-
     expect(runAgentMock).toHaveBeenCalledWith(
-      expect.objectContaining({credentials: {api_key: 'sk-runtime-secret'}}),
+      expect.objectContaining({provider: 'openai', model: 'gpt-5.1', thinking: 'low'}),
     );
   });
 
   it('fails with agent_invocation_failed when the agent run throws a generic error', async () => {
     runAgentMock.mockRejectedValue(new Error('provider returned 503'));
 
-    const result = await executeAgentStep(buildAgentStep(), {});
+    const result = await executeAgentStep(buildAgentStep(), {runtime: RUNTIME});
 
     expect(result.success).toBe(false);
     expect(result.error).toEqual({
@@ -97,7 +117,7 @@ describe('executeAgentStep', () => {
   it('fails with agent_config_invalid when the agent run throws an AgentConfigError', async () => {
     runAgentMock.mockRejectedValue(new AgentConfigError('Unknown provider "foo" for agent step.'));
 
-    const result = await executeAgentStep(buildAgentStep(), {});
+    const result = await executeAgentStep(buildAgentStep(), {runtime: RUNTIME});
 
     expect(result.success).toBe(false);
     expect(result.error).toEqual({
@@ -107,15 +127,19 @@ describe('executeAgentStep', () => {
   });
 
   it('rejects a non-agent step type without running the agent', async () => {
-    const result = await executeAgentStep(buildAgentStep({type: 'run', config: {run: 'x'}}), {});
+    const result = await executeAgentStep(buildAgentStep({type: 'run', config: {run: 'x'}}), {
+      runtime: RUNTIME,
+    });
 
     expect(result.success).toBe(false);
     expect(result.error?.message).toContain('Unsupported step type');
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 
-  it('fails with agent_config_invalid when the config is missing model or prompt', async () => {
-    const result = await executeAgentStep(buildAgentStep({config: {model: 'm'}}), {});
+  it('fails with agent_config_invalid when the config is missing prompt', async () => {
+    const result = await executeAgentStep(buildAgentStep({config: {model: 'm'}}), {
+      runtime: RUNTIME,
+    });
 
     expect(result.success).toBe(false);
     expect(result.error?.reason).toBe('agent_config_invalid');
@@ -133,7 +157,7 @@ describe('executeAgentStep', () => {
       });
     });
 
-    const promise = executeAgentStep(buildAgentStep(), {signal: ac.signal});
+    const promise = executeAgentStep(buildAgentStep(), {signal: ac.signal, runtime: RUNTIME});
     ac.abort();
     const result = await promise;
 
@@ -146,7 +170,10 @@ describe('executeAgentStep', () => {
     ac.abort();
     runAgentMock.mockRejectedValue(new Error('agent rejected after abort'));
 
-    const result = await executeAgentStep(buildAgentStep(), {signal: ac.signal});
+    const result = await executeAgentStep(buildAgentStep(), {
+      signal: ac.signal,
+      runtime: RUNTIME,
+    });
 
     expect(result.success).toBe(false);
   });

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -3,39 +3,38 @@ import type {StepResult} from '@shipfox/runner-execution';
 import {AgentConfigError} from '#core/errors.js';
 import {runAgent} from '#core/run-agent.js';
 
-const DEFAULT_THINKING = 'high';
-// Matches DEFAULT_AGENT_PROVIDER upstream; kept local so the runner stays decoupled from
-// the workflow-document package, and so a config materialized before `provider` existed
-// still resolves to anthropic.
-const DEFAULT_PROVIDER = 'anthropic';
-
 export function executeAgentStep(
   step: StepDto,
   options: {
     signal?: AbortSignal;
     cwd?: string;
-    credentials?: Record<string, string>;
+    runtime: {
+      provider: string;
+      model: string;
+      thinking: string;
+      credentials: Record<string, string>;
+    };
     onSessionEntry?: (line: string) => void;
-  } = {},
+  },
 ): Promise<StepResult> {
   if (step.type !== 'agent') {
     return Promise.resolve(agentFailure(`Unsupported step type: ${step.type}`));
   }
 
-  const {model, prompt, thinking, provider} = step.config;
-  if (typeof model !== 'string' || model === '' || typeof prompt !== 'string' || prompt === '') {
+  const {prompt} = step.config;
+  if (typeof prompt !== 'string' || prompt === '') {
     return Promise.resolve(
-      agentFailure('Agent step config is missing model or prompt', 'agent_config_invalid'),
+      agentFailure('Agent step config is missing prompt', 'agent_config_invalid'),
     );
   }
 
   return runAgentStep({
     cwd: options.cwd ?? process.cwd(),
-    model,
+    model: options.runtime.model,
     prompt,
-    thinking: typeof thinking === 'string' ? thinking : DEFAULT_THINKING,
-    provider: typeof provider === 'string' && provider !== '' ? provider : DEFAULT_PROVIDER,
-    credentials: options.credentials,
+    thinking: options.runtime.thinking,
+    provider: options.runtime.provider,
+    credentials: options.runtime.credentials,
     signal: options.signal,
     onSessionEntry: options.onSessionEntry,
   });
@@ -47,7 +46,7 @@ async function runAgentStep(params: {
   prompt: string;
   thinking: string;
   provider: string;
-  credentials: Record<string, string> | undefined;
+  credentials: Record<string, string>;
   signal: AbortSignal | undefined;
   onSessionEntry: ((line: string) => void) | undefined;
 }): Promise<StepResult> {
@@ -62,7 +61,7 @@ async function runAgentStep(params: {
         provider,
         thinking,
         prompt,
-        ...(credentials ? {credentials} : {}),
+        credentials,
         signal,
         ...(onSessionEntry ? {onSessionEntry} : {}),
       }),

--- a/libs/runner/logs/src/index.ts
+++ b/libs/runner/logs/src/index.ts
@@ -1,5 +1,6 @@
 export type {OutputSource} from '#core/framing.js';
 export type {LogDrainOutcome, LogStreamLifecycle} from '#core/lifecycle.js';
+export {buildSecretVariants} from '#core/secrets.js';
 export {
   createSessionLogStream,
   type SessionLogStream,

--- a/libs/runner/orchestration/package.json
+++ b/libs/runner/orchestration/package.json
@@ -40,6 +40,7 @@
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/redact": "workspace:*",
     "@shipfox/runner-agent": "workspace:*",
     "@shipfox/runner-execution": "workspace:*",
     "@shipfox/runner-logs": "workspace:*",

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -44,13 +44,14 @@ vi.mock('@shipfox/runner-execution', () => ({
 vi.mock('@shipfox/runner-logs', () => ({
   createStepLogStream: (...args: unknown[]) => createStepLogStreamMock(...args),
   createSessionLogStream: (...args: unknown[]) => createSessionLogStreamMock(...args),
+  buildSecretVariants: (secrets: string[]) => secrets.filter((secret) => secret !== ''),
 }));
 
 vi.mock('@shipfox/runner-agent', () => ({
   executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
 }));
 
-const {runJobSteps} = await import('#core/step-loop.js');
+const {executeStep, runJobSteps} = await import('#core/step-loop.js');
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
 const RUN_ID = '00000000-0000-0000-0000-0000000000ab';
@@ -646,7 +647,12 @@ describe('runJobSteps', () => {
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {
       signal: ac.signal,
       cwd: '/work',
-      credentials: {api_key: 'sk-runtime-secret'},
+      runtime: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        credentials: {api_key: 'sk-runtime-secret'},
+      },
       onSessionEntry: expect.any(Function),
     });
     expect(requestAgentRuntimeConfigMock).toHaveBeenCalledWith(leaseClient, {
@@ -664,6 +670,44 @@ describe('runJobSteps', () => {
       logOutcome: 'drained',
       signal: ac.signal,
     });
+  });
+
+  it('uses provider, model, and thinking from runtime config instead of stale step config', async () => {
+    const setup = buildSetupStep();
+    const agent = buildAgentStep({
+      config: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        prompt: 'Fix it.',
+      },
+    });
+    requestAgentRuntimeConfigMock.mockResolvedValueOnce({
+      provider_id: 'openai',
+      model: 'gpt-5.1',
+      thinking: 'medium',
+      credentials: {api_key: 'sk-openai-runtime'},
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(agent, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeAgentStepMock.mockResolvedValue({success: true, output: '', error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeAgentStepMock).toHaveBeenCalledWith(
+      agent,
+      expect.objectContaining({
+        runtime: {
+          provider: 'openai',
+          model: 'gpt-5.1',
+          thinking: 'medium',
+          credentials: {api_key: 'sk-openai-runtime'},
+        },
+      }),
+    );
   });
 
   it('opens a session stream for an agent step, forwards entries, and settles it', async () => {
@@ -718,7 +762,12 @@ describe('runJobSteps', () => {
     expect(executeAgentStepMock).toHaveBeenCalledWith(agent, {
       signal: ac.signal,
       cwd: '/work',
-      credentials: {api_key: 'sk-runtime-secret'},
+      runtime: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        credentials: {api_key: 'sk-runtime-secret'},
+      },
     });
     expect(reportStepMock).toHaveBeenCalledWith(
       leaseClient,
@@ -752,6 +801,44 @@ describe('runJobSteps', () => {
       leaseClient,
       expect.objectContaining({stepId: agent.id}),
     );
+  });
+
+  it('redacts runtime credential values from agent failures and blanks output before reporting', async () => {
+    const agent = buildAgentStep();
+    executeAgentStepMock.mockResolvedValue({
+      success: false,
+      output: 'provider echoed sk-runtime-secret',
+      error: {
+        message: 'provider rejected sk-runtime-secret',
+        reason: 'agent_invocation_failed' as const,
+      },
+      exit_code: null,
+    });
+    const ac = new AbortController();
+
+    const execution = await executeStep({
+      step: agent,
+      attempt: 1,
+      cwd: '/work',
+      logsDir: LOGS_DIR,
+      jobContext: JOB_CONTEXT,
+      leaseClient,
+      secrets: [],
+      signal: ac.signal,
+      workspacePrepared: true,
+      jobId: JOB_ID,
+      stepLabel: 'implement',
+    });
+
+    expect(execution.result).toEqual({
+      success: false,
+      output: '',
+      error: {
+        message: 'provider rejected ***',
+        reason: 'agent_invocation_failed',
+      },
+      exit_code: null,
+    });
   });
 
   it('reports agent_config_invalid when runtime credentials are rejected by the API', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -41,11 +41,15 @@ vi.mock('@shipfox/runner-execution', () => ({
   executeSetupStep: (...args: unknown[]) => executeSetupStepMock(...args),
 }));
 
-vi.mock('@shipfox/runner-logs', () => ({
-  createStepLogStream: (...args: unknown[]) => createStepLogStreamMock(...args),
-  createSessionLogStream: (...args: unknown[]) => createSessionLogStreamMock(...args),
-  buildSecretVariants: (secrets: string[]) => secrets.filter((secret) => secret !== ''),
-}));
+vi.mock('@shipfox/runner-logs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@shipfox/runner-logs')>('@shipfox/runner-logs');
+  return {
+    createStepLogStream: (...args: unknown[]) => createStepLogStreamMock(...args),
+    createSessionLogStream: (...args: unknown[]) => createSessionLogStreamMock(...args),
+    buildSecretVariants: actual.buildSecretVariants,
+  };
+});
 
 vi.mock('@shipfox/runner-agent', () => ({
   executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
@@ -805,11 +809,12 @@ describe('runJobSteps', () => {
 
   it('redacts runtime credential values from agent failures and blanks output before reporting', async () => {
     const agent = buildAgentStep();
+    const hexCredential = Buffer.from('sk-runtime-secret').toString('hex');
     executeAgentStepMock.mockResolvedValue({
       success: false,
       output: 'provider echoed sk-runtime-secret',
       error: {
-        message: 'provider rejected sk-runtime-secret',
+        message: `provider rejected sk-runtime-secret and ${hexCredential}`,
         reason: 'agent_invocation_failed' as const,
       },
       exit_code: null,
@@ -834,7 +839,7 @@ describe('runJobSteps', () => {
       success: false,
       output: '',
       error: {
-        message: 'provider rejected ***',
+        message: 'provider rejected *** and ***',
         reason: 'agent_invocation_failed',
       },
       exit_code: null,

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1,5 +1,6 @@
 import type {LogOutcomeDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
+import {redactSecrets} from '@shipfox/redact';
 import {executeAgentStep} from '@shipfox/runner-agent';
 import {
   type CommandStartMetadata,
@@ -9,6 +10,7 @@ import {
   type StepResult,
 } from '@shipfox/runner-execution';
 import {
+  buildSecretVariants,
   createSessionLogStream,
   createStepLogStream,
   type LogDrainOutcome,
@@ -279,7 +281,9 @@ export async function executeStep(params: {
       }
 
       let sessionStream: SessionLogStream | undefined;
-      const agentSecrets = [...secrets, ...Object.values(runtimeConfig.credentials)];
+      const runtimeCredentialValues = Object.values(runtimeConfig.credentials);
+      const runtimeSecretVariants = buildSecretVariants(runtimeCredentialValues);
+      const agentSecrets = [...secrets, ...runtimeCredentialValues];
       try {
         sessionStream = createSessionLogStream({
           logsDir,
@@ -298,13 +302,18 @@ export async function executeStep(params: {
       const result = await executeAgentStep(step, {
         signal,
         cwd,
-        credentials: runtimeConfig.credentials,
+        runtime: {
+          provider: runtimeConfig.provider_id,
+          model: runtimeConfig.model,
+          thinking: runtimeConfig.thinking,
+          credentials: runtimeConfig.credentials,
+        },
         ...(sessionStream
           ? {onSessionEntry: (line: string) => sessionStream?.writeEntry(line)}
           : {}),
       });
       return {
-        result,
+        result: maskAgentFailure(result, runtimeSecretVariants),
         stream,
         logOutcome: sessionStream ? undefined : 'abandoned',
         preparedWorkspace: false,
@@ -362,6 +371,15 @@ export async function executeStep(params: {
       preparedWorkspace: false,
     };
   }
+}
+
+function maskAgentFailure(result: StepResult, secretVariants: string[]): StepResult {
+  if (result.success) return result;
+  const error =
+    result.error === null || result.error === undefined
+      ? result.error
+      : {...result.error, message: redactSecrets(result.error.message, secretVariants)};
+  return {...result, output: '', error};
 }
 
 function agentRuntimeConfigFailure(error: unknown): StepResult {

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -252,6 +252,24 @@ describe('api-client auth contexts', () => {
     await expect(request).rejects.not.toThrow(ZOD_ERROR_TEXT_REGEX);
   });
 
+  it.each([
+    ['empty', ''],
+    ['invalid JSON', 'not json'],
+  ])('requestAgentRuntimeConfig classifies %s success bodies as invalid runtime config', async (_caseName, body) => {
+    stubFetch(() => new Response(body, {status: 200}));
+    const leaseClient = createLeaseClient('lease-runtime');
+
+    const request = requestAgentRuntimeConfig(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+    });
+
+    await expect(request).rejects.toMatchObject(
+      new AgentRuntimeConfigRequestError(200, 'agent-runtime-config-invalid'),
+    );
+    await expect(request).rejects.not.toThrow(SyntaxError);
+  });
+
   it('reportStep sends the lease token to the per-step report endpoint', async () => {
     stubFetch(() => jsonResponse({ok: true, cancel: false}));
     const leaseClient = createLeaseClient('lease-def');

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -24,6 +24,7 @@ const JOB_ID = crypto.randomUUID();
 const RUN_ID = crypto.randomUUID();
 const STEP_ID = crypto.randomUUID();
 const SESSION_ID = crypto.randomUUID();
+const ZOD_ERROR_TEXT_REGEX = /Zod|Invalid|Required/;
 
 let calls: Array<{url: string; method: string; authorization: string | null; body: string}>;
 let originalFetch: typeof globalThis.fetch;
@@ -196,6 +197,59 @@ describe('api-client auth contexts', () => {
     await expect(request).rejects.toMatchObject(
       new AgentRuntimeConfigRequestError(409, 'agent-config-invalid'),
     );
+  });
+
+  it('requestAgentRuntimeConfig retries transient 429 and 5xx responses', async () => {
+    const responses = [
+      new Response(null, {status: 429}),
+      new Response(null, {status: 500}),
+      jsonResponse({
+        provider_id: 'openai',
+        model: 'gpt-5.1',
+        thinking: 'medium',
+        credentials: {api_key: 'sk-runtime'},
+      }),
+    ];
+    stubFetch(() => responses.shift() ?? new Response(null, {status: 500}));
+    const leaseClient = createLeaseClient('lease-runtime');
+
+    const runtimeConfig = await requestAgentRuntimeConfig(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+    });
+
+    expect(runtimeConfig.provider_id).toBe('openai');
+    expect(calls).toHaveLength(3);
+  });
+
+  it('requestAgentRuntimeConfig surfaces transient retry exhaustion as a typed request error', async () => {
+    stubFetch(() => jsonResponse({code: 'temporarily-unavailable'}, 503));
+    const leaseClient = createLeaseClient('lease-runtime');
+
+    const request = requestAgentRuntimeConfig(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+    });
+
+    await expect(request).rejects.toMatchObject(
+      new AgentRuntimeConfigRequestError(503, 'temporarily-unavailable'),
+    );
+    expect(calls).toHaveLength(3);
+  });
+
+  it('requestAgentRuntimeConfig classifies malformed success bodies without leaking Zod text', async () => {
+    stubFetch(() => jsonResponse({provider_id: 'openai', credentials: {api_key: 'sk-runtime'}}));
+    const leaseClient = createLeaseClient('lease-runtime');
+
+    const request = requestAgentRuntimeConfig(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 2,
+    });
+
+    await expect(request).rejects.toMatchObject(
+      new AgentRuntimeConfigRequestError(200, 'agent-runtime-config-invalid'),
+    );
+    await expect(request).rejects.not.toThrow(ZOD_ERROR_TEXT_REGEX);
   });
 
   it('reportStep sends the lease token to the per-step report endpoint', async () => {

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -264,7 +264,14 @@ export async function requestAgentRuntimeConfig(
   }
 
   if (response.ok) {
-    const parsed = agentRuntimeCredentialsResponseSchema.safeParse(await response.json());
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new AgentRuntimeConfigRequestError(200, 'agent-runtime-config-invalid');
+    }
+
+    const parsed = agentRuntimeCredentialsResponseSchema.safeParse(body);
     if (!parsed.success) {
       throw new AgentRuntimeConfigRequestError(200, 'agent-runtime-config-invalid');
     }

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -246,14 +246,32 @@ export async function requestAgentRuntimeConfig(
     signal?: AbortSignal;
   },
 ): Promise<AgentRuntimeCredentialsResponseDto> {
-  const response = await leaseClient.get('runs/jobs/current/agent-runtime-config', {
-    searchParams: {step_id: params.stepId, attempt: params.attempt},
-    throwHttpErrors: false,
-    ...(params.signal ? {signal: params.signal} : {}),
-  });
+  let response: Response;
+  try {
+    response = await leaseClient.get('runs/jobs/current/agent-runtime-config', {
+      searchParams: {step_id: params.stepId, attempt: params.attempt},
+      retry: {
+        methods: ['get'],
+        statusCodes: [429, 500, 502, 503, 504],
+      },
+      ...(params.signal ? {signal: params.signal} : {}),
+    });
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      throw new AgentRuntimeConfigRequestError(
+        error.response.status,
+        codeFromBody(error.data) ?? (await errorCode(error.response)),
+      );
+    }
+    throw error;
+  }
 
   if (response.ok) {
-    return agentRuntimeCredentialsResponseSchema.parse(await response.json());
+    const parsed = agentRuntimeCredentialsResponseSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new AgentRuntimeConfigRequestError(200, 'agent-runtime-config-invalid');
+    }
+    return parsed.data;
   }
 
   throw new AgentRuntimeConfigRequestError(response.status, await errorCode(response));
@@ -331,9 +349,13 @@ export {HTTPError};
 async function errorCode(response: Response): Promise<string | undefined> {
   try {
     const body = (await response.json()) as unknown;
-    if (typeof body !== 'object' || body === null || !('code' in body)) return undefined;
-    return typeof body.code === 'string' ? body.code : undefined;
+    return codeFromBody(body);
   } catch {
     return undefined;
   }
+}
+
+function codeFromBody(body: unknown): string | undefined {
+  if (typeof body !== 'object' || body === null || !('code' in body)) return undefined;
+  return typeof body.code === 'string' ? body.code : undefined;
 }

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -258,10 +258,7 @@ export async function requestAgentRuntimeConfig(
     });
   } catch (error) {
     if (error instanceof HTTPError) {
-      throw new AgentRuntimeConfigRequestError(
-        error.response.status,
-        codeFromBody(error.data) ?? (await errorCode(error.response)),
-      );
+      throw new AgentRuntimeConfigRequestError(error.response.status, codeFromBody(error.data));
     }
     throw error;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3573,6 +3573,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/redact':
+        specifier: workspace:*
+        version: link:../../shared/common/redact
       '@shipfox/runner-agent':
         specifier: workspace:*
         version: link:../agent


### PR DESCRIPTION
Make the backend runtime-config endpoint the single source of truth for agent provider, model, thinking level, and credentials.

ENG-600 added the lease-scoped runtime-config endpoint, but runner execution still read provider/model/thinking from stale step config and could fall back to Pi's persisted or environment auth. This wires the endpoint response through the agent step invocation, requires runtime credentials, and keeps them in Pi's in-memory auth storage only.

This also closes the server-side leak path for failed agent steps by redacting runtime credential values from failure messages and blanking failed outputs before reporting. Runtime-config fetches now retry transient 429/5xx responses and classify malformed success bodies with a stable typed error instead of exposing parser text.

No changeset: the touched runner packages are private.

Fixes ENG-601

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the backend agent runtime-config the single source of truth for provider, model, thinking, and credentials. Credentials are short‑lived, required, and kept in-memory; failures are scrubbed and runtime-config fetch is resilient. Fixes ENG-601.

- New Features
  - Use API `agent-runtime-config` for provider/model/thinking/credentials; ignore stale step config.
  - Inject runtime credentials into Pi via in-memory auth only; fail early with `AgentConfigError` if workspace creds are missing.
  - Remove `ANTHROPIC_API_KEY` from runner docs; provider auth is API-only now.

- Bug Fixes
  - Redact runtime credential values (including common variants) in error messages and blank failed agent outputs before reporting, using `@shipfox/redact` and `@shipfox/runner-logs`.
  - Retry 429/5xx when fetching runtime config and return typed `AgentRuntimeConfigRequestError` for exhaustion or empty/invalid success bodies; simplify error code handling with no parser text leaks.

<sup>Written for commit d3c995bba82056c9a37701eb17e0182351098ea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

