### PR TITLE
[client-agent] Add workflow usage guide for agent providers

### DIFF
--- a/.changeset/clear-guides-open.md
+++ b/.changeset/clear-guides-open.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/client-agent": minor
+---
+
+Adds a workflow example usage modal for configured agent providers, with model selection, ready-to-copy workflow YAML, model id browsing, and automatic opening after first configuration.

--- a/.changeset/clear-guides-open.md
+++ b/.changeset/clear-guides-open.md
@@ -2,4 +2,4 @@
 "@shipfox/client-agent": minor
 ---
 
-Adds a workflow example usage modal for configured agent providers, with model selection, ready-to-copy workflow YAML, model id browsing, and automatic opening after first configuration.
+Add a workflow example usage modal for configured agent providers, with model selection, ready-to-copy workflow YAML, model id browsing, and automatic opening after first configuration.

--- a/libs/client/agent/package.json
+++ b/libs/client/agent/package.json
@@ -59,6 +59,7 @@
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@shipfox/workflow-document": "workspace:*",
     "@storybook/addon-vitest": "^10.3.6",
     "@storybook/react": "^10.0.0",
     "@storybook/react-vite": "^10.0.0",
@@ -77,6 +78,7 @@
     "storybook-addon-pseudo-states": "^10.0.0",
     "tailwindcss": "^4.1.13",
     "vite": "^8.0.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "yaml": "^2.8.3"
   }
 }

--- a/libs/client/agent/src/components/agent-provider-usage-modal.stories.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.stories.tsx
@@ -1,0 +1,74 @@
+import type {AgentProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
+
+interface AgentProviderUsageModalStoryProps {
+  variant: 'anthropic' | 'long-list';
+}
+
+function AgentProviderUsageModalStory({variant}: AgentProviderUsageModalStoryProps) {
+  const [open, setOpen] = useState(true);
+  const entry = variant === 'long-list' ? longListEntry() : anthropicEntry();
+
+  return (
+    <div className="min-h-screen bg-background-neutral-background p-24">
+      <AgentProviderUsageModal
+        entry={entry}
+        initialModel={entry.default_model}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Agent/ProviderUsageModal',
+  component: AgentProviderUsageModalStory,
+  parameters: {layout: 'fullscreen'},
+  args: {variant: 'anthropic'},
+} satisfies Meta<typeof AgentProviderUsageModalStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Anthropic: Story = {};
+
+export const LongModelList: Story = {
+  args: {variant: 'long-list'},
+};
+
+function anthropicEntry(): AgentProviderCatalogEntryDto {
+  return {
+    id: 'anthropic',
+    label: 'Anthropic',
+    support_status: 'supported',
+    default_model: 'claude-opus-4-8',
+    credential_fields: [{key: 'api_key', label: 'API key', secret: true}],
+    unsupported_reason: null,
+    models: [
+      {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+      {id: 'claude-sonnet-4-8', label: 'Claude Sonnet 4.8'},
+      {id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5'},
+    ],
+  };
+}
+
+function longListEntry(): AgentProviderCatalogEntryDto {
+  return {
+    id: 'cloudflare-workers-ai',
+    label: 'Cloudflare Workers AI',
+    support_status: 'supported',
+    default_model: '@cf/moonshotai/kimi-k2.7-code',
+    credential_fields: [{key: 'api_token', label: 'API token', secret: true}],
+    unsupported_reason: null,
+    models: Array.from({length: 56}, (_, index) => ({
+      id:
+        index === 0
+          ? '@cf/moonshotai/kimi-k2.7-code'
+          : `provider/research-lab/model-family-${String(index).padStart(2, '0')}-large-context`,
+      label: index === 0 ? 'Kimi K2.7 Code' : `Research Model ${index}`,
+    })),
+  };
+}

--- a/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
@@ -54,6 +54,18 @@ describe('AgentProviderUsageModal', () => {
     expect(within(list).getByRole('button', {name: 'Copy Kimi K2.7 Code id'})).toBeVisible();
   });
 
+  test('shows model ids in a tooltip instead of the row', async () => {
+    const user = userEvent.setup();
+
+    renderUsageModal();
+    expect(screen.queryByText('@cf/moonshotai/kimi-k2.7-code')).not.toBeInTheDocument();
+
+    await user.hover(await screen.findByText('Kimi K2.7 Code'));
+
+    const matches = await screen.findAllByText('@cf/moonshotai/kimi-k2.7-code');
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
   test('copies the full model id', async () => {
     const user = userEvent.setup();
     const writeText = vi.fn().mockResolvedValue(undefined);

--- a/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
@@ -3,6 +3,9 @@ import userEvent from '@testing-library/user-event';
 import {agentProviderEntry} from '#test/fixtures/agent-providers.js';
 import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
 
+const CLAUDE_MODEL_ROW_NAME = 'Copy Claude Opus 4.8 model id claude-opus-4-8';
+const KIMI_MODEL_ROW_NAME = 'Copy Kimi K2.7 Code model id @cf/moonshotai/kimi-k2.7-code';
+
 function renderUsageModal() {
   const onOpenChange = vi.fn();
   const entry = agentProviderEntry({
@@ -45,25 +48,13 @@ describe('AgentProviderUsageModal', () => {
     );
   });
 
-  test('renders reference model copy buttons', async () => {
+  test('renders reference models as clickable rows with inline ids', async () => {
     renderUsageModal();
 
     const list = await screen.findByRole('list');
     expect(within(list).getByText('Claude Opus 4.8')).toBeVisible();
-    expect(within(list).getByRole('button', {name: 'Copy Claude Opus 4.8 id'})).toBeVisible();
-    expect(within(list).getByRole('button', {name: 'Copy Kimi K2.7 Code id'})).toBeVisible();
-  });
-
-  test('shows model ids in a tooltip instead of the row', async () => {
-    const user = userEvent.setup();
-
-    renderUsageModal();
-    expect(screen.queryByText('@cf/moonshotai/kimi-k2.7-code')).not.toBeInTheDocument();
-
-    await user.hover(await screen.findByText('Kimi K2.7 Code'));
-
-    const matches = await screen.findAllByText('@cf/moonshotai/kimi-k2.7-code');
-    expect(matches.length).toBeGreaterThan(0);
+    expect(within(list).getByText('@cf/moonshotai/kimi-k2.7-code')).toBeVisible();
+    expect(within(list).getByRole('button', {name: KIMI_MODEL_ROW_NAME})).toBeVisible();
   });
 
   test('copies the full model id', async () => {
@@ -75,9 +66,10 @@ describe('AgentProviderUsageModal', () => {
     });
 
     renderUsageModal();
-    await user.click(await screen.findByRole('button', {name: 'Copy Kimi K2.7 Code id'}));
+    await user.click(await screen.findByRole('button', {name: KIMI_MODEL_ROW_NAME}));
 
     expect(writeText).toHaveBeenCalledWith('@cf/moonshotai/kimi-k2.7-code');
+    expect(await screen.findAllByText('Copied')).toHaveLength(2);
     expect(await screen.findByRole('status')).toHaveTextContent('Copied Kimi K2.7 Code id');
   });
 
@@ -94,7 +86,7 @@ describe('AgentProviderUsageModal', () => {
     });
 
     renderUsageModal();
-    await user.click(await screen.findByRole('button', {name: 'Copy Claude Opus 4.8 id'}));
+    await user.click(await screen.findByRole('button', {name: CLAUDE_MODEL_ROW_NAME}));
 
     await waitFor(() => expect(document.execCommand).toHaveBeenCalledWith('copy'));
     expect(await screen.findByRole('status')).toHaveTextContent(

--- a/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
@@ -1,0 +1,92 @@
+import {render, screen, waitFor, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {agentProviderEntry} from '#test/fixtures/agent-providers.js';
+import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
+
+function renderUsageModal() {
+  const onOpenChange = vi.fn();
+  const entry = agentProviderEntry({
+    default_model: 'claude-opus-4-8',
+    models: [
+      {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+      {id: '@cf/moonshotai/kimi-k2.7-code', label: 'Kimi K2.7 Code'},
+    ],
+  });
+
+  render(
+    <AgentProviderUsageModal
+      entry={entry}
+      initialModel="claude-opus-4-8"
+      open
+      onOpenChange={onOpenChange}
+    />,
+  );
+
+  return {entry, onOpenChange};
+}
+
+describe('AgentProviderUsageModal', () => {
+  test('changes the selected model in the workflow example', async () => {
+    const user = userEvent.setup();
+
+    renderUsageModal();
+    expect(await screen.findByText('model: claude-opus-4-8')).toBeVisible();
+
+    await user.click(screen.getByRole('button', {name: 'Model'}));
+    await user.click(await screen.findByRole('option', {name: 'Kimi K2.7 Code'}));
+
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        "model: '@cf/moonshotai/kimi-k2.7-code'",
+      ),
+    );
+    expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).not.toHaveTextContent(
+      'model: claude-opus-4-8',
+    );
+  });
+
+  test('renders reference model copy buttons', async () => {
+    renderUsageModal();
+
+    const list = await screen.findByRole('list');
+    expect(within(list).getByText('Claude Opus 4.8')).toBeVisible();
+    expect(within(list).getByRole('button', {name: 'Copy Claude Opus 4.8 id'})).toBeVisible();
+    expect(within(list).getByRole('button', {name: 'Copy Kimi K2.7 Code id'})).toBeVisible();
+  });
+
+  test('copies the full model id', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {writeText},
+    });
+
+    renderUsageModal();
+    await user.click(await screen.findByRole('button', {name: 'Copy Kimi K2.7 Code id'}));
+
+    expect(writeText).toHaveBeenCalledWith('@cf/moonshotai/kimi-k2.7-code');
+    expect(await screen.findByRole('status')).toHaveTextContent('Copied Kimi K2.7 Code id');
+  });
+
+  test('shows failed copy feedback', async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {writeText},
+    });
+    Object.defineProperty(document, 'execCommand', {
+      configurable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+
+    renderUsageModal();
+    await user.click(await screen.findByRole('button', {name: 'Copy Claude Opus 4.8 id'}));
+
+    await waitFor(() => expect(document.execCommand).toHaveBeenCalledWith('copy'));
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Could not copy Claude Opus 4.8 id',
+    );
+  });
+});

--- a/libs/client/agent/src/components/agent-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.tsx
@@ -11,7 +11,6 @@ import {
   CodeBlockHeader,
   CodeBlockItem,
   Combobox,
-  IconButton,
   Modal,
   ModalBody,
   ModalContent,
@@ -199,35 +198,33 @@ function AgentProviderModelRow({label, id}: {label: string; id: string}) {
   }
 
   return (
-    <li className="flex min-h-40 items-center gap-12 border-b border-border-neutral-base px-12 py-8 last:border-b-0">
-      <Tooltip>
+    <li className="border-b border-border-neutral-base last:border-b-0">
+      <Tooltip open={copyState === 'copied'}>
         <TooltipTrigger asChild>
-          <Text
-            as="span"
-            size="sm"
-            bold
-            tabIndex={0}
-            className="min-w-0 flex-1 truncate outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive"
+          <button
+            type="button"
+            aria-label={`Copy ${label} model id ${id}`}
+            className="flex min-h-40 w-full min-w-0 items-center gap-8 px-12 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none"
+            onClick={() => {
+              void handleCopy();
+            }}
           >
-            {label}
-          </Text>
+            <Text as="span" size="sm" bold className="max-w-[48%] shrink-0 truncate">
+              {label}
+            </Text>
+            <Code
+              as="span"
+              variant="label"
+              className="min-w-0 flex-1 truncate text-foreground-neutral-muted"
+            >
+              {id}
+            </Code>
+          </button>
         </TooltipTrigger>
-        <TooltipContent side="top" align="start" className="max-w-[min(520px,calc(100vw-32px))]">
-          <Code as="span" variant="label" className="break-all text-foreground-neutral-base">
-            {id}
-          </Code>
+        <TooltipContent side="top" align="center">
+          Copied
         </TooltipContent>
       </Tooltip>
-      <IconButton
-        type="button"
-        size="sm"
-        variant="transparent"
-        icon={copyState === 'copied' ? 'check' : copyState === 'failed' ? 'xCircleSolid' : 'copy'}
-        aria-label={`Copy ${label} id`}
-        onClick={() => {
-          void handleCopy();
-        }}
-      />
       {copyState === 'copied' ? (
         <span className="sr-only" role="status">
           Copied {label} id

--- a/libs/client/agent/src/components/agent-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.tsx
@@ -204,18 +204,18 @@ function AgentProviderModelRow({label, id}: {label: string; id: string}) {
           <button
             type="button"
             aria-label={`Copy ${label} model id ${id}`}
-            className="flex min-h-40 w-full min-w-0 items-center gap-8 px-12 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none"
+            className="flex min-h-40 w-full min-w-0 flex-col items-start gap-2 px-12 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none sm:flex-row sm:items-center sm:gap-8"
             onClick={() => {
               void handleCopy();
             }}
           >
-            <Text as="span" size="sm" bold className="max-w-[48%] shrink-0 truncate">
+            <Text as="span" size="sm" bold className="max-w-full shrink-0 truncate sm:max-w-[48%]">
               {label}
             </Text>
             <Code
               as="span"
               variant="label"
-              className="min-w-0 flex-1 truncate text-foreground-neutral-muted"
+              className="min-w-0 max-w-full truncate text-left text-foreground-neutral-muted sm:flex-1 sm:text-right"
             >
               {id}
             </Code>

--- a/libs/client/agent/src/components/agent-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.tsx
@@ -19,6 +19,9 @@ import {
   ModalHeader,
   ModalTitle,
   Text,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   useCopyToClipboard,
 } from '@shipfox/react-ui';
 import {useEffect, useMemo, useRef, useState} from 'react';
@@ -69,7 +72,10 @@ export function AgentProviderUsageModal({
 
   return (
     <Modal open={open && entry !== null} onOpenChange={handleOpenChange}>
-      <ModalContent aria-describedby={undefined} className="max-w-[640px]">
+      <ModalContent
+        aria-describedby={undefined}
+        className="max-h-[calc(100vh-32px)] max-w-[640px] [&>div]:flex [&>div]:min-h-0 [&>div]:flex-col"
+      >
         <ModalTitle className="sr-only">
           {entry ? `Use ${entry.label} in a workflow` : 'Use provider in a workflow'}
         </ModalTitle>
@@ -85,12 +91,9 @@ export function AgentProviderUsageModal({
         </ModalHeader>
         {entry && example ? (
           <>
-            <ModalBody className="gap-0">
-              <div className="flex max-h-[70vh] w-full flex-col gap-16 overflow-y-auto pr-2 scrollbar">
-                <div className="flex flex-col gap-6">
-                  <Text size="sm" bold>
-                    Model
-                  </Text>
+            <ModalBody className="min-h-0 flex-1 gap-0 overflow-y-auto overflow-x-clip scrollbar">
+              <div className="flex w-full flex-col gap-20">
+                <div>
                   <Combobox
                     aria-label="Model"
                     options={modelOptions}
@@ -105,43 +108,47 @@ export function AgentProviderUsageModal({
                   />
                 </div>
 
-                <CodeBlock data={data} className="h-auto min-h-0 rounded-8">
-                  <CodeBlockHeader>
-                    <CodeBlockFiles>
+                <div className="flex flex-col gap-8">
+                  <CodeBlock data={data} className="h-auto min-h-0 rounded-8">
+                    <CodeBlockHeader>
+                      <CodeBlockFiles>
+                        {(item) => (
+                          <CodeBlockFilename value={item.filename}>
+                            {item.filename}
+                          </CodeBlockFilename>
+                        )}
+                      </CodeBlockFiles>
+                      <CodeBlockCopyButton />
+                    </CodeBlockHeader>
+                    <CodeBlockBody>
                       {(item) => (
-                        <CodeBlockFilename value={item.filename}>{item.filename}</CodeBlockFilename>
+                        <CodeBlockItem value={item.filename}>
+                          <CodeBlockContent
+                            language="yaml"
+                            syntaxHighlighting
+                            highlightedLineRange={example.highlightedLineRange}
+                          >
+                            {item.code}
+                          </CodeBlockContent>
+                        </CodeBlockItem>
                       )}
-                    </CodeBlockFiles>
-                    <CodeBlockCopyButton />
-                  </CodeBlockHeader>
-                  <CodeBlockBody className="overflow-auto scrollbar">
-                    {(item) => (
-                      <CodeBlockItem value={item.filename}>
-                        <CodeBlockContent
-                          language="yaml"
-                          syntaxHighlighting
-                          highlightedLineRange={example.highlightedLineRange}
-                        >
-                          {item.code}
-                        </CodeBlockContent>
-                      </CodeBlockItem>
-                    )}
-                  </CodeBlockBody>
-                </CodeBlock>
+                    </CodeBlockBody>
+                  </CodeBlock>
 
-                <Text size="sm" className="text-foreground-neutral-muted">
-                  Add this to a workflow file under{' '}
-                  <Code as="span" variant="label">
-                    .shipfox/workflows/
-                  </Code>{' '}
-                  in your repository to run it.
-                </Text>
+                  <Text size="sm" className="text-foreground-neutral-muted">
+                    Add this to a workflow file under{' '}
+                    <Code as="span" variant="label">
+                      .shipfox/workflows/
+                    </Code>{' '}
+                    in your repository to run it.
+                  </Text>
+                </div>
 
                 <div className="flex flex-col gap-8">
                   <Text size="sm" bold>
                     Available models ({entry.models.length})
                   </Text>
-                  <ul className="max-h-240 overflow-auto rounded-8 border border-border-neutral-base scrollbar">
+                  <ul className="rounded-8 border border-border-neutral-base">
                     {entry.models.map((model) => (
                       <AgentProviderModelRow key={model.id} label={model.label} id={model.id} />
                     ))}
@@ -192,15 +199,25 @@ function AgentProviderModelRow({label, id}: {label: string; id: string}) {
   }
 
   return (
-    <li className="flex items-center gap-12 border-b border-border-neutral-base px-12 py-10 last:border-b-0">
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
-        <Text size="sm" bold className="truncate">
-          {label}
-        </Text>
-        <Code as="p" variant="label" className="truncate text-foreground-neutral-muted">
-          {id}
-        </Code>
-      </div>
+    <li className="flex min-h-40 items-center gap-12 border-b border-border-neutral-base px-12 py-8 last:border-b-0">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Text
+            as="span"
+            size="sm"
+            bold
+            tabIndex={0}
+            className="min-w-0 flex-1 truncate outline-none focus-visible:ring-2 focus-visible:ring-border-highlights-interactive"
+          >
+            {label}
+          </Text>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="start" className="max-w-[min(520px,calc(100vw-32px))]">
+          <Code as="span" variant="label" className="break-all text-foreground-neutral-base">
+            {id}
+          </Code>
+        </TooltipContent>
+      </Tooltip>
       <IconButton
         type="button"
         size="sm"

--- a/libs/client/agent/src/components/agent-provider-usage-modal.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.tsx
@@ -1,0 +1,226 @@
+import type {AgentProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+import {
+  Button,
+  Code,
+  CodeBlock,
+  CodeBlockBody,
+  CodeBlockContent,
+  CodeBlockCopyButton,
+  CodeBlockFilename,
+  CodeBlockFiles,
+  CodeBlockHeader,
+  CodeBlockItem,
+  Combobox,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Text,
+  useCopyToClipboard,
+} from '@shipfox/react-ui';
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {buildAgentWorkflowExample} from './agent-workflow-example.js';
+
+type CopyState = 'idle' | 'copied' | 'failed';
+
+const WORKFLOW_EXAMPLE_FILENAME = '.shipfox/workflows/agent.yml';
+
+export function AgentProviderUsageModal({
+  entry,
+  initialModel,
+  open,
+  onOpenChange,
+  closeFocusTarget,
+}: {
+  entry: AgentProviderCatalogEntryDto | null;
+  initialModel?: string | null | undefined;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  closeFocusTarget?: HTMLElement | null | undefined;
+}) {
+  const [selectedModel, setSelectedModel] = useState('');
+
+  useEffect(() => {
+    if (!entry) return;
+    setSelectedModel(initialModel ?? entry.default_model ?? entry.models[0]?.id ?? '');
+  }, [entry, initialModel]);
+
+  const modelOptions = useMemo(
+    () => entry?.models.map((model) => ({value: model.id, label: model.label})) ?? [],
+    [entry],
+  );
+  const example = entry
+    ? buildAgentWorkflowExample({providerId: entry.id, model: selectedModel})
+    : null;
+  const data =
+    example === null
+      ? []
+      : [{language: 'yaml', filename: WORKFLOW_EXAMPLE_FILENAME, code: example.code}];
+
+  function handleOpenChange(nextOpen: boolean) {
+    onOpenChange(nextOpen);
+    if (!nextOpen && closeFocusTarget) {
+      window.setTimeout(() => closeFocusTarget.focus(), 0);
+    }
+  }
+
+  return (
+    <Modal open={open && entry !== null} onOpenChange={handleOpenChange}>
+      <ModalContent aria-describedby={undefined} className="max-w-[640px]">
+        <ModalTitle className="sr-only">
+          {entry ? `Use ${entry.label} in a workflow` : 'Use provider in a workflow'}
+        </ModalTitle>
+        <ModalHeader>
+          <div className="flex min-w-0 flex-col gap-2">
+            <Text size="lg" aria-hidden="true" className="truncate">
+              {entry ? `Use ${entry.label} in a workflow` : 'Use provider in a workflow'}
+            </Text>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Reference this provider from a workflow agent step.
+            </Text>
+          </div>
+        </ModalHeader>
+        {entry && example ? (
+          <>
+            <ModalBody className="gap-0">
+              <div className="flex max-h-[70vh] w-full flex-col gap-16 overflow-y-auto pr-2 scrollbar">
+                <div className="flex flex-col gap-6">
+                  <Text size="sm" bold>
+                    Model
+                  </Text>
+                  <Combobox
+                    aria-label="Model"
+                    options={modelOptions}
+                    value={selectedModel}
+                    onValueChange={(value) => {
+                      if (value) setSelectedModel(value);
+                    }}
+                    placeholder="Select model..."
+                    searchPlaceholder="Search models..."
+                    emptyState="No model found."
+                    className="w-full"
+                  />
+                </div>
+
+                <CodeBlock data={data} className="h-auto min-h-0 rounded-8">
+                  <CodeBlockHeader>
+                    <CodeBlockFiles>
+                      {(item) => (
+                        <CodeBlockFilename value={item.filename}>{item.filename}</CodeBlockFilename>
+                      )}
+                    </CodeBlockFiles>
+                    <CodeBlockCopyButton />
+                  </CodeBlockHeader>
+                  <CodeBlockBody className="overflow-auto scrollbar">
+                    {(item) => (
+                      <CodeBlockItem value={item.filename}>
+                        <CodeBlockContent
+                          language="yaml"
+                          syntaxHighlighting
+                          highlightedLineRange={example.highlightedLineRange}
+                        >
+                          {item.code}
+                        </CodeBlockContent>
+                      </CodeBlockItem>
+                    )}
+                  </CodeBlockBody>
+                </CodeBlock>
+
+                <Text size="sm" className="text-foreground-neutral-muted">
+                  Add this to a workflow file under{' '}
+                  <Code as="span" variant="label">
+                    .shipfox/workflows/
+                  </Code>{' '}
+                  in your repository to run it.
+                </Text>
+
+                <div className="flex flex-col gap-8">
+                  <Text size="sm" bold>
+                    Available models ({entry.models.length})
+                  </Text>
+                  <ul className="max-h-240 overflow-auto rounded-8 border border-border-neutral-base scrollbar">
+                    {entry.models.map((model) => (
+                      <AgentProviderModelRow key={model.id} label={model.label} id={model.id} />
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </ModalBody>
+            <ModalFooter>
+              <Button type="button" onClick={() => handleOpenChange(false)}>
+                Done
+              </Button>
+            </ModalFooter>
+          </>
+        ) : null}
+      </ModalContent>
+    </Modal>
+  );
+}
+
+function AgentProviderModelRow({label, id}: {label: string; id: string}) {
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const {copy} = useCopyToClipboard({
+    text: id,
+    onCopy: () => {
+      setTemporaryCopyState('copied');
+    },
+  });
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  function setTemporaryCopyState(state: Exclude<CopyState, 'idle'>) {
+    setCopyState(state);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopyState('idle'), 2500);
+  }
+
+  async function handleCopy() {
+    try {
+      await copy();
+    } catch {
+      setTemporaryCopyState('failed');
+    }
+  }
+
+  return (
+    <li className="flex items-center gap-12 border-b border-border-neutral-base px-12 py-10 last:border-b-0">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <Text size="sm" bold className="truncate">
+          {label}
+        </Text>
+        <Code as="p" variant="label" className="truncate text-foreground-neutral-muted">
+          {id}
+        </Code>
+      </div>
+      <IconButton
+        type="button"
+        size="sm"
+        variant="transparent"
+        icon={copyState === 'copied' ? 'check' : copyState === 'failed' ? 'xCircleSolid' : 'copy'}
+        aria-label={`Copy ${label} id`}
+        onClick={() => {
+          void handleCopy();
+        }}
+      />
+      {copyState === 'copied' ? (
+        <span className="sr-only" role="status">
+          Copied {label} id
+        </span>
+      ) : null}
+      {copyState === 'failed' ? (
+        <span className="sr-only" role="status">
+          Could not copy {label} id
+        </span>
+      ) : null}
+    </li>
+  );
+}

--- a/libs/client/agent/src/components/agent-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.stories.tsx
@@ -123,6 +123,18 @@ export const ConfigureModalOpen: Story = {
   },
 };
 
+export const WorkflowExampleModalOpen: Story = {
+  args: {scenario: 'mixed'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(
+      await canvas.findByRole('button', {name: 'Open Anthropic provider actions'}),
+    );
+    await userEvent.click(await screen.findByRole('menuitem', {name: 'View workflow example'}));
+    await screen.findByRole('dialog', {name: 'Use Anthropic in a workflow'});
+  },
+};
+
 function fetchForScenario(scenario: Scenario): typeof fetch {
   return (input) => {
     const url = requestUrl(input);

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -220,6 +220,74 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(screen.queryByDisplayValue('sk-proj-secret')).not.toBeInTheDocument();
   });
 
+  test('does not automatically open the usage modal after configuring an additional provider', async () => {
+    const user = userEvent.setup();
+    let isOpenAiConfigured = false;
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderCatalogResponse([
+              agentProviderEntry(),
+              agentProviderEntry({
+                id: 'openai',
+                label: 'OpenAI',
+                default_model: 'gpt-5.5-pro',
+                models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+              }),
+            ]),
+          ),
+        );
+      }
+      if (request.method === 'PUT') {
+        isOpenAiConfigured = true;
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderConfig({
+              provider_id: 'openai',
+              default_model: 'gpt-5.5-pro',
+              key_fingerprints: {api_key: 'sk-proj...abcd'},
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(
+          agentProviderConfigsResponse({
+            configs: [
+              agentProviderConfig(),
+              ...(isOpenAiConfigured
+                ? [
+                    agentProviderConfig({
+                      provider_id: 'openai',
+                      default_model: 'gpt-5.5-pro',
+                      key_fingerprints: {api_key: 'sk-proj...abcd'},
+                    }),
+                  ]
+                : []),
+            ],
+            default_provider_id: 'anthropic',
+          }),
+        ),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await user.click(screen.getByRole('button', {name: 'Configure OpenAI'}));
+    await user.type(await screen.findByLabelText('API key'), 'sk-proj-secret');
+    await user.click(screen.getByRole('button', {name: 'Test & save'}));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(
+      screen.queryByRole('dialog', {name: 'Use OpenAI in a workflow'}),
+    ).not.toBeInTheDocument();
+    expect(await screen.findByText('OpenAI')).toBeVisible();
+  });
+
   test('submits null default model when configuring a provider with Latest selected', async () => {
     const user = userEvent.setup();
     let requestBody: unknown;

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -1,7 +1,7 @@
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {ReactElement} from 'react';
 import {
@@ -118,7 +118,7 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(await screen.findByRole('button', {name: 'Configure OpenAI'})).toBeVisible();
   });
 
-  test('configures a provider and moves it to configured after save', async () => {
+  test('configures a provider, opens the usage modal, and moves focus back on close', async () => {
     const user = userEvent.setup();
     let isConfigured = false;
     let requestBody: unknown;
@@ -198,12 +198,21 @@ describe('WorkspaceAgentProvidersSection', () => {
     await user.type(await screen.findByLabelText('API key'), 'sk-proj-secret');
     await user.click(screen.getByRole('button', {name: 'Test & save'}));
 
-    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    const usageDialog = await screen.findByRole('dialog', {name: 'Use OpenAI in a workflow'});
+    expect(within(usageDialog).getByText('model: gpt-5-mini')).toBeVisible();
     await waitFor(() =>
       expect(requestBody).toEqual({
         default_model: 'gpt-5-mini',
         credentials: {api_key: 'sk-proj-secret'},
       }),
+    );
+    await user.click(within(usageDialog).getByRole('button', {name: 'Done'}));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    await waitFor(() =>
+      expect(document.activeElement).toBe(
+        screen.getByRole('region', {name: 'Configured providers'}),
+      ),
     );
     expect(await screen.findByText('OpenAI')).toBeVisible();
     expect(screen.queryByText(OPENAI_FINGERPRINT_RE)).not.toBeInTheDocument();
@@ -324,7 +333,48 @@ describe('WorkspaceAgentProvidersSection', () => {
     await user.click(screen.getByRole('button', {name: 'Test & save'}));
 
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(
+      screen.queryByRole('dialog', {name: 'Use Anthropic in a workflow'}),
+    ).not.toBeInTheDocument();
     await waitFor(() => expect(requestBody).toEqual({credentials: {api_key: 'sk-ant-rotated'}}));
+  });
+
+  test('opens the usage modal from a configured provider action', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(
+            agentProviderCatalogResponse([
+              agentProviderEntry({
+                default_model: 'claude-opus-4-8',
+                models: [
+                  {id: 'claude-opus-4-8', label: 'Claude Opus 4.8'},
+                  {id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5'},
+                ],
+              }),
+            ]),
+          ),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(
+          agentProviderConfigsResponse({
+            configs: [agentProviderConfig({default_model: 'claude-haiku-4-5'})],
+            default_provider_id: 'anthropic',
+          }),
+        ),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    expect(await screen.findByText('Anthropic')).toBeVisible();
+    await openProviderActions(user, 'Anthropic');
+    await user.click(screen.getByRole('menuitem', {name: 'View workflow example'}));
+
+    const usageDialog = await screen.findByRole('dialog', {name: 'Use Anthropic in a workflow'});
+    expect(usageDialog).toHaveTextContent('model: claude-haiku-4-5');
   });
 
   test('surfaces provider validation errors without clearing the form', async () => {
@@ -558,6 +608,9 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(await screen.findByText('anthropic')).toBeVisible();
     await openProviderActions(user, 'anthropic');
     expect(screen.getByRole('menuitem', {name: 'Change default model'})).toHaveAttribute(
+      'data-disabled',
+    );
+    expect(screen.getByRole('menuitem', {name: 'View workflow example'})).toHaveAttribute(
       'data-disabled',
     );
     expect(screen.getByRole('menuitem', {name: 'Edit credentials'})).toHaveAttribute(

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -32,8 +32,8 @@ import {
   useDeleteAgentProviderConfigMutation,
   useSetDefaultAgentProviderMutation,
 } from '#hooks/api/agent-providers.js';
-import {AvailableProviderCard} from './available-provider-card.js';
 import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
+import {AvailableProviderCard} from './available-provider-card.js';
 import {ChangeDefaultModelForm} from './change-default-model-form.js';
 import {agentProviderConfigErrorToFormError} from './form-errors.js';
 import {AgentProviderTestAndSaveForm} from './test-and-save-form.js';

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -265,7 +265,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
               existingConfig={formState.config}
               onSaved={(savedDefaultModel) => {
                 toast.success(`${formState.entry.label} saved`);
-                if (formState.mode === 'configure') {
+                if (formState.mode === 'configure' && configs.length === 0) {
                   setPendingUsageTarget({
                     entry: formState.entry,
                     initialModel: savedDefaultModel,

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -25,7 +25,7 @@ import {
   TooltipTrigger,
   toast,
 } from '@shipfox/react-ui';
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {
   useAgentProviderCatalogQuery,
   useAgentProviderConfigsQuery,
@@ -33,6 +33,7 @@ import {
   useSetDefaultAgentProviderMutation,
 } from '#hooks/api/agent-providers.js';
 import {AvailableProviderCard} from './available-provider-card.js';
+import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
 import {ChangeDefaultModelForm} from './change-default-model-form.js';
 import {agentProviderConfigErrorToFormError} from './form-errors.js';
 import {AgentProviderTestAndSaveForm} from './test-and-save-form.js';
@@ -45,12 +46,22 @@ type ProviderFormState =
   | {mode: 'configure'; entry: AgentProviderCatalogEntryDto; config?: undefined}
   | {mode: 'edit'; entry: AgentProviderCatalogEntryDto; config: AgentProviderConfigDto};
 type ModelFormState = {entry: AgentProviderCatalogEntryDto; config: AgentProviderConfigDto};
+type UsageTarget = {
+  entry: AgentProviderCatalogEntryDto;
+  initialModel: string | null;
+  restoreFocusToConfiguredProviders: boolean;
+};
+
+const USAGE_MODAL_OPEN_DELAY_MS = 250;
 
 export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: string}) {
   const catalogQuery = useAgentProviderCatalogQuery();
   const configsQuery = useAgentProviderConfigsQuery(workspaceId);
   const [formState, setFormState] = useState<ProviderFormState | null>(null);
   const [modelFormState, setModelFormState] = useState<ModelFormState | null>(null);
+  const [usageTarget, setUsageTarget] = useState<UsageTarget | null>(null);
+  const [pendingUsageTarget, setPendingUsageTarget] = useState<UsageTarget | null>(null);
+  const configuredProvidersRegionRef = useRef<HTMLElement | null>(null);
 
   const providers = catalogQuery.data?.providers ?? [];
   const configs = configsQuery.data?.configs ?? [];
@@ -81,9 +92,25 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
     setModelFormState(null);
   }
 
+  useEffect(() => {
+    if (pendingUsageTarget === null || formState !== null) return undefined;
+
+    const timer = window.setTimeout(() => {
+      setUsageTarget(pendingUsageTarget);
+      setPendingUsageTarget(null);
+    }, USAGE_MODAL_OPEN_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [formState, pendingUsageTarget]);
+
   return (
     <div className="flex min-w-0 flex-col gap-32">
-      <section className="flex flex-col gap-16" aria-label="Configured providers">
+      <section
+        ref={configuredProvidersRegionRef}
+        className="flex flex-col gap-16 outline-none"
+        aria-label="Configured providers"
+        tabIndex={-1}
+      >
         <div className="flex flex-col gap-4">
           <Header variant="h3">Configured providers</Header>
           <Text size="sm" className="text-foreground-neutral-muted">
@@ -127,6 +154,15 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
                   }}
                   onChangeDefaultModel={() => {
                     if (entry) setModelFormState({entry, config});
+                  }}
+                  onShowUsage={() => {
+                    if (entry) {
+                      setUsageTarget({
+                        entry,
+                        initialModel: config.default_model,
+                        restoreFocusToConfiguredProviders: false,
+                      });
+                    }
                   }}
                 />
               );
@@ -226,8 +262,15 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
               workspaceId={workspaceId}
               entry={formState.entry}
               existingConfig={formState.config}
-              onSaved={() => {
+              onSaved={(savedDefaultModel) => {
                 toast.success(`${formState.entry.label} saved`);
+                if (formState.mode === 'configure') {
+                  setPendingUsageTarget({
+                    entry: formState.entry,
+                    initialModel: savedDefaultModel,
+                    restoreFocusToConfiguredProviders: true,
+                  });
+                }
                 closeForm();
               }}
             />
@@ -263,6 +306,20 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
           ) : null}
         </ModalContent>
       </Modal>
+
+      <AgentProviderUsageModal
+        entry={usageTarget?.entry ?? null}
+        initialModel={usageTarget?.initialModel ?? null}
+        open={usageTarget !== null}
+        closeFocusTarget={
+          usageTarget?.restoreFocusToConfiguredProviders
+            ? configuredProvidersRegionRef.current
+            : null
+        }
+        onOpenChange={(open) => {
+          if (!open) setUsageTarget(null);
+        }}
+      />
     </div>
   );
 }
@@ -280,6 +337,7 @@ function ConfiguredProviderRow({
   isDefault,
   onEdit,
   onChangeDefaultModel,
+  onShowUsage,
 }: {
   workspaceId: string;
   config: AgentProviderConfigDto;
@@ -287,6 +345,7 @@ function ConfiguredProviderRow({
   isDefault: boolean;
   onEdit: () => void;
   onChangeDefaultModel: () => void;
+  onShowUsage: () => void;
 }) {
   const setDefault = useSetDefaultAgentProviderMutation();
   const deleteConfig = useDeleteAgentProviderConfigMutation();
@@ -381,6 +440,9 @@ function ConfiguredProviderRow({
               onSelect={onChangeDefaultModel}
             >
               Change default model
+            </DropdownMenuItem>
+            <DropdownMenuItem icon="bookOpenLine" disabled={!entry} onSelect={onShowUsage}>
+              View workflow example
             </DropdownMenuItem>
             <DropdownMenuItem icon="editLine" disabled={!entry} onSelect={onEdit}>
               Edit credentials

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -157,6 +157,7 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
                   }}
                   onShowUsage={() => {
                     if (entry) {
+                      setPendingUsageTarget(null);
                       setUsageTarget({
                         entry,
                         initialModel: config.default_model,

--- a/libs/client/agent/src/components/agent-workflow-example.test.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.test.ts
@@ -1,0 +1,27 @@
+import {workflowDocumentSchema} from '@shipfox/workflow-document';
+import {parse} from 'yaml';
+import {buildAgentWorkflowExample} from './agent-workflow-example.js';
+
+describe('buildAgentWorkflowExample', () => {
+  it.each([
+    {model: 'claude-opus-4-8', expected: '        model: claude-opus-4-8'},
+    {model: 'anthropic/claude-opus-4.8', expected: '        model: anthropic/claude-opus-4.8'},
+    {
+      model: '@cf/moonshotai/kimi-k2.7-code',
+      expected: "        model: '@cf/moonshotai/kimi-k2.7-code'",
+    },
+    {model: "model: beta's", expected: "        model: 'model: beta''s'"},
+  ])('builds valid workflow YAML for model $model', ({model, expected}) => {
+    const example = buildAgentWorkflowExample({providerId: 'anthropic', model});
+
+    const lines = example.code.split('\n');
+    const parsed = parse(example.code);
+    const result = workflowDocumentSchema.safeParse(parsed);
+
+    expect(result.success).toBe(true);
+    expect(lines).toContain('        provider: anthropic');
+    expect(lines).toContain(expected);
+    expect(example.highlightedLineRange).toEqual({startLine: 11, endLine: 12});
+    expect(lines.slice(10, 12)).toEqual(['        provider: anthropic', expected]);
+  });
+});

--- a/libs/client/agent/src/components/agent-workflow-example.test.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.test.ts
@@ -4,24 +4,46 @@ import {buildAgentWorkflowExample} from './agent-workflow-example.js';
 
 describe('buildAgentWorkflowExample', () => {
   it.each([
-    {model: 'claude-opus-4-8', expected: '        model: claude-opus-4-8'},
-    {model: 'anthropic/claude-opus-4.8', expected: '        model: anthropic/claude-opus-4.8'},
     {
-      model: '@cf/moonshotai/kimi-k2.7-code',
-      expected: "        model: '@cf/moonshotai/kimi-k2.7-code'",
+      providerId: 'anthropic',
+      model: 'claude-opus-4-8',
+      expectedProvider: '        provider: anthropic',
+      expectedModel: '        model: claude-opus-4-8',
     },
-    {model: "model: beta's", expected: "        model: 'model: beta''s'"},
-  ])('builds valid workflow YAML for model $model', ({model, expected}) => {
-    const example = buildAgentWorkflowExample({providerId: 'anthropic', model});
+    {
+      providerId: 'anthropic',
+      model: 'anthropic/claude-opus-4.8',
+      expectedProvider: '        provider: anthropic',
+      expectedModel: '        model: anthropic/claude-opus-4.8',
+    },
+    {
+      providerId: 'anthropic',
+      model: '@cf/moonshotai/kimi-k2.7-code',
+      expectedProvider: '        provider: anthropic',
+      expectedModel: "        model: '@cf/moonshotai/kimi-k2.7-code'",
+    },
+    {
+      providerId: 'provider#beta',
+      model: "model: beta's",
+      expectedProvider: "        provider: 'provider#beta'",
+      expectedModel: "        model: 'model: beta''s'",
+    },
+  ])('builds valid workflow YAML for provider $providerId and model $model', ({
+    providerId,
+    model,
+    expectedProvider,
+    expectedModel,
+  }) => {
+    const example = buildAgentWorkflowExample({providerId, model});
 
     const lines = example.code.split('\n');
     const parsed = parse(example.code);
     const result = workflowDocumentSchema.safeParse(parsed);
 
     expect(result.success).toBe(true);
-    expect(lines).toContain('        provider: anthropic');
-    expect(lines).toContain(expected);
+    expect(lines).toContain(expectedProvider);
+    expect(lines).toContain(expectedModel);
     expect(example.highlightedLineRange).toEqual({startLine: 11, endLine: 12});
-    expect(lines.slice(10, 12)).toEqual(['        provider: anthropic', expected]);
+    expect(lines.slice(10, 12)).toEqual([expectedProvider, expectedModel]);
   });
 });

--- a/libs/client/agent/src/components/agent-workflow-example.test.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.test.ts
@@ -28,6 +28,12 @@ describe('buildAgentWorkflowExample', () => {
       expectedProvider: "        provider: 'provider#beta'",
       expectedModel: "        model: 'model: beta''s'",
     },
+    {
+      providerId: 'true',
+      model: '123',
+      expectedProvider: "        provider: 'true'",
+      expectedModel: "        model: '123'",
+    },
   ])('builds valid workflow YAML for provider $providerId and model $model', ({
     providerId,
     model,
@@ -38,9 +44,14 @@ describe('buildAgentWorkflowExample', () => {
 
     const lines = example.code.split('\n');
     const parsed = parse(example.code);
+    const parsedStep = parsed as {
+      jobs: {agent: {steps: Array<{provider?: unknown; model?: unknown}>}};
+    };
     const result = workflowDocumentSchema.safeParse(parsed);
 
     expect(result.success).toBe(true);
+    expect(parsedStep.jobs.agent.steps[0]?.provider).toBe(providerId);
+    expect(parsedStep.jobs.agent.steps[0]?.model).toBe(model);
     expect(lines).toContain(expectedProvider);
     expect(lines).toContain(expectedModel);
     expect(example.highlightedLineRange).toEqual({startLine: 11, endLine: 12});

--- a/libs/client/agent/src/components/agent-workflow-example.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.ts
@@ -1,6 +1,7 @@
 import type {CodeBlockHighlightedLineRange} from '@shipfox/react-ui';
 
-const YAML_PLAIN_SCALAR_LEADING_INDICATOR_RE = /^[@`[\]{}#,&*!?|>'"%:]/;
+const YAML_SAFE_PLAIN_SCALAR_RE = /^[A-Za-z][A-Za-z0-9._/-]*$/;
+const YAML_AMBIGUOUS_PLAIN_SCALAR_RE = /^(?:false|n|no|null|off|on|true|y|yes)$/i;
 
 export interface AgentWorkflowExample {
   code: string;
@@ -47,9 +48,5 @@ function formatYamlPlainOrSingleQuotedScalar(value: string): string {
 }
 
 function requiresYamlSingleQuotes(value: string): boolean {
-  return (
-    YAML_PLAIN_SCALAR_LEADING_INDICATOR_RE.test(value) ||
-    value.includes(': ') ||
-    value.includes('#')
-  );
+  return !YAML_SAFE_PLAIN_SCALAR_RE.test(value) || YAML_AMBIGUOUS_PLAIN_SCALAR_RE.test(value);
 }

--- a/libs/client/agent/src/components/agent-workflow-example.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.ts
@@ -25,7 +25,7 @@ export function buildAgentWorkflowExample({
     '    runner: ubuntu-latest',
     '    steps:',
     '      - name: implement',
-    `        provider: ${providerId}`,
+    `        provider: ${formatYamlPlainOrSingleQuotedScalar(providerId)}`,
     `        model: ${formatYamlPlainOrSingleQuotedScalar(model)}`,
     '        prompt: Describe the change you want the agent to make.',
   ];

--- a/libs/client/agent/src/components/agent-workflow-example.ts
+++ b/libs/client/agent/src/components/agent-workflow-example.ts
@@ -1,0 +1,55 @@
+import type {CodeBlockHighlightedLineRange} from '@shipfox/react-ui';
+
+const YAML_PLAIN_SCALAR_LEADING_INDICATOR_RE = /^[@`[\]{}#,&*!?|>'"%:]/;
+
+export interface AgentWorkflowExample {
+  code: string;
+  highlightedLineRange: CodeBlockHighlightedLineRange;
+}
+
+export function buildAgentWorkflowExample({
+  providerId,
+  model,
+}: {
+  providerId: string;
+  model: string;
+}): AgentWorkflowExample {
+  const lines = [
+    'name: Agent',
+    'triggers:',
+    '  on_demand:',
+    '    source: manual',
+    '    event: fire',
+    'jobs:',
+    '  agent:',
+    '    runner: ubuntu-latest',
+    '    steps:',
+    '      - name: implement',
+    `        provider: ${providerId}`,
+    `        model: ${formatYamlPlainOrSingleQuotedScalar(model)}`,
+    '        prompt: Describe the change you want the agent to make.',
+  ];
+  const providerLineIndex = lines.findIndex((line) => line.trimStart().startsWith('provider:'));
+  const modelLineIndex = lines.findIndex((line) => line.trimStart().startsWith('model:'));
+
+  return {
+    code: lines.join('\n'),
+    highlightedLineRange: {
+      startLine: providerLineIndex + 1,
+      endLine: modelLineIndex + 1,
+    },
+  };
+}
+
+function formatYamlPlainOrSingleQuotedScalar(value: string): string {
+  if (!requiresYamlSingleQuotes(value)) return value;
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function requiresYamlSingleQuotes(value: string): boolean {
+  return (
+    YAML_PLAIN_SCALAR_LEADING_INDICATOR_RE.test(value) ||
+    value.includes(': ') ||
+    value.includes('#')
+  );
+}

--- a/libs/client/agent/src/components/test-and-save-form.tsx
+++ b/libs/client/agent/src/components/test-and-save-form.tsx
@@ -37,7 +37,7 @@ export function AgentProviderTestAndSaveForm({
   workspaceId: string;
   entry: AgentProviderCatalogEntryDto;
   existingConfig?: AgentProviderConfigDto | undefined;
-  onSaved: () => void;
+  onSaved: (savedDefaultModel: string | null) => void;
   setAsDefaultOnSave?: boolean | undefined;
 }) {
   const upsertConfig = useUpsertAgentProviderConfigMutation();
@@ -68,7 +68,7 @@ export function AgentProviderTestAndSaveForm({
             ...(setAsDefaultOnSave ? {set_as_default: true} : {}),
           },
         });
-        onSaved();
+        onSaved(selectedModelForCredentialsPayload(selectedModel));
       } catch (error) {
         const mapped = agentProviderConfigErrorToFormError(error);
         setFormError(mapped.message);

--- a/libs/client/agent/src/pages/agent-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/agent-provider-onboarding-page.test.tsx
@@ -166,6 +166,9 @@ describe('AgentProviderOnboardingPage', () => {
       }),
     );
     expect(onConfigured).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole('dialog', {name: 'Use OpenAI in a workflow'}),
+    ).not.toBeInTheDocument();
   });
 
   test('keeps skip available when the catalog fails to load', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2227,6 +2227,9 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      '@shipfox/workflow-document':
+        specifier: workspace:*
+        version: link:../../shared/workflow/document
       '@storybook/addon-vitest':
         specifier: ^10.3.6
         version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9))(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)
@@ -2284,6 +2287,9 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.8.3
+        version: 2.9.0
 
   libs/client/api:
     dependencies:


### PR DESCRIPTION
Add a workflow usage modal to the agent provider settings screen so users can see how a configured provider maps into a runnable `.shipfox/workflows/agent.yml` agent step.

Users could previously configure credentials without any in-product guidance for the `provider:` and `model:` fields they need in workflow YAML. This adds a copyable minimal workflow example, a searchable model selector that drives the snippet, and a reference list for copying model ids.

The modal auto-opens only after the first provider configuration and is sequenced after the credential modal closes to avoid overlapping dialog focus traps. It is also available later from each configured provider's actions menu.