### PR TITLE
[client-integrations] Fix workspace route in stories

### DIFF
--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -68,26 +68,33 @@ function IntegrationGalleryStory({scenario}: IntegrationGalleryStoryProps) {
   }, []);
   const router = useMemo(() => {
     const rootRoute = createRootRoute({component: Outlet});
-    const galleryRoute = createRoute({
+    const workspaceRoute = createRoute({
       getParentRoute: () => rootRoute,
-      path: '/workspaces/$wid/settings/integrations',
+      path: '/workspaces/$wid',
+      component: Outlet,
+    });
+    const galleryRoute = createRoute({
+      getParentRoute: () => workspaceRoute,
+      path: 'settings/integrations',
       component: () => (
         <div className="mx-auto w-full max-w-[760px] bg-background-neutral-background p-24">
-          <IntegrationGallery />
+          <IntegrationGallery workspaceId={WORKSPACE_ID} />
         </div>
       ),
     });
     const setupRoutes = SETUP_PATHS.map((path) =>
       createRoute({
-        getParentRoute: () => rootRoute,
-        path,
+        getParentRoute: () => workspaceRoute,
+        path: path.replace('/workspaces/$wid/', ''),
         component: () => <div />,
       }),
     );
 
     return createRouter({
       history: createMemoryHistory({initialEntries: [WORKSPACE_PATH]}),
-      routeTree: rootRoute.addChildren([galleryRoute, ...setupRoutes]),
+      routeTree: rootRoute.addChildren([
+        workspaceRoute.addChildren([galleryRoute, ...setupRoutes]),
+      ]),
     });
   }, []);
 

--- a/libs/client/integrations/src/components/integration-gallery.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.tsx
@@ -17,6 +17,7 @@ import {ProviderGrid} from './provider-grid.js';
 export interface IntegrationGalleryProps {
   capability?: IntegrationCapabilityDto;
   emptyProvidersMessage?: string;
+  workspaceId?: string;
 }
 
 // Both gallery surfaces use the same card fill so they read as one system on
@@ -27,10 +28,54 @@ const SURFACE_CLASS =
 export function IntegrationGallery({
   capability,
   emptyProvidersMessage = 'Enable at least one provider in the application settings.',
+  workspaceId,
 }: IntegrationGalleryProps) {
+  if (workspaceId) {
+    return (
+      <IntegrationGalleryForWorkspace
+        workspaceId={workspaceId}
+        capability={capability}
+        emptyProvidersMessage={emptyProvidersMessage}
+      />
+    );
+  }
+
+  return (
+    <RoutedIntegrationGallery
+      capability={capability}
+      emptyProvidersMessage={emptyProvidersMessage}
+    />
+  );
+}
+
+function RoutedIntegrationGallery({
+  capability,
+  emptyProvidersMessage,
+}: {
+  capability: IntegrationCapabilityDto | undefined;
+  emptyProvidersMessage: string;
+}) {
   const workspace = useActiveWorkspace();
+  return (
+    <IntegrationGalleryForWorkspace
+      workspaceId={workspace.id}
+      capability={capability}
+      emptyProvidersMessage={emptyProvidersMessage}
+    />
+  );
+}
+
+function IntegrationGalleryForWorkspace({
+  capability,
+  emptyProvidersMessage,
+  workspaceId,
+}: {
+  capability: IntegrationCapabilityDto | undefined;
+  emptyProvidersMessage: string;
+  workspaceId: string;
+}) {
   const providersQuery = useIntegrationProvidersQuery(capability ? {capability} : undefined);
-  const connectionsQuery = useIntegrationConnectionsQuery(workspace.id);
+  const connectionsQuery = useIntegrationConnectionsQuery(workspaceId);
 
   const providers = providersQuery.data?.providers ?? [];
   const providersMap = new Map<string, IntegrationProviderDto>(
@@ -104,7 +149,7 @@ export function IntegrationGallery({
 
         <ProviderGrid
           providersQuery={providersQuery}
-          workspaceId={workspace.id}
+          workspaceId={workspaceId}
           emptyMessage={emptyProvidersMessage}
         />
       </section>


### PR DESCRIPTION
Fix the integrations gallery Storybook router so it models the real workspace route subtree.

The gallery calls `useActiveWorkspace()`, which expects a `wid` param from the `/workspaces/$wid` route. The story previously registered the settings route as a standalone absolute route, so Storybook could render it without the parent workspace match and hit the hook's developer-error guard.

This adds an explicit `/workspaces/$wid` parent route with an outlet and nests the gallery plus install target routes beneath it, matching the app route shape used in production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Integrations gallery Storybook routing and adds an explicit `workspaceId` prop so the gallery works outside routed contexts. Aligns the story with production and prevents `useActiveWorkspace()` guard errors.

- **Bug Fixes**
  - Nest gallery under `/workspaces/$wid` with an `Outlet`; make setup routes relative so they inherit the workspace param.

- **New Features**
  - Add optional `workspaceId` to `IntegrationGallery`; use it for queries and `ProviderGrid`.
  - Update story to pass `workspaceId` explicitly.

<sup>Written for commit db71c07873cc37132398928e581952a3e0a53103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

