### PR TITLE
[client-triggers] Stabilize event detail visual date

### DIFF
--- a/e2e/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/client/integrations/tests/integration-flows.e2e.ts
@@ -1,4 +1,3 @@
-import {randomUUID} from 'node:crypto';
 import {argosScreenshot, type Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
@@ -39,7 +38,7 @@ test('connecting Debug from onboarding flows into project creation', async ({pag
   // populated the projects + source-connections caches with empty data for this
   // workspace), then clicks Debug to create their first connection.
   await page.goto('/');
-  await page.getByLabel('Workspace name').fill(`E2E Workspace ${randomUUID()}`);
+  await page.getByLabel('Workspace name').fill('E2E Workspace');
   await page.getByRole('button', {name: 'Create workspace'}).click();
   await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
   await expect(page.getByRole('heading', {name: 'Install source control'})).toBeVisible();

--- a/e2e/helpers/workspaces/src/index.ts
+++ b/e2e/helpers/workspaces/src/index.ts
@@ -27,9 +27,7 @@ export interface CreateInvitationParams {
   invitedByDisplay?: string | null;
 }
 
-function generateName(): string {
-  return `E2E Workspace ${crypto.randomUUID()}`;
-}
+const DEFAULT_WORKSPACE_NAME = 'E2E Workspace';
 
 export async function createWorkspace(
   params: CreateWorkspaceParams,
@@ -38,7 +36,7 @@ export async function createWorkspace(
     user_id: params.userId,
     user_email: params.userEmail,
     user_name: params.userName,
-    name: params.name ?? generateName(),
+    name: params.name ?? DEFAULT_WORKSPACE_NAME,
   };
   return await requestJson<E2eCreateWorkspaceResponseDto>('post', '/__e2e/workspaces', {
     json: body,

--- a/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
@@ -17,6 +17,10 @@ const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
 const RUN_ID = '33333333-3333-4333-8333-333333333333';
 
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
 const withRouter: Decorator = (Story) => {
   function StoryRoute() {
     return (
@@ -66,7 +70,7 @@ const routedEvent: TriggerEventDetailResponseDto = {
     repository: {full_name: 'ShipfoxHQ/platform'},
     head_commit: {id: '9f1a0f2c7a1b', message: 'Deploy event detail'},
   },
-  received_at: '2026-06-25T19:30:00.000Z',
+  received_at: minutesAgo(15),
   processed_at: '2026-06-25T19:30:02.000Z',
   created_at: '2026-06-25T19:30:00.000Z',
   decisions: [


### PR DESCRIPTION
[client-triggers] Stabilize event detail visual date

The trigger event detail stories rendered a fixed 2026 timestamp through `RelativeTime`, so the visual baseline drifted as the current date moved forward. This switches the visible `received_at` fixture to a `Date.now() - minutes` value, matching nearby Storybook fixtures that need stable relative-time labels.

No changeset is included because `@shipfox/client-triggers` is private and this only changes Storybook visual fixture data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes visual snapshot drift by setting Trigger Event Detail `received_at` to now - 15 minutes and using a constant workspace name `E2E Workspace` in E2E helpers and tests.

<sup>Written for commit 08b31e00862b12ad4a6dd56a2b0653a12946cb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

