### PR TITLE
[api-agent] Thread cancellation into provider probes

### DIFF
--- a/libs/api/agent/src/core/provider-config-service.test.ts
+++ b/libs/api/agent/src/core/provider-config-service.test.ts
@@ -77,6 +77,24 @@ describe('testAndSaveProviderConfig', () => {
     expect(stored?.defaultModel).toBe('claude-haiku-4-5');
   });
 
+  it('passes the abort signal to the provider probe', async () => {
+    const credentials = {api_key: 'sk-ant-secret-abcd'};
+    const abortController = new AbortController();
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    await testAndSaveProviderConfig(
+      {workspaceId, providerId: 'anthropic', credentials, signal: abortController.signal},
+      {probe},
+    );
+
+    expect(probe).toHaveBeenCalledWith({
+      providerId: 'anthropic',
+      model: 'claude-opus-4-8',
+      credentials,
+      signal: abortController.signal,
+    });
+  });
+
   it('preserves an existing default model when rotating credentials without a model selection', async () => {
     await upsertAgentProviderConfig({
       workspaceId,

--- a/libs/api/agent/src/core/provider-config-service.test.ts
+++ b/libs/api/agent/src/core/provider-config-service.test.ts
@@ -95,6 +95,27 @@ describe('testAndSaveProviderConfig', () => {
     });
   });
 
+  it('rethrows aborted probe errors without treating them as validation failures', async () => {
+    const abortController = new AbortController();
+    const error = new Error('Provider probe aborted');
+    const probe = vi.fn().mockRejectedValue(error);
+    abortController.abort();
+
+    const save = testAndSaveProviderConfig(
+      {
+        workspaceId,
+        providerId: 'anthropic',
+        credentials: {api_key: 'sk-ant-secret-abcd'},
+        signal: abortController.signal,
+      },
+      {probe},
+    );
+
+    await expect(save).rejects.toBe(error);
+    const stored = await getAgentProviderConfig({workspaceId, providerId: 'anthropic'});
+    expect(stored).toBeUndefined();
+  });
+
   it('preserves an existing default model when rotating credentials without a model selection', async () => {
     await upsertAgentProviderConfig({
       workspaceId,

--- a/libs/api/agent/src/core/provider-config-service.ts
+++ b/libs/api/agent/src/core/provider-config-service.ts
@@ -79,6 +79,7 @@ export async function testAndSaveProviderConfig(
       ...(params.signal ? {signal: params.signal} : {}),
     });
   } catch (error) {
+    if (params.signal?.aborted) throw error;
     providerValidationCount.add(1, {provider: params.providerId, outcome: 'failed'});
     if (error instanceof InvalidAgentModelError) throw error;
 

--- a/libs/api/agent/src/core/provider-config-service.ts
+++ b/libs/api/agent/src/core/provider-config-service.ts
@@ -32,6 +32,7 @@ export interface TestAndSaveProviderConfigParams {
   defaultModel?: string | null | undefined;
   credentials: Record<string, string>;
   setAsDefault?: boolean | undefined;
+  signal?: AbortSignal | undefined;
 }
 
 export interface TestAndSaveProviderConfigOptions {
@@ -75,6 +76,7 @@ export async function testAndSaveProviderConfig(
       providerId: params.providerId,
       model: modelSelection.probeModel,
       credentials: params.credentials,
+      ...(params.signal ? {signal: params.signal} : {}),
     });
   } catch (error) {
     providerValidationCount.add(1, {provider: params.providerId, outcome: 'failed'});

--- a/libs/api/agent/src/presentation/routes/provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/provider-config.test.ts
@@ -219,6 +219,20 @@ describe('agent provider config routes', () => {
       expect(settings?.defaultProviderId).toBe('anthropic');
     });
 
+    it('passes a request-scoped abort signal to provider validation', async () => {
+      const res = await app.inject({
+        method: 'PUT',
+        url: `/workspaces/${workspaceId}/agent/providers/anthropic`,
+        headers: {authorization: 'Bearer user'},
+        payload: {credentials: {api_key: 'sk-ant-secret-abcd'}},
+      });
+
+      const [, , options] = vi.mocked(complete).mock.calls[0] ?? [];
+      expect(res.statusCode).toBe(200);
+      expect(options?.signal).toBeInstanceOf(AbortSignal);
+      expect(options?.signal?.aborted).toBe(false);
+    });
+
     it('replaces the workspace default when set_as_default is requested with existing settings', async () => {
       await seedProviderConfig({providerId: 'openai'});
       await setDefaultAgentProvider({workspaceId, providerId: 'openai'});

--- a/libs/api/agent/src/presentation/routes/provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/provider-config.test.ts
@@ -51,6 +51,7 @@ describe('agent provider config routes', () => {
     await db().execute(sql`TRUNCATE agent_provider_configs CASCADE`);
     await db().execute(sql`TRUNCATE agent_workspace_settings CASCADE`);
     workspaceId = crypto.randomUUID();
+    vi.mocked(complete).mockReset();
     vi.mocked(complete).mockResolvedValue({
       role: 'assistant',
       content: [{type: 'text', text: 'OK'}],
@@ -229,6 +230,7 @@ describe('agent provider config routes', () => {
 
       const [, , options] = vi.mocked(complete).mock.calls[0] ?? [];
       expect(res.statusCode).toBe(200);
+      expect(complete).toHaveBeenCalledTimes(1);
       expect(options?.signal).toBeInstanceOf(AbortSignal);
       expect(options?.signal?.aborted).toBe(false);
     });

--- a/libs/api/agent/src/presentation/routes/upsert-provider-config.ts
+++ b/libs/api/agent/src/presentation/routes/upsert-provider-config.ts
@@ -25,8 +25,17 @@ export const upsertProviderConfigRoute = defineRoute({
     },
   },
   errorHandler: translateAgentProviderRouteError,
-  handler: async (request) => {
+  handler: async (request, reply) => {
     const {workspaceId, providerId} = request.params;
+    const abortController = new AbortController();
+    let responseFinished = false;
+    reply.raw.on('finish', () => {
+      responseFinished = true;
+    });
+    reply.raw.on('close', () => {
+      if (!responseFinished) abortController.abort();
+    });
+
     await requireMembership({request, workspaceId});
 
     const config = await testAndSaveProviderConfig({
@@ -35,6 +44,7 @@ export const upsertProviderConfigRoute = defineRoute({
       ...('default_model' in request.body ? {defaultModel: request.body.default_model} : {}),
       credentials: request.body.credentials,
       setAsDefault: request.body.set_as_default,
+      signal: abortController.signal,
     });
 
     return toAgentProviderConfigDto(config);


### PR DESCRIPTION
Thread request cancellation into agent provider credential probes.

Provider configuration upserts synchronously validate credentials against Pi. Previously, that outbound probe continued even if the HTTP client disconnected. This wires a request-scoped abort signal through the upsert route and `testAndSaveProviderConfig` so canceled requests can stop provider validation while preserving existing timeout and upsert behavior.

`@shipfox/api-agent` is private, so this PR does not include a changeset.

Closes ENG-644

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threaded a request-scoped abort signal through provider credential validation in `@shipfox/api-agent` so probes stop if the client disconnects, while preserving existing timeouts and upsert behavior. Aborted probe errors are rethrown instead of treated as validation failures. Closes ENG-644.

- **Bug Fixes**
  - Upsert route creates an `AbortController`, aborts on early connection close, and passes `signal` to `testAndSaveProviderConfig`.
  - `testAndSaveProviderConfig` forwards the `signal` to the provider probe and rethrows errors once the request is aborted.
  - Added tests for signal propagation and aborted probe behavior; reset Pi mock call history to isolate route tests.

<sup>Written for commit 5cd01a78c3630888be62403cb418bccbb285c73d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

