### PR TITLE
[client-workflows] Show resolved agent config on run detail

### DIFF
--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -1,5 +1,7 @@
 export {
+  type AgentConfigIssue,
   type AgentRuntimeConfigQueryDto,
+  agentConfigIssueSchema,
   agentRuntimeConfigQuerySchema,
   type CheckoutIntentDto,
   type CheckoutTokenAuthDto,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -61,6 +61,8 @@ export {
   runStepDetailDtoSchema,
 } from './run-detail.js';
 export {
+  type AgentConfigIssue,
+  agentConfigIssueSchema,
   type StepAttemptDto,
   type StepDto,
   type StepErrorCategory,

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -1,4 +1,4 @@
-import {stepAttemptDtoSchema} from './step.js';
+import {stepAttemptDtoSchema, stepErrorDtoSchema} from './step.js';
 
 const baseAttempt = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -15,6 +15,32 @@ const baseAttempt = {
   started_at: '2026-01-01T00:00:00.000Z',
   finished_at: '2026-01-01T00:01:00.000Z',
 };
+
+describe('stepErrorDtoSchema', () => {
+  it('accepts an agent config issue with an agent config failure reason', () => {
+    const result = stepErrorDtoSchema.parse({
+      message: 'Agent provider credentials are not configured',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_not_configured',
+    });
+
+    expect(result).toEqual({
+      message: 'Agent provider credentials are not configured',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_not_configured',
+    });
+  });
+
+  it('rejects unknown agent config issues', () => {
+    const result = stepErrorDtoSchema.safeParse({
+      message: 'Agent provider credentials are not configured',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'unknown',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
 
 describe('stepAttemptDtoSchema', () => {
   it('accepts an attempt with no gate or restart result', () => {

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -40,6 +40,20 @@ describe('stepErrorDtoSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it.each([
+    undefined,
+    'workspace_prep_failed',
+    'agent_invocation_failed',
+  ] as const)('rejects an agent config issue when reason is %s', (reason) => {
+    const result = stepErrorDtoSchema.safeParse({
+      message: 'Agent provider credentials are not configured',
+      ...(reason === undefined ? {} : {reason}),
+      agent_config_issue: 'provider_not_configured',
+    });
+
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('stepAttemptDtoSchema', () => {

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -21,6 +21,16 @@ export const stepErrorReasonSchema = z.enum([
 
 export type StepErrorReason = z.infer<typeof stepErrorReasonSchema>;
 
+export const agentConfigIssueSchema = z.enum([
+  'step_config_invalid',
+  'provider_not_configured',
+  'provider_unsupported',
+  'model_unavailable',
+  'credentials_invalid',
+]);
+
+export type AgentConfigIssue = z.infer<typeof agentConfigIssueSchema>;
+
 // Whether a failure is infrastructure (`setup`) or user-code (`user`). Server-derived
 // from the step's type on the read path; the runner never sends it.
 export const stepErrorCategorySchema = z.enum(['setup', 'user']);
@@ -33,6 +43,7 @@ export const stepErrorDtoSchema = z
     exit_code: z.number().int().nullable().optional(),
     signal: z.string().optional(),
     reason: stepErrorReasonSchema.optional(),
+    agent_config_issue: agentConfigIssueSchema.optional(),
     category: stepErrorCategorySchema.optional(),
   })
   .nullable();

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -46,6 +46,13 @@ export const stepErrorDtoSchema = z
     agent_config_issue: agentConfigIssueSchema.optional(),
     category: stepErrorCategorySchema.optional(),
   })
+  .refine(
+    (error) => error.agent_config_issue === undefined || error.reason === 'agent_config_invalid',
+    {
+      message: 'agent_config_issue requires reason to be agent_config_invalid',
+      path: ['agent_config_issue'],
+    },
+  )
   .nullable();
 
 export type StepErrorDtoShape = z.infer<typeof stepErrorDtoSchema>;

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -23,9 +23,26 @@ function step(overrides: Partial<Step> & {type: string}): Step {
 
 describe('fromStepErrorDto', () => {
   it('persists the machine-readable reason in camelCase', () => {
-    const persisted = fromStepErrorDto({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+    const persisted = fromStepErrorDto({
+      message: 'mkdir denied',
+      reason: 'workspace_prep_failed',
+    });
 
     expect(persisted).toEqual({message: 'mkdir denied', reason: 'workspace_prep_failed'});
+  });
+
+  it('persists the machine-readable agent config issue in camelCase', () => {
+    const persisted = fromStepErrorDto({
+      message: 'Missing credentials',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_not_configured',
+    });
+
+    expect(persisted).toEqual({
+      message: 'Missing credentials',
+      reason: 'agent_config_invalid',
+      agentConfigIssue: 'provider_not_configured',
+    });
   });
 
   it('ignores a runner-supplied category (the server derives it on read)', () => {
@@ -73,13 +90,18 @@ describe('toStepDto error category', () => {
     const dto = toStepDto(
       step({
         type: 'agent',
-        error: {message: 'Unknown provider "foo" for agent step.', reason: 'agent_config_invalid'},
+        error: {
+          message: 'Unknown provider "foo" for agent step.',
+          reason: 'agent_config_invalid',
+          agentConfigIssue: 'provider_unsupported',
+        },
       }),
     );
 
     expect(dto.error).toEqual({
       message: 'Unknown provider "foo" for agent step.',
       reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_unsupported',
       category: 'user',
     });
   });

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -1,4 +1,5 @@
 import {
+  agentConfigIssueSchema,
   type StepAttemptDto,
   type StepDto,
   type StepErrorCategory,
@@ -23,11 +24,13 @@ function toStepErrorDto(
   const exitCode = error.exitCode;
   const signal = typeof error.signal === 'string' ? error.signal : undefined;
   const reason = stepErrorReasonSchema.safeParse(error.reason);
+  const agentConfigIssue = agentConfigIssueSchema.safeParse(error.agentConfigIssue);
   return {
     message,
     ...(exitCode === null || typeof exitCode === 'number' ? {exit_code: exitCode} : {}),
     ...(signal === undefined ? {} : {signal}),
     ...(reason.success ? {reason: reason.data} : {}),
+    ...(agentConfigIssue.success ? {agent_config_issue: agentConfigIssue.data} : {}),
     category,
   };
 }
@@ -47,6 +50,7 @@ export function fromStepErrorDto(
       : {}),
     ...(typeof error.signal === 'string' ? {signal: error.signal} : {}),
     ...(error.reason === undefined ? {} : {reason: error.reason}),
+    ...(error.agent_config_issue === undefined ? {} : {agentConfigIssue: error.agent_config_issue}),
   };
 }
 

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -242,7 +242,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    expect(res.json().code).toBe('agent-config-invalid');
+    expect(res.json().code).toBe('agent-step-config-invalid');
   });
 
   test('returns 409 when credentials are unavailable', async () => {
@@ -256,7 +256,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    expect(res.json().code).toBe('agent-config-invalid');
+    expect(res.json().code).toBe('agent-provider-not-configured');
   });
 
   test('returns 409 and reports when workspace credentials cannot be decrypted', async () => {
@@ -278,7 +278,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    expect(res.json().code).toBe('agent-config-invalid');
+    expect(res.json().code).toBe('agent-provider-credentials-invalid');
     expect(captureExceptionMock).toHaveBeenCalledWith(
       expect.objectContaining({name: 'CredentialDecryptionError'}),
     );

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -32,7 +32,7 @@ export const agentRuntimeConfigRoute = defineRoute({
       captureException(error);
       throw new ClientError(
         'Agent provider credentials could not be decrypted',
-        'agent-config-invalid',
+        'agent-provider-credentials-invalid',
         {
           status: 409,
           cause: error,
@@ -42,7 +42,7 @@ export const agentRuntimeConfigRoute = defineRoute({
     if (error instanceof AgentProviderConfigNotFoundError) {
       throw new ClientError(
         'Agent provider credentials are not configured',
-        'agent-config-invalid',
+        'agent-provider-not-configured',
         {
           status: 409,
         },
@@ -90,7 +90,7 @@ export const agentRuntimeConfigRoute = defineRoute({
       agentConfig = materializedAgentStepConfigSchema.parse(step.config);
     } catch (error) {
       if (error instanceof ZodError) {
-        throw new ClientError('Agent step config is invalid', 'agent-config-invalid', {
+        throw new ClientError('Agent step config is invalid', 'agent-step-config-invalid', {
           status: 409,
           cause: error,
         });

--- a/libs/client/projects/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.test.tsx
@@ -90,6 +90,14 @@ describe('ProjectWorkflowsPage', () => {
     fireEvent.click(workflowName);
 
     expect(await screen.findByText('Normalized definition')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Agent steps require prompt. Provider, model, and thinking are optional and resolve when a run starts.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((content) => content.includes('"prompt": "Fix the failing tests."')),
+    ).toBeInTheDocument();
     expect(screen.getByText((content) => content.includes('"deploy"'))).toBeInTheDocument();
 
     fireEvent.keyDown(document, {key: 'Escape'});
@@ -230,7 +238,7 @@ function baseDefinitionsDto() {
         workflow_document: {
           name: 'Deploy production',
           triggers: {on_demand: {source: 'manual', event: 'fire'}},
-          jobs: {deploy: {steps: [{run: './deploy.sh'}]}},
+          jobs: {deploy: {steps: [{prompt: 'Fix the failing tests.'}, {run: './deploy.sh'}]}},
         },
         workflow_model: {kind: 'workflow', name: 'Deploy production'},
         manual_trigger: {name: 'on_demand'},

--- a/libs/client/projects/src/pages/project-workflows-page.test.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.test.tsx
@@ -90,14 +90,6 @@ describe('ProjectWorkflowsPage', () => {
     fireEvent.click(workflowName);
 
     expect(await screen.findByText('Normalized definition')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Agent steps require prompt. Provider, model, and thinking are optional and resolve when a run starts.',
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText((content) => content.includes('"prompt": "Fix the failing tests."')),
-    ).toBeInTheDocument();
     expect(screen.getByText((content) => content.includes('"deploy"'))).toBeInTheDocument();
 
     fireEvent.keyDown(document, {key: 'Escape'});
@@ -238,7 +230,7 @@ function baseDefinitionsDto() {
         workflow_document: {
           name: 'Deploy production',
           triggers: {on_demand: {source: 'manual', event: 'fire'}},
-          jobs: {deploy: {steps: [{prompt: 'Fix the failing tests.'}, {run: './deploy.sh'}]}},
+          jobs: {deploy: {steps: [{run: './deploy.sh'}]}},
         },
         workflow_model: {kind: 'workflow', name: 'Deploy production'},
         manual_trigger: {name: 'on_demand'},

--- a/libs/client/projects/src/pages/project-workflows-page.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.tsx
@@ -413,10 +413,6 @@ function DefinitionSheet({
                 <Text size="sm" bold>
                   Normalized definition
                 </Text>
-                <Text size="xs" className="text-foreground-neutral-muted">
-                  Agent steps require prompt. Provider, model, and thinking are optional and resolve
-                  when a run starts.
-                </Text>
                 <pre className="max-h-[52vh] w-full overflow-auto rounded-8 border border-border-neutral-base bg-background-neutral-subtle p-12 scrollbar">
                   <Code as="code" className="whitespace-pre text-foreground-neutral-base">
                     {normalizedJson}

--- a/libs/client/projects/src/pages/project-workflows-page.tsx
+++ b/libs/client/projects/src/pages/project-workflows-page.tsx
@@ -413,6 +413,10 @@ function DefinitionSheet({
                 <Text size="sm" bold>
                   Normalized definition
                 </Text>
+                <Text size="xs" className="text-foreground-neutral-muted">
+                  Agent steps require prompt. Provider, model, and thinking are optional and resolve
+                  when a run starts.
+                </Text>
                 <pre className="max-h-[52vh] w-full overflow-auto rounded-8 border border-border-neutral-base bg-background-neutral-subtle p-12 scrollbar">
                   <Code as="code" className="whitespace-pre text-foreground-neutral-base">
                     {normalizedJson}

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
@@ -1,0 +1,135 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {within} from 'storybook/test';
+import type {WorkflowAgentStepConfig, WorkflowStepError} from '#core/workflow-run.js';
+import {AgentConfigFailureCallout} from './agent-config-failure-callout.js';
+
+const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
+const AGENT_PROVIDERS_LINK_NAME = 'Configure Agent Providers';
+
+const config: WorkflowAgentStepConfig = {
+  provider: 'anthropic',
+  model: 'claude-opus-4-8',
+  thinking: 'high',
+};
+
+const meta = {
+  title: 'Workflows/RunView/AgentConfigFailureCallout',
+  component: AgentConfigFailureCallout,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-560 bg-background-neutral-base p-16">
+        <Story />
+      </div>
+    ),
+    (Story) => {
+      const rootRoute = createRootRoute({component: Outlet});
+      const storyRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/',
+        component: () => <Story />,
+      });
+      const agentProviderSettingsRoute = createRoute({
+        getParentRoute: () => rootRoute,
+        path: '/workspaces/$wid/settings/agent-providers',
+        component: () => null,
+      });
+      const router = createRouter({
+        history: createMemoryHistory({initialEntries: ['/']}),
+        routeTree: rootRoute.addChildren([storyRoute, agentProviderSettingsRoute]),
+      });
+
+      return <RouterProvider router={router} />;
+    },
+  ],
+  args: {
+    workspaceId: WORKSPACE_ID,
+    config,
+    error: makeError('provider_not_configured'),
+  },
+} satisfies Meta<typeof AgentConfigFailureCallout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+type AgentConfigIssue = NonNullable<WorkflowStepError['agentConfigIssue']>;
+
+export const ProviderNotConfigured: Story = {
+  play: assertCallout('Configure credentials for anthropic', true),
+};
+
+export const CredentialsInvalid: Story = {
+  args: {
+    error: makeError('credentials_invalid'),
+  },
+  play: assertCallout('Update credentials for anthropic', true),
+};
+
+export const ProviderUnsupported: Story = {
+  args: {
+    error: makeError('provider_unsupported'),
+  },
+  play: assertCallout('Choose a supported agent provider', false),
+};
+
+export const ModelUnavailable: Story = {
+  args: {
+    error: makeError('model_unavailable'),
+  },
+  play: assertCallout('Choose an available model', false),
+};
+
+export const StepConfigInvalid: Story = {
+  args: {
+    error: makeError('step_config_invalid'),
+  },
+  play: assertCallout("Fix this step's agent settings", false),
+};
+
+export const UnknownConfigFailure: Story = {
+  args: {
+    error: {
+      message: 'Agent configuration is invalid',
+      exitCode: null,
+      signal: undefined,
+      reason: 'agent_config_invalid',
+      agentConfigIssue: undefined,
+      category: 'user',
+    },
+  },
+  play: assertCallout("We couldn't load the agent configuration for this step", true),
+};
+
+function makeError(agentConfigIssue: AgentConfigIssue): WorkflowStepError {
+  return {
+    message: 'Agent configuration is invalid',
+    exitCode: null,
+    signal: undefined,
+    reason: 'agent_config_invalid',
+    agentConfigIssue,
+    category: 'user',
+  };
+}
+
+function assertCallout(title: string, showsCta: boolean): Story['play'] {
+  return async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText(title);
+    const cta = canvas.queryByRole('link', {name: AGENT_PROVIDERS_LINK_NAME});
+    if (showsCta) {
+      await canvas.findByRole('link', {name: AGENT_PROVIDERS_LINK_NAME});
+    } else if (cta !== null) {
+      throw new Error(`Unexpected ${AGENT_PROVIDERS_LINK_NAME} CTA`);
+    }
+  };
+}

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
@@ -12,16 +12,15 @@ export function AgentConfigFailureCallout({workspaceId}: {workspaceId: string}) 
   return (
     <Alert variant="warning" animated={false} className="px-10 py-8">
       <AlertContent>
-        <AlertTitle>Agent configuration blocked this step</AlertTitle>
+        <AlertTitle>We couldn't load the agent configuration for this step</AlertTitle>
         <AlertDescription>
-          Review the workflow definition values for provider, model, thinking, and prompt. Configure
-          workspace provider credentials, or ask the instance operator to set default provider
-          credentials.
+          Check the step prompt, provider, model, and thinking values. Then configure Agent
+          Providers to add workspace credentials, or ask an admin to set a default provider.
         </AlertDescription>
         <AlertActions>
           <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
             <Link to="/workspaces/$wid/settings/agent-providers" params={{wid: workspaceId}}>
-              Agent Providers
+              Configure Agent Providers
             </Link>
           </Button>
         </AlertActions>

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
@@ -7,24 +7,87 @@ import {
   Button,
 } from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
+import type {WorkflowAgentStepConfig, WorkflowStepError} from '#core/workflow-run.js';
 
-export function AgentConfigFailureCallout({workspaceId}: {workspaceId: string}) {
+export function AgentConfigFailureCallout({
+  workspaceId,
+  config,
+  error,
+}: {
+  workspaceId: string;
+  config: WorkflowAgentStepConfig | null;
+  error: WorkflowStepError | null;
+}) {
+  const copy = agentConfigFailureCopy(config, error);
+
   return (
     <Alert variant="warning" animated={false} className="px-10 py-8">
       <AlertContent>
-        <AlertTitle>We couldn't load the agent configuration for this step</AlertTitle>
-        <AlertDescription>
-          Make sure the step prompt, provider, model, and thinking values are set. Then configure
-          Agent Providers to add workspace credentials.
-        </AlertDescription>
-        <AlertActions>
-          <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
-            <Link to="/workspaces/$wid/settings/agent-providers" params={{wid: workspaceId}}>
-              Configure Agent Providers
-            </Link>
-          </Button>
-        </AlertActions>
+        <AlertTitle>{copy.title}</AlertTitle>
+        <AlertDescription>{copy.description}</AlertDescription>
+        {copy.showProviderCta ? (
+          <AlertActions>
+            <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
+              <Link to="/workspaces/$wid/settings/agent-providers" params={{wid: workspaceId}}>
+                Configure Agent Providers
+              </Link>
+            </Button>
+          </AlertActions>
+        ) : null}
       </AlertContent>
     </Alert>
   );
+}
+
+function agentConfigFailureCopy(
+  config: WorkflowAgentStepConfig | null,
+  error: WorkflowStepError | null,
+): {title: string; description: string; showProviderCta: boolean} {
+  const provider = configValue(config?.provider, 'the selected provider');
+  const model = configValue(config?.model, 'the selected model');
+
+  switch (error?.agentConfigIssue) {
+    case 'provider_not_configured':
+      return {
+        title: `Configure credentials for ${provider}`,
+        description: `This step uses ${provider}, but no workspace credentials are configured for that provider. Configure ${provider} in Agent Providers, then re-run the workflow.`,
+        showProviderCta: true,
+      };
+    case 'credentials_invalid':
+      return {
+        title: `Update credentials for ${provider}`,
+        description: `This step uses ${provider}, but the saved credentials could not be used. Reconfigure ${provider} in Agent Providers, then re-run the workflow.`,
+        showProviderCta: true,
+      };
+    case 'provider_unsupported':
+      return {
+        title: `Choose a supported agent provider`,
+        description: `This step references ${provider}, which is not available to the agent runner. Update the workflow to use a supported provider, then re-run it.`,
+        showProviderCta: false,
+      };
+    case 'model_unavailable':
+      return {
+        title: `Choose an available model`,
+        description: `This step uses ${model} with ${provider}, but that model is not available for the provider. Update the model or provider in the workflow, then re-run it.`,
+        showProviderCta: false,
+      };
+    case 'step_config_invalid':
+      return {
+        title: "Fix this step's agent settings",
+        description:
+          'Make sure the step has a prompt, provider, model, and thinking value, then re-run the workflow.',
+        showProviderCta: false,
+      };
+    case undefined:
+      return {
+        title: "We couldn't load the agent configuration for this step",
+        description:
+          'Make sure the step has a prompt, provider, model, and thinking value. Then configure credentials for the provider in Agent Providers and re-run the workflow.',
+        showProviderCta: true,
+      };
+  }
+}
+
+function configValue(value: string | null | undefined, fallback: string): string {
+  return value ?? fallback;
 }

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
@@ -1,0 +1,31 @@
+import {
+  Alert,
+  AlertActions,
+  AlertContent,
+  AlertDescription,
+  AlertTitle,
+  Button,
+} from '@shipfox/react-ui';
+import {Link} from '@tanstack/react-router';
+
+export function AgentConfigFailureCallout({workspaceId}: {workspaceId: string}) {
+  return (
+    <Alert variant="warning" animated={false} className="px-10 py-8">
+      <AlertContent>
+        <AlertTitle>Agent configuration blocked this step</AlertTitle>
+        <AlertDescription>
+          Review the workflow definition values for provider, model, thinking, and prompt. Configure
+          workspace provider credentials, or ask the instance operator to set default provider
+          credentials.
+        </AlertDescription>
+        <AlertActions>
+          <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
+            <Link to="/workspaces/$wid/settings/agent-providers" params={{wid: workspaceId}}>
+              Agent Providers
+            </Link>
+          </Button>
+        </AlertActions>
+      </AlertContent>
+    </Alert>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.tsx
@@ -14,8 +14,8 @@ export function AgentConfigFailureCallout({workspaceId}: {workspaceId: string}) 
       <AlertContent>
         <AlertTitle>We couldn't load the agent configuration for this step</AlertTitle>
         <AlertDescription>
-          Check the step prompt, provider, model, and thinking values. Then configure Agent
-          Providers to add workspace credentials, or ask an admin to set a default provider.
+          Make sure the step prompt, provider, model, and thinking values are set. Then configure
+          Agent Providers to add workspace credentials.
         </AlertDescription>
         <AlertActions>
           <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">

--- a/libs/client/workflows/src/components/workflow-run-view/agent-step-config-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-step-config-panel.stories.tsx
@@ -1,0 +1,49 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {within} from 'storybook/test';
+import {AgentStepConfigPanel} from './agent-step-config-panel.js';
+
+const meta = {
+  title: 'Workflows/RunView/AgentStepConfigPanel',
+  component: AgentStepConfigPanel,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-480 bg-background-components-base p-16">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    config: {
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+    },
+  },
+} satisfies Meta<typeof AgentStepConfigPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Resolved: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByRole('region', {name: 'Resolved agent configuration'});
+    await canvas.findByText('anthropic');
+    await canvas.findByText('claude-opus-4-8');
+    await canvas.findByText('high');
+  },
+};
+
+export const MissingValues: Story = {
+  args: {
+    config: {
+      provider: null,
+      model: null,
+      thinking: null,
+    },
+  },
+};

--- a/libs/client/workflows/src/components/workflow-run-view/agent-step-config-panel.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-step-config-panel.tsx
@@ -1,0 +1,36 @@
+import {Code, Text} from '@shipfox/react-ui';
+import type {WorkflowAgentStepConfig} from '#core/workflow-run.js';
+
+export function AgentStepConfigPanel({config}: {config: WorkflowAgentStepConfig}) {
+  return (
+    <section aria-label="Resolved agent configuration" className="flex min-w-0 flex-col gap-6">
+      <Text as="h3" size="xs" bold className="text-foreground-neutral-subtle">
+        Resolved agent configuration
+      </Text>
+      <dl className="grid min-w-0 gap-8 sm:grid-cols-3">
+        <AgentConfigValue label="Provider" value={config.provider} />
+        <AgentConfigValue label="Model" value={config.model} />
+        <AgentConfigValue label="Thinking" value={config.thinking} />
+      </dl>
+    </section>
+  );
+}
+
+function AgentConfigValue({label, value}: {label: string; value: string | null}) {
+  return (
+    <div className="min-w-0">
+      <Text as="dt" size="xs" className="text-foreground-neutral-muted">
+        {label}
+      </Text>
+      <Code
+        as="dd"
+        variant="label"
+        className={
+          value ? 'truncate text-foreground-neutral-base' : 'text-foreground-neutral-muted'
+        }
+      >
+        {value ?? 'Not recorded'}
+      </Code>
+    </div>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -138,9 +138,8 @@ describe('WorkflowRunView', () => {
                       prompt: 'Fix the failing tests.',
                     },
                     error: {
-                      message: 'Agent provider credentials are not configured',
-                      reason: 'agent_config_invalid',
-                      agent_config_issue: 'provider_not_configured',
+                      message: 'Agent provider request failed',
+                      reason: 'agent_invocation_failed',
                       category: 'user',
                     },
                     attempts: [
@@ -150,6 +149,11 @@ describe('WorkflowRunView', () => {
                         job_id: BUILD_JOB_ID,
                         status: 'failed',
                         exit_code: 1,
+                        error: {
+                          message: 'Agent provider credentials are not configured',
+                          reason: 'agent_config_invalid',
+                          agentConfigIssue: 'provider_not_configured',
+                        },
                         finished_at: '2026-05-07T01:01:20.000Z',
                       }),
                     ],

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -103,6 +103,91 @@ describe('WorkflowRunView', () => {
     expect(logRequest?.searchParams.get('cursor')).toBe('0');
   });
 
+  test('shows resolved agent config and provider setup guidance for agent config failures', async () => {
+    const user = userEvent.setup();
+    const stepId = '99999999-9999-4999-8999-000000000004';
+    const attemptId = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000004';
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const url = requestUrl(input);
+      if (url.pathname === `/steps/${stepId}/attempts/1/logs`) {
+        return Promise.resolve(
+          jsonResponse(inlineLogBody(outputLine('configuration failed\n'), 1)),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(
+          workflowRunViewDetailDto({
+            jobs: [
+              workflowJobDto({
+                id: BUILD_JOB_ID,
+                run_id: RUN_ID,
+                name: 'build',
+                status: 'failed',
+                steps: [
+                  workflowStepDto({
+                    id: stepId,
+                    job_id: BUILD_JOB_ID,
+                    name: 'implement',
+                    display_name: 'Fix the failing tests.',
+                    type: 'agent',
+                    status: 'failed',
+                    config: {
+                      provider: 'anthropic',
+                      model: 'claude-opus-4-8',
+                      thinking: 'high',
+                      prompt: 'Fix the failing tests.',
+                    },
+                    error: {
+                      message: 'Provider credentials unavailable',
+                      reason: 'agent_config_invalid',
+                      category: 'user',
+                    },
+                    attempts: [
+                      workflowStepAttemptDto({
+                        id: attemptId,
+                        step_id: stepId,
+                        job_id: BUILD_JOB_ID,
+                        status: 'failed',
+                        exit_code: 1,
+                        finished_at: '2026-05-07T01:01:20.000Z',
+                      }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ),
+      );
+    });
+    configureApiClient({fetchImpl: fetchImpl as typeof fetch});
+
+    renderView();
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'Fix the failing tests., Failed, attempt 1, User',
+      }),
+    );
+
+    const config = screen.getByRole('region', {name: 'Resolved agent configuration'});
+    expect(within(config).getByText('Provider')).toBeInTheDocument();
+    expect(within(config).getByText('anthropic')).toBeInTheDocument();
+    expect(within(config).getByText('Model')).toBeInTheDocument();
+    expect(within(config).getByText('claude-opus-4-8')).toBeInTheDocument();
+    expect(within(config).getByText('Thinking')).toBeInTheDocument();
+    expect(within(config).getByText('high')).toBeInTheDocument();
+    expect(screen.getByText('Agent configuration blocked this step')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Review the workflow definition values for provider, model, thinking, and prompt. Configure workspace provider credentials, or ask the instance operator to set default provider credentials.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Agent Providers'})).toHaveAttribute(
+      'href',
+      `/workspaces/${PROJECT_TEST_WID}/settings/agent-providers`,
+    );
+  });
+
   test('renders skipped zero-attempt jobs as skipped instead of missing attempts', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() =>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -138,8 +138,9 @@ describe('WorkflowRunView', () => {
                       prompt: 'Fix the failing tests.',
                     },
                     error: {
-                      message: 'Provider credentials unavailable',
+                      message: 'Agent provider credentials are not configured',
                       reason: 'agent_config_invalid',
+                      agent_config_issue: 'provider_not_configured',
                       category: 'user',
                     },
                     attempts: [
@@ -176,12 +177,10 @@ describe('WorkflowRunView', () => {
     expect(within(config).getByText('claude-opus-4-8')).toBeInTheDocument();
     expect(within(config).getByText('Thinking')).toBeInTheDocument();
     expect(within(config).getByText('high')).toBeInTheDocument();
-    expect(
-      screen.getByText("We couldn't load the agent configuration for this step"),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Configure credentials for anthropic')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Make sure the step prompt, provider, model, and thinking values are set. Then configure Agent Providers to add workspace credentials.',
+        'This step uses anthropic, but no workspace credentials are configured for that provider. Configure anthropic in Agent Providers, then re-run the workflow.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Configure Agent Providers'})).toHaveAttribute(

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -193,6 +193,82 @@ describe('WorkflowRunView', () => {
     );
   });
 
+  test('falls back to the step error when an agent attempt has no typed error', async () => {
+    const user = userEvent.setup();
+    const stepId = '99999999-9999-4999-8999-000000000005';
+    const attemptId = 'aaaaaaaa-aaaa-4aaa-8aaa-000000000005';
+    configureApiClient({
+      fetchImpl: vi.fn((input: RequestInfo | URL) => {
+        const url = requestUrl(input);
+        if (url.pathname === `/steps/${stepId}/attempts/1/logs`) {
+          return Promise.resolve(
+            jsonResponse(inlineLogBody(outputLine('configuration failed\n'), 1)),
+          );
+        }
+        return Promise.resolve(
+          jsonResponse(
+            workflowRunViewDetailDto({
+              jobs: [
+                workflowJobDto({
+                  id: BUILD_JOB_ID,
+                  run_id: RUN_ID,
+                  name: 'build',
+                  status: 'failed',
+                  steps: [
+                    workflowStepDto({
+                      id: stepId,
+                      job_id: BUILD_JOB_ID,
+                      name: 'implement',
+                      display_name: 'Fix the failing tests.',
+                      type: 'agent',
+                      status: 'failed',
+                      config: {
+                        provider: 'anthropic',
+                        model: 'claude-opus-4-8',
+                        thinking: 'high',
+                        prompt: 'Fix the failing tests.',
+                      },
+                      error: {
+                        message: 'Agent provider credentials are not configured',
+                        reason: 'agent_config_invalid',
+                        agent_config_issue: 'provider_not_configured',
+                        category: 'user',
+                      },
+                      attempts: [
+                        workflowStepAttemptDto({
+                          id: attemptId,
+                          step_id: stepId,
+                          job_id: BUILD_JOB_ID,
+                          status: 'failed',
+                          exit_code: 1,
+                          error: null,
+                          finished_at: '2026-05-07T01:01:20.000Z',
+                        }),
+                      ],
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ),
+        );
+      }),
+    });
+
+    renderView();
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'Fix the failing tests., Failed, attempt 1, User',
+      }),
+    );
+
+    expect(screen.getByText('Configure credentials for anthropic')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Configure Agent Providers'})).toHaveAttribute(
+      'href',
+      `/workspaces/${PROJECT_TEST_WID}/settings/agent-providers`,
+    );
+  });
+
   test('renders skipped zero-attempt jobs as skipped instead of missing attempts', async () => {
     configureApiClient({
       fetchImpl: vi.fn(() =>

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -181,7 +181,7 @@ describe('WorkflowRunView', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Check the step prompt, provider, model, and thinking values. Then configure Agent Providers to add workspace credentials, or ask an admin to set a default provider.',
+        'Make sure the step prompt, provider, model, and thinking values are set. Then configure Agent Providers to add workspace credentials.',
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Configure Agent Providers'})).toHaveAttribute(

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.test.tsx
@@ -176,13 +176,15 @@ describe('WorkflowRunView', () => {
     expect(within(config).getByText('claude-opus-4-8')).toBeInTheDocument();
     expect(within(config).getByText('Thinking')).toBeInTheDocument();
     expect(within(config).getByText('high')).toBeInTheDocument();
-    expect(screen.getByText('Agent configuration blocked this step')).toBeInTheDocument();
+    expect(
+      screen.getByText("We couldn't load the agent configuration for this step"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Review the workflow definition values for provider, model, thinking, and prompt. Configure workspace provider credentials, or ask the instance operator to set default provider credentials.',
+        'Check the step prompt, provider, model, and thinking values. Then configure Agent Providers to add workspace credentials, or ask an admin to set a default provider.',
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Agent Providers'})).toHaveAttribute(
+    expect(screen.getByRole('link', {name: 'Configure Agent Providers'})).toHaveAttribute(
       'href',
       `/workspaces/${PROJECT_TEST_WID}/settings/agent-providers`,
     );

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -268,7 +268,7 @@ function StepAttemptDetailPanel({
   attemptError: Record<string, unknown> | null;
   attemptStatus: string;
 }) {
-  const selectedAttemptError = toSelectedAttemptError(step, attemptError);
+  const selectedAttemptError = toSelectedAttemptError(step, attemptError) ?? step.error;
 
   return (
     <div className="flex min-w-0 flex-col gap-10">
@@ -296,12 +296,19 @@ function toSelectedAttemptError(
     error.agentConfigIssue ?? error.agent_config_issue,
   );
   const exitCode = error.exitCode ?? error.exit_code;
+  const parsedReason = reason.success
+    ? reason.data
+    : agentConfigIssue.success
+      ? 'agent_config_invalid'
+      : undefined;
+
+  if (parsedReason === undefined) return null;
 
   return {
     message: typeof error.message === 'string' ? error.message : '',
     exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
     signal: typeof error.signal === 'string' ? error.signal : undefined,
-    reason: reason.success ? reason.data : undefined,
+    reason: parsedReason,
     agentConfigIssue: agentConfigIssue.success ? agentConfigIssue.data : undefined,
     category: step.type === 'setup' ? 'setup' : 'user',
   };

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -256,7 +256,13 @@ function StepAttemptDetailPanel({
   return (
     <div className="flex min-w-0 flex-col gap-10">
       {step.agentConfig ? <AgentStepConfigPanel config={step.agentConfig} /> : null}
-      {isAgentConfigFailure(step) ? <AgentConfigFailureCallout workspaceId={workspaceId} /> : null}
+      {isAgentConfigFailure(step) ? (
+        <AgentConfigFailureCallout
+          workspaceId={workspaceId}
+          config={step.agentConfig}
+          error={step.error}
+        />
+      ) : null}
       <StepAttemptLogPanel stepId={stepId} attempt={attempt} attemptStatus={attemptStatus} />
     </div>
   );

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,10 +1,19 @@
-import type {RerunMode} from '@shipfox/api-workflows-dto';
+import {
+  agentConfigIssueSchema,
+  type RerunMode,
+  stepErrorReasonSchema,
+} from '@shipfox/api-workflows-dto';
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {Code, EmptyState, RelativeTimeProvider, Text, toast} from '@shipfox/react-ui';
 import {useNavigate} from '@tanstack/react-router';
 import {useEffect, useId, useRef, useState} from 'react';
-import type {WorkflowAgentStepConfig, WorkflowJob, WorkflowStep} from '#core/workflow-run.js';
+import type {
+  WorkflowAgentStepConfig,
+  WorkflowJob,
+  WorkflowStep,
+  WorkflowStepError,
+} from '#core/workflow-run.js';
 import {
   type WorkflowRunSelectionInput,
   withoutWorkflowRunSelectionSearch,
@@ -211,7 +220,14 @@ function RunViewContent({
                 onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
                 autoSelectActiveAttempt
                 emptyState={emptyStateForJob(selectedJob)}
-                renderExpandedStep={({step, stepId, attempt, attemptStatus, carriedOver}) =>
+                renderExpandedStep={({
+                  step,
+                  stepId,
+                  attempt,
+                  attemptError,
+                  attemptStatus,
+                  carriedOver,
+                }) =>
                   carriedOver ? (
                     <CarriedOverStepPanel />
                   ) : (
@@ -220,6 +236,7 @@ function RunViewContent({
                       step={step}
                       stepId={stepId}
                       attempt={attempt}
+                      attemptError={attemptError}
                       attemptStatus={attemptStatus}
                     />
                   )
@@ -245,22 +262,26 @@ function StepAttemptDetailPanel({
   step,
   stepId,
   attempt,
+  attemptError,
   attemptStatus,
 }: {
   workspaceId: string;
   step: WorkflowStep;
   stepId: string;
   attempt: number;
+  attemptError: Record<string, unknown> | null;
   attemptStatus: string;
 }) {
+  const selectedAttemptError = toSelectedAttemptError(step, attemptError);
+
   return (
     <div className="flex min-w-0 flex-col gap-10">
       {step.agentConfig ? <AgentStepConfigPanel config={step.agentConfig} /> : null}
-      {isAgentConfigFailure(step) ? (
+      {isAgentConfigFailure(step, selectedAttemptError) ? (
         <AgentConfigFailureCallout
           workspaceId={workspaceId}
           config={step.agentConfig}
-          error={step.error}
+          error={selectedAttemptError}
         />
       ) : null}
       <StepAttemptLogPanel stepId={stepId} attempt={attempt} attemptStatus={attemptStatus} />
@@ -302,8 +323,30 @@ function AgentConfigValue({label, value}: {label: string; value: string | null})
   );
 }
 
-function isAgentConfigFailure(step: WorkflowStep): boolean {
-  return step.type === 'agent' && step.error?.reason === 'agent_config_invalid';
+function toSelectedAttemptError(
+  step: WorkflowStep,
+  error: Record<string, unknown> | null,
+): WorkflowStepError | null {
+  if (error === null) return null;
+
+  const reason = stepErrorReasonSchema.safeParse(error.reason);
+  const agentConfigIssue = agentConfigIssueSchema.safeParse(
+    error.agentConfigIssue ?? error.agent_config_issue,
+  );
+  const exitCode = error.exitCode ?? error.exit_code;
+
+  return {
+    message: typeof error.message === 'string' ? error.message : '',
+    exitCode: exitCode === null || typeof exitCode === 'number' ? exitCode : null,
+    signal: typeof error.signal === 'string' ? error.signal : undefined,
+    reason: reason.success ? reason.data : undefined,
+    agentConfigIssue: agentConfigIssue.success ? agentConfigIssue.data : undefined,
+    category: step.type === 'setup' ? 'setup' : 'user',
+  };
+}
+
+function isAgentConfigFailure(step: WorkflowStep, error: WorkflowStepError | null): boolean {
+  return step.type === 'agent' && error?.reason === 'agent_config_invalid';
 }
 
 function cancelErrorMessage(error: unknown): string {

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,20 +1,8 @@
 import type {RerunMode} from '@shipfox/api-workflows-dto';
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {
-  Alert,
-  AlertActions,
-  AlertContent,
-  AlertDescription,
-  AlertTitle,
-  Button,
-  Code,
-  EmptyState,
-  RelativeTimeProvider,
-  Text,
-  toast,
-} from '@shipfox/react-ui';
-import {Link, useNavigate} from '@tanstack/react-router';
+import {Code, EmptyState, RelativeTimeProvider, Text, toast} from '@shipfox/react-ui';
+import {useNavigate} from '@tanstack/react-router';
 import {useEffect, useId, useRef, useState} from 'react';
 import type {WorkflowAgentStepConfig, WorkflowJob, WorkflowStep} from '#core/workflow-run.js';
 import {
@@ -30,6 +18,7 @@ import {WorkflowJobsGraph} from '../workflow-jobs-graph/index.js';
 import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
 import {WorkflowSourcePanel} from '../workflow-source-panel/index.js';
 import {WorkflowStepList, type WorkflowStepListEmptyState} from '../workflow-step-list/index.js';
+import {AgentConfigFailureCallout} from './agent-config-failure-callout.js';
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
 import {
@@ -304,28 +293,6 @@ function AgentConfigValue({label, value}: {label: string; value: string | null})
         {value ?? 'Not recorded'}
       </Code>
     </div>
-  );
-}
-
-function AgentConfigFailureCallout({workspaceId}: {workspaceId: string}) {
-  return (
-    <Alert variant="warning" animated={false} className="px-10 py-8">
-      <AlertContent>
-        <AlertTitle>Agent configuration blocked this step</AlertTitle>
-        <AlertDescription>
-          Review the workflow definition values for provider, model, thinking, and prompt. Configure
-          workspace provider credentials, or ask the instance operator to set default provider
-          credentials.
-        </AlertDescription>
-        <AlertActions>
-          <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
-            <Link to="/workspaces/$wid/settings/agent-providers" params={{wid: workspaceId}}>
-              Agent Providers
-            </Link>
-          </Button>
-        </AlertActions>
-      </AlertContent>
-    </Alert>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -5,15 +5,10 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {Code, EmptyState, RelativeTimeProvider, Text, toast} from '@shipfox/react-ui';
+import {EmptyState, RelativeTimeProvider, toast} from '@shipfox/react-ui';
 import {useNavigate} from '@tanstack/react-router';
 import {useEffect, useId, useRef, useState} from 'react';
-import type {
-  WorkflowAgentStepConfig,
-  WorkflowJob,
-  WorkflowStep,
-  WorkflowStepError,
-} from '#core/workflow-run.js';
+import type {WorkflowJob, WorkflowStep, WorkflowStepError} from '#core/workflow-run.js';
 import {
   type WorkflowRunSelectionInput,
   withoutWorkflowRunSelectionSearch,
@@ -28,6 +23,7 @@ import {WorkflowRunSummary} from '../workflow-run-summary/index.js';
 import {WorkflowSourcePanel} from '../workflow-source-panel/index.js';
 import {WorkflowStepList, type WorkflowStepListEmptyState} from '../workflow-step-list/index.js';
 import {AgentConfigFailureCallout} from './agent-config-failure-callout.js';
+import {AgentStepConfigPanel} from './agent-step-config-panel.js';
 import {StepAttemptLogPanel} from './step-attempt-log-panel.js';
 import {resolveWorkflowRunSelection} from './workflow-run-selection.js';
 import {
@@ -285,40 +281,6 @@ function StepAttemptDetailPanel({
         />
       ) : null}
       <StepAttemptLogPanel stepId={stepId} attempt={attempt} attemptStatus={attemptStatus} />
-    </div>
-  );
-}
-
-function AgentStepConfigPanel({config}: {config: WorkflowAgentStepConfig}) {
-  return (
-    <section aria-label="Resolved agent configuration" className="flex min-w-0 flex-col gap-6">
-      <Text as="h3" size="xs" bold className="text-foreground-neutral-subtle">
-        Resolved agent configuration
-      </Text>
-      <dl className="grid min-w-0 gap-8 sm:grid-cols-3">
-        <AgentConfigValue label="Provider" value={config.provider} />
-        <AgentConfigValue label="Model" value={config.model} />
-        <AgentConfigValue label="Thinking" value={config.thinking} />
-      </dl>
-    </section>
-  );
-}
-
-function AgentConfigValue({label, value}: {label: string; value: string | null}) {
-  return (
-    <div className="min-w-0">
-      <Text as="dt" size="xs" className="text-foreground-neutral-muted">
-        {label}
-      </Text>
-      <Code
-        as="dd"
-        variant="label"
-        className={
-          value ? 'truncate text-foreground-neutral-base' : 'text-foreground-neutral-muted'
-        }
-      >
-        {value ?? 'Not recorded'}
-      </Code>
     </div>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/workflow-run-view.tsx
@@ -1,10 +1,22 @@
 import type {RerunMode} from '@shipfox/api-workflows-dto';
 import {ApiError} from '@shipfox/client-api';
 import {QueryLoadError} from '@shipfox/client-ui';
-import {EmptyState, RelativeTimeProvider, toast} from '@shipfox/react-ui';
-import {useNavigate} from '@tanstack/react-router';
+import {
+  Alert,
+  AlertActions,
+  AlertContent,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Code,
+  EmptyState,
+  RelativeTimeProvider,
+  Text,
+  toast,
+} from '@shipfox/react-ui';
+import {Link, useNavigate} from '@tanstack/react-router';
 import {useEffect, useId, useRef, useState} from 'react';
-import type {WorkflowJob} from '#core/workflow-run.js';
+import type {WorkflowAgentStepConfig, WorkflowJob, WorkflowStep} from '#core/workflow-run.js';
 import {
   type WorkflowRunSelectionInput,
   withoutWorkflowRunSelectionSearch,
@@ -210,11 +222,13 @@ function RunViewContent({
                 onSelectedAttemptChange={selectionControlled ? selectAttempt : undefined}
                 autoSelectActiveAttempt
                 emptyState={emptyStateForJob(selectedJob)}
-                renderExpandedStep={({stepId, attempt, attemptStatus, carriedOver}) =>
+                renderExpandedStep={({step, stepId, attempt, attemptStatus, carriedOver}) =>
                   carriedOver ? (
                     <CarriedOverStepPanel />
                   ) : (
-                    <StepAttemptLogPanel
+                    <StepAttemptDetailPanel
+                      workspaceId={workspaceId}
+                      step={step}
                       stepId={stepId}
                       attempt={attempt}
                       attemptStatus={attemptStatus}
@@ -235,6 +249,88 @@ function RunViewContent({
       />
     </>
   );
+}
+
+function StepAttemptDetailPanel({
+  workspaceId,
+  step,
+  stepId,
+  attempt,
+  attemptStatus,
+}: {
+  workspaceId: string;
+  step: WorkflowStep;
+  stepId: string;
+  attempt: number;
+  attemptStatus: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-10">
+      {step.agentConfig ? <AgentStepConfigPanel config={step.agentConfig} /> : null}
+      {isAgentConfigFailure(step) ? <AgentConfigFailureCallout workspaceId={workspaceId} /> : null}
+      <StepAttemptLogPanel stepId={stepId} attempt={attempt} attemptStatus={attemptStatus} />
+    </div>
+  );
+}
+
+function AgentStepConfigPanel({config}: {config: WorkflowAgentStepConfig}) {
+  return (
+    <section aria-label="Resolved agent configuration" className="flex min-w-0 flex-col gap-6">
+      <Text as="h3" size="xs" bold className="text-foreground-neutral-subtle">
+        Resolved agent configuration
+      </Text>
+      <dl className="grid min-w-0 gap-8 sm:grid-cols-3">
+        <AgentConfigValue label="Provider" value={config.provider} />
+        <AgentConfigValue label="Model" value={config.model} />
+        <AgentConfigValue label="Thinking" value={config.thinking} />
+      </dl>
+    </section>
+  );
+}
+
+function AgentConfigValue({label, value}: {label: string; value: string | null}) {
+  return (
+    <div className="min-w-0">
+      <Text as="dt" size="xs" className="text-foreground-neutral-muted">
+        {label}
+      </Text>
+      <Code
+        as="dd"
+        variant="label"
+        className={
+          value ? 'truncate text-foreground-neutral-base' : 'text-foreground-neutral-muted'
+        }
+      >
+        {value ?? 'Not recorded'}
+      </Code>
+    </div>
+  );
+}
+
+function AgentConfigFailureCallout({workspaceId}: {workspaceId: string}) {
+  return (
+    <Alert variant="warning" animated={false} className="px-10 py-8">
+      <AlertContent>
+        <AlertTitle>Agent configuration blocked this step</AlertTitle>
+        <AlertDescription>
+          Review the workflow definition values for provider, model, thinking, and prompt. Configure
+          workspace provider credentials, or ask the instance operator to set default provider
+          credentials.
+        </AlertDescription>
+        <AlertActions>
+          <Button asChild size="2xs" variant="secondary" iconRight="chevronRight">
+            <Link to="/workspaces/$wid/settings/agent-providers" params={{wid: workspaceId}}>
+              Agent Providers
+            </Link>
+          </Button>
+        </AlertActions>
+      </AlertContent>
+    </Alert>
+  );
+}
+
+function isAgentConfigFailure(step: WorkflowStep): boolean {
+  return step.type === 'agent' && step.error?.reason === 'agent_config_invalid';
 }
 
 function cancelErrorMessage(error: unknown): string {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.test.ts
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list-model.test.ts
@@ -264,6 +264,7 @@ describe('buildWorkflowStepListModel', () => {
       signal: undefined,
       category: 'setup',
       reason: 'checkout_failed',
+      agentConfigIssue: undefined,
     });
     expect(result.entries[0]?.error).toEqual({message: 'Opaque nested value', exitCode: 127});
     expect(result.entries[0]?.output).toEqual({tail: 'do not parse'});

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -79,7 +79,7 @@ const withAgentProviderSettingsRoute: Decorator = (Story) => {
 async function assertAgentConfigFailureCallout(ctx: WorkflowStepListStoryContext) {
   const canvas = within(ctx.canvasElement);
 
-  await canvas.findByText("We couldn't load the agent configuration for this step");
+  await canvas.findByText('Configure credentials for anthropic');
   await canvas.findByRole('link', {name: AGENT_PROVIDERS_LINK_NAME});
 }
 
@@ -272,6 +272,7 @@ export const AgentConfigFailureCallout: Story = {
         message: 'Agent provider credentials are not configured',
         category: 'user',
         reason: 'agent_config_invalid',
+        agent_config_issue: 'provider_not_configured',
       },
       attempts: [attempt],
     });
@@ -280,7 +281,20 @@ export const AgentConfigFailureCallout: Story = {
       <WorkflowStepList
         job={makeJob({status: 'failed', steps: [step]})}
         defaultSelectedAttemptId={attempt.id}
-        renderExpandedStep={() => <AgentConfigFailureCalloutView workspaceId={WORKSPACE_ID} />}
+        renderExpandedStep={() => (
+          <AgentConfigFailureCalloutView
+            workspaceId={WORKSPACE_ID}
+            config={{provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high'}}
+            error={{
+              message: 'Agent provider credentials are not configured',
+              reason: 'agent_config_invalid',
+              agentConfigIssue: 'provider_not_configured',
+              category: 'user',
+              exitCode: null,
+              signal: undefined,
+            }}
+          />
+        )}
       />
     );
   },

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -17,7 +17,7 @@ import {AgentConfigFailureCallout as AgentConfigFailureCalloutView} from '../wor
 import {WorkflowStepList} from './workflow-step-list.js';
 
 const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
-const AGENT_PROVIDERS_LINK_NAME = 'Agent Providers';
+const AGENT_PROVIDERS_LINK_NAME = 'Configure Agent Providers';
 
 const meta = {
   title: 'Workflows/StepList',
@@ -79,7 +79,7 @@ const withAgentProviderSettingsRoute: Decorator = (Story) => {
 async function assertAgentConfigFailureCallout(ctx: WorkflowStepListStoryContext) {
   const canvas = within(ctx.canvasElement);
 
-  await canvas.findByText('Agent configuration blocked this step');
+  await canvas.findByText("We couldn't load the agent configuration for this step");
   await canvas.findByRole('link', {name: AGENT_PROVIDERS_LINK_NAME});
 }
 

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -1,10 +1,23 @@
 import type {RunJobDetailDto, RunStepDetailDto, StepAttemptDto} from '@shipfox/api-workflows-dto';
 import {LogView, type LogViewProps} from '@shipfox/client-logs';
 import {Text} from '@shipfox/react-ui';
-import type {Meta, StoryObj} from '@storybook/react';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {within} from 'storybook/test';
 import type {WorkflowJob} from '#core/workflow-run.js';
 import {workflowJob, workflowStepAttemptDto, workflowStepDto} from '#test/fixtures/workflow-run.js';
+import {AgentConfigFailureCallout as AgentConfigFailureCalloutView} from '../workflow-run-view/agent-config-failure-callout.js';
 import {WorkflowStepList} from './workflow-step-list.js';
+
+const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
+const AGENT_PROVIDERS_LINK_NAME = 'Agent Providers';
 
 const meta = {
   title: 'Workflows/StepList',
@@ -41,6 +54,34 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+type WorkflowStepListStoryContext = Parameters<NonNullable<Story['play']>>[0];
+
+const withAgentProviderSettingsRoute: Decorator = (Story) => {
+  const rootRoute = createRootRoute({component: Outlet});
+  const storyRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => <Story />,
+  });
+  const agentProviderSettingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/settings/agent-providers',
+    component: () => null,
+  });
+  const router = createRouter({
+    history: createMemoryHistory({initialEntries: ['/']}),
+    routeTree: rootRoute.addChildren([storyRoute, agentProviderSettingsRoute]),
+  });
+
+  return <RouterProvider router={router} />;
+};
+
+async function assertAgentConfigFailureCallout(ctx: WorkflowStepListStoryContext) {
+  const canvas = within(ctx.canvasElement);
+
+  await canvas.findByText('Agent configuration blocked this step');
+  await canvas.findByRole('link', {name: AGENT_PROVIDERS_LINK_NAME});
+}
 
 export const Default: Story = {};
 
@@ -210,6 +251,40 @@ export const FailedStep: Story = {
       ],
     }),
   },
+};
+
+export const AgentConfigFailureCallout: Story = {
+  decorators: [withAgentProviderSettingsRoute],
+  render: () => {
+    const attempt = makeAttempt({status: 'failed', exit_code: 1});
+    const step = makeStep({
+      name: 'implement',
+      display_name: 'Fix the failing tests.',
+      type: 'agent',
+      status: 'failed',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        prompt: 'Fix the failing tests.',
+      },
+      error: {
+        message: 'Agent provider credentials are not configured',
+        category: 'user',
+        reason: 'agent_config_invalid',
+      },
+      attempts: [attempt],
+    });
+
+    return (
+      <WorkflowStepList
+        job={makeJob({status: 'failed', steps: [step]})}
+        defaultSelectedAttemptId={attempt.id}
+        renderExpandedStep={() => <AgentConfigFailureCalloutView workspaceId={WORKSPACE_ID} />}
+      />
+    );
+  },
+  play: assertAgentConfigFailureCallout,
 };
 
 export const CancelledAndPending: Story = {

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -17,7 +17,7 @@ import {
 import type {ReactNode} from 'react';
 import {useEffect, useId, useMemo, useRef, useState} from 'react';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
-import {isWorkflowStatus, type WorkflowJob} from '#core/workflow-run.js';
+import {isWorkflowStatus, type WorkflowJob, type WorkflowStep} from '#core/workflow-run.js';
 import {
   buildWorkflowStepListModel,
   humanizeStatus,
@@ -27,6 +27,7 @@ import {
 } from './workflow-step-list-model.js';
 
 export interface WorkflowStepExpandedContext {
+  step: WorkflowStep;
   stepId: string;
   attempt: number;
   attemptId: string;
@@ -181,6 +182,7 @@ function WorkflowStepListContent({
                   expandedContent={
                     selected
                       ? renderExpandedStep?.({
+                          step: entry.step,
                           stepId: entry.step.id,
                           attempt: entry.attempt,
                           attemptId: entry.id,

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.tsx
@@ -31,6 +31,7 @@ export interface WorkflowStepExpandedContext {
   stepId: string;
   attempt: number;
   attemptId: string;
+  attemptError: Record<string, unknown> | null;
   attemptStatus: string;
   carriedOver: boolean;
 }
@@ -186,6 +187,7 @@ function WorkflowStepListContent({
                           stepId: entry.step.id,
                           attempt: entry.attempt,
                           attemptId: entry.id,
+                          attemptError: entry.error,
                           attemptStatus: entry.statusVisual.kind,
                           carriedOver: entry.carriedOver,
                         })

--- a/libs/client/workflows/src/core/workflow-run.test.ts
+++ b/libs/client/workflows/src/core/workflow-run.test.ts
@@ -263,6 +263,54 @@ describe('workflow run model mapping', () => {
     });
   });
 
+  test('maps resolved agent step configuration from the opaque step config', () => {
+    const step = workflowStepDto({
+      type: 'agent',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        thinking: 'high',
+        prompt: 'Fix the failing tests.',
+      },
+    });
+    const missingConfigStep = workflowStepDto({
+      type: 'agent',
+      config: {provider: '', model: 42},
+    });
+
+    const detail = toWorkflowRunDetail(
+      workflowRunDetailDto({
+        jobs: [workflowJobDto({steps: [step, missingConfigStep]})],
+      }),
+    );
+
+    expect(detail.jobs[0]?.steps[0]?.agentConfig).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+    });
+    expect(detail.jobs[0]?.steps[1]?.agentConfig).toEqual({
+      provider: null,
+      model: null,
+      thinking: null,
+    });
+  });
+
+  test('leaves non-agent steps without agent configuration', () => {
+    const step = workflowStepDto({
+      type: 'run',
+      config: {provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high'},
+    });
+
+    const detail = toWorkflowRunDetail(
+      workflowRunDetailDto({
+        jobs: [workflowJobDto({steps: [step]})],
+      }),
+    );
+
+    expect(detail.jobs[0]?.steps[0]?.agentConfig).toBeNull();
+  });
+
   test('maps run attempt summaries', () => {
     const dto = workflowRunAttemptDto({
       id: '77777777-7777-4777-8777-777777777777',

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentConfigIssue,
   JobStatusDto,
   JobStatusReasonDto,
   RunAttemptDto,
@@ -21,6 +22,7 @@ export type WorkflowJobStatus = JobStatusDto;
 export type WorkflowJobStatusReason = JobStatusReasonDto;
 export type WorkflowStatus = WorkflowRunStatus | WorkflowJobStatus;
 export type WorkflowStepErrorReason = StepErrorReason;
+export type WorkflowAgentConfigIssue = AgentConfigIssue;
 export type WorkflowStepErrorCategory = StepErrorCategory;
 export type WorkflowStepGateResult = StepGateResultDto;
 export type WorkflowStepRestartResult = StepRestartResultDto;
@@ -69,6 +71,7 @@ export interface WorkflowStepError {
   exitCode: number | null;
   signal: string | undefined;
   reason: WorkflowStepErrorReason | undefined;
+  agentConfigIssue: WorkflowAgentConfigIssue | undefined;
   category: WorkflowStepErrorCategory | undefined;
 }
 
@@ -346,6 +349,7 @@ function toWorkflowStepError(dto: NonNullable<RunStepDetailDto['error']>): Workf
     exitCode: dto.exit_code ?? null,
     signal: dto.signal,
     reason: dto.reason,
+    agentConfigIssue: dto.agent_config_issue,
     category: dto.category,
   };
 }

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -72,6 +72,12 @@ export interface WorkflowStepError {
   category: WorkflowStepErrorCategory | undefined;
 }
 
+export interface WorkflowAgentStepConfig {
+  provider: string | null;
+  model: string | null;
+  thinking: string | null;
+}
+
 export interface WorkflowStepAttempt {
   id: string;
   stepId: string;
@@ -98,6 +104,7 @@ export interface WorkflowStep {
   status: string;
   type: string;
   config: Record<string, unknown>;
+  agentConfig: WorkflowAgentStepConfig | null;
   error: WorkflowStepError | null;
   position: number;
   currentAttempt: number;
@@ -280,6 +287,7 @@ export function toWorkflowStep(dto: RunStepDetailDto): WorkflowStep {
     status: dto.status,
     type: dto.type,
     config: dto.config,
+    agentConfig: toWorkflowAgentStepConfig(dto),
     error: dto.error ? toWorkflowStepError(dto.error) : null,
     position: dto.position,
     currentAttempt: dto.current_attempt,
@@ -340,4 +348,21 @@ function toWorkflowStepError(dto: NonNullable<RunStepDetailDto['error']>): Workf
     reason: dto.reason,
     category: dto.category,
   };
+}
+
+function toWorkflowAgentStepConfig(dto: RunStepDetailDto): WorkflowAgentStepConfig | null {
+  if (dto.type !== 'agent') return null;
+
+  return {
+    provider: stringConfigValue(dto.config.provider),
+    model: stringConfigValue(dto.config.model),
+    thinking: stringConfigValue(dto.config.thinking),
+  };
+}
+
+function stringConfigValue(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  const trimmedValue = value.trim();
+  return trimmedValue ? trimmedValue : null;
 }

--- a/libs/client/workflows/src/index.ts
+++ b/libs/client/workflows/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  WorkflowAgentConfigIssue,
   WorkflowJob,
   WorkflowJobStatus,
   WorkflowRun,

--- a/libs/client/workflows/test/pages.tsx
+++ b/libs/client/workflows/test/pages.tsx
@@ -45,10 +45,15 @@ function createTestRouter(
       return renderPage({runId});
     },
   });
+  const agentProviderSettingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/settings/agent-providers',
+    component: () => <div>Agent provider settings placeholder</div>,
+  });
 
   return createRouter({
     history: createMemoryHistory({initialEntries: [path]}),
-    routeTree: rootRoute.addChildren([runsRoute, runDetailRoute]),
+    routeTree: rootRoute.addChildren([runsRoute, runDetailRoute, agentProviderSettingsRoute]),
   });
 }
 

--- a/libs/runner/agent/src/core/errors.ts
+++ b/libs/runner/agent/src/core/errors.ts
@@ -1,3 +1,5 @@
+import type {AgentConfigIssue} from '@shipfox/api-workflows-dto';
+
 /**
  * A user-fixable agent-step configuration failure: an unknown provider, a
  * provider/model pair pi does not know, or workspace provider credentials that
@@ -6,7 +8,10 @@
  * (`agent_invocation_failed`).
  */
 export class AgentConfigError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    public readonly agentConfigIssue: AgentConfigIssue = 'step_config_invalid',
+  ) {
     super(message);
     this.name = 'AgentConfigError';
   }

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -162,7 +162,10 @@ describe('runAgent', () => {
     await expect(
       runAgent(invocation({provider: 'openai', credentials: {account_id: 'acct-1'}})),
     ).rejects.toThrow(
-      new AgentConfigError('Runtime credentials for provider "openai" are missing "api_key".'),
+      new AgentConfigError(
+        'Runtime credentials for provider "openai" are missing "api_key".',
+        'credentials_invalid',
+      ),
     );
     expect(findMock).not.toHaveBeenCalled();
     expect(createAgentSessionMock).not.toHaveBeenCalled();
@@ -179,6 +182,7 @@ describe('runAgent', () => {
     ).rejects.toThrow(
       new AgentConfigError(
         'Runtime credentials for provider "cloudflare-ai-gateway" are missing "gateway_id".',
+        'credentials_invalid',
       ),
     );
     expect(findMock).not.toHaveBeenCalled();
@@ -220,6 +224,7 @@ describe('runAgent', () => {
       new AgentConfigError(
         'Unknown provider "bogus" for agent step. ' +
           'Known providers are pi built-ins plus any from models.json.',
+        'provider_unsupported',
       ),
     );
     expect(createAgentSessionMock).not.toHaveBeenCalled();
@@ -236,6 +241,7 @@ describe('runAgent', () => {
       new AgentConfigError(
         'Model "gpt-5.1" is not available for provider "anthropic". ' +
           'Did you mean to set provider: openai?',
+        'model_unavailable',
       ),
     );
     expect(createAgentSessionMock).not.toHaveBeenCalled();
@@ -246,7 +252,10 @@ describe('runAgent', () => {
     getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
 
     await expect(runAgent(invocation({provider: 'anthropic', model: 'gpt-5.1'}))).rejects.toThrow(
-      new AgentConfigError('Model "gpt-5.1" is not available for provider "anthropic".'),
+      new AgentConfigError(
+        'Model "gpt-5.1" is not available for provider "anthropic".',
+        'model_unavailable',
+      ),
     );
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
@@ -259,6 +268,7 @@ describe('runAgent', () => {
       new AgentConfigError(
         'No credentials configured for provider "openai". ' +
           'Verify the provider is configured for this workspace.',
+        'provider_not_configured',
       ),
     );
     expect(createAgentSessionMock).not.toHaveBeenCalled();

--- a/libs/runner/agent/src/core/run-agent.ts
+++ b/libs/runner/agent/src/core/run-agent.ts
@@ -69,6 +69,7 @@ export async function runAgent(invocation: AgentInvocation): Promise<{summary?: 
     throw new AgentConfigError(
       `No credentials configured for provider "${provider}". ` +
         'Verify the provider is configured for this workspace.',
+      'provider_not_configured',
     );
   }
 
@@ -141,6 +142,7 @@ function resolveModel(
     throw new AgentConfigError(
       `Unknown provider "${provider}" for agent step. ` +
         'Known providers are pi built-ins plus any from models.json.',
+      'provider_unsupported',
     );
   }
 
@@ -151,6 +153,7 @@ function resolveModel(
       : ` Did you mean to set provider: ${alternativeProvider}?`;
   throw new AgentConfigError(
     `Model "${modelId}" is not available for provider "${provider}".${hint}`,
+    'model_unavailable',
   );
 }
 
@@ -194,6 +197,7 @@ function credentialValue(
   if (value === undefined || value === '') {
     throw new AgentConfigError(
       `Runtime credentials for provider "${provider}" are missing "${key}".`,
+      'credentials_invalid',
     );
   }
   return value;

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -115,7 +115,9 @@ describe('executeAgentStep', () => {
   });
 
   it('fails with agent_config_invalid when the agent run throws an AgentConfigError', async () => {
-    runAgentMock.mockRejectedValue(new AgentConfigError('Unknown provider "foo" for agent step.'));
+    runAgentMock.mockRejectedValue(
+      new AgentConfigError('Unknown provider "foo" for agent step.', 'provider_unsupported'),
+    );
 
     const result = await executeAgentStep(buildAgentStep(), {runtime: RUNTIME});
 
@@ -123,6 +125,7 @@ describe('executeAgentStep', () => {
     expect(result.error).toEqual({
       message: 'Unknown provider "foo" for agent step.',
       reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_unsupported',
     });
   });
 
@@ -143,6 +146,7 @@ describe('executeAgentStep', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.reason).toBe('agent_config_invalid');
+    expect(result.error?.agent_config_issue).toBe('step_config_invalid');
     expect(runAgentMock).not.toHaveBeenCalled();
   });
 

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -1,4 +1,9 @@
-import type {StepDto, StepErrorDtoShape, StepErrorReason} from '@shipfox/api-workflows-dto';
+import type {
+  AgentConfigIssue,
+  StepDto,
+  StepErrorDtoShape,
+  StepErrorReason,
+} from '@shipfox/api-workflows-dto';
 import type {StepResult} from '@shipfox/runner-execution';
 import {AgentConfigError} from '#core/errors.js';
 import {runAgent} from '#core/run-agent.js';
@@ -24,7 +29,11 @@ export function executeAgentStep(
   const {prompt} = step.config;
   if (typeof prompt !== 'string' || prompt === '') {
     return Promise.resolve(
-      agentFailure('Agent step config is missing prompt', 'agent_config_invalid'),
+      agentFailure(
+        'Agent step config is missing prompt',
+        'agent_config_invalid',
+        'step_config_invalid',
+      ),
     );
   }
 
@@ -71,7 +80,11 @@ async function runAgentStep(params: {
   } catch (error) {
     const reason: StepErrorReason =
       error instanceof AgentConfigError ? 'agent_config_invalid' : 'agent_invocation_failed';
-    return agentFailure(error instanceof Error ? error.message : String(error), reason);
+    return agentFailure(
+      error instanceof Error ? error.message : String(error),
+      reason,
+      error instanceof AgentConfigError ? error.agentConfigIssue : undefined,
+    );
   }
 }
 
@@ -115,7 +128,12 @@ function abortError(): Error {
 function agentFailure(
   message: string,
   reason: StepErrorReason = 'agent_invocation_failed',
+  agentConfigIssue?: AgentConfigIssue,
 ): StepResult {
-  const error: StepErrorDtoShape = {message, reason};
+  const error: StepErrorDtoShape = {
+    message,
+    reason,
+    ...(agentConfigIssue === undefined ? {} : {agent_config_issue: agentConfigIssue}),
+  };
   return {success: false, output: '', error, exit_code: null};
 }

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1,4 +1,4 @@
-import type {NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
+import type {AgentConfigIssue, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {HTTPError} from 'ky';
 
 const {AgentRuntimeConfigRequestError} = vi.hoisted(() => ({
@@ -6,6 +6,7 @@ const {AgentRuntimeConfigRequestError} = vi.hoisted(() => ({
     constructor(
       public readonly status: number,
       public readonly code: string | undefined,
+      public readonly agentConfigIssue: AgentConfigIssue | undefined = undefined,
     ) {
       super(
         code === undefined
@@ -846,7 +847,7 @@ describe('runJobSteps', () => {
     });
   });
 
-  it('reports agent_config_invalid when runtime credentials are rejected by the API', async () => {
+  it('reports agent config issues when runtime credentials are rejected by the API', async () => {
     const setup = buildSetupStep();
     const agent = buildAgentStep();
     requestNextStepMock
@@ -854,7 +855,11 @@ describe('runJobSteps', () => {
       .mockResolvedValueOnce(stepResponse(agent, 1))
       .mockResolvedValueOnce({kind: 'done', status: 'failed'});
     requestAgentRuntimeConfigMock.mockRejectedValueOnce(
-      new AgentRuntimeConfigRequestError(409, 'agent-config-invalid'),
+      new AgentRuntimeConfigRequestError(
+        409,
+        'agent-provider-not-configured',
+        'provider_not_configured',
+      ),
     );
     const ac = new AbortController();
 
@@ -866,7 +871,10 @@ describe('runJobSteps', () => {
       expect.objectContaining({
         stepId: agent.id,
         status: 'failed',
-        error: expect.objectContaining({reason: 'agent_config_invalid'}),
+        error: expect.objectContaining({
+          reason: 'agent_config_invalid',
+          agent_config_issue: 'provider_not_configured',
+        }),
       }),
     );
   });

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -384,14 +384,15 @@ function maskAgentFailure(result: StepResult, secretVariants: string[]): StepRes
 
 function agentRuntimeConfigFailure(error: unknown): StepResult {
   if (error instanceof AgentRuntimeConfigRequestError) {
+    const agentConfigIssue =
+      error.agentConfigIssue ??
+      (error.code === 'agent-config-invalid' ? 'step_config_invalid' : undefined);
     return {
       success: false,
       error: {
         message: error.message,
-        reason:
-          error.code === 'agent-config-invalid'
-            ? 'agent_config_invalid'
-            : 'agent_invocation_failed',
+        reason: agentConfigIssue ? 'agent_config_invalid' : 'agent_invocation_failed',
+        ...(agentConfigIssue ? {agent_config_issue: agentConfigIssue} : {}),
       },
       exit_code: null,
     };

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -185,8 +185,8 @@ describe('api-client auth contexts', () => {
     expect(calls[0]?.authorization).toBe('Bearer lease-runtime');
   });
 
-  it('requestAgentRuntimeConfig preserves the server error code on failure', async () => {
-    stubFetch(() => jsonResponse({code: 'agent-config-invalid'}, 409));
+  it('requestAgentRuntimeConfig maps server config errors to agent config issues', async () => {
+    stubFetch(() => jsonResponse({code: 'agent-provider-not-configured'}, 409));
     const leaseClient = createLeaseClient('lease-runtime');
 
     const request = requestAgentRuntimeConfig(leaseClient, {
@@ -195,7 +195,11 @@ describe('api-client auth contexts', () => {
     });
 
     await expect(request).rejects.toMatchObject(
-      new AgentRuntimeConfigRequestError(409, 'agent-config-invalid'),
+      new AgentRuntimeConfigRequestError(
+        409,
+        'agent-provider-not-configured',
+        'provider_not_configured',
+      ),
     );
   });
 

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -14,6 +14,7 @@ import {
   registerRunnerResponseSchema,
 } from '@shipfox/api-runners-dto';
 import {
+  type AgentConfigIssue,
   type CheckoutTokenResponseDto,
   checkoutTokenResponseSchema,
   type LogOutcomeDto,
@@ -97,6 +98,7 @@ export class AgentRuntimeConfigRequestError extends Error {
   constructor(
     public readonly status: number,
     public readonly code: string | undefined,
+    public readonly agentConfigIssue: AgentConfigIssue | undefined = agentConfigIssueForCode(code),
   ) {
     super(
       code === undefined
@@ -362,4 +364,23 @@ async function errorCode(response: Response): Promise<string | undefined> {
 function codeFromBody(body: unknown): string | undefined {
   if (typeof body !== 'object' || body === null || !('code' in body)) return undefined;
   return typeof body.code === 'string' ? body.code : undefined;
+}
+
+function agentConfigIssueForCode(code: string | undefined): AgentConfigIssue | undefined {
+  switch (code) {
+    case 'agent-config-invalid':
+    case 'agent-step-config-invalid':
+    case 'agent-runtime-config-invalid':
+      return 'step_config_invalid';
+    case 'agent-provider-not-configured':
+      return 'provider_not_configured';
+    case 'agent-provider-unsupported':
+      return 'provider_unsupported';
+    case 'agent-model-unavailable':
+      return 'model_unavailable';
+    case 'agent-provider-credentials-invalid':
+      return 'credentials_invalid';
+    default:
+      return undefined;
+  }
 }


### PR DESCRIPTION
Show resolved agent provider, model, and thinking values in the run detail step panel, with a targeted callout when agent configuration blocks a step.

Agent workflow authors need to see the concrete config values selected at run start, especially when provider credentials, provider/model choices, or required prompt values prevent execution. The callout points users toward the workflow definition values and workspace Agent Providers settings, and the warning now has Storybook coverage in the expanded step-list panel.

The touched client packages are private, so no changeset is included.

Closes ENG-604