### PR TITLE
Add design-sync state for Shipfox React UI claude.ai/design import

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,43 @@
+# design-sync notes — @shipfox/react-ui
+
+Repo-specific gotchas for syncing `libs/shared/react/ui` to claude.ai/design.
+
+## Build / config
+
+- **Shape: storybook.** Reference storybook built into `.design-sync/sb-reference` from `libs/shared/react/ui/.storybook` (run `storybook build` from the package dir — its node_modules has the storybook bin and react). 89 story entries → 31 components.
+- **`--node-modules` is the package's own** `libs/shared/react/ui/node_modules` (pnpm isolated — react is NOT hoisted to repo root). `--entry libs/shared/react/ui/dist/index.js`.
+- **buildCmd** `turbo run build --filter=@shipfox/react-ui...` (trailing `...` builds workspace deps too).
+- `[GENERAL]` **Decorator bundle fails** (`Could not resolve "tailwindcss"`): `.storybook/preview.tsx` imports `../index.css` which `@import "tailwindcss"` (Tailwind v4) — esbuild can't resolve it. CSS itself ships fine via the dist `styles.css` scrape, so the only thing lost is the `ThemeProvider` wrapper the `withTheme` decorator supplied. Fixed with `cfg.provider` = `ThemeProvider` (`defaultTheme: "system"`, `storageKey: "shipfox-theme-system"`), mirroring the decorator default. `ThemeProvider` is a bundle export.
+- `[GENERAL]` **titleMap**: two storybook titles don't match export names — `Loader` → `ShipfoxLoader` (story `component: ShipfoxLoader`), `Toast` → `Toaster` (story `component: Toaster`).
+- `[GENERAL]` **GRID_OVERFLOW (19 components)**: applied cardMode overrides — `column` for wide grids (Button, Alert, Badge, Card, Combobox, EmptyState, FormField, Input, IconButton, LoadErrorState, Modal, RadioGroup, ShipfoxLoader, Skeleton, Table, Tabs) and `single` (+ `primaryStory: Default`) for portal/fixed overlays (DropdownMenu, Sheet, Tooltip). Presentation-only — grades carry, targeted rebuild only.
+
+## Fonts
+
+- `[GENERAL]` **Remote fonts, served at runtime.** `index.css` `@import`s Inter from Google Fonts and declares `@font-face` for **Commit Mono** from a storyblok CDN URL. `[FONT_REMOTE]` for Inter is expected — both fonts load at runtime in the capture browser (verified: Text renders in Inter, Code renders in Commit Mono on both panels). Capture/grade requires network egress to fonts.googleapis.com and a.storyblok.com; a network-sandboxed shell would silently fall back on both panels.
+
+## Preview fidelity — general (from fan-out)
+
+- `[GENERAL]` **`@storybook/addon-pseudo-states` is not reproducible in previews.** Any story that forces `:hover`/`:focus`/`:focus-visible` via `parameters.pseudo` (mapping `.hover`→`:hover`, `.focus`→`:focus-visible`) shows those state visuals ONLY in storybook. The compiled preview renders the same inert classNames, so Hover/Focus columns look like Default. Not fixable by an owned `.tsx` (faking the state misrepresents the component). Grade `close` with a note. Known affected stories: **RadioGroup "States"**, **IconButton "Variants"**.
+- `[GENERAL]` **Capture viewport is fixed** (~900x700) while storybook captures full-page. Tall matrix stories (e.g. IconButton/Button "Variants" spanning sizes 2xs..xl) get framed to the top region in the preview — a framing artifact, not missing content. A `cfg.overrides.<Name>.viewport` bump would show more but re-grades.
+- **Animation freeze artifacts**: a few stories show a different frozen frame of an infinite-loop animation between panels (Icon spinner cell, ShipfoxLoader lit pixels, Combobox "Loading" spinner). Content/composition identical — graded `match` (or `close` for Combobox Loading where the spinner glyph appears on only one panel). Not a contract difference.
+
+## Accepted `close` (non-actionable, with rationale)
+
+- **RadioGroup "States"** — pseudo-states addon (see above); component renders identically otherwise.
+- **IconButton "Variants"** — pseudo-states addon (see above); real component (Default/Disabled, all sizes/variants) matches.
+- **Combobox "Loading"** — capture freeze-clock settles the CSS spin animation differently per panel; same component + state.
+
+## Render warns triaged (known, not new)
+
+- `tokens: ... (1 missing, below threshold)` — one undefined CSS custom property, below the validator threshold. Benign.
+- `[FONT_REMOTE] "Inter"` — see Fonts above; expected, no action.
+
+## Avatar
+
+- Avatar stories guard remote DiceBear images behind `navigator.webdriver` (`isTest ? 'letters' : 'image'`) — under the capture browser (webdriver=true) avatars render letters/logo, not remote images, on both panels. So Avatar is NOT the `[ASSETS_BLOCKED]` canary; the font egress above is the real remote-asset dependency.
+
+## Re-sync risks
+
+- **Provider distillation**: `cfg.provider` replaces the storybook decorators as the preview wrapper. If `ThemeProvider`'s API or the theme mechanism changes, re-verify a themed component after rebuild.
+- **Remote font egress**: grades assume fonts.googleapis.com + a.storyblok.com are reachable at capture time. If a future sync runs sandboxed, Text/Code (and any text rendering) would compare as "matching fallback" while shipping wrong fonts — never accept that as a pass.
+- **Avatar webdriver guard**: the `image` content path (remote DiceBear) is never exercised by the compare oracle. Only the letters/logo path is verified.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,38 @@
+{
+  "projectId": "f6a18036-8b26-4041-9cfe-7ae450df78ef",
+  "pkg": "@shipfox/react-ui",
+  "shape": "storybook",
+  "storybookConfigDir": "libs/shared/react/ui/.storybook",
+  "storybookStatic": ".design-sync/sb-reference",
+  "buildCmd": "turbo run build --filter=@shipfox/react-ui...",
+  "readmeHeader": ".design-sync/conventions.md",
+  "titleMap": {
+    "Loader": "ShipfoxLoader",
+    "Toast": "Toaster"
+  },
+  "provider": {
+    "component": "ThemeProvider",
+    "props": { "defaultTheme": "system", "storageKey": "shipfox-theme-system" }
+  },
+  "overrides": {
+    "IconButton": { "cardMode": "column" },
+    "Alert": { "cardMode": "column" },
+    "Badge": { "cardMode": "column" },
+    "Button": { "cardMode": "column" },
+    "Card": { "cardMode": "column" },
+    "Combobox": { "cardMode": "column" },
+    "EmptyState": { "cardMode": "column" },
+    "FormField": { "cardMode": "column" },
+    "Input": { "cardMode": "column" },
+    "LoadErrorState": { "cardMode": "column" },
+    "Modal": { "cardMode": "column" },
+    "RadioGroup": { "cardMode": "column" },
+    "ShipfoxLoader": { "cardMode": "column" },
+    "Skeleton": { "cardMode": "column" },
+    "Table": { "cardMode": "column" },
+    "Tabs": { "cardMode": "column" },
+    "DropdownMenu": { "cardMode": "single", "primaryStory": "Default" },
+    "Sheet": { "cardMode": "single", "primaryStory": "Default" },
+    "Tooltip": { "cardMode": "single", "primaryStory": "Default" }
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,77 @@
+# Shipfox React UI — how to build with it
+
+A React + Tailwind CSS v4 design system. You compose its real components and drive
+their look through **props** (variant / size / tone), not by hand-writing component
+styles. Use Tailwind utility classes only for your own layout glue around them.
+
+## Wrapping & theme
+
+Wrap the tree in **`ThemeProvider`** (a bundle export) so light/dark works — it sets
+the `dark` class that every component's `dark:` styles read, and supplies theme
+context that components like the theme switch consume. Without it components still
+render, but dark mode never toggles.
+
+```jsx
+<ThemeProvider defaultTheme="system">
+  <App />
+</ThemeProvider>
+```
+
+Fonts and component styles load from the bound **`styles.css`**, which `@import`s
+`_ds_bundle.css` (all component CSS + design tokens) and `fonts/fonts.css`
+(**Inter** for text via `--font-sans`, **Commit Mono** for code via `--font-mono`).
+Load `styles.css` once; nothing renders styled without it.
+
+## Styling idiom — props first, then utilities
+
+- **Component look comes from props.** Common axes:
+  - `Button` — `variant`: `primary` (inverted neutral / near-black), `secondary`,
+    `danger`, `success`, `transparent`, `transparentMuted`; `size`: `2xs|xs|sm|md|lg|xl`;
+    `iconLeft` / `iconRight` (icon-NAME strings, e.g. `"github"`); `isLoading`.
+  - `Badge` — `variant`: `info|success|warning|error|neutral|feature`; `size`: `2xs|xs`;
+    `radius`: `default|rounded`.
+  - `Header` — `variant`: `h1|h2|h3|h4`. `Text`/`Code` carry size/weight variants.
+  - `Icon` — `name` (string, e.g. `"check"`, `"close"`, `"copy"`, `"info"`, `"search"`,
+    `"github"`, `"google"`, `"microsoft"`, `"shipfox"`, `"slack"`, `"chevronRight"`),
+    plus `size`, `color`.
+- **Tailwind utilities for your own layout/spacing glue**, and note the spacing base:
+  this DS sets `--spacing: 1px`, so spacing/size/radius numbers are **1px-scaled** —
+  `p-16` = 16px, `gap-8` = 8px, `rounded-8` = 8px, `h-320` = 320px. Multiply the
+  number by 1px, not 0.25rem. Layout utilities (`flex`, `flex-col`, `items-center`,
+  `gap-*`, `grid`) work as usual.
+- **Color is via SEMANTIC utility classes, not a raw `primary`/`gray` scale.** Use:
+  - text: `text-foreground-neutral-base` / `-muted` / `-subtle` / `-on-color`,
+    `text-foreground-contrast-primary`, `text-foreground-highlight-interactive`
+  - surfaces: `bg-background-neutral-base` / `-background` / `-overlay` / `-disabled`,
+    `bg-background-subtle-base`, `bg-background-components-base`, `bg-background-field-base`
+  - borders: `border-border-neutral-base` / `-strong`
+  - tag accents: `bg-tag-{blue,success,warning,error,neutral,purple}-{bg,icon}`
+  The raw ramps `--color-primary-50…950` (orange), `--color-accent-*`,
+  `--color-alpha-{black,white}-*` exist only as CSS variables behind those semantic
+  classes — reach for them via `var(--color-…)` only when no semantic class fits.
+- **Brand orange is the focus / interactive-highlight color, not the primary fill.**
+  The default primary `Button` is inverted neutral (dark). For "interactive / you are
+  here" accents use the `*-foreground-highlight-interactive` classes, not a fill.
+
+## Where the truth lives
+
+Before styling, read the bound **`styles.css`** and the `_ds_bundle.css` /
+`fonts/fonts.css` it imports for the real token names, and each component's
+**`<Name>.prompt.md`** + **`<Name>.d.ts`** for its exact prop contract.
+
+## Example
+
+```jsx
+<ThemeProvider defaultTheme="system">
+  <div className="flex flex-col gap-12 p-16 rounded-8 bg-background-neutral-base text-foreground-neutral-base">
+    <div className="flex items-center gap-8">
+      <Badge variant="success" size="xs">Live</Badge>
+      <Header variant="h3">Deployments</Header>
+    </div>
+    <div className="flex gap-8">
+      <Button variant="primary" iconLeft="github">Connect repo</Button>
+      <Button variant="secondary">Cancel</Button>
+    </div>
+  </div>
+</ThemeProvider>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,11 @@ screenshots/
 
 # Local scratch backlog; tracked work lives in Linear
 TODOS.md
+
+# design-sync (claude.ai/design)
+.ds-sync/
+ds-bundle/
+.design-sync/sb-reference/
+.design-sync/learnings/
+.design-sync/.cache/
+.design-sync/node_modules


### PR DESCRIPTION
Records the deterministic inputs for syncing `@shipfox/react-ui` to a
claude.ai/design project, so future re-syncs are fast and reproducible from any
machine.

The import itself is already uploaded to the Design project; this PR only
commits the repo-side state the converter reads on the next run:

- `.design-sync/config.json` — shape (storybook), build command, the
  `ThemeProvider` preview wrapper, `titleMap` (Loader→ShipfoxLoader,
  Toast→Toaster), and 19 `cardMode` overrides for grid/portal card layout.
- `.design-sync/conventions.md` — the conventions header prepended to the
  generated README and read by the design agent. Every class, token, prop, and
  icon name in it was grep-verified against the built bundle/CSS: props-first
  styling, the 1px Tailwind spacing base, the semantic color classes
  (`bg-background-*`, `text-foreground-*`, `bg-tag-*`), Inter/Commit Mono fonts,
  and the `ThemeProvider` wrap.
- `.design-sync/NOTES.md` — repo-specific gotchas and re-sync risks (remote
  fonts served at runtime, the `addon-pseudo-states` grading limitation, the
  Avatar webdriver image guard).
- `.gitignore` — ignores the transient sync artifacts (reference storybook,
  `ds-bundle/` output, `.ds-sync/` scripts, verification cache).

No product code changes, so no changeset. All 31 components were imported and
verified (28 fully matched their Storybook render; 3 stories accepted as
non-actionable `close` — documented in NOTES.md).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic design-sync state for syncing `@shipfox/react-ui` to claude.ai/design so re-syncs are fast and reproducible. No product code changes.

- **New Features**
  - Added `.design-sync/config.json` with Storybook shape, reference paths, `buildCmd`, `titleMap`, `provider: ThemeProvider`, and 19 `cardMode` overrides.
  - Added `.design-sync/conventions.md` covering props-first styling, Tailwind v4 1px spacing scale, semantic color classes, fonts, and the required `ThemeProvider` wrap.
  - Added `.design-sync/NOTES.md` with repo-specific caveats (remote fonts, pseudo-state addon limits, fixed viewport framing, Avatar webdriver guard, re-sync risks).
  - Updated `.gitignore` to ignore design-sync artifacts (`sb-reference`, `ds-bundle/`, scripts/cache).

<sup>Written for commit 76ce12b49e4266f0956c92b3c57e0782953ce71b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

