### PR TITLE
[client-agent] Add provider catalog search

### DIFF
--- a/libs/client/agent/src/components/agent-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.stories.tsx
@@ -1,4 +1,8 @@
-import type {AgentProviderCatalogEntryDto, AgentProviderConfigDto} from '@shipfox/api-agent-dto';
+import type {
+  AgentProviderCatalogEntryDto,
+  AgentProviderConfigDto,
+  SupportedAgentProviderId,
+} from '@shipfox/api-agent-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui';
 import type {Meta, StoryObj} from '@storybook/react';
@@ -46,6 +50,48 @@ const CATALOG: AgentProviderCatalogEntryDto[] = [
     label: 'xAI',
     default_model: 'grok-code-fast-1',
     models: [{id: 'grok-code-fast-1', label: 'Grok Code Fast 1'}],
+  }),
+  providerEntry({
+    id: 'openrouter',
+    label: 'OpenRouter',
+    default_model: 'openrouter/auto',
+    models: [{id: 'openrouter/auto', label: 'OpenRouter Auto'}],
+  }),
+  providerEntry({
+    id: 'google',
+    label: 'Google Gemini',
+    default_model: 'gemini-3-pro',
+    models: [{id: 'gemini-3-pro', label: 'Gemini 3 Pro'}],
+  }),
+  providerEntry({
+    id: 'mistral',
+    label: 'Mistral AI',
+    default_model: 'codestral-latest',
+    models: [{id: 'codestral-latest', label: 'Codestral Latest'}],
+  }),
+  providerEntry({
+    id: 'groq',
+    label: 'Groq',
+    default_model: 'llama-4-fast',
+    models: [{id: 'llama-4-fast', label: 'Llama 4 Fast'}],
+  }),
+  providerEntry({
+    id: 'deepseek',
+    label: 'DeepSeek',
+    default_model: 'deepseek-coder',
+    models: [{id: 'deepseek-coder', label: 'DeepSeek Coder'}],
+  }),
+  providerEntry({
+    id: 'moonshotai',
+    label: 'Moonshot AI',
+    default_model: 'kimi-k2',
+    models: [{id: 'kimi-k2', label: 'Kimi K2'}],
+  }),
+  providerEntry({
+    id: 'azure-openai-responses',
+    label: 'Azure OpenAI Responses',
+    default_model: 'gpt-5.5-pro',
+    models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
   }),
   providerEntry({
     id: 'amazon-bedrock',
@@ -114,6 +160,30 @@ export const LongNames: Story = {
   args: {scenario: 'long-names'},
 };
 
+export const FilteredAvailableProviders: Story = {
+  args: {scenario: 'empty-configured'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(
+      await canvas.findByRole('searchbox', {name: 'Search providers'}),
+      'openrouter',
+    );
+    await canvas.findByRole('button', {name: 'Configure OpenRouter'});
+  },
+};
+
+export const NoMatchingAvailableProviders: Story = {
+  args: {scenario: 'empty-configured'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(
+      await canvas.findByRole('searchbox', {name: 'Search providers'}),
+      'not-a-provider',
+    );
+    await canvas.findByRole('button', {name: 'Clear search'});
+  },
+};
+
 export const ConfigureModalOpen: Story = {
   args: {scenario: 'empty-configured'},
   play: async ({canvasElement}) => {
@@ -174,11 +244,12 @@ function configsForScenario(scenario: Scenario) {
   }
   if (scenario === 'all-configured') {
     return {
-      configs: [
-        providerConfig({provider_id: 'anthropic'}),
-        providerConfig({provider_id: 'openai', key_fingerprints: {api_key: 'sk-proj...abcd'}}),
-        providerConfig({provider_id: 'xai', key_fingerprints: {api_key: 'xai...abcd'}}),
-      ],
+      configs: CATALOG.filter((entry) => entry.support_status === 'supported').map((entry) =>
+        providerConfig({
+          provider_id: entry.id as SupportedAgentProviderId,
+          key_fingerprints: {api_key: `${entry.id}...abcd`},
+        }),
+      ),
       default_provider_id: 'anthropic',
     };
   }

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -39,6 +39,29 @@ function requestPath(input: RequestInfo | URL): string {
   return new URL((input as Request).url).pathname;
 }
 
+const TEST_PROVIDER_IDS = [
+  'anthropic',
+  'openai',
+  'deepseek',
+  'nvidia',
+  'google',
+  'mistral',
+  'groq',
+  'cerebras',
+  'xai',
+] as const;
+
+function availableProviderEntries(count: number) {
+  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
+    agentProviderEntry({
+      id,
+      label: `Provider ${index}`,
+      default_model: `model-${index}`,
+      models: [{id: `model-${index}`, label: `Model ${index}`}],
+    }),
+  );
+}
+
 async function openProviderActions(user: ReturnType<typeof userEvent.setup>, label: string) {
   await user.click(screen.getByRole('button', {name: `Open ${label} provider actions`}));
 }
@@ -80,6 +103,55 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(screen.getByText('Unsupported providers')).toBeVisible();
     expect(screen.getByText('Amazon Bedrock')).toBeVisible();
     expect(screen.getByText('AWS cloud credentials are not supported yet.')).toBeVisible();
+  });
+
+  test('filters available providers and clears back to the full available list', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(agentProviderCatalogResponse(availableProviderEntries(9))),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(agentProviderConfigsResponse({configs: [], default_provider_id: null})),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+    const search = await screen.findByRole('searchbox', {name: 'Search providers'});
+
+    await user.type(search, 'provider 7');
+
+    expect(screen.getByRole('button', {name: 'Configure Provider 7'})).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'Configure Provider 1'})).not.toBeInTheDocument();
+    await user.clear(search);
+    await user.type(search, 'missing');
+    expect(screen.getByText('No providers match "missing"')).toBeVisible();
+    await user.click(screen.getByRole('button', {name: 'Clear search'}));
+
+    expect(screen.getByRole('button', {name: 'Configure Provider 1'})).toBeVisible();
+    await waitFor(() => expect(search).toHaveFocus());
+  });
+
+  test('hides available provider search when the unfiltered list is small', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      if (requestPath(input).endsWith('/agent/provider-catalog')) {
+        return Promise.resolve(
+          jsonResponse(agentProviderCatalogResponse(availableProviderEntries(8))),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse(agentProviderConfigsResponse({configs: [], default_provider_id: null})),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderAgentProviders(<WorkspaceAgentProvidersSection workspaceId={AGENT_TEST_WORKSPACE_ID} />);
+
+    expect(await screen.findByRole('button', {name: 'Configure Provider 0'})).toBeVisible();
+    expect(screen.queryByRole('searchbox', {name: 'Search providers'})).not.toBeInTheDocument();
   });
 
   test('waits for configured providers before rendering available provider cards', async () => {

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -10,6 +10,7 @@ import {
   agentProviderConfig,
   agentProviderConfigsResponse,
   agentProviderEntry,
+  testAgentProviderEntries,
   unsupportedAgentProviderEntry,
 } from '#test/fixtures/agent-providers.js';
 import {WorkspaceAgentProvidersSection} from './agent-providers-section.js';
@@ -37,29 +38,6 @@ const ANTHROPIC_FINGERPRINT_RE = /sk-ant-s\.\.\.abcd/;
 const OPENAI_FINGERPRINT_RE = /sk-proj\.\.\.abcd/;
 function requestPath(input: RequestInfo | URL): string {
   return new URL((input as Request).url).pathname;
-}
-
-const TEST_PROVIDER_IDS = [
-  'anthropic',
-  'openai',
-  'deepseek',
-  'nvidia',
-  'google',
-  'mistral',
-  'groq',
-  'cerebras',
-  'xai',
-] as const;
-
-function availableProviderEntries(count: number) {
-  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
-    agentProviderEntry({
-      id,
-      label: `Provider ${index}`,
-      default_model: `model-${index}`,
-      models: [{id: `model-${index}`, label: `Model ${index}`}],
-    }),
-  );
 }
 
 async function openProviderActions(user: ReturnType<typeof userEvent.setup>, label: string) {
@@ -110,7 +88,7 @@ describe('WorkspaceAgentProvidersSection', () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       if (requestPath(input).endsWith('/agent/provider-catalog')) {
         return Promise.resolve(
-          jsonResponse(agentProviderCatalogResponse(availableProviderEntries(9))),
+          jsonResponse(agentProviderCatalogResponse(testAgentProviderEntries(9))),
         );
       }
       return Promise.resolve(
@@ -139,7 +117,7 @@ describe('WorkspaceAgentProvidersSection', () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
       if (requestPath(input).endsWith('/agent/provider-catalog')) {
         return Promise.resolve(
-          jsonResponse(agentProviderCatalogResponse(availableProviderEntries(8))),
+          jsonResponse(agentProviderCatalogResponse(testAgentProviderEntries(8))),
         );
       }
       return Promise.resolve(

--- a/libs/client/agent/src/components/agent-providers-section.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.tsx
@@ -33,14 +33,13 @@ import {
   useSetDefaultAgentProviderMutation,
 } from '#hooks/api/agent-providers.js';
 import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
-import {AvailableProviderCard} from './available-provider-card.js';
+import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from './available-providers-grid.js';
 import {ChangeDefaultModelForm} from './change-default-model-form.js';
 import {agentProviderConfigErrorToFormError} from './form-errors.js';
 import {AgentProviderTestAndSaveForm} from './test-and-save-form.js';
 
 const SURFACE_CLASS =
   'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
-const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-12 max-[760px]:grid-cols-1';
 
 type ProviderFormState =
   | {mode: 'configure'; entry: AgentProviderCatalogEntryDto; config?: undefined}
@@ -199,15 +198,10 @@ export function WorkspaceAgentProvidersSection({workspaceId}: {workspaceId: stri
         ) : null}
 
         {configsLoaded && availableProviders.length > 0 ? (
-          <ul className={PROVIDER_GRID_CLASS}>
-            {availableProviders.map((entry) => (
-              <AvailableProviderCard
-                key={entry.id}
-                entry={entry}
-                onConfigure={() => setFormState({mode: 'configure', entry})}
-              />
-            ))}
-          </ul>
+          <AvailableProvidersGrid
+            entries={availableProviders}
+            onSelect={(entry) => setFormState({mode: 'configure', entry})}
+          />
         ) : null}
       </section>
 

--- a/libs/client/agent/src/components/available-providers-grid.test.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.test.tsx
@@ -1,0 +1,75 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {agentProviderEntry} from '#test/fixtures/agent-providers.js';
+import {AvailableProvidersGrid} from './available-providers-grid.js';
+
+const TEST_PROVIDER_IDS = [
+  'anthropic',
+  'openai',
+  'deepseek',
+  'nvidia',
+  'google',
+  'mistral',
+  'groq',
+  'cerebras',
+  'xai',
+] as const;
+
+function providerEntries(count: number) {
+  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
+    agentProviderEntry({
+      id,
+      label: `Provider ${index}`,
+      default_model: `model-${index}`,
+      models: [{id: `model-${index}`, label: `Model ${index}`}],
+    }),
+  );
+}
+
+describe('AvailableProvidersGrid', () => {
+  test('shows the search field when more than eight providers are available', () => {
+    render(<AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />);
+
+    expect(screen.getByRole('searchbox', {name: 'Search providers'})).toBeVisible();
+  });
+
+  test('hides the search field when eight or fewer providers are available without a query', () => {
+    render(<AvailableProvidersGrid entries={providerEntries(8)} onSelect={vi.fn()} />);
+
+    expect(screen.queryByRole('searchbox', {name: 'Search providers'})).not.toBeInTheDocument();
+  });
+
+  test('keeps the search field mounted when a query is active and the entries shrink below the threshold', async () => {
+    const user = userEvent.setup();
+    const {rerender} = render(
+      <AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />,
+    );
+    await user.type(screen.getByRole('searchbox', {name: 'Search providers'}), 'provider 1');
+
+    rerender(<AvailableProvidersGrid entries={providerEntries(8)} onSelect={vi.fn()} />);
+
+    expect(screen.getByRole('searchbox', {name: 'Search providers'})).toHaveValue('provider 1');
+  });
+
+  test('clear search resets the query and returns focus to the input', async () => {
+    const user = userEvent.setup();
+    render(<AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />);
+    const search = screen.getByRole('searchbox', {name: 'Search providers'});
+
+    await user.type(search, 'missing');
+    await user.click(screen.getByRole('button', {name: 'Clear search'}));
+
+    expect(search).toHaveValue('');
+    await waitFor(() => expect(search).toHaveFocus());
+    expect(screen.getByRole('button', {name: 'Configure Provider 0'})).toBeVisible();
+  });
+
+  test('announces the filtered result count while a query is active', async () => {
+    const user = userEvent.setup();
+    render(<AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />);
+
+    await user.type(screen.getByRole('searchbox', {name: 'Search providers'}), 'provider 1');
+
+    expect(screen.getByRole('status')).toHaveTextContent('1 providers match "provider 1"');
+  });
+});

--- a/libs/client/agent/src/components/available-providers-grid.test.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.test.tsx
@@ -37,6 +37,7 @@ describe('AvailableProvidersGrid', () => {
     render(<AvailableProvidersGrid entries={providerEntries(8)} onSelect={vi.fn()} />);
 
     expect(screen.queryByRole('searchbox', {name: 'Search providers'})).not.toBeInTheDocument();
+    expect(screen.getByRole('list', {name: 'Available providers'})).toBeVisible();
   });
 
   test('keeps the search field mounted when a query is active and the entries shrink below the threshold', async () => {
@@ -70,6 +71,7 @@ describe('AvailableProvidersGrid', () => {
 
     await user.type(screen.getByRole('searchbox', {name: 'Search providers'}), 'provider 1');
 
-    expect(screen.getByRole('status')).toHaveTextContent('1 providers match "provider 1"');
+    expect(screen.getByRole('status')).toHaveTextContent('1 provider matches "provider 1"');
+    expect(screen.getByRole('list', {name: 'Available providers matching search'})).toBeVisible();
   });
 });

--- a/libs/client/agent/src/components/available-providers-grid.test.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.test.tsx
@@ -1,60 +1,38 @@
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {agentProviderEntry} from '#test/fixtures/agent-providers.js';
+import {testAgentProviderEntries} from '#test/fixtures/agent-providers.js';
 import {AvailableProvidersGrid} from './available-providers-grid.js';
-
-const TEST_PROVIDER_IDS = [
-  'anthropic',
-  'openai',
-  'deepseek',
-  'nvidia',
-  'google',
-  'mistral',
-  'groq',
-  'cerebras',
-  'xai',
-] as const;
-
-function providerEntries(count: number) {
-  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
-    agentProviderEntry({
-      id,
-      label: `Provider ${index}`,
-      default_model: `model-${index}`,
-      models: [{id: `model-${index}`, label: `Model ${index}`}],
-    }),
-  );
-}
 
 describe('AvailableProvidersGrid', () => {
   test('shows the search field when more than eight providers are available', () => {
-    render(<AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />);
+    render(<AvailableProvidersGrid entries={testAgentProviderEntries(9)} onSelect={vi.fn()} />);
 
     expect(screen.getByRole('searchbox', {name: 'Search providers'})).toBeVisible();
   });
 
   test('hides the search field when eight or fewer providers are available without a query', () => {
-    render(<AvailableProvidersGrid entries={providerEntries(8)} onSelect={vi.fn()} />);
+    render(<AvailableProvidersGrid entries={testAgentProviderEntries(8)} onSelect={vi.fn()} />);
 
     expect(screen.queryByRole('searchbox', {name: 'Search providers'})).not.toBeInTheDocument();
     expect(screen.getByRole('list', {name: 'Available providers'})).toBeVisible();
+    expect(screen.getByRole('status')).toHaveTextContent('');
   });
 
   test('keeps the search field mounted when a query is active and the entries shrink below the threshold', async () => {
     const user = userEvent.setup();
     const {rerender} = render(
-      <AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />,
+      <AvailableProvidersGrid entries={testAgentProviderEntries(9)} onSelect={vi.fn()} />,
     );
     await user.type(screen.getByRole('searchbox', {name: 'Search providers'}), 'provider 1');
 
-    rerender(<AvailableProvidersGrid entries={providerEntries(8)} onSelect={vi.fn()} />);
+    rerender(<AvailableProvidersGrid entries={testAgentProviderEntries(8)} onSelect={vi.fn()} />);
 
     expect(screen.getByRole('searchbox', {name: 'Search providers'})).toHaveValue('provider 1');
   });
 
   test('clear search resets the query and returns focus to the input', async () => {
     const user = userEvent.setup();
-    render(<AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />);
+    render(<AvailableProvidersGrid entries={testAgentProviderEntries(9)} onSelect={vi.fn()} />);
     const search = screen.getByRole('searchbox', {name: 'Search providers'});
 
     await user.type(search, 'missing');
@@ -67,7 +45,7 @@ describe('AvailableProvidersGrid', () => {
 
   test('announces the filtered result count while a query is active', async () => {
     const user = userEvent.setup();
-    render(<AvailableProvidersGrid entries={providerEntries(9)} onSelect={vi.fn()} />);
+    render(<AvailableProvidersGrid entries={testAgentProviderEntries(9)} onSelect={vi.fn()} />);
 
     await user.type(screen.getByRole('searchbox', {name: 'Search providers'}), 'provider 1');
 

--- a/libs/client/agent/src/components/available-providers-grid.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.tsx
@@ -26,6 +26,8 @@ export function AvailableProvidersGrid({
   );
   const providerListLabel =
     trimmedSearch !== '' ? 'Available providers matching search' : 'Available providers';
+  const resultCountText =
+    trimmedSearch === '' ? '' : providerResultCountText(filteredEntries.length, trimmedSearch);
 
   function clearSearch() {
     setSearch('');
@@ -60,11 +62,9 @@ export function AvailableProvidersGrid({
         <NoProviderSearchResults search={trimmedSearch} onClear={clearSearch} />
       )}
 
-      {trimmedSearch !== '' ? (
-        <p role="status" aria-live="polite" className="sr-only">
-          {providerResultCountText(filteredEntries.length, trimmedSearch)}
-        </p>
-      ) : null}
+      <p role="status" aria-live="polite" className="sr-only">
+        {resultCountText}
+      </p>
     </div>
   );
 }

--- a/libs/client/agent/src/components/available-providers-grid.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.tsx
@@ -1,0 +1,88 @@
+import type {AgentProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+import {Button, EmptyState, Icon, Input} from '@shipfox/react-ui';
+import {useMemo, useRef, useState} from 'react';
+import {AvailableProviderCard} from './available-provider-card.js';
+import {providerMatchesSearch} from './provider-search.js';
+
+export const PROVIDER_GRID_CLASS = 'grid grid-cols-2 gap-12 max-[760px]:grid-cols-1';
+
+const SEARCH_VISIBILITY_THRESHOLD = 8;
+const MAX_ECHOED_QUERY_LENGTH = 40;
+
+export function AvailableProvidersGrid({
+  entries,
+  onSelect,
+}: {
+  entries: AgentProviderCatalogEntryDto[];
+  onSelect: (entry: AgentProviderCatalogEntryDto) => void;
+}) {
+  const [search, setSearch] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const trimmedSearch = search.trim();
+  const showSearch = entries.length > SEARCH_VISIBILITY_THRESHOLD || trimmedSearch !== '';
+  const filteredEntries = useMemo(
+    () => entries.filter((entry) => providerMatchesSearch(entry, search)),
+    [entries, search],
+  );
+
+  function clearSearch() {
+    setSearch('');
+    inputRef.current?.focus();
+  }
+
+  return (
+    <div className="flex flex-col gap-12">
+      {showSearch ? (
+        <Input
+          ref={inputRef}
+          type="search"
+          aria-label="Search providers"
+          placeholder="Search providers..."
+          value={search}
+          iconLeft={<Icon name="searchLine" className="size-16 text-foreground-neutral-muted" />}
+          onChange={(event) => setSearch(event.target.value)}
+        />
+      ) : null}
+
+      {filteredEntries.length > 0 ? (
+        <ul className={PROVIDER_GRID_CLASS} aria-label="Available providers matching search">
+          {filteredEntries.map((entry) => (
+            <AvailableProviderCard
+              key={entry.id}
+              entry={entry}
+              onConfigure={() => onSelect(entry)}
+            />
+          ))}
+        </ul>
+      ) : (
+        <NoProviderSearchResults search={trimmedSearch} onClear={clearSearch} />
+      )}
+
+      {trimmedSearch !== '' ? (
+        <p role="status" aria-live="polite" className="sr-only">
+          {filteredEntries.length} providers match "{trimmedSearch}"
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function NoProviderSearchResults({search, onClear}: {search: string; onClear: () => void}) {
+  return (
+    <EmptyState
+      icon="searchLine"
+      title={`No providers match "${truncateQuery(search)}"`}
+      description="Try a different search, or clear it to see all providers."
+      action={
+        <Button size="sm" variant="secondary" onClick={onClear}>
+          Clear search
+        </Button>
+      }
+    />
+  );
+}
+
+function truncateQuery(query: string): string {
+  if (query.length <= MAX_ECHOED_QUERY_LENGTH) return query;
+  return `${query.slice(0, MAX_ECHOED_QUERY_LENGTH - 3)}...`;
+}

--- a/libs/client/agent/src/components/available-providers-grid.tsx
+++ b/libs/client/agent/src/components/available-providers-grid.tsx
@@ -24,6 +24,8 @@ export function AvailableProvidersGrid({
     () => entries.filter((entry) => providerMatchesSearch(entry, search)),
     [entries, search],
   );
+  const providerListLabel =
+    trimmedSearch !== '' ? 'Available providers matching search' : 'Available providers';
 
   function clearSearch() {
     setSearch('');
@@ -45,7 +47,7 @@ export function AvailableProvidersGrid({
       ) : null}
 
       {filteredEntries.length > 0 ? (
-        <ul className={PROVIDER_GRID_CLASS} aria-label="Available providers matching search">
+        <ul className={PROVIDER_GRID_CLASS} aria-label={providerListLabel}>
           {filteredEntries.map((entry) => (
             <AvailableProviderCard
               key={entry.id}
@@ -60,7 +62,7 @@ export function AvailableProvidersGrid({
 
       {trimmedSearch !== '' ? (
         <p role="status" aria-live="polite" className="sr-only">
-          {filteredEntries.length} providers match "{trimmedSearch}"
+          {providerResultCountText(filteredEntries.length, trimmedSearch)}
         </p>
       ) : null}
     </div>
@@ -85,4 +87,9 @@ function NoProviderSearchResults({search, onClear}: {search: string; onClear: ()
 function truncateQuery(query: string): string {
   if (query.length <= MAX_ECHOED_QUERY_LENGTH) return query;
   return `${query.slice(0, MAX_ECHOED_QUERY_LENGTH - 3)}...`;
+}
+
+function providerResultCountText(count: number, query: string): string {
+  if (count === 1) return `1 provider matches "${query}"`;
+  return `${count} providers match "${query}"`;
 }

--- a/libs/client/agent/src/components/provider-search.test.ts
+++ b/libs/client/agent/src/components/provider-search.test.ts
@@ -1,0 +1,45 @@
+import {agentProviderEntry} from '#test/fixtures/agent-providers.js';
+import {providerMatchesSearch} from './provider-search.js';
+
+describe('providerMatchesSearch', () => {
+  test('matches empty and whitespace queries', () => {
+    const entry = agentProviderEntry();
+
+    expect(providerMatchesSearch(entry, '')).toBe(true);
+    expect(providerMatchesSearch(entry, '   ')).toBe(true);
+  });
+
+  test('matches provider labels case-insensitively', () => {
+    const entry = agentProviderEntry({label: 'Anthropic'});
+
+    const result = providerMatchesSearch(entry, 'anthro');
+
+    expect(result).toBe(true);
+  });
+
+  test('matches provider id substrings', () => {
+    const entry = agentProviderEntry({id: 'azure-openai-responses', label: 'Azure OpenAI'});
+
+    const result = providerMatchesSearch(entry, 'responses');
+
+    expect(result).toBe(true);
+  });
+
+  test('matches model ids and labels', () => {
+    const entry = agentProviderEntry({
+      models: [{id: 'claude-opus-4-8', label: 'Claude Opus 4.8'}],
+    });
+
+    const result = providerMatchesSearch(entry, 'claude');
+
+    expect(result).toBe(true);
+  });
+
+  test('returns false when no searchable field matches', () => {
+    const entry = agentProviderEntry();
+
+    const result = providerMatchesSearch(entry, 'gemini');
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/client/agent/src/components/provider-search.ts
+++ b/libs/client/agent/src/components/provider-search.ts
@@ -1,0 +1,11 @@
+import type {AgentProviderCatalogEntryDto} from '@shipfox/api-agent-dto';
+
+export function providerMatchesSearch(entry: AgentProviderCatalogEntryDto, query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') return true;
+
+  const haystack = `${entry.label} ${entry.id} ${entry.models
+    .map((model) => `${model.id} ${model.label}`)
+    .join(' ')}`.toLowerCase();
+  return haystack.includes(needle);
+}

--- a/libs/client/agent/src/pages/agent-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/agent-provider-onboarding-page.stories.tsx
@@ -41,6 +41,48 @@ const CATALOG: AgentProviderCatalogEntryDto[] = [
     models: [{id: 'grok-code-fast-1', label: 'Grok Code Fast 1'}],
   }),
   providerEntry({
+    id: 'openrouter',
+    label: 'OpenRouter',
+    default_model: 'openrouter/auto',
+    models: [{id: 'openrouter/auto', label: 'OpenRouter Auto'}],
+  }),
+  providerEntry({
+    id: 'google',
+    label: 'Google Gemini',
+    default_model: 'gemini-3-pro',
+    models: [{id: 'gemini-3-pro', label: 'Gemini 3 Pro'}],
+  }),
+  providerEntry({
+    id: 'mistral',
+    label: 'Mistral AI',
+    default_model: 'codestral-latest',
+    models: [{id: 'codestral-latest', label: 'Codestral Latest'}],
+  }),
+  providerEntry({
+    id: 'groq',
+    label: 'Groq',
+    default_model: 'llama-4-fast',
+    models: [{id: 'llama-4-fast', label: 'Llama 4 Fast'}],
+  }),
+  providerEntry({
+    id: 'deepseek',
+    label: 'DeepSeek',
+    default_model: 'deepseek-coder',
+    models: [{id: 'deepseek-coder', label: 'DeepSeek Coder'}],
+  }),
+  providerEntry({
+    id: 'moonshotai',
+    label: 'Moonshot AI',
+    default_model: 'kimi-k2',
+    models: [{id: 'kimi-k2', label: 'Kimi K2'}],
+  }),
+  providerEntry({
+    id: 'azure-openai-responses',
+    label: 'Azure OpenAI Responses',
+    default_model: 'gpt-5.5-pro',
+    models: [{id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro'}],
+  }),
+  providerEntry({
     id: 'amazon-bedrock',
     label: 'Amazon Bedrock',
     support_status: 'unsupported',
@@ -101,6 +143,30 @@ export const NoProvidersAvailable: Story = {
 
 export const LongNames: Story = {
   args: {scenario: 'long-names'},
+};
+
+export const FilteredProviders: Story = {
+  args: {scenario: 'available'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(
+      await canvas.findByRole('searchbox', {name: 'Search providers'}),
+      'openrouter',
+    );
+    await canvas.findByRole('button', {name: 'Configure OpenRouter'});
+  },
+};
+
+export const NoMatchingProviders: Story = {
+  args: {scenario: 'available'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(
+      await canvas.findByRole('searchbox', {name: 'Search providers'}),
+      'not-a-provider',
+    );
+    await canvas.findByRole('button', {name: 'Clear search'});
+  },
 };
 
 export const ConfigureModalOpen: Story = {

--- a/libs/client/agent/src/pages/agent-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/agent-provider-onboarding-page.test.tsx
@@ -10,6 +10,7 @@ import {
   agentProviderCatalogResponse,
   agentProviderConfig,
   agentProviderEntry,
+  testAgentProviderEntries,
 } from '#test/fixtures/agent-providers.js';
 import {AgentProviderOnboardingPage} from './agent-provider-onboarding-page.js';
 
@@ -33,29 +34,6 @@ function renderOnboarding(element: ReactElement) {
       {element}
       <Toaster />
     </QueryClientProvider>,
-  );
-}
-
-const TEST_PROVIDER_IDS = [
-  'anthropic',
-  'openai',
-  'deepseek',
-  'nvidia',
-  'google',
-  'mistral',
-  'groq',
-  'cerebras',
-  'xai',
-] as const;
-
-function supportedProviderEntries(count: number) {
-  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
-    agentProviderEntry({
-      id,
-      label: `Provider ${index}`,
-      default_model: `model-${index}`,
-      models: [{id: `model-${index}`, label: `Model ${index}`}],
-    }),
   );
 }
 
@@ -115,7 +93,7 @@ describe('AgentProviderOnboardingPage', () => {
       baseUrl: 'https://api.example.test',
       fetchImpl: vi
         .fn()
-        .mockResolvedValue(jsonResponse(agentProviderCatalogResponse(supportedProviderEntries(9)))),
+        .mockResolvedValue(jsonResponse(agentProviderCatalogResponse(testAgentProviderEntries(9)))),
     });
 
     renderOnboarding(

--- a/libs/client/agent/src/pages/agent-provider-onboarding-page.test.tsx
+++ b/libs/client/agent/src/pages/agent-provider-onboarding-page.test.tsx
@@ -36,6 +36,29 @@ function renderOnboarding(element: ReactElement) {
   );
 }
 
+const TEST_PROVIDER_IDS = [
+  'anthropic',
+  'openai',
+  'deepseek',
+  'nvidia',
+  'google',
+  'mistral',
+  'groq',
+  'cerebras',
+  'xai',
+] as const;
+
+function supportedProviderEntries(count: number) {
+  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
+    agentProviderEntry({
+      id,
+      label: `Provider ${index}`,
+      default_model: `model-${index}`,
+      models: [{id: `model-${index}`, label: `Model ${index}`}],
+    }),
+  );
+}
+
 describe('AgentProviderOnboardingPage', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -84,6 +107,37 @@ describe('AgentProviderOnboardingPage', () => {
     });
 
     expect(skip.compareDocumentPosition(provider)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  test('filters supported providers and clears a no-match search', async () => {
+    const user = userEvent.setup();
+    configureApiClient({
+      baseUrl: 'https://api.example.test',
+      fetchImpl: vi
+        .fn()
+        .mockResolvedValue(jsonResponse(agentProviderCatalogResponse(supportedProviderEntries(9)))),
+    });
+
+    renderOnboarding(
+      <AgentProviderOnboardingPage
+        workspaceId={AGENT_TEST_WORKSPACE_ID}
+        onSkip={vi.fn()}
+        onConfigured={vi.fn()}
+      />,
+    );
+    const search = await screen.findByRole('searchbox', {name: 'Search providers'});
+
+    await user.type(search, 'provider 6');
+
+    expect(screen.getByRole('button', {name: 'Configure Provider 6'})).toBeVisible();
+    expect(screen.queryByRole('button', {name: 'Configure Provider 1'})).not.toBeInTheDocument();
+    await user.clear(search);
+    await user.type(search, 'missing');
+    expect(screen.getByText('No providers match "missing"')).toBeVisible();
+    await user.click(screen.getByRole('button', {name: 'Clear search'}));
+
+    expect(screen.getByRole('button', {name: 'Configure Provider 1'})).toBeVisible();
+    await waitFor(() => expect(search).toHaveFocus());
   });
 
   test('skip still continues when localStorage rejects the dismissed write', async () => {

--- a/libs/client/agent/src/pages/agent-provider-onboarding-page.tsx
+++ b/libs/client/agent/src/pages/agent-provider-onboarding-page.tsx
@@ -13,7 +13,7 @@ import {
   toast,
 } from '@shipfox/react-ui';
 import {useState} from 'react';
-import {AvailableProviderCard} from '#components/available-provider-card.js';
+import {AvailableProvidersGrid, PROVIDER_GRID_CLASS} from '#components/available-providers-grid.js';
 import {AgentProviderTestAndSaveForm} from '#components/test-and-save-form.js';
 import {useAgentProviderCatalogQuery} from '#hooks/api/agent-providers.js';
 import {dismissAgentProviderOnboarding} from '#state/agent-provider-onboarding.js';
@@ -130,18 +130,12 @@ function ProviderPicker({
     );
   }
 
-  return (
-    <ul className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1">
-      {supportedProviders.map((entry) => (
-        <AvailableProviderCard key={entry.id} entry={entry} onConfigure={() => onSelect(entry)} />
-      ))}
-    </ul>
-  );
+  return <AvailableProvidersGrid entries={supportedProviders} onSelect={onSelect} />;
 }
 
 function ProviderGridSkeleton() {
   return (
-    <div className="grid grid-cols-2 gap-12 max-[760px]:grid-cols-1">
+    <div className={PROVIDER_GRID_CLASS}>
       {[0, 1, 2, 3].map((card) => (
         <Skeleton key={card} className="h-136 w-full" />
       ))}

--- a/libs/client/agent/test/fixtures/agent-providers.ts
+++ b/libs/client/agent/test/fixtures/agent-providers.ts
@@ -7,6 +7,18 @@ import type {
 
 export const AGENT_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 
+const TEST_PROVIDER_IDS = [
+  'anthropic',
+  'openai',
+  'deepseek',
+  'nvidia',
+  'google',
+  'mistral',
+  'groq',
+  'cerebras',
+  'xai',
+] as const;
+
 export function agentProviderEntry(
   overrides: Partial<AgentProviderCatalogEntryDto> = {},
 ): AgentProviderCatalogEntryDto {
@@ -35,6 +47,17 @@ export function unsupportedAgentProviderEntry(
     models: [],
     ...overrides,
   };
+}
+
+export function testAgentProviderEntries(count: number): AgentProviderCatalogEntryDto[] {
+  return TEST_PROVIDER_IDS.slice(0, count).map((id, index) =>
+    agentProviderEntry({
+      id,
+      label: `Provider ${index}`,
+      default_model: `model-${index}`,
+      models: [{id: `model-${index}`, label: `Model ${index}`}],
+    }),
+  );
 }
 
 export function agentProviderConfig(


### PR DESCRIPTION
Adds a shared searchable provider grid to the agent provider catalog surfaces in settings and onboarding.

The provider catalog has enough entries that scanning the full card grid is noisy. This lets users narrow available providers by provider label, provider id, or model name while keeping the filtering client-side over the already-loaded catalog.

The grid keeps the search field hidden for small unfiltered lists, keeps it mounted while a query is active, and includes a no-match recovery state plus screen-reader result count feedback. The settings and onboarding surfaces now share the grid layout class so loading skeletons and rendered cards stay aligned.

No changeset is included because `@shipfox/client-agent` is private.

Closes ENG-652

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a searchable provider catalog to settings and onboarding so users can quickly find providers by label, id, or model. Improves screen reader announcements with a persistent live region and better list labeling. Closes ENG-652.

- New Features
  - Added `AvailableProvidersGrid` with search (matches label, provider id, and model ids/labels).
  - Search shows when >8 providers and stays mounted while a query is active.
  - No-match state with “Clear search”; screen reader count uses correct singular/plural and list label changes when searching.
  - Shared `PROVIDER_GRID_CLASS` keeps cards and skeletons aligned across surfaces.

- Bug Fixes
  - Kept the live region mounted so screen readers reliably announce result counts across renders.

<sup>Written for commit ffe37c50ecbf32742e65df4d3dae86057af16a1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

