### PR TITLE
Make GitHub webhooks trigger workflows

### DIFF
--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -21,9 +21,8 @@ export const integrationEventReceivedSchema = z.object({
 });
 export type IntegrationEventReceivedEvent = z.infer<typeof integrationEventReceivedSchema>;
 
-// A source-control push, normalized by the producing provider. Carried both as the
-// generic `INTEGRATION_EVENT_RECEIVED` envelope payload (consumed opaquely by triggers)
-// and nested inside `INTEGRATION_SOURCE_COMMIT_PUSHED` (consumed by domain modules).
+// A source-control push, normalized by the producing provider and carried by
+// `INTEGRATION_SOURCE_COMMIT_PUSHED` for domain consumers.
 export const sourcePushSchema = z.object({
   externalRepositoryId: nonEmptyStringSchema,
   ref: nonEmptyStringSchema,

--- a/libs/api/integration/core-dto/src/ports.ts
+++ b/libs/api/integration/core-dto/src/ports.ts
@@ -34,6 +34,7 @@ export type PublishSourcePushFn = (params: {
   connectionName: string;
   deliveryId: string;
   receivedAt: string;
+  rawPayload?: unknown;
   push: SourcePushPayload;
 }) => Promise<{published: boolean}>;
 

--- a/libs/api/integration/core-dto/src/ports.ts
+++ b/libs/api/integration/core-dto/src/ports.ts
@@ -34,7 +34,7 @@ export type PublishSourcePushFn = (params: {
   connectionName: string;
   deliveryId: string;
   receivedAt: string;
-  rawPayload?: unknown;
+  rawPayload: unknown;
   push: SourcePushPayload;
 }) => Promise<{published: boolean}>;
 

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -168,24 +168,6 @@ describe('publishSourcePush', () => {
     });
   });
 
-  it('uses the raw provider payload for the generic envelope', async () => {
-    const params = buildSourcePushParams();
-
-    await db().transaction((tx) => publishSourcePush({tx, ...params}));
-
-    const outbox = await outboxFor(params.deliveryId);
-    const envelope = outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED);
-    const typed = outbox.find((row) => row.eventType === INTEGRATION_SOURCE_COMMIT_PUSHED);
-    expect(envelope?.payload).toMatchObject({
-      deliveryId: params.deliveryId,
-      payload: params.rawPayload,
-    });
-    expect(typed?.payload).toMatchObject({
-      deliveryId: params.deliveryId,
-      push: {externalRepositoryId: 'github:42', ref: 'main', headCommitSha: 'abc123'},
-    });
-  });
-
   it('writes nothing for a duplicate delivery', async () => {
     const params = buildSourcePushParams();
 

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -49,6 +49,11 @@ function buildPush(overrides: Partial<SourcePushPayload> = {}): SourcePushPayloa
 }
 
 function buildSourcePushParams() {
+  const rawPayload = {
+    ref: 'refs/heads/main',
+    after: 'abc123',
+    repository: {id: 42, default_branch: 'main'},
+  };
   return {
     provider: 'github',
     workspaceId: crypto.randomUUID(),
@@ -56,6 +61,7 @@ function buildSourcePushParams() {
     connectionName: 'Acme Production',
     deliveryId: crypto.randomUUID(),
     receivedAt: new Date().toISOString(),
+    rawPayload,
     push: buildPush(),
   };
 }
@@ -153,7 +159,7 @@ describe('publishSourcePush', () => {
       source: 'github',
       event: 'push',
       deliveryId: params.deliveryId,
-      payload: {externalRepositoryId: 'github:42', isDefaultBranch: true},
+      payload: params.rawPayload,
     });
     expect(typed?.payload).toMatchObject({
       provider: 'github',
@@ -162,13 +168,8 @@ describe('publishSourcePush', () => {
     });
   });
 
-  it('uses a raw payload for the generic envelope when provided', async () => {
-    const rawPayload = {
-      ref: 'refs/heads/main',
-      after: 'abc123',
-      repository: {id: 42, default_branch: 'main'},
-    };
-    const params = {...buildSourcePushParams(), rawPayload};
+  it('uses the raw provider payload for the generic envelope', async () => {
+    const params = buildSourcePushParams();
 
     await db().transaction((tx) => publishSourcePush({tx, ...params}));
 
@@ -177,24 +178,11 @@ describe('publishSourcePush', () => {
     const typed = outbox.find((row) => row.eventType === INTEGRATION_SOURCE_COMMIT_PUSHED);
     expect(envelope?.payload).toMatchObject({
       deliveryId: params.deliveryId,
-      payload: rawPayload,
+      payload: params.rawPayload,
     });
     expect(typed?.payload).toMatchObject({
       deliveryId: params.deliveryId,
       push: {externalRepositoryId: 'github:42', ref: 'main', headCommitSha: 'abc123'},
-    });
-  });
-
-  it('falls back to the normalized push payload for the generic envelope', async () => {
-    const params = buildSourcePushParams();
-
-    await db().transaction((tx) => publishSourcePush({tx, ...params}));
-
-    const outbox = await outboxFor(params.deliveryId);
-    const envelope = outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED);
-    expect(envelope?.payload).toMatchObject({
-      deliveryId: params.deliveryId,
-      payload: params.push,
     });
   });
 

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -162,6 +162,42 @@ describe('publishSourcePush', () => {
     });
   });
 
+  it('uses a raw payload for the generic envelope when provided', async () => {
+    const rawPayload = {
+      ref: 'refs/heads/main',
+      after: 'abc123',
+      repository: {id: 42, default_branch: 'main'},
+    };
+    const params = {...buildSourcePushParams(), rawPayload};
+
+    await db().transaction((tx) => publishSourcePush({tx, ...params}));
+
+    const outbox = await outboxFor(params.deliveryId);
+    const envelope = outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED);
+    const typed = outbox.find((row) => row.eventType === INTEGRATION_SOURCE_COMMIT_PUSHED);
+    expect(envelope?.payload).toMatchObject({
+      deliveryId: params.deliveryId,
+      payload: rawPayload,
+    });
+    expect(typed?.payload).toMatchObject({
+      deliveryId: params.deliveryId,
+      push: {externalRepositoryId: 'github:42', ref: 'main', headCommitSha: 'abc123'},
+    });
+  });
+
+  it('falls back to the normalized push payload for the generic envelope', async () => {
+    const params = buildSourcePushParams();
+
+    await db().transaction((tx) => publishSourcePush({tx, ...params}));
+
+    const outbox = await outboxFor(params.deliveryId);
+    const envelope = outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED);
+    expect(envelope?.payload).toMatchObject({
+      deliveryId: params.deliveryId,
+      payload: params.push,
+    });
+  });
+
   it('writes nothing for a duplicate delivery', async () => {
     const params = buildSourcePushParams();
 

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -56,15 +56,15 @@ export interface PublishSourcePushParams {
   connectionName: string;
   deliveryId: string;
   receivedAt: string;
-  rawPayload?: unknown;
+  rawPayload: unknown;
   push: SourcePushPayload;
 }
 
 // Emits a single source-control push as two outbox rows: the generic
-// `INTEGRATION_EVENT_RECEIVED` envelope (consumed opaquely by triggers) and the typed
-// `INTEGRATION_SOURCE_COMMIT_PUSHED` event (consumed by domain modules). One delivery-dedup
-// gates both, so a redelivered webhook writes nothing. Requires a transaction: the dedup
-// insert and both outbox rows must commit or roll back together.
+// `INTEGRATION_EVENT_RECEIVED` envelope with the raw provider payload for triggers, and the
+// typed `INTEGRATION_SOURCE_COMMIT_PUSHED` event for domain modules. One delivery-dedup gates
+// both, so a redelivered webhook writes nothing. Requires a transaction: the dedup insert and
+// both outbox rows must commit or roll back together.
 export async function publishSourcePush(
   params: PublishSourcePushParams,
 ): Promise<{published: boolean}> {
@@ -92,7 +92,7 @@ export async function publishSourcePush(
         connectionName: params.connectionName,
         deliveryId: params.deliveryId,
         receivedAt: params.receivedAt,
-        payload: params.rawPayload ?? params.push,
+        payload: params.rawPayload,
       },
     },
     {

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -56,6 +56,7 @@ export interface PublishSourcePushParams {
   connectionName: string;
   deliveryId: string;
   receivedAt: string;
+  rawPayload?: unknown;
   push: SourcePushPayload;
 }
 
@@ -91,7 +92,7 @@ export async function publishSourcePush(
         connectionName: params.connectionName,
         deliveryId: params.deliveryId,
         receivedAt: params.receivedAt,
-        payload: params.push,
+        payload: params.rawPayload ?? params.push,
       },
     },
     {

--- a/libs/api/integration/core/src/providers/github.ts
+++ b/libs/api/integration/core/src/providers/github.ts
@@ -3,7 +3,11 @@ import type {ConnectGithubInstallationInput} from '@shipfox/api-integration-gith
 import {config} from '#config.js';
 import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
 import {db} from '#db/db.js';
-import {publishSourcePush, recordDeliveryOnly} from '#db/webhook-deliveries.js';
+import {
+  publishIntegrationEventReceived,
+  publishSourcePush,
+  recordDeliveryOnly,
+} from '#db/webhook-deliveries.js';
 import type {IntegrationModuleParts, IntegrationProviderModule} from '#providers/types.js';
 
 // Stable migration-tracking table name for the GitHub provider database. This
@@ -62,6 +66,7 @@ async function loadGithubModuleParts(): Promise<IntegrationModuleParts> {
     provider: createGithubIntegrationProvider({
       getExistingGithubConnection,
       connectGithubInstallation,
+      publishIntegrationEventReceived,
       publishSourcePush,
       recordDeliveryOnly,
       getIntegrationConnectionById,

--- a/libs/api/integration/gitea/src/core/webhook.test.ts
+++ b/libs/api/integration/gitea/src/core/webhook.test.ts
@@ -77,15 +77,14 @@ describe('handleGiteaWebhook', () => {
     await seedConnection('shipfox', connection.id);
     const deliveryId = randomUUID();
     const handlers = deps({connection});
-    const rawBody = JSON.stringify(
-      giteaPushPayload({
-        owner: 'shipfox',
-        repo: 'api',
-        ref: 'refs/heads/main',
-        defaultBranch: 'main',
-        sha: 'abc123',
-      }),
-    );
+    const payload = giteaPushPayload({
+      owner: 'shipfox',
+      repo: 'api',
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      sha: 'abc123',
+    });
+    const rawBody = JSON.stringify(payload);
 
     const result = await handleGiteaWebhook({
       tx: db(),
@@ -111,6 +110,7 @@ describe('handleGiteaWebhook', () => {
       workspaceId: connection.workspaceId,
       connectionId: connection.id,
       connectionName: connection.displayName,
+      rawPayload: payload,
       push: {
         externalRepositoryId: 'gitea:shipfox/api',
         ref: 'main',
@@ -141,6 +141,7 @@ describe('handleGiteaWebhook', () => {
       deliveryId,
       workspaceId: connection.workspaceId,
       connectionId: connection.id,
+      rawPayload: capturedGiteaPushPayload,
       push: {
         externalRepositoryId: 'gitea:shipfox/api',
         ref: 'main',

--- a/libs/api/integration/gitea/src/core/webhook.ts
+++ b/libs/api/integration/gitea/src/core/webhook.ts
@@ -46,6 +46,7 @@ export interface HandleGiteaPushParams {
   tx: IntegrationTx;
   deliveryId: string;
   payload: GiteaPushPayloadDto;
+  rawPayload: unknown;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -75,10 +76,12 @@ export async function handleGiteaWebhook(
     return {outcome: 'recorded-only'};
   }
 
+  const {payload, rawPayload} = parseGiteaPushPayload(params.rawBody);
   return handleGiteaPush({
     tx: params.tx,
     deliveryId: params.deliveryId,
-    payload: parseGiteaPushPayload(params.rawBody),
+    payload,
+    rawPayload,
     publishSourcePush: params.publishSourcePush,
     recordDeliveryOnly: params.recordDeliveryOnly,
     getIntegrationConnectionById: params.getIntegrationConnectionById,
@@ -168,6 +171,7 @@ export async function handleGiteaPush(
     connectionName: connection.displayName,
     deliveryId: params.deliveryId,
     receivedAt: new Date().toISOString(),
+    rawPayload: params.rawPayload,
     push,
   });
 
@@ -178,7 +182,10 @@ function stripRefsHeads(ref: string): string {
   return ref.startsWith(REFS_HEADS_PREFIX) ? ref.slice(REFS_HEADS_PREFIX.length) : ref;
 }
 
-function parseGiteaPushPayload(rawBody: string): GiteaPushPayloadDto {
+function parseGiteaPushPayload(rawBody: string): {
+  payload: GiteaPushPayloadDto;
+  rawPayload: unknown;
+} {
   let parsedJson: unknown;
   try {
     parsedJson = JSON.parse(rawBody);
@@ -191,5 +198,5 @@ function parseGiteaPushPayload(rawBody: string): GiteaPushPayloadDto {
     throw new GiteaWebhookMalformedPushPayloadError(validated.error.issues);
   }
 
-  return validated.data;
+  return {payload: validated.data, rawPayload: parsedJson};
 }

--- a/libs/api/integration/github-dto/src/schemas/webhooks.ts
+++ b/libs/api/integration/github-dto/src/schemas/webhooks.ts
@@ -10,3 +10,9 @@ export const githubPushPayloadSchema = z.object({
   installation: z.object({id: z.number().int().positive()}).optional(),
 });
 export type GithubPushPayloadDto = z.infer<typeof githubPushPayloadSchema>;
+
+export const githubWebhookEnvelopeSchema = z.object({
+  action: z.string().min(1).optional(),
+  installation: z.object({id: z.number().int().positive()}).optional(),
+});
+export type GithubWebhookEnvelopeDto = z.infer<typeof githubWebhookEnvelopeSchema>;

--- a/libs/api/integration/github-dto/src/schemas/webhooks.ts
+++ b/libs/api/integration/github-dto/src/schemas/webhooks.ts
@@ -11,8 +11,17 @@ export const githubPushPayloadSchema = z.object({
 });
 export type GithubPushPayloadDto = z.infer<typeof githubPushPayloadSchema>;
 
-export const githubWebhookEnvelopeSchema = z.object({
+export const githubWebhookActionSchema = z.object({
   action: z.string().min(1).optional(),
+});
+export type GithubWebhookActionDto = z.infer<typeof githubWebhookActionSchema>;
+
+export const githubWebhookInstallationSchema = z.object({
   installation: z.object({id: z.number().int().positive()}).optional(),
 });
+export type GithubWebhookInstallationDto = z.infer<typeof githubWebhookInstallationSchema>;
+
+export const githubWebhookEnvelopeSchema = githubWebhookActionSchema.merge(
+  githubWebhookInstallationSchema,
+);
 export type GithubWebhookEnvelopeDto = z.infer<typeof githubWebhookEnvelopeSchema>;

--- a/libs/api/integration/github/src/connection-external-url.test.ts
+++ b/libs/api/integration/github/src/connection-external-url.test.ts
@@ -39,6 +39,7 @@ function createProvider(lookup: (connectionId: string) => Promise<GithubInstalla
     getExistingGithubConnection: vi.fn(() => Promise.resolve(undefined)),
     connectGithubInstallation: vi.fn() as never,
     coreDb: vi.fn() as never,
+    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
     publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -224,6 +224,43 @@ describe('handleGithubEvent', () => {
     expect(handlers.publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
   });
 
+  it('publishes a generic envelope when a push payload fails schema validation', async () => {
+    const installationId = 7786;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const payload = {
+      installation: {id: installationId},
+      ref: 'refs/heads/main',
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'push',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-envelope');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(
+      firstPublishIntegrationEventReceivedCall(handlers.publishIntegrationEventReceived),
+    ).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'push',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        payload,
+      },
+    });
+    expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
   it('publishes a generic envelope for a non-push event with an action', async () => {
     const installationId = 7781;
     const connection = fakeConnection();
@@ -265,6 +302,7 @@ describe('handleGithubEvent', () => {
     const connection = fakeConnection();
     await seedInstallation(installationId, connection.id);
     const handlers = deps({connection});
+    const deliveryId = randomUUID();
     const payload = {
       action: null,
       installation: {id: installationId},
@@ -273,7 +311,7 @@ describe('handleGithubEvent', () => {
 
     const result = await handleGithubEvent({
       tx: db(),
-      deliveryId: randomUUID(),
+      deliveryId,
       event: 'pull_request',
       payload,
       ...handlers,
@@ -284,7 +322,12 @@ describe('handleGithubEvent', () => {
       firstPublishIntegrationEventReceivedCall(handlers.publishIntegrationEventReceived),
     ).toMatchObject({
       event: {
+        source: 'github',
         event: 'pull_request',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
         payload,
       },
     });

--- a/libs/api/integration/github/src/core/webhook.test.ts
+++ b/libs/api/integration/github/src/core/webhook.test.ts
@@ -1,0 +1,411 @@
+import {randomUUID} from 'node:crypto';
+import type {
+  GetIntegrationConnectionByIdFn,
+  IntegrationConnection,
+  PublishIntegrationEventReceivedFn,
+  PublishSourcePushFn,
+  RecordDeliveryOnlyFn,
+} from '@shipfox/api-integration-core-dto';
+import {db} from '#db/db.js';
+import {githubInstallations} from '#db/schema/installations.js';
+import {githubInstallationFactory, githubPushPayload} from '#test/index.js';
+import {handleGithubEvent} from './webhook.js';
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  return {
+    id: randomUUID(),
+    workspaceId: randomUUID(),
+    provider: 'github',
+    externalAccountId: '123',
+    displayName: 'GitHub shipfox',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function deps(
+  options: {
+    connection?: IntegrationConnection | undefined;
+    publishIntegrationEventReceivedResult?: {published: boolean};
+    publishSourcePushResult?: {published: boolean};
+  } = {},
+) {
+  return {
+    publishIntegrationEventReceived: vi.fn<PublishIntegrationEventReceivedFn>(() =>
+      Promise.resolve(options.publishIntegrationEventReceivedResult ?? {published: true}),
+    ),
+    publishSourcePush: vi.fn<PublishSourcePushFn>(() =>
+      Promise.resolve(options.publishSourcePushResult ?? {published: true}),
+    ),
+    recordDeliveryOnly: vi.fn<RecordDeliveryOnlyFn>(() => Promise.resolve()),
+    getIntegrationConnectionById: vi.fn<GetIntegrationConnectionByIdFn>(() =>
+      Promise.resolve(options.connection ?? fakeConnection()),
+    ),
+  };
+}
+
+function firstPublishSourcePushCall(publishSourcePush: {
+  mock: {calls: Array<Parameters<PublishSourcePushFn>>};
+}): Parameters<PublishSourcePushFn>[0] {
+  const [call] = publishSourcePush.mock.calls;
+  if (!call) {
+    throw new Error('Expected publishSourcePush to be called');
+  }
+
+  return call[0];
+}
+
+function firstPublishIntegrationEventReceivedCall(publishIntegrationEventReceived: {
+  mock: {calls: Array<Parameters<PublishIntegrationEventReceivedFn>>};
+}): Parameters<PublishIntegrationEventReceivedFn>[0] {
+  const [call] = publishIntegrationEventReceived.mock.calls;
+  if (!call) {
+    throw new Error('Expected publishIntegrationEventReceived to be called');
+  }
+
+  return call[0];
+}
+
+function firstRecordDeliveryOnlyCall(recordDeliveryOnly: {
+  mock: {calls: Array<Parameters<RecordDeliveryOnlyFn>>};
+}): Parameters<RecordDeliveryOnlyFn>[0] {
+  const [call] = recordDeliveryOnly.mock.calls;
+  if (!call) {
+    throw new Error('Expected recordDeliveryOnly to be called');
+  }
+
+  return call[0];
+}
+
+async function seedInstallation(installationId: number, connectionId?: string): Promise<void> {
+  await githubInstallationFactory.create({
+    installationId: String(installationId),
+    ...(connectionId !== undefined && {connectionId}),
+  });
+}
+
+describe('handleGithubEvent', () => {
+  beforeEach(async () => {
+    await db().delete(githubInstallations);
+  });
+
+  it('publishes a mapped event for a valid push from a known installation', async () => {
+    const installationId = 7777;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const payload = githubPushPayload({
+      installationId,
+      repositoryId: 42,
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      sha: 'abc123',
+    });
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'push',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published');
+    expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(handlers.getIntegrationConnectionById).toHaveBeenCalledWith(
+      connection.id,
+      expect.objectContaining({tx: expect.anything()}),
+    );
+    expect(firstPublishSourcePushCall(handlers.publishSourcePush)).toMatchObject({
+      provider: 'github',
+      deliveryId,
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      connectionName: connection.displayName,
+      rawPayload: payload,
+      push: {
+        externalRepositoryId: 'github:42',
+        ref: 'main',
+        headCommitSha: 'abc123',
+        isDefaultBranch: true,
+      },
+    });
+  });
+
+  it('returns duplicate when a push delivery was already published', async () => {
+    const installationId = 7778;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection, publishSourcePushResult: {published: false}});
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'push',
+      payload: githubPushPayload({
+        installationId,
+        repositoryId: 42,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: 'abc123',
+      }),
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('duplicate');
+    expect(handlers.publishSourcePush).toHaveBeenCalledTimes(1);
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it('publishes a generic envelope for a branch deletion', async () => {
+    const installationId = 7779;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const payload = githubPushPayload({
+      installationId,
+      repositoryId: 42,
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      sha: '0000000000000000000000000000000000000000',
+    });
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'push',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-push-envelope-only');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(
+      firstPublishIntegrationEventReceivedCall(handlers.publishIntegrationEventReceived),
+    ).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'push',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        payload,
+      },
+    });
+  });
+
+  it('returns duplicate-push-envelope-only when a branch deletion was already published', async () => {
+    const installationId = 7780;
+    await seedInstallation(installationId);
+    const handlers = deps({publishIntegrationEventReceivedResult: {published: false}});
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'push',
+      payload: githubPushPayload({
+        installationId,
+        repositoryId: 42,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: '0000000000000000000000000000000000000000',
+      }),
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('duplicate-push-envelope-only');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes a generic envelope for a non-push event with an action', async () => {
+    const installationId = 7781;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const deliveryId = randomUUID();
+    const payload = {
+      action: 'opened',
+      installation: {id: installationId},
+      pull_request: {number: 17},
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'pull_request',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-envelope');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(
+      firstPublishIntegrationEventReceivedCall(handlers.publishIntegrationEventReceived),
+    ).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'pull_request.opened',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        deliveryId,
+        payload,
+      },
+    });
+  });
+
+  it('publishes a bare resource envelope when action is malformed', async () => {
+    const installationId = 7782;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+    const payload = {
+      action: null,
+      installation: {id: installationId},
+      pull_request: {number: 17},
+    };
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'pull_request',
+      payload,
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('published-envelope');
+    expect(
+      firstPublishIntegrationEventReceivedCall(handlers.publishIntegrationEventReceived),
+    ).toMatchObject({
+      event: {
+        event: 'pull_request',
+        payload,
+      },
+    });
+    expect(handlers.recordDeliveryOnly).not.toHaveBeenCalled();
+  });
+
+  it('returns duplicate-envelope when a generic envelope delivery was already published', async () => {
+    const installationId = 7783;
+    await seedInstallation(installationId);
+    const handlers = deps({publishIntegrationEventReceivedResult: {published: false}});
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'fork',
+      payload: {installation: {id: installationId}},
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('duplicate-envelope');
+    expect(handlers.publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the delivery only when there is no installation id', async () => {
+    const handlers = deps();
+    const deliveryId = randomUUID();
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'push',
+      payload: {ref: 'refs/heads/main'},
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('no-installation-id');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(firstRecordDeliveryOnlyCall(handlers.recordDeliveryOnly)).toMatchObject({
+      provider: 'github',
+      deliveryId,
+    });
+  });
+
+  it('records the delivery only for an unknown installation', async () => {
+    const handlers = deps();
+    const deliveryId = randomUUID();
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId,
+      event: 'push',
+      payload: githubPushPayload({
+        installationId: 999999,
+        repositoryId: 42,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: 'abc123',
+      }),
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('unknown-installation');
+    expect(handlers.getIntegrationConnectionById).not.toHaveBeenCalled();
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(firstRecordDeliveryOnlyCall(handlers.recordDeliveryOnly)).toMatchObject({
+      provider: 'github',
+      deliveryId,
+    });
+  });
+
+  it('records the delivery only when the installation has no connection', async () => {
+    const installationId = 7784;
+    await seedInstallation(installationId);
+    const handlers = deps();
+    handlers.getIntegrationConnectionById.mockResolvedValue(undefined);
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'push',
+      payload: githubPushPayload({
+        installationId,
+        repositoryId: 42,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: 'abc123',
+      }),
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('missing-connection');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'disabled',
+    'error',
+  ] as const)('records the delivery only when the connection is %s', async (lifecycleStatus) => {
+    const installationId = 7785;
+    const connection = fakeConnection({lifecycleStatus});
+    await seedInstallation(installationId, connection.id);
+    const handlers = deps({connection});
+
+    const result = await handleGithubEvent({
+      tx: db(),
+      deliveryId: randomUUID(),
+      event: 'push',
+      payload: githubPushPayload({
+        installationId,
+        repositoryId: 42,
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        sha: 'abc123',
+      }),
+      ...handlers,
+    });
+
+    expect(result.outcome).toBe('inactive-connection');
+    expect(handlers.publishSourcePush).not.toHaveBeenCalled();
+    expect(handlers.recordDeliveryOnly).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -2,11 +2,16 @@ import {
   buildProviderRepositoryId,
   type GetIntegrationConnectionByIdFn,
   type IntegrationTx,
+  type PublishIntegrationEventReceivedFn,
   type PublishSourcePushFn,
   type RecordDeliveryOnlyFn,
   type SourcePushPayload,
 } from '@shipfox/api-integration-core-dto';
-import type {GithubPushPayloadDto} from '@shipfox/api-integration-github-dto';
+import {
+  type GithubPushPayloadDto,
+  githubPushPayloadSchema,
+  githubWebhookEnvelopeSchema,
+} from '@shipfox/api-integration-github-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {getGithubInstallationByInstallationId} from '#db/installations.js';
 
@@ -15,20 +20,26 @@ const GITHUB_SOURCE = 'github';
 // GitHub sends a `push` webhook for a branch deletion with `after` set to this all-zero SHA.
 const DELETED_BRANCH_SHA = '0'.repeat(40);
 
-export interface HandleGithubPushParams {
+export interface HandleGithubEventParams {
   tx: IntegrationTx;
   deliveryId: string;
-  payload: GithubPushPayloadDto;
+  event: string;
+  payload: unknown;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
 }
 
-export type HandleGithubPushOutcome =
+export type HandleGithubEventOutcome =
   | 'published'
   | 'duplicate'
-  | 'deleted'
+  | 'published-envelope'
+  | 'duplicate-envelope'
+  | 'published-push-envelope-only'
+  | 'duplicate-push-envelope-only'
   | 'unknown-installation'
+  | 'missing-connection'
   | 'inactive-connection'
   | 'no-installation-id';
 
@@ -36,18 +47,18 @@ function isBranchDeletion(after: string): boolean {
   return after === DELETED_BRANCH_SHA;
 }
 
-export async function handleGithubPush(
-  params: HandleGithubPushParams,
-): Promise<{outcome: HandleGithubPushOutcome}> {
-  // A branch deletion is not a commit. Dropping it here, before `publishSourcePush`,
-  // emits neither the typed source-commit event (projects) nor the generic
-  // `INTEGRATION_EVENT_RECEIVED` envelope (triggers), so a deletion triggers nothing.
-  if (isBranchDeletion(params.payload.after)) {
-    return {outcome: 'deleted'};
-  }
-
-  const installationId = params.payload.installation?.id;
+export async function handleGithubEvent(
+  params: HandleGithubEventParams,
+): Promise<{outcome: HandleGithubEventOutcome}> {
+  const envelope = githubWebhookEnvelopeSchema.safeParse(params.payload);
+  const action = envelope.success ? envelope.data.action : undefined;
+  const installationId = envelope.success ? envelope.data.installation?.id : undefined;
   if (installationId === undefined) {
+    await params.recordDeliveryOnly({
+      tx: params.tx,
+      provider: GITHUB_SOURCE,
+      deliveryId: params.deliveryId,
+    });
     return {outcome: 'no-installation-id'};
   }
 
@@ -80,7 +91,7 @@ export async function handleGithubPush(
       provider: GITHUB_SOURCE,
       deliveryId: params.deliveryId,
     });
-    return {outcome: 'unknown-installation'};
+    return {outcome: 'missing-connection'};
   }
 
   if (connection.lifecycleStatus !== 'active') {
@@ -105,30 +116,106 @@ export async function handleGithubPush(
     return {outcome: 'inactive-connection'};
   }
 
-  const ref = stripRefsHeads(params.payload.ref);
-  const defaultBranch = params.payload.repository.default_branch;
+  if (params.event === 'push') {
+    const validated = githubPushPayloadSchema.safeParse(params.payload);
+    if (!validated.success) {
+      logger().warn(
+        {deliveryId: params.deliveryId, issues: validated.error.issues},
+        'github webhook push payload failed schema validation; publishing generic envelope only',
+      );
+      return publishGithubEnvelopeOnly({params, connection, event: 'push'});
+    }
+
+    return publishGithubPush({
+      ...params,
+      eventPayload: validated.data,
+      rawPayload: params.payload,
+      connection,
+    });
+  }
+
+  const eventName = action ? `${params.event}.${action}` : params.event;
+  return publishGithubEnvelopeOnly({params, connection, event: eventName});
+}
+
+async function publishGithubPush(params: {
+  tx: IntegrationTx;
+  deliveryId: string;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  publishSourcePush: PublishSourcePushFn;
+  eventPayload: GithubPushPayloadDto;
+  rawPayload: unknown;
+  connection: {
+    id: string;
+    workspaceId: string;
+    displayName: string;
+  };
+}): Promise<{outcome: HandleGithubEventOutcome}> {
+  if (isBranchDeletion(params.eventPayload.after)) {
+    const result = await params.publishIntegrationEventReceived({
+      tx: params.tx,
+      event: {
+        source: GITHUB_SOURCE,
+        event: 'push',
+        workspaceId: params.connection.workspaceId,
+        connectionId: params.connection.id,
+        connectionName: params.connection.displayName,
+        deliveryId: params.deliveryId,
+        receivedAt: new Date().toISOString(),
+        payload: params.rawPayload,
+      },
+    });
+    return {
+      outcome: result.published ? 'published-push-envelope-only' : 'duplicate-push-envelope-only',
+    };
+  }
+
+  const ref = stripRefsHeads(params.eventPayload.ref);
+  const defaultBranch = params.eventPayload.repository.default_branch;
   const push: SourcePushPayload = {
     externalRepositoryId: buildProviderRepositoryId(
       GITHUB_SOURCE,
-      String(params.payload.repository.id),
+      String(params.eventPayload.repository.id),
     ),
     ref,
-    headCommitSha: params.payload.after,
+    headCommitSha: params.eventPayload.after,
     defaultBranch,
     isDefaultBranch: ref === defaultBranch,
   };
   const result = await params.publishSourcePush({
     tx: params.tx,
     provider: GITHUB_SOURCE,
-    workspaceId: connection.workspaceId,
-    connectionId: connection.id,
-    connectionName: connection.displayName,
+    workspaceId: params.connection.workspaceId,
+    connectionId: params.connection.id,
+    connectionName: params.connection.displayName,
     deliveryId: params.deliveryId,
     receivedAt: new Date().toISOString(),
+    rawPayload: params.rawPayload,
     push,
   });
 
   return {outcome: result.published ? 'published' : 'duplicate'};
+}
+
+async function publishGithubEnvelopeOnly(params: {
+  params: HandleGithubEventParams;
+  connection: {id: string; workspaceId: string; displayName: string};
+  event: string;
+}): Promise<{outcome: HandleGithubEventOutcome}> {
+  const result = await params.params.publishIntegrationEventReceived({
+    tx: params.params.tx,
+    event: {
+      source: GITHUB_SOURCE,
+      event: params.event,
+      workspaceId: params.connection.workspaceId,
+      connectionId: params.connection.id,
+      connectionName: params.connection.displayName,
+      deliveryId: params.params.deliveryId,
+      receivedAt: new Date().toISOString(),
+      payload: params.params.payload,
+    },
+  });
+  return {outcome: result.published ? 'published-envelope' : 'duplicate-envelope'};
 }
 
 function stripRefsHeads(ref: string): string {

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -10,7 +10,8 @@ import {
 import {
   type GithubPushPayloadDto,
   githubPushPayloadSchema,
-  githubWebhookEnvelopeSchema,
+  githubWebhookActionSchema,
+  githubWebhookInstallationSchema,
 } from '@shipfox/api-integration-github-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {getGithubInstallationByInstallationId} from '#db/installations.js';
@@ -50,9 +51,12 @@ function isBranchDeletion(after: string): boolean {
 export async function handleGithubEvent(
   params: HandleGithubEventParams,
 ): Promise<{outcome: HandleGithubEventOutcome}> {
-  const envelope = githubWebhookEnvelopeSchema.safeParse(params.payload);
-  const action = envelope.success ? envelope.data.action : undefined;
-  const installationId = envelope.success ? envelope.data.installation?.id : undefined;
+  const actionEnvelope = githubWebhookActionSchema.safeParse(params.payload);
+  const action = actionEnvelope.success ? actionEnvelope.data.action : undefined;
+  const installationEnvelope = githubWebhookInstallationSchema.safeParse(params.payload);
+  const installationId = installationEnvelope.success
+    ? installationEnvelope.data.installation?.id
+    : undefined;
   if (installationId === undefined) {
     await params.recordDeliveryOnly({
       tx: params.tx,
@@ -123,7 +127,14 @@ export async function handleGithubEvent(
         {deliveryId: params.deliveryId, issues: validated.error.issues},
         'github webhook push payload failed schema validation; publishing generic envelope only',
       );
-      return publishGithubEnvelopeOnly({params, connection, event: 'push'});
+      return publishGithubEnvelopeOnly({
+        tx: params.tx,
+        deliveryId: params.deliveryId,
+        payload: params.payload,
+        publishIntegrationEventReceived: params.publishIntegrationEventReceived,
+        connection,
+        event: 'push',
+      });
     }
 
     return publishGithubPush({
@@ -135,7 +146,14 @@ export async function handleGithubEvent(
   }
 
   const eventName = action ? `${params.event}.${action}` : params.event;
-  return publishGithubEnvelopeOnly({params, connection, event: eventName});
+  return publishGithubEnvelopeOnly({
+    tx: params.tx,
+    deliveryId: params.deliveryId,
+    payload: params.payload,
+    publishIntegrationEventReceived: params.publishIntegrationEventReceived,
+    connection,
+    event: eventName,
+  });
 }
 
 async function publishGithubPush(params: {
@@ -198,21 +216,24 @@ async function publishGithubPush(params: {
 }
 
 async function publishGithubEnvelopeOnly(params: {
-  params: HandleGithubEventParams;
+  tx: IntegrationTx;
+  deliveryId: string;
+  payload: unknown;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   connection: {id: string; workspaceId: string; displayName: string};
   event: string;
 }): Promise<{outcome: HandleGithubEventOutcome}> {
-  const result = await params.params.publishIntegrationEventReceived({
-    tx: params.params.tx,
+  const result = await params.publishIntegrationEventReceived({
+    tx: params.tx,
     event: {
       source: GITHUB_SOURCE,
       event: params.event,
       workspaceId: params.connection.workspaceId,
       connectionId: params.connection.id,
       connectionName: params.connection.displayName,
-      deliveryId: params.params.deliveryId,
+      deliveryId: params.deliveryId,
       receivedAt: new Date().toISOString(),
-      payload: params.params.payload,
+      payload: params.payload,
     },
   });
   return {outcome: result.published ? 'published-envelope' : 'duplicate-envelope'};

--- a/libs/api/integration/github/src/index.ts
+++ b/libs/api/integration/github/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   GetIntegrationConnectionByIdFn,
+  PublishIntegrationEventReceivedFn,
   PublishSourcePushFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
@@ -20,8 +21,8 @@ export {GithubIntegrationProviderError} from '#core/errors.js';
 export type {ConnectGithubInstallationInput} from '#core/install.js';
 export {handleGithubCallback} from '#core/install.js';
 export {signGithubInstallState, verifyGithubInstallState} from '#core/state.js';
-export type {HandleGithubPushOutcome} from '#core/webhook.js';
-export {handleGithubPush} from '#core/webhook.js';
+export type {HandleGithubEventOutcome} from '#core/webhook.js';
+export {handleGithubEvent} from '#core/webhook.js';
 export type {GithubInstallation, UpsertGithubInstallationParams} from '#db/installations.js';
 export {
   getGithubInstallationByConnectionId,
@@ -34,6 +35,7 @@ export interface CreateGithubIntegrationProviderOptions
   extends Omit<CreateGithubIntegrationRoutesOptions, 'github'> {
   github?: GithubApiClient | undefined;
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -69,6 +71,7 @@ export function createGithubIntegrationProvider(options: CreateGithubIntegration
       }),
       createGithubWebhookRoutes({
         coreDb: options.coreDb,
+        publishIntegrationEventReceived: options.publishIntegrationEventReceived,
         publishSourcePush: options.publishSourcePush,
         recordDeliveryOnly: options.recordDeliveryOnly,
         getIntegrationConnectionById: options.getIntegrationConnectionById,

--- a/libs/api/integration/github/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/install.test.ts
@@ -104,6 +104,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
     }),
     // Webhook receiver dependencies — install/OAuth tests don't exercise them.
     coreDb: vi.fn() as never,
+    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: false})),
     publishSourcePush: vi.fn(() => Promise.resolve({published: false})),
     recordDeliveryOnly: vi.fn(() => Promise.resolve()),
     getIntegrationConnectionById: vi.fn(() => Promise.resolve(undefined)),

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -32,12 +32,14 @@ function fakeConnection(overrides: Partial<IntegrationConnection> = {}): Integra
 
 interface TestApp {
   app: FastifyInstance;
+  publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
   publishSourcePush: ReturnType<typeof vi.fn>;
   recordDeliveryOnly: ReturnType<typeof vi.fn>;
   getIntegrationConnectionById: ReturnType<typeof vi.fn>;
 }
 
 async function createTestApp(options: {connection?: IntegrationConnection} = {}): Promise<TestApp> {
+  const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
   const publishSourcePush = vi.fn(() => Promise.resolve({published: true}));
   const recordDeliveryOnly = vi.fn(() => Promise.resolve());
   const getIntegrationConnectionById = vi.fn(() =>
@@ -45,13 +47,20 @@ async function createTestApp(options: {connection?: IntegrationConnection} = {})
   );
   const routes = createGithubWebhookRoutes({
     coreDb: db,
+    publishIntegrationEventReceived,
     publishSourcePush,
     recordDeliveryOnly,
     getIntegrationConnectionById,
   });
   const app = await createApp({routes: [routes], swagger: false});
   await app.ready();
-  return {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById};
+  return {
+    app,
+    publishIntegrationEventReceived,
+    publishSourcePush,
+    recordDeliveryOnly,
+    getIntegrationConnectionById,
+  };
 }
 
 async function seedInstallation(installationId: number, connectionId?: string): Promise<void> {
@@ -98,15 +107,14 @@ describe('GitHub webhook route', () => {
     const {app, publishSourcePush, recordDeliveryOnly, getIntegrationConnectionById} =
       await createTestApp({connection});
     const deliveryId = randomUUID();
-    const body = JSON.stringify(
-      githubPushPayload({
-        installationId,
-        repositoryId: 42,
-        ref: 'refs/heads/main',
-        defaultBranch: 'main',
-        sha: 'abc123',
-      }),
-    );
+    const rawPayload = githubPushPayload({
+      installationId,
+      repositoryId: 42,
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      sha: 'abc123',
+    });
+    const body = JSON.stringify(rawPayload);
 
     const res = await app.inject({
       method: 'POST',
@@ -131,6 +139,7 @@ describe('GitHub webhook route', () => {
       workspaceId: connection.workspaceId,
       connectionId: connection.id,
       connectionName: connection.displayName,
+      rawPayload,
       push: {
         externalRepositoryId: 'github:42',
         ref: 'main',
@@ -170,21 +179,21 @@ describe('GitHub webhook route', () => {
     });
   });
 
-  it('ignores a branch deletion (all-zero after SHA) without publishing', async () => {
+  it('publishes a generic envelope for a branch deletion without publishing a typed push', async () => {
     const installationId = 7783;
     const connection = fakeConnection();
     await seedInstallation(installationId, connection.id);
-    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp({connection});
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp({connection});
     const deliveryId = randomUUID();
-    const body = JSON.stringify(
-      githubPushPayload({
-        installationId,
-        repositoryId: 42,
-        ref: 'refs/heads/main',
-        defaultBranch: 'main',
-        sha: '0000000000000000000000000000000000000000',
-      }),
-    );
+    const rawPayload = githubPushPayload({
+      installationId,
+      repositoryId: 42,
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      sha: '0000000000000000000000000000000000000000',
+    });
+    const body = JSON.stringify(rawPayload);
 
     const res = await app.inject({
       method: 'POST',
@@ -195,11 +204,24 @@ describe('GitHub webhook route', () => {
 
     expect(res.statusCode).toBe(204);
     expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0]).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'push',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        payload: rawPayload,
+      },
+    });
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
-  it('records the delivery only for non-push events', async () => {
-    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
+  it('records the delivery only for events without an installation id', async () => {
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify({zen: 'Practicality beats purity.'});
 
@@ -211,9 +233,82 @@ describe('GitHub webhook route', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
     expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
+  });
+
+  it('publishes a generic envelope for a non-push event with an action', async () => {
+    const installationId = 7784;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp({connection});
+    const deliveryId = randomUUID();
+    const rawPayload = {
+      action: 'opened',
+      installation: {id: installationId},
+      pull_request: {number: 17},
+    };
+    const body = JSON.stringify(rawPayload);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/github',
+      headers: signedHeaders(body, 'pull_request', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0]).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'pull_request.opened',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
+        deliveryId,
+        payload: rawPayload,
+      },
+    });
+  });
+
+  it('publishes a generic envelope for a non-push event without an action', async () => {
+    const installationId = 7785;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp({connection});
+    const deliveryId = randomUUID();
+    const rawPayload = {
+      installation: {id: installationId},
+      forkee: {full_name: 'shipfox/forked'},
+    };
+    const body = JSON.stringify(rawPayload);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/github',
+      headers: signedHeaders(body, 'fork', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0]).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'fork',
+        deliveryId,
+        payload: rawPayload,
+      },
+    });
   });
 
   it('records the delivery only for pushes from unknown installations', async () => {
@@ -309,7 +404,7 @@ describe('GitHub webhook route', () => {
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
-  it('ignores pushes whose payload has no installation id', async () => {
+  it('records the delivery only when a push payload has no installation id', async () => {
     const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const deliveryId = randomUUID();
     const body = JSON.stringify({
@@ -327,7 +422,8 @@ describe('GitHub webhook route', () => {
 
     expect(res.statusCode).toBe(204);
     expect(publishSourcePush).not.toHaveBeenCalled();
-    expect(recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+    expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
   it('rejects an invalid signature with 401 and persists nothing', async () => {
@@ -405,20 +501,36 @@ describe('GitHub webhook route', () => {
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
   });
 
-  it('rejects push payloads that fail schema validation with 400', async () => {
-    const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
-    const body = JSON.stringify({ref: 'refs/heads/main'});
+  it('publishes a generic envelope when a routable push payload fails schema validation', async () => {
+    const installationId = 7786;
+    const connection = fakeConnection();
+    await seedInstallation(installationId, connection.id);
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp({connection});
+    const deliveryId = randomUUID();
+    const rawPayload = {ref: 'refs/heads/main', installation: {id: installationId}};
+    const body = JSON.stringify(rawPayload);
 
     const res = await app.inject({
       method: 'POST',
       url: '/webhooks/integrations/github',
-      headers: signedHeaders(body, 'push', randomUUID()),
+      headers: signedHeaders(body, 'push', deliveryId),
       payload: body,
     });
 
-    expect(res.statusCode).toBe(400);
-    expect(res.json()).toMatchObject({error: 'malformed push payload'});
+    expect(res.statusCode).toBe(204);
     expect(publishSourcePush).not.toHaveBeenCalled();
     expect(recordDeliveryOnly).not.toHaveBeenCalled();
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0]).toMatchObject({
+      event: {
+        source: 'github',
+        event: 'push',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        deliveryId,
+        payload: rawPayload,
+      },
+    });
   });
 });

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -305,6 +305,9 @@ describe('GitHub webhook route', () => {
       event: {
         source: 'github',
         event: 'fork',
+        workspaceId: connection.workspaceId,
+        connectionId: connection.id,
+        connectionName: connection.displayName,
         deliveryId,
         payload: rawPayload,
       },

--- a/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.test.ts
@@ -426,6 +426,26 @@ describe('GitHub webhook route', () => {
     expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
   });
 
+  it('records the delivery only when a malformed push payload has no installation id', async () => {
+    const {app, publishIntegrationEventReceived, publishSourcePush, recordDeliveryOnly} =
+      await createTestApp();
+    const deliveryId = randomUUID();
+    const body = JSON.stringify({ref: 'refs/heads/main'});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/webhooks/integrations/github',
+      headers: signedHeaders(body, 'push', deliveryId),
+      payload: body,
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+    expect(publishSourcePush).not.toHaveBeenCalled();
+    expect(recordDeliveryOnly).toHaveBeenCalledTimes(1);
+    expect(recordDeliveryOnly.mock.calls[0]?.[0]).toMatchObject({provider: 'github', deliveryId});
+  });
+
   it('rejects an invalid signature with 401 and persists nothing', async () => {
     const {app, publishSourcePush, recordDeliveryOnly} = await createTestApp();
     const body = JSON.stringify(

--- a/libs/api/integration/github/src/presentation/routes/webhooks.ts
+++ b/libs/api/integration/github/src/presentation/routes/webhooks.ts
@@ -2,10 +2,10 @@ import {Buffer} from 'node:buffer';
 import {Webhooks} from '@octokit/webhooks';
 import type {
   GetIntegrationConnectionByIdFn,
+  PublishIntegrationEventReceivedFn,
   PublishSourcePushFn,
   RecordDeliveryOnlyFn,
 } from '@shipfox/api-integration-core-dto';
-import {githubPushPayloadSchema} from '@shipfox/api-integration-github-dto';
 import {
   defineRoute,
   type RouteGroup,
@@ -15,15 +15,15 @@ import {
 import {logger} from '@shipfox/node-opentelemetry';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import {config} from '#config.js';
-import {handleGithubPush} from '#core/webhook.js';
+import {handleGithubEvent} from '#core/webhook.js';
 
 const SIGNATURE_HEADER = 'x-hub-signature-256';
 const EVENT_HEADER = 'x-github-event';
 const DELIVERY_HEADER = 'x-github-delivery';
-const GITHUB_PROVIDER = 'github';
 
 export interface CreateGithubWebhookRoutesOptions {
   coreDb: () => NodePgDatabase<Record<string, unknown>>;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
   publishSourcePush: PublishSourcePushFn;
   recordDeliveryOnly: RecordDeliveryOnlyFn;
   getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
@@ -75,18 +75,6 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
         return {error: 'invalid signature'};
       }
 
-      if (event !== 'push') {
-        await options.coreDb().transaction(async (tx) => {
-          await options.recordDeliveryOnly({
-            tx,
-            provider: GITHUB_PROVIDER,
-            deliveryId,
-          });
-        });
-        reply.code(204);
-        return null;
-      }
-
       let parsedJson: unknown;
       try {
         parsedJson = JSON.parse(rawBody);
@@ -96,21 +84,13 @@ export function createGithubWebhookRoutes(options: CreateGithubWebhookRoutesOpti
         return {error: 'malformed JSON'};
       }
 
-      const validated = githubPushPayloadSchema.safeParse(parsedJson);
-      if (!validated.success) {
-        logger().warn(
-          {deliveryId, issues: validated.error.issues},
-          'github webhook push payload failed schema validation',
-        );
-        reply.code(400);
-        return {error: 'malformed push payload'};
-      }
-
       await options.coreDb().transaction(async (tx) => {
-        await handleGithubPush({
+        await handleGithubEvent({
           tx,
           deliveryId,
-          payload: validated.data,
+          event,
+          payload: parsedJson,
+          publishIntegrationEventReceived: options.publishIntegrationEventReceived,
           publishSourcePush: options.publishSourcePush,
           recordDeliveryOnly: options.recordDeliveryOnly,
           getIntegrationConnectionById: options.getIntegrationConnectionById,

--- a/libs/api/triggers/README.md
+++ b/libs/api/triggers/README.md
@@ -59,6 +59,17 @@ fires every subscription that matches its `(source, event)` in the
 workspace. Narrowing by branch, repository, or payload contents is left to
 user-defined filters, applied in a later iteration.
 
+GitHub triggers use the raw GitHub webhook resource name, plus the payload
+`action` when one is present. For example, a pull request open event is
+`pull_request.opened`, an issue close event is `issues.closed`, and a
+release publish event is `release.published`. Events without an action use
+the bare resource name, such as `push` or `fork`. Common GitHub events are:
+`push`, `pull_request.opened`, `pull_request.closed`, `issues.opened`,
+`issues.closed`, `issue_comment.created`, `release.published`,
+`workflow_run.completed`, `installation.created`, and
+`installation_repositories.added`. GitHub only sends events that the GitHub
+App is subscribed to in its Permissions & events settings.
+
 ## Setup
 
 This package is private to the workspace. Add it to another workspace
@@ -106,7 +117,7 @@ Three words, used the same way at every layer.
 | --- | --- | --- |
 | **source** | Where the trigger came from. | `github`, `gitlab`, `sentry`, `manual`, `cron` |
 | **event** | The specific thing that happened, scoped to a source. | `push`, `issue_comment`, `alert_triggered`, `fire`, `tick` |
-| **payload** | The data carried by the event, set by the producing integration. Triggers passes it through opaquely. | `{ref, headCommitSha, ...}` for `(github, push)` |
+| **payload** | The data carried by the event, set by the producing integration. Triggers passes it through opaquely. | GitHub's raw webhook JSON for `(github, push)` |
 
 The `name` field on a subscription is the YAML map key (for example
 `on_push`). It identifies the trigger inside a workflow definition and is


### PR DESCRIPTION
Make GitHub App webhook deliveries usable as workflow triggers beyond `push`.

GitHub previously recorded non-push deliveries for dedup and dropped them before they could reach the generic integration event path. This routes install-scoped GitHub webhook payloads through `INTEGRATION_EVENT_RECEIVED` using the `resource.action` convention when an action is present, so workflows can subscribe to events like `pull_request.opened`, `issues.closed`, or bare-resource events like `fork`.

Push deliveries keep publishing the normalized `INTEGRATION_SOURCE_COMMIT_PUSHED` event for domain consumers, while trigger payloads now receive the full raw GitHub webhook JSON. Branch-deletion pushes and routable malformed push payloads publish a generic envelope only.

The touched packages are private, so no changeset was added. GitHub will only deliver events that the App is subscribed to in its Permissions & events settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables workflows to trigger from any GitHub App webhook, not just push. All install-scoped events emit a generic integration event with the raw GitHub payload; pushes still emit the normalized source-commit event, and routing is hardened so malformed fields don’t drop events.

- **New Features**
  - Routes install-scoped GitHub webhooks through `INTEGRATION_EVENT_RECEIVED` using `resource.action` when valid, else the bare resource (e.g. `pull_request.opened`, `fork`).
  - Pushes publish both the generic envelope (raw payload) and `INTEGRATION_SOURCE_COMMIT_PUSHED`; branch-deletion pushes and schema-invalid push payloads publish the envelope only.
  - Decouples installation routing from action parsing: deliveries without an installation id are recorded only; unknown/missing or inactive connections are recorded only.

- **Migration**
  - Replace `handleGithubPush` with `handleGithubEvent` from `@shipfox/api-integration-github`.
  - Pass `publishIntegrationEventReceived` into `createGithubIntegrationProvider` and `createGithubWebhookRoutes` in `@shipfox/api-integration-github`.
  - Update implementations to the new `PublishSourcePushFn` signature with required `rawPayload`; pass the original webhook JSON for the envelope while keeping the normalized push on the typed event.

<sup>Written for commit 4e6bb83d4545991d2ae54180016fc65fc66fd74f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

