### PR TITLE
[provisioner] Add Docker runner lifecycle management

### DIFF
--- a/.changeset/steady-runners-launch.md
+++ b/.changeset/steady-runners-launch.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/provisioner-core": patch
+"@shipfox/provisioner-docker-provider": patch
+---
+
+Adds Docker provisioner lifecycle management so reserved runners launch as containers, report state, reconcile local Docker resources, and reap stale pre-run containers.

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -12,32 +12,57 @@ configuration and launcher live in
 
 On each cycle the provisioner:
 
-1. Advertises its current per-template capacity (free slots, starting, running).
-2. Long-polls the API for demand and receives count-based reservations.
-3. Chooses a local template for each reservation's label set, deterministically,
+1. Observes local Docker containers owned by this provisioner and reports lifecycle.
+2. Advertises its current per-template capacity (free slots, starting, running).
+3. Long-polls the API for demand and receives count-based reservations.
+4. Chooses a local template for each reservation's label set, deterministically,
    filling the cheapest matching template first.
-4. Batch-mints one single-use registration token per planned runner.
+5. Batch-mints one single-use registration token per planned runner.
+6. Creates and starts one Docker container per runner.
 
 It respects each template's `max_concurrency` before requesting reservations, so it
 never reserves more than it can start.
 
-The current launcher logs each planned runner instead of starting containers,
-reporting lifecycle, reconciling on restart, or reaping stale containers. Do not run
-it against a production API until the launcher is configured to create containers.
+Containers are named by `provisioned_runner_id` and labeled with `shipfox.*` metadata
+so a restarted provisioner can rebuild local capacity from Docker state. Running
+containers are re-reported every tick to keep the backend active-runner view fresh.
+Exited containers are reported as `stopped` or `failed`, then removed after the report
+is accepted. Containers stuck in Docker's `created` state past the registration deadline
+are reaped as stale pre-run resources; running containers are never locally killed.
+
+If Docker cannot be observed, the provisioner advertises no free capacity and backs off
+until observation succeeds.
 
 ## Configuration
 
 | Variable | Required | Default | Purpose |
 | --- | --- | --- | --- |
 | `SHIPFOX_API_URL` | yes | — | Base URL of the Shipfox API. |
+| `SHIPFOX_RUNNER_API_URL` | no | `SHIPFOX_API_URL` | API URL injected into runner containers as `SHIPFOX_API_URL`; set it when containers reach the API through a different address. |
 | `SHIPFOX_PROVISIONER_TOKEN` | yes | — | Long-lived provisioner token (keep it in `.env.local`, never commit it). |
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the YAML template file (see `templates.example.yaml`). |
+| `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
+| `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | — | Docker network attached to runner containers, for example a Compose network that can reach the API. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before being reaped as stale. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Long-poll wait per demand request. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Base delay between polls; backs off on error. |
 | `SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS` | no | `5000` | Backoff ceiling. |
 | `SHIPFOX_PROVISIONER_MAX_RESERVATIONS` | no | `250` | Most reservations requested per poll (also capped by free capacity and the API's limit of 1000). |
 | `SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE` | no | `250` | Tokens minted per request (1–1000); must not exceed the API's `REGISTRATION_TOKEN_BATCH_MAX` (default 500), or the mint is rejected. |
 | `SHIPFOX_RUNNER_POLL_MAX_DURATION_MS` | no | `300000` | Injected into each runner as `SHIPFOX_POLL_MAX_DURATION_MS`. |
+
+## Runner image
+
+Each template `image` must run the Shipfox runner process and consume the injected
+environment:
+
+- `SHIPFOX_API_URL`
+- `SHIPFOX_RUNNER_TOKEN`
+- `SHIPFOX_RUNNER_LABELS`
+- `SHIPFOX_POLL_MAX_DURATION_MS`
+
+Do not bake a static runner token into the image or container environment. The
+provisioner mints one single-use registration token per reserved runner.
 
 ## Run locally
 

--- a/libs/provisioner/core/src/api-client.test.ts
+++ b/libs/provisioner/core/src/api-client.test.ts
@@ -78,6 +78,29 @@ describe('createProvisionerClient', () => {
     expect(calls[0]?.authorization).toBe(`Bearer ${TOKEN}`);
   });
 
+  it('reportProvisionedRunners posts lifecycle events with the token and parses the response', async () => {
+    stubFetch(() => jsonResponse({accepted: 1, reservations_released: 1}));
+
+    const result = await client().reportProvisionedRunners({
+      events: [
+        {
+          provisioned_runner_id: 'provisioned-runner-1',
+          reservation_id: RESERVATION_ID,
+          template_key: 'small',
+          labels: ['ubuntu22'],
+          state: 'running',
+          reported_at: '2026-01-01T00:00:00.000Z',
+          provider_kind: 'docker',
+        },
+      ],
+    });
+
+    expect(result).toEqual({accepted: 1, reservations_released: 1});
+    expect(calls[0]?.url).toContain('provisioners/provisioned-runners/report');
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
   it('maps a 401 on getIdentity to ProvisionerAuthenticationError', async () => {
     stubFetch(() => new Response(null, {status: 401}));
 
@@ -92,6 +115,23 @@ describe('createProvisionerClient', () => {
       max_reservations: 0,
       templates: [
         {template_key: 'small', labels: ['ubuntu22'], available_slots: 0, starting: 0, running: 0},
+      ],
+    });
+
+    await expect(request).rejects.toThrow(ProvisionerAuthenticationError);
+  });
+
+  it('maps a 403 on reportProvisionedRunners to ProvisionerAuthenticationError', async () => {
+    stubFetch(() => new Response(null, {status: 403}));
+
+    const request = client().reportProvisionedRunners({
+      events: [
+        {
+          provisioned_runner_id: 'provisioned-runner-1',
+          labels: ['ubuntu22'],
+          state: 'running',
+          reported_at: '2026-01-01T00:00:00.000Z',
+        },
       ],
     });
 

--- a/libs/provisioner/core/src/api-client.ts
+++ b/libs/provisioner/core/src/api-client.ts
@@ -7,6 +7,9 @@ import {
   type ProvisionerIdentityResponseDto,
   pollDemandResponseSchema,
   provisionerIdentityResponseSchema,
+  type ReportProvisionedRunnersBodyDto,
+  type ReportProvisionedRunnersResponseDto,
+  reportProvisionedRunnersResponseSchema,
 } from '@shipfox/api-runners-dto';
 import ky, {HTTPError, type KyInstance} from 'ky';
 
@@ -31,6 +34,10 @@ export interface ProvisionerClient {
     body: MintRegistrationTokensBatchBodyDto,
     options?: {signal?: AbortSignal},
   ): Promise<MintRegistrationTokensBatchResponseDto>;
+  reportProvisionedRunners(
+    body: ReportProvisionedRunnersBodyDto,
+    options?: {signal?: AbortSignal},
+  ): Promise<ReportProvisionedRunnersResponseDto>;
 }
 
 export function createProvisionerClient(params: {
@@ -69,6 +76,16 @@ export function createProvisionerClient(params: {
           ...(options.signal ? {signal: options.signal} : {}),
         });
         return mintRegistrationTokensBatchResponseSchema.parse(await response.json());
+      });
+    },
+
+    reportProvisionedRunners(body, options = {}) {
+      return withAuthMapping(async () => {
+        const response = await api.post('provisioners/provisioned-runners/report', {
+          json: body,
+          ...(options.signal ? {signal: options.signal} : {}),
+        });
+        return reportProvisionedRunnersResponseSchema.parse(await response.json());
       });
     },
   };

--- a/libs/provisioner/core/src/config.ts
+++ b/libs/provisioner/core/src/config.ts
@@ -9,6 +9,10 @@ export const config = createConfig({
   SHIPFOX_API_URL: url({
     desc: 'Base URL of the Shipfox API the provisioner connects to, such as https://api.shipfox.io. Required.',
   }),
+  SHIPFOX_RUNNER_API_URL: url({
+    desc: 'Base URL injected into runner containers as SHIPFOX_API_URL. Defaults to SHIPFOX_API_URL; set it when containers reach the API through a different address than the provisioner uses.',
+    default: undefined,
+  }),
   SHIPFOX_PROVISIONER_TOKEN: str({
     desc: 'Long-lived provisioner token used to authenticate control-plane calls. Required, with no default, so startup fails when it is missing rather than sending a predictable token.',
   }),

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -1,9 +1,13 @@
+export type {ProvisionerClient} from '#api-client.js';
 export {ProvisionerAuthenticationError} from '#api-client.js';
 export {loggingLaunch} from '#launcher.js';
 export {type StartProvisionerOptions, startProvisioner} from '#provisioner.js';
+export type {ProvisionedRunnerTracker} from '#tracker.js';
 export type {
   LaunchRunner,
   ProvisionedRunnerLaunch,
   ProvisionerAdapter,
+  ProvisionerIdentity,
+  ProvisionerRuntime,
   ProvisionerTemplate,
 } from '#types.js';

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -1,0 +1,172 @@
+import type {
+  MintRegistrationTokensBatchBodyDto,
+  PollDemandBodyDto,
+  PollDemandResponseDto,
+} from '@shipfox/api-runners-dto';
+import type {ProvisionerClient} from '#api-client.js';
+import {runProvisionerIteration} from '#provisioner.js';
+import {createInMemoryTracker} from '#tracker.js';
+import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
+
+const EXPIRES_AT = '2026-01-01T00:00:00.000Z';
+
+const template: ProvisionerTemplate<null> = {
+  key: 'small',
+  labels: ['ubuntu22'],
+  maxConcurrency: 5,
+  cost: 1,
+  spec: null,
+};
+
+describe('runProvisionerIteration', () => {
+  it('runs onTick before polling demand', async () => {
+    const events: string[] = [];
+    const {client} = harness({
+      response: {stats: [], reservations: []},
+      onPoll: () => events.push('poll'),
+    });
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => {
+        events.push('observe');
+        return Promise.resolve();
+      },
+    };
+
+    await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      degraded: false,
+    });
+
+    expect(events).toEqual(['observe', 'poll']);
+  });
+
+  it('advertises no free capacity and backs off when onTick fails', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => Promise.reject(new Error('docker daemon down')),
+    };
+
+    const result = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      degraded: false,
+    });
+
+    expect(pollBodies[0]?.max_reservations).toBe(0);
+    expect(result).toEqual({nextInterval: 1500, degraded: true});
+  });
+
+  it('keeps advertising no capacity while startup is degraded and observe still fails', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => Promise.reject(new Error('docker daemon down')),
+    };
+
+    const result = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      degraded: true,
+    });
+
+    expect(pollBodies[0]?.max_reservations).toBe(0);
+    expect(result).toEqual({nextInterval: 1500, degraded: true});
+  });
+
+  it('backs off when every attempted launch fails', async () => {
+    const {client} = harness({response: {stats: [], reservations: [reservation(2)]}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.reject(new Error('start failed')),
+      onTick: () => Promise.resolve(),
+    };
+
+    const result = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      degraded: false,
+    });
+
+    expect(result).toEqual({nextInterval: 1500, degraded: false});
+  });
+
+  it('resets to the base interval after a healthy observe and successful launch', async () => {
+    const {client} = harness({response: {stats: [], reservations: [reservation(1)]}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+      onTick: () => Promise.resolve(),
+    };
+
+    const result = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 3000,
+      degraded: true,
+    });
+
+    expect(result).toEqual({nextInterval: 1000, degraded: false});
+  });
+});
+
+function harness(options: {response: PollDemandResponseDto; onPoll?: () => void}): {
+  client: ProvisionerClient;
+  pollBodies: PollDemandBodyDto[];
+  mintBodies: MintRegistrationTokensBatchBodyDto[];
+} {
+  const pollBodies: PollDemandBodyDto[] = [];
+  const mintBodies: MintRegistrationTokensBatchBodyDto[] = [];
+
+  return {
+    pollBodies,
+    mintBodies,
+    client: {
+      getIdentity: () => Promise.resolve({id: 'provisioner', workspace_id: 'workspace'}),
+      pollDemand: (body) => {
+        options.onPoll?.();
+        pollBodies.push(body);
+        return Promise.resolve(options.response);
+      },
+      mintRegistrationTokens: (body) => {
+        mintBodies.push(body);
+        return Promise.resolve({
+          tokens: body.provisioned_runners.map((runner) => ({
+            provisioned_runner_id: runner.provisioned_runner_id,
+            registration_token: `sfrt_${runner.provisioned_runner_id}`,
+            expires_at: EXPIRES_AT,
+          })),
+        });
+      },
+      reportProvisionedRunners: () => Promise.resolve({accepted: 0, reservations_released: 0}),
+    },
+  };
+}
+
+function reservation(count: number) {
+  return {
+    reservation_id: '00000000-0000-4000-8000-000000000001',
+    labels: ['ubuntu22'],
+    count,
+    expires_at: EXPIRES_AT,
+  };
+}

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -88,6 +88,26 @@ describe('runProvisionerIteration', () => {
     expect(result).toEqual({nextInterval: 1500, degraded: true});
   });
 
+  it('keeps degraded mode when no observe hook is available', async () => {
+    const {client, pollBodies} = harness({response: {stats: [], reservations: []}});
+    const adapter: ProvisionerAdapter<null> = {
+      loadTemplates: () => Promise.resolve([template]),
+      launch: () => Promise.resolve(),
+    };
+
+    const result = await runProvisionerIteration({
+      adapter,
+      client,
+      templates: [template],
+      tracker: createInMemoryTracker(),
+      currentInterval: 1000,
+      degraded: true,
+    });
+
+    expect(pollBodies[0]?.max_reservations).toBe(0);
+    expect(result).toEqual({nextInterval: 1500, degraded: true});
+  });
+
   it('backs off when every attempted launch fails', async () => {
     const {client} = harness({response: {stats: [], reservations: [reservation(2)]}});
     const adapter: ProvisionerAdapter<null> = {

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -142,8 +142,10 @@ export async function runProvisionerIteration<Spec>(
   let maxReservations = config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS;
 
   try {
-    await deps.adapter.onTick?.();
-    degraded = false;
+    if (deps.adapter.onTick) {
+      await deps.adapter.onTick();
+      degraded = false;
+    }
   } catch (error) {
     degraded = true;
     maxReservations = 0;

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -1,10 +1,14 @@
 import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
 import {logger} from '@shipfox/node-opentelemetry';
-import {createProvisionerClient, ProvisionerAuthenticationError} from '#api-client.js';
+import {
+  createProvisionerClient,
+  ProvisionerAuthenticationError,
+  type ProvisionerClient,
+} from '#api-client.js';
 import {config} from '#config.js';
-import {runProvisionerTick} from '#tick.js';
-import {createInMemoryTracker} from '#tracker.js';
-import type {ProvisionerAdapter} from '#types.js';
+import {type RunnerEnvFactory, runProvisionerTick} from '#tick.js';
+import {createInMemoryTracker, type ProvisionedRunnerTracker} from '#tracker.js';
+import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
 
 /** The demand poll accepts at most 100 advertised templates per request. */
 const MAX_TEMPLATES_PER_POLL = 100;
@@ -18,6 +22,21 @@ let pollAbortController: AbortController | undefined;
 
 export interface StartProvisionerOptions<Spec> {
   readonly adapter: ProvisionerAdapter<Spec>;
+}
+
+export interface RunProvisionerIterationDeps<Spec> {
+  readonly adapter: ProvisionerAdapter<Spec>;
+  readonly client: ProvisionerClient;
+  readonly templates: readonly ProvisionerTemplate<Spec>[];
+  readonly tracker: ProvisionedRunnerTracker;
+  readonly currentInterval: number;
+  readonly degraded: boolean;
+  readonly signal?: AbortSignal;
+}
+
+export interface RunProvisionerIterationResult {
+  readonly nextInterval: number;
+  readonly degraded: boolean;
 }
 
 /**
@@ -63,40 +82,37 @@ export async function startProvisioner<Spec>(
   );
 
   const tracker = createInMemoryTracker();
+  let degraded = false;
+  try {
+    await options.adapter.onStart?.({
+      client,
+      identity: {id: identity.id, workspaceId: identity.workspace_id},
+      tracker,
+    });
+  } catch (error) {
+    degraded = true;
+    logger().error(
+      {err: error},
+      'Provisioner startup reconciliation failed; advertising no free capacity until observe succeeds',
+    );
+  }
+
   let currentInterval = config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS;
 
   while (running) {
     pollAbortController = new AbortController();
     try {
-      const result = await runProvisionerTick({
+      const iteration: RunProvisionerIterationResult = await runProvisionerIteration({
+        adapter: options.adapter,
         client,
         templates,
         tracker,
-        launch: options.adapter.launch,
-        buildRunnerEnv: ({template, registrationToken}) => ({
-          SHIPFOX_API_URL: config.SHIPFOX_API_URL,
-          SHIPFOX_RUNNER_TOKEN: registrationToken,
-          SHIPFOX_RUNNER_LABELS: template.labels.join(','),
-          SHIPFOX_POLL_MAX_DURATION_MS: String(config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS),
-        }),
-        maxReservations: config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS,
-        waitSeconds: config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS,
-        registrationTokenBatchSize: config.SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE,
+        currentInterval,
+        degraded,
         signal: pollAbortController.signal,
       });
-
-      if (result.reservationCount > 0 || result.launchedCount > 0) {
-        logger().info(
-          {
-            reservations: result.reservationCount,
-            planned: result.plannedCount,
-            launched: result.launchedCount,
-          },
-          'Provisioner tick complete',
-        );
-      }
-
-      currentInterval = config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS;
+      currentInterval = iteration.nextInterval;
+      degraded = iteration.degraded;
       await interruptableSleep(withJitter(currentInterval));
     } catch (error) {
       if (!running) break;
@@ -115,8 +131,78 @@ export async function startProvisioner<Spec>(
     }
   }
 
+  await options.adapter.onStop?.();
   logger().info('Provisioner stopped');
 }
+
+export async function runProvisionerIteration<Spec>(
+  deps: RunProvisionerIterationDeps<Spec>,
+): Promise<RunProvisionerIterationResult> {
+  let degraded = deps.degraded;
+  let maxReservations = config.SHIPFOX_PROVISIONER_MAX_RESERVATIONS;
+
+  try {
+    await deps.adapter.onTick?.();
+    degraded = false;
+  } catch (error) {
+    degraded = true;
+    maxReservations = 0;
+    logger().error(
+      {err: error},
+      'Provisioner observe failed; advertising no free capacity until observe succeeds',
+    );
+  }
+
+  if (degraded) maxReservations = 0;
+
+  const result = await runProvisionerTick({
+    client: deps.client,
+    templates: deps.templates,
+    tracker: deps.tracker,
+    launch: deps.adapter.launch,
+    buildRunnerEnv,
+    maxReservations,
+    waitSeconds: config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS,
+    registrationTokenBatchSize: config.SHIPFOX_PROVISIONER_REGISTRATION_TOKEN_BATCH_SIZE,
+    ...(deps.signal ? {signal: deps.signal} : {}),
+  });
+
+  if (result.reservationCount > 0 || result.launchedCount > 0) {
+    logger().info(
+      {
+        reservations: result.reservationCount,
+        planned: result.plannedCount,
+        launchAttempts: result.launchAttemptedCount,
+        launched: result.launchedCount,
+      },
+      'Provisioner tick complete',
+    );
+  }
+
+  const allAttemptedLaunchesFailed = result.launchAttemptedCount > 0 && result.launchedCount === 0;
+  const shouldBackOff = degraded || allAttemptedLaunchesFailed;
+
+  if (allAttemptedLaunchesFailed) {
+    logger().warn(
+      {attempted: result.launchAttemptedCount},
+      'All attempted provisioned runner launches failed; backing off',
+    );
+  }
+
+  return {
+    nextInterval: shouldBackOff
+      ? nextBackoffInterval(deps.currentInterval)
+      : config.SHIPFOX_PROVISIONER_POLL_INTERVAL_MS,
+    degraded,
+  };
+}
+
+export const buildRunnerEnv: RunnerEnvFactory<unknown> = ({template, registrationToken}) => ({
+  SHIPFOX_API_URL: config.SHIPFOX_RUNNER_API_URL ?? config.SHIPFOX_API_URL,
+  SHIPFOX_RUNNER_TOKEN: registrationToken,
+  SHIPFOX_RUNNER_LABELS: template.labels.join(','),
+  SHIPFOX_POLL_MAX_DURATION_MS: String(config.SHIPFOX_RUNNER_POLL_MAX_DURATION_MS),
+});
 
 export function nextBackoffInterval(ms: number): number {
   return Math.min(ms * 1.5, config.SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS);

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -53,6 +53,7 @@ function harness(options: {response: PollDemandResponseDto; mintError?: Error}):
         })),
       });
     },
+    reportProvisionedRunners: () => Promise.resolve({accepted: 0, reservations_released: 0}),
   };
 
   return {pollBodies, mintBodies, launches, client, tracker: createInMemoryTracker()};
@@ -99,7 +100,12 @@ describe('runProvisionerTick', () => {
     expect(fixture.mintBodies[0]?.reservation_id).toBe('r1');
     expect(fixture.mintBodies[0]?.provisioned_runners).toHaveLength(3);
     expect(fixture.launches).toHaveLength(3);
-    expect(result).toMatchObject({reservationCount: 1, plannedCount: 3, launchedCount: 3});
+    expect(result).toMatchObject({
+      reservationCount: 1,
+      plannedCount: 3,
+      launchAttemptedCount: 3,
+      launchedCount: 3,
+    });
   });
 
   it('injects the minted token into the runner env and tracks each as starting', async () => {
@@ -221,6 +227,7 @@ describe('runProvisionerTick', () => {
             expires_at: EXPIRES_AT,
           })),
         }),
+      reportProvisionedRunners: () => Promise.resolve({accepted: 0, reservations_released: 0}),
     };
 
     const result = await runProvisionerTick({
@@ -238,6 +245,7 @@ describe('runProvisionerTick', () => {
     });
 
     expect(launches).toHaveLength(1);
+    expect(result.launchAttemptedCount).toBe(1);
     expect(result.launchedCount).toBe(1);
   });
 
@@ -257,6 +265,7 @@ describe('runProvisionerTick', () => {
     });
 
     expect(fixture.mintBodies).toHaveLength(1);
+    expect(result.launchAttemptedCount).toBe(1);
     expect(result.launchedCount).toBe(0);
     // The failed runner must not keep occupying a slot, or a persistent failure wedges the loop.
     expect(fixture.tracker.countsByTemplate()).toEqual(new Map());

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -34,6 +34,7 @@ export interface ProvisionerTickResult {
   readonly stats: readonly DemandStatDto[];
   readonly reservationCount: number;
   readonly plannedCount: number;
+  readonly launchAttemptedCount: number;
   readonly launchedCount: number;
 }
 
@@ -89,16 +90,20 @@ export async function runProvisionerTick<Spec>(
 
   const plannedCount = planned.reduce((sum, group) => sum + group.count, 0);
 
+  let launchAttemptedCount = 0;
   let launchedCount = 0;
   for (const [reservationId, groups] of groupByReservation(planned)) {
     if (deps.signal?.aborted) break;
-    launchedCount += await launchReservation(reservationId, groups, deps);
+    const result = await launchReservation(reservationId, groups, deps);
+    launchAttemptedCount += result.attempted;
+    launchedCount += result.launched;
   }
 
   return {
     stats: response.stats,
     reservationCount: response.reservations.length,
     plannedCount,
+    launchAttemptedCount,
     launchedCount,
   };
 }
@@ -107,7 +112,7 @@ async function launchReservation<Spec>(
   reservationId: string,
   groups: readonly PlannedLaunchGroup<Spec>[],
   deps: ProvisionerTickDeps<Spec>,
-): Promise<number> {
+): Promise<{attempted: number; launched: number}> {
   // A fresh, never-reused id per runner: it binds the ephemeral registration token,
   // names the resource, and keys idempotent reporting and reconciliation. Uniqueness is
   // all the loop needs, so a random UUID suffices.
@@ -121,6 +126,7 @@ async function launchReservation<Spec>(
     plannedRunners.map((runner) => [runner.provisionedRunnerId, runner.template]),
   );
 
+  let attempted = 0;
   let launched = 0;
   for (const batch of chunk(plannedRunners, deps.registrationTokenBatchSize)) {
     if (deps.signal?.aborted) break;
@@ -160,6 +166,7 @@ async function launchReservation<Spec>(
         provisionedRunnerId: token.provisioned_runner_id,
         templateKey: template.key,
       });
+      attempted += 1;
       try {
         await deps.launch({
           provisionedRunnerId: token.provisioned_runner_id,
@@ -183,7 +190,7 @@ async function launchReservation<Spec>(
     }
   }
 
-  return launched;
+  return {attempted, launched};
 }
 
 function groupByReservation<Spec>(

--- a/libs/provisioner/core/src/tracker.ts
+++ b/libs/provisioner/core/src/tracker.ts
@@ -13,6 +13,13 @@ export interface ProvisionedRunnerTracker {
   recordStarting(args: {provisionedRunnerId: string; templateKey: string}): void;
   markRunning(provisionedRunnerId: string): void;
   remove(provisionedRunnerId: string): void;
+  replaceAll(
+    runners: readonly {
+      provisionedRunnerId: string;
+      templateKey: string;
+      state: ProvisionedRunnerLifecycle;
+    }[],
+  ): void;
   countsByTemplate(): Map<string, TemplateCounts>;
 }
 
@@ -34,6 +41,15 @@ export function createInMemoryTracker(): ProvisionedRunnerTracker {
     },
     remove(provisionedRunnerId) {
       runners.delete(provisionedRunnerId);
+    },
+    replaceAll(nextRunners) {
+      runners.clear();
+      for (const runner of nextRunners) {
+        runners.set(runner.provisionedRunnerId, {
+          templateKey: runner.templateKey,
+          state: runner.state,
+        });
+      }
     },
     countsByTemplate() {
       const counts = new Map<string, {starting: number; running: number}>();

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -1,3 +1,6 @@
+import type {ProvisionerClient} from '#api-client.js';
+import type {ProvisionedRunnerTracker} from '#tracker.js';
+
 /**
  * A machine template the provisioner can start runners from. The control loop is
  * provider-agnostic and only reads the fields needed to match demand and respect
@@ -45,6 +48,17 @@ export interface ProvisionedRunnerLaunch<Spec = unknown> {
 /** Starts one provisioned runner. The provider implementation owns the side effect. */
 export type LaunchRunner<Spec = unknown> = (launch: ProvisionedRunnerLaunch<Spec>) => Promise<void>;
 
+export interface ProvisionerIdentity {
+  readonly id: string;
+  readonly workspaceId: string;
+}
+
+export interface ProvisionerRuntime {
+  readonly client: ProvisionerClient;
+  readonly identity: ProvisionerIdentity;
+  readonly tracker: ProvisionedRunnerTracker;
+}
+
 /**
  * The provider plug-in the control loop drives. A provider supplies its templates
  * (parsed and validated from local config) and a launcher that actually starts a
@@ -53,4 +67,7 @@ export type LaunchRunner<Spec = unknown> = (launch: ProvisionedRunnerLaunch<Spec
 export interface ProvisionerAdapter<Spec = unknown> {
   loadTemplates(): Promise<readonly ProvisionerTemplate<Spec>[]>;
   readonly launch: LaunchRunner<Spec>;
+  onStart?(runtime: ProvisionerRuntime): Promise<void>;
+  onTick?(): Promise<void>;
+  onStop?(): Promise<void>;
 }

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -36,5 +36,47 @@ becomes the template's selection cost, so generic demand lands on the cheapest b
 ## Current behavior
 
 This package loads and validates Docker template configuration, joins the shared
-provisioner control loop, and logs each planned runner. It does not start containers,
-report lifecycle, or reconcile existing containers on restart.
+provisioner control loop, and starts one Docker container per reserved runner. Each
+container is named by its `provisioned_runner_id` and carries `shipfox.*` labels so a
+restarted provisioner can rebuild local capacity from Docker state.
+
+The provider reports lifecycle through the API:
+
+- `starting` before container creation.
+- `running` on every observe tick for running containers.
+- `stopped` or `failed` after exited containers, then removes them.
+- `terminated` for dead/removing containers and stale pre-run `created` containers.
+
+At startup and at the top of every control-loop iteration, the provider lists local
+containers owned by the provisioner token and refreshes tracker capacity before demand
+polling. If Docker cannot be observed, the core loop advertises no free capacity and
+backs off, avoiding duplicate launches during daemon outages.
+
+## Runtime configuration
+
+The runnable app reads the shared core provisioner variables plus these Docker-specific
+variables:
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file describing labels, image, cpu, memory, and max concurrency. |
+| `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
+| `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | - | Docker network attached to runner containers, useful for Compose-local API access. |
+| `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before being reaped as stale. |
+
+The core `SHIPFOX_RUNNER_API_URL` variable is injected into runner containers as
+`SHIPFOX_API_URL` and defaults to `SHIPFOX_API_URL`. Set it when containers reach the
+API through a different hostname or network address than the provisioner process uses.
+
+## Runner image
+
+Template `image` values must point to an image that runs the Shipfox runner process and
+honors the injected environment:
+
+- `SHIPFOX_API_URL`
+- `SHIPFOX_RUNNER_TOKEN`
+- `SHIPFOX_RUNNER_LABELS`
+- `SHIPFOX_POLL_MAX_DURATION_MS`
+
+The image must not bake in a static runner token. Registration uses the single-use token
+minted for the reserved `provisioned_runner_id`.

--- a/libs/provisioner/docker/package.json
+++ b/libs/provisioner/docker/package.json
@@ -37,10 +37,12 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/provisioner-core": "workspace:*",
     "@shipfox/runner-labels": "workspace:*",
+    "dockerode": "^4.0.9",
     "js-yaml": "^4.1.0",
     "zod": "^4.4.3"
   },
@@ -50,6 +52,7 @@
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
+    "@types/dockerode": "^3.3.43",
     "@types/js-yaml": "^4.0.9"
   }
 }

--- a/libs/provisioner/docker/package.json
+++ b/libs/provisioner/docker/package.json
@@ -52,7 +52,7 @@
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
-    "@types/dockerode": "^3.3.43",
+    "@types/dockerode": "^4.0.0",
     "@types/js-yaml": "^4.0.9"
   }
 }

--- a/libs/provisioner/docker/src/config.ts
+++ b/libs/provisioner/docker/src/config.ts
@@ -1,7 +1,28 @@
-import {createConfig, str} from '@shipfox/config';
+import {createConfig, num, str} from '@shipfox/config';
 
 export const config = createConfig({
   SHIPFOX_PROVISIONER_TEMPLATES_FILE: str({
     desc: 'Path to the YAML file describing the Docker runner templates this provisioner can start. Required. Each template lists its labels, image, cpu, memory, and max_concurrency.',
   }),
+  SHIPFOX_PROVISIONER_DOCKER_HOST: str({
+    desc: 'Docker daemon host used by dockerode. Leave unset to use the local Docker socket, or set a Docker host URL when the daemon is remote.',
+    default: undefined,
+  }),
+  SHIPFOX_PROVISIONER_DOCKER_NETWORK: str({
+    desc: 'Docker network attached to runner containers. Set it when containers must join a Compose or bridge network to reach SHIPFOX_RUNNER_API_URL.',
+    default: undefined,
+  }),
+  SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS: num({
+    desc: 'How long a created runner container may remain unstarted before the provisioner reaps it as a stale pre-run resource, in milliseconds.',
+    default: 120_000,
+  }),
 });
+
+if (
+  !Number.isInteger(config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS) ||
+  config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS <= 0
+) {
+  throw new Error(
+    `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS must be a positive integer; got ${config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS}.`,
+  );
+}

--- a/libs/provisioner/docker/src/container-identity.test.ts
+++ b/libs/provisioner/docker/src/container-identity.test.ts
@@ -1,0 +1,70 @@
+import type {ProvisionedRunnerLaunch, ProvisionerIdentity} from '@shipfox/provisioner-core';
+import {buildContainerLabels, parseContainerIdentity, SHIPFOX_LABELS} from '#container-identity.js';
+import type {DockerContainerView} from '#docker-engine.js';
+import type {DockerTemplateSpec} from '#templates.js';
+
+const identity: ProvisionerIdentity = {
+  id: '00000000-0000-4000-8000-000000000001',
+  workspaceId: '00000000-0000-4000-8000-000000000002',
+};
+
+const launch: ProvisionedRunnerLaunch<DockerTemplateSpec> = {
+  provisionedRunnerId: 'runner-1',
+  reservationId: '00000000-0000-4000-8000-000000000003',
+  registrationToken: 'sfrt_secret',
+  registrationTokenExpiresAt: '2026-01-01T00:00:00.000Z',
+  runnerEnv: {},
+  template: {
+    key: 'small',
+    labels: ['ubuntu22', 'ubuntu22-2vcpu'],
+    maxConcurrency: 1,
+    cost: 1,
+    spec: {image: 'runner:latest', cpu: 1, memory: '1g'},
+  },
+};
+
+describe('container identity labels', () => {
+  it('round-trips launch identity through Docker labels', () => {
+    const labels = buildContainerLabels({launch, identity});
+
+    const parsed = parseContainerIdentity(view({name: 'runner-1', labels}));
+
+    expect(parsed).toEqual({
+      provisionedRunnerId: 'runner-1',
+      provisionerId: identity.id,
+      reservationId: launch.reservationId,
+      templateKey: 'small',
+      workspaceId: identity.workspaceId,
+      labels: ['ubuntu22', 'ubuntu22-2vcpu'],
+    });
+  });
+
+  it('falls back to the container name when the provisioned runner label is missing', () => {
+    const labels = buildContainerLabels({launch, identity});
+    delete labels[SHIPFOX_LABELS.provisionedRunnerId];
+
+    const parsed = parseContainerIdentity(view({name: '/runner-1', labels}));
+
+    expect(parsed.provisionedRunnerId).toBe('runner-1');
+  });
+
+  it('allows reservation_id to be absent', () => {
+    const labels = buildContainerLabels({launch, identity});
+    delete labels[SHIPFOX_LABELS.reservationId];
+
+    const parsed = parseContainerIdentity(view({name: 'runner-1', labels}));
+
+    expect(parsed.reservationId).toBeUndefined();
+    expect(parsed.labels).toEqual(['ubuntu22', 'ubuntu22-2vcpu']);
+  });
+});
+
+function view(args: {name: string; labels: Record<string, string>}): DockerContainerView {
+  return {
+    id: 'container-id',
+    name: args.name,
+    labels: args.labels,
+    state: 'running',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  };
+}

--- a/libs/provisioner/docker/src/container-identity.ts
+++ b/libs/provisioner/docker/src/container-identity.ts
@@ -1,0 +1,63 @@
+import type {ProvisionedRunnerLaunch, ProvisionerIdentity} from '@shipfox/provisioner-core';
+import {canonicalizeLabels, parseLabelList} from '@shipfox/runner-labels';
+import type {DockerContainerView} from '#docker-engine.js';
+import type {DockerTemplateSpec} from '#templates.js';
+
+const LEADING_SLASH = /^\//;
+
+export const SHIPFOX_LABELS = {
+  provisionedRunnerId: 'shipfox.provisioned_runner_id',
+  provisionerId: 'shipfox.provisioner_id',
+  reservationId: 'shipfox.reservation_id',
+  templateKey: 'shipfox.template_key',
+  workspaceId: 'shipfox.workspace_id',
+  labels: 'shipfox.labels',
+} as const;
+
+export interface ParsedContainerIdentity {
+  readonly provisionedRunnerId: string;
+  readonly provisionerId?: string;
+  readonly reservationId?: string;
+  readonly templateKey?: string;
+  readonly workspaceId?: string;
+  readonly labels: readonly string[];
+}
+
+export function buildContainerLabels(args: {
+  launch: ProvisionedRunnerLaunch<DockerTemplateSpec>;
+  identity: ProvisionerIdentity;
+}): Record<string, string> {
+  return {
+    [SHIPFOX_LABELS.provisionedRunnerId]: args.launch.provisionedRunnerId,
+    [SHIPFOX_LABELS.provisionerId]: args.identity.id,
+    [SHIPFOX_LABELS.reservationId]: args.launch.reservationId,
+    [SHIPFOX_LABELS.templateKey]: args.launch.template.key,
+    [SHIPFOX_LABELS.workspaceId]: args.identity.workspaceId,
+    [SHIPFOX_LABELS.labels]: args.launch.template.labels.join(','),
+  };
+}
+
+export function parseContainerIdentity(
+  view: Pick<DockerContainerView, 'name' | 'labels'>,
+): ParsedContainerIdentity {
+  const provisionedRunnerId =
+    view.labels[SHIPFOX_LABELS.provisionedRunnerId] ?? view.name.replace(LEADING_SLASH, '');
+  const labels = canonicalizeLabels(parseLabelList(view.labels[SHIPFOX_LABELS.labels] ?? ''));
+
+  return {
+    provisionedRunnerId,
+    ...(view.labels[SHIPFOX_LABELS.provisionerId]
+      ? {provisionerId: view.labels[SHIPFOX_LABELS.provisionerId]}
+      : {}),
+    ...(view.labels[SHIPFOX_LABELS.reservationId]
+      ? {reservationId: view.labels[SHIPFOX_LABELS.reservationId]}
+      : {}),
+    ...(view.labels[SHIPFOX_LABELS.templateKey]
+      ? {templateKey: view.labels[SHIPFOX_LABELS.templateKey]}
+      : {}),
+    ...(view.labels[SHIPFOX_LABELS.workspaceId]
+      ? {workspaceId: view.labels[SHIPFOX_LABELS.workspaceId]}
+      : {}),
+    labels,
+  };
+}

--- a/libs/provisioner/docker/src/docker-engine.integration.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.integration.test.ts
@@ -7,23 +7,25 @@ describe.skipIf(!hasDockerDaemon())('DockerEngine integration', () => {
     const engine = createDockerEngine();
     const name = `shipfox-test-${randomUUID()}`;
 
-    await engine.createAndStart({
-      name,
-      image: 'alpine:3.20',
-      env: {},
-      labels: {
-        'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
-        'shipfox.provisioned_runner_id': name,
-      },
-      nanoCpus: 100_000_000,
-      memoryBytes: 32 * 1024 * 1024,
-    });
+    try {
+      await engine.createAndStart({
+        name,
+        image: 'alpine:3.20',
+        env: {},
+        labels: {
+          'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+          'shipfox.provisioned_runner_id': name,
+        },
+        nanoCpus: 100_000_000,
+        memoryBytes: 32 * 1024 * 1024,
+      });
 
-    const containers = await engine.listManaged('00000000-0000-4000-8000-000000000001');
+      const containers = await engine.listManaged('00000000-0000-4000-8000-000000000001');
 
-    expect(containers.some((container) => container.name === name)).toBe(true);
-
-    await engine.remove(name);
+      expect(containers.some((container) => container.name === name)).toBe(true);
+    } finally {
+      await engine.remove(name);
+    }
   });
 });
 

--- a/libs/provisioner/docker/src/docker-engine.integration.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.integration.test.ts
@@ -1,0 +1,37 @@
+import {execFileSync} from 'node:child_process';
+import {randomUUID} from 'node:crypto';
+import {createDockerEngine} from '#docker-engine.js';
+
+describe.skipIf(!hasDockerDaemon())('DockerEngine integration', () => {
+  it('creates, lists, inspects, and removes a managed container', async () => {
+    const engine = createDockerEngine();
+    const name = `shipfox-test-${randomUUID()}`;
+
+    await engine.createAndStart({
+      name,
+      image: 'alpine:3.20',
+      env: {},
+      labels: {
+        'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+        'shipfox.provisioned_runner_id': name,
+      },
+      nanoCpus: 100_000_000,
+      memoryBytes: 32 * 1024 * 1024,
+    });
+
+    const containers = await engine.listManaged('00000000-0000-4000-8000-000000000001');
+
+    expect(containers.some((container) => container.name === name)).toBe(true);
+
+    await engine.remove(name);
+  });
+});
+
+function hasDockerDaemon(): boolean {
+  try {
+    execFileSync('docker', ['info'], {stdio: 'ignore'});
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/libs/provisioner/docker/src/docker-engine.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.test.ts
@@ -1,0 +1,171 @@
+import {Readable} from 'node:stream';
+import {createDockerEngine, DockerEngineError} from '#docker-engine.js';
+
+describe('createDockerEngine', () => {
+  it('pulls an image when absent and skips pull when present', async () => {
+    const docker = fakeDocker({missingImages: new Set(['runner:missing'])});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await engine.ensureImage('runner:present');
+    await engine.ensureImage('runner:missing');
+
+    expect(docker.pulled).toEqual(['runner:missing']);
+  });
+
+  it('creates and starts a container with Docker resource limits', async () => {
+    const docker = fakeDocker();
+    const engine = createDockerEngine({docker: docker as never, network: 'shipfox'});
+
+    await engine.createAndStart({
+      name: 'runner-1',
+      image: 'runner:latest',
+      env: {A: '1'},
+      labels: {'shipfox.provisioner_id': 'p1'},
+      nanoCpus: 1_000_000_000,
+      memoryBytes: 1024,
+    });
+
+    expect(docker.created[0]).toMatchObject({
+      Image: 'runner:latest',
+      name: 'runner-1',
+      Env: ['A=1'],
+      HostConfig: {
+        NanoCpus: 1_000_000_000,
+        Memory: 1024,
+        RestartPolicy: {Name: 'no'},
+        NetworkMode: 'shipfox',
+      },
+    });
+    expect(docker.started).toEqual(['runner-1']);
+  });
+
+  it('removes a created container when start fails', async () => {
+    const docker = fakeDocker({startError: new Error('start failed')});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await expect(
+      engine.createAndStart({
+        name: 'runner-1',
+        image: 'runner:latest',
+        env: {},
+        labels: {'shipfox.provisioner_id': 'p1'},
+        nanoCpus: 1,
+        memoryBytes: 1,
+      }),
+    ).rejects.toMatchObject({reason: 'start-failed'});
+
+    expect(docker.removed).toEqual(['runner-1']);
+  });
+
+  it('maps connection errors to daemon-unreachable', async () => {
+    const error = new Error('connect') as NodeJS.ErrnoException;
+    error.code = 'ECONNREFUSED';
+    const docker = fakeDocker({listError: error});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await expect(engine.listManaged('p1')).rejects.toMatchObject({
+      reason: 'daemon-unreachable',
+    });
+  });
+
+  it('inspects exited containers for exit code and OOM status', async () => {
+    const docker = fakeDocker({
+      containers: [
+        {
+          Id: 'id1',
+          Names: ['/runner-1'],
+          Labels: {'shipfox.provisioner_id': 'p1'},
+          State: 'exited',
+          Created: 1,
+        },
+      ],
+      inspectById: new Map([['id1', {State: {ExitCode: 137, OOMKilled: true}}]]),
+    });
+    const engine = createDockerEngine({docker: docker as never});
+
+    const result = await engine.listManaged('p1');
+
+    expect(result[0]).toMatchObject({
+      id: 'id1',
+      name: 'runner-1',
+      state: 'exited',
+      exitCode: 137,
+      oomKilled: true,
+    });
+  });
+});
+
+function fakeDocker(
+  options: {
+    missingImages?: Set<string>;
+    startError?: Error;
+    listError?: Error;
+    containers?: unknown[];
+    inspectById?: Map<string, unknown>;
+  } = {},
+) {
+  const pulled: string[] = [];
+  const created: unknown[] = [];
+  const started: string[] = [];
+  const removed: string[] = [];
+  const missingImages = options.missingImages ?? new Set<string>();
+
+  return {
+    pulled,
+    created,
+    started,
+    removed,
+    modem: {
+      followProgress: (_stream: NodeJS.ReadableStream, callback: (error: Error | null) => void) =>
+        callback(null),
+    },
+    getImage: (image: string) => ({
+      inspect: () => {
+        if (missingImages.has(image)) {
+          missingImages.delete(image);
+          return Promise.reject(statusError(404));
+        }
+        return Promise.resolve({});
+      },
+    }),
+    pull: (image: string) => {
+      pulled.push(image);
+      return Promise.resolve(Readable.from([]));
+    },
+    createContainer: (params: unknown) => {
+      created.push(params);
+      const name = (params as {name: string}).name;
+      return Promise.resolve({
+        start: () => {
+          if (options.startError) return Promise.reject(options.startError);
+          started.push(name);
+          return Promise.resolve();
+        },
+        remove: () => {
+          removed.push(name);
+          return Promise.resolve();
+        },
+      });
+    },
+    listContainers: () => {
+      if (options.listError) return Promise.reject(options.listError);
+      return Promise.resolve(options.containers ?? []);
+    },
+    getContainer: (id: string) => ({
+      inspect: () => Promise.resolve(options.inspectById?.get(id) ?? {}),
+      remove: () => {
+        removed.push(id);
+        return Promise.resolve();
+      },
+      kill: () => Promise.resolve(),
+    }),
+  };
+}
+
+function statusError(statusCode: number): DockerEngineError & {statusCode: number} {
+  const error = new DockerEngineError('unknown', 'docker error') as DockerEngineError & {
+    statusCode: number;
+  };
+  error.statusCode = statusCode;
+  return error;
+}

--- a/libs/provisioner/docker/src/docker-engine.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.test.ts
@@ -1,5 +1,5 @@
 import {Readable} from 'node:stream';
-import {createDockerEngine, DockerEngineError} from '#docker-engine.js';
+import {createDockerEngine} from '#docker-engine.js';
 
 describe('createDockerEngine', () => {
   it('pulls an image when absent and skips pull when present', async () => {
@@ -57,6 +57,22 @@ describe('createDockerEngine', () => {
     expect(docker.removed).toEqual(['runner-1']);
   });
 
+  it('maps create conflicts to name-conflict', async () => {
+    const docker = fakeDocker({createError: statusError(409)});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await expect(
+      engine.createAndStart({
+        name: 'runner-1',
+        image: 'runner:latest',
+        env: {},
+        labels: {'shipfox.provisioner_id': 'p1'},
+        nanoCpus: 1,
+        memoryBytes: 1,
+      }),
+    ).rejects.toMatchObject({reason: 'name-conflict'});
+  });
+
   it('maps connection errors to daemon-unreachable', async () => {
     const error = new Error('connect') as NodeJS.ErrnoException;
     error.code = 'ECONNREFUSED';
@@ -93,15 +109,55 @@ describe('createDockerEngine', () => {
       oomKilled: true,
     });
   });
+
+  it('keeps listed exited containers when inspect races with removal', async () => {
+    const docker = fakeDocker({
+      containers: [
+        {
+          Id: 'id1',
+          Names: ['/runner-1'],
+          Labels: {'shipfox.provisioner_id': 'p1'},
+          State: 'exited',
+          Created: 1,
+        },
+      ],
+      inspectErrorById: new Map([['id1', statusError(404)]]),
+    });
+    const engine = createDockerEngine({docker: docker as never});
+
+    const result = await engine.listManaged('p1');
+
+    expect(result).toEqual([
+      {
+        id: 'id1',
+        name: 'runner-1',
+        labels: {'shipfox.provisioner_id': 'p1'},
+        state: 'exited',
+        createdAt: new Date(1000),
+      },
+    ]);
+  });
+
+  it('removes containers when kill reports not running', async () => {
+    const docker = fakeDocker({killErrorById: new Map([['runner-1', statusError(409)]])});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await engine.killAndRemove('runner-1');
+
+    expect(docker.removed).toEqual(['runner-1']);
+  });
 });
 
 function fakeDocker(
   options: {
     missingImages?: Set<string>;
+    createError?: Error;
     startError?: Error;
     listError?: Error;
     containers?: unknown[];
     inspectById?: Map<string, unknown>;
+    inspectErrorById?: Map<string, Error>;
+    killErrorById?: Map<string, Error>;
   } = {},
 ) {
   const pulled: string[] = [];
@@ -133,6 +189,7 @@ function fakeDocker(
       return Promise.resolve(Readable.from([]));
     },
     createContainer: (params: unknown) => {
+      if (options.createError) return Promise.reject(options.createError);
       created.push(params);
       const name = (params as {name: string}).name;
       return Promise.resolve({
@@ -152,20 +209,26 @@ function fakeDocker(
       return Promise.resolve(options.containers ?? []);
     },
     getContainer: (id: string) => ({
-      inspect: () => Promise.resolve(options.inspectById?.get(id) ?? {}),
+      inspect: () => {
+        const inspectError = options.inspectErrorById?.get(id);
+        if (inspectError) return Promise.reject(inspectError);
+        return Promise.resolve(options.inspectById?.get(id) ?? {});
+      },
       remove: () => {
         removed.push(id);
         return Promise.resolve();
       },
-      kill: () => Promise.resolve(),
+      kill: () => {
+        const killError = options.killErrorById?.get(id);
+        if (killError) return Promise.reject(killError);
+        return Promise.resolve();
+      },
     }),
   };
 }
 
-function statusError(statusCode: number): DockerEngineError & {statusCode: number} {
-  const error = new DockerEngineError('unknown', 'docker error') as DockerEngineError & {
-    statusCode: number;
-  };
+function statusError(statusCode: number): Error & {statusCode: number} {
+  const error = new Error('docker error') as Error & {statusCode: number};
   error.statusCode = statusCode;
   return error;
 }

--- a/libs/provisioner/docker/src/docker-engine.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.test.ts
@@ -1,5 +1,5 @@
 import {Readable} from 'node:stream';
-import {createDockerEngine} from '#docker-engine.js';
+import {createDockerEngine, dockerOptionsForHost} from '#docker-engine.js';
 
 describe('createDockerEngine', () => {
   it('pulls an image when absent and skips pull when present', async () => {
@@ -71,6 +71,13 @@ describe('createDockerEngine', () => {
         memoryBytes: 1,
       }),
     ).rejects.toMatchObject({reason: 'name-conflict'});
+  });
+
+  it('preserves image-not-found for image 404s', async () => {
+    const docker = fakeDocker({pullError: statusError(404), missingImages: new Set(['missing'])});
+    const engine = createDockerEngine({docker: docker as never});
+
+    await expect(engine.ensureImage('missing')).rejects.toMatchObject({reason: 'image-not-found'});
   });
 
   it('maps connection errors to daemon-unreachable', async () => {
@@ -146,6 +153,21 @@ describe('createDockerEngine', () => {
 
     expect(docker.removed).toEqual(['runner-1']);
   });
+
+  it.each([
+    ['unix:///var/run/docker.sock', {socketPath: '/var/run/docker.sock'}],
+    ['tcp://127.0.0.1:2375', {protocol: 'http', host: '127.0.0.1', port: 2375}],
+    [
+      'https://docker.example.test:2376',
+      {protocol: 'https', host: 'docker.example.test', port: 2376},
+    ],
+    ['ssh://docker.example.test:22', {protocol: 'ssh', host: 'docker.example.test', port: 22}],
+    ['docker.example.test', {host: 'docker.example.test'}],
+  ])('parses Docker host %s', (host, expected) => {
+    const result = dockerOptionsForHost(host);
+
+    expect(result).toEqual(expected);
+  });
 });
 
 function fakeDocker(
@@ -153,6 +175,7 @@ function fakeDocker(
     missingImages?: Set<string>;
     createError?: Error;
     startError?: Error;
+    pullError?: Error;
     listError?: Error;
     containers?: unknown[];
     inspectById?: Map<string, unknown>;
@@ -185,6 +208,7 @@ function fakeDocker(
       },
     }),
     pull: (image: string) => {
+      if (options.pullError) return Promise.reject(options.pullError);
       pulled.push(image);
       return Promise.resolve(Readable.from([]));
     },

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -65,7 +65,7 @@ export interface CreateDockerEngineOptions {
 }
 
 export function createDockerEngine(options: CreateDockerEngineOptions = {}): DockerEngine {
-  const docker = options.docker ?? new Docker(options.host ? {host: options.host} : {});
+  const docker = options.docker ?? new Docker(dockerOptionsForHost(options.host));
 
   return {
     async ensureImage(image) {
@@ -238,9 +238,39 @@ function mapError(
   if (error instanceof DockerEngineError) return error;
   if (isConnectionError(error))
     return new DockerEngineError('daemon-unreachable', message, {cause: error});
-  if (isNotFound(error)) return new DockerEngineError('not-found', message, {cause: error});
+  if (isNotFound(error))
+    return new DockerEngineError(fallback === 'image-not-found' ? fallback : 'not-found', message, {
+      cause: error,
+    });
   if (isConflict(error)) return new DockerEngineError('name-conflict', message, {cause: error});
   return new DockerEngineError(fallback, message, {cause: error});
+}
+
+export function dockerOptionsForHost(host: string | undefined): Docker.DockerOptions {
+  if (!host) return {};
+  if (host.startsWith('unix://')) return {socketPath: new URL(host).pathname};
+
+  try {
+    const url = new URL(host);
+    if (url.protocol === 'tcp:' || url.protocol === 'http:' || url.protocol === 'https:') {
+      return {
+        protocol: url.protocol === 'https:' ? 'https' : 'http',
+        host: url.hostname,
+        ...(url.port ? {port: Number(url.port)} : {}),
+      };
+    }
+    if (url.protocol === 'ssh:') {
+      return {
+        protocol: 'ssh',
+        host: url.hostname,
+        ...(url.port ? {port: Number(url.port)} : {}),
+      };
+    }
+  } catch {
+    return {host};
+  }
+
+  return {host};
 }
 
 function isConnectionError(error: unknown): boolean {

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -143,8 +143,7 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
         return Promise.all(
           containers.map(async (container) => {
             const state = normalizeState(container.State);
-            const inspected =
-              state === 'exited' ? await docker.getContainer(container.Id).inspect() : undefined;
+            const inspected = state === 'exited' ? await inspectContainer(container.Id) : undefined;
             return {
               id: container.Id,
               name: container.Names?.[0]?.replace(LEADING_SLASH, '') ?? container.Id,
@@ -179,7 +178,7 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
       try {
         await container.kill();
       } catch (error) {
-        if (!isNotFound(error)) {
+        if (!isNotFound(error) && !isConflict(error)) {
           throw mapError(error, 'unknown', `Cannot kill Docker container ${name}.`);
         }
       }
@@ -192,6 +191,15 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
       }
     },
   };
+
+  async function inspectContainer(id: string): Promise<Docker.ContainerInspectInfo | undefined> {
+    try {
+      return await docker.getContainer(id).inspect();
+    } catch (error) {
+      if (isNotFound(error)) return undefined;
+      throw error;
+    }
+  }
 }
 
 async function followProgress(docker: Docker, stream: NodeJS.ReadableStream): Promise<void> {

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -1,0 +1,264 @@
+import Docker from 'dockerode';
+import {SHIPFOX_LABELS} from '#container-identity.js';
+
+const LEADING_SLASH = /^\//;
+
+export type DockerEngineErrorReason =
+  | 'daemon-unreachable'
+  | 'image-not-found'
+  | 'name-conflict'
+  | 'create-failed'
+  | 'start-failed'
+  | 'not-found'
+  | 'unknown';
+
+export class DockerEngineError extends Error {
+  constructor(
+    public readonly reason: DockerEngineErrorReason,
+    message: string,
+    options?: {cause?: unknown},
+  ) {
+    super(message, options);
+    this.name = 'DockerEngineError';
+  }
+}
+
+export type DockerContainerState =
+  | 'created'
+  | 'running'
+  | 'exited'
+  | 'dead'
+  | 'removing'
+  | 'paused'
+  | 'restarting'
+  | 'unknown';
+
+export interface DockerContainerView {
+  readonly id: string;
+  readonly name: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly state: DockerContainerState;
+  readonly exitCode?: number;
+  readonly oomKilled?: boolean;
+  readonly createdAt: Date;
+}
+
+export interface DockerEngine {
+  ensureImage(image: string): Promise<void>;
+  createAndStart(args: {
+    name: string;
+    image: string;
+    env: Readonly<Record<string, string>>;
+    labels: Readonly<Record<string, string>>;
+    nanoCpus: number;
+    memoryBytes: number;
+  }): Promise<void>;
+  listManaged(provisionerId: string): Promise<DockerContainerView[]>;
+  remove(name: string): Promise<void>;
+  killAndRemove(name: string): Promise<void>;
+}
+
+export interface CreateDockerEngineOptions {
+  readonly host?: string;
+  readonly network?: string;
+  readonly docker?: Docker;
+}
+
+export function createDockerEngine(options: CreateDockerEngineOptions = {}): DockerEngine {
+  const docker = options.docker ?? new Docker(options.host ? {host: options.host} : {});
+
+  return {
+    async ensureImage(image) {
+      try {
+        await docker.getImage(image).inspect();
+        return;
+      } catch (error) {
+        if (!isNotFound(error))
+          throw mapError(error, 'image-not-found', `Cannot inspect image ${image}.`);
+      }
+
+      try {
+        const stream = await docker.pull(image);
+        await followProgress(docker, stream);
+      } catch (error) {
+        throw mapError(error, 'image-not-found', `Cannot pull image ${image}.`);
+      }
+
+      try {
+        await docker.getImage(image).inspect();
+      } catch (error) {
+        if (isNotFound(error)) {
+          throw new DockerEngineError(
+            'image-not-found',
+            `Image ${image} is not available after pull.`,
+            {
+              cause: error,
+            },
+          );
+        }
+        throw mapError(error, 'image-not-found', `Image ${image} is not available after pull.`);
+      }
+    },
+
+    async createAndStart(args) {
+      await this.ensureImage(args.image);
+      let container: Docker.Container | undefined;
+
+      try {
+        container = await docker.createContainer({
+          Image: args.image,
+          name: args.name,
+          Labels: {...args.labels},
+          Env: Object.entries(args.env).map(([key, value]) => `${key}=${value}`),
+          HostConfig: {
+            NanoCpus: args.nanoCpus,
+            Memory: args.memoryBytes,
+            RestartPolicy: {Name: 'no'},
+            ...(options.network ? {NetworkMode: options.network} : {}),
+          },
+        });
+      } catch (error) {
+        throw mapError(
+          error,
+          isConflict(error) ? 'name-conflict' : 'create-failed',
+          'Cannot create runner container.',
+        );
+      }
+
+      try {
+        await container.start();
+      } catch (error) {
+        await removeContainer(container).catch(() => undefined);
+        throw mapError(error, 'start-failed', 'Cannot start runner container.');
+      }
+    },
+
+    async listManaged(provisionerId) {
+      try {
+        const containers = await docker.listContainers({
+          all: true,
+          filters: {label: [`${SHIPFOX_LABELS.provisionerId}=${provisionerId}`]},
+        });
+
+        return Promise.all(
+          containers.map(async (container) => {
+            const state = normalizeState(container.State);
+            const inspected =
+              state === 'exited' ? await docker.getContainer(container.Id).inspect() : undefined;
+            return {
+              id: container.Id,
+              name: container.Names?.[0]?.replace(LEADING_SLASH, '') ?? container.Id,
+              labels: container.Labels ?? {},
+              state,
+              ...(inspected?.State?.ExitCode !== undefined
+                ? {exitCode: inspected.State.ExitCode}
+                : {}),
+              ...(inspected?.State?.OOMKilled !== undefined
+                ? {oomKilled: inspected.State.OOMKilled}
+                : {}),
+              createdAt: new Date(container.Created * 1000),
+            };
+          }),
+        );
+      } catch (error) {
+        throw mapError(error, 'unknown', 'Cannot list managed Docker containers.');
+      }
+    },
+
+    async remove(name) {
+      try {
+        await docker.getContainer(name).remove({force: true});
+      } catch (error) {
+        if (isNotFound(error)) return;
+        throw mapError(error, 'unknown', `Cannot remove Docker container ${name}.`);
+      }
+    },
+
+    async killAndRemove(name) {
+      const container = docker.getContainer(name);
+      try {
+        await container.kill();
+      } catch (error) {
+        if (!isNotFound(error)) {
+          throw mapError(error, 'unknown', `Cannot kill Docker container ${name}.`);
+        }
+      }
+
+      try {
+        await container.remove({force: true});
+      } catch (error) {
+        if (isNotFound(error)) return;
+        throw mapError(error, 'unknown', `Cannot remove Docker container ${name}.`);
+      }
+    },
+  };
+}
+
+async function followProgress(docker: Docker, stream: NodeJS.ReadableStream): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    docker.modem.followProgress(stream, (error: Error | null) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function removeContainer(container: Docker.Container): Promise<void> {
+  await container.remove({force: true});
+}
+
+function normalizeState(state: string | undefined): DockerContainerState {
+  switch (state) {
+    case 'created':
+    case 'running':
+    case 'exited':
+    case 'dead':
+    case 'removing':
+    case 'paused':
+    case 'restarting':
+      return state;
+    default:
+      return 'unknown';
+  }
+}
+
+function mapError(
+  error: unknown,
+  fallback: DockerEngineErrorReason,
+  message: string,
+): DockerEngineError {
+  if (error instanceof DockerEngineError) return error;
+  if (isConnectionError(error))
+    return new DockerEngineError('daemon-unreachable', message, {cause: error});
+  if (isNotFound(error)) return new DockerEngineError('not-found', message, {cause: error});
+  if (isConflict(error)) return new DockerEngineError('name-conflict', message, {cause: error});
+  return new DockerEngineError(fallback, message, {cause: error});
+}
+
+function isConnectionError(error: unknown): boolean {
+  return (
+    isNodeError(error) &&
+    ['ECONNREFUSED', 'ENOENT', 'EACCES', 'EPIPE', 'ECONNRESET'].includes(String(error.code))
+  );
+}
+
+function isNotFound(error: unknown): boolean {
+  return hasStatusCode(error, 404);
+}
+
+function isConflict(error: unknown): boolean {
+  return hasStatusCode(error, 409);
+}
+
+function hasStatusCode(error: unknown, statusCode: number): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'statusCode' in error &&
+    (error as {statusCode?: unknown}).statusCode === statusCode
+  );
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -1,0 +1,325 @@
+import type {
+  ReportProvisionedRunnersBodyDto,
+  ReportProvisionedRunnersResponseDto,
+} from '@shipfox/api-runners-dto';
+import type {
+  ProvisionedRunnerLaunch,
+  ProvisionedRunnerTracker,
+  ProvisionerClient,
+  ProvisionerTemplate,
+} from '@shipfox/provisioner-core';
+import {type DockerContainerView, type DockerEngine, DockerEngineError} from '#docker-engine.js';
+import {createDockerLifecycle} from '#lifecycle.js';
+import type {DockerTemplateSpec} from '#templates.js';
+
+const NOW = new Date('2026-01-01T00:10:00.000Z');
+const RESERVATION_ID = '00000000-0000-4000-8000-000000000003';
+
+const template: ProvisionerTemplate<DockerTemplateSpec> = {
+  key: 'small',
+  labels: ['ubuntu22'],
+  maxConcurrency: 10,
+  cost: 1,
+  spec: {image: 'runner:latest', cpu: 1.5, memory: '2g'},
+};
+
+describe('createDockerLifecycle', () => {
+  it('launch reports starting and creates a labeled container with resources and env', async () => {
+    const engine = fakeEngine();
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.launch(launch());
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      reservation_id: RESERVATION_ID,
+      template_key: 'small',
+      labels: ['ubuntu22'],
+      state: 'starting',
+      provider_kind: 'docker',
+    });
+    expect(engine.created[0]).toMatchObject({
+      name: 'runner-1',
+      image: 'runner:latest',
+      env: {SHIPFOX_RUNNER_TOKEN: 'sfrt_secret'},
+      nanoCpus: 1_500_000_000,
+      memoryBytes: 2 * 1024 ** 3,
+    });
+    expect(engine.created[0]?.labels['shipfox.provisioned_runner_id']).toBe('runner-1');
+  });
+
+  it('reports failed and rethrows when the engine fails to launch', async () => {
+    const engine = fakeEngine({
+      createError: new DockerEngineError('start-failed', 'cannot start'),
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.launch(launch())).rejects.toThrow(DockerEngineError);
+
+    expect(client.reportBodies.map((body) => body.events[0]?.state)).toEqual([
+      'starting',
+      'failed',
+    ]);
+    expect(client.reportBodies[1]?.events[0]?.reason).toBe('start-failed');
+  });
+
+  it('observe re-reports running containers every tick', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+    await lifecycle.observe();
+
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'running',
+      'running',
+    ]);
+  });
+
+  it('reports terminal exited containers and removes them only after report succeeds', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 0})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies[0]?.events[0]?.state).toBe('stopped');
+    expect(engine.removed).toEqual(['runner-1']);
+  });
+
+  it('does not remove terminal containers when reporting fails', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const client = fakeClient({reportError: new Error('api down')});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.observe()).rejects.toThrow('api down');
+
+    expect(engine.removed).toEqual([]);
+  });
+
+  it('marks OOM exits as failed with an oom reason', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 137, oomKilled: true})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'failed', reason: 'oom'});
+  });
+
+  it('reaps only created containers past the registration deadline', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          name: 'created-old',
+          state: 'created',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+        container({
+          name: 'running-old',
+          state: 'running',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await lifecycle.observe();
+
+    expect(engine.killedAndRemoved).toEqual(['created-old']);
+    expect(engine.removed).toEqual([]);
+    expect(client.reportBodies.flatMap((body) => body.events.map((event) => event.state))).toEqual([
+      'running',
+      'terminated',
+    ]);
+  });
+
+  it('reconcile rebuilds tracker counts from listed containers', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({name: 'starting-1', state: 'created'}),
+        container({name: 'running-1', state: 'running'}),
+      ],
+    });
+    const tracker = testTracker();
+    const lifecycle = makeLifecycle({engine, tracker});
+
+    await lifecycle.reconcile();
+
+    expect(tracker.countsByTemplate()).toEqual(new Map([['small', {starting: 1, running: 1}]]));
+  });
+
+  it('chunks report batches at 1000 events', async () => {
+    const engine = fakeEngine({
+      containers: Array.from({length: 1001}, (_, index) =>
+        container({name: `runner-${index}`, state: 'running'}),
+      ),
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies.map((body) => body.events.length)).toEqual([1000, 1]);
+  });
+});
+
+function makeLifecycle(
+  args: {
+    engine?: ReturnType<typeof fakeEngine>;
+    client?: ReturnType<typeof fakeClient>;
+    tracker?: ProvisionedRunnerTracker;
+    registrationDeadlineMs?: number;
+  } = {},
+) {
+  return createDockerLifecycle({
+    engine: args.engine ?? fakeEngine(),
+    client: args.client ?? fakeClient(),
+    identity: {
+      id: '00000000-0000-4000-8000-000000000001',
+      workspaceId: '00000000-0000-4000-8000-000000000002',
+    },
+    tracker: args.tracker ?? testTracker(),
+    templates: [template],
+    now: () => NOW,
+    registrationDeadlineMs: args.registrationDeadlineMs ?? 120_000,
+    providerKind: 'docker',
+  });
+}
+
+function launch(): ProvisionedRunnerLaunch<DockerTemplateSpec> {
+  return {
+    provisionedRunnerId: 'runner-1',
+    reservationId: RESERVATION_ID,
+    registrationToken: 'sfrt_secret',
+    registrationTokenExpiresAt: '2026-01-01T00:00:00.000Z',
+    runnerEnv: {SHIPFOX_RUNNER_TOKEN: 'sfrt_secret'},
+    template,
+  };
+}
+
+function fakeClient(options: {reportError?: Error} = {}): ProvisionerClient & {
+  reportBodies: ReportProvisionedRunnersBodyDto[];
+} {
+  const reportBodies: ReportProvisionedRunnersBodyDto[] = [];
+  return {
+    reportBodies,
+    getIdentity: () =>
+      Promise.resolve({
+        id: '00000000-0000-4000-8000-000000000001',
+        workspace_id: '00000000-0000-4000-8000-000000000002',
+      }),
+    pollDemand: () => Promise.resolve({stats: [], reservations: []}),
+    mintRegistrationTokens: () => Promise.resolve({tokens: []}),
+    reportProvisionedRunners: (body): Promise<ReportProvisionedRunnersResponseDto> => {
+      reportBodies.push(body);
+      if (options.reportError) return Promise.reject(options.reportError);
+      return Promise.resolve({accepted: body.events.length, reservations_released: 0});
+    },
+  };
+}
+
+function fakeEngine(
+  options: {containers?: DockerContainerView[]; createError?: Error} = {},
+): DockerEngine & {
+  created: Parameters<DockerEngine['createAndStart']>[0][];
+  removed: string[];
+  killedAndRemoved: string[];
+} {
+  const created: Parameters<DockerEngine['createAndStart']>[0][] = [];
+  const removed: string[] = [];
+  const killedAndRemoved: string[] = [];
+
+  return {
+    created,
+    removed,
+    killedAndRemoved,
+    ensureImage: () => Promise.resolve(),
+    createAndStart: (args) => {
+      if (options.createError) return Promise.reject(options.createError);
+      created.push(args);
+      return Promise.resolve();
+    },
+    listManaged: () => Promise.resolve(options.containers ?? []),
+    remove: (name) => {
+      removed.push(name);
+      return Promise.resolve();
+    },
+    killAndRemove: (name) => {
+      killedAndRemoved.push(name);
+      return Promise.resolve();
+    },
+  };
+}
+
+function testTracker(): ProvisionedRunnerTracker {
+  const runners = new Map<string, {templateKey: string; state: 'starting' | 'running'}>();
+  return {
+    recordStarting: ({provisionedRunnerId, templateKey}) => {
+      runners.set(provisionedRunnerId, {templateKey, state: 'starting'});
+    },
+    markRunning: (provisionedRunnerId) => {
+      const runner = runners.get(provisionedRunnerId);
+      if (runner) runner.state = 'running';
+    },
+    remove: (provisionedRunnerId) => {
+      runners.delete(provisionedRunnerId);
+    },
+    replaceAll: (nextRunners) => {
+      runners.clear();
+      for (const runner of nextRunners) {
+        runners.set(runner.provisionedRunnerId, {
+          templateKey: runner.templateKey,
+          state: runner.state,
+        });
+      }
+    },
+    countsByTemplate: () => {
+      const counts = new Map<string, {starting: number; running: number}>();
+      for (const runner of runners.values()) {
+        const current = counts.get(runner.templateKey) ?? {starting: 0, running: 0};
+        current[runner.state] += 1;
+        counts.set(runner.templateKey, current);
+      }
+      return counts;
+    },
+  };
+}
+
+function container(args: {
+  name?: string;
+  state: DockerContainerView['state'];
+  exitCode?: number;
+  oomKilled?: boolean;
+  createdAt?: Date;
+}): DockerContainerView {
+  const name = args.name ?? 'runner-1';
+  return {
+    id: name,
+    name,
+    labels: {
+      'shipfox.provisioned_runner_id': name,
+      'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
+      'shipfox.reservation_id': RESERVATION_ID,
+      'shipfox.template_key': 'small',
+      'shipfox.workspace_id': '00000000-0000-4000-8000-000000000002',
+      'shipfox.labels': 'ubuntu22',
+    },
+    state: args.state,
+    ...(args.exitCode !== undefined ? {exitCode: args.exitCode} : {}),
+    ...(args.oomKilled !== undefined ? {oomKilled: args.oomKilled} : {}),
+    createdAt: args.createdAt ?? NOW,
+  };
+}

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -106,6 +106,23 @@ describe('createDockerLifecycle', () => {
     expect(engine.removed).toEqual([]);
   });
 
+  it('does not reap stale created containers when reporting fails', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({
+          state: 'created',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        }),
+      ],
+    });
+    const client = fakeClient({reportError: new Error('api down')});
+    const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
+
+    await expect(lifecycle.observe()).rejects.toThrow('api down');
+
+    expect(engine.killedAndRemoved).toEqual([]);
+  });
+
   it('marks OOM exits as failed with an oom reason', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'exited', exitCode: 137, oomKilled: true})],

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -130,8 +130,8 @@ export function createDockerLifecycle(args: {
     if (liveEvents.length > 0) await report(liveEvents);
 
     for (const action of terminalActions) {
-      if (action.killAndRemove) await args.engine.killAndRemove(action.killAndRemove);
       await report([action.event]);
+      if (action.killAndRemove) await args.engine.killAndRemove(action.killAndRemove);
       if (action.remove) await args.engine.remove(action.remove);
       knownLiveIds.delete(action.event.provisioned_runner_id);
       knownTemplateKeys.delete(action.event.provisioned_runner_id);

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -1,0 +1,262 @@
+import type {ProvisionedRunnerReportEventDto} from '@shipfox/api-runners-dto';
+import {logger} from '@shipfox/node-opentelemetry';
+import type {
+  ProvisionedRunnerLaunch,
+  ProvisionedRunnerTracker,
+  ProvisionerClient,
+  ProvisionerIdentity,
+  ProvisionerTemplate,
+} from '@shipfox/provisioner-core';
+import {buildContainerLabels, parseContainerIdentity} from '#container-identity.js';
+import {type DockerContainerView, type DockerEngine, DockerEngineError} from '#docker-engine.js';
+import {parseMemoryToBytes} from '#memory.js';
+import type {DockerTemplateSpec} from '#templates.js';
+
+const MAX_REPORT_BATCH = 1000;
+const MAX_REASON_LENGTH = 500;
+
+type TrackerSeed = {
+  provisionedRunnerId: string;
+  templateKey: string;
+  state: 'starting' | 'running';
+};
+
+export interface DockerLifecycle {
+  launch(launch: ProvisionedRunnerLaunch<DockerTemplateSpec>): Promise<void>;
+  observe(): Promise<void>;
+  reconcile(): Promise<void>;
+  flush(): Promise<void>;
+}
+
+export function createDockerLifecycle(args: {
+  engine: DockerEngine;
+  client: ProvisionerClient;
+  identity: ProvisionerIdentity;
+  tracker: ProvisionedRunnerTracker;
+  templates: readonly ProvisionerTemplate<DockerTemplateSpec>[];
+  now?: () => Date;
+  registrationDeadlineMs: number;
+  providerKind: string;
+}): DockerLifecycle {
+  const now = args.now ?? (() => new Date());
+  const templatesByKey = new Map(args.templates.map((template) => [template.key, template]));
+  const knownLiveIds = new Set<string>();
+  const knownTemplateKeys = new Map<string, string>();
+
+  async function report(events: ProvisionedRunnerReportEventDto[]): Promise<void> {
+    for (const batch of chunk(events, MAX_REPORT_BATCH)) {
+      await args.client.reportProvisionedRunners({events: batch});
+    }
+  }
+
+  async function observe(): Promise<void> {
+    const containers = await args.engine.listManaged(args.identity.id);
+    const listedIds = new Set<string>();
+    const trackerRunners: TrackerSeed[] = [];
+    const liveEvents: ProvisionedRunnerReportEventDto[] = [];
+    const terminalActions: Array<{
+      event: ProvisionedRunnerReportEventDto;
+      remove?: string;
+      killAndRemove?: string;
+    }> = [];
+
+    for (const container of containers) {
+      const parsed = parseContainerIdentity(container);
+      listedIds.add(parsed.provisionedRunnerId);
+      const labels = labelsFor(parsed.templateKey, parsed.labels);
+      if (labels.length === 0) {
+        logger().warn(
+          {provisionedRunnerId: parsed.provisionedRunnerId},
+          'Skipping provisioned runner report because labels are unavailable',
+        );
+        continue;
+      }
+
+      if (
+        container.state === 'created' &&
+        isPastDeadline(container.createdAt, now(), args.registrationDeadlineMs)
+      ) {
+        terminalActions.push({
+          event: eventFor(container, 'terminated', labels, args.providerKind, now()),
+          killAndRemove: container.name,
+        });
+        continue;
+      }
+
+      const mapped = mapContainerState(container);
+      if (mapped.state === 'starting' || mapped.state === 'running') {
+        knownLiveIds.add(parsed.provisionedRunnerId);
+        if (parsed.templateKey)
+          knownTemplateKeys.set(parsed.provisionedRunnerId, parsed.templateKey);
+        liveEvents.push(
+          eventFor(container, mapped.state, labels, args.providerKind, now(), mapped.reason),
+        );
+        const templateKey = parsed.templateKey;
+        if (templateKey) {
+          trackerRunners.push({
+            provisionedRunnerId: parsed.provisionedRunnerId,
+            templateKey,
+            state: mapped.state,
+          });
+        }
+      } else {
+        terminalActions.push({
+          event: eventFor(container, mapped.state, labels, args.providerKind, now(), mapped.reason),
+          remove: container.name,
+        });
+      }
+    }
+
+    for (const provisionedRunnerId of [...knownLiveIds]) {
+      if (listedIds.has(provisionedRunnerId)) continue;
+      knownLiveIds.delete(provisionedRunnerId);
+      const templateKey = knownTemplateKeys.get(provisionedRunnerId);
+      knownTemplateKeys.delete(provisionedRunnerId);
+      const template = templateKey ? templatesByKey.get(templateKey) : undefined;
+      if (!template) continue;
+      terminalActions.push({
+        event: {
+          provisioned_runner_id: provisionedRunnerId,
+          template_key: template.key,
+          labels: [...template.labels],
+          state: 'terminated',
+          reported_at: now().toISOString(),
+          provider_kind: args.providerKind,
+        },
+      });
+    }
+
+    args.tracker.replaceAll(trackerRunners);
+    if (liveEvents.length > 0) await report(liveEvents);
+
+    for (const action of terminalActions) {
+      if (action.killAndRemove) await args.engine.killAndRemove(action.killAndRemove);
+      await report([action.event]);
+      if (action.remove) await args.engine.remove(action.remove);
+      knownLiveIds.delete(action.event.provisioned_runner_id);
+      knownTemplateKeys.delete(action.event.provisioned_runner_id);
+      args.tracker.remove(action.event.provisioned_runner_id);
+    }
+  }
+
+  return {
+    async launch(launch) {
+      const labels = buildContainerLabels({launch, identity: args.identity});
+      await report([
+        {
+          provisioned_runner_id: launch.provisionedRunnerId,
+          reservation_id: launch.reservationId,
+          template_key: launch.template.key,
+          labels: [...launch.template.labels],
+          state: 'starting',
+          reported_at: now().toISOString(),
+          provider_kind: args.providerKind,
+        },
+      ]);
+
+      try {
+        await args.engine.createAndStart({
+          name: launch.provisionedRunnerId,
+          image: launch.template.spec.image,
+          env: launch.runnerEnv,
+          labels,
+          nanoCpus: Math.round(launch.template.spec.cpu * 1_000_000_000),
+          memoryBytes: parseMemoryToBytes(launch.template.spec.memory),
+        });
+        knownLiveIds.add(launch.provisionedRunnerId);
+        knownTemplateKeys.set(launch.provisionedRunnerId, launch.template.key);
+      } catch (error) {
+        await report([
+          {
+            provisioned_runner_id: launch.provisionedRunnerId,
+            reservation_id: launch.reservationId,
+            template_key: launch.template.key,
+            labels: [...launch.template.labels],
+            state: 'failed',
+            reason: truncateReason(errorReason(error)),
+            reported_at: now().toISOString(),
+            provider_kind: args.providerKind,
+          },
+        ]);
+        throw error;
+      }
+    },
+    observe,
+    reconcile: observe,
+    flush: () => Promise.resolve(),
+  };
+
+  function labelsFor(
+    templateKey: string | undefined,
+    labels: readonly string[],
+  ): readonly string[] {
+    if (labels.length > 0) return labels;
+    return templateKey ? (templatesByKey.get(templateKey)?.labels ?? []) : [];
+  }
+}
+
+function eventFor(
+  container: DockerContainerView,
+  state: ProvisionedRunnerReportEventDto['state'],
+  labels: readonly string[],
+  providerKind: string,
+  reportedAt: Date,
+  reason?: string,
+): ProvisionedRunnerReportEventDto {
+  const parsed = parseContainerIdentity(container);
+  return {
+    provisioned_runner_id: parsed.provisionedRunnerId,
+    ...(parsed.reservationId ? {reservation_id: parsed.reservationId} : {}),
+    ...(parsed.templateKey ? {template_key: parsed.templateKey} : {}),
+    labels: [...labels],
+    state,
+    ...(reason ? {reason: truncateReason(reason)} : {}),
+    reported_at: reportedAt.toISOString(),
+    provider_kind: providerKind,
+  };
+}
+
+function mapContainerState(container: DockerContainerView): {
+  state: ProvisionedRunnerReportEventDto['state'];
+  reason?: string;
+} {
+  switch (container.state) {
+    case 'created':
+      return {state: 'starting'};
+    case 'running':
+    case 'paused':
+    case 'restarting':
+      return {state: 'running'};
+    case 'exited':
+      if (container.oomKilled) return {state: 'failed', reason: 'oom'};
+      return container.exitCode === 0
+        ? {state: 'stopped'}
+        : {state: 'failed', reason: `exit-code-${container.exitCode ?? 'unknown'}`};
+    case 'dead':
+    case 'removing':
+      return {state: 'terminated'};
+    default:
+      return {state: 'running', reason: `docker-state-${container.state}`};
+  }
+}
+
+function isPastDeadline(createdAt: Date, now: Date, deadlineMs: number): boolean {
+  return now.getTime() - createdAt.getTime() > deadlineMs;
+}
+
+function errorReason(error: unknown): string {
+  if (error instanceof DockerEngineError) return error.reason;
+  return error instanceof Error ? error.message : String(error);
+}
+
+function truncateReason(reason: string): string {
+  return reason.slice(0, MAX_REASON_LENGTH);
+}
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -28,7 +28,7 @@ export interface DockerLifecycle {
   flush(): Promise<void>;
 }
 
-export function createDockerLifecycle(args: {
+interface DockerLifecycleOptions {
   engine: DockerEngine;
   client: ProvisionerClient;
   identity: ProvisionerIdentity;
@@ -37,162 +37,265 @@ export function createDockerLifecycle(args: {
   now?: () => Date;
   registrationDeadlineMs: number;
   providerKind: string;
-}): DockerLifecycle {
+}
+
+interface DockerLifecycleContext {
+  readonly engine: DockerEngine;
+  readonly client: ProvisionerClient;
+  readonly identity: ProvisionerIdentity;
+  readonly tracker: ProvisionedRunnerTracker;
+  readonly templatesByKey: ReadonlyMap<string, ProvisionerTemplate<DockerTemplateSpec>>;
+  readonly now: () => Date;
+  readonly registrationDeadlineMs: number;
+  readonly providerKind: string;
+  readonly knownLiveIds: Set<string>;
+  readonly knownTemplateKeys: Map<string, string>;
+}
+
+interface ObservationPlan {
+  readonly trackerRunners: TrackerSeed[];
+  readonly liveEvents: ProvisionedRunnerReportEventDto[];
+  readonly terminalActions: TerminalAction[];
+}
+
+interface TerminalAction {
+  readonly event: ProvisionedRunnerReportEventDto;
+  readonly remove?: string;
+  readonly killAndRemove?: string;
+}
+
+type LiveContainerState = {
+  state: 'starting' | 'running';
+  reason?: string;
+};
+type ParsedContainerIdentity = ReturnType<typeof parseContainerIdentity>;
+
+export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifecycle {
   const now = args.now ?? (() => new Date());
-  const templatesByKey = new Map(args.templates.map((template) => [template.key, template]));
-  const knownLiveIds = new Set<string>();
-  const knownTemplateKeys = new Map<string, string>();
-
-  async function report(events: ProvisionedRunnerReportEventDto[]): Promise<void> {
-    for (const batch of chunk(events, MAX_REPORT_BATCH)) {
-      await args.client.reportProvisionedRunners({events: batch});
-    }
-  }
-
-  async function observe(): Promise<void> {
-    const containers = await args.engine.listManaged(args.identity.id);
-    const listedIds = new Set<string>();
-    const trackerRunners: TrackerSeed[] = [];
-    const liveEvents: ProvisionedRunnerReportEventDto[] = [];
-    const terminalActions: Array<{
-      event: ProvisionedRunnerReportEventDto;
-      remove?: string;
-      killAndRemove?: string;
-    }> = [];
-
-    for (const container of containers) {
-      const parsed = parseContainerIdentity(container);
-      listedIds.add(parsed.provisionedRunnerId);
-      const labels = labelsFor(parsed.templateKey, parsed.labels);
-      if (labels.length === 0) {
-        logger().warn(
-          {provisionedRunnerId: parsed.provisionedRunnerId},
-          'Skipping provisioned runner report because labels are unavailable',
-        );
-        continue;
-      }
-
-      if (
-        container.state === 'created' &&
-        isPastDeadline(container.createdAt, now(), args.registrationDeadlineMs)
-      ) {
-        terminalActions.push({
-          event: eventFor(container, 'terminated', labels, args.providerKind, now()),
-          killAndRemove: container.name,
-        });
-        continue;
-      }
-
-      const mapped = mapContainerState(container);
-      if (mapped.state === 'starting' || mapped.state === 'running') {
-        knownLiveIds.add(parsed.provisionedRunnerId);
-        if (parsed.templateKey)
-          knownTemplateKeys.set(parsed.provisionedRunnerId, parsed.templateKey);
-        liveEvents.push(
-          eventFor(container, mapped.state, labels, args.providerKind, now(), mapped.reason),
-        );
-        const templateKey = parsed.templateKey;
-        if (templateKey) {
-          trackerRunners.push({
-            provisionedRunnerId: parsed.provisionedRunnerId,
-            templateKey,
-            state: mapped.state,
-          });
-        }
-      } else {
-        terminalActions.push({
-          event: eventFor(container, mapped.state, labels, args.providerKind, now(), mapped.reason),
-          remove: container.name,
-        });
-      }
-    }
-
-    for (const provisionedRunnerId of [...knownLiveIds]) {
-      if (listedIds.has(provisionedRunnerId)) continue;
-      knownLiveIds.delete(provisionedRunnerId);
-      const templateKey = knownTemplateKeys.get(provisionedRunnerId);
-      knownTemplateKeys.delete(provisionedRunnerId);
-      const template = templateKey ? templatesByKey.get(templateKey) : undefined;
-      if (!template) continue;
-      terminalActions.push({
-        event: {
-          provisioned_runner_id: provisionedRunnerId,
-          template_key: template.key,
-          labels: [...template.labels],
-          state: 'terminated',
-          reported_at: now().toISOString(),
-          provider_kind: args.providerKind,
-        },
-      });
-    }
-
-    args.tracker.replaceAll(trackerRunners);
-    if (liveEvents.length > 0) await report(liveEvents);
-
-    for (const action of terminalActions) {
-      await report([action.event]);
-      if (action.killAndRemove) await args.engine.killAndRemove(action.killAndRemove);
-      if (action.remove) await args.engine.remove(action.remove);
-      knownLiveIds.delete(action.event.provisioned_runner_id);
-      knownTemplateKeys.delete(action.event.provisioned_runner_id);
-      args.tracker.remove(action.event.provisioned_runner_id);
-    }
-  }
-
-  return {
-    async launch(launch) {
-      const labels = buildContainerLabels({launch, identity: args.identity});
-      await report([
-        {
-          provisioned_runner_id: launch.provisionedRunnerId,
-          reservation_id: launch.reservationId,
-          template_key: launch.template.key,
-          labels: [...launch.template.labels],
-          state: 'starting',
-          reported_at: now().toISOString(),
-          provider_kind: args.providerKind,
-        },
-      ]);
-
-      try {
-        await args.engine.createAndStart({
-          name: launch.provisionedRunnerId,
-          image: launch.template.spec.image,
-          env: launch.runnerEnv,
-          labels,
-          nanoCpus: Math.round(launch.template.spec.cpu * 1_000_000_000),
-          memoryBytes: parseMemoryToBytes(launch.template.spec.memory),
-        });
-        knownLiveIds.add(launch.provisionedRunnerId);
-        knownTemplateKeys.set(launch.provisionedRunnerId, launch.template.key);
-      } catch (error) {
-        await report([
-          {
-            provisioned_runner_id: launch.provisionedRunnerId,
-            reservation_id: launch.reservationId,
-            template_key: launch.template.key,
-            labels: [...launch.template.labels],
-            state: 'failed',
-            reason: truncateReason(errorReason(error)),
-            reported_at: now().toISOString(),
-            provider_kind: args.providerKind,
-          },
-        ]);
-        throw error;
-      }
-    },
-    observe,
-    reconcile: observe,
-    flush: () => Promise.resolve(),
+  const context: DockerLifecycleContext = {
+    engine: args.engine,
+    client: args.client,
+    identity: args.identity,
+    tracker: args.tracker,
+    templatesByKey: new Map(args.templates.map((template) => [template.key, template])),
+    now,
+    registrationDeadlineMs: args.registrationDeadlineMs,
+    providerKind: args.providerKind,
+    knownLiveIds: new Set<string>(),
+    knownTemplateKeys: new Map<string, string>(),
   };
 
-  function labelsFor(
-    templateKey: string | undefined,
-    labels: readonly string[],
-  ): readonly string[] {
-    if (labels.length > 0) return labels;
-    return templateKey ? (templatesByKey.get(templateKey)?.labels ?? []) : [];
+  return {
+    launch: (runner) => launch(context, runner),
+    observe: () => observe(context),
+    reconcile: () => observe(context),
+    flush: () => Promise.resolve(),
+  };
+}
+
+async function launch(
+  context: DockerLifecycleContext,
+  runner: ProvisionedRunnerLaunch<DockerTemplateSpec>,
+): Promise<void> {
+  const labels = buildContainerLabels({launch: runner, identity: context.identity});
+  await reportEvents(context, [
+    {
+      provisioned_runner_id: runner.provisionedRunnerId,
+      reservation_id: runner.reservationId,
+      template_key: runner.template.key,
+      labels: [...runner.template.labels],
+      state: 'starting',
+      reported_at: context.now().toISOString(),
+      provider_kind: context.providerKind,
+    },
+  ]);
+
+  try {
+    await context.engine.createAndStart({
+      name: runner.provisionedRunnerId,
+      image: runner.template.spec.image,
+      env: runner.runnerEnv,
+      labels,
+      nanoCpus: Math.round(runner.template.spec.cpu * 1_000_000_000),
+      memoryBytes: parseMemoryToBytes(runner.template.spec.memory),
+    });
+    context.knownLiveIds.add(runner.provisionedRunnerId);
+    context.knownTemplateKeys.set(runner.provisionedRunnerId, runner.template.key);
+  } catch (error) {
+    await reportEvents(context, [
+      {
+        provisioned_runner_id: runner.provisionedRunnerId,
+        reservation_id: runner.reservationId,
+        template_key: runner.template.key,
+        labels: [...runner.template.labels],
+        state: 'failed',
+        reason: truncateReason(errorReason(error)),
+        reported_at: context.now().toISOString(),
+        provider_kind: context.providerKind,
+      },
+    ]);
+    throw error;
   }
+}
+
+async function observe(context: DockerLifecycleContext): Promise<void> {
+  const containers = await context.engine.listManaged(context.identity.id);
+  const plan = buildObservationPlan(context, containers);
+
+  context.tracker.replaceAll(plan.trackerRunners);
+  if (plan.liveEvents.length > 0) await reportEvents(context, plan.liveEvents);
+  await applyTerminalActions(context, plan.terminalActions);
+}
+
+function buildObservationPlan(
+  context: DockerLifecycleContext,
+  containers: readonly DockerContainerView[],
+): ObservationPlan {
+  const listedIds = new Set<string>();
+  const plan: ObservationPlan = {
+    trackerRunners: [],
+    liveEvents: [],
+    terminalActions: [],
+  };
+
+  for (const container of containers) {
+    recordContainerObservation(context, plan, listedIds, container);
+  }
+  synthesizeVanishedContainers(context, plan, listedIds);
+
+  return plan;
+}
+
+function recordContainerObservation(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+  listedIds: Set<string>,
+  container: DockerContainerView,
+): void {
+  const parsed = parseContainerIdentity(container);
+  listedIds.add(parsed.provisionedRunnerId);
+  const labels = labelsFor(context, parsed.templateKey, parsed.labels);
+  if (labels.length === 0) {
+    logger().warn(
+      {provisionedRunnerId: parsed.provisionedRunnerId},
+      'Skipping provisioned runner report because labels are unavailable',
+    );
+    return;
+  }
+
+  if (
+    container.state === 'created' &&
+    isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs)
+  ) {
+    plan.terminalActions.push({
+      event: eventFor(container, 'terminated', labels, context.providerKind, context.now()),
+      killAndRemove: container.name,
+    });
+    return;
+  }
+
+  const mapped = mapContainerState(container);
+  if (mapped.state === 'starting' || mapped.state === 'running') {
+    const liveState: LiveContainerState = {
+      state: mapped.state,
+      ...(mapped.reason ? {reason: mapped.reason} : {}),
+    };
+    recordLiveContainer(context, plan, container, parsed, labels, liveState);
+    return;
+  }
+
+  plan.terminalActions.push({
+    event: eventFor(
+      container,
+      mapped.state,
+      labels,
+      context.providerKind,
+      context.now(),
+      mapped.reason,
+    ),
+    remove: container.name,
+  });
+}
+
+function recordLiveContainer(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+  container: DockerContainerView,
+  parsed: ParsedContainerIdentity,
+  labels: readonly string[],
+  mapped: LiveContainerState,
+): void {
+  context.knownLiveIds.add(parsed.provisionedRunnerId);
+  if (parsed.templateKey) {
+    context.knownTemplateKeys.set(parsed.provisionedRunnerId, parsed.templateKey);
+  }
+  plan.liveEvents.push(
+    eventFor(container, mapped.state, labels, context.providerKind, context.now(), mapped.reason),
+  );
+  if (parsed.templateKey) {
+    plan.trackerRunners.push({
+      provisionedRunnerId: parsed.provisionedRunnerId,
+      templateKey: parsed.templateKey,
+      state: mapped.state,
+    });
+  }
+}
+
+function synthesizeVanishedContainers(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+  listedIds: ReadonlySet<string>,
+): void {
+  for (const provisionedRunnerId of [...context.knownLiveIds]) {
+    if (listedIds.has(provisionedRunnerId)) continue;
+    context.knownLiveIds.delete(provisionedRunnerId);
+    const templateKey = context.knownTemplateKeys.get(provisionedRunnerId);
+    context.knownTemplateKeys.delete(provisionedRunnerId);
+    const template = templateKey ? context.templatesByKey.get(templateKey) : undefined;
+    if (!template) continue;
+    plan.terminalActions.push({
+      event: {
+        provisioned_runner_id: provisionedRunnerId,
+        template_key: template.key,
+        labels: [...template.labels],
+        state: 'terminated',
+        reported_at: context.now().toISOString(),
+        provider_kind: context.providerKind,
+      },
+    });
+  }
+}
+
+async function applyTerminalActions(
+  context: DockerLifecycleContext,
+  actions: readonly TerminalAction[],
+): Promise<void> {
+  for (const action of actions) {
+    await reportEvents(context, [action.event]);
+    if (action.killAndRemove) await context.engine.killAndRemove(action.killAndRemove);
+    if (action.remove) await context.engine.remove(action.remove);
+    context.knownLiveIds.delete(action.event.provisioned_runner_id);
+    context.knownTemplateKeys.delete(action.event.provisioned_runner_id);
+    context.tracker.remove(action.event.provisioned_runner_id);
+  }
+}
+
+async function reportEvents(
+  context: DockerLifecycleContext,
+  events: readonly ProvisionedRunnerReportEventDto[],
+): Promise<void> {
+  for (const batch of chunk(events, MAX_REPORT_BATCH)) {
+    await context.client.reportProvisionedRunners({events: batch});
+  }
+}
+
+function labelsFor(
+  context: DockerLifecycleContext,
+  templateKey: string | undefined,
+  labels: readonly string[],
+): readonly string[] {
+  if (labels.length > 0) return labels;
+  return templateKey ? (context.templatesByKey.get(templateKey)?.labels ?? []) : [];
 }
 
 function eventFor(

--- a/libs/provisioner/docker/src/memory.test.ts
+++ b/libs/provisioner/docker/src/memory.test.ts
@@ -1,0 +1,19 @@
+import {parseMemoryToBytes} from '#memory.js';
+
+describe('parseMemoryToBytes', () => {
+  it.each([
+    ['4GiB', 4 * 1024 ** 3],
+    ['512m', 512 * 1024 ** 2],
+    ['2g', 2 * 1024 ** 3],
+    ['2gib', 2 * 1024 ** 3],
+    ['512', 512],
+  ])('parses %s', (input, expected) => {
+    const result = parseMemoryToBytes(input);
+
+    expect(result).toBe(expected);
+  });
+
+  it('throws on invalid memory values', () => {
+    expect(() => parseMemoryToBytes('potato')).toThrow('Invalid Docker memory value');
+  });
+});

--- a/libs/provisioner/docker/src/memory.ts
+++ b/libs/provisioner/docker/src/memory.ts
@@ -1,0 +1,34 @@
+export const MEMORY_PATTERN = /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|kib|mib|gib|tib|k|m|g|t)?$/i;
+const MEMORY_PARTS_PATTERN = /^(\d+(?:\.\d+)?)\s*([a-z]+)?$/i;
+
+const UNITS: Record<string, number> = {
+  b: 1,
+  k: 1024,
+  kb: 1024,
+  kib: 1024,
+  m: 1024 ** 2,
+  mb: 1024 ** 2,
+  mib: 1024 ** 2,
+  g: 1024 ** 3,
+  gb: 1024 ** 3,
+  gib: 1024 ** 3,
+  t: 1024 ** 4,
+  tb: 1024 ** 4,
+  tib: 1024 ** 4,
+};
+
+export function parseMemoryToBytes(memory: string): number {
+  const match = memory.trim().match(MEMORY_PARTS_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid Docker memory value: ${memory}.`);
+  }
+
+  const value = Number(match[1]);
+  const unit = match[2]?.toLowerCase() ?? 'b';
+  const multiplier = UNITS[unit];
+  if (!Number.isFinite(value) || multiplier === undefined) {
+    throw new Error(`Invalid Docker memory value: ${memory}.`);
+  }
+
+  return Math.floor(value * multiplier);
+}

--- a/libs/provisioner/docker/src/memory.ts
+++ b/libs/provisioner/docker/src/memory.ts
@@ -1,4 +1,4 @@
-export const MEMORY_PATTERN = /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|kib|mib|gib|tib|k|m|g|t)$/i;
+export const MEMORY_PATTERN = /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|kib|mib|gib|tib|k|m|g|t)?$/i;
 const MEMORY_PARTS_PATTERN = /^(\d+(?:\.\d+)?)\s*([a-z]+)?$/i;
 
 const UNITS: Record<string, number> = {

--- a/libs/provisioner/docker/src/memory.ts
+++ b/libs/provisioner/docker/src/memory.ts
@@ -1,4 +1,4 @@
-export const MEMORY_PATTERN = /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|kib|mib|gib|tib|k|m|g|t)?$/i;
+export const MEMORY_PATTERN = /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|kib|mib|gib|tib|k|m|g|t)$/i;
 const MEMORY_PARTS_PATTERN = /^(\d+(?:\.\d+)?)\s*([a-z]+)?$/i;
 
 const UNITS: Record<string, number> = {

--- a/libs/provisioner/docker/src/provisioner.ts
+++ b/libs/provisioner/docker/src/provisioner.ts
@@ -1,6 +1,7 @@
-import {logger} from '@shipfox/node-opentelemetry';
-import {loggingLaunch, startProvisioner} from '@shipfox/provisioner-core';
+import {startProvisioner} from '@shipfox/provisioner-core';
 import {config} from '#config.js';
+import {createDockerEngine} from '#docker-engine.js';
+import {createDockerLifecycle, type DockerLifecycle} from '#lifecycle.js';
 import {type DockerTemplateSpec, loadDockerTemplates} from '#templates.js';
 
 /**
@@ -8,16 +9,43 @@ import {type DockerTemplateSpec, loadDockerTemplates} from '#templates.js';
  * the provider-agnostic control loop against them with the configured launcher.
  */
 export function startDockerProvisioner(): Promise<void> {
-  // This launcher reserves demand and mints registration tokens but does not start
-  // containers, so it must not be pointed at a production API.
-  logger().warn(
-    'Docker provisioner is running with a logging launcher: it reserves demand and mints registration tokens but does NOT start runner containers. Do not run it against a production API.',
-  );
+  const templates = loadDockerTemplates(config.SHIPFOX_PROVISIONER_TEMPLATES_FILE);
+  const engine = createDockerEngine({
+    ...(config.SHIPFOX_PROVISIONER_DOCKER_HOST
+      ? {host: config.SHIPFOX_PROVISIONER_DOCKER_HOST}
+      : {}),
+    ...(config.SHIPFOX_PROVISIONER_DOCKER_NETWORK
+      ? {network: config.SHIPFOX_PROVISIONER_DOCKER_NETWORK}
+      : {}),
+  });
+  let lifecycle: DockerLifecycle | undefined;
+
   return startProvisioner<DockerTemplateSpec>({
     adapter: {
-      loadTemplates: () =>
-        Promise.resolve(loadDockerTemplates(config.SHIPFOX_PROVISIONER_TEMPLATES_FILE)),
-      launch: loggingLaunch,
+      loadTemplates: () => Promise.resolve(templates),
+      launch: (launch) => {
+        if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
+        return lifecycle.launch(launch);
+      },
+      async onStart(runtime) {
+        lifecycle = createDockerLifecycle({
+          engine,
+          client: runtime.client,
+          identity: runtime.identity,
+          tracker: runtime.tracker,
+          templates,
+          registrationDeadlineMs: config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS,
+          providerKind: 'docker',
+        });
+        await lifecycle.reconcile();
+      },
+      onTick() {
+        if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
+        return lifecycle.observe();
+      },
+      onStop() {
+        return lifecycle?.flush() ?? Promise.resolve();
+      },
     },
   });
 }

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -120,7 +120,7 @@ templates:
     expect(() => loadDockerTemplates(path)).toThrow('memory');
   });
 
-  it('accepts a memory value with no unit as bytes', () => {
+  it('throws on a memory value with no unit', () => {
     const path = writeTemplates(`
 templates:
   t:
@@ -131,9 +131,7 @@ templates:
     max_concurrency: 1
 `);
 
-    const [template] = loadDockerTemplates(path);
-
-    expect(template?.spec.memory).toBe('512');
+    expect(() => loadDockerTemplates(path)).toThrow('memory');
   });
 
   it('throws on a label that cannot be a runner label', () => {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -120,7 +120,7 @@ templates:
     expect(() => loadDockerTemplates(path)).toThrow('memory');
   });
 
-  it('throws on a memory value with no unit', () => {
+  it('accepts a memory value with no unit as bytes', () => {
     const path = writeTemplates(`
 templates:
   t:
@@ -131,7 +131,8 @@ templates:
     max_concurrency: 1
 `);
 
-    expect(() => loadDockerTemplates(path)).toThrow('memory');
+    const [template] = loadDockerTemplates(path);
+    expect(template?.spec.memory).toBe('512');
   });
 
   it('throws on a label that cannot be a runner label', () => {

--- a/libs/provisioner/docker/src/templates.test.ts
+++ b/libs/provisioner/docker/src/templates.test.ts
@@ -120,7 +120,7 @@ templates:
     expect(() => loadDockerTemplates(path)).toThrow('memory');
   });
 
-  it('throws on a memory value with no unit (a bare number would mean bytes)', () => {
+  it('accepts a memory value with no unit as bytes', () => {
     const path = writeTemplates(`
 templates:
   t:
@@ -131,7 +131,9 @@ templates:
     max_concurrency: 1
 `);
 
-    expect(() => loadDockerTemplates(path)).toThrow('memory');
+    const [template] = loadDockerTemplates(path);
+
+    expect(template?.spec.memory).toBe('512');
   });
 
   it('throws on a label that cannot be a runner label', () => {

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -26,7 +26,7 @@ const dockerTemplateSchema = z.object({
   labels: z.array(z.string()).min(1),
   image: z.string().trim().min(1),
   cpu: z.number().positive(),
-  memory: z.string().regex(MEMORY_PATTERN, 'must be a size like "4GiB", "512m", or "2g"'),
+  memory: z.string().regex(MEMORY_PATTERN, 'must be a size like "4GiB", "512m", "2g", or "512"'),
   max_concurrency: z.number().int().positive().max(MAX_TEMPLATE_CONCURRENCY),
 });
 

--- a/libs/provisioner/docker/src/templates.ts
+++ b/libs/provisioner/docker/src/templates.ts
@@ -3,6 +3,7 @@ import type {ProvisionerTemplate} from '@shipfox/provisioner-core';
 import {canonicalizeLabels, findInvalidLabels, MAX_RUNNER_LABELS} from '@shipfox/runner-labels';
 import yaml from 'js-yaml';
 import {z} from 'zod';
+import {MEMORY_PATTERN} from '#memory.js';
 
 /** Docker-specific launch details the launcher needs to run one runner container. */
 export interface DockerTemplateSpec {
@@ -18,11 +19,6 @@ export class DockerTemplateConfigError extends Error {
     this.name = 'DockerTemplateConfigError';
   }
 }
-
-// A memory size Docker understands, such as `4GiB`, `512m`, or `2g`. The unit is
-// required because a bare number like `512` would silently mean 512 bytes, which is
-// never the intent.
-const MEMORY_PATTERN = /^\d+(\.\d+)?\s*(b|kb|mb|gb|tb|kib|mib|gib|tib|k|m|g|t)$/i;
 
 const MAX_TEMPLATE_CONCURRENCY = 100_000;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3571,8 +3571,8 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/vitest
       '@types/dockerode':
-        specifier: ^3.3.43
-        version: 3.3.47
+        specifier: ^4.0.0
+        version: 4.0.1
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -8543,8 +8543,8 @@ packages:
   '@types/docker-modem@3.0.6':
     resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
 
-  '@types/dockerode@3.3.47':
-    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
@@ -16561,7 +16561,7 @@ snapshots:
       '@types/node': 25.9.3
       '@types/ssh2': 1.15.5
 
-  '@types/dockerode@3.3.47':
+  '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
       '@types/node': 25.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3530,6 +3530,9 @@ importers:
 
   libs/provisioner/docker:
     dependencies:
+      '@shipfox/api-runners-dto':
+        specifier: workspace:*
+        version: link:../../api/runners-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
@@ -3542,6 +3545,9 @@ importers:
       '@shipfox/runner-labels':
         specifier: workspace:*
         version: link:../../shared/common/runner-labels
+      dockerode:
+        specifier: ^4.0.9
+        version: 4.0.12
       js-yaml:
         specifier: ^4.1.0
         version: 4.2.0
@@ -3564,6 +3570,9 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../tools/vitest
+      '@types/dockerode':
+        specifier: ^3.3.43
+        version: 3.3.47
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -4975,6 +4984,9 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
+
   '@biomejs/biome@2.5.0':
     resolution: {integrity: sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==}
     engines: {node: '>=14.21.3'}
@@ -5711,6 +5723,11 @@ packages:
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@grpc/proto-loader@0.8.1':
     resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
@@ -8523,6 +8540,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.47':
+    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
@@ -8558,6 +8581,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
@@ -8599,6 +8625,9 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -8902,6 +8931,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -8954,6 +8986,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
@@ -8974,6 +9009,9 @@ packages:
   binary-version@7.1.0:
     resolution: {integrity: sha512-Iy//vPc3ANPNlIWd242Npqc8MK0a/i4kVcHDlDA6HNMv5zMxz4ulIFhOSYJVKw/8AbHdHy0CnGYEt1QqSXxPsw==}
     engines: {node: '>=18'}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -9018,6 +9056,10 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -9095,6 +9137,9 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -9209,6 +9254,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -9357,6 +9406,14 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.12:
+    resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
+    engines: {node: '>= 8.0'}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -9810,6 +9867,9 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -10680,6 +10740,9 @@ packages:
     resolution: {integrity: sha512-cOrV1zC8SekUpZ2YGT174iWADRnuttYMtrAypQ1UvYXOUCOUc1DvwB8Dx8DH9+51+WyA0fNVOmUDx1Bc8qztqQ==}
     hasBin: true
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -10703,6 +10766,9 @@ packages:
   ms@3.0.0-canary.1:
     resolution: {integrity: sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==}
     engines: {node: '>=12.13'}
+
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -11669,12 +11735,19 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -11836,6 +11909,13 @@ packages:
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.7:
@@ -12017,6 +12097,9 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -12040,6 +12123,9 @@ packages:
 
   unbzip2-stream@1.4.3:
     resolution: {integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -12139,6 +12225,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
@@ -12937,6 +13028,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@balena/dockerignore@1.0.2': {}
+
   '@biomejs/biome@2.5.0':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.5.0
@@ -13588,6 +13681,13 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.4
+      yargs: 17.7.3
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
@@ -16456,6 +16556,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 25.9.3
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.47':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 25.9.3
+      '@types/ssh2': 1.15.5
+
   '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.9': {}
@@ -16489,6 +16600,10 @@ snapshots:
       '@types/node': 25.9.3
 
   '@types/node@12.20.55': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@24.13.2':
     dependencies:
@@ -16539,6 +16654,10 @@ snapshots:
   '@types/resolve@1.20.6': {}
 
   '@types/retry@0.12.0': {}
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -16924,6 +17043,10 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -16963,6 +17086,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.38: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   before-after-hook@4.0.0: {}
 
   better-path-resolve@1.0.0:
@@ -16985,6 +17112,12 @@ snapshots:
     dependencies:
       execa: 8.0.1
       find-versions: 6.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   boolbase@1.0.0: {}
 
@@ -17038,6 +17171,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   bundle-name@4.1.0:
     dependencies:
@@ -17127,6 +17263,8 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chownr@1.1.4: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -17223,6 +17361,12 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -17392,6 +17536,27 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.12:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.6.4
+      tar-fs: 2.1.5
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   doctrine@3.0.0:
     dependencies:
@@ -17848,6 +18013,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -19025,6 +19192,8 @@ snapshots:
       - typescript
       - uncss
 
+  mkdirp-classic@0.5.3: {}
+
   module-details-from-path@1.0.4: {}
 
   motion-dom@12.40.0:
@@ -19040,6 +19209,9 @@ snapshots:
   ms@2.1.3: {}
 
   ms@3.0.0-canary.1: {}
+
+  nan@2.28.0:
+    optional: true
 
   nanoid@3.3.12: {}
 
@@ -20051,9 +20223,19 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split-ca@1.0.1: {}
+
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
 
   stackback@0.0.2: {}
 
@@ -20229,6 +20411,21 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.8.0
@@ -20375,6 +20572,8 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  tweetnacl@0.14.5: {}
+
   type-fest@4.41.0: {}
 
   typebox@1.1.38: {}
@@ -20390,6 +20589,8 @@ snapshots:
     dependencies:
       buffer: 5.7.1
       through: 2.3.8
+
+  undici-types@5.26.5: {}
 
   undici-types@7.18.2: {}
 
@@ -20490,6 +20691,8 @@ snapshots:
       react: 19.2.7
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   uuid@11.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,11 @@ minimumReleaseAge: 2880
 allowBuilds:
   '@google/genai': true
   '@swc/core': true
+  cpu-features: true
   esbuild: true
   protobufjs: true
   sharp: true
+  ssh2: true
 
 packages:
   - "apps/*"


### PR DESCRIPTION
Add Docker runner lifecycle management for self-hosted provisioners.

The Docker provisioner previously reserved demand and minted runner registration tokens, but used a logging launcher that never created containers. This wires the shared provisioner loop to a real Docker provider so reserved runners become labeled Docker containers, report lifecycle state back to the API, reconcile local Docker state after restart, and clean up terminal or stale pre-run resources.

The core loop now has lifecycle hooks for provider observation and startup reconciliation. When Docker cannot be observed, the loop advertises no free capacity and backs off so a restarted provisioner does not duplicate local work. Docker-specific code is isolated behind a `DockerEngine` port with dockerode confined to one adapter file.

Review areas: lifecycle state mapping, exact cleanup ordering after terminal report acknowledgement, and the fail-closed behavior when Docker observation fails.

Closes ENG-618

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Docker runner lifecycle management so reserved runners start as labeled containers, report state, reconcile on restart, and reap stale pre-run containers. Tightens degraded-mode and error handling (stays degraded until observe succeeds, better Docker host URL handling, preserves image-not-found errors). Implements ENG-618 end-to-end.

- New Features
  - Docker provider launches one container per reservation and injects env: SHIPFOX_API_URL (from `SHIPFOX_RUNNER_API_URL` if set), SHIPFOX_RUNNER_TOKEN, SHIPFOX_RUNNER_LABELS, SHIPFOX_POLL_MAX_DURATION_MS.
  - Lifecycle reporting: starting; running (re-reported each tick); stopped/failed with exit-code/OOM reasons; terminated for dead/removing containers and stale created containers. Batches up to 1000 events.
  - Startup/restart reconciliation: observes managed containers (named by provisioned runner id, labeled `shipfox.*`), rebuilds local capacity, stays degraded and advertises zero capacity until Docker observe succeeds, and backs off when all launch attempts fail.
  - Core loop/provider: adds `reportProvisionedRunners` to `@shipfox/provisioner-core`, adapter hooks (`onStart`/`onTick`/`onStop`), tracker `replaceAll`, and isolates Docker behind a `DockerEngine` (`dockerode` confined to one file, accurate Docker host URL handling, image-not-found preserved).

- Migration
  - Ensure runner images read: SHIPFOX_API_URL, SHIPFOX_RUNNER_TOKEN, SHIPFOX_RUNNER_LABELS, SHIPFOX_POLL_MAX_DURATION_MS. Do not bake a static runner token.
  - Configure as needed: `SHIPFOX_RUNNER_API_URL`, `SHIPFOX_PROVISIONER_DOCKER_HOST`, `SHIPFOX_PROVISIONER_DOCKER_NETWORK`, `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS`.
  - Define Docker templates (image/cpu/memory/max_concurrency). Memory may be a bare number (bytes) or include a unit (e.g., “2g”, “512m”, “4GiB”).

<sup>Written for commit 5896f8a94c79657124312cfbb1e82f5869c3db90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

