### PR TITLE
Add generic webhook integration provider

### DIFF
--- a/libs/api/integration/core-dto/src/events.test.ts
+++ b/libs/api/integration/core-dto/src/events.test.ts
@@ -7,6 +7,7 @@ import {
 } from './events.js';
 
 const validEventReceived = {
+  provider: 'github',
   source: 'github',
   event: 'push',
   workspaceId: 'ws-1',

--- a/libs/api/integration/core-dto/src/events.ts
+++ b/libs/api/integration/core-dto/src/events.ts
@@ -8,6 +8,7 @@ const requiredUnknownSchema = z.custom<unknown>((value) => value !== undefined);
 const nullableConnectionNameSchema = nonEmptyStringSchema.nullish().default(null);
 
 export const integrationEventReceivedSchema = z.object({
+  provider: nonEmptyStringSchema,
   source: nonEmptyStringSchema,
   event: nonEmptyStringSchema,
   workspaceId: nonEmptyStringSchema,

--- a/libs/api/integration/core-dto/src/ports.ts
+++ b/libs/api/integration/core-dto/src/ports.ts
@@ -24,6 +24,17 @@ export type PublishIntegrationEventReceivedFn = (params: {
   event: IntegrationEventReceivedEvent;
 }) => Promise<{published: boolean}>;
 
+export type CreateIntegrationConnectionFn = (
+  params: {
+    workspaceId: string;
+    provider: string;
+    externalAccountId: string;
+    displayName: string;
+    lifecycleStatus?: IntegrationConnectionLifecycleStatus | undefined;
+  },
+  options?: {tx?: IntegrationTx},
+) => Promise<IntegrationConnection>;
+
 // Emitted by source-control providers for a single push. The delivery dedup and the outbox
 // rows it writes must commit together, so it requires a transaction, never a bare connection.
 export type PublishSourcePushFn = (params: {
@@ -52,4 +63,9 @@ export type GetIntegrationConnectionByIdFn = (
 export type UpdateIntegrationConnectionLifecycleStatusFn = (
   params: {id: string; lifecycleStatus: IntegrationConnectionLifecycleStatus},
   options?: {tx?: IntegrationTx},
-) => Promise<unknown>;
+) => Promise<IntegrationConnection | undefined>;
+
+export type DeleteIntegrationConnectionFn = (
+  params: {id: string},
+  options?: {tx?: IntegrationTx},
+) => Promise<boolean>;

--- a/libs/api/integration/core/drizzle/0000_initial.sql
+++ b/libs/api/integration/core/drizzle/0000_initial.sql
@@ -24,9 +24,10 @@ CREATE TABLE "integrations_outbox" (
 --> statement-breakpoint
 CREATE TABLE "integrations_webhook_deliveries" (
 	"provider" text NOT NULL,
+	"dedup_scope" text NOT NULL,
 	"delivery_id" text NOT NULL,
 	"received_at" timestamp with time zone DEFAULT now() NOT NULL,
-	CONSTRAINT "integrations_webhook_deliveries_provider_delivery_id_pk" PRIMARY KEY("provider","delivery_id")
+	CONSTRAINT "integrations_webhook_deliveries_dedup_pk" PRIMARY KEY("provider","dedup_scope","delivery_id")
 );
 --> statement-breakpoint
 CREATE UNIQUE INDEX "integrations_connections_workspace_external_unique" ON "integrations_connections" USING btree ("workspace_id","provider","external_account_id");--> statement-breakpoint

--- a/libs/api/integration/core/drizzle/meta/0001_snapshot.json
+++ b/libs/api/integration/core/drizzle/meta/0001_snapshot.json
@@ -244,6 +244,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "dedup_scope": {
+          "name": "dedup_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
         "delivery_id": {
           "name": "delivery_id",
           "type": "text",
@@ -277,9 +283,9 @@
       },
       "foreignKeys": {},
       "compositePrimaryKeys": {
-        "integrations_webhook_deliveries_provider_delivery_id_pk": {
-          "name": "integrations_webhook_deliveries_provider_delivery_id_pk",
-          "columns": ["provider", "delivery_id"]
+        "integrations_webhook_deliveries_dedup_pk": {
+          "name": "integrations_webhook_deliveries_dedup_pk",
+          "columns": ["provider", "dedup_scope", "delivery_id"]
         }
       },
       "uniqueConstraints": {},

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -17,4 +17,8 @@ export const config = createConfig({
     desc: 'Enables the Sentry integration provider so users can connect Sentry.',
     default: false,
   }),
+  INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER: bool({
+    desc: 'Enables the generic webhook integration provider so users can create inbound webhook URLs.',
+    default: false,
+  }),
 });

--- a/libs/api/integration/core/src/core/errors.ts
+++ b/libs/api/integration/core/src/core/errors.ts
@@ -22,6 +22,17 @@ export class IntegrationConnectionWorkspaceMismatchError extends Error {
   }
 }
 
+export class IntegrationConnectionAlreadyExistsError extends Error {
+  constructor(
+    public readonly workspaceId: string,
+    public readonly provider: IntegrationProviderKind,
+    public readonly externalAccountId: string,
+  ) {
+    super(`Integration connection already exists: ${workspaceId}/${provider}/${externalAccountId}`);
+    this.name = 'IntegrationConnectionAlreadyExistsError';
+  }
+}
+
 export class IntegrationCapabilityUnavailableError extends Error {
   constructor(capability: IntegrationCapability, provider: IntegrationProviderKind) {
     super(`Integration provider ${provider} does not expose ${capability}`);

--- a/libs/api/integration/core/src/db/connections.test.ts
+++ b/libs/api/integration/core/src/db/connections.test.ts
@@ -1,5 +1,8 @@
 import {upsertGithubInstallation} from '@shipfox/api-integration-github';
+import {IntegrationConnectionAlreadyExistsError} from '#core/errors.js';
 import {
+  createIntegrationConnection,
+  deleteIntegrationConnection,
   getIntegrationConnectionById,
   listIntegrationConnections,
   listIntegrationConnectionsByProvider,
@@ -51,6 +54,28 @@ describe('integration connection queries', () => {
     const result = await listIntegrationConnections({workspaceId});
 
     expect(result).toHaveLength(2);
+  });
+
+  it('creates a connection without upserting duplicates', async () => {
+    const first = await createIntegrationConnection({
+      workspaceId,
+      provider: 'webhook',
+      externalAccountId: 'stripe',
+      displayName: 'Stripe',
+    });
+
+    const result = createIntegrationConnection({
+      workspaceId,
+      provider: 'webhook',
+      externalAccountId: 'stripe',
+      displayName: 'Renamed Stripe',
+    });
+
+    await expect(result).rejects.toBeInstanceOf(IntegrationConnectionAlreadyExistsError);
+    const connections = await listIntegrationConnections({workspaceId});
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.id).toBe(first.id);
+    expect(connections[0]?.displayName).toBe('Stripe');
   });
 
   it('lists workspace connections across all lifecycle statuses', async () => {
@@ -137,6 +162,22 @@ describe('integration connection queries', () => {
     });
 
     expect(result).toBeUndefined();
+  });
+
+  it('deletes a connection and reports whether a row was removed', async () => {
+    const connection = await upsertIntegrationConnection({
+      workspaceId,
+      provider: 'webhook',
+      externalAccountId: 'stripe',
+      displayName: 'Stripe',
+    });
+
+    const deleted = await deleteIntegrationConnection({id: connection.id});
+    const deletedAgain = await deleteIntegrationConnection({id: connection.id});
+
+    expect(deleted).toBe(true);
+    expect(deletedAgain).toBe(false);
+    expect(await getIntegrationConnectionById(connection.id)).toBeUndefined();
   });
 
   it('rolls back a connection when provider-specific installation persistence fails', async () => {

--- a/libs/api/integration/core/src/db/connections.ts
+++ b/libs/api/integration/core/src/db/connections.ts
@@ -4,6 +4,7 @@ import type {
   IntegrationConnectionLifecycleStatus,
 } from '#core/entities/connection.js';
 import type {IntegrationProviderKind} from '#core/entities/provider.js';
+import {IntegrationConnectionAlreadyExistsError} from '#core/errors.js';
 import {db} from './db.js';
 import {integrationConnections, toIntegrationConnection} from './schema/connections.js';
 
@@ -51,6 +52,62 @@ export async function upsertIntegrationConnection(
   return toIntegrationConnection(row);
 }
 
+export interface CreateIntegrationConnectionParams {
+  workspaceId: string;
+  provider: IntegrationProviderKind;
+  externalAccountId: string;
+  displayName: string;
+  lifecycleStatus?: IntegrationConnectionLifecycleStatus | undefined;
+}
+
+function isIntegrationConnectionUniqueViolation(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current != null; depth += 1) {
+    if (typeof current !== 'object') return false;
+    const {code, constraint} = current as {code?: unknown; constraint?: unknown};
+    if (code === '23505' && constraint === 'integrations_connections_workspace_external_unique') {
+      return true;
+    }
+    current = (current as {cause?: unknown}).cause;
+  }
+  return false;
+}
+
+export async function createIntegrationConnection(
+  params: CreateIntegrationConnectionParams,
+  options: {tx?: IntegrationDb | IntegrationTx | undefined} = {},
+): Promise<IntegrationConnection> {
+  const executor = options.tx ?? db();
+  let rows: (typeof integrationConnections.$inferSelect)[];
+  try {
+    rows = await executor
+      .insert(integrationConnections)
+      .values({
+        workspaceId: params.workspaceId,
+        provider: params.provider,
+        externalAccountId: params.externalAccountId,
+        displayName: params.displayName,
+        lifecycleStatus: params.lifecycleStatus ?? 'active',
+      })
+      .returning();
+  } catch (error) {
+    if (isIntegrationConnectionUniqueViolation(error)) {
+      throw new IntegrationConnectionAlreadyExistsError(
+        params.workspaceId,
+        params.provider,
+        params.externalAccountId,
+      );
+    }
+    throw error;
+  }
+
+  const row = rows[0];
+  if (!row) throw new Error('Integration connection insert returned no rows');
+  return toIntegrationConnection(row);
+}
+
+export type CreateIntegrationConnectionFn = typeof createIntegrationConnection;
+
 export async function getIntegrationConnectionById(
   id: string,
   options: {tx?: IntegrationDb | IntegrationTx | undefined} = {},
@@ -89,6 +146,19 @@ export async function updateIntegrationConnectionLifecycleStatus(
 
 export type UpdateIntegrationConnectionLifecycleStatusFn =
   typeof updateIntegrationConnectionLifecycleStatus;
+
+export async function deleteIntegrationConnection(
+  params: {id: string},
+  options: {tx?: IntegrationDb | IntegrationTx | undefined} = {},
+): Promise<boolean> {
+  const executor = options.tx ?? db();
+  const result = await executor
+    .delete(integrationConnections)
+    .where(eq(integrationConnections.id, params.id));
+  return (result.rowCount ?? 0) > 0;
+}
+
+export type DeleteIntegrationConnectionFn = typeof deleteIntegrationConnection;
 
 export interface ListIntegrationConnectionsParams {
   workspaceId: string;

--- a/libs/api/integration/core/src/db/schema/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/schema/webhook-deliveries.ts
@@ -5,11 +5,15 @@ export const integrationsWebhookDeliveries = pgTable(
   'webhook_deliveries',
   {
     provider: text('provider').notNull(),
+    dedupScope: text('dedup_scope').notNull(),
     deliveryId: text('delivery_id').notNull(),
     receivedAt: timestamp('received_at', {withTimezone: true}).notNull().defaultNow(),
   },
   (table) => [
-    primaryKey({columns: [table.provider, table.deliveryId]}),
+    primaryKey({
+      name: 'integrations_webhook_deliveries_dedup_pk',
+      columns: [table.provider, table.dedupScope, table.deliveryId],
+    }),
     index('integrations_webhook_deliveries_received_at_idx').on(table.receivedAt),
   ],
 );

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -118,6 +118,35 @@ describe('integration webhook delivery persistence', () => {
     expect(await outboxFor(event.deliveryId)).toHaveLength(1);
   });
 
+  it('deduplicates received events per connection', async () => {
+    const deliveryId = crypto.randomUUID();
+    const firstConnectionEvent = buildEvent({
+      provider: 'webhook',
+      source: 'stripe-prod',
+      event: 'received',
+      deliveryId,
+    });
+    const secondConnectionEvent = buildEvent({
+      provider: 'webhook',
+      source: 'stripe-dev',
+      event: 'received',
+      deliveryId,
+    });
+
+    const first = await publishIntegrationEventReceived({tx: db(), event: firstConnectionEvent});
+    const second = await publishIntegrationEventReceived({tx: db(), event: secondConnectionEvent});
+    const duplicate = await publishIntegrationEventReceived({
+      tx: db(),
+      event: firstConnectionEvent,
+    });
+
+    expect(first.published).toBe(true);
+    expect(second.published).toBe(true);
+    expect(duplicate.published).toBe(false);
+    expect(await deliveriesFor('webhook', deliveryId)).toHaveLength(2);
+    expect(await outboxFor(deliveryId)).toHaveLength(2);
+  });
+
   it('records a delivery without writing an outbox event', async () => {
     const deliveryId = crypto.randomUUID();
 

--- a/libs/api/integration/core/src/db/webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.test.ts
@@ -19,6 +19,7 @@ function buildEvent(
   overrides: Partial<IntegrationEventReceivedEvent> = {},
 ): IntegrationEventReceivedEvent {
   return {
+    provider: 'github',
     source: 'github',
     event: 'push',
     workspaceId: crypto.randomUUID(),
@@ -92,11 +93,12 @@ describe('integration webhook delivery persistence', () => {
     const result = await publishIntegrationEventReceived({tx: db(), event});
 
     expect(result.published).toBe(true);
-    expect(await deliveriesFor(event.source, event.deliveryId)).toHaveLength(1);
+    expect(await deliveriesFor(event.provider, event.deliveryId)).toHaveLength(1);
     const outbox = await outboxFor(event.deliveryId);
     expect(outbox).toHaveLength(1);
     expect(outbox[0]?.eventType).toBe(INTEGRATION_EVENT_RECEIVED);
     expect(outbox[0]?.payload).toMatchObject({
+      provider: 'github',
       source: 'github',
       event: 'push',
       deliveryId: event.deliveryId,
@@ -112,7 +114,7 @@ describe('integration webhook delivery persistence', () => {
 
     expect(first.published).toBe(true);
     expect(second.published).toBe(false);
-    expect(await deliveriesFor(event.source, event.deliveryId)).toHaveLength(1);
+    expect(await deliveriesFor(event.provider, event.deliveryId)).toHaveLength(1);
     expect(await outboxFor(event.deliveryId)).toHaveLength(1);
   });
 
@@ -156,6 +158,7 @@ describe('publishSourcePush', () => {
     const envelope = outbox.find((row) => row.eventType === INTEGRATION_EVENT_RECEIVED);
     const typed = outbox.find((row) => row.eventType === INTEGRATION_SOURCE_COMMIT_PUSHED);
     expect(envelope?.payload).toMatchObject({
+      provider: 'github',
       source: 'github',
       event: 'push',
       deliveryId: params.deliveryId,

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -30,7 +30,7 @@ export async function publishIntegrationEventReceived(
   const inserted = await params.tx
     .insert(integrationsWebhookDeliveries)
     .values({
-      provider: params.event.source,
+      provider: params.event.provider,
       deliveryId: params.event.deliveryId,
     })
     .onConflictDoNothing({
@@ -85,6 +85,7 @@ export async function publishSourcePush(
     {
       type: INTEGRATION_EVENT_RECEIVED,
       payload: {
+        provider: params.provider,
         source: params.provider,
         event: 'push',
         workspaceId: params.workspaceId,

--- a/libs/api/integration/core/src/db/webhook-deliveries.ts
+++ b/libs/api/integration/core/src/db/webhook-deliveries.ts
@@ -15,6 +15,19 @@ type IntegrationDb = ReturnType<typeof db>;
 type IntegrationTx = Parameters<Parameters<IntegrationDb['transaction']>[0]>[0];
 type Executor = IntegrationDb | IntegrationTx;
 
+function connectionDedupScope(connectionId: string): string {
+  return `connection:${connectionId}`;
+}
+
+function providerDedupScope(provider: string): string {
+  return `provider:${provider}`;
+}
+
+function receivedEventDedupScope(event: IntegrationEventReceivedEvent): string {
+  if (event.provider === 'webhook') return connectionDedupScope(event.connectionId);
+  return providerDedupScope(event.provider);
+}
+
 export interface PublishIntegrationEventReceivedParams {
   tx: Executor;
   event: IntegrationEventReceivedEvent;
@@ -31,10 +44,15 @@ export async function publishIntegrationEventReceived(
     .insert(integrationsWebhookDeliveries)
     .values({
       provider: params.event.provider,
+      dedupScope: receivedEventDedupScope(params.event),
       deliveryId: params.event.deliveryId,
     })
     .onConflictDoNothing({
-      target: [integrationsWebhookDeliveries.provider, integrationsWebhookDeliveries.deliveryId],
+      target: [
+        integrationsWebhookDeliveries.provider,
+        integrationsWebhookDeliveries.dedupScope,
+        integrationsWebhookDeliveries.deliveryId,
+      ],
     })
     .returning({deliveryId: integrationsWebhookDeliveries.deliveryId});
 
@@ -72,10 +90,15 @@ export async function publishSourcePush(
     .insert(integrationsWebhookDeliveries)
     .values({
       provider: params.provider,
+      dedupScope: providerDedupScope(params.provider),
       deliveryId: params.deliveryId,
     })
     .onConflictDoNothing({
-      target: [integrationsWebhookDeliveries.provider, integrationsWebhookDeliveries.deliveryId],
+      target: [
+        integrationsWebhookDeliveries.provider,
+        integrationsWebhookDeliveries.dedupScope,
+        integrationsWebhookDeliveries.deliveryId,
+      ],
     })
     .returning({deliveryId: integrationsWebhookDeliveries.deliveryId});
 
@@ -152,10 +175,15 @@ export async function recordDeliveryOnly(params: RecordDeliveryOnlyParams): Prom
     .insert(integrationsWebhookDeliveries)
     .values({
       provider: params.provider,
+      dedupScope: providerDedupScope(params.provider),
       deliveryId: params.deliveryId,
     })
     .onConflictDoNothing({
-      target: [integrationsWebhookDeliveries.provider, integrationsWebhookDeliveries.deliveryId],
+      target: [
+        integrationsWebhookDeliveries.provider,
+        integrationsWebhookDeliveries.dedupScope,
+        integrationsWebhookDeliveries.deliveryId,
+      ],
     });
 }
 

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -3,6 +3,7 @@ import {giteaProviderModule} from '#providers/gitea.js';
 import {githubProviderModule} from '#providers/github.js';
 import {sentryProviderModule} from '#providers/sentry.js';
 import type {IntegrationModuleParts} from '#providers/types.js';
+import {webhookProviderModule} from '#providers/webhook.js';
 
 // Order is significant: databases are migrated in this order, so list a provider
 // before any that depend on its tables.
@@ -11,6 +12,7 @@ const providerModules = [
   githubProviderModule,
   sentryProviderModule,
   giteaProviderModule,
+  webhookProviderModule,
 ];
 
 export async function loadEnabledProviderModules(): Promise<IntegrationModuleParts[]> {

--- a/libs/api/integration/core/src/providers/webhook.ts
+++ b/libs/api/integration/core/src/providers/webhook.ts
@@ -1,0 +1,30 @@
+import {config} from '#config.js';
+import {
+  createIntegrationConnection,
+  deleteIntegrationConnection,
+  getIntegrationConnectionById,
+  listIntegrationConnections,
+  updateIntegrationConnectionLifecycleStatus,
+} from '#db/connections.js';
+import {db} from '#db/db.js';
+import {publishIntegrationEventReceived} from '#db/webhook-deliveries.js';
+import type {IntegrationProviderModule} from '#providers/types.js';
+
+export const webhookProviderModule: IntegrationProviderModule = {
+  id: 'webhook',
+  enabled: config.INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER,
+  load: async () => {
+    const {createWebhookIntegrationProvider} = await import('@shipfox/api-integration-webhook');
+    return {
+      provider: createWebhookIntegrationProvider({
+        coreDb: db,
+        createIntegrationConnection,
+        listIntegrationConnections,
+        getIntegrationConnectionById,
+        updateIntegrationConnectionLifecycleStatus,
+        deleteIntegrationConnection,
+        publishIntegrationEventReceived,
+      }),
+    };
+  },
+};

--- a/libs/api/integration/core/src/temporal/activities/prune-webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/temporal/activities/prune-webhook-deliveries.test.ts
@@ -7,7 +7,7 @@ import {pruneWebhookDeliveriesActivity} from './prune-webhook-deliveries.js';
 async function insertDelivery(deliveryId: string, receivedAt: Date): Promise<void> {
   await db()
     .insert(integrationsWebhookDeliveries)
-    .values({provider: 'github', deliveryId, receivedAt});
+    .values({provider: 'github', dedupScope: 'provider:github', deliveryId, receivedAt});
 }
 
 describe('pruneWebhookDeliveriesActivity', () => {

--- a/libs/api/integration/github/src/core/webhook.ts
+++ b/libs/api/integration/github/src/core/webhook.ts
@@ -173,6 +173,7 @@ async function publishGithubPush(params: {
     const result = await params.publishIntegrationEventReceived({
       tx: params.tx,
       event: {
+        provider: GITHUB_SOURCE,
         source: GITHUB_SOURCE,
         event: 'push',
         workspaceId: params.connection.workspaceId,
@@ -226,6 +227,7 @@ async function publishGithubEnvelopeOnly(params: {
   const result = await params.publishIntegrationEventReceived({
     tx: params.tx,
     event: {
+      provider: GITHUB_SOURCE,
       source: GITHUB_SOURCE,
       event: params.event,
       workspaceId: params.connection.workspaceId,

--- a/libs/api/integration/sentry/src/core/webhook.ts
+++ b/libs/api/integration/sentry/src/core/webhook.ts
@@ -68,6 +68,7 @@ export async function handleSentryIssueEvent(params: HandleSentryIssueEventParam
   await params.publishIntegrationEventReceived({
     tx: params.tx,
     event: {
+      provider: SENTRY_SOURCE,
       source: SENTRY_SOURCE,
       event: `issue.${params.payload.action}`,
       workspaceId: connection.workspaceId,

--- a/libs/api/integration/webhook-dto/package.json
+++ b/libs/api/integration/webhook-dto/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shipfox/api-integration-webhook-dto",
+  "license": "MIT",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "libs/api/integration/webhook-dto"
+  },
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "depcruise": "shipfox-depcruise",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/depcruise": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/libs/api/integration/webhook-dto/src/index.ts
+++ b/libs/api/integration/webhook-dto/src/index.ts
@@ -1,0 +1,52 @@
+import {z} from 'zod';
+
+export const WEBHOOK_PROVIDER = 'webhook' as const;
+export const WEBHOOK_RECEIVED_EVENT = 'received' as const;
+export const WEBHOOK_RESERVED_SLUGS = ['github', 'gitea', 'sentry', 'manual', 'cron'] as const;
+
+const webhookReservedSlugSet = new Set<string>(WEBHOOK_RESERVED_SLUGS);
+
+export const webhookSlugSchema = z
+  .string()
+  .min(1)
+  .max(50)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+  .refine((slug) => !webhookReservedSlugSet.has(slug), {
+    message: 'Slug is reserved',
+  });
+
+export const createWebhookConnectionBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  name: z.string().min(1).max(100),
+  slug: webhookSlugSchema,
+});
+export type CreateWebhookConnectionBodyDto = z.infer<typeof createWebhookConnectionBodySchema>;
+
+export const updateWebhookConnectionBodySchema = z.object({
+  lifecycle_status: z.enum(['active', 'disabled']),
+});
+export type UpdateWebhookConnectionBodyDto = z.infer<typeof updateWebhookConnectionBodySchema>;
+
+export const webhookConnectionDtoSchema = z.object({
+  id: z.string().uuid(),
+  workspace_id: z.string().uuid(),
+  name: z.string(),
+  slug: webhookSlugSchema,
+  lifecycle_status: z.enum(['active', 'disabled', 'error']),
+  inbound_url: z.string().url(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type WebhookConnectionDto = z.infer<typeof webhookConnectionDtoSchema>;
+
+export const listWebhookConnectionsQuerySchema = z.object({
+  workspace_id: z.string().uuid(),
+});
+export type ListWebhookConnectionsQueryDto = z.infer<typeof listWebhookConnectionsQuerySchema>;
+
+export const listWebhookConnectionsResponseSchema = z.object({
+  connections: z.array(webhookConnectionDtoSchema),
+});
+export type ListWebhookConnectionsResponseDto = z.infer<
+  typeof listWebhookConnectionsResponseSchema
+>;

--- a/libs/api/integration/webhook-dto/tsconfig.build.json
+++ b/libs/api/integration/webhook-dto/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/integration/webhook-dto/tsconfig.json
+++ b/libs/api/integration/webhook-dto/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/integration/webhook-dto/tsconfig.test.json
+++ b/libs/api/integration/webhook-dto/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/integration/webhook-dto/vitest.config.ts
+++ b/libs/api/integration/webhook-dto/vitest.config.ts
@@ -1,0 +1,1 @@
+export {defineConfig as default} from '@shipfox/vitest';

--- a/libs/api/integration/webhook/package.json
+++ b/libs/api/integration/webhook/package.json
@@ -49,14 +49,10 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
-    "@shipfox/node-drizzle": "workspace:*",
-    "@shipfox/node-opentelemetry": "workspace:*",
-    "@shipfox/node-postgres": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
-    "drizzle-orm": "^0.45.2",
     "fastify": "^5.3.3",
     "fastify-type-provider-zod": "^6.0.0"
   }

--- a/libs/api/integration/webhook/package.json
+++ b/libs/api/integration/webhook/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@shipfox/api-integration-core",
+  "name": "@shipfox/api-integration-webhook",
   "license": "MIT",
   "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "libs/api/integration/core"
+    "directory": "libs/api/integration/webhook"
   },
   "private": true,
   "type": "module",
@@ -37,43 +37,27 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@fastify/formbody": "^8.0.2",
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-integration-core-dto": "workspace:*",
-    "@shipfox/api-integration-debug": "workspace:*",
-    "@shipfox/api-integration-gitea": "workspace:*",
-    "@shipfox/api-integration-github": "workspace:*",
-    "@shipfox/api-integration-sentry": "workspace:*",
-    "@shipfox/api-integration-webhook": "workspace:*",
+    "@shipfox/api-integration-webhook-dto": "workspace:*",
     "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
-    "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",
-    "@shipfox/node-module": "workspace:*",
-    "@shipfox/node-opentelemetry": "workspace:*",
-    "@shipfox/node-outbox": "workspace:*",
-    "@shipfox/node-postgres": "workspace:*",
-    "@shipfox/node-temporal": "workspace:*",
-    "@shipfox/regex": "workspace:*",
-    "@shipfox/redact": "workspace:*",
-    "@temporalio/workflow": "^1.16.1",
-    "drizzle-orm": "^0.45.2",
+    "fastify-plugin": "^5.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/node-drizzle": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-postgres": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vitest": "workspace:*",
-    "@temporalio/activity": "^1.16.1",
-    "@temporalio/client": "^1.16.1",
-    "@temporalio/common": "^1.16.1",
-    "@temporalio/testing": "^1.16.1",
-    "@temporalio/worker": "^1.16.1",
-    "@types/pg": "^8.15.5",
-    "drizzle-kit": "^0.31.10",
+    "drizzle-orm": "^0.45.2",
     "fastify": "^5.3.3",
-    "fastify-type-provider-zod": "^6.0.0",
-    "fishery": "^2.2.2"
+    "fastify-type-provider-zod": "^6.0.0"
   }
 }

--- a/libs/api/integration/webhook/src/config.ts
+++ b/libs/api/integration/webhook/src/config.ts
@@ -1,0 +1,8 @@
+import {createConfig, url} from '@shipfox/config';
+
+export const config = createConfig({
+  WEBHOOK_PUBLIC_URL: url({
+    desc: 'Public origin of the API used to build webhook inbound URLs returned to users. Set it to the externally reachable API URL, including the scheme.',
+    default: 'http://localhost:3000',
+  }),
+});

--- a/libs/api/integration/webhook/src/constants.test.ts
+++ b/libs/api/integration/webhook/src/constants.test.ts
@@ -1,0 +1,23 @@
+import {redactHeaders} from './constants.js';
+
+describe('redactHeaders', () => {
+  it('keeps allowlisted headers and redacts every other value', () => {
+    const result = redactHeaders({
+      'content-type': 'application/json',
+      'user-agent': 'test-agent',
+      'x-delivery-id': 'delivery-1',
+      authorization: 'Bearer secret',
+      cookie: 'sid=secret',
+      'x-custom-secret': ['one', 'two'],
+    });
+
+    expect(result).toEqual({
+      'content-type': 'application/json',
+      'user-agent': 'test-agent',
+      'x-delivery-id': 'delivery-1',
+      authorization: '[redacted]',
+      cookie: '[redacted]',
+      'x-custom-secret': '[redacted]',
+    });
+  });
+});

--- a/libs/api/integration/webhook/src/constants.ts
+++ b/libs/api/integration/webhook/src/constants.ts
@@ -1,0 +1,21 @@
+export const WEBHOOK_INBOUND_BODY_LIMIT = 1 * 1024 * 1024;
+
+export const WEBHOOK_FORWARDED_HEADERS = [
+  'content-type',
+  'user-agent',
+  'x-delivery-id',
+  'x-request-id',
+] as const;
+
+const forwardedHeaderSet = new Set<string>(WEBHOOK_FORWARDED_HEADERS);
+
+export function redactHeaders(
+  headers: Record<string, string | string[] | undefined>,
+): Record<string, string | string[]> {
+  const redacted: Record<string, string | string[]> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    redacted[name] = forwardedHeaderSet.has(name.toLowerCase()) ? value : '[redacted]';
+  }
+  return redacted;
+}

--- a/libs/api/integration/webhook/src/index.ts
+++ b/libs/api/integration/webhook/src/index.ts
@@ -1,0 +1,52 @@
+import type {
+  CreateIntegrationConnectionFn,
+  DeleteIntegrationConnectionFn,
+  GetIntegrationConnectionByIdFn,
+  IntegrationConnection,
+  IntegrationTx,
+  PublishIntegrationEventReceivedFn,
+  UpdateIntegrationConnectionLifecycleStatusFn,
+} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_PROVIDER} from '@shipfox/api-integration-webhook-dto';
+import {config} from '#config.js';
+import {createWebhookConnectionRoutes} from '#presentation/routes/connections.js';
+import {createWebhookInboundRoutes} from '#presentation/routes/inbound.js';
+
+export {redactHeaders, WEBHOOK_FORWARDED_HEADERS, WEBHOOK_INBOUND_BODY_LIMIT} from '#constants.js';
+
+export interface CreateWebhookIntegrationProviderOptions {
+  coreDb: () => {
+    transaction<T>(callback: (tx: IntegrationTx) => Promise<T>): Promise<T>;
+  };
+  createIntegrationConnection: CreateIntegrationConnectionFn;
+  listIntegrationConnections: (params: {workspaceId: string}) => Promise<IntegrationConnection[]>;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  updateIntegrationConnectionLifecycleStatus: UpdateIntegrationConnectionLifecycleStatusFn;
+  deleteIntegrationConnection: DeleteIntegrationConnectionFn;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+  baseUrl?: string | undefined;
+}
+
+export function createWebhookIntegrationProvider(options: CreateWebhookIntegrationProviderOptions) {
+  const baseUrl = options.baseUrl ?? config.WEBHOOK_PUBLIC_URL;
+  return {
+    provider: WEBHOOK_PROVIDER,
+    displayName: 'Webhook',
+    routes: [
+      createWebhookConnectionRoutes({
+        baseUrl,
+        createIntegrationConnection: options.createIntegrationConnection,
+        listIntegrationConnections: options.listIntegrationConnections,
+        getIntegrationConnectionById: options.getIntegrationConnectionById,
+        updateIntegrationConnectionLifecycleStatus:
+          options.updateIntegrationConnectionLifecycleStatus,
+        deleteIntegrationConnection: options.deleteIntegrationConnection,
+      }),
+      createWebhookInboundRoutes({
+        coreDb: options.coreDb,
+        getIntegrationConnectionById: options.getIntegrationConnectionById,
+        publishIntegrationEventReceived: options.publishIntegrationEventReceived,
+      }),
+    ],
+  };
+}

--- a/libs/api/integration/webhook/src/presentation/dto/connections.ts
+++ b/libs/api/integration/webhook/src/presentation/dto/connections.ts
@@ -1,0 +1,20 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
+
+const TRAILING_SLASHES_RE = /\/+$/;
+
+export function toWebhookConnectionDto(
+  connection: IntegrationConnection,
+  baseUrl: string,
+): WebhookConnectionDto {
+  return {
+    id: connection.id,
+    workspace_id: connection.workspaceId,
+    name: connection.displayName,
+    slug: connection.externalAccountId,
+    lifecycle_status: connection.lifecycleStatus,
+    inbound_url: `${baseUrl.replace(TRAILING_SLASHES_RE, '')}/webhook/${connection.id}`,
+    created_at: connection.createdAt.toISOString(),
+    updated_at: connection.updatedAt.toISOString(),
+  };
+}

--- a/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
@@ -1,5 +1,6 @@
 import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
 import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_RESERVED_SLUGS} from '@shipfox/api-integration-webhook-dto';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import type {CreateWebhookIntegrationProviderOptions} from '#index.js';
@@ -224,6 +225,48 @@ describe('webhook connection routes', () => {
     expect(res.json().lifecycle_status).toBe('disabled');
   });
 
+  it.each([
+    {description: 'missing connection', connectionId: crypto.randomUUID()},
+    {
+      description: 'non-webhook connection',
+      connectionId: undefined,
+      seed: (store: ReturnType<typeof createStore>) =>
+        store.seed(fakeConnection({provider: 'github'})).id,
+    },
+  ])('returns 404 when patching a $description', async ({connectionId, seed}) => {
+    const store = createStore();
+    const id = seed ? seed(store) : connectionId;
+    const {app} = await createTestApp(store);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/integrations/webhook/connections/${id}`,
+      headers: {authorization: 'Bearer user'},
+      payload: {lifecycle_status: 'disabled'},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('not-found');
+    expect(store.updateIntegrationConnectionLifecycleStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when a webhook connection disappears during patch', async () => {
+    const store = createStore();
+    const connection = store.seed(fakeConnection());
+    store.updateIntegrationConnectionLifecycleStatus.mockResolvedValueOnce(undefined);
+    const {app} = await createTestApp(store);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/integrations/webhook/connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+      payload: {lifecycle_status: 'disabled'},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('not-found');
+  });
+
   it('deletes a webhook connection', async () => {
     const store = createStore();
     const connection = store.seed(fakeConnection());
@@ -240,16 +283,50 @@ describe('webhook connection routes', () => {
   });
 
   it.each([
-    {name: 'Reserved', slug: 'github'},
-    {name: 'Malformed', slug: 'Stripe_Prod'},
-  ])('rejects invalid slug $slug', async (payload) => {
+    {description: 'missing connection', connectionId: crypto.randomUUID()},
+    {
+      description: 'non-webhook connection',
+      connectionId: undefined,
+      seed: (store: ReturnType<typeof createStore>) =>
+        store.seed(fakeConnection({provider: 'github'})).id,
+    },
+  ])('returns 404 when deleting a $description', async ({connectionId, seed}) => {
+    const store = createStore();
+    const id = seed ? seed(store) : connectionId;
+    const {app} = await createTestApp(store);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integrations/webhook/connections/${id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('not-found');
+    expect(store.deleteIntegrationConnection).not.toHaveBeenCalled();
+  });
+
+  it.each(WEBHOOK_RESERVED_SLUGS)('rejects reserved slug %s', async (slug) => {
     const {app} = await createTestApp();
 
     const res = await app.inject({
       method: 'POST',
       url: '/integrations/webhook/connections',
       headers: {authorization: 'Bearer user'},
-      payload: {workspace_id: crypto.randomUUID(), ...payload},
+      payload: {workspace_id: crypto.randomUUID(), name: 'Reserved', slug},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a malformed slug', async () => {
+    const {app} = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/webhook/connections',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: crypto.randomUUID(), name: 'Malformed', slug: 'Stripe_Prod'},
     });
 
     expect(res.statusCode).toBe(400);

--- a/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
@@ -1,0 +1,257 @@
+import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance, FastifyRequest} from 'fastify';
+import type {CreateWebhookIntegrationProviderOptions} from '#index.js';
+import {createWebhookIntegrationProvider} from '#index.js';
+
+type CreateConnectionFn = CreateWebhookIntegrationProviderOptions['createIntegrationConnection'];
+type ListConnectionsFn = CreateWebhookIntegrationProviderOptions['listIntegrationConnections'];
+type GetConnectionFn = CreateWebhookIntegrationProviderOptions['getIntegrationConnectionById'];
+type UpdateConnectionFn =
+  CreateWebhookIntegrationProviderOptions['updateIntegrationConnectionLifecycleStatus'];
+type DeleteConnectionFn = CreateWebhookIntegrationProviderOptions['deleteIntegrationConnection'];
+
+const INBOUND_URL_RE = /^https:\/\/api\.example\.com\/webhook\//;
+
+vi.mock('@shipfox/api-workspaces', () => ({
+  requireMembership: vi.fn(({workspaceId}) =>
+    Promise.resolve({
+      workspaceId,
+      workspace: {
+        id: workspaceId,
+        name: 'Workspace',
+        status: 'active',
+        settings: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      userId: 'user-1',
+      role: 'admin',
+    }),
+  ),
+}));
+
+const fakeUserAuth: AuthMethod = {
+  name: AUTH_USER,
+  authenticate: (request: FastifyRequest) => {
+    if (request.headers.authorization !== 'Bearer user') {
+      throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
+    }
+
+    setUserContext(
+      request,
+      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+    );
+    return Promise.resolve();
+  },
+};
+
+function duplicateSlugError(): Error {
+  const error = new Error('duplicate connection');
+  error.name = 'IntegrationConnectionAlreadyExistsError';
+  return error;
+}
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  const now = new Date();
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    provider: 'webhook',
+    externalAccountId: 'stripe',
+    displayName: 'Stripe',
+    lifecycleStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createStore() {
+  const byId = new Map<string, IntegrationConnection>();
+  const byUnique = new Map<string, string>();
+  const seed = (connection: IntegrationConnection) => {
+    byId.set(connection.id, connection);
+    byUnique.set(
+      `${connection.workspaceId}:${connection.provider}:${connection.externalAccountId}`,
+      connection.id,
+    );
+    return connection;
+  };
+
+  return {
+    seed,
+    createIntegrationConnection: vi.fn<CreateConnectionFn>((input) => {
+      const key = `${input.workspaceId}:${input.provider}:${input.externalAccountId}`;
+      if (byUnique.has(key)) throw duplicateSlugError();
+      const connection = fakeConnection({
+        workspaceId: input.workspaceId,
+        provider: input.provider,
+        externalAccountId: input.externalAccountId,
+        displayName: input.displayName,
+        lifecycleStatus: input.lifecycleStatus ?? 'active',
+      });
+      seed(connection);
+      return Promise.resolve(connection);
+    }),
+    listIntegrationConnections: vi.fn<ListConnectionsFn>(({workspaceId}) =>
+      Promise.resolve(
+        [...byId.values()].filter((connection) => connection.workspaceId === workspaceId),
+      ),
+    ),
+    getIntegrationConnectionById: vi.fn<GetConnectionFn>((id) => Promise.resolve(byId.get(id))),
+    updateIntegrationConnectionLifecycleStatus: vi.fn<UpdateConnectionFn>(
+      ({id, lifecycleStatus}) => {
+        const connection = byId.get(id);
+        if (!connection) return Promise.resolve(undefined);
+        const updated = {...connection, lifecycleStatus, updatedAt: new Date()};
+        byId.set(id, updated);
+        return Promise.resolve(updated);
+      },
+    ),
+    deleteIntegrationConnection: vi.fn<DeleteConnectionFn>(({id}) =>
+      Promise.resolve(byId.delete(id)),
+    ),
+  };
+}
+
+async function createTestApp(store = createStore()): Promise<{
+  app: FastifyInstance;
+  store: ReturnType<typeof createStore>;
+}> {
+  const provider = createWebhookIntegrationProvider({
+    baseUrl: 'https://api.example.com/',
+    coreDb: () => ({transaction: (callback) => callback({})}),
+    publishIntegrationEventReceived: vi.fn(() => Promise.resolve({published: true})),
+    ...store,
+  } satisfies CreateWebhookIntegrationProviderOptions);
+  const app = await createApp({
+    auth: [fakeUserAuth],
+    routes: provider.routes,
+    swagger: false,
+  });
+  await app.ready();
+  return {app, store};
+}
+
+describe('webhook connection routes', () => {
+  beforeEach(async () => {
+    await closeApp();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('creates a webhook connection with its inbound URL', async () => {
+    const workspaceId = crypto.randomUUID();
+    const {app} = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/webhook/connections',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: workspaceId, name: 'Stripe', slug: 'stripe-prod'},
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      workspace_id: workspaceId,
+      name: 'Stripe',
+      slug: 'stripe-prod',
+      lifecycle_status: 'active',
+      inbound_url: expect.stringMatching(INBOUND_URL_RE),
+    });
+  });
+
+  it('returns 409 for a duplicate slug in the workspace', async () => {
+    const workspaceId = crypto.randomUUID();
+    const {app} = await createTestApp();
+    const payload = {workspace_id: workspaceId, name: 'Stripe', slug: 'stripe-prod'};
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/integrations/webhook/connections',
+      headers: {authorization: 'Bearer user'},
+      payload,
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/integrations/webhook/connections',
+      headers: {authorization: 'Bearer user'},
+      payload,
+    });
+
+    expect(first.statusCode).toBe(201);
+    expect(second.statusCode).toBe(409);
+    expect(second.json().code).toBe('slug-already-exists');
+  });
+
+  it('lists only webhook connections for the workspace', async () => {
+    const workspaceId = crypto.randomUUID();
+    const store = createStore();
+    const webhook = store.seed(fakeConnection({workspaceId, externalAccountId: 'stripe'}));
+    store.seed(fakeConnection({workspaceId, provider: 'github', externalAccountId: 'gh'}));
+    store.seed(fakeConnection({workspaceId: crypto.randomUUID(), externalAccountId: 'other'}));
+    const {app} = await createTestApp(store);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/integrations/webhook/connections?workspace_id=${workspaceId}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().connections).toEqual([
+      expect.objectContaining({id: webhook.id, slug: 'stripe'}),
+    ]);
+  });
+
+  it('updates a webhook connection lifecycle status', async () => {
+    const store = createStore();
+    const connection = store.seed(fakeConnection());
+    const {app} = await createTestApp(store);
+
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/integrations/webhook/connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+      payload: {lifecycle_status: 'disabled'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().lifecycle_status).toBe('disabled');
+  });
+
+  it('deletes a webhook connection', async () => {
+    const store = createStore();
+    const connection = store.seed(fakeConnection());
+    const {app} = await createTestApp(store);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: `/integrations/webhook/connections/${connection.id}`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(store.deleteIntegrationConnection).toHaveBeenCalledWith({id: connection.id});
+  });
+
+  it.each([
+    {name: 'Reserved', slug: 'github'},
+    {name: 'Malformed', slug: 'Stripe_Prod'},
+  ])('rejects invalid slug $slug', async (payload) => {
+    const {app} = await createTestApp();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/integrations/webhook/connections',
+      headers: {authorization: 'Bearer user'},
+      payload: {workspace_id: crypto.randomUUID(), ...payload},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/libs/api/integration/webhook/src/presentation/routes/connections.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/connections.ts
@@ -1,0 +1,181 @@
+import {AUTH_USER} from '@shipfox/api-auth-context';
+import type {
+  CreateIntegrationConnectionFn,
+  DeleteIntegrationConnectionFn,
+  GetIntegrationConnectionByIdFn,
+  IntegrationConnection,
+  UpdateIntegrationConnectionLifecycleStatusFn,
+} from '@shipfox/api-integration-core-dto';
+import {
+  createWebhookConnectionBodySchema,
+  listWebhookConnectionsQuerySchema,
+  listWebhookConnectionsResponseSchema,
+  updateWebhookConnectionBodySchema,
+  WEBHOOK_PROVIDER,
+  webhookConnectionDtoSchema,
+} from '@shipfox/api-integration-webhook-dto';
+import {requireMembership} from '@shipfox/api-workspaces';
+import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {FastifyRequest} from 'fastify';
+import {z} from 'zod';
+import {toWebhookConnectionDto} from '#presentation/dto/connections.js';
+
+export interface CreateWebhookConnectionRoutesOptions {
+  baseUrl: string;
+  createIntegrationConnection: CreateIntegrationConnectionFn;
+  listIntegrationConnections: (params: {workspaceId: string}) => Promise<IntegrationConnection[]>;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  updateIntegrationConnectionLifecycleStatus: UpdateIntegrationConnectionLifecycleStatusFn;
+  deleteIntegrationConnection: DeleteIntegrationConnectionFn;
+}
+
+const connectionParamsSchema = z.object({
+  connectionId: z.string().uuid(),
+});
+
+function isConnectionAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as {name?: unknown}).name === 'IntegrationConnectionAlreadyExistsError'
+  );
+}
+
+async function requireWebhookConnection(params: {
+  request: FastifyRequest;
+  connectionId: string;
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+}): Promise<IntegrationConnection> {
+  const connection = await params.getIntegrationConnectionById(params.connectionId);
+  if (!connection || connection.provider !== WEBHOOK_PROVIDER) {
+    throw new ClientError('Webhook connection not found', 'not-found', {status: 404});
+  }
+
+  await requireMembership({request: params.request, workspaceId: connection.workspaceId});
+  return connection;
+}
+
+export function createWebhookConnectionRoutes(
+  options: CreateWebhookConnectionRoutesOptions,
+): RouteGroup {
+  const createConnectionRoute = defineRoute({
+    method: 'POST',
+    path: '/connections',
+    auth: AUTH_USER,
+    description: 'Create a generic webhook connection.',
+    schema: {
+      body: createWebhookConnectionBodySchema,
+      response: {
+        201: webhookConnectionDtoSchema,
+      },
+    },
+    errorHandler: (error) => {
+      if (isConnectionAlreadyExistsError(error)) {
+        throw new ClientError('Webhook slug already exists', 'slug-already-exists', {status: 409});
+      }
+      throw error;
+    },
+    handler: async (request, reply) => {
+      const {workspace_id: workspaceId, name, slug} = request.body;
+
+      await requireMembership({request, workspaceId});
+      const connection = await options.createIntegrationConnection({
+        workspaceId,
+        provider: WEBHOOK_PROVIDER,
+        externalAccountId: slug,
+        displayName: name,
+      });
+
+      reply.status(201);
+      return toWebhookConnectionDto(connection, options.baseUrl);
+    },
+  });
+
+  const listConnectionsRoute = defineRoute({
+    method: 'GET',
+    path: '/connections',
+    auth: AUTH_USER,
+    description: 'List generic webhook connections for a workspace.',
+    schema: {
+      querystring: listWebhookConnectionsQuerySchema,
+      response: {
+        200: listWebhookConnectionsResponseSchema,
+      },
+    },
+    handler: async (request) => {
+      const {workspace_id: workspaceId} = request.query;
+
+      await requireMembership({request, workspaceId});
+      const connections = (await options.listIntegrationConnections({workspaceId})).filter(
+        (connection) => connection.provider === WEBHOOK_PROVIDER,
+      );
+      return {
+        connections: connections.map((connection) =>
+          toWebhookConnectionDto(connection, options.baseUrl),
+        ),
+      };
+    },
+  });
+
+  const updateConnectionRoute = defineRoute({
+    method: 'PATCH',
+    path: '/connections/:connectionId',
+    auth: AUTH_USER,
+    description: 'Update a generic webhook connection.',
+    schema: {
+      params: connectionParamsSchema,
+      body: updateWebhookConnectionBodySchema,
+      response: {
+        200: webhookConnectionDtoSchema,
+      },
+    },
+    handler: async (request) => {
+      const connection = await requireWebhookConnection({
+        request,
+        connectionId: request.params.connectionId,
+        getIntegrationConnectionById: options.getIntegrationConnectionById,
+      });
+      const updated = await options.updateIntegrationConnectionLifecycleStatus({
+        id: connection.id,
+        lifecycleStatus: request.body.lifecycle_status,
+      });
+      if (!updated) {
+        throw new ClientError('Webhook connection not found', 'not-found', {status: 404});
+      }
+      return toWebhookConnectionDto(updated, options.baseUrl);
+    },
+  });
+
+  const deleteConnectionRoute = defineRoute({
+    method: 'DELETE',
+    path: '/connections/:connectionId',
+    auth: AUTH_USER,
+    description: 'Delete a generic webhook connection.',
+    schema: {
+      params: connectionParamsSchema,
+      response: {
+        204: z.void(),
+      },
+    },
+    handler: async (request, reply) => {
+      const connection = await requireWebhookConnection({
+        request,
+        connectionId: request.params.connectionId,
+        getIntegrationConnectionById: options.getIntegrationConnectionById,
+      });
+
+      await options.deleteIntegrationConnection({id: connection.id});
+      reply.code(204);
+    },
+  });
+
+  return {
+    prefix: '/integrations/webhook',
+    routes: [
+      createConnectionRoute,
+      listConnectionsRoute,
+      updateConnectionRoute,
+      deleteConnectionRoute,
+    ],
+  };
+}

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
@@ -1,0 +1,190 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import type {FastifyInstance} from 'fastify';
+import {createWebhookInboundRoutes} from './inbound.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function fakeConnection(overrides: Partial<IntegrationConnection> = {}): IntegrationConnection {
+  const now = new Date();
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    provider: 'webhook',
+    externalAccountId: 'stripe-prod',
+    displayName: 'Stripe Production',
+    lifecycleStatus: 'active',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+async function createTestApp(
+  options: {connection?: IntegrationConnection | undefined} = {},
+): Promise<{
+  app: FastifyInstance;
+  publishIntegrationEventReceived: ReturnType<typeof vi.fn>;
+  getIntegrationConnectionById: ReturnType<typeof vi.fn>;
+}> {
+  const connection = options.connection ?? fakeConnection();
+  const publishIntegrationEventReceived = vi.fn(() => Promise.resolve({published: true}));
+  const getIntegrationConnectionById = vi.fn((id: string) =>
+    Promise.resolve(id === connection.id ? connection : undefined),
+  );
+  const routes = createWebhookInboundRoutes({
+    coreDb: () => ({transaction: (callback) => callback({})}),
+    getIntegrationConnectionById,
+    publishIntegrationEventReceived,
+  });
+  const app = await createApp({routes: [routes], swagger: false});
+  await app.ready();
+  return {app, publishIntegrationEventReceived, getIntegrationConnectionById};
+}
+
+describe('webhook inbound route', () => {
+  beforeEach(async () => {
+    await closeApp();
+  });
+
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  it('publishes a JSON delivery envelope', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}?mode=test`,
+      headers: {
+        'content-type': 'application/json',
+        'x-delivery-id': 'evt-1',
+        authorization: 'Bearer secret',
+      },
+      payload: {ok: true},
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(res.json().delivery_id).toBe(`${connection.id}:evt-1`);
+    expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0].event).toMatchObject({
+      provider: 'webhook',
+      source: 'stripe-prod',
+      event: 'received',
+      workspaceId: connection.workspaceId,
+      connectionId: connection.id,
+      connectionName: 'Stripe Production',
+      deliveryId: `${connection.id}:evt-1`,
+      payload: {
+        method: 'POST',
+        query: {mode: 'test'},
+        body: {ok: true},
+        headers: {
+          'content-type': 'application/json',
+          'x-delivery-id': 'evt-1',
+          authorization: '[redacted]',
+        },
+      },
+    });
+  });
+
+  it('publishes a form delivery envelope', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}`,
+      headers: {'content-type': 'application/x-www-form-urlencoded'},
+      payload: 'status=paid&amount=1200',
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0].event.payload.body).toEqual({
+      status: 'paid',
+      amount: '1200',
+    });
+  });
+
+  it('publishes a text delivery envelope', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}`,
+      headers: {'content-type': 'text/plain'},
+      payload: 'hello',
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(publishIntegrationEventReceived.mock.calls[0]?.[0].event.payload.body).toBe('hello');
+  });
+
+  it('rejects unsupported content types without publishing', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}`,
+      headers: {'content-type': 'application/xml'},
+      payload: '<ok />',
+    });
+
+    expect(res.statusCode).toBe(415);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed JSON without publishing', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}`,
+      headers: {'content-type': 'application/json'},
+      payload: '{"ok":',
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {connection: undefined, description: 'unknown connection'},
+    {connection: fakeConnection({lifecycleStatus: 'disabled'}), description: 'disabled connection'},
+    {connection: fakeConnection({provider: 'github'}), description: 'wrong provider'},
+  ])('returns 404 for $description without publishing', async ({connection}) => {
+    const activeConnection = connection ?? fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${activeConnection.id}`,
+      headers: {'content-type': 'application/json'},
+      payload: {ok: true},
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
+
+  it('uses a random delivery ID when no header is present', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}`,
+      headers: {'content-type': 'application/json'},
+      payload: {ok: true},
+    });
+
+    expect(res.statusCode).toBe(202);
+    const deliveryId = publishIntegrationEventReceived.mock.calls[0]?.[0].event.deliveryId;
+    expect(deliveryId).toMatch(UUID_RE);
+  });
+});

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
@@ -67,7 +67,7 @@ describe('webhook inbound route', () => {
     });
 
     expect(res.statusCode).toBe(202);
-    expect(res.json().delivery_id).toBe(`${connection.id}:evt-1`);
+    expect(res.json().delivery_id).toBe('evt-1');
     expect(publishIntegrationEventReceived).toHaveBeenCalledTimes(1);
     expect(publishIntegrationEventReceived.mock.calls[0]?.[0].event).toMatchObject({
       provider: 'webhook',
@@ -76,7 +76,7 @@ describe('webhook inbound route', () => {
       workspaceId: connection.workspaceId,
       connectionId: connection.id,
       connectionName: 'Stripe Production',
-      deliveryId: `${connection.id}:evt-1`,
+      deliveryId: 'evt-1',
       payload: {
         method: 'POST',
         query: {mode: 'test'},

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.test.ts
@@ -187,4 +187,23 @@ describe('webhook inbound route', () => {
     const deliveryId = publishIntegrationEventReceived.mock.calls[0]?.[0].event.deliveryId;
     expect(deliveryId).toMatch(UUID_RE);
   });
+
+  it('rejects an overlong delivery ID header without publishing', async () => {
+    const connection = fakeConnection();
+    const {app, publishIntegrationEventReceived} = await createTestApp({connection});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/webhook/${connection.id}`,
+      headers: {
+        'content-type': 'application/json',
+        'x-delivery-id': 'x'.repeat(201),
+      },
+      payload: {ok: true},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().code).toBe('delivery-id-too-long');
+    expect(publishIntegrationEventReceived).not.toHaveBeenCalled();
+  });
 });

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.ts
@@ -1,0 +1,132 @@
+import type {Buffer} from 'node:buffer';
+import {randomUUID} from 'node:crypto';
+import formBodyPlugin from '@fastify/formbody';
+import type {
+  GetIntegrationConnectionByIdFn,
+  IntegrationTx,
+  PublishIntegrationEventReceivedFn,
+} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_PROVIDER, WEBHOOK_RECEIVED_EVENT} from '@shipfox/api-integration-webhook-dto';
+import {ClientError, defineRoute, type RouteGroup} from '@shipfox/node-fastify';
+import type {FastifyPluginAsync} from 'fastify';
+import fp from 'fastify-plugin';
+import {z} from 'zod';
+import {redactHeaders, WEBHOOK_INBOUND_BODY_LIMIT} from '#constants.js';
+
+const MAX_DELIVERY_ID_HEADER_LENGTH = 200;
+const acceptedContentTypes = new Set([
+  'application/json',
+  'application/x-www-form-urlencoded',
+  'text/plain',
+]);
+const FORM_URLENCODED_CONTENT_TYPE_RE = /^application\/x-www-form-urlencoded(?:;.*)?$/i;
+
+const formBodyRoutePlugin: FastifyPluginAsync = fp(async (app) => {
+  await app.register(formBodyPlugin, {bodyLimit: WEBHOOK_INBOUND_BODY_LIMIT});
+
+  app.addContentTypeParser(
+    FORM_URLENCODED_CONTENT_TYPE_RE,
+    {parseAs: 'buffer', bodyLimit: WEBHOOK_INBOUND_BODY_LIMIT},
+    (_request, body: Buffer, done) => {
+      done(null, Object.fromEntries(new URLSearchParams(body.toString('utf8'))));
+    },
+  );
+});
+
+export interface CreateWebhookInboundRoutesOptions {
+  coreDb: () => {
+    transaction<T>(callback: (tx: IntegrationTx) => Promise<T>): Promise<T>;
+  };
+  getIntegrationConnectionById: GetIntegrationConnectionByIdFn;
+  publishIntegrationEventReceived: PublishIntegrationEventReceivedFn;
+}
+
+const inboundParamsSchema = z.object({
+  connectionId: z.string().uuid(),
+});
+
+const inboundQuerySchema = z.record(z.string(), z.unknown());
+
+const inboundAcceptedResponseSchema = z.object({
+  delivery_id: z.string(),
+});
+
+function contentType(requestContentType: string | undefined): string | undefined {
+  return requestContentType?.split(';', 1)[0]?.trim().toLowerCase();
+}
+
+function deliveryIdFor(connectionId: string, header: string | string[] | undefined): string {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return randomUUID();
+  if (value.length > MAX_DELIVERY_ID_HEADER_LENGTH) {
+    throw new ClientError('Delivery ID header is too long', 'delivery-id-too-long', {status: 400});
+  }
+  return `${connectionId}:${value}`;
+}
+
+export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOptions): RouteGroup {
+  const inboundRoute = defineRoute({
+    method: 'POST',
+    path: '/:connectionId',
+    auth: [],
+    description: 'Generic webhook receiver.',
+    options: {bodyLimit: WEBHOOK_INBOUND_BODY_LIMIT},
+    schema: {
+      params: inboundParamsSchema,
+      querystring: inboundQuerySchema,
+      response: {
+        202: inboundAcceptedResponseSchema,
+      },
+    },
+    handler: async (request, reply) => {
+      const mediaType = contentType(request.headers['content-type']);
+      if (!mediaType || !acceptedContentTypes.has(mediaType)) {
+        throw new ClientError('Unsupported content type', 'unsupported-media-type', {status: 415});
+      }
+
+      const {connectionId} = request.params;
+      const connection = await options.getIntegrationConnectionById(connectionId);
+      if (
+        !connection ||
+        connection.provider !== WEBHOOK_PROVIDER ||
+        connection.lifecycleStatus !== 'active'
+      ) {
+        throw new ClientError('Webhook connection not found', 'not-found', {status: 404});
+      }
+
+      const deliveryId = deliveryIdFor(connectionId, request.headers['x-delivery-id']);
+      const receivedAt = new Date().toISOString();
+      await options.coreDb().transaction(async (tx) => {
+        await options.publishIntegrationEventReceived({
+          tx,
+          event: {
+            provider: WEBHOOK_PROVIDER,
+            source: connection.externalAccountId,
+            event: WEBHOOK_RECEIVED_EVENT,
+            workspaceId: connection.workspaceId,
+            connectionId: connection.id,
+            connectionName: connection.displayName,
+            deliveryId,
+            receivedAt,
+            payload: {
+              method: request.method,
+              headers: redactHeaders(request.headers),
+              query: request.query,
+              body: request.body,
+            },
+          },
+        });
+      });
+
+      reply.code(202);
+      return {delivery_id: deliveryId};
+    },
+  });
+
+  return {
+    prefix: '/webhook',
+    auth: [],
+    plugins: [formBodyRoutePlugin],
+    routes: [inboundRoute],
+  };
+}

--- a/libs/api/integration/webhook/src/presentation/routes/inbound.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/inbound.ts
@@ -55,13 +55,13 @@ function contentType(requestContentType: string | undefined): string | undefined
   return requestContentType?.split(';', 1)[0]?.trim().toLowerCase();
 }
 
-function deliveryIdFor(connectionId: string, header: string | string[] | undefined): string {
+function deliveryIdFor(header: string | string[] | undefined): string {
   const value = Array.isArray(header) ? header[0] : header;
   if (!value) return randomUUID();
   if (value.length > MAX_DELIVERY_ID_HEADER_LENGTH) {
     throw new ClientError('Delivery ID header is too long', 'delivery-id-too-long', {status: 400});
   }
-  return `${connectionId}:${value}`;
+  return value;
 }
 
 export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOptions): RouteGroup {
@@ -94,7 +94,7 @@ export function createWebhookInboundRoutes(options: CreateWebhookInboundRoutesOp
         throw new ClientError('Webhook connection not found', 'not-found', {status: 404});
       }
 
-      const deliveryId = deliveryIdFor(connectionId, request.headers['x-delivery-id']);
+      const deliveryId = deliveryIdFor(request.headers['x-delivery-id']);
       const receivedAt = new Date().toISOString();
       await options.coreDb().transaction(async (tx) => {
         await options.publishIntegrationEventReceived({

--- a/libs/api/integration/webhook/test/env.ts
+++ b/libs/api/integration/webhook/test/env.ts
@@ -1,0 +1,7 @@
+process.env.POSTGRES_HOST = 'localhost';
+process.env.POSTGRES_PORT = '5432';
+process.env.POSTGRES_USERNAME = 'shipfox';
+process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_DATABASE = 'api_test';
+process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.TZ = 'UTC';

--- a/libs/api/integration/webhook/test/globalSetup.ts
+++ b/libs/api/integration/webhook/test/globalSetup.ts
@@ -1,0 +1,5 @@
+import './env.js';
+
+export async function setup() {
+  await Promise.resolve();
+}

--- a/libs/api/integration/webhook/test/setup.ts
+++ b/libs/api/integration/webhook/test/setup.ts
@@ -1,0 +1,6 @@
+import './env.js';
+import {afterEach, vi} from '@shipfox/vitest/vi';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});

--- a/libs/api/integration/webhook/tsconfig.build.json
+++ b/libs/api/integration/webhook/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/api/integration/webhook/tsconfig.json
+++ b/libs/api/integration/webhook/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/api/integration/webhook/tsconfig.test.json
+++ b/libs/api/integration/webhook/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/api/integration/webhook/vitest.config.ts
+++ b/libs/api/integration/webhook/vitest.config.ts
@@ -1,0 +1,12 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig(
+  {
+    test: {
+      fileParallelism: false,
+      globalSetup: ['test/globalSetup.ts'],
+      setupFiles: ['test/setup.ts'],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.history-failure.test.ts
@@ -42,6 +42,7 @@ describe('dispatchIntegrationEvent resilience to history-write failure', () => {
       dispatchIntegrationEvent({
         eventRef: crypto.randomUUID(),
         workspaceId,
+        provider: 'github',
         source: 'github',
         event: 'push',
         connectionId: crypto.randomUUID(),

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -40,6 +40,7 @@ const {dispatchIntegrationEvent} = await import('./dispatch-integration-event.js
 interface DispatchOverrides {
   eventRef?: string;
   workspaceId?: string;
+  provider?: string;
   source?: string;
   event?: string;
   deliveryId?: string;
@@ -51,6 +52,7 @@ interface DispatchOverrides {
 function dispatch(overrides: DispatchOverrides = {}): Promise<void> {
   return dispatchIntegrationEvent({
     eventRef: overrides.eventRef ?? crypto.randomUUID(),
+    provider: overrides.provider ?? overrides.source ?? 'github',
     source: overrides.source ?? 'github',
     event: overrides.event ?? 'push',
     workspaceId: overrides.workspaceId ?? crypto.randomUUID(),
@@ -121,7 +123,13 @@ describe('dispatchIntegrationEvent', () => {
 
     expect(runWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
-        triggerPayload: {source: 'github', event: 'push', deliveryId, data: payload},
+        triggerPayload: {
+          provider: 'github',
+          source: 'github',
+          event: 'push',
+          deliveryId,
+          data: payload,
+        },
       }),
     );
   });

--- a/libs/api/triggers/src/core/dispatch-integration-event.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.ts
@@ -11,6 +11,7 @@ import {beginTriggerHistory, toReason} from './record-trigger-history.js';
 export interface DispatchIntegrationEventParams {
   eventRef: string;
   workspaceId: string;
+  provider: string;
   source: string;
   event: string;
   deliveryId: string;
@@ -34,7 +35,7 @@ export interface DispatchIntegrationEventParams {
 export async function dispatchIntegrationEvent(
   params: DispatchIntegrationEventParams,
 ): Promise<void> {
-  eventReceivedCount.add(1, {source: params.source});
+  eventReceivedCount.add(1, {provider: params.provider});
 
   const history = await beginTriggerHistory({
     eventRef: params.eventRef,
@@ -56,7 +57,7 @@ export async function dispatchIntegrationEvent(
   });
 
   if (subscriptions.length === 0) {
-    eventOutcomeCount.add(1, {source: params.source, outcome: 'discarded'});
+    eventOutcomeCount.add(1, {provider: params.provider, outcome: 'discarded'});
     await history.discarded();
     return;
   }
@@ -72,6 +73,7 @@ export async function dispatchIntegrationEvent(
         projectId: subscription.projectId,
         definitionId: subscription.workflowDefinitionId,
         triggerPayload: {
+          provider: params.provider,
           source: params.source,
           event: params.event,
           deliveryId: params.deliveryId,
@@ -82,7 +84,7 @@ export async function dispatchIntegrationEvent(
       });
       await history.triggered(subscription, run);
       triggeredCount += 1;
-      subscriptionTriggeredCount.add(1, {source: params.source});
+      subscriptionTriggeredCount.add(1, {provider: params.provider});
     } catch (error) {
       await history.errored(subscription, toReason(error));
       // Track presence with a flag, not `firstTransientError === undefined`: a thrown
@@ -95,17 +97,17 @@ export async function dispatchIntegrationEvent(
   }
 
   if (sawTransientError) {
-    eventOutcomeCount.add(1, {source: params.source, outcome: 'failed'});
+    eventOutcomeCount.add(1, {provider: params.provider, outcome: 'failed'});
     await history.failed(subscriptions.length);
     throw firstTransientError;
   }
 
   if (triggeredCount > 0) {
-    eventOutcomeCount.add(1, {source: params.source, outcome: 'routed'});
+    eventOutcomeCount.add(1, {provider: params.provider, outcome: 'routed'});
     await history.routed(subscriptions.length);
     return;
   }
 
-  eventOutcomeCount.add(1, {source: params.source, outcome: 'errored'});
+  eventOutcomeCount.add(1, {provider: params.provider, outcome: 'errored'});
   await history.allErrored(subscriptions.length);
 }

--- a/libs/api/triggers/src/core/fire-manual.ts
+++ b/libs/api/triggers/src/core/fire-manual.ts
@@ -52,7 +52,7 @@ export async function fireManualSubscription(
     receivedAt: new Date(),
   };
 
-  eventReceivedCount.add(1, {source: 'manual'});
+  eventReceivedCount.add(1, {provider: 'manual'});
 
   let run: WorkflowRun;
   try {
@@ -61,6 +61,7 @@ export async function fireManualSubscription(
       projectId: subscription.projectId,
       definitionId: subscription.workflowDefinitionId,
       triggerPayload: {
+        provider: 'manual',
         source: 'manual',
         event: 'fire',
         subscriptionId: subscription.id,
@@ -72,10 +73,10 @@ export async function fireManualSubscription(
     const failure = await beginTriggerHistory({...historyBase, eventRef: randomUUID()});
     await failure.errored(subscription, toReason(error));
     if (isPermanentRunWorkflowError(error)) {
-      eventOutcomeCount.add(1, {source: 'manual', outcome: 'errored'});
+      eventOutcomeCount.add(1, {provider: 'manual', outcome: 'errored'});
       await failure.allErrored(1);
     } else {
-      eventOutcomeCount.add(1, {source: 'manual', outcome: 'failed'});
+      eventOutcomeCount.add(1, {provider: 'manual', outcome: 'failed'});
       await failure.failed(1);
     }
     throw error;
@@ -83,8 +84,8 @@ export async function fireManualSubscription(
 
   const history = await beginTriggerHistory({...historyBase, eventRef: run.id});
   await history.triggered(subscription, run);
-  subscriptionTriggeredCount.add(1, {source: 'manual'});
-  eventOutcomeCount.add(1, {source: 'manual', outcome: 'routed'});
+  subscriptionTriggeredCount.add(1, {provider: 'manual'});
+  eventOutcomeCount.add(1, {provider: 'manual', outcome: 'routed'});
   await history.routed(1);
   return run;
 }

--- a/libs/api/triggers/src/metrics/instance.ts
+++ b/libs/api/triggers/src/metrics/instance.ts
@@ -3,20 +3,20 @@ import {instanceMetrics} from '@shipfox/node-opentelemetry';
 const meter = instanceMetrics.getMeter('triggers');
 
 export const eventReceivedCount = meter.createCounter<{
-  source: string;
+  provider: string;
 }>('triggers_event_received', {
-  description: 'Trigger events received by source (e.g. github, gitlab, manual)',
+  description: 'Trigger events received by provider (e.g. github, gitea, sentry, manual)',
 });
 
 export const subscriptionTriggeredCount = meter.createCounter<{
-  source: string;
+  provider: string;
 }>('triggers_subscription_triggered', {
-  description: 'Subscriptions that resulted in a workflow run, by source',
+  description: 'Subscriptions that resulted in a workflow run, by provider',
 });
 
 export const eventOutcomeCount = meter.createCounter<{
-  source: string;
+  provider: string;
   outcome: 'discarded' | 'routed' | 'failed' | 'errored';
 }>('triggers_event_outcome', {
-  description: 'Final outcomes of trigger events by source and outcome',
+  description: 'Final outcomes of trigger events by provider and outcome',
 });

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.test.ts
@@ -18,6 +18,7 @@ describe('onIntegrationEventReceived', () => {
   test('passes the integration envelope to the core dispatcher', async () => {
     const receivedAt = '2026-06-21T03:20:00.000Z';
     const envelope: IntegrationEventReceivedEvent = {
+      provider: 'github',
       source: 'github',
       event: 'push',
       workspaceId: crypto.randomUUID(),
@@ -39,6 +40,7 @@ describe('onIntegrationEventReceived', () => {
     expect(dispatchIntegrationEvent).toHaveBeenCalledWith({
       eventRef: event.id,
       workspaceId: envelope.workspaceId,
+      provider: envelope.provider,
       source: envelope.source,
       event: envelope.event,
       deliveryId: envelope.deliveryId,

--- a/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
+++ b/libs/api/triggers/src/presentation/subscribers/on-integration-event-received.ts
@@ -9,6 +9,7 @@ export async function onIntegrationEventReceived(
   await dispatchIntegrationEvent({
     eventRef: event.id,
     workspaceId: envelope.workspaceId,
+    provider: envelope.provider,
     source: envelope.source,
     event: envelope.event,
     deliveryId: envelope.deliveryId,

--- a/libs/api/workflows/src/core/entities/workflow-run.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run.ts
@@ -25,12 +25,14 @@ export interface WorkflowSourceSnapshot {
 export type TriggerPayload =
   | {
       source: 'manual';
+      provider?: 'manual' | undefined;
       event: 'fire';
       subscriptionId: string;
       userId: string;
     }
   | {
       source: 'cron';
+      provider?: 'cron' | undefined;
       event: 'tick';
       scheduleId: string;
     }
@@ -39,6 +41,7 @@ export type TriggerPayload =
   // triggers module having to know each source's shape.
   | {
       source: string;
+      provider?: string | undefined;
       event: string;
       deliveryId: string;
       data: unknown;

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -215,7 +215,8 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     return {run, created: true};
   });
 
-  if (result.created) recordWorkflowRunCreated(result.run.triggerSource);
+  if (result.created)
+    recordWorkflowRunCreated(result.run.triggerPayload.provider ?? result.run.triggerSource);
 
   return result.run;
 }
@@ -386,7 +387,7 @@ export async function createRerunWorkflowRun(
     return toWorkflowRun(newRunRow);
   });
 
-  recordWorkflowRunCreated(result.triggerSource);
+  recordWorkflowRunCreated(result.triggerPayload.provider ?? result.triggerSource);
 
   return result;
 }

--- a/libs/api/workflows/src/metrics/instance.ts
+++ b/libs/api/workflows/src/metrics/instance.ts
@@ -5,8 +5,8 @@ import type {WorkflowRunStatus} from '#core/entities/workflow-run.js';
 
 const meter = instanceMetrics.getMeter('workflows');
 
-const runCreatedCount = meter.createCounter<{trigger_source: string}>('workflows_run_created', {
-  description: 'Workflow runs created by trigger source',
+const runCreatedCount = meter.createCounter<{provider: string}>('workflows_run_created', {
+  description: 'Workflow runs created by bounded trigger provider',
 });
 
 const runStatusChangedCount = meter.createCounter<{status: WorkflowRunStatus}>(
@@ -47,8 +47,8 @@ const stepRestartEnqueuedCount = meter.createCounter<Record<string, never>>(
   {description: 'Durable step restart events enqueued after a restartable gate failure'},
 );
 
-export function recordWorkflowRunCreated(triggerSource: string): void {
-  runCreatedCount.add(1, {trigger_source: triggerSource});
+export function recordWorkflowRunCreated(provider: string): void {
+  runCreatedCount.add(1, {provider});
 }
 
 export function recordWorkflowRunStatusChanged(status: WorkflowRunStatus): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -942,6 +942,9 @@ importers:
       '@shipfox/api-integration-sentry':
         specifier: workspace:*
         version: link:../sentry
+      '@shipfox/api-integration-webhook':
+        specifier: workspace:*
+        version: link:../webhook
       '@shipfox/api-workspaces':
         specifier: workspace:*
         version: link:../../workspaces
@@ -1419,6 +1422,95 @@ importers:
       '@shipfox/api-integration-core-dto':
         specifier: workspace:*
         version: link:../core-dto
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/depcruise':
+        specifier: workspace:*
+        version: link:../../../../tools/depcruise
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
+  libs/api/integration/webhook:
+    dependencies:
+      '@fastify/formbody':
+        specifier: ^8.0.2
+        version: 8.0.2
+      '@shipfox/api-auth-context':
+        specifier: workspace:*
+        version: link:../../auth-context
+      '@shipfox/api-integration-core-dto':
+        specifier: workspace:*
+        version: link:../core-dto
+      '@shipfox/api-integration-webhook-dto':
+        specifier: workspace:*
+        version: link:../webhook-dto
+      '@shipfox/api-workspaces':
+        specifier: workspace:*
+        version: link:../../workspaces
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../../shared/common/config
+      '@shipfox/node-fastify':
+        specifier: workspace:*
+        version: link:../../../shared/node/fastify
+      fastify-plugin:
+        specifier: ^5.1.0
+        version: 5.1.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/node-drizzle':
+        specifier: workspace:*
+        version: link:../../../shared/node/drizzle
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../../shared/node/opentelemetry
+      '@shipfox/node-postgres':
+        specifier: workspace:*
+        version: link:../../../shared/node/postgres
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      fastify:
+        specifier: ^5.3.3
+        version: 5.8.5
+      fastify-type-provider-zod:
+        specifier: ^6.0.0
+        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.3)
+
+  libs/api/integration/webhook-dto:
+    dependencies:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -5666,6 +5758,9 @@ packages:
 
   '@fastify/fast-json-stringify-compiler@5.0.3':
     resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/formbody@8.0.2':
+    resolution: {integrity: sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==}
 
   '@fastify/forwarded@3.0.1':
     resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
@@ -13524,6 +13619,11 @@ snapshots:
   '@fastify/fast-json-stringify-compiler@5.0.3':
     dependencies:
       fast-json-stringify: 6.3.0
+
+  '@fastify/formbody@8.0.2':
+    dependencies:
+      fast-querystring: 1.1.2
+      fastify-plugin: 5.1.0
 
   '@fastify/forwarded@3.0.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1478,15 +1478,6 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../../tools/biome
-      '@shipfox/node-drizzle':
-        specifier: workspace:*
-        version: link:../../../shared/node/drizzle
-      '@shipfox/node-opentelemetry':
-        specifier: workspace:*
-        version: link:../../../shared/node/opentelemetry
-      '@shipfox/node-postgres':
-        specifier: workspace:*
-        version: link:../../../shared/node/postgres
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../../../tools/swc
@@ -1499,9 +1490,6 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../../../tools/vitest
-      drizzle-orm:
-        specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
       fastify:
         specifier: ^5.3.3
         version: 5.8.5


### PR DESCRIPTION
Adds a backend-managed generic webhook integration provider so workspaces can create named inbound webhook connections without provider-specific OAuth or install flows.

The new provider exposes authenticated management routes for creating, listing, updating, and deleting webhook connections, plus a public inbound delivery route that accepts JSON, form, and text payloads. Deliveries are normalized into the generic integration event pipeline with redacted headers and provider-aware idempotency/metrics.

This also threads `provider` through generic integration events and trigger/workflow metrics so webhook events can be counted by bounded provider labels while existing source matching behavior stays intact.

All touched packages are private, so this PR does not include a changeset.

Refs ENG-686

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-managed generic webhook provider so workspaces can create named inbound URLs and receive events without OAuth. Events and metrics now use a bounded provider label, and webhook deliveries dedupe per connection while preserving sender `x-delivery-id`, aligning with ENG-686.

- **New Features**
  - New packages: `@shipfox/api-integration-webhook`, `@shipfox/api-integration-webhook-dto`.
  - Management routes (authed): create/list/update/delete connections; create returns the inbound URL.
  - Inbound route: `POST /webhook/:connectionId` accepts JSON, form, and text; 1 MB limit; returns 202 with `delivery_id`; honors `x-delivery-id` (200-char max) or generates a UUID; headers redacted via allowlist.
  - Slug validation (kebab-case) with reserved slugs (`github`, `gitea`, `sentry`, `manual`, `cron`).
  - DB helpers: create without upsert (duplicate → 409) and delete-by-id; delivery dedupe keyed by provider + scope + delivery (scope is per-connection for `webhook`, provider-wide for others).
  - Integration envelope includes `provider`; tests cover CRUD, inbound content types, reject paths, and overlong delivery IDs.
  - Metrics use a bounded `provider` label across triggers and workflow run creation.

- **Migration**
  - Enable with `INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER=true`.
  - Set `WEBHOOK_PUBLIC_URL` to build returned inbound URLs.
  - Update dashboards/alerts to use the `provider` label (replaces `source`) for `triggers_*` and `workflows_run_created`.

<sup>Written for commit 45834c913577d52960ee070b209e0c5501a922c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

