### PR TITLE
Add Conductor worktree service isolation

### DIFF
--- a/.changeset/brisk-harbors-listen.md
+++ b/.changeset/brisk-harbors-listen.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/node-fastify": minor
+---
+
+Adds optional host and port overrides to the Fastify listener for app-owned server configuration.

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,17 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+run_mode = "concurrent"
+setup = """
+mise trust
+mise install
+if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
+  mise exec -- node dev/worktree-services.mjs up
+fi
+mise exec -- pnpm -r install --frozen-lockfile
+"""
+archive = """
+if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
+  mise exec -- node dev/worktree-services.mjs destroy
+fi
+"""

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,5 +1,5 @@
 import {isIP} from 'node:net';
-import {bool, createConfig, str} from '@shipfox/config';
+import {bool, createConfig, port, str} from '@shipfox/config';
 
 export type ApiTrustProxy = false | true | number | string;
 
@@ -12,6 +12,10 @@ export const config = createConfig({
   }),
   E2E_ADMIN_API_KEY: str({
     desc: 'Bearer token that protects the E2E admin routes. Set it when E2E_ENABLED is true.',
+    default: undefined,
+  }),
+  API_PORT: port({
+    desc: 'Port the API HTTP server listens on. When unset, the shared PORT setting controls the server port.',
     default: undefined,
   }),
   API_TRUST_PROXY: str({

--- a/apps/api/src/core/run.test.ts
+++ b/apps/api/src/core/run.test.ts
@@ -16,6 +16,11 @@ const mocks = vi.hoisted(() => {
     createIntegrationsContext: vi.fn(),
     createPostgresClient: vi.fn(),
     createProjectsModule: vi.fn(),
+    apiConfig: {
+      API_PORT: undefined as number | undefined,
+      API_TRUST_PROXY: 'false',
+      E2E_ENABLED: false,
+    },
     initializeModules: vi.fn(),
     listen: vi.fn(),
     logger: {
@@ -73,7 +78,7 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
 }));
 vi.mock('@shipfox/node-postgres', () => ({createPostgresClient: mocks.createPostgresClient}));
 vi.mock('../config.js', () => ({
-  config: {API_TRUST_PROXY: 'false', E2E_ENABLED: false},
+  config: mocks.apiConfig,
   parseApiTrustProxy: mocks.parseApiTrustProxy,
 }));
 vi.mock('./e2e.js', () => ({
@@ -109,6 +114,9 @@ describe('run', () => {
     mocks.createIntegrationsContext.mockReset();
     mocks.createPostgresClient.mockReset();
     mocks.createProjectsModule.mockReset();
+    mocks.apiConfig.API_PORT = undefined;
+    mocks.apiConfig.API_TRUST_PROXY = 'false';
+    mocks.apiConfig.E2E_ENABLED = false;
     mocks.initializeModules.mockReset();
     mocks.listen.mockReset();
     mocks.logger.error.mockReset();
@@ -172,6 +180,14 @@ describe('run', () => {
     expect(mocks.startModuleWorkers.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.listen.mock.invocationCallOrder[0] ?? 0,
     );
+  });
+
+  it('passes API_PORT to the HTTP listener when configured', async () => {
+    mocks.apiConfig.API_PORT = 55_291;
+
+    await run();
+
+    expect(mocks.listen).toHaveBeenCalledWith({port: 55_291});
   });
 
   it('does not listen when module worker startup fails', async () => {

--- a/apps/api/src/core/run.ts
+++ b/apps/api/src/core/run.ts
@@ -66,7 +66,8 @@ export async function run(): Promise<void> {
   await startModuleWorkers({workers, onWorkerFailure: handleModuleWorkerFailure});
 
   logger().info('Starting HTTP server');
-  const address = await listen();
+  const address =
+    config.API_PORT === undefined ? await listen() : await listen({port: config.API_PORT});
   logger().info({address}, 'HTTP server listening');
 }
 

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -2,12 +2,21 @@ import {defineConfig} from '@shipfox/vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 
+const rawPort = process.env.SHIPFOX_CLIENT_PORT ?? process.env.VITE_PORT;
+const port = Number(rawPort ?? 5173);
+
+if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+  throw new Error(`SHIPFOX_CLIENT_PORT must be a valid TCP port; got ${rawPort}`);
+}
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
-    port: 5173,
+    port,
+    strictPort: true,
   },
   preview: {
-    port: 5173,
+    port,
+    strictPort: true,
   },
 });

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     port,
+    // Worktree ports must fail fast instead of silently shifting to another port.
     strictPort: true,
   },
   preview: {

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -6,7 +6,9 @@ const rawPort = process.env.SHIPFOX_CLIENT_PORT ?? process.env.VITE_PORT;
 const port = Number(rawPort ?? 5173);
 
 if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
-  throw new Error(`SHIPFOX_CLIENT_PORT must be a valid TCP port; got ${rawPort}`);
+  throw new Error(
+    `Client port must be a valid TCP port (1-65535); got ${rawPort} from SHIPFOX_CLIENT_PORT or VITE_PORT`,
+  );
 }
 
 export default defineConfig({

--- a/apps/provisioner-docker/README.md
+++ b/apps/provisioner-docker/README.md
@@ -43,6 +43,7 @@ until observation succeeds.
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | — | Path to the YAML template file (see `templates.example.yaml`). |
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
 | `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | — | Docker network attached to runner containers, for example a Compose network that can reach the API. |
+| `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | — | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | How long a `created` runner container may linger before being reaped as stale. |
 | `SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS` | no | `30` | Long-poll wait per demand request. |
 | `SHIPFOX_PROVISIONER_POLL_INTERVAL_MS` | no | `1000` | Base delay between polls; backs off on error. |

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
-    container_name: postgres
     image: postgres:18.4
+    network_mode: bridge
     environment:
       POSTGRES_USER: "shipfox"
       POSTGRES_PASSWORD: "password"
@@ -10,7 +10,7 @@ services:
       - postgres:/data/postgres
       - ./dev/postgres/init.sql:/docker-entrypoint-initdb.d/docker_postgres_init.sql
     ports:
-      - 127.0.0.1:5432:5432
+      - 127.0.0.1:${SHIPFOX_POSTGRES_PORT:-5432}:5432
     restart: unless-stopped
     healthcheck:
       test: [CMD, pg_isready, -U, shipfox, -d, api]
@@ -19,26 +19,26 @@ services:
       retries: 5
 
   temporal:
-    container_name: temporal
     image: temporalio/temporal:1.7.2
+    network_mode: bridge
     ports:
-      - 127.0.0.1:7233:7233
-      - 127.0.0.1:8233:8233
+      - 127.0.0.1:${SHIPFOX_TEMPORAL_PORT:-7233}:7233
+      - 127.0.0.1:${SHIPFOX_TEMPORAL_UI_PORT:-8233}:8233
     volumes:
       - temporal:/home/temporal
     command: "server start-dev --ip 0.0.0.0 --db-filename /home/temporal/temporal.db"
 
   garage:
-    container_name: garage
     image: dxflrs/garage:v2.3.0
+    network_mode: bridge
     volumes:
       - garage_meta:/var/lib/garage/meta
       - garage_data:/var/lib/garage/data
       - ./dev/garage/garage.toml:/etc/garage.toml:ro
     ports:
-      - 127.0.0.1:3900:3900
-      - 127.0.0.1:3901:3901
-      - 127.0.0.1:3903:3903
+      - 127.0.0.1:${SHIPFOX_GARAGE_S3_PORT:-3900}:3900
+      - 127.0.0.1:${SHIPFOX_GARAGE_RPC_PORT-3901}:3901
+      - 127.0.0.1:${SHIPFOX_GARAGE_ADMIN_PORT-3903}:3903
     restart: unless-stopped
     healthcheck:
       test: [CMD, /garage, status]
@@ -48,21 +48,25 @@ services:
 
   garage-init:
     image: alpine:3.24
+    network_mode: bridge
     depends_on:
       garage:
         condition: service_healthy
+    links:
+      - garage
     volumes:
       - ./dev/garage/bootstrap.sh:/bootstrap.sh:ro
     environment:
       GARAGE_URL: http://garage:3903
       GARAGE_S3_ENDPOINT: http://garage:3900
+      GARAGE_CORS_ALLOWED_ORIGINS: http://localhost:${SHIPFOX_CLIENT_PORT:-5173}
     entrypoint: [sh, -c, apk add --no-cache curl jq aws-cli >/dev/null && /bootstrap.sh]
     restart: "no"
 
   gitea:
-    container_name: gitea
     # This release fixes CVE-2026-28744 / CVE-2026-28699 on the git-http checkout path.
     image: gitea/gitea:1.26.2
+    network_mode: bridge
     environment:
       USER_UID: "1000"
       USER_GID: "1000"
@@ -71,13 +75,13 @@ services:
       # Bootstrap needs one open registration to create the first site admin.
       GITEA__service__DISABLE_REGISTRATION: "false"
       # Gitea derives clone/html URLs from ROOT_URL; the dev API and runner reach it via localhost.
-      GITEA__server__ROOT_URL: http://localhost:3000/
+      GITEA__server__ROOT_URL: http://localhost:${SHIPFOX_GITEA_HTTP_PORT:-3000}/
       GITEA__server__DOMAIN: localhost
       GITEA__server__HTTP_PORT: "3000"
       # Advertise SSH clone URLs on the published dev port.
       GITEA__server__START_SSH_SERVER: "true"
       GITEA__server__SSH_DOMAIN: localhost
-      GITEA__server__SSH_PORT: "2222"
+      GITEA__server__SSH_PORT: "${SHIPFOX_GITEA_SSH_PORT:-2222}"
       GITEA__server__SSH_LISTEN_PORT: "2222"
       # Dev webhooks target host.docker.internal, which Gitea blocks by default.
       GITEA__webhook__ALLOWED_HOST_LIST: "*"
@@ -85,8 +89,8 @@ services:
     volumes:
       - gitea:/data
     ports:
-      - 127.0.0.1:3000:3000
-      - 127.0.0.1:2222:2222
+      - 127.0.0.1:${SHIPFOX_GITEA_HTTP_PORT:-3000}:3000
+      - 127.0.0.1:${SHIPFOX_GITEA_SSH_PORT:-2222}:2222
     restart: unless-stopped
     healthcheck:
       test: [CMD, wget, -q, -O, "-", "http://127.0.0.1:3000/api/healthz"]
@@ -97,9 +101,12 @@ services:
 
   gitea-init:
     image: alpine:3.24
+    network_mode: bridge
     depends_on:
       gitea:
         condition: service_healthy
+    links:
+      - gitea
     volumes:
       - ./dev/gitea/bootstrap.sh:/bootstrap.sh:ro
       - ./dev/gitea/seed:/seed:ro
@@ -110,7 +117,7 @@ services:
       GITEA_SERVICE_TOKEN: shipfox-bot-dev-password
       GITEA_ORG: shipfox
       # Register the org push webhook as admin; the service account is read-only.
-      GITEA_WEBHOOK_TARGET_URL: http://host.docker.internal:16101/webhooks/integrations/gitea
+      GITEA_WEBHOOK_TARGET_URL: http://host.docker.internal:${SHIPFOX_API_PORT:-16101}/webhooks/integrations/gitea
       GITEA_WEBHOOK_SECRET: shipfox-gitea-dev-webhook-secret
     entrypoint: [sh, -c, apk add --no-cache curl jq >/dev/null && /bootstrap.sh]
     restart: "no"

--- a/compose.yml
+++ b/compose.yml
@@ -36,6 +36,7 @@ services:
       - garage_data:/var/lib/garage/data
       - ./dev/garage/garage.toml:/etc/garage.toml:ro
     ports:
+      # RPC/admin take ephemeral host ports per worktree (empty env + bare -); only S3 needs a fixed host port.
       - 127.0.0.1:${SHIPFOX_GARAGE_S3_PORT:-3900}:3900
       - 127.0.0.1:${SHIPFOX_GARAGE_RPC_PORT-3901}:3901
       - 127.0.0.1:${SHIPFOX_GARAGE_ADMIN_PORT-3903}:3903

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+import {spawnSync} from 'node:child_process';
+import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+const stateDir = resolve('.context/local-services');
+const portsFile = resolve(stateDir, 'ports.env');
+const composeEnvFile = resolve(stateDir, 'compose.env');
+const appEnvFile = resolve(stateDir, 'env');
+
+const commands = new Set(['up', 'stop', 'destroy', 'status']);
+const command = process.argv[2];
+
+if (!commands.has(command)) {
+  usage();
+  process.exit(1);
+}
+
+const workspaceName = requireConductorWorkspace();
+const projectName = resolveProjectName(workspaceName);
+
+switch (command) {
+  case 'up':
+    up(workspaceName, projectName);
+    break;
+  case 'stop':
+    stop(projectName);
+    break;
+  case 'destroy':
+    destroy(projectName);
+    break;
+  case 'status':
+    status(projectName);
+    break;
+}
+
+function up(workspaceName, projectName) {
+  mkdirSync(stateDir, {recursive: true});
+
+  const existing = readEnvFile(portsFile);
+  const ports =
+    Object.keys(existing).length > 0 ? portsFromEnv(existing) : portsFromBase(requireBasePort());
+
+  writeEnvFile(portsFile, {
+    SHIPFOX_WORKTREE_SERVICES_WORKSPACE: workspaceName,
+    SHIPFOX_WORKTREE_SERVICES_PROJECT: projectName,
+    SHIPFOX_PORT_BASE: String(ports.base),
+    ...portEnv(ports),
+  });
+  writeEnvFile(composeEnvFile, composeEnv(ports));
+  writeAppEnvFile(appEnvFile, appEnv(ports));
+
+  runDockerCompose(projectName, ['up', '-d', '--wait', 'postgres', 'temporal', 'garage', 'gitea']);
+  runDockerCompose(projectName, ['run', '--rm', 'garage-init']);
+  runDockerCompose(projectName, ['run', '--rm', 'gitea-init']);
+
+  console.log(`Worktree services are ready for ${workspaceName}.`);
+  console.log(`Docker Compose project: ${projectName}`);
+  console.log(`Mise environment: ${relativePath(appEnvFile)}`);
+}
+
+function stop(projectName) {
+  requireComposeState();
+  runDockerCompose(projectName, ['down', '--remove-orphans']);
+}
+
+function destroy(projectName) {
+  if (!existsSync(composeEnvFile)) {
+    rmSync(stateDir, {recursive: true, force: true});
+    return;
+  }
+  runDockerCompose(projectName, ['down', '-v', '--remove-orphans']);
+  rmSync(stateDir, {recursive: true, force: true});
+}
+
+function status(projectName) {
+  requireComposeState();
+  runDockerCompose(projectName, ['ps']);
+}
+
+function requireConductorWorkspace() {
+  const name = process.env.CONDUCTOR_WORKSPACE_NAME;
+  if (!name) {
+    fail('This script must run from a Conductor workspace. CONDUCTOR_WORKSPACE_NAME is not set.');
+  }
+  return name;
+}
+
+function requireBasePort() {
+  const raw = process.env.CONDUCTOR_PORT;
+  const port = Number(raw);
+  if (!raw || !Number.isInteger(port) || port <= 0 || port > 65_526) {
+    fail('CONDUCTOR_PORT must be set to a valid base port for worktree services.');
+  }
+  return port;
+}
+
+function requireComposeState() {
+  if (!existsSync(composeEnvFile)) {
+    fail(`Missing ${relativePath(composeEnvFile)}. Run "worktree-services.mjs up" first.`);
+  }
+}
+
+function portsFromBase(base) {
+  return {
+    base,
+    client: base,
+    api: base + 1,
+    postgres: base + 2,
+    temporal: base + 3,
+    temporalUi: base + 4,
+    garageS3: base + 5,
+    giteaHttp: base + 6,
+    giteaSsh: base + 7,
+    otelInstance: base + 8,
+    otelService: base + 9,
+  };
+}
+
+function portsFromEnv(env) {
+  const base = numberFromEnv(env, 'SHIPFOX_PORT_BASE');
+  const ports = {
+    base,
+    client: numberFromEnv(env, 'SHIPFOX_CLIENT_PORT'),
+    api: numberFromEnv(env, 'SHIPFOX_API_PORT'),
+    postgres: numberFromEnv(env, 'SHIPFOX_POSTGRES_PORT'),
+    temporal: numberFromEnv(env, 'SHIPFOX_TEMPORAL_PORT'),
+    temporalUi: numberFromEnv(env, 'SHIPFOX_TEMPORAL_UI_PORT'),
+    garageS3: numberFromEnv(env, 'SHIPFOX_GARAGE_S3_PORT'),
+    giteaHttp: numberFromEnv(env, 'SHIPFOX_GITEA_HTTP_PORT'),
+    giteaSsh: numberFromEnv(env, 'SHIPFOX_GITEA_SSH_PORT'),
+    otelInstance: numberFromEnv(env, 'SHIPFOX_OTEL_INSTANCE_METRICS_PORT'),
+    otelService: numberFromEnv(env, 'SHIPFOX_OTEL_SERVICE_METRICS_PORT'),
+  };
+  return ports;
+}
+
+function numberFromEnv(env, key) {
+  const port = Number(env[key]);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    fail(`${portsFile} contains an invalid ${key}: ${env[key] ?? '<missing>'}`);
+  }
+  return port;
+}
+
+function portEnv(ports) {
+  return {
+    SHIPFOX_CLIENT_PORT: String(ports.client),
+    SHIPFOX_API_PORT: String(ports.api),
+    SHIPFOX_POSTGRES_PORT: String(ports.postgres),
+    SHIPFOX_TEMPORAL_PORT: String(ports.temporal),
+    SHIPFOX_TEMPORAL_UI_PORT: String(ports.temporalUi),
+    SHIPFOX_GARAGE_S3_PORT: String(ports.garageS3),
+    SHIPFOX_GITEA_HTTP_PORT: String(ports.giteaHttp),
+    SHIPFOX_GITEA_SSH_PORT: String(ports.giteaSsh),
+    SHIPFOX_OTEL_INSTANCE_METRICS_PORT: String(ports.otelInstance),
+    SHIPFOX_OTEL_SERVICE_METRICS_PORT: String(ports.otelService),
+  };
+}
+
+function composeEnv(ports) {
+  return {
+    ...portEnv(ports),
+    SHIPFOX_GARAGE_RPC_PORT: '',
+    SHIPFOX_GARAGE_ADMIN_PORT: '',
+  };
+}
+
+function appEnv(ports) {
+  const apiUrl = `http://localhost:${ports.api}`;
+  const clientUrl = `http://localhost:${ports.client}`;
+  return {
+    API_PORT: String(ports.api),
+    CLIENT_BASE_URL: clientUrl,
+    POSTGRES_HOST: 'localhost',
+    POSTGRES_PORT: String(ports.postgres),
+    POSTGRES_USERNAME: 'shipfox',
+    POSTGRES_PASSWORD: 'password',
+    POSTGRES_DATABASE: 'api',
+    TEMPORAL_ADDRESS: `localhost:${ports.temporal}`,
+    GITEA_BASE_URL: `http://localhost:${ports.giteaHttp}`,
+    LOG_STORAGE_S3_ENDPOINT: `http://localhost:${ports.garageS3}`,
+    OTEL_INSTANCE_METRICS_PORT: String(ports.otelInstance),
+    OTEL_SERVICE_METRICS_PORT: String(ports.otelService),
+    VITE_API_URL: apiUrl,
+    SHIPFOX_CLIENT_PORT: String(ports.client),
+    SHIPFOX_API_URL: apiUrl,
+    SHIPFOX_RUNNER_API_URL: `http://host.docker.internal:${ports.api}`,
+  };
+}
+
+function runDockerCompose(projectName, args) {
+  const result = spawnSync(
+    'docker',
+    ['compose', '--env-file', composeEnvFile, '-p', projectName, ...args],
+    {stdio: 'inherit'},
+  );
+  if (result.error) fail(result.error.message);
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+function resolveProjectName(workspaceName) {
+  const existing = readEnvFile(portsFile);
+  return existing.SHIPFOX_WORKTREE_SERVICES_PROJECT || composeProjectName(workspaceName);
+}
+
+function composeProjectName(workspaceName) {
+  const normalized = workspaceName.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+/, '');
+  const suffix = normalized || 'workspace';
+  return `shipfox-${suffix}`.slice(0, 63);
+}
+
+function readEnvFile(file) {
+  if (!existsSync(file)) return {};
+
+  const entries = {};
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex);
+    const value = trimmed.slice(separatorIndex + 1);
+    entries[key] = value;
+  }
+  return entries;
+}
+
+function writeEnvFile(file, values) {
+  const body = `${Object.entries(values)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')}\n`;
+  writeFileSync(file, body);
+}
+
+function writeAppEnvFile(file, values) {
+  const body = [
+    '# Loaded by mise.toml for commands run in this worktree.',
+    '# It is generated by dev/worktree-services.mjs.',
+    ...Object.entries(values).map(([key, value]) => `${key}=${dotenvQuote(value)}`),
+    '',
+  ].join('\n');
+  writeFileSync(file, body);
+}
+
+function dotenvQuote(value) {
+  return JSON.stringify(String(value));
+}
+
+function relativePath(file) {
+  return file.startsWith(`${process.cwd()}/`) ? file.slice(process.cwd().length + 1) : file;
+}
+
+function usage() {
+  console.error('Usage: node dev/worktree-services.mjs <up|stop|destroy|status>');
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -1,15 +1,19 @@
 #!/usr/bin/env node
 import {spawnSync} from 'node:child_process';
+import {createHash} from 'node:crypto';
 import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
+const composeProjectNameMaxLength = 63;
+const composeProjectNamePrefix = 'shipfox-';
 const stateDir = resolve('.context/local-services');
 const portsFile = resolve(stateDir, 'ports.env');
 const composeEnvFile = resolve(stateDir, 'compose.env');
 const appEnvFile = resolve(stateDir, 'env');
 const composeProjectNameInvalidChars = /[^a-z0-9_-]+/g;
 const composeProjectNameLeadingDashes = /^-+/;
+const composeProjectNameTrailingDashes = /-+$/;
 
 if (isCliEntryPoint()) {
   main(process.argv[2]);
@@ -173,7 +177,7 @@ function composeEnv(ports) {
   };
 }
 
-function appEnv(ports) {
+export function appEnv(ports) {
   const apiUrl = `http://localhost:${ports.api}`;
   const clientUrl = `http://localhost:${ports.client}`;
   return {
@@ -193,6 +197,7 @@ function appEnv(ports) {
     SHIPFOX_CLIENT_PORT: String(ports.client),
     SHIPFOX_API_URL: apiUrl,
     SHIPFOX_RUNNER_API_URL: `http://host.docker.internal:${ports.api}`,
+    SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS: 'host.docker.internal:host-gateway',
   };
 }
 
@@ -216,8 +221,14 @@ export function composeProjectName(workspaceName) {
     .toLowerCase()
     .replace(composeProjectNameInvalidChars, '-')
     .replace(composeProjectNameLeadingDashes, '');
-  const suffix = normalized || 'workspace';
-  return `shipfox-${suffix}`.slice(0, 63);
+  const hash = createHash('sha256').update(workspaceName).digest('hex').slice(0, 8);
+  const suffixLength =
+    composeProjectNameMaxLength - composeProjectNamePrefix.length - hash.length - 1;
+  const suffix =
+    (normalized || 'workspace')
+      .slice(0, suffixLength)
+      .replace(composeProjectNameTrailingDashes, '') || 'workspace';
+  return `${composeProjectNamePrefix}${suffix}-${hash}`;
 }
 
 function readEnvFile(file) {

--- a/dev/worktree-services.mjs
+++ b/dev/worktree-services.mjs
@@ -2,36 +2,43 @@
 import {spawnSync} from 'node:child_process';
 import {existsSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const stateDir = resolve('.context/local-services');
 const portsFile = resolve(stateDir, 'ports.env');
 const composeEnvFile = resolve(stateDir, 'compose.env');
 const appEnvFile = resolve(stateDir, 'env');
+const composeProjectNameInvalidChars = /[^a-z0-9_-]+/g;
+const composeProjectNameLeadingDashes = /^-+/;
 
-const commands = new Set(['up', 'stop', 'destroy', 'status']);
-const command = process.argv[2];
-
-if (!commands.has(command)) {
-  usage();
-  process.exit(1);
+if (isCliEntryPoint()) {
+  main(process.argv[2]);
 }
 
-const workspaceName = requireConductorWorkspace();
-const projectName = resolveProjectName(workspaceName);
+export function main(command) {
+  const commands = new Set(['up', 'stop', 'destroy', 'status']);
+  if (!commands.has(command)) {
+    usage();
+    process.exit(1);
+  }
 
-switch (command) {
-  case 'up':
-    up(workspaceName, projectName);
-    break;
-  case 'stop':
-    stop(projectName);
-    break;
-  case 'destroy':
-    destroy(projectName);
-    break;
-  case 'status':
-    status(projectName);
-    break;
+  const workspaceName = requireConductorWorkspace();
+  const projectName = resolveProjectName(workspaceName);
+
+  switch (command) {
+    case 'up':
+      up(workspaceName, projectName);
+      break;
+    case 'stop':
+      stop(projectName);
+      break;
+    case 'destroy':
+      destroy(projectName);
+      break;
+    case 'status':
+      status(projectName);
+      break;
+  }
 }
 
 function up(workspaceName, projectName) {
@@ -54,9 +61,9 @@ function up(workspaceName, projectName) {
   runDockerCompose(projectName, ['run', '--rm', 'garage-init']);
   runDockerCompose(projectName, ['run', '--rm', 'gitea-init']);
 
-  console.log(`Worktree services are ready for ${workspaceName}.`);
-  console.log(`Docker Compose project: ${projectName}`);
-  console.log(`Mise environment: ${relativePath(appEnvFile)}`);
+  printLine(`Worktree services are ready for ${workspaceName}.`);
+  printLine(`Docker Compose project: ${projectName}`);
+  printLine(`Mise environment: ${relativePath(appEnvFile)}`);
 }
 
 function stop(projectName) {
@@ -88,8 +95,8 @@ function requireConductorWorkspace() {
 
 function requireBasePort() {
   const raw = process.env.CONDUCTOR_PORT;
-  const port = Number(raw);
-  if (!raw || !Number.isInteger(port) || port <= 0 || port > 65_526) {
+  const port = parseBasePort(raw);
+  if (port === undefined) {
     fail('CONDUCTOR_PORT must be set to a valid base port for worktree services.');
   }
   return port;
@@ -101,7 +108,7 @@ function requireComposeState() {
   }
 }
 
-function portsFromBase(base) {
+export function portsFromBase(base) {
   return {
     base,
     client: base,
@@ -136,8 +143,8 @@ function portsFromEnv(env) {
 }
 
 function numberFromEnv(env, key) {
-  const port = Number(env[key]);
-  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+  const port = parsePort(env[key]);
+  if (port === undefined) {
     fail(`${portsFile} contains an invalid ${key}: ${env[key] ?? '<missing>'}`);
   }
   return port;
@@ -204,17 +211,22 @@ function resolveProjectName(workspaceName) {
   return existing.SHIPFOX_WORKTREE_SERVICES_PROJECT || composeProjectName(workspaceName);
 }
 
-function composeProjectName(workspaceName) {
-  const normalized = workspaceName.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+/, '');
+export function composeProjectName(workspaceName) {
+  const normalized = workspaceName
+    .toLowerCase()
+    .replace(composeProjectNameInvalidChars, '-')
+    .replace(composeProjectNameLeadingDashes, '');
   const suffix = normalized || 'workspace';
   return `shipfox-${suffix}`.slice(0, 63);
 }
 
 function readEnvFile(file) {
-  if (!existsSync(file)) return {};
+  return existsSync(file) ? parseEnvFile(readFileSync(file, 'utf8')) : {};
+}
 
+export function parseEnvFile(content) {
   const entries = {};
-  for (const line of readFileSync(file, 'utf8').split('\n')) {
+  for (const line of content.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith('#')) continue;
 
@@ -226,6 +238,16 @@ function readEnvFile(file) {
     entries[key] = value;
   }
   return entries;
+}
+
+export function parsePort(raw) {
+  const port = Number(raw);
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : undefined;
+}
+
+export function parseBasePort(raw) {
+  const port = parsePort(raw);
+  return port !== undefined && port <= 65_526 ? port : undefined;
 }
 
 function writeEnvFile(file, values) {
@@ -254,10 +276,24 @@ function relativePath(file) {
 }
 
 function usage() {
-  console.error('Usage: node dev/worktree-services.mjs <up|stop|destroy|status>');
+  printError('Usage: node dev/worktree-services.mjs <up|stop|destroy|status>');
 }
 
 function fail(message) {
-  console.error(message);
+  printError(message);
   process.exit(1);
+}
+
+function isCliEntryPoint() {
+  return (
+    process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+function printLine(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function printError(message) {
+  process.stderr.write(`${message}\n`);
 }

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import {describe, test} from 'node:test';
 
 import {
+  appEnv,
   composeProjectName,
   parseBasePort,
   parseEnvFile,
@@ -9,7 +10,7 @@ import {
   portsFromBase,
 } from './worktree-services.mjs';
 
-const longShipfoxProjectName = /^shipfox-a+$/;
+const longShipfoxProjectName = /^shipfox-a+-[a-f0-9]{8}$/;
 
 describe('portsFromBase', () => {
   test('assigns stable offsets from the base port', () => {
@@ -35,20 +36,38 @@ describe('composeProjectName', () => {
   test('normalizes workspace names into Compose project names', () => {
     const projectName = composeProjectName('Kolkata ! Workspace');
 
-    assert.equal(projectName, 'shipfox-kolkata-workspace');
+    assert.equal(projectName, 'shipfox-kolkata-workspace-f5f09833');
   });
 
-  test('caps project names at the Docker Compose limit', () => {
+  test('caps project names at the Docker Compose limit with a stable hash suffix', () => {
     const projectName = composeProjectName('a'.repeat(100));
 
     assert.equal(projectName.length, 63);
     assert.match(projectName, longShipfoxProjectName);
   });
 
+  test('keeps long workspace names distinct after truncation', () => {
+    const first = composeProjectName(`${'a'.repeat(100)}-first`);
+    const second = composeProjectName(`${'a'.repeat(100)}-second`);
+
+    assert.notEqual(first, second);
+    assert.equal(first.length, 63);
+    assert.equal(second.length, 63);
+  });
+
   test('uses a fallback when normalization removes every character', () => {
     const projectName = composeProjectName('!!!');
 
-    assert.equal(projectName, 'shipfox-workspace');
+    assert.equal(projectName, 'shipfox-workspace-e84c538e');
+  });
+});
+
+describe('appEnv', () => {
+  test('sets runner container host access for worktree APIs', () => {
+    const env = appEnv(portsFromBase(55_290));
+
+    assert.equal(env.SHIPFOX_RUNNER_API_URL, 'http://host.docker.internal:55291');
+    assert.equal(env.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS, 'host.docker.internal:host-gateway');
   });
 });
 

--- a/dev/worktree-services.test.mjs
+++ b/dev/worktree-services.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import {describe, test} from 'node:test';
+
+import {
+  composeProjectName,
+  parseBasePort,
+  parseEnvFile,
+  parsePort,
+  portsFromBase,
+} from './worktree-services.mjs';
+
+const longShipfoxProjectName = /^shipfox-a+$/;
+
+describe('portsFromBase', () => {
+  test('assigns stable offsets from the base port', () => {
+    const ports = portsFromBase(65_000);
+
+    assert.deepEqual(ports, {
+      base: 65_000,
+      client: 65_000,
+      api: 65_001,
+      postgres: 65_002,
+      temporal: 65_003,
+      temporalUi: 65_004,
+      garageS3: 65_005,
+      giteaHttp: 65_006,
+      giteaSsh: 65_007,
+      otelInstance: 65_008,
+      otelService: 65_009,
+    });
+  });
+});
+
+describe('composeProjectName', () => {
+  test('normalizes workspace names into Compose project names', () => {
+    const projectName = composeProjectName('Kolkata ! Workspace');
+
+    assert.equal(projectName, 'shipfox-kolkata-workspace');
+  });
+
+  test('caps project names at the Docker Compose limit', () => {
+    const projectName = composeProjectName('a'.repeat(100));
+
+    assert.equal(projectName.length, 63);
+    assert.match(projectName, longShipfoxProjectName);
+  });
+
+  test('uses a fallback when normalization removes every character', () => {
+    const projectName = composeProjectName('!!!');
+
+    assert.equal(projectName, 'shipfox-workspace');
+  });
+});
+
+describe('parseEnvFile', () => {
+  test('parses simple dotenv-style entries', () => {
+    const env = parseEnvFile(`
+      # generated
+      SHIPFOX_CLIENT_PORT=55290
+      EMPTY=
+      URL=http://localhost:3900/path?x=1
+      invalid
+    `);
+
+    assert.deepEqual(env, {
+      SHIPFOX_CLIENT_PORT: '55290',
+      EMPTY: '',
+      URL: 'http://localhost:3900/path?x=1',
+    });
+  });
+});
+
+describe('parsePort', () => {
+  test('accepts TCP port bounds', () => {
+    assert.equal(parsePort('1'), 1);
+    assert.equal(parsePort('65535'), 65_535);
+  });
+
+  test('rejects missing, non-integer, and out-of-range values', () => {
+    assert.equal(parsePort(undefined), undefined);
+    assert.equal(parsePort(''), undefined);
+    assert.equal(parsePort('0'), undefined);
+    assert.equal(parsePort('12.5'), undefined);
+    assert.equal(parsePort('65536'), undefined);
+    assert.equal(parsePort('abc'), undefined);
+  });
+});
+
+describe('parseBasePort', () => {
+  test('keeps the base port low enough for every service offset', () => {
+    assert.equal(parseBasePort('65526'), 65_526);
+    assert.equal(parseBasePort('65527'), undefined);
+  });
+});

--- a/libs/api/agent/test/env.ts
+++ b/libs/api/agent/test/env.ts
@@ -1,8 +1,8 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';
 process.env.AGENT_CREDENTIALS_ENCRYPTION_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';

--- a/libs/api/auth/test/env.ts
+++ b/libs/api/auth/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';

--- a/libs/api/definitions/test/env.ts
+++ b/libs/api/definitions/test/env.ts
@@ -1,7 +1,7 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';

--- a/libs/api/integration/core/test/env.ts
+++ b/libs/api/integration/core/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';
 process.env.GITHUB_APP_ID = '1';
 process.env.GITHUB_APP_PRIVATE_KEY = 'test-private-key';

--- a/libs/api/integration/debug/test/env.ts
+++ b/libs/api/integration/debug/test/env.ts
@@ -1,7 +1,7 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';

--- a/libs/api/integration/gitea/test/env.ts
+++ b/libs/api/integration/gitea/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';
 process.env.GITEA_BASE_URL = 'https://gitea.example.com';
 process.env.GITEA_SERVICE_USERNAME = 'shipfox-bot';

--- a/libs/api/integration/github/test/env.ts
+++ b/libs/api/integration/github/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';
 process.env.GITHUB_APP_ID = '1';
 process.env.GITHUB_APP_PRIVATE_KEY = 'test-private-key';

--- a/libs/api/integration/sentry/test/env.ts
+++ b/libs/api/integration/sentry/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';
 process.env.SENTRY_APP_CLIENT_ID = 'test-client-id';
 process.env.SENTRY_APP_CLIENT_SECRET = 'test-client-secret';

--- a/libs/api/logs/test/env.ts
+++ b/libs/api/logs/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';
@@ -26,7 +26,7 @@ process.env.LOG_READ_INLINE_MAX_BYTES = '256';
 
 // Real Garage dev credentials (bootstrap.sh creates the shipfox-logs-test bucket and grants
 // this key). Compaction tests upload to and read back from live Garage from compose.yml.
-process.env.LOG_STORAGE_S3_ENDPOINT = 'http://localhost:3900';
+process.env.LOG_STORAGE_S3_ENDPOINT ??= 'http://localhost:3900';
 process.env.LOG_STORAGE_S3_REGION = 'garage';
 process.env.LOG_STORAGE_S3_BUCKET = 'shipfox-logs-test';
 process.env.LOG_STORAGE_S3_ACCESS_KEY_ID = 'GK000000000000000000000000';

--- a/libs/api/projects/test/env.ts
+++ b/libs/api/projects/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.TZ = 'UTC';
 process.env.GITHUB_APP_ID = '1';
 process.env.GITHUB_APP_PRIVATE_KEY = 'test-private-key';

--- a/libs/api/runners/test/env.ts
+++ b/libs/api/runners/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.WORKSPACE_JWT_SECRET = 'test-secret';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';

--- a/libs/api/triggers/test/env.ts
+++ b/libs/api/triggers/test/env.ts
@@ -1,8 +1,8 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.AGENT_CREDENTIALS_ENCRYPTION_KEY = 'MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=';
 process.env.TZ = 'UTC';

--- a/libs/api/workflows/test/env.ts
+++ b/libs/api/workflows/test/env.ts
@@ -1,9 +1,9 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.AUTH_JWT_SECRET = 'test-secret';
 process.env.AUTH_JOB_LEASE_TOKEN_SECRET = 'test-lease-secret';
 process.env.AUTH_RUNNER_SESSION_TOKEN_SECRET = 'test-runner-session-secret';

--- a/libs/api/workspaces/test/env.ts
+++ b/libs/api/workspaces/test/env.ts
@@ -1,8 +1,8 @@
-process.env.POSTGRES_HOST = 'localhost';
-process.env.POSTGRES_PORT = '5432';
-process.env.POSTGRES_USERNAME = 'shipfox';
-process.env.POSTGRES_PASSWORD = 'password';
+process.env.POSTGRES_HOST ??= 'localhost';
+process.env.POSTGRES_PORT ??= '5432';
+process.env.POSTGRES_USERNAME ??= 'shipfox';
+process.env.POSTGRES_PASSWORD ??= 'password';
 process.env.POSTGRES_DATABASE = 'api_test';
-process.env.POSTGRES_MAX_CONNECTIONS = '5';
+process.env.POSTGRES_MAX_CONNECTIONS ??= '5';
 process.env.WORKSPACE_JWT_SECRET = 'test-secret';
 process.env.TZ = 'UTC';

--- a/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
@@ -46,7 +46,7 @@ describe('AgentProviderUsageModal', () => {
     expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).not.toHaveTextContent(
       'model: claude-opus-4-8',
     );
-  });
+  }, 10_000);
 
   test('renders reference models as clickable rows with inline ids', async () => {
     renderUsageModal();

--- a/libs/client/agent/src/components/agent-providers-section.test.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.test.tsx
@@ -268,7 +268,7 @@ describe('WorkspaceAgentProvidersSection', () => {
     expect(screen.queryByText(OPENAI_FINGERPRINT_RE)).not.toBeInTheDocument();
     expect(screen.queryByText('GPT-5 Mini')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('sk-proj-secret')).not.toBeInTheDocument();
-  });
+  }, 10_000);
 
   test('does not automatically open the usage modal after configuring an additional provider', async () => {
     const user = userEvent.setup();

--- a/libs/provisioner/docker/README.md
+++ b/libs/provisioner/docker/README.md
@@ -62,6 +62,7 @@ variables:
 | `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | - | YAML template file describing labels, image, cpu, memory, and max concurrency. |
 | `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | local Docker socket | Docker daemon host used by dockerode. |
 | `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | - | Docker network attached to runner containers, useful for Compose-local API access. |
+| `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | - | Comma-separated host mappings added to runner containers, such as `host.docker.internal:host-gateway`. |
 | `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS` | no | `120000` | Maximum time a `created` container may linger before being reaped as stale. |
 
 The core `SHIPFOX_RUNNER_API_URL` variable is injected into runner containers as

--- a/libs/provisioner/docker/src/config.ts
+++ b/libs/provisioner/docker/src/config.ts
@@ -12,11 +12,19 @@ export const config = createConfig({
     desc: 'Docker network attached to runner containers. Set it when containers must join a Compose or bridge network to reach SHIPFOX_RUNNER_API_URL.',
     default: undefined,
   }),
+  SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS: str({
+    desc: 'Comma-separated host mappings added to runner containers, such as host.docker.internal:host-gateway. Set it when containers need Docker host names that are not available by default.',
+    default: undefined,
+  }),
   SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS: num({
     desc: 'How long a created runner container may remain unstarted before the provisioner reaps it as a stale pre-run resource, in milliseconds.',
     default: 120_000,
   }),
 });
+
+export const dockerExtraHosts = parseDockerExtraHosts(
+  config.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS,
+);
 
 if (
   !Number.isInteger(config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS) ||
@@ -25,4 +33,12 @@ if (
   throw new Error(
     `SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS must be a positive integer; got ${config.SHIPFOX_PROVISIONER_REGISTRATION_DEADLINE_MS}.`,
   );
+}
+
+function parseDockerExtraHosts(value: string | undefined): string[] | undefined {
+  const hosts = value
+    ?.split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return hosts && hosts.length > 0 ? hosts : undefined;
 }

--- a/libs/provisioner/docker/src/docker-engine.test.ts
+++ b/libs/provisioner/docker/src/docker-engine.test.ts
@@ -14,7 +14,11 @@ describe('createDockerEngine', () => {
 
   it('creates and starts a container with Docker resource limits', async () => {
     const docker = fakeDocker();
-    const engine = createDockerEngine({docker: docker as never, network: 'shipfox'});
+    const engine = createDockerEngine({
+      docker: docker as never,
+      extraHosts: ['host.docker.internal:host-gateway'],
+      network: 'shipfox',
+    });
 
     await engine.createAndStart({
       name: 'runner-1',
@@ -33,6 +37,7 @@ describe('createDockerEngine', () => {
         NanoCpus: 1_000_000_000,
         Memory: 1024,
         RestartPolicy: {Name: 'no'},
+        ExtraHosts: ['host.docker.internal:host-gateway'],
         NetworkMode: 'shipfox',
       },
     });

--- a/libs/provisioner/docker/src/docker-engine.ts
+++ b/libs/provisioner/docker/src/docker-engine.ts
@@ -61,6 +61,7 @@ export interface DockerEngine {
 export interface CreateDockerEngineOptions {
   readonly host?: string;
   readonly network?: string;
+  readonly extraHosts?: readonly string[];
   readonly docker?: Docker;
 }
 
@@ -115,6 +116,7 @@ export function createDockerEngine(options: CreateDockerEngineOptions = {}): Doc
             Memory: args.memoryBytes,
             RestartPolicy: {Name: 'no'},
             ...(options.network ? {NetworkMode: options.network} : {}),
+            ...(options.extraHosts ? {ExtraHosts: [...options.extraHosts]} : {}),
           },
         });
       } catch (error) {

--- a/libs/provisioner/docker/src/provisioner.ts
+++ b/libs/provisioner/docker/src/provisioner.ts
@@ -1,5 +1,5 @@
 import {startProvisioner} from '@shipfox/provisioner-core';
-import {config} from '#config.js';
+import {config, dockerExtraHosts} from '#config.js';
 import {createDockerEngine} from '#docker-engine.js';
 import {createDockerLifecycle, type DockerLifecycle} from '#lifecycle.js';
 import {type DockerTemplateSpec, loadDockerTemplates} from '#templates.js';
@@ -17,6 +17,7 @@ export function startDockerProvisioner(): Promise<void> {
     ...(config.SHIPFOX_PROVISIONER_DOCKER_NETWORK
       ? {network: config.SHIPFOX_PROVISIONER_DOCKER_NETWORK}
       : {}),
+    ...(dockerExtraHosts ? {extraHosts: dockerExtraHosts} : {}),
   });
   let lifecycle: DockerLifecycle | undefined;
 

--- a/libs/shared/node/fastify/src/index.ts
+++ b/libs/shared/node/fastify/src/index.ts
@@ -46,6 +46,11 @@ export {
 
 let _app: FastifyInstance | undefined;
 
+export type ListenOptions = {
+  host?: string;
+  port?: number;
+};
+
 export async function createApp(appConfig?: AppConfig): Promise<FastifyInstance> {
   clearAuthMethods();
 
@@ -102,11 +107,14 @@ export function app(): FastifyInstance {
   return _app;
 }
 
-export async function listen(): Promise<string> {
+export async function listen(options: ListenOptions = {}): Promise<string> {
   if (!_app) {
     throw new Error('Fastify app has not been created');
   }
-  const address = await _app.listen({host: config.HOST, port: config.PORT});
+  const address = await _app.listen({
+    host: options.host ?? config.HOST,
+    port: options.port ?? config.PORT,
+  });
   return address;
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ gh = "2.95.0"
 
 [env]
 _.path = ['{{config_root}}/node_modules/.bin']
+_.file = '.context/local-services/env'
 
 [settings]
 lockfile       = true

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "packageManager": "pnpm@11.7.0",
   "type": "module",
   "scripts": {
+    "test": "node --test dev/*.test.mjs",
     "release:publish": "turbo type build type:emit --filter='./libs/**' --filter='./tools/**' && changeset publish"
   },
   "devDependencies": {

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -42,6 +42,17 @@
     },
     "test": {
       "cache": true,
+      "passThroughEnv": [
+        "CLIENT_BASE_URL",
+        "GITEA_BASE_URL",
+        "LOG_STORAGE_S3_ENDPOINT",
+        "OTEL_INSTANCE_METRICS_PORT",
+        "OTEL_SERVICE_METRICS_PORT",
+        "POSTGRES_*",
+        "SHIPFOX_*",
+        "TEMPORAL_ADDRESS",
+        "VITE_API_URL"
+      ],
       "dependsOn": ["^build", "build"]
     },
     "test:e2e": {


### PR DESCRIPTION
Add Conductor-managed local service isolation for parallel worktree development.

Conductor workspaces previously shared the same Docker Compose project and fixed service ports, so agents working in parallel could collide on PostgreSQL, Garage, Gitea, Temporal, and dev server ports. This adds a repo-shared Conductor setup/archive flow that provisions a workspace-specific Compose project, writes a mise-loaded local env file, and tears the stack down when the workspace is archived.

The API app now owns `API_PORT` and passes it to the shared Fastify listener, while Fastify keeps its generic `PORT` default. The client dev server uses `SHIPFOX_CLIENT_PORT`, and API test env setup files preserve worktree-provided DB/service connection values while still forcing `api_test`.

Review areas: Docker Compose interpolation and init sequencing, the generated env contract in `dev/worktree-services.mjs`, and the `@shipfox/node-fastify` listener override added for app-owned server config.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates local dev services per Conductor workspace so multiple worktrees can run in parallel without port conflicts. Adds a workspace-scoped Docker Compose project, a mise-loaded env, strict port validation, and hardened service bootstrap.

- New Features
  - Conductor integration: `.conductor/settings.toml` runs `dev/worktree-services.mjs up` on setup and `destroy` on archive.
  - `dev/worktree-services.mjs`: generates `.context/local-services` env, allocates ports from `CONDUCTOR_PORT`, derives a stable Compose project name, waits for health, runs Garage/Gitea init, and supports `up|stop|destroy|status`. Writes app env with `API_PORT`, client/API URLs, runner URL, and `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS`.
  - Compose: all ports parameterized via `SHIPFOX_*`; Garage RPC/admin use ephemeral host ports; CORS origins come from the client port; webhooks target the API port; services use bridge networking.
  - API: adds `API_PORT` and passes it to the HTTP listener.
  - `@shipfox/node-fastify`: adds `listen({host, port})` override for app-owned server config.
  - Client: dev/preview ports read `SHIPFOX_CLIENT_PORT` (fallback `VITE_PORT`), validated, with `strictPort: true`.
  - Docker provisioner: supports `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` and wires `ExtraHosts` into runner containers; docs updated.
  - Tests/Tooling: test env defaults now use `??=` to respect worktree overrides; adds unit tests for `dev/worktree-services.mjs` (wired to `pnpm test`); `mise.toml` auto-loads the worktree env; `turbo.jsonc` passes through `SHIPFOX_*` and related service envs; stabilizes client agent provider tests with 10s timeouts.

- Migration
  - Use Conductor workspaces; setup/teardown is automatic.
  - If you need fixed ports, set `API_PORT` for the API and `SHIPFOX_CLIENT_PORT` for the client. Defaults still work outside Conductor.

<sup>Written for commit c6dae6a7b67a5fb83a75f8687cf3ab2387ddc58a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

