### PR TITLE
[runner] Resolve shell before applying step PATH

### DIFF
--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -1,13 +1,13 @@
-import {mkdtemp, rm} from 'node:fs/promises';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {basename, join} from 'node:path';
+import {basename, isAbsolute, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {type CommandStartMetadata, executeRunStep, type OutputSink} from '#core/run-step.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const ESRCH_REGEX = /ESRCH/;
-const SHELL_EXECUTABLE_REGEX = /^(bash|sh)$/;
+const SHELL_EXECUTABLE_REGEX = /(?:^|\/)(bash|sh)$/;
 const SCRIPT_PATH_REGEX = /shipfox-runner-.*\.sh$/;
 
 function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
@@ -72,6 +72,37 @@ describe('executeRunStep', () => {
       } else {
         process.env.SHIPFOX_ENV_TEST_EXISTING = previous;
       }
+    }
+  });
+
+  it('does not resolve the shell executable through step env PATH', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'shipfox-shell-path-test-'));
+    try {
+      await writeFile(join(dir, 'bash'), '#!/bin/sh\necho fake-bash\nexit 42\n', {mode: 0o700});
+      const step = buildStep({
+        config: {
+          run: 'printf "%s" "$PATH"',
+          env: {PATH: dir},
+        },
+      });
+      const output = collectOutput();
+      let metadata: CommandStartMetadata | undefined;
+
+      const result = await executeRunStep(step, {
+        onCommandStart: (value) => {
+          metadata = value;
+        },
+        onOutput: output.sink,
+      });
+
+      expect(result.success).toBe(true);
+      expect(output.text()).toBe(dir);
+      expect(metadata).toBeDefined();
+      if (!metadata) throw new Error('expected command metadata');
+      expect(isAbsolute(metadata.shell.executable)).toBe(true);
+      expect(metadata.shell.executable).not.toBe(join(dir, 'bash'));
+    } finally {
+      await rm(dir, {recursive: true, force: true});
     }
   });
 
@@ -231,6 +262,7 @@ describe('executeRunStep', () => {
         command: 'echo hello',
         cwd: dir,
       });
+      expect(isAbsolute(metadata.shell.executable)).toBe(true);
       expect(metadata.shell.executable).toMatch(SHELL_EXECUTABLE_REGEX);
       expect(metadata.shell.args.at(-1)).toMatch(SCRIPT_PATH_REGEX);
       expect(metadata.shell.display).toContain('{0}');

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -1,8 +1,9 @@
-import {execFileSync, spawn} from 'node:child_process';
+import {spawn} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
+import {accessSync, constants, statSync} from 'node:fs';
 import {unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
-import {join} from 'node:path';
+import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
 import type {StepDto, StepErrorDtoShape} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {StepResult} from '#core/step-result.js';
@@ -212,11 +213,32 @@ function readStepEnv(step: StepDto): Readonly<Record<string, string>> {
 }
 
 function findShell(): string {
+  return findExecutable('bash') ?? findExecutable('sh') ?? '/bin/sh';
+}
+
+function findExecutable(name: 'bash' | 'sh'): string | undefined {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    if (!directory) continue;
+
+    const candidate = isAbsolute(directory)
+      ? join(directory, name)
+      : resolve(process.cwd(), directory, name);
+    if (isExecutableFile(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function isExecutableFile(path: string): boolean {
   try {
-    execFileSync('bash', ['--version'], {stdio: 'ignore'});
-    return 'bash';
+    if (!statSync(path).isFile()) {
+      return false;
+    }
+    accessSync(path, constants.X_OK);
+    return true;
   } catch {
-    return 'sh';
+    return false;
   }
 }
 
@@ -227,7 +249,7 @@ function commandStartMetadata(args: {
 }): CommandStartMetadata {
   const executable = findShell();
   const shellArgs =
-    executable === 'bash'
+    basename(executable) === 'bash'
       ? ['--noprofile', '--norc', '-eo', 'pipefail', args.scriptPath]
       : ['-e', args.scriptPath];
   const displayArgs = shellArgs.map((arg) => (arg === args.scriptPath ? '{0}' : arg));


### PR DESCRIPTION
Resolve the run-step shell executable before applying workflow-provided environment variables.

Workflow authors can set `PATH` for the script process, but that value should not affect which infrastructure shell the runner itself launches. This resolves `bash` or `sh` to an absolute path using the runner process environment, then spawns that absolute executable while still passing the step env through to the script.

The regression test creates a fake `bash` in the step `PATH` and proves the script sees that `PATH` without redirecting shell selection.

No changeset is included because `@shipfox/runner-execution` is private.

Fixes ENG-626

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve shell for run steps to an absolute executable using the runner’s env before applying the step env, so a workflow `PATH` cannot change which shell the runner launches. Fixes ENG-626 while keeping the step `PATH` effective for the script.

- **Bug Fixes**
  - Resolve `bash`/`sh` from the runner `PATH` to an absolute path and spawn that executable; pass the step env only to the script.
  - Include absolute shell path in start metadata and update matching to handle full paths; add regression test to ensure a fake `bash` in step `PATH` isn’t selected.

<sup>Written for commit a7bc5ee9ee5c94e542152f0f36303478074587e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

