### PR TITLE
[client-workflows] Scope run trigger tooltips to labels

### DIFF
--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-run-row.tsx
@@ -63,19 +63,7 @@ export function WorkflowRunRow({
 
       <div className="flex min-w-0 items-center gap-8">
         {run.triggerDisplayLabel ? (
-          <span className="flex min-w-0 flex-1 items-center gap-8">
-            <TriggerSourceIcon
-              source={run.triggerSource}
-              aria-hidden
-              className="size-14 shrink-0 text-foreground-neutral-muted"
-            />
-            <Code
-              variant="label"
-              className="min-w-0 flex-1 truncate text-foreground-neutral-subtle"
-            >
-              {run.triggerDisplayLabel}
-            </Code>
-          </span>
+          <TriggerLabel run={run} />
         ) : (
           <span className="flex min-w-0 flex-1 items-center gap-8 truncate text-foreground-neutral-muted">
             <span aria-hidden="true" className="size-14 shrink-0" />
@@ -93,27 +81,10 @@ export function WorkflowRunRow({
   // replaces them on the next poll, so they render non-interactively instead of as a link
   // that would navigate to a run id the detail route rejects.
   if (run.isTemporary) {
-    if (!run.triggerDisplayLabel) {
-      return (
-        <div className="relative flex w-full flex-col gap-4 rounded-8 border border-transparent px-10 py-8 text-left">
-          {body}
-        </div>
-      );
-    }
-
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            aria-label={run.triggerLabel}
-            className="relative flex w-full flex-col gap-4 rounded-8 border border-transparent bg-transparent px-10 py-8 text-left outline-none focus-visible:shadow-border-interactive-with-active"
-          >
-            {body}
-          </button>
-        </TooltipTrigger>
-        <TriggerTooltip label={run.triggerLabel} />
-      </Tooltip>
+      <div className="relative flex w-full flex-col gap-4 rounded-8 border border-transparent px-10 py-8 text-left">
+        {body}
+      </div>
     );
   }
 
@@ -136,13 +107,28 @@ export function WorkflowRunRow({
     </Link>
   );
 
-  if (!run.triggerDisplayLabel) return runLink;
+  return runLink;
+}
 
+function TriggerLabel({run}: {run: WorkflowRun}) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>{runLink}</TooltipTrigger>
-      <TriggerTooltip label={run.triggerLabel} />
-    </Tooltip>
+    <span className="flex min-w-0 flex-1 items-center">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="flex w-fit max-w-full min-w-0 items-center gap-8 rounded-6 outline-none">
+            <TriggerSourceIcon
+              source={run.triggerSource}
+              aria-hidden
+              className="size-14 shrink-0 text-foreground-neutral-muted"
+            />
+            <Code variant="label" className="min-w-0 truncate text-foreground-neutral-subtle">
+              {run.triggerDisplayLabel}
+            </Code>
+          </span>
+        </TooltipTrigger>
+        <TriggerTooltip label={run.triggerLabel} />
+      </Tooltip>
+    </span>
   );
 }
 

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list-view.test.tsx
@@ -62,6 +62,24 @@ describe('WorkflowRunsListView', () => {
     expect(screen.getByText('queued-build')).toBeInTheDocument();
   });
 
+  test('scopes the trigger tooltip to the trigger label', async () => {
+    const user = userEvent.setup();
+    renderListView([run('failed', 'integration-tests')]);
+
+    await user.hover(
+      await screen.findByRole('link', {
+        name: (name) =>
+          name.includes('integration-tests') && name.includes('github') && name.includes('push'),
+      }),
+    );
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    await user.hover(screen.getByText('push'));
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('github · push');
+  });
+
   test('restores every row after the filters are cleared', async () => {
     const user = userEvent.setup();
     renderListView([


### PR DESCRIPTION
Scope workflow run trigger tooltips to the trigger icon and event label instead of the entire run list row.

Hovering any part of a run row previously opened the trigger metadata tooltip because the row link itself was the tooltip trigger. This moves the tooltip trigger to the inline trigger affordance while preserving row navigation, so users only see the tooltip when they hover the metadata it describes.

The workflow runs list test now covers the hover boundary to prevent the tooltip target from expanding back to the full row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped workflow run trigger tooltips to only the trigger icon and label, not the whole row. Link navigation and focus behavior are unchanged.

- **Bug Fixes**
  - Introduced `TriggerLabel` to wrap the icon and text as the tooltip trigger.
  - Temporary runs render as non-interactive rows with no tooltip.
  - Added a test to ensure no tooltip on row hover and show it only when hovering the trigger label.

<sup>Written for commit f7e891f264e5da001ce1e071e2e9e4869443dcc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

