### PR TITLE
[api] Fix flaky database cleanup in tests

### DIFF
--- a/libs/api/agent/src/presentation/routes/provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/provider-config.test.ts
@@ -3,7 +3,7 @@ import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-con
 import {requireMembership} from '@shipfox/api-workspaces';
 import type {AuthMethod, FastifyRequest} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {
   getAgentProviderConfig,
@@ -48,8 +48,6 @@ describe('agent provider config routes', () => {
 
   beforeEach(async () => {
     await closeApp();
-    await db().execute(sql`TRUNCATE agent_provider_configs CASCADE`);
-    await db().execute(sql`TRUNCATE agent_workspace_settings CASCADE`);
     workspaceId = crypto.randomUUID();
     vi.mocked(complete).mockReset();
     vi.mocked(complete).mockResolvedValue({

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -421,8 +421,6 @@ describe('definition queries', () => {
     });
 
     test('applyVcsDefinitionsBatch skips outbox events for unchanged content hashes', async () => {
-      await db().execute(sql`TRUNCATE definitions_outbox CASCADE`);
-
       const first = await applyVcsDefinitionsBatch({
         projectId,
         workspaceId,
@@ -451,7 +449,6 @@ describe('definition queries', () => {
     });
 
     test('softDeleteVcsDefinitionsNotIn writes a DEFINITION_DELETED event per pruned row', async () => {
-      await db().execute(sql`TRUNCATE definitions_outbox CASCADE`);
       const pruned = await upsertDefinition({
         projectId,
         workspaceId,
@@ -522,10 +519,6 @@ describe('definition queries', () => {
   });
 
   describe('outbox integration', () => {
-    beforeEach(async () => {
-      await db().execute(sql`TRUNCATE definitions_outbox CASCADE`);
-    });
-
     test('writes a definitions.definition.resolved event to the outbox', async () => {
       const definition = await upsertDefinition({
         projectId,
@@ -589,9 +582,8 @@ describe('definition queries', () => {
   });
 
   describe('publisher registry (drainAll + markDispatched)', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       resetPublishers();
-      await db().execute(sql`TRUNCATE definitions_outbox CASCADE`);
       registerPublisher({
         name: 'definitions',
         table: definitionsOutbox,
@@ -950,6 +942,10 @@ describe('definition queries', () => {
       const remaining = await listOutboxRowsForProject(projectId);
       expect(result).toEqual([{source: 'definitions', deleted: 2, capped: true}]);
       expect(remaining).toHaveLength(1);
+      await db()
+        .update(definitionsOutbox)
+        .set({dispatchedAt: new Date()})
+        .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
     });
 
     test('pruneDispatchedOutboxRows returns zero when no rows are eligible', async () => {

--- a/libs/api/workflows/test/globalSetup.ts
+++ b/libs/api/workflows/test/globalSetup.ts
@@ -26,10 +26,6 @@ export async function setup() {
     '__drizzle_migrations_runners',
   );
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_workflows');
-  await db().execute(sql`TRUNCATE agent_provider_configs CASCADE`);
-  await db().execute(sql`TRUNCATE agent_workspace_settings CASCADE`);
-  await db().execute(sql`TRUNCATE runners_pending_jobs CASCADE`);
-  await db().execute(sql`TRUNCATE runners_running_jobs CASCADE`);
   await db().execute(sql`TRUNCATE workflows_workflow_runs CASCADE`);
   await db().execute(sql`TRUNCATE workflows_outbox CASCADE`);
 


### PR DESCRIPTION
Remove table-wide cleanup from tests and setup paths that can run concurrently with other suites.

The provider config flake came from one test truncating shared Postgres tables while another test saved a row and then read it back. This change keeps suite-level cleanup package-owned, removes cross-package truncation from workflow setup, and relies on generated test ids for isolation instead of resetting shared tables mid-run.

The definitions outbox tests already scope assertions by project id. The capped-prune case now makes its intentionally remaining row non-eligible for later prune assertions rather than clearing the whole outbox table.

No changeset: this is test-only cleanup with no package runtime or public API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky DB tests by removing table-wide truncation that caused cross-suite interference. Tests now isolate via generated IDs and package-owned cleanup.

- **Bug Fixes**
  - Removed table-wide TRUNCATEs from provider config and definitions tests, and from `workflows` global setup.
  - Updated outbox tests to scope by `projectId` and set `dispatchedAt` on the capped row to keep prune checks isolated.
  - Kept cleanup suite-local; no runtime or public API changes.

<sup>Written for commit 8e26fca8a48a96ed9ee3d75bbd20357e6ddb97d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

