### PR TITLE
[api/auth] Stabilize rate limit tests

### DIFF
--- a/libs/api/auth/src/core/rate-limit.test.ts
+++ b/libs/api/auth/src/core/rate-limit.test.ts
@@ -145,6 +145,7 @@ describe('checkAuthRateLimit', () => {
           limit: 100,
           windowSeconds: 60,
           now,
+          timeoutMs: 5_000,
         }),
       ),
     );

--- a/libs/api/auth/src/presentation/routes/password/change-password.test.ts
+++ b/libs/api/auth/src/presentation/routes/password/change-password.test.ts
@@ -1,9 +1,11 @@
 import type {FastifyInstance} from 'fastify';
 import {signUserToken} from '#core/jwt.js';
+import {verifyPassword} from '#core/password.js';
+import {findUserByEmail} from '#db/users.js';
 import {
   cookieHeader,
   createAuthTestApp,
-  login,
+  createVerifiedSession,
   ROUTE_TEST_SECRET,
   resetCapturedMail,
   signupVerifyLogin,
@@ -25,7 +27,7 @@ describe('POST /auth/change-password', () => {
   });
 
   test('updates credentials and rejects the old password', async () => {
-    const account = await signupVerifyLogin(app, 'change-password');
+    const account = await createVerifiedSession('change-password');
 
     const change = await app.inject({
       method: 'POST',
@@ -39,18 +41,26 @@ describe('POST /auth/change-password', () => {
         new_password: 'new password is long',
       },
     });
-    const oldLogin = await login(app, {email: account.email, password: account.password});
-    const newLogin = await login(app, {email: account.email, password: 'new password is long'});
+    const updatedUser = await findUserByEmail({email: account.email});
     const refresh = await app.inject({
       method: 'POST',
       url: '/auth/refresh',
       headers: {cookie: cookieHeader(account.refreshCookie)},
       payload: {},
     });
+    const oldPasswordValid = await verifyPassword({
+      password: account.password,
+      hash: updatedUser?.hashedPassword ?? '',
+    });
+    const newPasswordValid = await verifyPassword({
+      password: 'new password is long',
+      hash: updatedUser?.hashedPassword ?? '',
+    });
 
     expect(change.statusCode).toBe(204);
-    expect(oldLogin.statusCode).toBe(401);
-    expect(newLogin.statusCode).toBe(200);
+    expect(updatedUser).toBeDefined();
+    expect(oldPasswordValid).toBe(false);
+    expect(newPasswordValid).toBe(true);
     expect(refresh.statusCode).toBe(200);
   });
 

--- a/libs/api/auth/src/presentation/routes/rate-limit.test.ts
+++ b/libs/api/auth/src/presentation/routes/rate-limit.test.ts
@@ -4,7 +4,6 @@ import {and, eq, sql} from 'drizzle-orm';
 import {
   type AuthRateLimitAction,
   type AuthRateLimitScope,
-  checkAuthRateLimit,
   hashAuthRateLimitIdentifier,
 } from '#core/rate-limit.js';
 import {db} from '#db/db.js';
@@ -24,22 +23,30 @@ function uniqueIp(): string {
   return `203.0.113.${ipCounter}`;
 }
 
-async function exhaustBucket(params: {
+async function seedExhaustedBucket(params: {
   action: AuthRateLimitAction;
   scope: AuthRateLimitScope;
   identifier: string;
   limit: number;
   windowSeconds: number;
 }): Promise<void> {
-  for (let index = 0; index < params.limit; index += 1) {
-    await checkAuthRateLimit({
+  const now = new Date();
+  const windowStart = windowStartFor(now, params.windowSeconds);
+  const identifierHmac = hashAuthRateLimitIdentifier({
+    action: params.action,
+    scope: params.scope,
+    identifier: params.identifier,
+  });
+  await db()
+    .insert(authRateLimits)
+    .values({
       action: params.action,
       scope: params.scope,
-      identifier: params.identifier,
-      limit: params.limit,
-      windowSeconds: params.windowSeconds,
+      identifierHmac,
+      windowStart,
+      count: params.limit,
+      expiresAt: new Date(windowStart.getTime() + params.windowSeconds * 1000),
     });
-  }
 }
 
 async function countBucket(params: {
@@ -140,7 +147,7 @@ describe('auth rate-limit routes', () => {
 
   it('blocks exhausted login IP buckets before login work runs', async () => {
     const ip = uniqueIp();
-    await exhaustBucket({
+    await seedExhaustedBucket({
       action: 'login',
       scope: 'ip',
       identifier: ip,
@@ -166,7 +173,7 @@ describe('auth rate-limit routes', () => {
   it('blocks exhausted login email buckets after the IP bucket passes', async () => {
     const ip = uniqueIp();
     const email = uniqueEmail('login-email-block');
-    await exhaustBucket({
+    await seedExhaustedBucket({
       action: 'login',
       scope: 'email',
       identifier: email,
@@ -220,7 +227,7 @@ describe('auth rate-limit routes', () => {
   it('blocks exhausted email-send IP buckets before consuming email buckets', async () => {
     const ip = uniqueIp();
     const blockedEmail = uniqueEmail('email-send-ip-blocked');
-    await exhaustBucket({
+    await seedExhaustedBucket({
       action: 'email-send',
       scope: 'ip',
       identifier: ip,
@@ -303,7 +310,7 @@ describe('auth rate-limit routes', () => {
     });
     const ip = uniqueIp();
     const email = uniqueEmail('log-privacy');
-    await exhaustBucket({
+    await seedExhaustedBucket({
       action: 'login',
       scope: 'email',
       identifier: email,

--- a/libs/api/auth/test/routes.ts
+++ b/libs/api/auth/test/routes.ts
@@ -251,3 +251,25 @@ export async function signupVerifyLogin(
     userId: loginRes.json().user.id,
   };
 }
+
+export async function createVerifiedSession(prefix: string): Promise<{
+  email: string;
+  password: string;
+  refreshCookie: string;
+  token: string;
+  userId: string;
+}> {
+  const {createUser, createSessionForUser} = await import('#core/auth.js');
+  const email = uniqueEmail(prefix);
+  const password = 'correct horse battery staple';
+  const user = await createUser({email, password, name: prefix, verified: true});
+  const session = await createSessionForUser({userId: user.id});
+
+  return {
+    email,
+    password,
+    refreshCookie: `shipfox_refresh_token=${session.refreshToken}`,
+    token: session.token,
+    userId: user.id,
+  };
+}


### PR DESCRIPTION
Stabilize auth rate-limit and password-change tests that were flaky in busy environments.

The affected tests were doing unnecessary database and password-hashing work while proving route behavior. This seeds exhausted rate-limit buckets directly where exhaustion is only a precondition, gives the intentional concurrent upsert stress test a test-specific timeout, and creates a verified session directly for the password-change route test.

No changeset is included because `@shipfox/api-auth` is private and this PR only changes tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes auth rate-limit and change-password tests by avoiding unnecessary work and seeding rate-limit state directly. This removes flakiness under load and speeds up the test suite.

- **Bug Fixes**
  - Seed exhausted rate-limit buckets directly in DB (using `hashAuthRateLimitIdentifier` and window start) instead of looping through `checkAuthRateLimit`.
  - Add a 5s test-specific timeout to the concurrent upsert stress test.
  - Use `createVerifiedSession` in change-password tests to skip signup/verify/login.
  - Validate the password update via `findUserByEmail` + `verifyPassword`, and ensure the existing refresh cookie still works.

<sup>Written for commit 836ae9ff6dab9eb4af407e437681fe8427b08a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

