### PR TITLE
Add shared Ollama startup for Conductor worktrees

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -6,6 +6,11 @@ setup = """
 mise trust
 mise install
 if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
+  if [ -n "${CONDUCTOR_ROOT_PATH:-}" ]; then
+    mise -C "$CONDUCTOR_ROOT_PATH" trust
+    mise -C "$CONDUCTOR_ROOT_PATH" install
+  fi
+  mise run ollama:up
   mise exec -- node dev/worktree-services.mjs up
 fi
 mise exec -- pnpm -r install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,12 +74,14 @@ mise run ollama:up
 
 From a worktree, that task delegates to the root checkout and runs the root
 `ollama:up` task. From the root checkout, it starts `ollama serve`, pulls
-`qwen3.5:0.8b`, and preloads the model with a 24 hour keep-alive.
+`qwen3.5:0.8b`, and then reports the API as ready. A background warmup request
+preloads the model with a 24 hour keep-alive, so callers can start using the
+Ollama HTTP API as soon as the pull completes.
 
 Useful commands:
 
 ```sh
-mise run ollama:up       # start the shared server and preload qwen3.5:0.8b
+mise run ollama:up       # start the shared server and pull qwen3.5:0.8b
 mise run ollama:status   # show endpoint, root path, and managed process status
 mise run ollama:stop     # stop the server if this repo started it
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,25 @@ By participating, you are expected to uphold this code.
 
 ## Prerequisites
 
-- [mise](https://mise.jdx.dev/): manages tool versions (Node.js, pnpm, [Turbo](https://turbo.build/))
+- [mise](https://mise.jdx.dev/): manages tool versions (Node.js, pnpm, [Turbo](https://turbo.build/), Ollama)
 - [Docker](https://docs.docker.com/get-docker/): runs local service dependencies (PostgreSQL, etc.)
 
 ## Getting Started
 
 ### Install tooling
 
-[mise](https://mise.jdx.dev/) reads `mise.toml` and installs the correct versions of Node.js, pnpm, and Turbo.
+[mise](https://mise.jdx.dev/) reads `mise.toml` and installs the correct versions of Node.js, pnpm, Turbo, and Ollama.
 
 ```sh
 mise install
+```
+
+Use mise-managed tools directly after activation, or through `mise exec` in
+non-interactive scripts:
+
+```sh
+mise exec -- pnpm install
+mise exec -- turbo build
 ```
 
 ### Start local services
@@ -37,6 +45,76 @@ Build a specific package and its dependencies:
 ```sh
 turbo build --filter=@shipfox/api...
 ```
+
+## Local Tooling
+
+### Mise Tasks
+
+The repository defines project tasks in `mise.toml`. List them with:
+
+```sh
+mise tasks
+```
+
+Mise tasks are safe to run from the main checkout or from a Conductor worktree.
+When a task needs the main checkout, it detects `CONDUCTOR_ROOT_PATH` and
+delegates to `mise -C "$CONDUCTOR_ROOT_PATH" run <task>`.
+
+### Shared Ollama
+
+Ollama is installed by mise and is used as a shared local service. It is started
+from the main checkout, not from each Conductor worktree, because the server is
+heavy and stateless.
+
+Conductor setup runs this automatically for local workspaces:
+
+```sh
+mise run ollama:up
+```
+
+From a worktree, that task delegates to the root checkout and runs the root
+`ollama:up` task. From the root checkout, it starts `ollama serve`, pulls
+`qwen3.5:0.8b`, and preloads the model with a 24 hour keep-alive.
+
+Useful commands:
+
+```sh
+mise run ollama:up       # start the shared server and preload qwen3.5:0.8b
+mise run ollama:status   # show endpoint, root path, and managed process status
+mise run ollama:stop     # stop the server if this repo started it
+```
+
+The helper stores process state and logs under:
+
+```text
+$CONDUCTOR_ROOT_PATH/.context/shared-ollama/
+```
+
+The default endpoint is `http://127.0.0.1:11434`. Override it only when needed:
+
+```sh
+SHIPFOX_OLLAMA_BASE_URL=http://127.0.0.1:11500 mise run ollama:up
+SHIPFOX_OLLAMA_MODEL=other:model mise run ollama:up
+SHIPFOX_OLLAMA_KEEP_ALIVE=2h mise run ollama:up
+```
+
+### Conductor Worktree Services
+
+Conductor workspaces run `dev/worktree-services.mjs up` during setup. This
+creates per-worktree Docker services, assigns ports from `CONDUCTOR_PORT`, and
+writes the generated app environment to `.context/local-services/env`, which is
+loaded by `mise.toml`.
+
+Common commands:
+
+```sh
+mise exec -- node dev/worktree-services.mjs status
+mise exec -- node dev/worktree-services.mjs stop
+mise exec -- node dev/worktree-services.mjs destroy
+```
+
+`destroy` removes the worktree Docker volumes and generated local-service state.
+The shared Ollama service is intentionally not stopped during workspace archive.
 
 ## Directory Structure
 

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -223,6 +223,7 @@ function writeProcessState(context, state) {
 function readManagedProcess(context) {
   const state = readProcessState(context.stateFile);
   if (state === undefined || !isProcessAlive(state.pid)) return undefined;
+  if (!processStateMatchesContext(state, context)) return undefined;
   if (!processIdentityMatches(state)) return undefined;
   return state;
 }
@@ -231,7 +232,12 @@ function readLiveUnverifiedPid(context) {
   const pid = readPid(context.pidFile);
   if (pid === undefined || !isProcessAlive(pid)) return undefined;
   const state = readProcessState(context.stateFile);
-  if (state !== undefined && state.pid === pid && processIdentityMatches(state)) {
+  if (
+    state !== undefined &&
+    state.pid === pid &&
+    processStateMatchesContext(state, context) &&
+    processIdentityMatches(state)
+  ) {
     return undefined;
   }
   return pid;
@@ -257,6 +263,10 @@ function readProcessState(stateFile) {
 function processIdentityMatches(state) {
   if (state.processStartTime === undefined) return false;
   return processStartTime(state.pid) === state.processStartTime;
+}
+
+function processStateMatchesContext(state, context) {
+  return state.listenHost === context.listenHost;
 }
 
 function processStartTime(pid) {
@@ -334,4 +344,10 @@ function printError(message) {
   process.stderr.write(`${message}\n`);
 }
 
-export {ollamaListenHost, processIdentityMatches, processStartTime, serviceContext};
+export {
+  ollamaListenHost,
+  processIdentityMatches,
+  processStartTime,
+  processStateMatchesContext,
+  serviceContext,
+};

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+import {spawn, spawnSync} from 'node:child_process';
+import {existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const defaultModel = 'qwen3.5:0.8b';
+const defaultKeepAlive = '24h';
+const defaultBaseUrl = 'http://127.0.0.1:11434';
+const startupTimeoutMs = 30_000;
+const pollIntervalMs = 500;
+
+if (isCliEntryPoint()) {
+  await main(process.argv[2]);
+}
+
+export async function main(command) {
+  const commands = new Set(['up', 'stop', 'status']);
+  if (!commands.has(command)) {
+    usage();
+    process.exit(1);
+  }
+
+  const context = serviceContext();
+
+  switch (command) {
+    case 'up':
+      await up(context);
+      break;
+    case 'stop':
+      await stop(context);
+      break;
+    case 'status':
+      await status(context);
+      break;
+  }
+}
+
+function serviceContext(env = process.env, cwd = process.cwd()) {
+  const rootPath = resolve(env.CONDUCTOR_ROOT_PATH || cwd);
+  const stateDir = resolve(rootPath, '.context/shared-ollama');
+  const baseUrl = env.SHIPFOX_OLLAMA_BASE_URL || env.OLLAMA_BASE_URL || defaultBaseUrl;
+  const model = env.SHIPFOX_OLLAMA_MODEL || defaultModel;
+  return {
+    rootPath,
+    stateDir,
+    pidFile: resolve(stateDir, 'ollama.pid'),
+    logFile: resolve(stateDir, 'ollama.log'),
+    baseUrl,
+    listenHost: ollamaListenHost(baseUrl),
+    model,
+    keepAlive: env.SHIPFOX_OLLAMA_KEEP_ALIVE || defaultKeepAlive,
+  };
+}
+
+async function up(context) {
+  mkdirSync(context.stateDir, {recursive: true});
+
+  if (!(await isHealthy(context.baseUrl))) {
+    removeStalePid(context.pidFile);
+    startServer(context);
+    await waitForHealthy(context.baseUrl);
+  }
+
+  runRootMise(context, ['exec', '--', 'ollama', 'pull', context.model]);
+  await preloadModel(context);
+
+  printLine(`Shared Ollama is ready at ${context.baseUrl}.`);
+  printLine(`Model: ${context.model}`);
+  printLine(`Root: ${context.rootPath}`);
+  printLine(`Log: ${context.logFile}`);
+}
+
+async function stop(context) {
+  const pid = readPid(context.pidFile);
+  if (pid === undefined || !isProcessAlive(pid)) {
+    rmSync(context.pidFile, {force: true});
+    printLine('Shared Ollama is not managed by this repo, or it is already stopped.');
+    return;
+  }
+
+  killProcessGroup(pid, 'SIGTERM');
+  await waitForProcessExit(pid, 5_000);
+  if (isProcessAlive(pid)) killProcessGroup(pid, 'SIGKILL');
+  rmSync(context.pidFile, {force: true});
+  printLine('Shared Ollama stopped.');
+}
+
+async function status(context) {
+  const healthy = await isHealthy(context.baseUrl);
+  const pid = readPid(context.pidFile);
+  const managed = pid !== undefined && isProcessAlive(pid);
+
+  printLine(`Root: ${context.rootPath}`);
+  printLine(`Endpoint: ${context.baseUrl}`);
+  printLine(`Managed process: ${managed ? `running (${pid})` : 'not running'}`);
+  printLine(`HTTP health: ${healthy ? 'healthy' : 'unavailable'}`);
+}
+
+function startServer(context) {
+  const log = openSync(context.logFile, 'a');
+  const child = spawn(
+    'mise',
+    ['-C', context.rootPath, 'exec', '--', 'ollama', 'serve'],
+    {
+      cwd: context.rootPath,
+      detached: true,
+      env: {
+        ...process.env,
+        OLLAMA_HOST: context.listenHost,
+      },
+      stdio: ['ignore', log, log],
+    },
+  );
+  child.unref();
+  writeFileSync(context.pidFile, `${child.pid}\n`);
+}
+
+function runRootMise(context, args) {
+  const result = spawnSync('mise', ['-C', context.rootPath, ...args], {
+    cwd: context.rootPath,
+    env: {
+      ...process.env,
+      OLLAMA_HOST: context.listenHost,
+    },
+    stdio: 'inherit',
+  });
+  if (result.error) fail(result.error.message);
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+async function preloadModel(context) {
+  const response = await fetch(`${context.baseUrl}/api/generate`, {
+    method: 'POST',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify({
+      model: context.model,
+      prompt: '',
+      stream: false,
+      keep_alive: context.keepAlive,
+    }),
+  });
+  if (!response.ok) {
+    fail(`Failed to preload ${context.model}: ${response.status} ${response.statusText}`);
+  }
+}
+
+async function waitForHealthy(baseUrl) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < startupTimeoutMs) {
+    if (await isHealthy(baseUrl)) return;
+    await sleep(pollIntervalMs);
+  }
+  fail(`Ollama did not become healthy at ${baseUrl} within ${startupTimeoutMs}ms.`);
+}
+
+async function isHealthy(baseUrl) {
+  try {
+    const response = await fetch(`${baseUrl}/api/tags`, {signal: AbortSignal.timeout(1_000)});
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function ollamaListenHost(baseUrl) {
+  const url = new URL(baseUrl);
+  return `${url.hostname}:${url.port || (url.protocol === 'https:' ? '443' : '80')}`;
+}
+
+function removeStalePid(pidFile) {
+  const pid = readPid(pidFile);
+  if (pid !== undefined && isProcessAlive(pid)) return;
+  rmSync(pidFile, {force: true});
+}
+
+function readPid(pidFile) {
+  if (!existsSync(pidFile)) return undefined;
+  const pid = Number(readFileSync(pidFile, 'utf8').trim());
+  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killProcessGroup(pid, signal) {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      return;
+    }
+  }
+}
+
+async function waitForProcessExit(pid, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (!isProcessAlive(pid)) return;
+    await sleep(100);
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function usage() {
+  printError('Usage: node dev/shared-ollama.mjs <up|stop|status>');
+}
+
+function fail(message) {
+  printError(message);
+  process.exit(1);
+}
+
+function isCliEntryPoint() {
+  return (
+    process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+function printLine(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function printError(message) {
+  process.stderr.write(`${message}\n`);
+}
+
+export {ollamaListenHost, serviceContext};

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -15,7 +15,7 @@ if (isCliEntryPoint()) {
 }
 
 export async function main(command) {
-  const commands = new Set(['up', 'stop', 'status']);
+  const commands = new Set(['up', 'stop', 'status', 'warm']);
   if (!commands.has(command)) {
     usage();
     process.exit(1);
@@ -32,6 +32,9 @@ export async function main(command) {
       break;
     case 'status':
       await status(context);
+      break;
+    case 'warm':
+      await preloadModel(context);
       break;
   }
 }
@@ -63,7 +66,7 @@ async function up(context) {
   }
 
   runRootMise(context, ['exec', '--', 'ollama', 'pull', context.model]);
-  await preloadModel(context);
+  startWarmup(context);
 
   printLine(`Shared Ollama is ready at ${context.baseUrl}.`);
   printLine(`Model: ${context.model}`);
@@ -114,6 +117,23 @@ function startServer(context) {
   );
   child.unref();
   writeFileSync(context.pidFile, `${child.pid}\n`);
+}
+
+function startWarmup(context) {
+  const log = openSync(context.logFile, 'a');
+  const child = spawn(process.execPath, [fileURLToPath(import.meta.url), 'warm'], {
+    cwd: context.rootPath,
+    detached: true,
+    env: {
+      ...process.env,
+      CONDUCTOR_ROOT_PATH: context.rootPath,
+      SHIPFOX_OLLAMA_BASE_URL: context.baseUrl,
+      SHIPFOX_OLLAMA_KEEP_ALIVE: context.keepAlive,
+      SHIPFOX_OLLAMA_MODEL: context.model,
+    },
+    stdio: ['ignore', log, log],
+  });
+  child.unref();
 }
 
 function runRootMise(context, args) {

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -48,6 +48,7 @@ function serviceContext(env = process.env, cwd = process.cwd()) {
     rootPath,
     stateDir,
     pidFile: resolve(stateDir, 'ollama.pid'),
+    stateFile: resolve(stateDir, 'ollama-process.json'),
     logFile: resolve(stateDir, 'ollama.log'),
     baseUrl,
     listenHost: ollamaListenHost(baseUrl),
@@ -60,7 +61,22 @@ async function up(context) {
   mkdirSync(context.stateDir, {recursive: true});
 
   if (!(await isHealthy(context.baseUrl))) {
-    removeStalePid(context.pidFile);
+    const managedProcess = readManagedProcess(context);
+    if (managedProcess !== undefined) {
+      await stopManagedProcess(context, managedProcess.pid);
+    } else {
+      const unverifiedPid = readLiveUnverifiedPid(context);
+      if (unverifiedPid !== undefined) {
+        fail(
+          [
+            `Recorded Ollama pid ${unverifiedPid} is alive but missing valid process metadata.`,
+            'Stop it manually before running ollama:up again.',
+          ].join(' '),
+        );
+      }
+      removeProcessState(context);
+    }
+
     startServer(context);
     await waitForHealthy(context.baseUrl);
   }
@@ -75,28 +91,27 @@ async function up(context) {
 }
 
 async function stop(context) {
-  const pid = readPid(context.pidFile);
-  if (pid === undefined || !isProcessAlive(pid)) {
-    rmSync(context.pidFile, {force: true});
+  const managedProcess = readManagedProcess(context);
+  if (managedProcess === undefined) {
+    const unverifiedPid = readLiveUnverifiedPid(context);
+    if (unverifiedPid === undefined) removeProcessState(context);
     printLine('Shared Ollama is not managed by this repo, or it is already stopped.');
     return;
   }
 
-  killProcessGroup(pid, 'SIGTERM');
-  await waitForProcessExit(pid, 5_000);
-  if (isProcessAlive(pid)) killProcessGroup(pid, 'SIGKILL');
-  rmSync(context.pidFile, {force: true});
+  await stopManagedProcess(context, managedProcess.pid);
   printLine('Shared Ollama stopped.');
 }
 
 async function status(context) {
   const healthy = await isHealthy(context.baseUrl);
-  const pid = readPid(context.pidFile);
-  const managed = pid !== undefined && isProcessAlive(pid);
+  const managedProcess = readManagedProcess(context);
 
   printLine(`Root: ${context.rootPath}`);
   printLine(`Endpoint: ${context.baseUrl}`);
-  printLine(`Managed process: ${managed ? `running (${pid})` : 'not running'}`);
+  const managedLabel =
+    managedProcess !== undefined ? `running (${managedProcess.pid})` : 'not running';
+  printLine(`Managed process: ${managedLabel}`);
   printLine(`HTTP health: ${healthy ? 'healthy' : 'unavailable'}`);
 }
 
@@ -117,6 +132,12 @@ function startServer(context) {
   );
   child.unref();
   writeFileSync(context.pidFile, `${child.pid}\n`);
+  writeProcessState(context, {
+    pid: child.pid,
+    processStartTime: processStartTime(child.pid),
+    listenHost: context.listenHost,
+    startedAt: new Date().toISOString(),
+  });
 }
 
 function startWarmup(context) {
@@ -188,10 +209,67 @@ function ollamaListenHost(baseUrl) {
   return `${url.hostname}:${url.port || (url.protocol === 'https:' ? '443' : '80')}`;
 }
 
-function removeStalePid(pidFile) {
-  const pid = readPid(pidFile);
-  if (pid !== undefined && isProcessAlive(pid)) return;
-  rmSync(pidFile, {force: true});
+async function stopManagedProcess(context, pid) {
+  killProcessGroup(pid, 'SIGTERM');
+  await waitForProcessExit(pid, 5_000);
+  if (isProcessAlive(pid)) killProcessGroup(pid, 'SIGKILL');
+  removeProcessState(context);
+}
+
+function writeProcessState(context, state) {
+  writeFileSync(context.stateFile, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+function readManagedProcess(context) {
+  const state = readProcessState(context.stateFile);
+  if (state === undefined || !isProcessAlive(state.pid)) return undefined;
+  if (!processIdentityMatches(state)) return undefined;
+  return state;
+}
+
+function readLiveUnverifiedPid(context) {
+  const pid = readPid(context.pidFile);
+  if (pid === undefined || !isProcessAlive(pid)) return undefined;
+  const state = readProcessState(context.stateFile);
+  if (state !== undefined && state.pid === pid && processIdentityMatches(state)) {
+    return undefined;
+  }
+  return pid;
+}
+
+function readProcessState(stateFile) {
+  if (!existsSync(stateFile)) return undefined;
+  try {
+    const state = JSON.parse(readFileSync(stateFile, 'utf8'));
+    if (!Number.isInteger(state.pid) || state.pid <= 0) return undefined;
+    return {
+      pid: state.pid,
+      processStartTime:
+        typeof state.processStartTime === 'string' ? state.processStartTime : undefined,
+      listenHost: typeof state.listenHost === 'string' ? state.listenHost : undefined,
+      startedAt: typeof state.startedAt === 'string' ? state.startedAt : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function processIdentityMatches(state) {
+  if (state.processStartTime === undefined) return false;
+  return processStartTime(state.pid) === state.processStartTime;
+}
+
+function processStartTime(pid) {
+  const result = spawnSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+    encoding: 'utf8',
+  });
+  if (result.error || result.status !== 0) return undefined;
+  return result.stdout.trim() || undefined;
+}
+
+function removeProcessState(context) {
+  rmSync(context.pidFile, {force: true});
+  rmSync(context.stateFile, {force: true});
 }
 
 function readPid(pidFile) {
@@ -256,4 +334,4 @@ function printError(message) {
   process.stderr.write(`${message}\n`);
 }
 
-export {ollamaListenHost, serviceContext};
+export {ollamaListenHost, processIdentityMatches, processStartTime, serviceContext};

--- a/dev/shared-ollama.test.mjs
+++ b/dev/shared-ollama.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import {describe, test} from 'node:test';
 
-import {ollamaListenHost, serviceContext} from './shared-ollama.mjs';
+import {
+  ollamaListenHost,
+  processIdentityMatches,
+  processStartTime,
+  serviceContext,
+} from './shared-ollama.mjs';
 
 describe('serviceContext', () => {
   test('stores shared Ollama state under the Conductor root path', () => {
@@ -15,6 +20,7 @@ describe('serviceContext', () => {
     assert.equal(context.rootPath, '/repo/root');
     assert.equal(context.stateDir, '/repo/root/.context/shared-ollama');
     assert.equal(context.pidFile, '/repo/root/.context/shared-ollama/ollama.pid');
+    assert.equal(context.stateFile, '/repo/root/.context/shared-ollama/ollama-process.json');
     assert.equal(context.logFile, '/repo/root/.context/shared-ollama/ollama.log');
   });
 
@@ -44,5 +50,25 @@ describe('serviceContext', () => {
 describe('ollamaListenHost', () => {
   test('converts the API base URL into the OLLAMA_HOST bind value', () => {
     assert.equal(ollamaListenHost('http://127.0.0.1:11434'), '127.0.0.1:11434');
+  });
+});
+
+describe('processIdentityMatches', () => {
+  test('matches a process by pid and recorded start time', () => {
+    const currentStartTime = processStartTime(process.pid);
+
+    assert.equal(typeof currentStartTime, 'string');
+    assert.equal(
+      processIdentityMatches({pid: process.pid, processStartTime: currentStartTime}),
+      true,
+    );
+    assert.equal(
+      processIdentityMatches({
+        pid: process.pid,
+        processStartTime: 'Mon Jan  1 00:00:00 2001',
+      }),
+      false,
+    );
+    assert.equal(processIdentityMatches({pid: process.pid}), false);
   });
 });

--- a/dev/shared-ollama.test.mjs
+++ b/dev/shared-ollama.test.mjs
@@ -57,21 +57,31 @@ describe('ollamaListenHost', () => {
 describe('processIdentityMatches', () => {
   test('matches a process by pid and recorded start time', () => {
     const currentStartTime = processStartTime(process.pid);
+    if (currentStartTime === undefined) throw new Error('Current process start time unavailable');
     const matchingState = {pid: process.pid, processStartTime: currentStartTime};
-    const mismatchedState = {
+
+    const result = processIdentityMatches(matchingState);
+
+    assert.equal(result, true);
+  });
+
+  test('rejects a reused pid with a different start time', () => {
+    const state = {
       pid: process.pid,
       processStartTime: 'Mon Jan  1 00:00:00 2001',
     };
-    const missingStartTimeState = {pid: process.pid};
 
-    const matchingResult = processIdentityMatches(matchingState);
-    const mismatchedResult = processIdentityMatches(mismatchedState);
-    const missingStartTimeResult = processIdentityMatches(missingStartTimeState);
+    const result = processIdentityMatches(state);
 
-    assert.equal(typeof currentStartTime, 'string');
-    assert.equal(matchingResult, true);
-    assert.equal(mismatchedResult, false);
-    assert.equal(missingStartTimeResult, false);
+    assert.equal(result, false);
+  });
+
+  test('rejects process state without a start time', () => {
+    const state = {pid: process.pid};
+
+    const result = processIdentityMatches(state);
+
+    assert.equal(result, false);
   });
 });
 

--- a/dev/shared-ollama.test.mjs
+++ b/dev/shared-ollama.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import {describe, test} from 'node:test';
+
+import {ollamaListenHost, serviceContext} from './shared-ollama.mjs';
+
+describe('serviceContext', () => {
+  test('stores shared Ollama state under the Conductor root path', () => {
+    const context = serviceContext(
+      {
+        CONDUCTOR_ROOT_PATH: '/repo/root',
+      },
+      '/repo/worktrees/amsterdam-v1',
+    );
+
+    assert.equal(context.rootPath, '/repo/root');
+    assert.equal(context.stateDir, '/repo/root/.context/shared-ollama');
+    assert.equal(context.pidFile, '/repo/root/.context/shared-ollama/ollama.pid');
+    assert.equal(context.logFile, '/repo/root/.context/shared-ollama/ollama.log');
+  });
+
+  test('falls back to cwd outside Conductor', () => {
+    const context = serviceContext({}, '/repo/root');
+
+    assert.equal(context.rootPath, '/repo/root');
+    assert.equal(context.stateDir, '/repo/root/.context/shared-ollama');
+  });
+
+  test('allows overriding the model and endpoint', () => {
+    const context = serviceContext(
+      {
+        SHIPFOX_OLLAMA_BASE_URL: 'http://127.0.0.1:11500',
+        SHIPFOX_OLLAMA_KEEP_ALIVE: '2h',
+        SHIPFOX_OLLAMA_MODEL: 'custom:model',
+      },
+      '/repo/root',
+    );
+
+    assert.equal(context.baseUrl, 'http://127.0.0.1:11500');
+    assert.equal(context.keepAlive, '2h');
+    assert.equal(context.model, 'custom:model');
+  });
+});
+
+describe('ollamaListenHost', () => {
+  test('converts the API base URL into the OLLAMA_HOST bind value', () => {
+    assert.equal(ollamaListenHost('http://127.0.0.1:11434'), '127.0.0.1:11434');
+  });
+});

--- a/dev/shared-ollama.test.mjs
+++ b/dev/shared-ollama.test.mjs
@@ -5,6 +5,7 @@ import {
   ollamaListenHost,
   processIdentityMatches,
   processStartTime,
+  processStateMatchesContext,
   serviceContext,
 } from './shared-ollama.mjs';
 
@@ -56,19 +57,34 @@ describe('ollamaListenHost', () => {
 describe('processIdentityMatches', () => {
   test('matches a process by pid and recorded start time', () => {
     const currentStartTime = processStartTime(process.pid);
+    const matchingState = {pid: process.pid, processStartTime: currentStartTime};
+    const mismatchedState = {
+      pid: process.pid,
+      processStartTime: 'Mon Jan  1 00:00:00 2001',
+    };
+    const missingStartTimeState = {pid: process.pid};
+
+    const matchingResult = processIdentityMatches(matchingState);
+    const mismatchedResult = processIdentityMatches(mismatchedState);
+    const missingStartTimeResult = processIdentityMatches(missingStartTimeState);
 
     assert.equal(typeof currentStartTime, 'string');
-    assert.equal(
-      processIdentityMatches({pid: process.pid, processStartTime: currentStartTime}),
-      true,
-    );
-    assert.equal(
-      processIdentityMatches({
-        pid: process.pid,
-        processStartTime: 'Mon Jan  1 00:00:00 2001',
-      }),
-      false,
-    );
-    assert.equal(processIdentityMatches({pid: process.pid}), false);
+    assert.equal(matchingResult, true);
+    assert.equal(mismatchedResult, false);
+    assert.equal(missingStartTimeResult, false);
+  });
+});
+
+describe('processStateMatchesContext', () => {
+  test('matches a managed process by listen host', () => {
+    const context = serviceContext({SHIPFOX_OLLAMA_BASE_URL: 'http://127.0.0.1:11500'});
+    const matchingState = {pid: process.pid, listenHost: '127.0.0.1:11500'};
+    const mismatchedState = {pid: process.pid, listenHost: '127.0.0.1:11434'};
+
+    const matchingResult = processStateMatchesContext(matchingState, context);
+    const mismatchedResult = processStateMatchesContext(mismatchedState, context);
+
+    assert.equal(matchingResult, true);
+    assert.equal(mismatchedResult, false);
   });
 });

--- a/mise.lock
+++ b/mise.lock
@@ -78,3 +78,35 @@ backend = "npm:pnpm"
 [[tools."npm:turbo"]]
 version = "2.9.18"
 backend = "npm:turbo"
+
+[[tools.ollama]]
+version = "0.30.11"
+backend = "aqua:ollama/ollama"
+
+[tools.ollama."platforms.linux-arm64"]
+checksum = "sha256:7779570efb5c9ad71f67796e7f850bba1afdf634f8fe2d15bcaa64ec8caca5c5"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-linux-arm64.tar.zst"
+
+[tools.ollama."platforms.linux-arm64-musl"]
+checksum = "sha256:7779570efb5c9ad71f67796e7f850bba1afdf634f8fe2d15bcaa64ec8caca5c5"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-linux-arm64.tar.zst"
+
+[tools.ollama."platforms.linux-x64"]
+checksum = "sha256:11dc89b6c68f136f85ef10e00957530ffab61c35f227696dbf8a11169b47f165"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-linux-amd64.tar.zst"
+
+[tools.ollama."platforms.linux-x64-musl"]
+checksum = "sha256:11dc89b6c68f136f85ef10e00957530ffab61c35f227696dbf8a11169b47f165"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-linux-amd64.tar.zst"
+
+[tools.ollama."platforms.macos-arm64"]
+checksum = "sha256:4620272018aa974fb146741e51fa69dbecd141922143354d4643a45381faf2e6"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-darwin.tgz"
+
+[tools.ollama."platforms.macos-x64"]
+checksum = "sha256:4620272018aa974fb146741e51fa69dbecd141922143354d4643a45381faf2e6"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-darwin.tgz"
+
+[tools.ollama."platforms.windows-x64"]
+checksum = "sha256:43d534c10040ea676c99af19836377a315daa8cb3bb6c3d9d609b4c23dd37b88"
+url = "https://github.com/ollama/ollama/releases/download/v0.30.11/ollama-windows-amd64.zip"

--- a/mise.toml
+++ b/mise.toml
@@ -2,14 +2,45 @@ min_version = "2026.5.18"
 
 [tools]
 gh = "2.95.0"
-"node"      = "24.17.0"
-"npm:pnpm"  = "11.7.0"
+"node" = "24.17.0"
+"npm:pnpm" = "11.7.0"
 "npm:turbo" = "2.9.18"
+ollama = "0.30.11"
 
 [env]
 _.path = ['{{config_root}}/node_modules/.bin']
 _.file = '.context/local-services/env'
 
+[tasks."ollama:up"]
+description = "Start the shared root Ollama server and preload the default model"
+run = """
+if [ -n "${CONDUCTOR_ROOT_PATH:-}" ] && [ "$(pwd -P)" != "$(cd "$CONDUCTOR_ROOT_PATH" && pwd -P)" ]; then
+  mise -C "$CONDUCTOR_ROOT_PATH" run ollama:up
+else
+  node dev/shared-ollama.mjs up
+fi
+"""
+
+[tasks."ollama:status"]
+description = "Show the shared root Ollama server status"
+run = """
+if [ -n "${CONDUCTOR_ROOT_PATH:-}" ] && [ "$(pwd -P)" != "$(cd "$CONDUCTOR_ROOT_PATH" && pwd -P)" ]; then
+  mise -C "$CONDUCTOR_ROOT_PATH" run ollama:status
+else
+  node dev/shared-ollama.mjs status
+fi
+"""
+
+[tasks."ollama:stop"]
+description = "Stop the shared root Ollama server if this repo started it"
+run = """
+if [ -n "${CONDUCTOR_ROOT_PATH:-}" ] && [ "$(pwd -P)" != "$(cd "$CONDUCTOR_ROOT_PATH" && pwd -P)" ]; then
+  mise -C "$CONDUCTOR_ROOT_PATH" run ollama:stop
+else
+  node dev/shared-ollama.mjs stop
+fi
+"""
+
 [settings]
-lockfile       = true
+lockfile = true
 minimum_release_age = "48h"


### PR DESCRIPTION
Install Ollama through mise and add root-scoped tasks that start a shared server for `qwen3.5:0.8b`. Conductor setup now trusts and installs the root mise config before invoking `ollama:up`, so worktrees delegate to the main checkout instead of starting their own Ollama process.

This keeps heavy model startup out of per-worktree setup while preserving a simple `mise run ollama:up`, `mise run ollama:status`, and `mise run ollama:stop` workflow. The helper stores managed process state and logs under the root `.context/shared-ollama` directory and preloads the configured model with a keep-alive.

Considered letting each worktree own its own Ollama lifecycle, but the server is effectively stateless and expensive enough that a shared root process is simpler for frequent Conductor workspace cycling.

Validated locally with the changed-graph build, test, and check gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `ollama` via `mise` and add a root-managed, shared Ollama server for Conductor worktrees. `ollama:up` verifies the managed process identity and endpoint, pulls `qwen3.5:0.8b`, and starts a 24h warmup keep-alive to reduce per-worktree overhead.

- **New Features**
  - Root-shared Ollama lifecycle managed by `dev/shared-ollama.mjs`; state/logs under `.context/shared-ollama/`.
  - Expose `ollama:up`, `ollama:status`, and `ollama:stop`; Conductor setup trusts/installs the root `mise` config and runs `ollama:up`; tasks delegate to the root checkout from worktrees.
  - `ollama:up` starts `ollama serve` at `http://127.0.0.1:11434`, pulls the model, and launches a background warmup; override via `SHIPFOX_OLLAMA_BASE_URL`, `SHIPFOX_OLLAMA_MODEL`, `SHIPFOX_OLLAMA_KEEP_ALIVE`.
  - Verify managed process identity (pid + start time) and endpoint to avoid stopping non-owned servers and detect stale/mismatched PIDs; added docs and tests, and fixed test structure.

- **Dependencies**
  - Add `ollama` `0.30.11` via `mise` (`mise.toml` and `mise.lock` updated with platform assets).

<sup>Written for commit 3a4c83f90f406368f5dce12bcb5b4e53e7129653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

