### PR TITLE
[client-integrations] Fix source control onboarding test race

### DIFF
--- a/libs/client/integrations/src/pages/source-control-onboarding-page.test.tsx
+++ b/libs/client/integrations/src/pages/source-control-onboarding-page.test.tsx
@@ -31,7 +31,7 @@ describe('SourceControlOnboardingPage', () => {
     });
 
     expect(await screen.findByRole('heading', {name: 'Install source control'})).toBeVisible();
-    expect(screen.getByRole('link', {name: 'Install GitHub'})).toBeVisible();
+    expect(await screen.findByRole('link', {name: 'Install GitHub'})).toBeVisible();
     expect(screen.queryByRole('region', {name: 'Installed integrations'})).not.toBeInTheDocument();
     expect(screen.queryByRole('region', {name: 'Available integrations'})).not.toBeInTheDocument();
     expect(


### PR DESCRIPTION
[client-integrations] Fix source control onboarding test race

The source control onboarding page test waited for the static page heading before asserting that the GitHub install card was visible. The heading renders before the providers query resolves, so the assertion could run while the provider grid was still showing its loading skeleton.

This changes the test to wait for the install link itself, matching the async boundary that determines whether provider cards have rendered.

No changeset is included because this is a test-only stabilization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky Source Control onboarding test by awaiting the "Install GitHub" link instead of the static page heading. This aligns the wait with provider card rendering and prevents assertions from running while the grid is still loading.

<sup>Written for commit f02bb99ad6d1f97fd932bf5d31953a6f1343ac88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

