### PR TITLE
[api/triggers] Lock webhook trigger contract

### DIFF
--- a/.changeset/brisk-hooks-validate.md
+++ b/.changeset/brisk-hooks-validate.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-webhook-dto": patch
+---
+
+Adds reserved webhook slug validation while keeping legacy webhook response DTOs readable.

--- a/libs/api/integration/webhook-dto/package.json
+++ b/libs/api/integration/webhook-dto/package.json
@@ -32,6 +32,8 @@
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "depcruise": "shipfox-depcruise",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },

--- a/libs/api/integration/webhook-dto/src/index.test.ts
+++ b/libs/api/integration/webhook-dto/src/index.test.ts
@@ -1,4 +1,9 @@
-import {WEBHOOK_RESERVED_SLUGS, webhookSlugSchema} from './index.js';
+import {
+  createWebhookConnectionBodySchema,
+  WEBHOOK_RESERVED_SLUGS,
+  webhookConnectionDtoSchema,
+  webhookSlugSchema,
+} from './index.js';
 
 describe('webhookSlugSchema', () => {
   it.each(WEBHOOK_RESERVED_SLUGS)('rejects reserved slug %s', (slug) => {
@@ -9,6 +14,37 @@ describe('webhookSlugSchema', () => {
 
   it.each(['stripe', 'stripe-prod', 'stripe_prod'])('accepts normal lowercase slug %s', (slug) => {
     const result = webhookSlugSchema.safeParse(slug);
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('createWebhookConnectionBodySchema', () => {
+  it.each(WEBHOOK_RESERVED_SLUGS)('rejects reserved slug %s', (slug) => {
+    const result = createWebhookConnectionBodySchema.safeParse({
+      workspace_id: crypto.randomUUID(),
+      name: 'Reserved',
+      slug,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('webhookConnectionDtoSchema', () => {
+  it.each(WEBHOOK_RESERVED_SLUGS)('accepts legacy reserved response slug %s', (slug) => {
+    const now = new Date().toISOString();
+
+    const result = webhookConnectionDtoSchema.safeParse({
+      id: crypto.randomUUID(),
+      workspace_id: crypto.randomUUID(),
+      name: 'Legacy',
+      slug,
+      lifecycle_status: 'active',
+      inbound_url: 'https://example.com/webhook/legacy',
+      created_at: now,
+      updated_at: now,
+    });
 
     expect(result.success).toBe(true);
   });

--- a/libs/api/integration/webhook-dto/src/index.test.ts
+++ b/libs/api/integration/webhook-dto/src/index.test.ts
@@ -1,0 +1,15 @@
+import {WEBHOOK_RESERVED_SLUGS, webhookSlugSchema} from './index.js';
+
+describe('webhookSlugSchema', () => {
+  it.each(WEBHOOK_RESERVED_SLUGS)('rejects reserved slug %s', (slug) => {
+    const result = webhookSlugSchema.safeParse(slug);
+
+    expect(result.success).toBe(false);
+  });
+
+  it.each(['stripe', 'stripe-prod', 'stripe_prod'])('accepts normal lowercase slug %s', (slug) => {
+    const result = webhookSlugSchema.safeParse(slug);
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/libs/api/integration/webhook-dto/src/index.ts
+++ b/libs/api/integration/webhook-dto/src/index.ts
@@ -30,7 +30,7 @@ export const webhookConnectionDtoSchema = z.object({
   id: z.string().uuid(),
   workspace_id: z.string().uuid(),
   name: z.string(),
-  slug: webhookSlugSchema,
+  slug: connectionSlugSchema,
   lifecycle_status: z.enum(['active', 'disabled', 'error']),
   inbound_url: z.string().url(),
   created_at: z.string(),

--- a/libs/api/integration/webhook-dto/src/index.ts
+++ b/libs/api/integration/webhook-dto/src/index.ts
@@ -3,7 +3,7 @@ import {z} from 'zod';
 
 export const WEBHOOK_PROVIDER = 'webhook' as const;
 export const WEBHOOK_RECEIVED_EVENT = 'received' as const;
-export const WEBHOOK_RESERVED_SLUGS = ['manual', 'cron'] as const;
+export const WEBHOOK_RESERVED_SLUGS = ['github', 'gitea', 'sentry', 'manual', 'cron'] as const;
 
 const webhookReservedSlugSet = new Set<string>(WEBHOOK_RESERVED_SLUGS);
 

--- a/libs/api/triggers/README.md
+++ b/libs/api/triggers/README.md
@@ -59,6 +59,27 @@ fires every subscription that matches its `(source, event)` in the
 workspace. Narrowing by branch, repository, or payload contents is left to
 user-defined filters, applied in a later iteration.
 
+Webhook triggers use the webhook connection slug as `source` and the fixed
+event name `received`. A delivery to `POST /webhook/:connectionId` publishes
+an `INTEGRATION_EVENT_RECEIVED` envelope with `provider: webhook`,
+`source: <connection.slug>`, `event: received`, and payload
+`{method, headers, query, body}`. Trigger dispatch matches only on
+`(workspace_id, source, event)`, so a workflow that listens to a webhook uses
+the slug plus `event: received`:
+
+```yaml
+triggers:
+  on_stripe:
+    source: stripe_prod
+    event: received
+```
+
+Workflow interpolation exposes the webhook envelope as `event`, so steps can
+read values such as `${{ event.body.payment_id }}` and
+`${{ event.headers["x-stripe-signature"] }}`. Header/body-derived event
+subtypes and dispatch-time trigger filter evaluation are not part of this
+contract.
+
 GitHub triggers use the raw GitHub webhook resource name, plus the payload
 `action` when one is present. For example, a pull request open event is
 `pull_request.opened`, an issue close event is `issues.closed`, and a

--- a/libs/api/triggers/src/core/dispatch-integration-event.test.ts
+++ b/libs/api/triggers/src/core/dispatch-integration-event.test.ts
@@ -153,6 +153,66 @@ describe('dispatchIntegrationEvent', () => {
     );
   });
 
+  test('routes webhook events only when workspace, source, and received event match', async () => {
+    const workspaceId = crypto.randomUUID();
+    const matching = await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'stripe_prod',
+      event: 'received',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId: crypto.randomUUID(),
+      source: 'stripe_prod',
+      event: 'received',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'stripe_stage',
+      event: 'received',
+      config: {},
+    });
+    await triggerSubscriptionFactory.create({
+      workspaceId,
+      source: 'stripe_prod',
+      event: 'ping',
+      config: {},
+    });
+
+    await dispatch({
+      provider: 'webhook',
+      workspaceId,
+      source: 'stripe_prod',
+      event: 'received',
+      payload: {
+        method: 'POST',
+        headers: {'x-stripe-signature': 'sig_123'},
+        query: {mode: 'live'},
+        body: {payment_id: 'pay_123'},
+      },
+    });
+
+    expect(runWorkflow).toHaveBeenCalledTimes(1);
+    expect(runWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: matching.projectId,
+        definitionId: matching.workflowDefinitionId,
+        triggerPayload: expect.objectContaining({
+          provider: 'webhook',
+          source: 'stripe_prod',
+          event: 'received',
+          data: {
+            method: 'POST',
+            headers: {'x-stripe-signature': 'sig_123'},
+            query: {mode: 'live'},
+            body: {payment_id: 'pay_123'},
+          },
+        }),
+      }),
+    );
+  });
+
   test('passes triggerIdempotencyKey = subscription.id:eventRef to runWorkflow', async () => {
     const workspaceId = crypto.randomUUID();
     const subscription = await triggerSubscriptionFactory.create({

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -324,6 +324,52 @@ describe('workflow run queries', () => {
       });
     });
 
+    test('resolves webhook trigger payload body and headers into step config', async () => {
+      const model = normalizeWorkflowDocument({
+        name: 'Webhook workflow',
+        runner: 'ubuntu-latest',
+        env: {
+          PAYMENT_ID: template('event.body.payment_id'),
+          SIGNATURE: template('event.headers["x-stripe-signature"]'),
+        },
+        jobs: {
+          build: {
+            steps: [{run: 'echo webhook'}],
+          },
+        },
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          provider: 'webhook',
+          source: 'stripe_prod',
+          event: 'received',
+          deliveryId: 'delivery-1',
+          data: {
+            method: 'POST',
+            headers: {'x-stripe-signature': 'sig_123'},
+            query: {mode: 'live'},
+            body: {payment_id: 'pay_123'},
+          },
+        },
+      });
+
+      const [job] = await getJobsByWorkflowRunId(run.id);
+      const steps = await getStepsByJobId(job?.id as string);
+
+      expect(steps[1]?.config).toEqual({
+        run: 'echo webhook',
+        env: {
+          PAYMENT_ID: 'pay_123',
+          SIGNATURE: 'sig_123',
+        },
+      });
+    });
+
     test('logs enriched diagnostics for missing untrusted interpolation paths', async () => {
       const warn = vi.fn();
       vi.spyOn(opentelemetry, 'logger').mockReturnValue({warn} as never);


### PR DESCRIPTION
Lock the generic webhook trigger contract around connection slugs, the fixed `received` event, and the `{method, headers, query, body}` payload envelope exposed to workflow steps.

Webhook slugs could previously be created with names that collide with built-in trigger sources such as `github`, `manual`, or `cron`. This expands the shared reserved-slug list and adds DTO, route, dispatch, and workflow runtime coverage so webhook deliveries only route by `(workspace_id, source, event)` and the payload remains available as `event.body.*` and `event.headers[...]`.

The trigger docs now call out that dispatch-time trigger filters and header/body-derived event subtypes are intentionally outside this contract.

Closes ENG-687

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the webhook trigger contract to use the connection slug as `source`, a fixed `received` event, and a `{method, headers, query, body}` payload envelope. Prevents slug collisions with built-in sources by expanding the reserved list, while allowing legacy slugs to serialize in responses. Addresses ENG-687.

- **New Features**
  - Dispatch matches only on `(workspace_id, source, event)` for webhook deliveries.
  - Reserved slugs expanded to `github`, `gitea`, `sentry`, `manual`, `cron`; create bodies reject them, response DTOs allow legacy ones.
  - Workflow steps can read `event.body.*` and `event.headers[...]`; docs clarify no subtype or dispatch-time filter support.

<sup>Written for commit c709f657411bbbe9ea08a2ecc16b9906d93dd97e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

