### PR TITLE
Add workflow run durations

### DIFF
--- a/.changeset/steady-clocks-show.md
+++ b/.changeset/steady-clocks-show.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-workflows-dto": patch
+"@shipfox/client-workflows": minor
+---
+
+Derives workflow run attempt durations on the client and displays them in the run list and run header.

--- a/libs/api/workflows-dto/src/schemas/workflow-run-detail.ts
+++ b/libs/api/workflows-dto/src/schemas/workflow-run-detail.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 import {jobDtoSchema} from './job.js';
 import {workflowExecutionEventSchema} from './job-listening.js';
 import {stepAttemptDtoSchema, stepDtoSchema} from './step.js';
-import {workflowRunResponseSchema, workflowRunStatusSchema} from './workflow-run.js';
+import {workflowRunAttemptDtoSchema, workflowRunResponseSchema} from './workflow-run.js';
 
 export const jobExecutionStatusSchema = z.enum([
   'pending',
@@ -55,16 +55,7 @@ export type WorkflowRunJobDetailDto = z.infer<typeof workflowRunJobDetailDtoSche
 // The run detail read model returned by `GET /workflows/runs/:id`: a run plus its
 // jobs, each job's steps, and each step's attempt history.
 export const workflowRunDetailResponseSchema = workflowRunResponseSchema.extend({
-  run_attempt: z.object({
-    id: z.string().uuid(),
-    workflow_run_id: z.string().uuid(),
-    attempt: z.number().int().positive(),
-    status: workflowRunStatusSchema,
-    created_at: z.string(),
-    started_at: z.string().nullable(),
-    finished_at: z.string().nullable(),
-    rerun_mode: z.enum(['all', 'failed']).nullable(),
-  }),
+  run_attempt: workflowRunAttemptDtoSchema,
   jobs: z.array(workflowRunJobDetailDtoSchema),
 });
 

--- a/libs/client/workflows/src/components/workflow-run-duration-label.tsx
+++ b/libs/client/workflows/src/components/workflow-run-duration-label.tsx
@@ -1,0 +1,115 @@
+import {Code, cn, humanDuration, Icon, useTimeTick} from '@shipfox/react-ui';
+import type {WorkflowRunAttemptDisplayDuration} from '#core/workflow-run.js';
+
+export function WorkflowRunDurationLabel({
+  duration,
+  className,
+}: {
+  duration: WorkflowRunAttemptDisplayDuration | null;
+  className?: string | undefined;
+}) {
+  if (duration === null) return null;
+
+  switch (duration.state) {
+    case 'fixed': {
+      const display = formatFixedDurationLabel(duration.elapsed);
+      return (
+        <DurationText className={className} ariaLabel={`ran ${display}`}>
+          {display}
+        </DurationText>
+      );
+    }
+    case 'live':
+      return <LiveDurationText duration={duration} className={className} />;
+    default: {
+      const exhaustive: never = duration;
+      return exhaustive;
+    }
+  }
+}
+
+export function useWorkflowRunDurationAccessibleLabel(
+  duration: WorkflowRunAttemptDisplayDuration | null,
+): string | undefined {
+  useTimeTick();
+  return workflowRunDurationAccessibleLabel(duration);
+}
+
+export function workflowRunDurationAccessibleLabel(
+  duration: WorkflowRunAttemptDisplayDuration | null,
+): string | undefined {
+  if (duration === null) return undefined;
+
+  switch (duration.state) {
+    case 'live':
+      return `running ${humanDuration(duration.fromIso)}`;
+    case 'fixed':
+      return `ran ${formatFixedDurationLabel(duration.elapsed)}`;
+    default: {
+      const exhaustive: never = duration;
+      return exhaustive;
+    }
+  }
+}
+
+function LiveDurationText({
+  duration,
+  className,
+}: {
+  duration: Extract<WorkflowRunAttemptDisplayDuration, {state: 'live'}>;
+  className?: string | undefined;
+}) {
+  useTimeTick();
+  const display = humanDuration(duration.fromIso);
+  return (
+    <DurationText className={className} ariaLabel={`running ${display}`}>
+      {display}
+    </DurationText>
+  );
+}
+
+function DurationText({
+  children,
+  className,
+  ariaLabel,
+}: {
+  children: string;
+  className?: string | undefined;
+  ariaLabel?: string | undefined;
+}) {
+  return (
+    <Code
+      as="span"
+      variant="label"
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-4 tabular-nums text-foreground-neutral-muted',
+        className,
+      )}
+    >
+      <Icon name="timerLine" className="size-12 shrink-0" aria-hidden="true" />
+      {children}
+    </Code>
+  );
+}
+
+function formatFixedDurationLabel({
+  years = 0,
+  months = 0,
+  weeks = 0,
+  days = 0,
+  hours = 0,
+  minutes = 0,
+  seconds = 0,
+}: Extract<WorkflowRunAttemptDisplayDuration, {state: 'fixed'}>['elapsed']): string {
+  const totalDays = years * 365 + months * 30 + weeks * 7 + days;
+  const totalHours = totalDays * 24 + hours;
+
+  if (totalHours > 0) return `${totalHours}h ${pad2(minutes)}m`;
+  if (minutes > 0) return `${minutes}m ${pad2(seconds)}s`;
+  return `${seconds}s`;
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, '0');
+}

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -20,6 +20,11 @@ function loadedQuery(): WorkflowRunListQuery {
 }
 
 describe('WorkflowRunListView', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   test('narrows the list to the selected status filter', async () => {
     const user = userEvent.setup();
     renderListView([
@@ -60,6 +65,44 @@ describe('WorkflowRunListView', () => {
     expect(links.some((link) => link.textContent?.includes('deploy-web'))).toBe(true);
     expect(links.some((link) => link.textContent?.includes('queued-build'))).toBe(false);
     expect(screen.getByText('queued-build')).toBeInTheDocument();
+  });
+
+  test('shows a finished run duration in the row metadata', async () => {
+    renderListView([
+      run('succeeded', 'build-image', 'run-build-image', {
+        started_at: '2026-05-07T01:00:00.000Z',
+        finished_at: '2026-05-07T01:02:14.000Z',
+      }),
+    ]);
+
+    const duration = await screen.findByText('2m 14s');
+    expect(duration).toBeInTheDocument();
+    expect(duration).toHaveAttribute('aria-label', 'ran 2m 14s');
+    expect(
+      screen.getByRole('link', {
+        name: (name) => name.includes('build-image') && name.includes('ran 2m 14s'),
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows a live running run duration in the row metadata', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-05-07T01:02:14.000Z'));
+
+    renderListView([
+      run('running', 'deploy-web', 'run-deploy-web', {
+        started_at: '2026-05-07T01:00:00.000Z',
+        finished_at: null,
+      }),
+    ]);
+
+    const duration = await screen.findByText('2m 14s');
+    expect(duration).toBeInTheDocument();
+    expect(duration).toHaveAttribute('aria-label', 'running 2m 14s');
+    expect(
+      screen.getByRole('link', {
+        name: (name) => name.includes('deploy-web') && name.includes('running 2m 14s'),
+      }),
+    ).toBeInTheDocument();
   });
 
   test('scopes the trigger tooltip to the trigger label', async () => {
@@ -111,7 +154,12 @@ function renderListView(runs: WorkflowRunListItem[]) {
   ));
 }
 
-function run(status: WorkflowRunStatus, name: string, id = `run-${name}`): WorkflowRunListItem {
+function run(
+  status: WorkflowRunStatus,
+  name: string,
+  id = `run-${name}`,
+  overrides: NonNullable<Parameters<typeof workflowRunListItem>[0]> = {},
+): WorkflowRunListItem {
   return workflowRunListItem({
     id,
     project_id: PROJECT_ID,
@@ -123,5 +171,6 @@ function run(status: WorkflowRunStatus, name: string, id = `run-${name}`): Workf
     trigger_event: 'push',
     created_at: '2026-05-07T01:01:00.000Z',
     updated_at: '2026-05-07T01:02:00.000Z',
+    ...overrides,
   });
 }

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.tsx
@@ -1,4 +1,4 @@
-import {cn, RelativeTimeProvider} from '@shipfox/react-ui';
+import {cn, TimeTickerProvider} from '@shipfox/react-ui';
 import {useState} from 'react';
 import {runMatchesSearch, runMatchesStatusFilter} from './run-display.js';
 import type {WorkflowRunListStatusFilter, WorkflowRunListViewProps} from './types.js';
@@ -27,7 +27,7 @@ export function WorkflowRunListView({
   }
 
   return (
-    <RelativeTimeProvider>
+    <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
       <aside
         className={cn(
           'flex w-304 shrink-0 flex-col border-r border-border-neutral-base bg-background-subtle-base',
@@ -51,6 +51,6 @@ export function WorkflowRunListView({
           onClearFilters={handleClearFilters}
         />
       </aside>
-    </RelativeTimeProvider>
+    </TimeTickerProvider>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-row.tsx
@@ -9,6 +9,11 @@ import {
   TooltipTrigger,
 } from '@shipfox/react-ui';
 import {Link} from '@tanstack/react-router';
+import {
+  useWorkflowRunDurationAccessibleLabel,
+  WorkflowRunDurationLabel,
+} from '#components/workflow-run-duration-label.js';
+import {getWorkflowStatusVisual} from '#components/workflow-status/status-visuals.js';
 import {WorkflowStatusIcon} from '#components/workflow-status/workflow-status-icon.js';
 import type {WorkflowRunListItem} from '#core/workflow-run.js';
 import {withoutWorkflowRunSelectionSearch} from '#core/workflow-run-url-state.js';
@@ -53,6 +58,8 @@ export function WorkflowRunRow({
   projectId: string;
   selected: boolean;
 }) {
+  const durationLabel = useWorkflowRunDurationAccessibleLabel(run.runAttempt.displayDuration);
+  const statusLabel = getWorkflowStatusVisual(run.status).label;
   const body = (
     <>
       {selected ? (
@@ -78,10 +85,16 @@ export function WorkflowRunRow({
             <span className="sr-only">Run updated </span>
           </span>
         )}
-        <RelativeTime
-          value={run.updatedAt}
-          className="shrink-0 whitespace-nowrap text-xs leading-20 text-foreground-neutral-disabled"
-        />
+        <span className="ml-auto flex shrink-0 items-center gap-6">
+          <WorkflowRunDurationLabel
+            duration={run.runAttempt.displayDuration}
+            className="text-foreground-neutral-disabled"
+          />
+          {durationLabel ? <RunMetadataSeparator /> : null}
+          <Code variant="label" className="shrink-0 text-foreground-neutral-disabled">
+            <RelativeTime value={run.updatedAt} />
+          </Code>
+        </span>
       </div>
     </>
   );
@@ -106,7 +119,9 @@ export function WorkflowRunRow({
           withoutWorkflowRunSelectionSearch(previous)) as never
       }
       aria-current={selected ? 'page' : undefined}
-      aria-label={run.triggerLabel ? `${run.name}, ${run.status}, ${run.triggerLabel}` : undefined}
+      aria-label={[run.name, statusLabel, durationLabel, run.triggerLabel]
+        .filter((part): part is string => Boolean(part))
+        .join(', ')}
       className={cn(
         'group relative flex w-full flex-col gap-4 rounded-8 border border-transparent px-10 py-8 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
         selected && 'bg-background-components-hover',
@@ -149,5 +164,18 @@ function TriggerTooltip({label}: {label: string}) {
         {label}
       </Text>
     </TooltipContent>
+  );
+}
+
+function RunMetadataSeparator() {
+  return (
+    <Code
+      as="span"
+      variant="label"
+      aria-hidden="true"
+      className="shrink-0 text-foreground-neutral-disabled"
+    >
+      ·
+    </Code>
   );
 }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -14,7 +14,7 @@ import {
 import type {ReactNode} from 'react';
 import {useEffect, useState} from 'react';
 import {screen, userEvent, within} from 'storybook/test';
-import type {WorkflowRunStatus} from '#core/workflow-run.js';
+import {WorkflowRunAttempt, type WorkflowRunStatus} from '#core/workflow-run.js';
 import {
   runAttemptsResponseDto,
   workflowJobDto,
@@ -30,6 +30,8 @@ const WORKSPACE_ID = '44444444-4444-4444-8444-444444444444';
 const PROJECT_ID = '55555555-5555-4555-8555-555555555555';
 const SWITCH_ATTEMPT_PATTERN = /Switch attempt/;
 const ATTEMPT_3_PATTERN = /Attempt 3/;
+const STORYBOOK_NOW = '2026-06-26T12:00:00.000Z';
+const RUN_STARTED_AT = '2026-06-26T11:57:46.000Z';
 const RUN_ATTEMPTS_RESPONSE = runAttemptsResponseDto({
   attempts: [
     workflowRunAttemptDto({
@@ -195,6 +197,37 @@ export const WithAttemptsOpen: Story = {
   args: ATTEMPT_SUMMARY_ARGS,
 };
 
+export const Durations: Story = {
+  render: () => (
+    <div className="flex flex-col">
+      <WorkflowRunSummary
+        run={workflowRunDetail({
+          status: 'succeeded',
+          name: 'release-finished',
+          run_attempt: workflowRunAttemptDto({
+            status: 'succeeded',
+            created_at: RUN_STARTED_AT,
+            started_at: RUN_STARTED_AT,
+            finished_at: STORYBOOK_NOW,
+          }),
+        })}
+      />
+      <WorkflowRunSummary
+        run={workflowRunDetail({
+          status: 'running',
+          name: 'release-running',
+          run_attempt: workflowRunAttemptDto({
+            status: 'running',
+            created_at: RUN_STARTED_AT,
+            started_at: RUN_STARTED_AT,
+            finished_at: null,
+          }),
+        })}
+      />
+    </div>
+  ),
+};
+
 export const Cancellable: Story = {
   args: {
     run: workflowRunDetail({status: 'running'}),
@@ -285,7 +318,7 @@ const ACTION_VARIANTS = [
   },
 ] satisfies Array<{
   label: string;
-  run: ReturnType<typeof workflowRun>;
+  run: ReturnType<typeof workflowRunDetail>;
   props: Pick<
     Parameters<typeof WorkflowRunSummary>[0],
     'cancelling' | 'onCancel' | 'rerunPending' | 'onRerun'
@@ -325,7 +358,7 @@ export const ActionVariantsWithAttempts: Story = {
             ...run,
             id: `22222222-2222-4222-8222-${String(index + 2).padStart(12, '0')}`,
             currentAttempt: 2,
-            runAttempt: {
+            runAttempt: new WorkflowRunAttempt({
               id: `22222222-2222-4222-8222-${String(index + 2).padStart(12, '0')}`,
               workflowRunId: `22222222-2222-4222-8222-${String(index + 2).padStart(12, '0')}`,
               attempt: 2,
@@ -334,7 +367,7 @@ export const ActionVariantsWithAttempts: Story = {
               startedAt: null,
               finishedAt: null,
               rerunMode: null,
-            },
+            }),
           }}
           latestAttempt={3}
           {...props}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -31,6 +31,11 @@ beforeEach(() => {
 });
 
 describe('WorkflowRunSummary', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   test('renders status, trigger metadata, and trigger time', async () => {
     renderSummary();
 
@@ -129,6 +134,50 @@ describe('WorkflowRunSummary', () => {
     expect(sourceButton).toHaveAttribute('aria-controls', 'workflow-source-panel');
     expect(sourceButton).toHaveAttribute('aria-expanded', 'false');
     expect(onSourceToggle).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows the selected attempt duration, not the top-level run duration', async () => {
+    renderSummary({
+      started_at: '2026-05-07T00:00:00.000Z',
+      finished_at: '2026-05-07T00:10:00.000Z',
+      run_attempt: {
+        id: '11111111-1111-4111-8111-000000000001',
+        workflow_run_id: RUN_ID,
+        attempt: 1,
+        status: 'succeeded',
+        created_at: '2026-05-07T01:01:00.000Z',
+        started_at: '2026-05-07T01:00:00.000Z',
+        finished_at: '2026-05-07T01:02:14.000Z',
+        rerun_mode: null,
+      },
+    });
+
+    await screen.findByRole('region', {name: 'deploy-web'});
+
+    expect(screen.getByText('2m 14s')).toBeInTheDocument();
+    expect(screen.queryByText('10m 00s')).not.toBeInTheDocument();
+  });
+
+  test('shows a live selected attempt duration for running runs', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-05-07T01:02:14.000Z'));
+    renderSummary({
+      run_attempt: {
+        id: '11111111-1111-4111-8111-000000000001',
+        workflow_run_id: RUN_ID,
+        attempt: 1,
+        status: 'running',
+        created_at: '2026-05-07T01:01:00.000Z',
+        started_at: '2026-05-07T01:00:00.000Z',
+        finished_at: null,
+        rerun_mode: null,
+      },
+    });
+
+    await screen.findByRole('region', {name: 'deploy-web'});
+
+    const duration = screen.getByText('2m 14s');
+    expect(duration).toBeInTheDocument();
+    expect(duration).toHaveAttribute('aria-label', 'running 2m 14s');
   });
 
   test('omits source control when source is unavailable', async () => {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -10,6 +10,7 @@ import {
   Header,
   RelativeTime,
   Text,
+  TimeTickerProvider,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -23,6 +24,7 @@ import {
   WORKFLOW_RUN_STATUSES,
   type WorkflowRunDetail,
 } from '#core/workflow-run.js';
+import {WorkflowRunDurationLabel} from '../workflow-run-duration-label.js';
 import {getWorkflowStatusVisual} from '../workflow-status/status-visuals.js';
 import {WorkflowRunAttemptSwitcher} from './workflow-run-attempt-switcher.js';
 
@@ -70,113 +72,126 @@ export function WorkflowRunSummary({
     latestAttempt && latestAttempt > 1 && workspaceId && projectId
       ? {workspaceId, projectId, latestAttempt}
       : null;
+  const displayDuration = run.runAttempt.displayDuration;
   const {ref: headingTextRef, isTruncated: isHeadingTruncated} =
     useIsTextTruncated<HTMLSpanElement>(run.name);
 
   return (
-    <section
-      aria-labelledby={headingId}
-      className="border-b border-border-neutral-base bg-background-subtle-base px-16 py-8"
-    >
-      <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-4 overflow-hidden">
-        <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-8">
-          <Badge variant={status.badge} size="xs">
-            <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
-              {status.label}
-            </span>
-          </Badge>
-
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Header id={headingId} variant="h3" className="min-w-0 truncate">
-                <span ref={headingTextRef} className="block min-w-0 truncate">
-                  {run.name}
-                </span>
-              </Header>
-            </TooltipTrigger>
-            {isHeadingTruncated ? (
-              <TooltipContent>
-                <Text as="span" size="xs" className="max-w-[360px] break-words">
-                  {run.name}
-                </Text>
-              </TooltipContent>
-            ) : null}
-          </Tooltip>
-        </div>
-
-        <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end">
-          <WorkflowRunActionSlot
-            action={action}
-            cancelling={cancelling}
-            onCancel={onCancel}
-            rerunPending={rerunPending}
-            onRerun={onRerun}
-          />
-          {sourceAvailable ? (
-            <Button
-              ref={sourceButtonRef}
-              type="button"
-              variant="secondary"
-              size="xs"
-              aria-controls={sourcePanelId}
-              aria-expanded={sourceOpen}
-              onClick={onSourceToggle}
-            >
-              View source
-            </Button>
-          ) : null}
-        </div>
-
-        <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-muted">
-          {attemptSwitcher ? (
-            <WorkflowRunAttemptSwitcher
-              workspaceId={attemptSwitcher.workspaceId}
-              projectId={attemptSwitcher.projectId}
-              run={run}
-              latestAttempt={attemptSwitcher.latestAttempt}
-            />
-          ) : null}
-
-          {run.triggerDisplayLabel ? (
-            <>
-              {attemptSwitcher ? <MetadataSeparator /> : null}
-              <span className="min-w-0">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      aria-label={run.triggerLabel}
-                      className="inline-flex max-w-full min-w-0 items-center gap-4 rounded-6 border-0 bg-transparent p-0 text-left text-foreground-neutral-muted outline-none focus-visible:shadow-button-neutral-focus"
-                    >
-                      <TriggerSourceIcon
-                        provider={run.triggerProvider}
-                        source={run.triggerSource}
-                        aria-hidden="true"
-                        className="size-12 shrink-0"
-                      />
-                      <Text as="span" size="xs" className="min-w-0 truncate">
-                        {run.triggerDisplayLabel}
-                      </Text>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <Text as="span" size="xs" className="block max-w-[360px] break-words">
-                      {run.triggerLabel}
-                    </Text>
-                  </TooltipContent>
-                </Tooltip>
+    <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
+      <section
+        aria-labelledby={headingId}
+        className="border-b border-border-neutral-base bg-background-subtle-base px-16 py-8"
+      >
+        <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-x-12 gap-y-4 overflow-hidden">
+          <div className="col-start-1 row-start-1 flex min-w-0 items-center gap-8">
+            <Badge variant={status.badge} size="xs">
+              <span className="text-center" style={{width: `${STATUS_BADGE_LABEL_WIDTH_CH}ch`}}>
+                {status.label}
               </span>
-            </>
-          ) : null}
+            </Badge>
 
-          {attemptSwitcher || run.triggerDisplayLabel ? <MetadataSeparator /> : null}
-          <RelativeTime
-            value={run.runAttempt.createdAt}
-            className="shrink-0 whitespace-nowrap text-xs leading-20 text-foreground-neutral-muted"
-          />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Header id={headingId} variant="h3" className="min-w-0 truncate">
+                  <span ref={headingTextRef} className="block min-w-0 truncate">
+                    {run.name}
+                  </span>
+                </Header>
+              </TooltipTrigger>
+              {isHeadingTruncated ? (
+                <TooltipContent>
+                  <Text as="span" size="xs" className="max-w-[360px] break-words">
+                    {run.name}
+                  </Text>
+                </TooltipContent>
+              ) : null}
+            </Tooltip>
+          </div>
+
+          <div className="col-start-2 row-start-1 flex min-w-max items-center gap-6 justify-self-end">
+            <WorkflowRunActionSlot
+              action={action}
+              cancelling={cancelling}
+              onCancel={onCancel}
+              rerunPending={rerunPending}
+              onRerun={onRerun}
+            />
+            {sourceAvailable ? (
+              <Button
+                ref={sourceButtonRef}
+                type="button"
+                variant="secondary"
+                size="xs"
+                aria-controls={sourcePanelId}
+                aria-expanded={sourceOpen}
+                onClick={onSourceToggle}
+              >
+                View source
+              </Button>
+            ) : null}
+          </div>
+
+          <div className="col-span-2 row-start-2 flex min-w-0 items-center gap-12 overflow-hidden text-foreground-neutral-muted">
+            {attemptSwitcher ? (
+              <WorkflowRunAttemptSwitcher
+                workspaceId={attemptSwitcher.workspaceId}
+                projectId={attemptSwitcher.projectId}
+                run={run}
+                latestAttempt={attemptSwitcher.latestAttempt}
+              />
+            ) : null}
+
+            {run.triggerDisplayLabel ? (
+              <>
+                {attemptSwitcher ? <MetadataSeparator /> : null}
+                <span className="min-w-0">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={run.triggerLabel}
+                        className="inline-flex max-w-full min-w-0 items-center gap-4 rounded-6 border-0 bg-transparent p-0 text-left text-foreground-neutral-muted outline-none focus-visible:shadow-button-neutral-focus"
+                      >
+                        <TriggerSourceIcon
+                          provider={run.triggerProvider}
+                          source={run.triggerSource}
+                          aria-hidden="true"
+                          className="size-12 shrink-0"
+                        />
+                        <Text as="span" size="xs" className="min-w-0 truncate">
+                          {run.triggerDisplayLabel}
+                        </Text>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <Text as="span" size="xs" className="block max-w-[360px] break-words">
+                        {run.triggerLabel}
+                      </Text>
+                    </TooltipContent>
+                  </Tooltip>
+                </span>
+              </>
+            ) : null}
+
+            {attemptSwitcher || run.triggerDisplayLabel ? <MetadataSeparator /> : null}
+            <RelativeTime
+              value={run.runAttempt.createdAt}
+              className="shrink-0 whitespace-nowrap text-xs leading-20 text-foreground-neutral-muted"
+            />
+
+            {displayDuration ? (
+              <>
+                <MetadataSeparator />
+                <WorkflowRunDurationLabel
+                  duration={displayDuration}
+                  className="text-foreground-neutral-muted"
+                />
+              </>
+            ) : null}
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </TimeTickerProvider>
   );
 }
 

--- a/libs/client/workflows/src/core/entities/workflow-run-attempt.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run-attempt.ts
@@ -1,19 +1,55 @@
 import type {WorkflowRunAttemptDto} from '@shipfox/api-workflows-dto';
+import {type Duration, intervalToDuration} from 'date-fns';
 import type {WorkflowRunStatus} from './workflow-run.js';
 
-export interface WorkflowRunAttempt {
-  id: string;
+export type WorkflowRunAttemptDisplayDuration =
+  | {state: 'fixed'; elapsed: Duration}
+  | {state: 'live'; fromIso: string};
+
+interface WorkflowRunAttemptSummaryFields {
   workflowRunId: string;
   attempt: number;
   status: WorkflowRunStatus;
   createdAt: string;
   startedAt: string | null;
   finishedAt: string | null;
+}
+
+interface WorkflowRunAttemptFields extends WorkflowRunAttemptSummaryFields {
+  id: string;
   rerunMode: 'all' | 'failed' | null;
 }
 
+export class WorkflowRunAttemptSummary {
+  workflowRunId!: string;
+  attempt!: number;
+  status!: WorkflowRunStatus;
+  createdAt!: string;
+  startedAt!: string | null;
+  finishedAt!: string | null;
+
+  constructor(fields: WorkflowRunAttemptSummaryFields) {
+    Object.assign(this, fields);
+  }
+
+  get displayDuration(): WorkflowRunAttemptDisplayDuration | null {
+    return workflowRunAttemptDisplayDurationFromTimestamps(this);
+  }
+}
+
+export class WorkflowRunAttempt extends WorkflowRunAttemptSummary {
+  id!: string;
+  rerunMode!: 'all' | 'failed' | null;
+
+  constructor(fields: WorkflowRunAttemptFields) {
+    super(fields);
+    this.id = fields.id;
+    this.rerunMode = fields.rerunMode;
+  }
+}
+
 export function toWorkflowRunAttempt(dto: WorkflowRunAttemptDto): WorkflowRunAttempt {
-  return {
+  return new WorkflowRunAttempt({
     id: dto.id,
     workflowRunId: dto.workflow_run_id,
     attempt: dto.attempt,
@@ -22,5 +58,30 @@ export function toWorkflowRunAttempt(dto: WorkflowRunAttemptDto): WorkflowRunAtt
     startedAt: dto.started_at ?? null,
     finishedAt: dto.finished_at ?? null,
     rerunMode: dto.rerun_mode,
-  };
+  });
+}
+
+export function workflowRunAttemptDisplayDurationFromTimestamps({
+  startedAt,
+  finishedAt,
+}: {
+  startedAt: string | null;
+  finishedAt: string | null;
+}): WorkflowRunAttemptDisplayDuration | null {
+  if (startedAt === null) return null;
+  if (finishedAt === null) return {state: 'live', fromIso: startedAt};
+
+  const elapsed = durationBetween(startedAt, finishedAt);
+  return elapsed === null ? null : {state: 'fixed', elapsed};
+}
+
+function durationBetween(from: string, to: string): Duration | null {
+  const start = new Date(from);
+  const end = new Date(to);
+  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime())) return null;
+
+  return intervalToDuration({
+    start,
+    end: end < start ? start : end,
+  });
 }

--- a/libs/client/workflows/src/core/entities/workflow-run.ts
+++ b/libs/client/workflows/src/core/entities/workflow-run.ts
@@ -5,7 +5,11 @@ import type {
   WorkflowRunStatusDto,
 } from '@shipfox/api-workflows-dto';
 import {type Job, toJob, WORKFLOW_JOB_STATUSES} from './job.js';
-import {toWorkflowRunAttempt, type WorkflowRunAttempt} from './workflow-run-attempt.js';
+import {
+  toWorkflowRunAttempt,
+  type WorkflowRunAttempt,
+  WorkflowRunAttemptSummary,
+} from './workflow-run-attempt.js';
 
 export type WorkflowRunStatus = WorkflowRunStatusDto;
 export type WorkflowStatus = WorkflowRunStatus | (typeof WORKFLOW_JOB_STATUSES)[number];
@@ -58,8 +62,7 @@ export interface WorkflowRun {
 export interface WorkflowRunListItem extends WorkflowRun {
   status: WorkflowRunStatus;
   latestAttempt: number;
-  startedAt: string | null;
-  finishedAt: string | null;
+  runAttempt: WorkflowRunAttemptSummary;
 }
 
 export interface WorkflowRunDetail extends WorkflowRun {
@@ -142,8 +145,14 @@ export function toWorkflowRunListItem(dto: WorkflowRunResponseDto): WorkflowRunL
     ...toWorkflowRun(dto),
     status: dto.status,
     latestAttempt: dto.latest_attempt,
-    startedAt: dto.started_at ?? null,
-    finishedAt: dto.finished_at ?? null,
+    runAttempt: new WorkflowRunAttemptSummary({
+      workflowRunId: dto.id,
+      attempt: dto.current_attempt,
+      status: dto.status,
+      createdAt: dto.created_at,
+      startedAt: dto.started_at ?? null,
+      finishedAt: dto.finished_at ?? null,
+    }),
   };
 }
 

--- a/libs/client/workflows/src/core/workflow-run.test.ts
+++ b/libs/client/workflows/src/core/workflow-run.test.ts
@@ -107,8 +107,21 @@ describe('workflow run model mapping', () => {
     expect(run).toMatchObject({
       status: 'running',
       latestAttempt: 4,
-      startedAt: '2026-05-07T01:01:10.000Z',
-      finishedAt: null,
+      runAttempt: {
+        workflowRunId: dto.id,
+        attempt: 1,
+        status: 'running',
+        createdAt: dto.created_at,
+        startedAt: '2026-05-07T01:01:10.000Z',
+        finishedAt: null,
+      },
+    });
+    expect(run).not.toHaveProperty('startedAt');
+    expect(run).not.toHaveProperty('finishedAt');
+    expect(run).not.toHaveProperty('displayDuration');
+    expect(run.runAttempt.displayDuration).toEqual({
+      state: 'live',
+      fromIso: '2026-05-07T01:01:10.000Z',
     });
   });
 
@@ -579,7 +592,7 @@ describe('workflow run model mapping', () => {
 
     const attempt = toWorkflowRunAttempt(dto);
 
-    expect(attempt).toEqual({
+    expect(attempt).toMatchObject({
       id: '77777777-7777-4777-8777-777777777777',
       workflowRunId: '11111111-1111-4111-8111-111111111111',
       attempt: 2,
@@ -589,6 +602,7 @@ describe('workflow run model mapping', () => {
       finishedAt: '2026-05-07T01:03:00.000Z',
       rerunMode: 'all',
     });
+    expect(attempt.displayDuration).toMatchObject({state: 'fixed', elapsed: {seconds: 50}});
   });
 });
 

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -59,5 +59,9 @@ export {
   workflowRunTriggerDisplayLabel,
   workflowRunTriggerLabel,
 } from './entities/workflow-run.js';
-export type {WorkflowRunAttempt} from './entities/workflow-run-attempt.js';
-export {toWorkflowRunAttempt} from './entities/workflow-run-attempt.js';
+export type {WorkflowRunAttemptDisplayDuration} from './entities/workflow-run-attempt.js';
+export {
+  toWorkflowRunAttempt,
+  WorkflowRunAttempt,
+  WorkflowRunAttemptSummary,
+} from './entities/workflow-run-attempt.js';


### PR DESCRIPTION
Adds workflow-level duration descriptors from run and attempt timestamps, then renders those durations in the run list and run header.

This follows the job-duration model from PR #410 but keeps workflow duration scoped to the workflow run or selected attempt wall-clock span. It intentionally does not sum job durations, because parallel jobs and skipped/cancelled paths would make that number misleading.

Run list rows use the top-level run duration. The run header uses the selected run attempt duration, so historical attempt views keep their own timing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client-derived workflow run attempt durations and displays them in the runs list and run header with live, accessible labels. Duration is the wall-clock span for the run or selected attempt; it does not sum job times.

- **New Features**
  - API (`@shipfox/api-workflows-dto`)
    - `GET /workflows/runs/:id` `run_attempt` now uses `workflowRunAttemptDtoSchema`.
  - Client (`@shipfox/client-workflows`)
    - Added `WorkflowRunDurationLabel` and `useWorkflowRunDurationAccessibleLabel`; live updates via `TimeTickerProvider`.
    - Runs list shows the current attempt duration next to the updated time and includes status + duration in link/aria labels (“running 2m 14s”, “ran 2m 14s”).
    - Run header shows the selected attempt duration with a11y labels and live updates.
    - Introduced `WorkflowRunAttempt` and `WorkflowRunAttemptSummary` with `displayDuration`; list items now expose `runAttempt` and drop top-level `startedAt`/`finishedAt`. Exported `WorkflowRunAttemptDisplayDuration`.

<sup>Written for commit 46a68e65e4e685ad60348284d13f8a17115fc5b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

