### PR TITLE
[client-workflows] Add step attempt durations

### DIFF
--- a/libs/client/workflows/src/components/step-list/step-list-model.ts
+++ b/libs/client/workflows/src/components/step-list/step-list-model.ts
@@ -9,6 +9,7 @@ import {
   JobExecution,
   type Step,
   type StepAttempt,
+  type StepAttemptDisplayDuration,
 } from '#core/workflow-run.js';
 
 export interface StepStatusVisual extends Omit<WorkflowStatusVisual, 'kind'> {
@@ -17,6 +18,7 @@ export interface StepStatusVisual extends Omit<WorkflowStatusVisual, 'kind'> {
 }
 
 export interface StepAttemptModel extends StepAttempt {
+  displayDuration: StepAttemptDisplayDuration | null;
   statusVisual: StepStatusVisual;
   carriedOver: boolean;
 }
@@ -113,6 +115,7 @@ export function humanizeStatus(status: string): string {
 function toStepModel(step: Step, index: number): StepModel {
   const attempts = [...step.attempts].sort(compareAttempts).map((attempt) => ({
     ...attempt,
+    displayDuration: attempt.displayDuration,
     statusVisual: getStepStatusVisual(attempt.status),
     carriedOver: false,
   }));
@@ -161,6 +164,7 @@ function toStepEntries(step: StepModel, carriedOverJob: boolean): StepListEntryM
       restartResult: null,
       startedAt: step.createdAt,
       finishedAt: null,
+      displayDuration: null,
       statusVisual: getStepStatusVisual(step.status),
       carriedOver: true,
       step,

--- a/libs/client/workflows/src/components/step-list/step-list.test.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.test.tsx
@@ -392,6 +392,31 @@ describe('StepList', () => {
     expect(screen.queryByText('Gate failed')).not.toBeInTheDocument();
   });
 
+  test('renders finished attempt duration from the step attempt model', () => {
+    render(
+      <StepList
+        job={makeJob({
+          steps: [
+            makeStep({
+              name: 'deploy',
+              status: 'succeeded',
+              attempts: [
+                makeAttempt({
+                  status: 'succeeded',
+                  started_at: '2026-06-21T12:00:00.000Z',
+                  finished_at: '2026-06-21T12:01:05.000Z',
+                }),
+              ],
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole('button', {name: 'deploy, Succeeded, attempt 1'})).toBeInTheDocument();
+    expect(screen.getByText('1m 05s')).toBeInTheDocument();
+  });
+
   test('omits zero-attempt steps and hides the attempt chip for one-attempt rows', () => {
     render(
       <StepList

--- a/libs/client/workflows/src/components/step-list/step-list.tsx
+++ b/libs/client/workflows/src/components/step-list/step-list.tsx
@@ -5,14 +5,18 @@ import {
   AccordionTrigger,
   Badge,
   type BadgeVariant,
+  Code,
   cn,
   Dot,
   EmptyState,
+  humanDuration,
   Icon,
   Text,
+  TimeTickerProvider,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  useTimeTick,
 } from '@shipfox/react-ui';
 import type {ReactNode} from 'react';
 import {useEffect, useId, useMemo, useRef, useState} from 'react';
@@ -24,6 +28,7 @@ import {
   type Step,
   type StepSourceLocation,
 } from '#core/workflow-run.js';
+import {formatJobExecutionTimeLabel} from '../job-graph/job-duration-format.js';
 import {
   buildStepListModel,
   defaultStepListJobExecution,
@@ -164,65 +169,72 @@ function StepListContent({
   }
 
   return (
-    <section
-      aria-labelledby={showHeader ? titleId : undefined}
-      className={cn(
-        'flex min-h-0 flex-col rounded-8 border border-border-neutral-base bg-background-components-base',
-        className,
-      )}
-    >
-      {showHeader ? (
-        <div className="flex min-h-40 items-center border-b border-border-neutral-base px-16 py-8">
-          <Text as="h2" id={titleId} size="sm" bold className="text-foreground-neutral-base">
-            {model.jobName}
-          </Text>
-        </div>
-      ) : null}
+    <TimeTickerProvider intervalMs={1000} reducedMotionIntervalMs={10_000}>
+      <section
+        aria-labelledby={showHeader ? titleId : undefined}
+        className={cn(
+          'flex min-h-0 flex-col rounded-8 border border-border-neutral-base bg-background-components-base',
+          className,
+        )}
+      >
+        {showHeader ? (
+          <div className="flex min-h-40 items-center border-b border-border-neutral-base px-16 py-8">
+            <Text as="h2" id={titleId} size="sm" bold className="text-foreground-neutral-base">
+              {model.jobName}
+            </Text>
+          </div>
+        ) : null}
 
-      {model.entries.length === 0 ? (
-        <StepListEmptyStateView emptyState={emptyState} />
-      ) : (
-        <Accordion type="multiple" value={selectedAttemptIds} onValueChange={selectAttempt} asChild>
-          <ol>
-            {model.entries.map((entry) => {
-              const selected = selectedAttemptIds.includes(entry.id);
-              return (
-                <StepRow
-                  key={entry.id}
-                  entry={entry}
-                  selected={selected}
-                  hasExpandedContent={hasExpandedContent}
-                  onSelect={() => {
-                    selectAttempt(
-                      hasExpandedContent
-                        ? toggleAttemptId(selectedAttemptIds, entry.id)
-                        : selected
-                          ? []
-                          : [entry.id],
-                    );
-                  }}
-                  expandedContent={
-                    selected
-                      ? renderExpandedStep?.({
-                          step: entry.step,
-                          stepId: entry.step.id,
-                          stepLabel: entry.step.label,
-                          sourceLocation: entry.step.sourceLocation,
-                          attempt: entry.attempt,
-                          attemptId: entry.id,
-                          attemptError: entry.error,
-                          attemptStatus: entry.statusVisual.kind,
-                          carriedOver: entry.carriedOver,
-                        })
-                      : null
-                  }
-                />
-              );
-            })}
-          </ol>
-        </Accordion>
-      )}
-    </section>
+        {model.entries.length === 0 ? (
+          <StepListEmptyStateView emptyState={emptyState} />
+        ) : (
+          <Accordion
+            type="multiple"
+            value={selectedAttemptIds}
+            onValueChange={selectAttempt}
+            asChild
+          >
+            <ol>
+              {model.entries.map((entry) => {
+                const selected = selectedAttemptIds.includes(entry.id);
+                return (
+                  <StepRow
+                    key={entry.id}
+                    entry={entry}
+                    selected={selected}
+                    hasExpandedContent={hasExpandedContent}
+                    onSelect={() => {
+                      selectAttempt(
+                        hasExpandedContent
+                          ? toggleAttemptId(selectedAttemptIds, entry.id)
+                          : selected
+                            ? []
+                            : [entry.id],
+                      );
+                    }}
+                    expandedContent={
+                      selected
+                        ? renderExpandedStep?.({
+                            step: entry.step,
+                            stepId: entry.step.id,
+                            stepLabel: entry.step.label,
+                            sourceLocation: entry.step.sourceLocation,
+                            attempt: entry.attempt,
+                            attemptId: entry.id,
+                            attemptError: entry.error,
+                            attemptStatus: entry.statusVisual.kind,
+                            carriedOver: entry.carriedOver,
+                          })
+                        : null
+                    }
+                  />
+                );
+              })}
+            </ol>
+          </Accordion>
+        )}
+      </section>
+    </TimeTickerProvider>
   );
 }
 
@@ -311,10 +323,11 @@ function StepRow({
           {entry.carriedOver ? <CarriedOverBadge /> : null}
         </div>
       </div>
+      <StepAttemptDurationLabel attempt={entry} />
     </>
   );
   const rowClasses = cn(
-    'group grid min-h-44 w-full grid-cols-[14px_14px_minmax(0,1fr)] items-center gap-x-8 px-12 py-6 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
+    'group grid min-h-44 w-full grid-cols-[14px_14px_minmax(0,1fr)_auto] items-center gap-x-8 px-12 py-6 text-left transition-colors hover:bg-background-components-hover focus-visible:shadow-border-interactive-with-active focus-visible:outline-none',
     selected && 'bg-background-components-hover',
     entry.carriedOver && 'opacity-[0.55]',
   );
@@ -352,10 +365,11 @@ function StepRow({
       {triggerNode}
       {selected && expandedContent ? (
         <AccordionContent className="border-t border-border-neutral-base bg-background-neutral-base px-12 py-12">
-          <div className="grid grid-cols-[14px_14px_minmax(0,1fr)] gap-x-8">
+          <div className="grid grid-cols-[14px_14px_minmax(0,1fr)_auto] gap-x-8">
             <span aria-hidden="true" />
             <span aria-hidden="true" />
             <div className="min-w-0">{expandedContent}</div>
+            <span aria-hidden="true" />
           </div>
         </AccordionContent>
       ) : null}
@@ -459,4 +473,28 @@ function entryAccessibleLabel(entry: StepListEntryModel): string {
   const parts = [entry.step.label, entry.statusVisual.label, `attempt ${entry.attempt}`];
   if (entry.step.error?.category) parts.push(humanizeStatus(entry.step.error.category));
   return parts.join(', ');
+}
+
+function StepAttemptDurationLabel({attempt}: {attempt: StepAttemptModel}) {
+  const duration = attempt.displayDuration;
+  if (duration === null) return null;
+
+  if (duration.state === 'live') {
+    return <LiveDurationText fromIso={duration.fromIso} />;
+  }
+
+  return <DurationText>{formatJobExecutionTimeLabel(duration)}</DurationText>;
+}
+
+function LiveDurationText({fromIso}: {fromIso: string}) {
+  useTimeTick();
+  return <DurationText>{humanDuration(fromIso)}</DurationText>;
+}
+
+function DurationText({children}: {children: string}) {
+  return (
+    <Code as="span" variant="label" className="shrink-0 tabular-nums text-foreground-neutral-muted">
+      {children}
+    </Code>
+  );
 }

--- a/libs/client/workflows/src/core/entities/step-attempt.ts
+++ b/libs/client/workflows/src/core/entities/step-attempt.ts
@@ -3,11 +3,15 @@ import type {
   StepGateResultDto,
   StepRestartResultDto,
 } from '@shipfox/api-workflows-dto';
+import {type Duration, intervalToDuration} from 'date-fns';
 
 export type StepGateResult = StepGateResultDto;
 export type StepRestartResult = StepRestartResultDto;
+export type StepAttemptDisplayDuration =
+  | {state: 'fixed'; elapsed: Duration}
+  | {state: 'live'; fromIso: string};
 
-export interface StepAttempt {
+interface StepAttemptFields {
   id: string;
   stepId: string;
   jobExecutionId: string;
@@ -24,8 +28,33 @@ export interface StepAttempt {
   finishedAt: string | null;
 }
 
+export class StepAttempt {
+  id!: string;
+  stepId!: string;
+  jobExecutionId!: string;
+  attempt!: number;
+  executionOrder!: number;
+  status!: string;
+  exitCode!: number | null;
+  output!: Record<string, unknown> | null;
+  error!: Record<string, unknown> | null;
+  gateResult!: StepGateResult;
+  restartReason!: string | null;
+  restartResult!: StepRestartResult;
+  startedAt!: string;
+  finishedAt!: string | null;
+
+  constructor(fields: StepAttemptFields) {
+    Object.assign(this, fields);
+  }
+
+  get displayDuration(): StepAttemptDisplayDuration | null {
+    return stepAttemptDisplayDurationFromTimestamps(this);
+  }
+}
+
 export function toStepAttempt(dto: StepAttemptDto, jobExecutionId: string): StepAttempt {
-  return {
+  return new StepAttempt({
     id: dto.id,
     stepId: dto.step_id,
     jobExecutionId,
@@ -40,5 +69,29 @@ export function toStepAttempt(dto: StepAttemptDto, jobExecutionId: string): Step
     restartResult: dto.restart_result ?? null,
     startedAt: dto.started_at,
     finishedAt: dto.finished_at ?? null,
-  };
+  });
+}
+
+export function stepAttemptDisplayDurationFromTimestamps({
+  startedAt,
+  finishedAt,
+}: {
+  startedAt: string;
+  finishedAt: string | null;
+}): StepAttemptDisplayDuration | null {
+  if (finishedAt === null) return {state: 'live', fromIso: startedAt};
+
+  const elapsed = durationBetween(startedAt, finishedAt);
+  return elapsed === null ? null : {state: 'fixed', elapsed};
+}
+
+function durationBetween(from: string, to: string): Duration | null {
+  const start = new Date(from);
+  const end = new Date(to);
+  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime())) return null;
+
+  return intervalToDuration({
+    start,
+    end: end < start ? start : end,
+  });
 }

--- a/libs/client/workflows/src/core/workflow-run.test.ts
+++ b/libs/client/workflows/src/core/workflow-run.test.ts
@@ -256,6 +256,10 @@ describe('workflow run model mapping', () => {
       startedAt: '2026-05-07T01:01:10.000Z',
       finishedAt: '2026-05-07T01:01:20.000Z',
     });
+    expect(detail.jobs[0]?.jobExecutions[0]?.steps[0]?.attempts[0]?.displayDuration).toMatchObject({
+      state: 'fixed',
+      elapsed: {seconds: 10},
+    });
   });
 
   test('maps listening job state', () => {
@@ -420,6 +424,22 @@ describe('workflow run model mapping', () => {
       kind: 'run',
       state: 'live',
       fromIso: '2026-05-07T01:00:05.000Z',
+    });
+  });
+
+  test('maps live step attempt duration as an anchored model getter', () => {
+    const attempt = workflowStepAttemptDto({
+      started_at: '2026-06-21T12:00:00.000Z',
+      finished_at: null,
+    });
+    const step = workflowStepDto({attempts: [attempt]});
+    const dto = workflowRunDetailDto({jobs: [workflowJobDto({steps: [step]})]});
+
+    const detail = toWorkflowRunDetail(dto);
+
+    expect(detail.jobs[0]?.jobExecutions[0]?.steps[0]?.attempts[0]?.displayDuration).toEqual({
+      state: 'live',
+      fromIso: '2026-06-21T12:00:00.000Z',
     });
   });
 

--- a/libs/client/workflows/src/core/workflow-run.ts
+++ b/libs/client/workflows/src/core/workflow-run.ts
@@ -31,8 +31,12 @@ export type {
   StepSourceLocation,
 } from './entities/step.js';
 export {toStep} from './entities/step.js';
-export type {StepAttempt, StepGateResult, StepRestartResult} from './entities/step-attempt.js';
-export {toStepAttempt} from './entities/step-attempt.js';
+export type {
+  StepAttemptDisplayDuration,
+  StepGateResult,
+  StepRestartResult,
+} from './entities/step-attempt.js';
+export {StepAttempt, toStepAttempt} from './entities/step-attempt.js';
 export type {
   WorkflowRun,
   WorkflowRunDetail,

--- a/libs/client/workflows/src/index.ts
+++ b/libs/client/workflows/src/index.ts
@@ -7,6 +7,7 @@ export type {
   JobStatus,
   Step,
   StepAttempt,
+  StepAttemptDisplayDuration,
   StepError,
   StepErrorCategory,
   StepErrorReason,


### PR DESCRIPTION
Add step attempt durations to workflow run details and the step list.

Step attempts already expose started and finished timestamps, but the UI did not project them into the same duration model used for job nodes. This adds a duration descriptor to the step attempt DTO, maps it through the client model, and renders a compact live/static duration on each real step attempt row.

Carried-over synthetic rows stay durationless because they did not execute in the current run attempt. I skipped a changeset because the touched packages are marked private in their package manifests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show step attempt durations in run details and the step list. Live for running attempts and static for finished; carried‑over synthetic rows show none.

- **New Features**
  - Added a `displayDuration` getter on the `StepAttempt` entity and a `StepAttemptDisplayDuration` type; computed from `started_at`/`finished_at` timestamps.
  - Render a compact duration column in `WorkflowStepList` with live updates via `TimeTickerProvider`/`useTimeTick` and `humanDuration` from `@shipfox/react-ui`; finished attempts use `formatJobExecutionTimeLabel`.
  - Extended the step list model to carry `displayDuration`; synthetic rows set it to `null`.
  - Exported `StepAttemptDisplayDuration` and `StepAttempt` from the client package; added tests for fixed/live durations and UI rendering.

<sup>Written for commit 6b313cef369df83288b747a8bda8ca307d81b417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

