### PR TITLE
[runner] Fix abort reporting for run steps

### DIFF
--- a/.changeset/quiet-shells-stop.md
+++ b/.changeset/quiet-shells-stop.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-execution": patch
+---
+
+Reports aborted run steps as signal kills even when the shell exits with the encoded signal status.

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -55,6 +55,15 @@ async function waitForProcessExit(pid: number): Promise<void> {
   );
 }
 
+async function waitForProcessAlive(pid: number): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(() => process.kill(pid, 0)).not.toThrow();
+    },
+    {timeout: PROCESS_TEST_WAIT_TIMEOUT_MS},
+  );
+}
+
 describe('executeRunStep', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -378,12 +387,13 @@ describe('executeRunStep', () => {
     const promise = executeRunStep(step, {signal: ac.signal, onOutput: output.sink});
 
     const match = await waitForOutputMatch(output, GRANDCHILD_PID_REGEX);
+    const grandchildPid = Number(match[1]);
+    await waitForProcessAlive(grandchildPid);
+
     ac.abort();
 
     const result = await promise;
     expect(result.success).toBe(false);
-
-    const grandchildPid = Number(match[1]);
 
     await waitForProcessExit(grandchildPid);
   });

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -106,27 +106,32 @@ function spawnAndCapture(
       options.onOutput?.(chunk, 'stderr');
     });
 
-    let abortRequested = options.signal?.aborted === true;
+    let childExited = false;
+    let abortKillSignal: NodeJS.Signals | undefined;
 
-    const killGroup = () => {
+    const killGroup = (): NodeJS.Signals | undefined => {
       if (child.pid !== undefined) {
         try {
           // Negative pid signals the entire process group.
-          process.kill(-child.pid, 'SIGKILL');
+          const signal: NodeJS.Signals = 'SIGKILL';
+          process.kill(-child.pid, signal);
+          return signal;
         } catch {
           // Process already exited.
         }
       }
+      return undefined;
     };
 
     let onAbort: (() => void) | undefined;
     if (options.signal) {
       if (options.signal.aborted) {
-        killGroup();
+        abortKillSignal = killGroup();
       } else {
         onAbort = () => {
-          abortRequested = true;
-          killGroup();
+          if (!childExited) {
+            abortKillSignal = killGroup();
+          }
         };
         options.signal.addEventListener('abort', onAbort, {once: true});
       }
@@ -139,19 +144,20 @@ function spawnAndCapture(
       }
     };
 
+    child.on('exit', () => {
+      childExited = true;
+    });
+
     child.on('close', (code, signal) => {
       cleanupAbortListener();
-      // Only report an abort kill when the child was actually terminated by a signal
-      // (code === null). If abort fired in the exit→close race but the process had
-      // already exited on its own, `code` is set — fall through to report its real
-      // outcome rather than masking a genuine success/failure as a kill.
-      if (abortRequested && code === null) {
+      if (abortKillSignal) {
+        const resultSignal = signal ?? abortKillSignal;
         resolve({
           success: false,
           error: {
-            message: `Killed by signal ${signal ?? 'SIGKILL'}`,
+            message: `Killed by signal ${resultSignal}`,
             exit_code: null,
-            signal: signal ?? 'SIGKILL',
+            signal: resultSignal,
           },
           exit_code: null,
         });

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -150,7 +150,7 @@ function spawnAndCapture(
 
     child.on('close', (code, signal) => {
       cleanupAbortListener();
-      if (abortKillSignal) {
+      if (abortKillSignal && isSignalKillResult(code, abortKillSignal)) {
         const resultSignal = signal ?? abortKillSignal;
         resolve({
           success: false,
@@ -190,6 +190,15 @@ function spawnAndCapture(
       });
     });
   });
+}
+
+function isSignalKillResult(code: number | null, signal: NodeJS.Signals): boolean {
+  return code === null || code === signalExitCode(signal);
+}
+
+function signalExitCode(signal: NodeJS.Signals): number | undefined {
+  if (signal === 'SIGKILL') return 137;
+  return undefined;
 }
 
 function readStepEnv(step: StepDto): Readonly<Record<string, string>> {


### PR DESCRIPTION
[runner] Fix abort reporting for run steps.

Aborted run steps could be reported as an exit-code failure when the shell surfaced SIGKILL as 137 instead of Node reporting a signal. That made abort assertions flaky and produced inconsistent step errors.

This tracks successful abort process-group kills separately from normal process exit, so aborted runs consistently report SIGKILL with a null exit code. The process-group test now waits for the background child to be alive before aborting, avoiding a setup race.

Includes a patch changeset for @shipfox/runner-execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix abort reporting for run steps so aborted processes are consistently reported as signal kills (SIGKILL) with a null exit code, even when shells encode it as 137. Real success/failure results are preserved.

- **Bug Fixes**
  - Store the abort kill signal and, on close, report SIGKILL with `exit_code: null` only if the result reflects a signal kill (code is null or 137).
  - Kill the entire process group with `process.kill(-pid, 'SIGKILL')` and ignore aborts after the child has exited.
  - Stabilize the process-group test by waiting for the grandchild to be alive before aborting.
  - Publish a patch for `@shipfox/runner-execution`.

<sup>Written for commit 0f093200801850e19b8cd71b52bd786d0cf475ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

