### PR TITLE
Fix Gitea seed workflow step keys

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/build-and-deploy.yaml
@@ -11,25 +11,32 @@ triggers:
 jobs:
   prepare:
     steps:
-      - name: checkout-summary
+      - key: checkout-summary
+        name: Checkout Summary
         run: echo "Preparing demo workspace"
-      - name: validate-package
+      - key: validate-package
+        name: Validate Package
         run: node --check src/index.js
   test:
     needs: prepare
     steps:
-      - name: unit-tests
+      - key: unit-tests
+        name: Unit Tests
         run: node --test
-      - name: forced-failure
+      - key: forced-failure
+        name: Forced Failure
         run: |
           echo "Intentional demo failure"
           exit 1
-      - name: skipped-after-failure
+      - key: skipped-after-failure
+        name: Skipped After Failure
         run: echo "This step is cancelled after the forced failure"
   deploy:
     needs: test
     steps:
-      - name: package
+      - key: package
+        name: Package
         run: echo "Packaging demo"
-      - name: publish
+      - key: publish
+        name: Publish
         run: echo "Deploying demo"

--- a/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
@@ -11,9 +11,11 @@ triggers:
 jobs:
   gated-retry:
     steps:
-      - name: first-setup
+      - key: first-setup
+        name: First setup
         run: mkdir -p .shipfox/demo-gates
-      - name: first-gate
+      - key: first-gate
+        name: First gate
         run: |
           marker=.shipfox/demo-gates/first-gate-passed
           if [ ! -f "$marker" ]; then
@@ -27,9 +29,11 @@ jobs:
           on_failure:
             restart_from: first-setup
             output: First gate failed once; retrying from first setup.
-      - name: second-setup
+      - key: second-setup
+        name: Second setup
         run: mkdir -p .shipfox/demo-gates
-      - name: second-gate
+      - key: second-gate
+        name: Second gate
         run: |
           marker=.shipfox/demo-gates/second-gate-passed
           if [ ! -f "$marker" ]; then
@@ -43,7 +47,8 @@ jobs:
           on_failure:
             restart_from: second-setup
             output: Second gate failed once; retrying from second setup.
-      - name: third-gate
+      - key: third-gate
+        name: Third gate
         run: |
           counter=.shipfox/demo-gates/third-gate-attempts
           attempts=0
@@ -62,5 +67,6 @@ jobs:
           on_failure:
             restart_from: second-setup
             output: Third gate failed; retrying from second setup.
-      - name: finish
+      - key: finish
+        name: Finish
         run: echo "All three gates passed; job succeeded"


### PR DESCRIPTION
Fix the Gitea demo seed workflows so restart targets use explicit step keys while UI-facing names remain human-readable.

The gated retry seed was still using slug-like `name` values as restart targets after workflow steps split stable `key` from display `name`. That made the seeded `gates.yml` fail validation because `restart_from` must point at an earlier keyed step. This updates the Gitea seed workflows to keep slug values in `key` and show capitalized, spaced labels in `name`.

No system behavior changes are included; this is seed data repair only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Gitea demo seed workflows by adding explicit step keys and keeping human-readable names, so gated retries target valid steps and validation passes. No runtime changes; this repairs seed data only.

- **Bug Fixes**
  - Added `key` to every step and kept display labels in `name`.
  - Updated `gates.yml` `restart_from` to reference step keys.
  - Touched `build-and-deploy.yaml` and `gates.yml` only; seeds now validate.

<sup>Written for commit eb8601c09b41befb8754bc0708b84761f2c22cdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

