### PR TITLE
Organize Storybook stories around playground coverage

### DIFF
--- a/.changeset/tidy-stories-align.md
+++ b/.changeset/tidy-stories-align.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Aligns React UI Storybook stories around playground-first coverage and grouped visual states.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,6 +629,32 @@ describe.each(runnerEventTypeEnum.enumValues)('createRunnerEvent "%s"', (eventTy
 });
 ```
 
+## Storybook story structure
+
+Story files should be ordered for exploration first, broad visual coverage
+second, composition coverage third, and interaction tests last.
+
+Start every component story file with `Playground` when the component can be
+rendered as a single basic example. `Playground` shows the neutral/default
+component and exposes Storybook controls for meaningful visual and content props.
+Rename old `Default` stories to `Playground` unless the story is not an
+interactive playground.
+
+After `Playground`, group variant axes into as few stories as practical. Prefer
+matrix stories such as `Variants`, `Sizes`, `States`, `Content`, `Errors`, or
+`DataStates` that render rows/columns of related states in one canvas. Do not add
+one screenshot-producing story per enum value when a grouped matrix can show the
+same coverage.
+
+Put composition stories after variant matrices. Name them `Compositions` or with
+a specific scenario name, and group related complex scenarios in one canvas when
+that keeps Argos coverage clear and cheaper.
+
+Put pure test stories last. Use `play` for assertions or interactions that prove
+behavior, not for visual states that can be rendered directly with args or
+fixtures. Prefix test-only exports with `Test` or give them a `Tests / ...`
+display name so they are easy to distinguish from visual coverage.
+
 ## Visual Regression Testing
 
 Argos catches UI drift on every PR via one named build per source package. The

--- a/libs/client/agent/src/components/agent-provider-usage-modal.stories.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.stories.tsx
@@ -33,7 +33,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Anthropic: Story = {};
+export const Playground: Story = {};
 
 export const LongModelList: Story = {
   args: {variant: 'long-list'},

--- a/libs/client/agent/src/components/agent-providers-section.stories.tsx
+++ b/libs/client/agent/src/components/agent-providers-section.stories.tsx
@@ -134,7 +134,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const MixedProviderStates: Story = {};
+export const Playground: Story = {};
 
 export const EmptyConfigured: Story = {
   args: {scenario: 'empty-configured'},

--- a/libs/client/agent/src/pages/agent-provider-onboarding-page.stories.tsx
+++ b/libs/client/agent/src/pages/agent-provider-onboarding-page.stories.tsx
@@ -127,7 +127,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const AvailableProviders: Story = {};
+export const Playground: Story = {};
 
 export const Loading: Story = {
   args: {scenario: 'loading'},

--- a/libs/client/auth/src/components/workspace-switcher.stories.tsx
+++ b/libs/client/auth/src/components/workspace-switcher.stories.tsx
@@ -101,7 +101,7 @@ async function captureSwitcher(ctx: WorkspaceSwitcherStoryContext, screenshotNam
   await argosScreenshot(ctx, screenshotName);
 }
 
-export const Open: Story = {
+export const Playground: Story = {
   play: async (ctx) => {
     await captureSwitcher(ctx, 'Workspace Switcher Open');
   },

--- a/libs/client/integrations/src/components/integration-gallery.stories.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.stories.tsx
@@ -118,7 +118,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const MixedLifecycleStates: Story = {};
+export const Playground: Story = {};
 
 export const EmptyConnections: Story = {
   args: {scenario: 'empty-connections'},

--- a/libs/client/logs/src/components/log-group.stories.tsx
+++ b/libs/client/logs/src/components/log-group.stories.tsx
@@ -64,7 +64,7 @@ type Story = StoryObj<typeof meta>;
 
 const BUILD_TRIGGER = /Build/;
 
-export const Collapsed: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows>
@@ -191,7 +191,7 @@ export const ErrorBar: Story = {
 };
 
 export const Toggle: Story = {
-  ...Collapsed,
+  ...Playground,
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
     const user = userEvent.setup();

--- a/libs/client/logs/src/components/log-view.stories.tsx
+++ b/libs/client/logs/src/components/log-view.stories.tsx
@@ -353,7 +353,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Showcase: Story = {
+export const Playground: Story = {
   render: (args) => (
     <div className="max-w-3xl">
       <LogView {...args} records={showcaseRecords} />

--- a/libs/client/logs/src/components/output-log-row.stories.tsx
+++ b/libs/client/logs/src/components/output-log-row.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Streams: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows>

--- a/libs/client/logs/src/components/system-markers.stories.tsx
+++ b/libs/client/logs/src/components/system-markers.stories.tsx
@@ -14,7 +14,21 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const All: Story = {
+export const Playground: Story = {
+  render: () => (
+    <div className="max-w-3xl">
+      <LogRows>
+        <EndMarker
+          record={{v: 1, ts, type: 'end', total_bytes: 15_360}}
+          lineCount={412}
+          durationMs={2100}
+        />
+      </LogRows>
+    </div>
+  ),
+};
+
+export const Variants: Story = {
   render: () => (
     <div className="max-w-3xl">
       <LogRows>

--- a/libs/client/triggers/src/components/events-list.stories.tsx
+++ b/libs/client/triggers/src/components/events-list.stories.tsx
@@ -3,7 +3,9 @@ import type {
   TriggerEventListItemDto,
   TriggerEventOutcomeDto,
 } from '@shipfox/api-triggers-dto';
+import {Code} from '@shipfox/react-ui';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
+import type {ReactNode} from 'react';
 import {EventsList} from './events-list.js';
 import type {TriggerEventsListQuery} from './types.js';
 
@@ -98,22 +100,36 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithEvents: Story = {};
+export const Playground: Story = {};
 
-export const Loading: Story = {
-  args: {events: [], query: makeQuery({isPending: true, data: undefined})},
+export const DataStates: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-32">
+      <StateExample label="Loading">
+        <EventsList {...args} events={[]} query={makeQuery({isPending: true, data: undefined})} />
+      </StateExample>
+      <StateExample label="Empty">
+        <EventsList {...args} events={[]} facets={{sources: [], events: []}} />
+      </StateExample>
+      <StateExample label="No matches">
+        <EventsList {...args} events={[]} filters={{outcome: ['failed']}} />
+      </StateExample>
+      <StateExample label="Load error">
+        <EventsList {...args} events={[]} query={makeQuery({isError: true, data: undefined})} />
+      </StateExample>
+    </div>
+  ),
 };
 
-// No events and no active filters: the first-run empty state with the Integrations CTA.
-export const Empty: Story = {
-  args: {events: [], facets: {sources: [], events: []}},
-};
-
-// Filters are active but match nothing: the distinct "no matching events" + Clear state.
-export const NoMatches: Story = {
-  args: {events: [], filters: {outcome: ['failed']}},
-};
-
-export const LoadError: Story = {
-  args: {events: [], query: makeQuery({isError: true, data: undefined})},
-};
+function StateExample({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <Code variant="label" className="text-foreground-neutral-subtle">
+        {label}
+      </Code>
+      <div className="min-h-280 rounded-8 border border-border-neutral-base bg-background-neutral-base p-12">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
@@ -147,7 +147,7 @@ async function captureDetail(ctx: Parameters<NonNullable<Story['play']>>[0], nam
 
 export const Playground: Story = {
   play: async (ctx) => {
-    await captureDetail(ctx, 'Trigger Event Detail Routed');
+    await captureDetail(ctx, 'Trigger Event Detail Playground');
   },
 };
 

--- a/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.stories.tsx
@@ -145,7 +145,7 @@ async function captureDetail(ctx: Parameters<NonNullable<Story['play']>>[0], nam
   await argosScreenshot(ctx, name);
 }
 
-export const Routed: Story = {
+export const Playground: Story = {
   play: async (ctx) => {
     await captureDetail(ctx, 'Trigger Event Detail Routed');
   },

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-job-node.stories.tsx
@@ -64,7 +64,24 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const AllStatuses: Story = {
+export const Playground: Story = {
+  render: () => (
+    <WorkflowJobNode
+      node={makeNode({
+        id: 'job-build',
+        label: 'build',
+        status: 'running',
+        position: 0,
+        dependencies: [],
+      })}
+      selected
+      onSelect={() => undefined}
+      onKeyDown={ignoreKeyDown}
+    />
+  ),
+};
+
+export const Statuses: Story = {
   render: () => (
     <div className="grid w-720 grid-cols-2 gap-12">
       {storyNodes.map((node) => (

--- a/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-jobs-graph/workflow-jobs-graph.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SingleJob: Story = {
+export const Playground: Story = {
   args: {run: makeRun({jobs: [makeJob({name: 'build'})]})},
 };
 

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.stories.tsx
@@ -158,7 +158,7 @@ const ATTEMPT_SUMMARY_ARGS = {
   latestAttempt: 3,
 };
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const WithSourceButton: Story = {
   args: {

--- a/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-config-failure-callout.stories.tsx
@@ -1,3 +1,4 @@
+import {Code} from '@shipfox/react-ui';
 import type {Meta, StoryObj} from '@storybook/react';
 import {
   createMemoryHistory,
@@ -63,40 +64,17 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 type WorkflowAgentConfigIssueValue = NonNullable<WorkflowStepError['agentConfigIssue']>;
 
-export const ProviderNotConfigured: Story = {
-  play: assertCallout('Configure credentials for anthropic', true),
-};
-
-export const CredentialsInvalid: Story = {
-  args: {
-    error: makeError('credentials_invalid'),
-  },
-  play: assertCallout('Update credentials for anthropic', true),
-};
-
-export const ProviderUnsupported: Story = {
-  args: {
-    error: makeError('provider_unsupported'),
-  },
-  play: assertCallout('Choose a supported agent provider', false),
-};
-
-export const ModelUnavailable: Story = {
-  args: {
-    error: makeError('model_unavailable'),
-  },
-  play: assertCallout('Choose an available model', false),
-};
-
-export const StepConfigInvalid: Story = {
-  args: {
-    error: makeError('step_config_invalid'),
-  },
-  play: assertCallout("Fix this step's agent settings", false),
-};
-
-export const UnknownConfigFailure: Story = {
-  args: {
+const errorCases: Array<{
+  label: string;
+  error: WorkflowStepError;
+}> = [
+  {label: 'Provider not configured', error: makeError('provider_not_configured')},
+  {label: 'Credentials invalid', error: makeError('credentials_invalid')},
+  {label: 'Provider unsupported', error: makeError('provider_unsupported')},
+  {label: 'Model unavailable', error: makeError('model_unavailable')},
+  {label: 'Step config invalid', error: makeError('step_config_invalid')},
+  {
+    label: 'Unknown config failure',
     error: {
       message: 'Agent configuration is invalid',
       exitCode: null,
@@ -106,7 +84,34 @@ export const UnknownConfigFailure: Story = {
       category: 'user',
     },
   },
-  play: assertCallout("We couldn't load the agent configuration for this step", true),
+];
+
+export const Playground: Story = {};
+
+export const ErrorVariants: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-20">
+      {errorCases.map((item) => (
+        <div key={item.label} className="flex flex-col gap-8">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            {item.label}
+          </Code>
+          <AgentConfigFailureCallout {...args} error={item.error} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const TestProviderNotConfigured: Story = {
+  play: assertCallout('Configure credentials for anthropic', true),
+};
+
+export const TestProviderUnsupported: Story = {
+  args: {
+    error: makeError('provider_unsupported'),
+  },
+  play: assertCallout('Choose a supported agent provider', false),
 };
 
 function makeError(agentConfigIssue: WorkflowAgentConfigIssueValue): WorkflowStepError {

--- a/libs/client/workflows/src/components/workflow-run-view/agent-step-config-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-run-view/agent-step-config-panel.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Resolved: Story = {
+export const Playground: Story = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 

--- a/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-runs-list/workflow-runs-list.stories.tsx
@@ -1,4 +1,6 @@
+import {Code} from '@shipfox/react-ui';
 import type {Meta, StoryObj} from '@storybook/react';
+import type {ReactNode} from 'react';
 import {expect, userEvent, within} from 'storybook/test';
 import type {WorkflowRun, WorkflowRunStatus} from '#core/workflow-run.js';
 import {sequencedWorkflowRun} from '#test/fixtures/workflow-run.js';
@@ -58,24 +60,36 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithRuns: Story = {};
+export const Playground: Story = {};
 
 export const Selected: Story = {
   args: {selectedWorkflowRunId: SAMPLE_RUNS[1].id},
 };
 
-export const Loading: Story = {
-  args: {query: makeQuery({isPending: true, data: undefined})},
+export const DataStates: Story = {
+  render: (args) => (
+    <div className="flex gap-24">
+      <StateExample label="Loading">
+        <WorkflowRunsListView {...args} query={makeQuery({isPending: true, data: undefined})} />
+      </StateExample>
+      <StateExample label="Empty">
+        <WorkflowRunsListView {...args} runs={[]} />
+      </StateExample>
+      <StateExample label="Load error">
+        <WorkflowRunsListView
+          {...args}
+          runs={[]}
+          query={makeQuery({isError: true, data: undefined})}
+        />
+      </StateExample>
+      <StateExample label="Stale error">
+        <WorkflowRunsListView {...args} query={makeQuery({isError: true})} />
+      </StateExample>
+    </div>
+  ),
 };
 
-export const Empty: Story = {
-  args: {runs: []},
-};
-
-// Runs exist but the search matches none of them: a distinct empty state ("No matching
-// runs" + Clear filters) from the never-ran Empty story. Typed in via the real search box
-// since the view owns the query, so the story shows the whole rail in that state.
-export const NoMatches: Story = {
+export const TestNoMatches: Story = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText('Search runs'), 'no-such-run');
@@ -83,10 +97,15 @@ export const NoMatches: Story = {
   },
 };
 
-export const LoadError: Story = {
-  args: {runs: [], query: makeQuery({isError: true, data: undefined})},
-};
-
-export const StaleError: Story = {
-  args: {query: makeQuery({isError: true})},
-};
+function StateExample({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <div className="flex w-260 flex-col gap-8">
+      <Code variant="label" className="text-foreground-neutral-subtle">
+        {label}
+      </Code>
+      <div className="flex h-560 rounded-8 border border-border-neutral-base bg-background-neutral-base">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.stories.tsx
@@ -64,7 +64,7 @@ async function captureHighlightedSourcePanel(
   await argosScreenshot(ctx, screenshotName);
 }
 
-export const Open: Story = {
+export const Playground: Story = {
   play: async (ctx) => {
     await captureHighlightedSourcePanel(ctx, 'Workflow Source Panel Open');
   },

--- a/libs/client/workflows/src/components/workflow-status/workflow-status-icon.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-status/workflow-status-icon.stories.tsx
@@ -17,6 +17,23 @@ const meta = {
   title: 'Workflows/StatusIcon',
   component: WorkflowStatusIcon,
   parameters: {layout: 'centered'},
+  argTypes: {
+    status: {
+      control: 'select',
+      options: statuses,
+    },
+    size: {
+      control: {type: 'number', min: 8, max: 24, step: 1},
+    },
+    ripple: {
+      control: 'boolean',
+    },
+  },
+  args: {
+    status: 'running',
+    size: 14,
+    ripple: false,
+  },
   decorators: [
     (Story) => (
       <div className="bg-background-neutral-base p-24">
@@ -30,7 +47,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Every state at the surface size (14px) plus a compact size, sharing the tuned glyph scale.
-export const AllStates: Story = {
+export const Playground: Story = {};
+
+export const Variants: Story = {
   render: () => (
     <div className="flex flex-col gap-32">
       <Scale label="DAG node / run row (14px)" size={14} />

--- a/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
+++ b/libs/client/workflows/src/components/workflow-step-list/workflow-step-list.stories.tsx
@@ -1,6 +1,6 @@
 import type {StepAttemptDto, WorkflowRunStepDetailDto} from '@shipfox/api-workflows-dto';
 import {LogView, type LogViewProps} from '@shipfox/client-logs';
-import {Text} from '@shipfox/react-ui';
+import {Code, Text} from '@shipfox/react-ui';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {
   createMemoryHistory,
@@ -10,6 +10,7 @@ import {
   Outlet,
   RouterProvider,
 } from '@tanstack/react-router';
+import type {ReactNode} from 'react';
 import {within} from 'storybook/test';
 import type {WorkflowJob} from '#core/workflow-run.js';
 import {
@@ -88,104 +89,103 @@ async function assertAgentConfigFailureCallout(ctx: WorkflowStepListStoryContext
   await canvas.findByRole('link', {name: AGENT_PROVIDERS_LINK_NAME});
 }
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
-export const AllStatuses: Story = {
-  args: {
-    job: makeJob({
-      steps: [
-        makeStep({
-          name: 'running',
-          position: 3,
-          status: 'running',
-          attempts: [makeAttempt({status: 'running'})],
-        }),
-        makeStep({
-          name: 'succeeded',
-          position: 4,
-          status: 'succeeded',
-          attempts: [makeAttempt({status: 'succeeded'})],
-        }),
-        makeStep({
-          name: 'failed',
-          position: 5,
-          status: 'failed',
-          attempts: [makeAttempt({status: 'failed', exit_code: 1})],
-        }),
-        makeStep({
-          name: 'cancelled',
-          position: 6,
-          status: 'cancelled',
-          attempts: [makeAttempt({status: 'cancelled'})],
-        }),
-        makeStep({
-          name: 'timed-out',
-          position: 7,
-          status: 'timed_out',
-          attempts: [makeAttempt({status: 'timed_out'})],
-        }),
-      ],
-    }),
-  },
-};
-
-export const SetupAndUnnamedSteps: Story = {
-  args: {
-    job: makeJob({
-      steps: [
-        makeStep({
-          name: 'Set up job',
-          type: 'setup',
-          status: 'succeeded',
-          attempts: [makeAttempt({status: 'succeeded'})],
-        }),
-        makeStep({
-          key: null,
-          name: 'pnpm test --filter=@shipfox/client-workflows',
-          position: 1,
-          type: 'run',
-          config: {run: 'pnpm test --filter=@shipfox/client-workflows'},
-          status: 'succeeded',
-          attempts: [makeAttempt({status: 'succeeded'})],
-        }),
-        makeStep({
-          key: null,
-          name: 'claude-opus-4-8 · Review the failing workflow step tests and propose the smallest fix.',
-          position: 2,
-          type: 'agent',
-          config: {
-            model: 'claude-opus-4-8',
-            prompt: 'Review the failing workflow step tests and propose the smallest fix.',
-          },
-          status: 'failed',
-          error: {
-            message: 'Agent invocation failed',
-            category: 'user',
-            reason: 'agent_invocation_failed',
-          },
-          attempts: [makeAttempt({status: 'failed', exit_code: 1})],
-        }),
-      ],
-    }),
-  },
-};
-
-export const CollapsedAndExpanded: Story = {
+export const Statuses: Story = {
   render: () => {
-    const build = makeStep({name: 'build', attempts: [makeAttempt()]});
-    const deployAttempt = makeAttempt();
-    const deploy = makeStep({name: 'deploy', position: 1, attempts: [deployAttempt]});
-
     return (
-      <WorkflowStepList
-        job={makeJob({steps: [build, deploy]})}
-        defaultSelectedAttemptId={deployAttempt.id}
-        renderExpandedStep={({stepId}) => (
-          <Text size="sm" className="text-foreground-neutral-subtle">
-            Slot content for {stepId}
-          </Text>
-        )}
-      />
+      <div className="flex flex-col gap-24">
+        <StoryExample label="All statuses">
+          <WorkflowStepList
+            job={makeJob({
+              steps: [
+                makeStep({
+                  name: 'running',
+                  position: 3,
+                  status: 'running',
+                  attempts: [makeAttempt({status: 'running'})],
+                }),
+                makeStep({
+                  name: 'succeeded',
+                  position: 4,
+                  status: 'succeeded',
+                  attempts: [makeAttempt({status: 'succeeded'})],
+                }),
+                makeStep({
+                  name: 'failed',
+                  position: 5,
+                  status: 'failed',
+                  attempts: [makeAttempt({status: 'failed', exit_code: 1})],
+                }),
+                makeStep({
+                  name: 'cancelled',
+                  position: 6,
+                  status: 'cancelled',
+                  attempts: [makeAttempt({status: 'cancelled'})],
+                }),
+                makeStep({
+                  name: 'timed-out',
+                  position: 7,
+                  status: 'timed_out',
+                  attempts: [makeAttempt({status: 'timed_out'})],
+                }),
+              ],
+            })}
+          />
+        </StoryExample>
+        <StoryExample label="Failed step">
+          <WorkflowStepList
+            job={makeJob({
+              steps: [
+                makeStep({
+                  name: 'test',
+                  status: 'failed',
+                  error: {
+                    message: 'Tests failed',
+                    category: 'user',
+                    reason: 'agent_invocation_failed',
+                  },
+                  attempts: [makeAttempt({status: 'failed', exit_code: 1})],
+                }),
+              ],
+            })}
+          />
+        </StoryExample>
+        <StoryExample label="Cancelled and pending">
+          <WorkflowStepList
+            job={makeJob({
+              steps: [
+                makeStep({
+                  name: 'package',
+                  status: 'cancelled',
+                  attempts: [makeAttempt({status: 'cancelled'})],
+                }),
+                makeStep({name: 'deploy', position: 1, status: 'pending'}),
+              ],
+            })}
+          />
+        </StoryExample>
+        <StoryExample label="Skipped before start">
+          <WorkflowStepList
+            job={makeJob({status: 'skipped', status_reason: 'dependency_not_completed', steps: []})}
+            emptyState={{
+              title: 'This job was skipped',
+              description: 'A required job did not complete, so this job was skipped.',
+              status: 'skipped',
+            }}
+          />
+        </StoryExample>
+        <StoryExample label="Running before first step">
+          <WorkflowStepList
+            job={makeJob({status: 'running', steps: []})}
+            emptyState={{
+              title: 'Waiting for the first step',
+              description: 'This job is running, but no steps have started yet.',
+              status: 'running',
+            }}
+          />
+        </StoryExample>
+      </div>
     );
   },
 };
@@ -221,285 +221,329 @@ const activeLogRecords: LogViewProps['records'] = [
   },
 ];
 
-export const ActiveExpandedLogs: Story = {
+export const Attempts: Story = {
   render: () => {
-    const attempt = makeAttempt({status: 'running'});
-    const step = makeStep({
-      name: 'pnpm test --filter=@shipfox/client-workflows',
-      status: 'running',
-      attempts: [attempt],
-    });
-
     return (
-      <WorkflowStepList
-        job={makeJob({steps: [step]})}
-        autoSelectActiveAttempt
-        renderExpandedStep={() => (
-          <LogView records={activeLogRecords} className="max-h-[280px] rounded-8" />
-        )}
-      />
-    );
-  },
-};
-
-export const FailedStep: Story = {
-  args: {
-    job: makeJob({
-      steps: [
-        makeStep({
-          name: 'test',
-          status: 'failed',
-          error: {message: 'Tests failed', category: 'user', reason: 'agent_invocation_failed'},
-          attempts: [makeAttempt({status: 'failed', exit_code: 1})],
-        }),
-      ],
-    }),
-  },
-};
-
-export const AgentConfigFailureCallout: Story = {
-  decorators: [withAgentProviderSettingsRoute],
-  render: () => {
-    const attempt = makeAttempt({status: 'failed', exit_code: 1});
-    const step = makeStep({
-      key: 'implement',
-      name: 'Fix the failing tests.',
-      type: 'agent',
-      status: 'failed',
-      config: {
-        provider: 'anthropic',
-        model: 'claude-opus-4-8',
-        thinking: 'high',
-        prompt: 'Fix the failing tests.',
-      },
-      error: {
-        message: 'Agent provider credentials are not configured',
-        category: 'user',
-        reason: 'agent_config_invalid',
-        agent_config_issue: 'provider_not_configured',
-      },
-      attempts: [attempt],
-    });
-
-    return (
-      <WorkflowStepList
-        job={makeJob({status: 'failed', steps: [step]})}
-        defaultSelectedAttemptId={attempt.id}
-        renderExpandedStep={() => (
-          <AgentConfigFailureCalloutView
-            workspaceId={WORKSPACE_ID}
-            config={{provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high'}}
-            error={{
-              message: 'Agent provider credentials are not configured',
-              reason: 'agent_config_invalid',
-              agentConfigIssue: 'provider_not_configured',
-              category: 'user',
-              exitCode: null,
-              signal: undefined,
-            }}
+      <div className="flex flex-col gap-24">
+        <StoryExample label="Multiple attempts">
+          <WorkflowStepList
+            job={makeJob({
+              steps: [
+                makeStep({
+                  name: 'release',
+                  status: 'succeeded',
+                  current_attempt: 3,
+                  attempts: [
+                    makeAttempt({attempt: 1, status: 'failed', exit_code: 1}),
+                    makeAttempt({
+                      attempt: 2,
+                      status: 'failed',
+                      exit_code: 1,
+                      restart_reason: 'retry',
+                    }),
+                    makeAttempt({attempt: 3, status: 'succeeded', restart_reason: 'retry'}),
+                  ],
+                }),
+              ],
+            })}
           />
-        )}
-      />
+        </StoryExample>
+        <StoryExample label="Restart execution timeline">
+          <WorkflowStepList
+            job={makeJob({
+              name: 'build',
+              status: 'succeeded',
+              steps: [
+                makeStep({
+                  name: 'checkout',
+                  position: 0,
+                  status: 'succeeded',
+                  attempts: [makeAttempt({attempt: 1, execution_order: 1, status: 'succeeded'})],
+                }),
+                makeStep({
+                  name: 'compile',
+                  position: 1,
+                  status: 'succeeded',
+                  current_attempt: 2,
+                  attempts: [
+                    makeAttempt({attempt: 1, execution_order: 2, status: 'failed', exit_code: 1}),
+                    makeAttempt({attempt: 2, execution_order: 4, status: 'succeeded'}),
+                  ],
+                }),
+                makeStep({
+                  name: 'test',
+                  position: 2,
+                  status: 'succeeded',
+                  current_attempt: 2,
+                  attempts: [
+                    makeAttempt({attempt: 1, execution_order: 3, status: 'failed', exit_code: 1}),
+                    makeAttempt({attempt: 2, execution_order: 5, status: 'succeeded'}),
+                  ],
+                }),
+                makeStep({
+                  name: 'package',
+                  position: 3,
+                  status: 'succeeded',
+                  attempts: [makeAttempt({attempt: 1, execution_order: 6, status: 'succeeded'})],
+                }),
+              ],
+            })}
+          />
+        </StoryExample>
+        <StoryExample label="Running retry attempts">
+          <WorkflowStepList
+            job={makeJob({
+              steps: [
+                makeStep({
+                  name: 'gate',
+                  status: 'running',
+                  attempts: [
+                    makeAttempt({attempt: 1, status: 'failed', exit_code: 1}),
+                    makeAttempt({attempt: 2, status: 'running', restart_reason: 'manual approval'}),
+                  ],
+                }),
+              ],
+            })}
+          />
+        </StoryExample>
+        <StoryExample label="Long name with attempt chips" className="w-440">
+          <WorkflowStepList
+            job={makeJob({
+              name: 'release-production',
+              steps: [
+                makeStep({
+                  name: 'run-production-canary-smoke-tests-with-cross-region-checkout-payment-and-notification-validation',
+                  status: 'running',
+                  current_attempt: 4,
+                  attempts: [
+                    makeAttempt({attempt: 1, status: 'failed', exit_code: 1}),
+                    makeAttempt({attempt: 2, status: 'failed', exit_code: 1}),
+                    makeAttempt({attempt: 3, status: 'succeeded'}),
+                    makeAttempt({attempt: 4, status: 'running'}),
+                  ],
+                }),
+              ],
+            })}
+          />
+        </StoryExample>
+      </div>
     );
   },
+};
+
+export const ContentVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-24">
+      <StoryExample label="Setup and unnamed steps">
+        <WorkflowStepList
+          job={makeJob({
+            steps: [
+              makeStep({
+                name: 'Set up job',
+                type: 'setup',
+                status: 'succeeded',
+                attempts: [makeAttempt({status: 'succeeded'})],
+              }),
+              makeStep({
+                key: null,
+                name: 'pnpm test --filter=@shipfox/client-workflows',
+                position: 1,
+                type: 'run',
+                config: {run: 'pnpm test --filter=@shipfox/client-workflows'},
+                status: 'succeeded',
+                attempts: [makeAttempt({status: 'succeeded'})],
+              }),
+              makeStep({
+                key: null,
+                name: 'claude-opus-4-8 · Review the failing workflow step tests and propose the smallest fix.',
+                position: 2,
+                type: 'agent',
+                config: {
+                  model: 'claude-opus-4-8',
+                  prompt: 'Review the failing workflow step tests and propose the smallest fix.',
+                },
+                status: 'failed',
+                error: {
+                  message: 'Agent invocation failed',
+                  category: 'user',
+                  reason: 'agent_invocation_failed',
+                },
+                attempts: [makeAttempt({status: 'failed', exit_code: 1})],
+              }),
+            ],
+          })}
+        />
+      </StoryExample>
+      <StoryExample label="Long content" className="w-360">
+        <WorkflowStepList
+          job={makeJob({
+            name: 'release-production-multi-region-with-canary-validation-and-post-deploy-observability',
+            steps: [
+              makeStep({
+                name: 'prepare-release-artifacts-for-production-eu-west-and-us-east-regions',
+                status: 'succeeded',
+                attempts: [makeAttempt({status: 'succeeded'})],
+              }),
+              makeStep({
+                name: 'run-canary-smoke-tests-against-checkout-payment-and-notification-services',
+                position: 1,
+                status: 'running',
+                attempts: [makeAttempt({status: 'running'})],
+              }),
+              makeStep({
+                name: 'publish-observability-summary-with-alert-links-and-rollout-decision',
+                position: 2,
+                status: 'pending',
+              }),
+            ],
+          })}
+        />
+      </StoryExample>
+    </div>
+  ),
+};
+
+export const Compositions: Story = {
+  render: () => (
+    <div className="flex flex-col gap-24">
+      <StoryExample label="Collapsed and expanded">{renderCollapsedAndExpanded()}</StoryExample>
+      <StoryExample label="Active expanded logs">{renderActiveExpandedLogs()}</StoryExample>
+      <StoryExample label="Expanded slot">{renderExpandedSlot()}</StoryExample>
+    </div>
+  ),
+};
+
+export const TestAgentConfigFailureCallout: Story = {
+  decorators: [withAgentProviderSettingsRoute],
+  render: renderAgentConfigFailureCallout,
   play: assertAgentConfigFailureCallout,
 };
 
-export const CancelledAndPending: Story = {
-  args: {
-    job: makeJob({
-      steps: [
-        makeStep({
-          name: 'package',
-          status: 'cancelled',
-          attempts: [makeAttempt({status: 'cancelled'})],
-        }),
-        makeStep({name: 'deploy', position: 1, status: 'pending'}),
-      ],
-    }),
-  },
-};
-
-export const SkippedBeforeStart: Story = {
-  args: {
-    job: makeJob({status: 'skipped', status_reason: 'dependency_not_completed', steps: []}),
-    emptyState: {
-      title: 'This job was skipped',
-      description: 'A required job did not complete, so this job was skipped.',
-      status: 'skipped',
-    },
-  },
-};
-
-export const RunningBeforeFirstStep: Story = {
-  args: {
-    job: makeJob({status: 'running', steps: []}),
-    emptyState: {
-      title: 'Waiting for the first step',
-      description: 'This job is running, but no steps have started yet.',
-      status: 'running',
-    },
-  },
-};
-
-export const MultipleAttempts: Story = {
-  args: {
-    job: makeJob({
-      steps: [
-        makeStep({
-          name: 'release',
-          status: 'succeeded',
-          current_attempt: 3,
-          attempts: [
-            makeAttempt({attempt: 1, status: 'failed', exit_code: 1}),
-            makeAttempt({attempt: 2, status: 'failed', exit_code: 1, restart_reason: 'retry'}),
-            makeAttempt({attempt: 3, status: 'succeeded', restart_reason: 'retry'}),
-          ],
-        }),
-      ],
-    }),
-  },
-};
-
-export const RestartExecutionTimeline: Story = {
-  args: {
-    job: makeJob({
-      name: 'build',
-      status: 'succeeded',
-      steps: [
-        makeStep({
-          name: 'checkout',
-          position: 0,
-          status: 'succeeded',
-          attempts: [makeAttempt({attempt: 1, execution_order: 1, status: 'succeeded'})],
-        }),
-        makeStep({
-          name: 'compile',
-          position: 1,
-          status: 'succeeded',
-          current_attempt: 2,
-          attempts: [
-            makeAttempt({attempt: 1, execution_order: 2, status: 'failed', exit_code: 1}),
-            makeAttempt({attempt: 2, execution_order: 4, status: 'succeeded'}),
-          ],
-        }),
-        makeStep({
-          name: 'test',
-          position: 2,
-          status: 'succeeded',
-          current_attempt: 2,
-          attempts: [
-            makeAttempt({attempt: 1, execution_order: 3, status: 'failed', exit_code: 1}),
-            makeAttempt({attempt: 2, execution_order: 5, status: 'succeeded'}),
-          ],
-        }),
-        makeStep({
-          name: 'package',
-          position: 3,
-          status: 'succeeded',
-          attempts: [makeAttempt({attempt: 1, execution_order: 6, status: 'succeeded'})],
-        }),
-      ],
-    }),
-  },
-};
-
-export const LongNameWithAttemptChips: Story = {
-  decorators: [
-    (Story) => (
-      <div className="w-440 bg-background-neutral-base p-16">
-        <Story />
+function StoryExample({
+  label,
+  children,
+  className,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <Code variant="label" className="text-foreground-neutral-subtle">
+        {label}
+      </Code>
+      <div
+        className={[
+          'rounded-8 border border-border-neutral-base bg-background-neutral-base p-12',
+          className,
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {children}
       </div>
-    ),
-  ],
-  args: {
-    job: makeJob({
-      name: 'release-production',
-      steps: [
-        makeStep({
-          name: 'run-production-canary-smoke-tests-with-cross-region-checkout-payment-and-notification-validation',
-          status: 'running',
-          current_attempt: 4,
-          attempts: [
-            makeAttempt({attempt: 1, status: 'failed', exit_code: 1}),
-            makeAttempt({attempt: 2, status: 'failed', exit_code: 1}),
-            makeAttempt({attempt: 3, status: 'succeeded'}),
-            makeAttempt({attempt: 4, status: 'running'}),
-          ],
-        }),
-      ],
-    }),
-  },
-};
+    </div>
+  );
+}
 
-export const RunningRetryAttempts: Story = {
-  args: {
-    job: makeJob({
-      steps: [
-        makeStep({
-          name: 'gate',
-          status: 'running',
-          attempts: [
-            makeAttempt({attempt: 1, status: 'failed', exit_code: 1}),
-            makeAttempt({attempt: 2, status: 'running', restart_reason: 'manual approval'}),
-          ],
-        }),
-      ],
-    }),
-  },
-};
+function renderCollapsedAndExpanded() {
+  const build = makeStep({name: 'build', attempts: [makeAttempt()]});
+  const deployAttempt = makeAttempt();
+  const deploy = makeStep({name: 'deploy', position: 1, attempts: [deployAttempt]});
 
-export const LongContent: Story = {
-  decorators: [
-    (Story) => (
-      <div className="w-360 bg-background-neutral-base p-16">
-        <Story />
-      </div>
-    ),
-  ],
-  args: {
-    job: makeJob({
-      name: 'release-production-multi-region-with-canary-validation-and-post-deploy-observability',
-      steps: [
-        makeStep({
-          name: 'prepare-release-artifacts-for-production-eu-west-and-us-east-regions',
-          status: 'succeeded',
-          attempts: [makeAttempt({status: 'succeeded'})],
-        }),
-        makeStep({
-          name: 'run-canary-smoke-tests-against-checkout-payment-and-notification-services',
-          position: 1,
-          status: 'running',
-          attempts: [makeAttempt({status: 'running'})],
-        }),
-        makeStep({
-          name: 'publish-observability-summary-with-alert-links-and-rollout-decision',
-          position: 2,
-          status: 'pending',
-        }),
-      ],
-    }),
-  },
-};
+  return (
+    <WorkflowStepList
+      job={makeJob({steps: [build, deploy]})}
+      defaultSelectedAttemptId={deployAttempt.id}
+      renderExpandedStep={({stepId}) => (
+        <Text size="sm" className="text-foreground-neutral-subtle">
+          Slot content for {stepId}
+        </Text>
+      )}
+    />
+  );
+}
 
-export const ExpandedSlot: Story = {
-  render: () => {
-    const attempt = makeAttempt();
-    const step = makeStep({name: 'run integration tests', attempts: [attempt]});
+function renderActiveExpandedLogs() {
+  const attempt = makeAttempt({status: 'running'});
+  const step = makeStep({
+    name: 'pnpm test --filter=@shipfox/client-workflows',
+    status: 'running',
+    attempts: [attempt],
+  });
 
-    return (
-      <WorkflowStepList
-        job={makeJob({steps: [step]})}
-        defaultSelectedAttemptId={attempt.id}
-        renderExpandedStep={({stepId}) => (
-          <Text size="sm" className="text-foreground-neutral-subtle">
-            Injected detail placeholder for {stepId}
-          </Text>
-        )}
-      />
-    );
-  },
-};
+  return (
+    <WorkflowStepList
+      job={makeJob({steps: [step]})}
+      autoSelectActiveAttempt
+      renderExpandedStep={() => (
+        <LogView records={activeLogRecords} className="max-h-[280px] rounded-8" />
+      )}
+    />
+  );
+}
+
+function renderExpandedSlot() {
+  const attempt = makeAttempt();
+  const step = makeStep({name: 'run integration tests', attempts: [attempt]});
+
+  return (
+    <WorkflowStepList
+      job={makeJob({steps: [step]})}
+      defaultSelectedAttemptId={attempt.id}
+      renderExpandedStep={({stepId}) => (
+        <Text size="sm" className="text-foreground-neutral-subtle">
+          Injected detail placeholder for {stepId}
+        </Text>
+      )}
+    />
+  );
+}
+
+function renderAgentConfigFailureCallout() {
+  const attempt = makeAttempt({status: 'failed', exit_code: 1});
+  const step = makeStep({
+    key: 'implement',
+    name: 'Fix the failing tests.',
+    type: 'agent',
+    status: 'failed',
+    config: {
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      thinking: 'high',
+      prompt: 'Fix the failing tests.',
+    },
+    error: {
+      message: 'Agent provider credentials are not configured',
+      category: 'user',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'provider_not_configured',
+    },
+    attempts: [attempt],
+  });
+
+  return (
+    <WorkflowStepList
+      job={makeJob({status: 'failed', steps: [step]})}
+      defaultSelectedAttemptId={attempt.id}
+      renderExpandedStep={() => (
+        <AgentConfigFailureCalloutView
+          workspaceId={WORKSPACE_ID}
+          config={{provider: 'anthropic', model: 'claude-opus-4-8', thinking: 'high'}}
+          error={{
+            message: 'Agent provider credentials are not configured',
+            reason: 'agent_config_invalid',
+            agentConfigIssue: 'provider_not_configured',
+            category: 'user',
+            exitCode: null,
+            signal: undefined,
+          }}
+        />
+      )}
+    />
+  );
+}
 
 function makeJob(overrides: WorkflowJobDtoOverrides = {}): WorkflowJob {
   return workflowJob(overrides);

--- a/libs/shared/react/ui/src/components/accordion/accordion.stories.tsx
+++ b/libs/shared/react/ui/src/components/accordion/accordion.stories.tsx
@@ -20,7 +20,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Single: Story = {
+export const Playground: Story = {
   render: () => (
     <Accordion type="single" collapsible defaultValue="repository" className="w-[420px]">
       <AccordionItem value="repository">

--- a/libs/shared/react/ui/src/components/alert/alert.stories.tsx
+++ b/libs/shared/react/ui/src/components/alert/alert.stories.tsx
@@ -33,7 +33,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => (
     <Alert {...args}>
       <AlertContent>

--- a/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
+++ b/libs/shared/react/ui/src/components/avatar/avatar.stories.tsx
@@ -56,7 +56,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   args: {
     content: 'logo',
     fallback: 'Shipfox',

--- a/libs/shared/react/ui/src/components/badge/badge.stories.tsx
+++ b/libs/shared/react/ui/src/components/badge/badge.stories.tsx
@@ -42,7 +42,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const AllVariants: Story = {
   render: () => (

--- a/libs/shared/react/ui/src/components/button/button-link.stories.tsx
+++ b/libs/shared/react/ui/src/components/button/button-link.stories.tsx
@@ -30,7 +30,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Variants: Story = {
   render: (args) => (

--- a/libs/shared/react/ui/src/components/button/button.stories.tsx
+++ b/libs/shared/react/ui/src/components/button/button.stories.tsx
@@ -39,7 +39,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Variants: Story = {
   render: (args) => (

--- a/libs/shared/react/ui/src/components/button/icon-button.stories.tsx
+++ b/libs/shared/react/ui/src/components/button/icon-button.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Variants: Story = {
   render: (args) => (

--- a/libs/shared/react/ui/src/components/calendar/calendar.stories.tsx
+++ b/libs/shared/react/ui/src/components/calendar/calendar.stories.tsx
@@ -17,7 +17,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Single: Story = {
+export const Playground: Story = {
   render: () => {
     const [selected, setSelected] = useState<Date | undefined>(new Date(2024, 0, 12));
     return (

--- a/libs/shared/react/ui/src/components/card/card.stories.tsx
+++ b/libs/shared/react/ui/src/components/card/card.stories.tsx
@@ -20,7 +20,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <Card className="w-360">
       <CardHeader>

--- a/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-block.stories.tsx
@@ -100,7 +100,7 @@ function CodeBlockShowcase({
   );
 }
 
-export const Basic: Story = {
+export const Playground: Story = {
   render: () => <CodeBlockShowcase data={[workflowFile]} />,
 };
 

--- a/libs/shared/react/ui/src/components/code-block/code-tabs.stories.tsx
+++ b/libs/shared/react/ui/src/components/code-block/code-tabs.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const CommandTabs: Story = {
+export const Playground: Story = {
   args: {
     codes: {
       npm: 'npm install @shipfox/tooling',

--- a/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
+++ b/libs/shared/react/ui/src/components/collapsible/collapsible.stories.tsx
@@ -40,7 +40,7 @@ function TriggerRow({children}: {children: React.ReactNode}) {
   );
 }
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <Collapsible className="flex w-[420px] flex-col gap-4">
       <TriggerRow>Repository access</TriggerRow>

--- a/libs/shared/react/ui/src/components/combobox/combobox.stories.tsx
+++ b/libs/shared/react/ui/src/components/combobox/combobox.stories.tsx
@@ -31,7 +31,6 @@ const sampleItems: ComboboxOption[] = [
 ];
 
 const repositoriesLabel = /repositories/i;
-const moreSelectedLabel = /more selected/i;
 const emptyStateSupportText = /Repository list is limited to 100/i;
 
 const meta = {
@@ -59,7 +58,7 @@ async function clickCommandOption(user: ReturnType<typeof userEvent.setup>, labe
   await user.click(item);
 }
 
-export const Default: Story = {
+export const Playground: Story = {
   args: {} as never,
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
@@ -86,7 +85,118 @@ export const Default: Story = {
   },
 };
 
-export const MultiSelect: Story = {
+const overflowValues = [
+  'apache',
+  'apache-superset',
+  'release-production-multi-region-canary',
+  'apollo',
+  'apify',
+];
+
+export const ChipVariants: Story = {
+  args: {} as never,
+  render: () => {
+    const [growingValue, setGrowingValue] = useState<string[]>(overflowValues);
+    const [compactValue, setCompactValue] = useState<string[]>(overflowValues);
+
+    return (
+      <div className="flex flex-col gap-20">
+        <div className="w-280">
+          <Label htmlFor="combobox-growing">Growing (default)</Label>
+          <Combobox
+            id="combobox-growing"
+            multiple
+            options={sampleItems}
+            value={growingValue}
+            onValueChange={setGrowingValue}
+            placeholder="Select repositories..."
+            searchPlaceholder="Search repositories..."
+          />
+        </div>
+        <div className="w-280">
+          <Label htmlFor="combobox-compact">Compact (maxVisibleChips=2)</Label>
+          <Combobox
+            id="combobox-compact"
+            multiple
+            options={sampleItems}
+            value={compactValue}
+            onValueChange={setCompactValue}
+            maxVisibleChips={2}
+            placeholder="Select repositories..."
+            searchPlaceholder="Search repositories..."
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+export const States: Story = {
+  args: {} as never,
+  render: () => {
+    const [loadingValue, setLoadingValue] = useState('');
+    const [disabledValue, setDisabledValue] = useState<string[]>(['apache', 'apollo']);
+
+    return (
+      <div className="flex flex-col gap-20">
+        <div className="w-[80vw] md:w-500">
+          <Label htmlFor="combobox-loading">Loading</Label>
+          <Combobox
+            id="combobox-loading"
+            options={sampleItems}
+            value={loadingValue}
+            onValueChange={setLoadingValue}
+            placeholder="Type to search..."
+            searchPlaceholder="Search repositories..."
+            isLoading
+          />
+        </div>
+        <div className="w-[80vw] md:w-500">
+          <Label htmlFor="combobox-disabled">Disabled</Label>
+          <Combobox
+            id="combobox-disabled"
+            multiple
+            options={sampleItems}
+            value={disabledValue}
+            onValueChange={setDisabledValue}
+            maxVisibleChips={2}
+            disabled
+            placeholder="Disabled input"
+            searchPlaceholder="Search repositories..."
+            emptyState="No results found"
+          />
+        </div>
+      </div>
+    );
+  },
+};
+
+export const PrimitiveComposition: Story = {
+  args: {} as never,
+  render: () => {
+    const [value, setValue] = useState<string[]>(['apache', 'apollo']);
+
+    return (
+      <div className="w-[80vw] md:w-500">
+        <Label htmlFor="combobox-primitives">Primitive composition</Label>
+        <ComboboxRoot
+          multiple
+          options={sampleItems}
+          value={value}
+          onValueChange={setValue}
+          maxVisibleChips={2}
+        >
+          <ComboboxTrigger id="combobox-primitives" placeholder="Pick repositories..." />
+          <ComboboxContent>
+            <ComboboxList emptyState="No repositories match." />
+          </ComboboxContent>
+        </ComboboxRoot>
+      </div>
+    );
+  },
+};
+
+export const TestMultiSelect: Story = {
   args: {} as never,
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
@@ -135,106 +245,7 @@ export const MultiSelect: Story = {
   },
 };
 
-export const PrimitiveComposition: Story = {
-  args: {} as never,
-  render: () => {
-    const [value, setValue] = useState<string[]>(['apache', 'apollo']);
-
-    return (
-      <div className="w-[80vw] md:w-500">
-        <Label htmlFor="combobox-primitives">Primitive composition</Label>
-        <ComboboxRoot
-          multiple
-          options={sampleItems}
-          value={value}
-          onValueChange={setValue}
-          maxVisibleChips={2}
-        >
-          <ComboboxTrigger id="combobox-primitives" placeholder="Pick repositories..." />
-          <ComboboxContent>
-            <ComboboxList emptyState="No repositories match." />
-          </ComboboxContent>
-        </ComboboxRoot>
-      </div>
-    );
-  },
-};
-
-const overflowValues = [
-  'apache',
-  'apache-superset',
-  'release-production-multi-region-canary',
-  'apollo',
-  'apify',
-];
-
-export const GrowingChips: Story = {
-  args: {} as never,
-  play: async ({canvasElement, step}) => {
-    const canvas = within(canvasElement);
-
-    await step('Every chip is shown; the field grows instead of collapsing', async () => {
-      await canvas.findByLabelText('Remove apache');
-      await canvas.findByLabelText('Remove apify');
-      await canvas.findByLabelText('Remove release-production-multi-region-canary');
-      expect(canvas.queryByText(moreSelectedLabel)).toBeNull();
-    });
-  },
-  render: () => {
-    const [value, setValue] = useState<string[]>(overflowValues);
-
-    return (
-      <div className="w-280">
-        <Label htmlFor="combobox-growing">Growing (default)</Label>
-        <Combobox
-          id="combobox-growing"
-          multiple
-          options={sampleItems}
-          value={value}
-          onValueChange={setValue}
-          placeholder="Select repositories..."
-          searchPlaceholder="Search repositories..."
-        />
-      </div>
-    );
-  },
-};
-
-export const CompactChips: Story = {
-  args: {} as never,
-  play: async ({canvasElement, step}) => {
-    const canvas = within(canvasElement);
-
-    await step('maxVisibleChips collapses the rest into a "+N" summary', async () => {
-      await canvas.findByLabelText('Remove apache');
-      await canvas.findByLabelText('Remove apache-superset');
-      await canvas.findByText('+3');
-      await canvas.findByText(moreSelectedLabel);
-      expect(canvas.queryByLabelText('Remove apify')).toBeNull();
-    });
-  },
-  render: () => {
-    const [value, setValue] = useState<string[]>(overflowValues);
-
-    return (
-      <div className="w-280">
-        <Label htmlFor="combobox-compact">Compact (maxVisibleChips=2)</Label>
-        <Combobox
-          id="combobox-compact"
-          multiple
-          options={sampleItems}
-          value={value}
-          onValueChange={setValue}
-          maxVisibleChips={2}
-          placeholder="Select repositories..."
-          searchPlaceholder="Search repositories..."
-        />
-      </div>
-    );
-  },
-};
-
-export const ClearAllAndBackspace: Story = {
+export const TestClearAllAndBackspace: Story = {
   args: {} as never,
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
@@ -282,7 +293,7 @@ export const ClearAllAndBackspace: Story = {
   },
 };
 
-export const TypeToFilterMulti: Story = {
+export const TestTypeToFilterMulti: Story = {
   args: {} as never,
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
@@ -323,7 +334,7 @@ export const TypeToFilterMulti: Story = {
   },
 };
 
-export const UncontrolledMulti: Story = {
+export const TestUncontrolledMulti: Story = {
   args: {} as never,
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
@@ -351,7 +362,7 @@ export const UncontrolledMulti: Story = {
   ),
 };
 
-export const KeyboardNavMulti: Story = {
+export const TestKeyboardNavMulti: Story = {
   args: {} as never,
   play: async ({canvasElement, step}) => {
     const canvas = within(canvasElement);
@@ -390,7 +401,7 @@ export const KeyboardNavMulti: Story = {
   },
 };
 
-export const KeyboardNavSingle: Story = {
+export const TestKeyboardNavSingle: Story = {
   args: {} as never,
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
@@ -422,7 +433,7 @@ export const KeyboardNavSingle: Story = {
   },
 };
 
-export const EmptyState: Story = {
+export const TestEmptyState: Story = {
   args: {} as never,
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
@@ -458,57 +469,6 @@ export const EmptyState: Story = {
               for support.
             </p>
           }
-        />
-      </div>
-    );
-  },
-};
-
-export const LoadingState: Story = {
-  args: {} as never,
-  render: () => {
-    const [value, setValue] = useState('');
-    return (
-      <div className="w-[80vw] md:w-500">
-        <Label htmlFor="combobox-loading">Loading</Label>
-        <Combobox
-          id="combobox-loading"
-          options={sampleItems}
-          value={value}
-          onValueChange={setValue}
-          placeholder="Type to search..."
-          searchPlaceholder="Search repositories..."
-          isLoading
-        />
-      </div>
-    );
-  },
-};
-
-export const DisabledState: Story = {
-  args: {} as never,
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-
-    await expect(canvas.getByRole('combobox')).toBeDisabled();
-  },
-  render: () => {
-    const [value, setValue] = useState<string[]>(['apache', 'apollo']);
-
-    return (
-      <div className="w-[80vw] md:w-500">
-        <Label htmlFor="combobox-disabled">Disabled</Label>
-        <Combobox
-          id="combobox-disabled"
-          multiple
-          options={sampleItems}
-          value={value}
-          onValueChange={setValue}
-          maxVisibleChips={2}
-          disabled
-          placeholder="Disabled input"
-          searchPlaceholder="Search repositories..."
-          emptyState="No results found"
         />
       </div>
     );

--- a/libs/shared/react/ui/src/components/command/command.stories.tsx
+++ b/libs/shared/react/ui/src/components/command/command.stories.tsx
@@ -24,7 +24,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <Command className="rounded-10 shadow-tooltip max-w-400">
       <CommandInput placeholder="Type a command or search..." />

--- a/libs/shared/react/ui/src/components/date-picker/date-picker.stories.tsx
+++ b/libs/shared/react/ui/src/components/date-picker/date-picker.stories.tsx
@@ -55,7 +55,7 @@ function ControlledPicker({
   );
 }
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => <ControlledPicker {...args} />,
 };
 

--- a/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.stories.tsx
+++ b/libs/shared/react/ui/src/components/date-range-picker/date-range-picker.stories.tsx
@@ -62,7 +62,7 @@ function ControlledPicker({
   );
 }
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => <ControlledPicker {...args} />,
 };
 

--- a/libs/shared/react/ui/src/components/dot/dot.stories.tsx
+++ b/libs/shared/react/ui/src/components/dot/dot.stories.tsx
@@ -25,7 +25,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Ripple: Story = {
   args: {variant: 'info', ripple: true},

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -130,7 +130,7 @@ export const Playground: Story = {
 
 export const Open: Story = {
   play: (ctx) => screenshotOpenMenu(ctx, 'DropdownMenu Open'),
-  render: function DefaultStory(args) {
+  render: function OpenStory(args) {
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
 
     return (

--- a/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/libs/shared/react/ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -100,8 +100,36 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  play: (ctx) => screenshotOpenMenu(ctx, 'DropdownMenu Default Open'),
+export const Playground: Story = {
+  render: function PlaygroundStory(args) {
+    const [container, setContainer] = useState<HTMLDivElement | null>(null);
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div
+        ref={setContainer}
+        className="relative flex h-500 w-500 items-center justify-center rounded-16 bg-background-subtle-base shadow-tooltip overflow-visible"
+      >
+        {container && (
+          <DropdownMenu open={open} onOpenChange={setOpen}>
+            <DropdownMenuTrigger asChild>
+              <Button variant="secondary">Open Menu</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent {...args} container={container}>
+              <DropdownMenuItem icon="editLine">Edit</DropdownMenuItem>
+              <DropdownMenuItem icon="addLine">Add</DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem icon="deleteBinLine">Delete</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+    );
+  },
+};
+
+export const Open: Story = {
+  play: (ctx) => screenshotOpenMenu(ctx, 'DropdownMenu Open'),
   render: function DefaultStory(args) {
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
 

--- a/libs/shared/react/ui/src/components/empty-state/empty-state.stories.tsx
+++ b/libs/shared/react/ui/src/components/empty-state/empty-state.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => (
     <div className="w-400">
       <EmptyState {...args} />

--- a/libs/shared/react/ui/src/components/form-field/form-field.stories.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.stories.tsx
@@ -19,7 +19,7 @@ function WiredInput(props: {placeholder?: string; defaultValue?: string; type?: 
   return <Input {...useFormField()} {...props} />;
 }
 
-export const Idle: Story = {
+export const Playground: Story = {
   render: (args) => (
     <div className="w-360">
       <FormField {...args}>

--- a/libs/shared/react/ui/src/components/icon/icon.stories.tsx
+++ b/libs/shared/react/ui/src/components/icon/icon.stories.tsx
@@ -22,7 +22,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const CommonIcons: Story = {
   render: () => (

--- a/libs/shared/react/ui/src/components/inline-tips/inline-tips.stories.tsx
+++ b/libs/shared/react/ui/src/components/inline-tips/inline-tips.stories.tsx
@@ -43,7 +43,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => (
     <InlineTips {...args}>
       <InlineTipsContent>

--- a/libs/shared/react/ui/src/components/input/input.stories.tsx
+++ b/libs/shared/react/ui/src/components/input/input.stories.tsx
@@ -28,7 +28,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const States: Story = {
   render: (args) => (

--- a/libs/shared/react/ui/src/components/kbd/kbd.stories.tsx
+++ b/libs/shared/react/ui/src/components/kbd/kbd.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="flex flex-wrap gap-8">
       <Kbd>Ctrl</Kbd>

--- a/libs/shared/react/ui/src/components/label/label.stories.tsx
+++ b/libs/shared/react/ui/src/components/label/label.stories.tsx
@@ -15,7 +15,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const WithInput: Story = {
   render: (args) => (

--- a/libs/shared/react/ui/src/components/load-error-state/load-error-state.stories.tsx
+++ b/libs/shared/react/ui/src/components/load-error-state/load-error-state.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args) => (
     <div className="w-400">
       <LoadErrorState {...args} />

--- a/libs/shared/react/ui/src/components/loader/loader.stories.tsx
+++ b/libs/shared/react/ui/src/components/loader/loader.stories.tsx
@@ -39,7 +39,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Variants: Story = {
   render: () => (

--- a/libs/shared/react/ui/src/components/log/log-disclosure.stories.tsx
+++ b/libs/shared/react/ui/src/components/log/log-disclosure.stories.tsx
@@ -35,7 +35,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Disclosure: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="max-w-2xl">
       <LogRows>

--- a/libs/shared/react/ui/src/components/modal/modal.stories.tsx
+++ b/libs/shared/react/ui/src/components/modal/modal.stories.tsx
@@ -32,7 +32,40 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div className="flex h-[calc(100vh/2)] w-[calc(100vw/2)] items-center justify-center rounded-16 bg-background-subtle-base shadow-tooltip">
+        <Modal open={open} onOpenChange={setOpen}>
+          <ModalTrigger asChild>
+            <Button>Open Modal</Button>
+          </ModalTrigger>
+          <ModalContent aria-describedby={undefined}>
+            <ModalTitle className="sr-only">Modal Title</ModalTitle>
+            <ModalHeader title="Modal Title" />
+            <ModalBody>
+              <Text size="sm" className="text-foreground-neutral-subtle w-full">
+                This modal automatically adapts between dialog and drawer layouts.
+              </Text>
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="transparent" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={() => setOpen(false)}>
+                Confirm
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+      </div>
+    );
+  },
+};
+
+export const Open: Story = {
   play: async (ctx) => {
     const {canvasElement, step} = ctx;
     const canvas = within(canvasElement);
@@ -48,7 +81,7 @@ export const Default: Story = {
       await new Promise((resolve) => setTimeout(resolve, 100));
     });
 
-    await argosScreenshot(ctx, 'Default Modal Open');
+    await argosScreenshot(ctx, 'Modal Open');
   },
   render: () => {
     const [open, setOpen] = useState(false);

--- a/libs/shared/react/ui/src/components/radio-group/radio-group.stories.tsx
+++ b/libs/shared/react/ui/src/components/radio-group/radio-group.stories.tsx
@@ -28,7 +28,7 @@ const SAMPLE_CONNECTIONS = [
   {id: 'conn-3', name: 'Other GitHub Source', subtitle: 'github · acme-fork'},
 ];
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => {
     function ControlledRadioGroup() {
       const [value, setValue] = useState<string>('conn-1');

--- a/libs/shared/react/ui/src/components/search/search.stories.tsx
+++ b/libs/shared/react/ui/src/components/search/search.stories.tsx
@@ -24,7 +24,7 @@ export default meta;
 
 type Story = StoryObj;
 
-export const Inline: Story = {
+export const Playground: Story = {
   render: () => {
     function InlineDemo() {
       const [value, setValue] = useState('');

--- a/libs/shared/react/ui/src/components/select/select.stories.tsx
+++ b/libs/shared/react/ui/src/components/select/select.stories.tsx
@@ -21,7 +21,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <Select>
       <SelectTrigger className="w-200">

--- a/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
+++ b/libs/shared/react/ui/src/components/sheet/sheet.stories.tsx
@@ -45,8 +45,45 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  play: (ctx) => screenshotOpenSheet(ctx, 'Default Sheet Open'),
+export const Playground: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div className="flex h-[calc(100vh/2)] w-[calc(100vw/2)] items-center justify-center rounded-16 bg-background-subtle-base shadow-tooltip">
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>
+            <Button>Open Sheet</Button>
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>Sheet Title</SheetTitle>
+            </SheetHeader>
+            <SheetBody>
+              <SheetDescription>
+                This sheet displays supplementary information or actions.
+              </SheetDescription>
+              <Text size="sm" className="text-foreground-neutral-subtle w-full">
+                Add forms, lists, or related details in the sheet body.
+              </Text>
+            </SheetBody>
+            <SheetFooter>
+              <Button variant="transparent" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button variant="primary" onClick={() => setOpen(false)}>
+                Save
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      </div>
+    );
+  },
+};
+
+export const Open: Story = {
+  play: (ctx) => screenshotOpenSheet(ctx, 'Sheet Open'),
   render: () => {
     const [open, setOpen] = useState(isTestEnvironment());
 

--- a/libs/shared/react/ui/src/components/shiny-text/shiny-text.stories.tsx
+++ b/libs/shared/react/ui/src/components/shiny-text/shiny-text.stories.tsx
@@ -27,7 +27,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Disabled: Story = {
   args: {

--- a/libs/shared/react/ui/src/components/skeleton/skeleton.stories.tsx
+++ b/libs/shared/react/ui/src/components/skeleton/skeleton.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => <Skeleton className="h-24 w-240" />,
 };
 

--- a/libs/shared/react/ui/src/components/table/table.stories.tsx
+++ b/libs/shared/react/ui/src/components/table/table.stories.tsx
@@ -38,7 +38,7 @@ const workflows = [
   },
 ];
 
-export const WorkflowRows: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="w-760 rounded-8 border border-border-neutral-base bg-background-neutral-base">
       <Table>

--- a/libs/shared/react/ui/src/components/tabs/tabs.stories.tsx
+++ b/libs/shared/react/ui/src/components/tabs/tabs.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   args: {defaultValue: 'analytics'} as never,
   play: async (ctx) => {
     // Wait for requestAnimationFrame inside TabsList to fire and position the

--- a/libs/shared/react/ui/src/components/toast/toast.stories.tsx
+++ b/libs/shared/react/ui/src/components/toast/toast.stories.tsx
@@ -13,7 +13,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="flex gap-12">
       <Toaster />

--- a/libs/shared/react/ui/src/components/tooltip/tooltip.stories.tsx
+++ b/libs/shared/react/ui/src/components/tooltip/tooltip.stories.tsx
@@ -55,7 +55,7 @@ export default meta;
 
 type Story = StoryObj<TooltipStoryArgs>;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: (args: TooltipStoryArgs) => {
     const defaultOpen = args.defaultOpen ?? false;
     const delayDuration = args.delayDuration ?? 0;

--- a/libs/shared/react/ui/src/components/typography/code.stories.tsx
+++ b/libs/shared/react/ui/src/components/typography/code.stories.tsx
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof meta>;
 
 const variants = ['label', 'paragraph'] as const;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="flex flex-col gap-16">
       {variants.map((variant) => (

--- a/libs/shared/react/ui/src/components/typography/header.stories.tsx
+++ b/libs/shared/react/ui/src/components/typography/header.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 
 const variants = ['h1', 'h2', 'h3', 'h4'] as const;
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="flex flex-col gap-16">
       {variants.map((variant) => (

--- a/libs/shared/react/ui/src/components/typography/text.stories.tsx
+++ b/libs/shared/react/ui/src/components/typography/text.stories.tsx
@@ -16,7 +16,7 @@ const sizes = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 const textParagraph =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
 
-export const Default: Story = {
+export const Playground: Story = {
   render: () => (
     <div className="flex flex-col gap-16">
       {sizes.map((size) => (


### PR DESCRIPTION
Organize Storybook stories around playground-first coverage.

Storybook had grown unevenly across shared UI and client feature packages, with many files starting from one-off visual states or interaction-only stories. This normalizes the catalog so each story file begins with a `Playground`, adds AGENTS.md guidance for future Storybook structure, and groups several high-cost state families into matrix-style stories.

The cleanup keeps interaction assertions where they are useful, but moves them behind visual coverage with `Test*` naming in the largest refactors. The biggest screenshot-cost reductions are in workflow step lists, workflow runs lists, trigger events, agent config callouts, and combobox coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Organizes Storybook around a Playground‑first structure, adds compact matrix stories for broad visual coverage, and isolates “open” states into dedicated stories. This reduces Argos snapshots and makes stories easier to browse across `@shipfox/react-ui` and client packages.

- **Refactors**
  - Set the first export to `Playground` across stories; renamed prior `Default`/`Showcase`/etc.
  - Grouped state families into concise stories (`Variants`, `Statuses`, `DataStates`, `Attempts`, `ContentVariants`, `Compositions`) for workflows steps/runs, trigger events, combobox chips/states, status icons, and logs.
  - Moved interaction-only stories behind `Test*` exports (e.g., combobox, runs list, workflow steps, agent config callouts); kept visual states in grouped canvases.
  - Split always-open UIs into dedicated `Open` stories and aligned snapshot names (e.g., `Modal Open`, `Sheet Open`, `DropdownMenu Open`, `Trigger Event Detail Playground`).
  - Added controls to `WorkflowStatusIcon` `Playground` and documented the story structure in AGENTS.md; added a patch changeset for `@shipfox/react-ui`.

<sup>Written for commit 71b97342f720dcb3c2d15449573531070a132586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

