### PR TITLE
[api-agent] Add custom provider egress guard

### DIFF
--- a/.changeset/calm-lemons-guard.md
+++ b/.changeset/calm-lemons-guard.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-agent": patch
+---
+
+Adds a reusable custom-provider egress guard with instance config for private-network and host-denylist policy.

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -36,6 +36,16 @@
         "default": "./dist/core/errors.js"
       }
     },
+    "./core/egress-guard": {
+      "development": {
+        "types": "./src/core/egress-guard.ts",
+        "default": "./src/core/egress-guard.ts"
+      },
+      "default": {
+        "types": "./dist/core/egress-guard.d.ts",
+        "default": "./dist/core/egress-guard.js"
+      }
+    },
     "./core/resolve-agent-config": {
       "development": {
         "types": "./src/core/resolve-agent-config.ts",
@@ -90,6 +100,7 @@
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/redact": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "ipaddr.js": "2.3.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/libs/api/agent/src/config.test.ts
+++ b/libs/api/agent/src/config.test.ts
@@ -52,4 +52,28 @@ describe('agent config', () => {
     expect(module.config.AGENT_DEFAULT_PROVIDER).toBe('azure-openai-responses');
     expect(module.config.AGENT_DEFAULT_PROVIDER_API_KEY).toBeUndefined();
   });
+
+  it('defaults custom provider egress to local-development friendly settings', async () => {
+    vi.resetModules();
+    vi.stubEnv('AGENT_CREDENTIALS_ENCRYPTION_KEY', ENCRYPTION_KEY);
+
+    const module = await import('./config.js');
+
+    expect(module.config.AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS).toBe(true);
+    expect(module.config.AGENT_CUSTOM_PROVIDER_HOST_DENYLIST).toBe('');
+  });
+
+  it('imports custom provider egress cloud overrides', async () => {
+    vi.resetModules();
+    vi.stubEnv('AGENT_CREDENTIALS_ENCRYPTION_KEY', ENCRYPTION_KEY);
+    vi.stubEnv('AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS', 'false');
+    vi.stubEnv('AGENT_CUSTOM_PROVIDER_HOST_DENYLIST', 'metadata.google.internal,10.0.0.0/8');
+
+    const module = await import('./config.js');
+
+    expect(module.config.AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS).toBe(false);
+    expect(module.config.AGENT_CUSTOM_PROVIDER_HOST_DENYLIST).toBe(
+      'metadata.google.internal,10.0.0.0/8',
+    );
+  });
 });

--- a/libs/api/agent/src/config.ts
+++ b/libs/api/agent/src/config.ts
@@ -4,7 +4,7 @@ import {
   SUPPORTED_AGENT_PROVIDER_IDS,
   type SupportedAgentProviderId,
 } from '@shipfox/api-agent-dto';
-import {createConfig, num, str} from '@shipfox/config';
+import {bool, createConfig, num, str} from '@shipfox/config';
 
 const AGENT_THINKING_CHOICES = agentThinkingSchema.options;
 
@@ -33,6 +33,14 @@ export const config = createConfig({
   AGENT_PROVIDER_VALIDATION_TIMEOUT_MS: num({
     desc: 'Maximum time in milliseconds to wait for the live provider test request when saving credentials.',
     default: 10000,
+  }),
+  AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS: bool({
+    desc: 'Allows custom agent providers to use private, loopback, link-local, metadata, and .internal network targets. Keep this true for local development and self-hosted private networks. Set it to false on cloud instances.',
+    default: true,
+  }),
+  AGENT_CUSTOM_PROVIDER_HOST_DENYLIST: str({
+    desc: 'Comma-separated hosts and IP ranges that custom agent providers may not call. Accepts exact hosts, suffix patterns such as .internal.example or *.internal.example, IP literals, and CIDR blocks such as 10.0.0.0/8.',
+    default: '',
   }),
 });
 

--- a/libs/api/agent/src/core/egress-guard.test.ts
+++ b/libs/api/agent/src/core/egress-guard.test.ts
@@ -140,6 +140,19 @@ describe('assertEgressAllowed', () => {
     });
   });
 
+  it('fails closed for malformed CIDR denylist entries', async () => {
+    const probe = assertEgressAllowed('https://8.8.8.8/v1', {
+      ...openPolicy(),
+      hostDenylist: ['8.8.8.0/not-a-prefix'],
+    });
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'host-denylist',
+      target: '8.8.8.0/not-a-prefix',
+    });
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
   it('parses comma-separated host denylist config', () => {
     const entries = parseEgressHostDenylist(
       ' blocked.example.test, *.corp.example.test, 10.0.0.0/8 ',

--- a/libs/api/agent/src/core/egress-guard.test.ts
+++ b/libs/api/agent/src/core/egress-guard.test.ts
@@ -10,7 +10,7 @@ const lookupMock = vi.mocked(lookup);
 describe('assertEgressAllowed', () => {
   beforeEach(() => {
     lookupMock.mockReset();
-    mockLookupAddresses([{address: '203.0.113.10', family: 4}]);
+    mockLookupAddresses([{address: '8.8.8.8', family: 4}]);
   });
 
   it('allows http and https URLs', async () => {
@@ -31,15 +31,15 @@ describe('assertEgressAllowed', () => {
   });
 
   it('checks IP literals without DNS resolution', async () => {
-    await assertEgressAllowed('https://203.0.113.10/v1', lockedPolicy());
+    await assertEgressAllowed('https://8.8.8.8/v1', lockedPolicy());
 
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
   it('resolves hostnames to all addresses', async () => {
     mockLookupAddresses([
-      {address: '203.0.113.10', family: 4},
-      {address: '2001:db8::1', family: 6},
+      {address: '8.8.8.8', family: 4},
+      {address: '2001:4860:4860::8888', family: 6},
     ]);
 
     await assertEgressAllowed('https://models.example.test/v1', lockedPolicy());
@@ -51,8 +51,13 @@ describe('assertEgressAllowed', () => {
     ['loopback', 'http://127.0.0.1/v1'],
     ['rfc1918', 'http://10.0.0.12/v1'],
     ['metadata', 'http://169.254.169.254/latest/meta-data'],
+    ['unspecified ipv4', 'http://0.0.0.0/v1'],
+    ['broadcast ipv4', 'http://255.255.255.255/v1'],
     ['ipv6 link-local', 'http://[fe80::1]/v1'],
     ['ipv6 unique local', 'http://[fd00::1]/v1'],
+    ['unspecified ipv6', 'http://[::]/v1'],
+    ['6to4 ipv6', 'http://[2002:0a00:0001::]/v1'],
+    ['rfc6052 ipv6', 'http://[64:ff9b::0a00:0001]/v1'],
   ])('rejects %s addresses when private networks are locked', async (_label, url) => {
     const probe = assertEgressAllowed(url, lockedPolicy());
 
@@ -111,9 +116,9 @@ describe('assertEgressAllowed', () => {
   });
 
   it('enforces IP literal denylist entries', async () => {
-    const probe = assertEgressAllowed('https://203.0.113.10/v1', {
+    const probe = assertEgressAllowed('https://8.8.8.8/v1', {
       ...openPolicy(),
-      hostDenylist: ['203.0.113.10'],
+      hostDenylist: ['8.8.8.8'],
     });
 
     await expect(probe).rejects.toMatchObject({
@@ -123,11 +128,11 @@ describe('assertEgressAllowed', () => {
   });
 
   it('enforces CIDR denylist entries against resolved addresses', async () => {
-    mockLookupAddresses([{address: '203.0.113.10', family: 4}]);
+    mockLookupAddresses([{address: '8.8.8.8', family: 4}]);
 
     const probe = assertEgressAllowed('https://models.example.test/v1', {
       ...openPolicy(),
-      hostDenylist: ['203.0.113.0/24'],
+      hostDenylist: ['8.8.8.0/24'],
     });
 
     await expect(probe).rejects.toMatchObject({

--- a/libs/api/agent/src/core/egress-guard.test.ts
+++ b/libs/api/agent/src/core/egress-guard.test.ts
@@ -1,0 +1,157 @@
+import {lookup} from 'node:dns/promises';
+import {assertEgressAllowed, EgressDeniedError, parseEgressHostDenylist} from './egress-guard.js';
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+const lookupMock = vi.mocked(lookup);
+
+describe('assertEgressAllowed', () => {
+  beforeEach(() => {
+    lookupMock.mockReset();
+    mockLookupAddresses([{address: '203.0.113.10', family: 4}]);
+  });
+
+  it('allows http and https URLs', async () => {
+    await assertEgressAllowed('http://models.example.test/v1', lockedPolicy());
+    await assertEgressAllowed('https://models.example.test/v1', lockedPolicy());
+
+    expect(lookupMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects non-http URL schemes', async () => {
+    const probe = assertEgressAllowed('ftp://models.example.test/v1', lockedPolicy());
+
+    await expect(probe).rejects.toMatchObject({
+      name: 'EgressDeniedError',
+      reason: 'invalid-scheme',
+    });
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('checks IP literals without DNS resolution', async () => {
+    await assertEgressAllowed('https://203.0.113.10/v1', lockedPolicy());
+
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('resolves hostnames to all addresses', async () => {
+    mockLookupAddresses([
+      {address: '203.0.113.10', family: 4},
+      {address: '2001:db8::1', family: 6},
+    ]);
+
+    await assertEgressAllowed('https://models.example.test/v1', lockedPolicy());
+
+    expect(lookupMock).toHaveBeenCalledWith('models.example.test', {all: true});
+  });
+
+  it.each([
+    ['loopback', 'http://127.0.0.1/v1'],
+    ['rfc1918', 'http://10.0.0.12/v1'],
+    ['metadata', 'http://169.254.169.254/latest/meta-data'],
+    ['ipv6 link-local', 'http://[fe80::1]/v1'],
+    ['ipv6 unique local', 'http://[fd00::1]/v1'],
+  ])('rejects %s addresses when private networks are locked', async (_label, url) => {
+    const probe = assertEgressAllowed(url, lockedPolicy());
+
+    await expect(probe).rejects.toBeInstanceOf(EgressDeniedError);
+  });
+
+  it('rejects hostnames resolving to private addresses when private networks are locked', async () => {
+    mockLookupAddresses([{address: '192.168.1.10', family: 4}]);
+
+    const probe = assertEgressAllowed('https://models.example.test/v1', lockedPolicy());
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'private-network',
+    });
+  });
+
+  it('rejects .internal hosts when private networks are locked', async () => {
+    const probe = assertEgressAllowed('https://model-gateway.internal/v1', lockedPolicy());
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'internal-host',
+    });
+  });
+
+  it('allows private and internal targets under the open policy', async () => {
+    await assertEgressAllowed('http://localhost:11434/v1', openPolicy());
+    await assertEgressAllowed('http://10.0.0.12/v1', openPolicy());
+    await assertEgressAllowed('https://model-gateway.internal/v1', openPolicy());
+
+    expect(lookupMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('enforces exact hostname denylist entries', async () => {
+    const probe = assertEgressAllowed('https://blocked.example.test/v1', {
+      ...openPolicy(),
+      hostDenylist: ['blocked.example.test'],
+    });
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'host-denylist',
+    });
+  });
+
+  it.each([
+    '*.corp.example.test',
+    '.corp.example.test',
+  ])('enforces suffix denylist entry "%s"', async (entry) => {
+    const probe = assertEgressAllowed('https://models.corp.example.test/v1', {
+      ...openPolicy(),
+      hostDenylist: [entry],
+    });
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'host-denylist',
+    });
+  });
+
+  it('enforces IP literal denylist entries', async () => {
+    const probe = assertEgressAllowed('https://203.0.113.10/v1', {
+      ...openPolicy(),
+      hostDenylist: ['203.0.113.10'],
+    });
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'host-denylist',
+    });
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('enforces CIDR denylist entries against resolved addresses', async () => {
+    mockLookupAddresses([{address: '203.0.113.10', family: 4}]);
+
+    const probe = assertEgressAllowed('https://models.example.test/v1', {
+      ...openPolicy(),
+      hostDenylist: ['203.0.113.0/24'],
+    });
+
+    await expect(probe).rejects.toMatchObject({
+      reason: 'host-denylist',
+    });
+  });
+
+  it('parses comma-separated host denylist config', () => {
+    const entries = parseEgressHostDenylist(
+      ' blocked.example.test, *.corp.example.test, 10.0.0.0/8 ',
+    );
+
+    expect(entries).toEqual(['blocked.example.test', '*.corp.example.test', '10.0.0.0/8']);
+  });
+});
+
+function lockedPolicy() {
+  return {allowPrivateNetworks: false};
+}
+
+function openPolicy() {
+  return {allowPrivateNetworks: true};
+}
+
+function mockLookupAddresses(addresses: Array<{address: string; family: 4 | 6}>): void {
+  lookupMock.mockResolvedValue(addresses as never);
+}

--- a/libs/api/agent/src/core/egress-guard.ts
+++ b/libs/api/agent/src/core/egress-guard.ts
@@ -127,6 +127,7 @@ function parseDenylistEntry(entry: string): DenylistEntry | undefined {
 
   const range = parseCidrRange(normalized);
   if (range) return {kind: 'cidr', range};
+  if (normalized.includes('/')) throw new EgressDeniedError('host-denylist', normalized);
 
   const address = parseIpAddress(normalized);
   if (address) return {kind: 'ip', address};

--- a/libs/api/agent/src/core/egress-guard.ts
+++ b/libs/api/agent/src/core/egress-guard.ts
@@ -1,0 +1,184 @@
+import {lookup} from 'node:dns/promises';
+import * as ipaddr from 'ipaddr.js';
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+const METADATA_ADDRESS = '169.254.169.254';
+const TRAILING_DOT_PATTERN = /\.$/;
+
+export type EgressDeniedReason =
+  | 'invalid-scheme'
+  | 'host-denylist'
+  | 'internal-host'
+  | 'metadata-address'
+  | 'private-network';
+
+export interface EgressPolicy {
+  allowPrivateNetworks: boolean;
+  hostDenylist?: readonly string[] | undefined;
+}
+
+export class EgressDeniedError extends Error {
+  constructor(
+    public readonly reason: EgressDeniedReason,
+    public readonly target: string,
+  ) {
+    super(`Egress denied for ${target}: ${reason}`);
+    this.name = 'EgressDeniedError';
+  }
+}
+
+type ParsedAddress = ipaddr.IPv4 | ipaddr.IPv6;
+
+type DenylistEntry =
+  | {kind: 'host'; host: string}
+  | {kind: 'suffix'; suffix: string}
+  | {kind: 'ip'; address: ParsedAddress}
+  | {kind: 'cidr'; range: [ParsedAddress, number]};
+
+export async function assertEgressAllowed(url: string, policy: EgressPolicy): Promise<void> {
+  const parsed = new URL(url);
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new EgressDeniedError('invalid-scheme', parsed.protocol);
+  }
+
+  const hostname = normalizeHostname(parsed.hostname);
+  const hostAddress = parseIpAddress(hostname);
+  const addresses = hostAddress ? [hostAddress] : await resolveHostname(hostname);
+  const denylist = parseDenylist(policy.hostDenylist ?? []);
+
+  assertNotDenylisted(hostname, addresses, denylist);
+
+  if (policy.allowPrivateNetworks) return;
+  if (hostname.endsWith('.internal')) throw new EgressDeniedError('internal-host', hostname);
+
+  for (const address of addresses) {
+    assertPublicAddress(address);
+  }
+}
+
+export function parseEgressHostDenylist(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function normalizeHostname(hostname: string): string {
+  return stripIpv6Brackets(hostname).toLowerCase().replace(TRAILING_DOT_PATTERN, '');
+}
+
+function stripIpv6Brackets(value: string): string {
+  if (!value.startsWith('[') || !value.endsWith(']')) return value;
+  return value.slice(1, -1);
+}
+
+async function resolveHostname(hostname: string): Promise<ParsedAddress[]> {
+  const records = await lookup(hostname, {all: true});
+  return records.map((record) => parseIpAddress(record.address)).filter(isParsedAddress);
+}
+
+function parseIpAddress(value: string): ParsedAddress | undefined {
+  if (!ipaddr.isValid(value)) return undefined;
+  const address = ipaddr.parse(value);
+  if (isIpv6Address(address)) {
+    return normalizeIpv6Address(address);
+  }
+  return address;
+}
+
+function isParsedAddress(address: ParsedAddress | undefined): address is ParsedAddress {
+  return address !== undefined;
+}
+
+function assertNotDenylisted(
+  hostname: string,
+  addresses: ParsedAddress[],
+  denylist: DenylistEntry[],
+): void {
+  for (const entry of denylist) {
+    if (entry.kind === 'host' && hostname === entry.host) {
+      throw new EgressDeniedError('host-denylist', hostname);
+    }
+    if (entry.kind === 'suffix' && hostname.endsWith(entry.suffix)) {
+      throw new EgressDeniedError('host-denylist', hostname);
+    }
+
+    for (const address of addresses) {
+      if (
+        entry.kind === 'ip' &&
+        address.toNormalizedString() === entry.address.toNormalizedString()
+      ) {
+        throw new EgressDeniedError('host-denylist', address.toString());
+      }
+      if (entry.kind === 'cidr' && addressMatchesRange(address, entry.range)) {
+        throw new EgressDeniedError('host-denylist', address.toString());
+      }
+    }
+  }
+}
+
+function parseDenylist(entries: readonly string[]): DenylistEntry[] {
+  return entries.map(parseDenylistEntry).filter(isDenylistEntry);
+}
+
+function parseDenylistEntry(entry: string): DenylistEntry | undefined {
+  const normalized = normalizeHostname(entry.trim());
+  if (!normalized) return undefined;
+
+  const range = parseCidrRange(normalized);
+  if (range) return {kind: 'cidr', range};
+
+  const address = parseIpAddress(normalized);
+  if (address) return {kind: 'ip', address};
+
+  if (normalized.startsWith('*.')) return {kind: 'suffix', suffix: normalized.slice(1)};
+  if (normalized.startsWith('.')) return {kind: 'suffix', suffix: normalized};
+
+  return {kind: 'host', host: normalized};
+}
+
+function parseCidrRange(value: string): [ParsedAddress, number] | undefined {
+  try {
+    const [address, prefix] = ipaddr.parseCIDR(value);
+    const normalizedAddress = isIpv6Address(address) ? normalizeIpv6Address(address) : address;
+    return [normalizedAddress, prefix];
+  } catch {
+    return undefined;
+  }
+}
+
+function isIpv6Address(address: ParsedAddress): address is ipaddr.IPv6 {
+  return address.kind() === 'ipv6';
+}
+
+function normalizeIpv6Address(address: ipaddr.IPv6): ParsedAddress {
+  if (address.isIPv4MappedAddress()) return address.toIPv4Address();
+  return address;
+}
+
+function isDenylistEntry(entry: DenylistEntry | undefined): entry is DenylistEntry {
+  return entry !== undefined;
+}
+
+function addressMatchesRange(address: ParsedAddress, range: [ParsedAddress, number]): boolean {
+  const [rangeAddress, prefix] = range;
+  if (address.kind() !== rangeAddress.kind()) return false;
+  return address.match(rangeAddress, prefix);
+}
+
+function assertPublicAddress(address: ParsedAddress): void {
+  if (address.kind() === 'ipv4' && address.toString() === METADATA_ADDRESS) {
+    throw new EgressDeniedError('metadata-address', address.toString());
+  }
+
+  if (isPrivateAddress(address)) {
+    throw new EgressDeniedError('private-network', address.toString());
+  }
+}
+
+function isPrivateAddress(address: ParsedAddress): boolean {
+  const range = address.range();
+  return (
+    range === 'loopback' || range === 'private' || range === 'linkLocal' || range === 'uniqueLocal'
+  );
+}

--- a/libs/api/agent/src/core/egress-guard.ts
+++ b/libs/api/agent/src/core/egress-guard.ts
@@ -171,14 +171,11 @@ function assertPublicAddress(address: ParsedAddress): void {
     throw new EgressDeniedError('metadata-address', address.toString());
   }
 
-  if (isPrivateAddress(address)) {
+  if (!isPublicUnicastAddress(address)) {
     throw new EgressDeniedError('private-network', address.toString());
   }
 }
 
-function isPrivateAddress(address: ParsedAddress): boolean {
-  const range = address.range();
-  return (
-    range === 'loopback' || range === 'private' || range === 'linkLocal' || range === 'uniqueLocal'
-  );
+function isPublicUnicastAddress(address: ParsedAddress): boolean {
+  return address.range() === 'unicast';
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,6 +501,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)
+      ipaddr.js:
+        specifier: 2.3.0
+        version: 2.3.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
Add a reusable egress guard for custom agent providers.

Custom model providers need to validate user-configured base URLs before later streams wire them into discovery, validation probes, and runner execution. This adds the shared guard now so those call sites can reject non-HTTP(S) schemes, private network targets under locked policy, metadata addresses, `.internal` hosts, and explicit host/IP/CIDR denylist entries through one API.

The instance config defaults private-network access open for local development and self-hosted deployments, while cloud deployments can set `AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS=false` and optionally provide `AGENT_CUSTOM_PROVIDER_HOST_DENYLIST`.

The guard is exported only through `@shipfox/api-agent/core/egress-guard`; no runtime call sites are wired in this stream.

Closes ENG-681

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable egress/SSRF guard for custom agent providers with policy controls for private networks and host/IP/CIDR denylists. Exposed as `@shipfox/api-agent/core/egress-guard`; defaults keep local/self-hosted open while enabling cloud lockdown, aligning with ENG-681.

- **New Features**
  - Enforces HTTP/HTTPS only.
  - Resolves hostnames; under locked policy denies all non-public-unicast IPs (loopback, link-local, RFC1918/ULA, unspecified/broadcast/CGNAT/reserved, 6to4/RFC6052), metadata `169.254.169.254`, and `.internal` hosts.
  - Supports host/IP/CIDR denylist and `parseEgressHostDenylist()` for comma-separated config; fails closed on malformed CIDR entries.
  - New config: `AGENT_CUSTOM_PROVIDER_ALLOW_PRIVATE_NETWORKS` (default true) and `AGENT_CUSTOM_PROVIDER_HOST_DENYLIST` (default ''). Unit tests included; no runtime call sites yet.

- **Dependencies**
  - Add `ipaddr.js@2.3.0`.

<sup>Written for commit 7bf63cd351f1e3e6f2c989fecb15164764587275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

