### PR TITLE
[provisioner] Reconcile Docker runners with backend intent

### DIFF
--- a/.changeset/backend-runners-reconcile.md
+++ b/.changeset/backend-runners-reconcile.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/provisioner-core": patch
+"@shipfox/provisioner-docker-provider": patch
+---
+
+Adds backend-aware Docker provisioner reconciliation with terminate-intent teardown and buffered lifecycle report retries.

--- a/libs/provisioner/core/src/api-client.test.ts
+++ b/libs/provisioner/core/src/api-client.test.ts
@@ -103,6 +103,37 @@ describe('createProvisionerClient', () => {
     expect(calls[0]?.authorization).toBe(`Bearer ${TOKEN}`);
   });
 
+  it('reconcileProvisionedRunners posts observed ids with the token and parses intent', async () => {
+    stubFetch(() =>
+      jsonResponse({
+        runners: [
+          {
+            provisioned_runner_id: 'runner-1',
+            state: 'running',
+            reservation_id: RESERVATION_ID,
+            runner_session_id: null,
+            bound_job: null,
+            desired_intent: 'keep',
+          },
+        ],
+        terminated_absent_provisioned_runner_ids: ['runner-2'],
+      }),
+    );
+
+    const result = await client().reconcileProvisionedRunners({
+      observed_provisioned_runner_ids: ['runner-1'],
+    });
+
+    expect(result.runners[0]?.desired_intent).toBe('keep');
+    expect(result.terminated_absent_provisioned_runner_ids).toEqual(['runner-2']);
+    expect(calls[0]?.url).toContain('provisioners/provisioned-runners/reconcile');
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.authorization).toBe(`Bearer ${TOKEN}`);
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({
+      observed_provisioned_runner_ids: ['runner-1'],
+    });
+  });
+
   it('maps a 401 on getIdentity to ProvisionerAuthenticationError', async () => {
     stubFetch(() => new Response(null, {status: 401}));
 
@@ -135,6 +166,16 @@ describe('createProvisionerClient', () => {
           reported_at: '2026-01-01T00:00:00.000Z',
         },
       ],
+    });
+
+    await expect(request).rejects.toThrow(ProvisionerAuthenticationError);
+  });
+
+  it('maps a 401 on reconcileProvisionedRunners to ProvisionerAuthenticationError', async () => {
+    stubFetch(() => new Response(null, {status: 401}));
+
+    const request = client().reconcileProvisionedRunners({
+      observed_provisioned_runner_ids: ['runner-1'],
     });
 
     await expect(request).rejects.toThrow(ProvisionerAuthenticationError);

--- a/libs/provisioner/core/src/api-client.ts
+++ b/libs/provisioner/core/src/api-client.ts
@@ -7,8 +7,11 @@ import {
   type ProvisionerIdentityResponseDto,
   pollDemandResponseSchema,
   provisionerIdentityResponseSchema,
+  type ReconcileProvisionedRunnersBodyDto,
+  type ReconcileProvisionedRunnersResponseDto,
   type ReportProvisionedRunnersBodyDto,
   type ReportProvisionedRunnersResponseDto,
+  reconcileProvisionedRunnersResponseSchema,
   reportProvisionedRunnersResponseSchema,
 } from '@shipfox/api-runners-dto';
 import ky, {HTTPError, type KyInstance} from 'ky';
@@ -38,6 +41,10 @@ export interface ProvisionerClient {
     body: ReportProvisionedRunnersBodyDto,
     options?: {signal?: AbortSignal},
   ): Promise<ReportProvisionedRunnersResponseDto>;
+  reconcileProvisionedRunners(
+    body: ReconcileProvisionedRunnersBodyDto,
+    options?: {signal?: AbortSignal},
+  ): Promise<ReconcileProvisionedRunnersResponseDto>;
 }
 
 export function createProvisionerClient(params: {
@@ -86,6 +93,16 @@ export function createProvisionerClient(params: {
           ...(options.signal ? {signal: options.signal} : {}),
         });
         return reportProvisionedRunnersResponseSchema.parse(await response.json());
+      });
+    },
+
+    reconcileProvisionedRunners(body, options = {}) {
+      return withAuthMapping(async () => {
+        const response = await api.post('provisioners/provisioned-runners/reconcile', {
+          json: body,
+          ...(options.signal ? {signal: options.signal} : {}),
+        });
+        return reconcileProvisionedRunnersResponseSchema.parse(await response.json());
       });
     },
   };

--- a/libs/provisioner/core/src/index.ts
+++ b/libs/provisioner/core/src/index.ts
@@ -10,4 +10,5 @@ export type {
   ProvisionerIdentity,
   ProvisionerRuntime,
   ProvisionerTemplate,
+  TerminateRunners,
 } from '#types.js';

--- a/libs/provisioner/core/src/provisioner.test.ts
+++ b/libs/provisioner/core/src/provisioner.test.ts
@@ -184,6 +184,8 @@ function harness(options: {response: PollDemandResponseFixture; onPoll?: () => v
         });
       },
       reportProvisionedRunners: () => Promise.resolve({accepted: 0, reservations_released: 0}),
+      reconcileProvisionedRunners: () =>
+        Promise.resolve({runners: [], terminated_absent_provisioned_runner_ids: []}),
     },
   };
 }

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -162,6 +162,7 @@ export async function runProvisionerIteration<Spec>(
     templates: deps.templates,
     tracker: deps.tracker,
     launch: deps.adapter.launch,
+    ...(deps.adapter.terminate ? {terminate: deps.adapter.terminate} : {}),
     buildRunnerEnv,
     maxReservations,
     waitSeconds: config.SHIPFOX_PROVISIONER_POLL_WAIT_SECONDS,

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -27,6 +27,8 @@ interface Harness {
   readonly pollBodies: PollDemandBodyDto[];
   readonly mintBodies: MintRegistrationTokensBatchBodyDto[];
   readonly launches: ProvisionedRunnerLaunch<null>[];
+  readonly terminatedIds: string[][];
+  readonly events: string[];
   readonly client: ProvisionerClient;
   readonly tracker: ProvisionedRunnerTracker;
 }
@@ -38,10 +40,13 @@ function harness(options: {response: PollDemandResponseFixture; mintError?: Erro
   const pollBodies: PollDemandBodyDto[] = [];
   const mintBodies: MintRegistrationTokensBatchBodyDto[] = [];
   const launches: ProvisionedRunnerLaunch<null>[] = [];
+  const terminatedIds: string[][] = [];
+  const events: string[] = [];
 
   const client: ProvisionerClient = {
     getIdentity: () => Promise.resolve({id: 'provisioner', workspace_id: 'workspace'}),
     pollDemand: (body) => {
+      events.push('poll');
       pollBodies.push(body);
       return Promise.resolve({
         ...options.response,
@@ -49,6 +54,7 @@ function harness(options: {response: PollDemandResponseFixture; mintError?: Erro
       });
     },
     mintRegistrationTokens: (body): Promise<MintRegistrationTokensBatchResponseDto> => {
+      events.push('mint');
       mintBodies.push(body);
       if (options.mintError) return Promise.reject(options.mintError);
       return Promise.resolve({
@@ -60,9 +66,19 @@ function harness(options: {response: PollDemandResponseFixture; mintError?: Erro
       });
     },
     reportProvisionedRunners: () => Promise.resolve({accepted: 0, reservations_released: 0}),
+    reconcileProvisionedRunners: () =>
+      Promise.resolve({runners: [], terminated_absent_provisioned_runner_ids: []}),
   };
 
-  return {pollBodies, mintBodies, launches, client, tracker: createInMemoryTracker()};
+  return {
+    pollBodies,
+    mintBodies,
+    launches,
+    terminatedIds,
+    events,
+    client,
+    tracker: createInMemoryTracker(),
+  };
 }
 
 function reservation(count: number, labels: string[] = ['ubuntu22'], id = 'r1') {
@@ -81,7 +97,13 @@ function runTick(
     client: fixture.client,
     templates: params.templates,
     tracker: fixture.tracker,
+    terminate: (ids) => {
+      fixture.events.push('terminate');
+      fixture.terminatedIds.push([...ids]);
+      return Promise.resolve();
+    },
     launch: (launch) => {
+      fixture.events.push('launch');
       fixture.launches.push(launch);
       return Promise.resolve();
     },
@@ -245,6 +267,8 @@ describe('runProvisionerTick', () => {
           })),
         }),
       reportProvisionedRunners: () => Promise.resolve({accepted: 0, reservations_released: 0}),
+      reconcileProvisionedRunners: () =>
+        Promise.resolve({runners: [], terminated_absent_provisioned_runner_ids: []}),
     };
 
     const result = await runProvisionerTick({
@@ -290,5 +314,63 @@ describe('runProvisionerTick', () => {
     expect(result.launchedCount).toBe(0);
     // The failed runner must not keep occupying a slot, or a persistent failure wedges the loop.
     expect(fixture.tracker.countsByTemplate()).toEqual(new Map());
+  });
+
+  it('calls the terminate port with backend terminate intents before minting', async () => {
+    const template = ubuntuTemplate({key: 'small'});
+    const fixture = harness({
+      response: {
+        stats: [],
+        reservations: [reservation(1)],
+        terminate_provisioned_runner_ids: ['runner-old'],
+      },
+    });
+
+    await runTick(fixture, {templates: [template]});
+
+    expect(fixture.terminatedIds).toEqual([['runner-old']]);
+    expect(fixture.events).toEqual(['poll', 'terminate', 'mint', 'launch']);
+  });
+
+  it('does not call the terminate port when the backend returns no terminate intents', async () => {
+    const template = ubuntuTemplate({key: 'small'});
+    const fixture = harness({response: {stats: [], reservations: []}});
+
+    await runTick(fixture, {templates: [template]});
+
+    expect(fixture.terminatedIds).toEqual([]);
+  });
+
+  it('propagates terminate failures so the loop can back off', async () => {
+    const template = ubuntuTemplate({key: 'small'});
+    const fixture = harness({
+      response: {
+        stats: [],
+        reservations: [reservation(1)],
+        terminate_provisioned_runner_ids: ['runner-old'],
+      },
+    });
+    const error = new Error('docker daemon down');
+
+    const request = runProvisionerTick({
+      client: fixture.client,
+      templates: [template],
+      tracker: fixture.tracker,
+      terminate: () => Promise.reject(error),
+      launch: (launch) => {
+        fixture.launches.push(launch);
+        return Promise.resolve();
+      },
+      buildRunnerEnv: ({registrationToken}) => ({
+        SHIPFOX_RUNNER_REGISTRATION_TOKEN: registrationToken,
+      }),
+      maxReservations: 250,
+      waitSeconds: 30,
+      registrationTokenBatchSize: 250,
+    });
+
+    await expect(request).rejects.toThrow(error);
+    expect(fixture.mintBodies).toHaveLength(0);
+    expect(fixture.launches).toHaveLength(0);
   });
 });

--- a/libs/provisioner/core/src/tick.test.ts
+++ b/libs/provisioner/core/src/tick.test.ts
@@ -10,6 +10,7 @@ import {createInMemoryTracker, type ProvisionedRunnerTracker} from '#tracker.js'
 import type {ProvisionedRunnerLaunch, ProvisionerTemplate} from '#types.js';
 
 const EXPIRES_AT = '2026-01-01T00:00:00.000Z';
+const UUID_V7_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function ubuntuTemplate(
   overrides: Partial<ProvisionerTemplate<null>> & {key: string},
@@ -153,6 +154,18 @@ describe('runProvisionerTick', () => {
     expect(fixture.tracker.countsByTemplate()).toEqual(
       new Map([['small', {starting: 2, running: 0}]]),
     );
+  });
+
+  it('generates UUIDv7 provisioned runner ids', async () => {
+    const template = ubuntuTemplate({key: 'small'});
+    const fixture = harness({response: {stats: [], reservations: [reservation(2)]}});
+
+    await runTick(fixture, {templates: [template]});
+
+    expect(fixture.mintBodies[0]?.provisioned_runners).toHaveLength(2);
+    for (const runner of fixture.mintBodies[0]?.provisioned_runners ?? []) {
+      expect(runner.provisioned_runner_id).toMatch(UUID_V7_PATTERN);
+    }
   });
 
   it('asks for no reservations once a template is at its concurrency cap', async () => {

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -8,7 +8,7 @@ import {logger} from '@shipfox/node-opentelemetry';
 import type {ProvisionerClient} from '#api-client.js';
 import {type PlannedLaunchGroup, planLaunches, templateAvailableSlots} from '#capacity.js';
 import type {ProvisionedRunnerTracker} from '#tracker.js';
-import type {LaunchRunner, ProvisionerTemplate} from '#types.js';
+import type {LaunchRunner, ProvisionerTemplate, TerminateRunners} from '#types.js';
 
 /** The API caps reservations per poll at 1000; never advertise a larger appetite. */
 const MAX_RESERVATIONS_PER_POLL = 1000;
@@ -23,6 +23,7 @@ export interface ProvisionerTickDeps<Spec> {
   readonly templates: readonly ProvisionerTemplate<Spec>[];
   readonly tracker: ProvisionedRunnerTracker;
   readonly launch: LaunchRunner<Spec>;
+  readonly terminate?: TerminateRunners;
   readonly buildRunnerEnv: RunnerEnvFactory<Spec>;
   readonly maxReservations: number;
   readonly waitSeconds: number;
@@ -77,6 +78,14 @@ export async function runProvisionerTick<Spec>(
     {wait_seconds: deps.waitSeconds, max_reservations: maxReservations, templates: advertisements},
     deps.signal ? {signal: deps.signal} : {},
   );
+
+  if (
+    response.terminate_provisioned_runner_ids.length > 0 &&
+    !deps.signal?.aborted &&
+    deps.terminate
+  ) {
+    await deps.terminate(response.terminate_provisioned_runner_ids);
+  }
 
   const planned = planLaunches({
     reservations: response.reservations.map((reservation) => ({

--- a/libs/provisioner/core/src/tick.ts
+++ b/libs/provisioner/core/src/tick.ts
@@ -1,4 +1,4 @@
-import {randomUUID} from 'node:crypto';
+import * as nodeCrypto from 'node:crypto';
 import type {
   DemandStatDto,
   MintRegistrationTokensBatchResponseDto,
@@ -12,6 +12,10 @@ import type {LaunchRunner, ProvisionerTemplate, TerminateRunners} from '#types.j
 
 /** The API caps reservations per poll at 1000; never advertise a larger appetite. */
 const MAX_RESERVATIONS_PER_POLL = 1000;
+
+const cryptoWithUuidV7 = nodeCrypto as typeof nodeCrypto & {
+  randomUUIDv7(): string;
+};
 
 export type RunnerEnvFactory<Spec> = (args: {
   template: ProvisionerTemplate<Spec>;
@@ -123,11 +127,11 @@ async function launchReservation<Spec>(
   deps: ProvisionerTickDeps<Spec>,
 ): Promise<{attempted: number; launched: number}> {
   // A fresh, never-reused id per runner: it binds the ephemeral registration token,
-  // names the resource, and keys idempotent reporting and reconciliation. Uniqueness is
-  // all the loop needs, so a random UUID suffices.
+  // names the resource, and keys idempotent reporting and reconciliation. UUIDv7 keeps
+  // generated ids time-ordered without adding a dependency.
   const plannedRunners = groups.flatMap((group) =>
     Array.from({length: group.count}, () => ({
-      provisionedRunnerId: randomUUID(),
+      provisionedRunnerId: cryptoWithUuidV7.randomUUIDv7(),
       template: group.template,
     })),
   );

--- a/libs/provisioner/core/src/types.ts
+++ b/libs/provisioner/core/src/types.ts
@@ -48,6 +48,9 @@ export interface ProvisionedRunnerLaunch<Spec = unknown> {
 /** Starts one provisioned runner. The provider implementation owns the side effect. */
 export type LaunchRunner<Spec = unknown> = (launch: ProvisionedRunnerLaunch<Spec>) => Promise<void>;
 
+/** Tears down provider resources by provisioned runner id when the backend requests it. */
+export type TerminateRunners = (provisionedRunnerIds: readonly string[]) => Promise<void>;
+
 export interface ProvisionerIdentity {
   readonly id: string;
   readonly workspaceId: string;
@@ -67,6 +70,7 @@ export interface ProvisionerRuntime {
 export interface ProvisionerAdapter<Spec = unknown> {
   loadTemplates(): Promise<readonly ProvisionerTemplate<Spec>[]>;
   readonly launch: LaunchRunner<Spec>;
+  readonly terminate?: TerminateRunners;
   onStart?(runtime: ProvisionerRuntime): Promise<void>;
   onTick?(): Promise<void>;
   onStop?(): Promise<void>;

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -231,6 +231,33 @@ describe('createDockerLifecycle', () => {
     expect(client.reconcileBodies).toEqual([{observed_provisioned_runner_ids: []}]);
   });
 
+  it('tick retries backend reconcile until the first success, then observes locally', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+    });
+    const client = fakeClient({
+      reconcileErrors: [new Error('api down')],
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provisioned_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.tick()).rejects.toThrow('api down');
+    expect(client.reconcileBodies).toHaveLength(1);
+    expect(client.reportBodies).toHaveLength(0);
+
+    await lifecycle.tick();
+    await lifecycle.tick();
+
+    expect(client.reconcileBodies).toHaveLength(2);
+    expect(client.reportBodies.map((body) => body.events[0]?.state)).toEqual([
+      'running',
+      'running',
+    ]);
+  });
+
   it('reconcile tears down backend terminate-intent containers', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'running'})],
@@ -546,6 +573,7 @@ function launch(): ProvisionedRunnerLaunch<DockerTemplateSpec> {
 function fakeClient(
   options: {
     reportErrors?: Error[];
+    reconcileErrors?: Error[];
     reconcileResponse?: ReconcileProvisionedRunnersResponseDto;
   } = {},
 ): ProvisionerClient & {
@@ -555,6 +583,7 @@ function fakeClient(
   const reportBodies: ReportProvisionedRunnersBodyDto[] = [];
   const reconcileBodies: ReconcileProvisionedRunnersBodyDto[] = [];
   const reportErrors = [...(options.reportErrors ?? [])];
+  const reconcileErrors = [...(options.reconcileErrors ?? [])];
   return {
     reportBodies,
     reconcileBodies,
@@ -574,6 +603,8 @@ function fakeClient(
     },
     reconcileProvisionedRunners: (body): Promise<ReconcileProvisionedRunnersResponseDto> => {
       reconcileBodies.push(body);
+      const error = reconcileErrors.shift();
+      if (error) return Promise.reject(error);
       return Promise.resolve(
         options.reconcileResponse ?? {
           runners: [],

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -116,6 +116,40 @@ describe('createDockerLifecycle', () => {
     });
   });
 
+  it('buffers non-400 report errors and still removes terminal containers', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const client = fakeClient({reportErrors: [httpError(409)]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+
+    expect(engine.removed).toEqual(['runner-1']);
+
+    await lifecycle.flush();
+
+    expect(client.reportBodies[1]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'failed',
+    });
+  });
+
+  it('does not report terminal state when Docker remove fails', async () => {
+    const error = new DockerEngineError('unknown', 'remove failed');
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 0})],
+      removeError: error,
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.observe()).rejects.toThrow(error);
+
+    expect(engine.removed).toEqual(['runner-1']);
+    expect(client.reportBodies).toEqual([]);
+  });
+
   it('buffers stale-created terminal reports and still kills containers when reporting transiently fails', async () => {
     const engine = fakeEngine({
       containers: [
@@ -218,6 +252,26 @@ describe('createDockerLifecycle', () => {
       reason: 'backend-terminate',
     });
     expect(engine.killedAndRemoved).toEqual(['runner-1']);
+  });
+
+  it('does not report backend terminate state when Docker kill fails', async () => {
+    const error = new DockerEngineError('unknown', 'kill failed');
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+      killAndRemoveError: error,
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provisioned_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await expect(lifecycle.reconcile()).rejects.toThrow(error);
+
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+    expect(client.reportBodies).toEqual([]);
   });
 
   it('reconcile adopts backend keep-intent live containers', async () => {
@@ -366,7 +420,7 @@ describe('createDockerLifecycle', () => {
     expect(client.reportBodies).toHaveLength(1);
   });
 
-  it('propagates auth failures from report delivery', async () => {
+  it('propagates auth failures from report delivery after local cleanup', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'exited', exitCode: 1})],
     });
@@ -376,7 +430,7 @@ describe('createDockerLifecycle', () => {
     });
 
     await expect(lifecycle.observe()).rejects.toThrow(ProvisionerAuthenticationError);
-    expect(engine.removed).toEqual([]);
+    expect(engine.removed).toEqual(['runner-1']);
   });
 
   it('preserves terminal reports over live reports when the retry queue overflows', async () => {
@@ -423,6 +477,23 @@ describe('createDockerLifecycle', () => {
   it('does not block container creation when the launch starting report is buffered', async () => {
     const engine = fakeEngine();
     const client = fakeClient({reportErrors: [new Error('api down')]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.launch(launch());
+
+    expect(engine.created).toHaveLength(1);
+
+    await lifecycle.flush();
+
+    expect(client.reportBodies[1]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'starting',
+    });
+  });
+
+  it('does not block container creation when the launch starting report gets a non-400 error', async () => {
+    const engine = fakeEngine();
+    const client = fakeClient({reportErrors: [httpError(429)]});
     const lifecycle = makeLifecycle({engine, client});
 
     await lifecycle.launch(launch());
@@ -514,7 +585,13 @@ function fakeClient(
 }
 
 function fakeEngine(
-  options: {containers?: DockerContainerView[]; createError?: Error; listError?: Error} = {},
+  options: {
+    containers?: DockerContainerView[];
+    createError?: Error;
+    listError?: Error;
+    removeError?: Error;
+    killAndRemoveError?: Error;
+  } = {},
 ): DockerEngine & {
   created: Parameters<DockerEngine['createAndStart']>[0][];
   removed: string[];
@@ -546,10 +623,12 @@ function fakeEngine(
     },
     remove: (name) => {
       removed.push(name);
+      if (options.removeError) return Promise.reject(options.removeError);
       return Promise.resolve();
     },
     killAndRemove: (name) => {
       killedAndRemoved.push(name);
+      if (options.killAndRemoveError) return Promise.reject(options.killAndRemoveError);
       return Promise.resolve();
     },
   };

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -358,6 +358,27 @@ describe('createDockerLifecycle', () => {
     ]);
   });
 
+  it('tick retries backend reconcile after an oversized observed set later fits the API limit', async () => {
+    const containers = Array.from({length: 5001}, (_, index) =>
+      container({name: `runner-${index}`, state: 'running'}),
+    );
+    const engine = fakeEngine({containers});
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provisioned_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.tick();
+    containers.splice(1);
+    await lifecycle.tick();
+    await lifecycle.tick();
+
+    expect(client.reconcileBodies).toEqual([{observed_provisioned_runner_ids: ['runner-0']}]);
+  });
+
   it('terminate kills and reports matching managed containers', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'running'}), container({name: 'runner-2', state: 'running'})],

--- a/libs/provisioner/docker/src/lifecycle.test.ts
+++ b/libs/provisioner/docker/src/lifecycle.test.ts
@@ -1,4 +1,6 @@
 import type {
+  ReconcileProvisionedRunnersBodyDto,
+  ReconcileProvisionedRunnersResponseDto,
   ReportProvisionedRunnersBodyDto,
   ReportProvisionedRunnersResponseDto,
 } from '@shipfox/api-runners-dto';
@@ -8,6 +10,7 @@ import type {
   ProvisionerClient,
   ProvisionerTemplate,
 } from '@shipfox/provisioner-core';
+import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
 import {type DockerContainerView, type DockerEngine, DockerEngineError} from '#docker-engine.js';
 import {createDockerLifecycle} from '#lifecycle.js';
 import type {DockerTemplateSpec} from '#templates.js';
@@ -94,19 +97,26 @@ describe('createDockerLifecycle', () => {
     expect(engine.removed).toEqual(['runner-1']);
   });
 
-  it('does not remove terminal containers when reporting fails', async () => {
+  it('buffers terminal reports and still removes containers when reporting transiently fails', async () => {
     const engine = fakeEngine({
       containers: [container({state: 'exited', exitCode: 1})],
     });
-    const client = fakeClient({reportError: new Error('api down')});
+    const client = fakeClient({reportErrors: [new Error('api down')]});
     const lifecycle = makeLifecycle({engine, client});
 
-    await expect(lifecycle.observe()).rejects.toThrow('api down');
+    await lifecycle.observe();
 
-    expect(engine.removed).toEqual([]);
+    expect(engine.removed).toEqual(['runner-1']);
+
+    await lifecycle.observe();
+
+    expect(client.reportBodies[1]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'failed',
+    });
   });
 
-  it('does not reap stale created containers when reporting fails', async () => {
+  it('buffers stale-created terminal reports and still kills containers when reporting transiently fails', async () => {
     const engine = fakeEngine({
       containers: [
         container({
@@ -115,12 +125,12 @@ describe('createDockerLifecycle', () => {
         }),
       ],
     });
-    const client = fakeClient({reportError: new Error('api down')});
+    const client = fakeClient({reportErrors: [new Error('api down')]});
     const lifecycle = makeLifecycle({engine, client, registrationDeadlineMs: 60_000});
 
-    await expect(lifecycle.observe()).rejects.toThrow('api down');
+    await lifecycle.observe();
 
-    expect(engine.killedAndRemoved).toEqual([]);
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
   });
 
   it('marks OOM exits as failed with an oom reason', async () => {
@@ -178,6 +188,156 @@ describe('createDockerLifecycle', () => {
     expect(tracker.countsByTemplate()).toEqual(new Map([['small', {starting: 1, running: 1}]]));
   });
 
+  it('reconcile submits deduped observed ids, including the empty set', async () => {
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([{observed_provisioned_runner_ids: []}]);
+  });
+
+  it('reconcile tears down backend terminate-intent containers', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'terminate')],
+        terminated_absent_provisioned_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies[0]).toEqual({observed_provisioned_runner_ids: ['runner-1']});
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'terminated',
+      reason: 'backend-terminate',
+    });
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+  });
+
+  it('reconcile adopts backend keep-intent live containers', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'running'})],
+    });
+    const tracker = testTracker();
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provisioned_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client, tracker});
+
+    await lifecycle.reconcile();
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'running',
+    });
+    expect(tracker.countsByTemplate()).toEqual(new Map([['small', {starting: 0, running: 1}]]));
+  });
+
+  it('reconcile keeps local terminal handling for backend keep-intent exited containers', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 0})],
+    });
+    const client = fakeClient({
+      reconcileResponse: {
+        runners: [reconciledRunner('runner-1', 'keep')],
+        terminated_absent_provisioned_runner_ids: [],
+      },
+    });
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({state: 'stopped'});
+    expect(engine.removed).toEqual(['runner-1']);
+  });
+
+  it('reconcile falls back to local observe when the observed id count exceeds the API limit', async () => {
+    const engine = fakeEngine({
+      containers: Array.from({length: 5001}, (_, index) =>
+        container({name: `runner-${index}`, state: 'running'}),
+      ),
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.reconcile();
+
+    expect(client.reconcileBodies).toEqual([]);
+    expect(client.reportBodies.map((body) => body.events.length)).toEqual([
+      1000, 1000, 1000, 1000, 1000, 1,
+    ]);
+  });
+
+  it('terminate kills and reports matching managed containers', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'running'}), container({name: 'runner-2', state: 'running'})],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.terminate(['runner-1']);
+
+    expect(client.reportBodies[0]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'terminated',
+      reason: 'backend-terminate',
+    });
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+  });
+
+  it('terminate is a true no-op when no managed container matches the id', async () => {
+    const engine = fakeEngine({
+      containers: [container({name: 'runner-2', state: 'running'})],
+    });
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.terminate(['runner-1']);
+
+    expect(engine.killedAndRemoved).toEqual([]);
+    expect(engine.removed).toEqual([]);
+  });
+
+  it('terminate still kills matching containers when labels are unresolvable', async () => {
+    const engine = fakeEngine({
+      containers: [
+        container({state: 'running', labels: {'shipfox.provisioned_runner_id': 'runner-1'}}),
+      ],
+    });
+    const client = fakeClient();
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.terminate(['runner-1']);
+
+    expect(client.reportBodies).toEqual([]);
+    expect(engine.killedAndRemoved).toEqual(['runner-1']);
+  });
+
+  it('terminate does not list Docker for an empty id set', async () => {
+    const engine = fakeEngine();
+    const lifecycle = makeLifecycle({engine});
+
+    await lifecycle.terminate([]);
+
+    expect(engine.listManagedCalls).toBe(0);
+  });
+
+  it('terminate propagates Docker list failures', async () => {
+    const lifecycle = makeLifecycle({
+      engine: fakeEngine({listError: new DockerEngineError('unknown', 'daemon down')}),
+    });
+
+    await expect(lifecycle.terminate(['runner-1'])).rejects.toThrow(DockerEngineError);
+  });
+
   it('chunks report batches at 1000 events', async () => {
     const engine = fakeEngine({
       containers: Array.from({length: 1001}, (_, index) =>
@@ -190,6 +350,91 @@ describe('createDockerLifecycle', () => {
     await lifecycle.observe();
 
     expect(client.reportBodies.map((body) => body.events.length)).toEqual([1000, 1]);
+  });
+
+  it('drops permanent 400 report batches instead of retrying them forever', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const client = fakeClient({reportErrors: [httpError(400)]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+    await lifecycle.flush();
+
+    expect(engine.removed).toEqual(['runner-1']);
+    expect(client.reportBodies).toHaveLength(1);
+  });
+
+  it('propagates auth failures from report delivery', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const lifecycle = makeLifecycle({
+      engine,
+      client: fakeClient({reportErrors: [new ProvisionerAuthenticationError(401)]}),
+    });
+
+    await expect(lifecycle.observe()).rejects.toThrow(ProvisionerAuthenticationError);
+    expect(engine.removed).toEqual([]);
+  });
+
+  it('preserves terminal reports over live reports when the retry queue overflows', async () => {
+    const engine = fakeEngine({
+      containers: [
+        ...Array.from({length: 5001}, (_, index) =>
+          container({name: `runner-${index}`, state: 'running'}),
+        ),
+        container({name: 'terminal-runner', state: 'exited', exitCode: 0}),
+      ],
+    });
+    const client = fakeClient({reportErrors: [new Error('api down'), new Error('api down')]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+    await lifecycle.flush();
+
+    expect(
+      client.reportBodies
+        .slice(2)
+        .flatMap((body) => body.events)
+        .some(
+          (event) => event.provisioned_runner_id === 'terminal-runner' && event.state === 'stopped',
+        ),
+    ).toBe(true);
+  });
+
+  it('flush drains buffered reports', async () => {
+    const engine = fakeEngine({
+      containers: [container({state: 'exited', exitCode: 1})],
+    });
+    const client = fakeClient({reportErrors: [new Error('api down')]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.observe();
+    await lifecycle.flush();
+
+    expect(client.reportBodies[1]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'failed',
+    });
+  });
+
+  it('does not block container creation when the launch starting report is buffered', async () => {
+    const engine = fakeEngine();
+    const client = fakeClient({reportErrors: [new Error('api down')]});
+    const lifecycle = makeLifecycle({engine, client});
+
+    await lifecycle.launch(launch());
+
+    expect(engine.created).toHaveLength(1);
+
+    await lifecycle.flush();
+
+    expect(client.reportBodies[1]?.events[0]).toMatchObject({
+      provisioned_runner_id: 'runner-1',
+      state: 'starting',
+    });
   });
 });
 
@@ -227,12 +472,21 @@ function launch(): ProvisionedRunnerLaunch<DockerTemplateSpec> {
   };
 }
 
-function fakeClient(options: {reportError?: Error} = {}): ProvisionerClient & {
+function fakeClient(
+  options: {
+    reportErrors?: Error[];
+    reconcileResponse?: ReconcileProvisionedRunnersResponseDto;
+  } = {},
+): ProvisionerClient & {
   reportBodies: ReportProvisionedRunnersBodyDto[];
+  reconcileBodies: ReconcileProvisionedRunnersBodyDto[];
 } {
   const reportBodies: ReportProvisionedRunnersBodyDto[] = [];
+  const reconcileBodies: ReconcileProvisionedRunnersBodyDto[] = [];
+  const reportErrors = [...(options.reportErrors ?? [])];
   return {
     reportBodies,
+    reconcileBodies,
     getIdentity: () =>
       Promise.resolve({
         id: '00000000-0000-4000-8000-000000000001',
@@ -243,34 +497,53 @@ function fakeClient(options: {reportError?: Error} = {}): ProvisionerClient & {
     mintRegistrationTokens: () => Promise.resolve({tokens: []}),
     reportProvisionedRunners: (body): Promise<ReportProvisionedRunnersResponseDto> => {
       reportBodies.push(body);
-      if (options.reportError) return Promise.reject(options.reportError);
+      const error = reportErrors.shift();
+      if (error) return Promise.reject(error);
       return Promise.resolve({accepted: body.events.length, reservations_released: 0});
+    },
+    reconcileProvisionedRunners: (body): Promise<ReconcileProvisionedRunnersResponseDto> => {
+      reconcileBodies.push(body);
+      return Promise.resolve(
+        options.reconcileResponse ?? {
+          runners: [],
+          terminated_absent_provisioned_runner_ids: [],
+        },
+      );
     },
   };
 }
 
 function fakeEngine(
-  options: {containers?: DockerContainerView[]; createError?: Error} = {},
+  options: {containers?: DockerContainerView[]; createError?: Error; listError?: Error} = {},
 ): DockerEngine & {
   created: Parameters<DockerEngine['createAndStart']>[0][];
   removed: string[];
   killedAndRemoved: string[];
+  listManagedCalls: number;
 } {
   const created: Parameters<DockerEngine['createAndStart']>[0][] = [];
   const removed: string[] = [];
   const killedAndRemoved: string[] = [];
+  let listManagedCalls = 0;
 
   return {
     created,
     removed,
     killedAndRemoved,
+    get listManagedCalls() {
+      return listManagedCalls;
+    },
     ensureImage: () => Promise.resolve(),
     createAndStart: (args) => {
       if (options.createError) return Promise.reject(options.createError);
       created.push(args);
       return Promise.resolve();
     },
-    listManaged: () => Promise.resolve(options.containers ?? []),
+    listManaged: () => {
+      listManagedCalls += 1;
+      if (options.listError) return Promise.reject(options.listError);
+      return Promise.resolve(options.containers ?? []);
+    },
     remove: (name) => {
       removed.push(name);
       return Promise.resolve();
@@ -322,12 +595,13 @@ function container(args: {
   exitCode?: number;
   oomKilled?: boolean;
   createdAt?: Date;
+  labels?: Readonly<Record<string, string>>;
 }): DockerContainerView {
   const name = args.name ?? 'runner-1';
   return {
     id: name,
     name,
-    labels: {
+    labels: args.labels ?? {
       'shipfox.provisioned_runner_id': name,
       'shipfox.provisioner_id': '00000000-0000-4000-8000-000000000001',
       'shipfox.reservation_id': RESERVATION_ID,
@@ -340,4 +614,22 @@ function container(args: {
     ...(args.oomKilled !== undefined ? {oomKilled: args.oomKilled} : {}),
     createdAt: args.createdAt ?? NOW,
   };
+}
+
+function reconciledRunner(
+  provisionedRunnerId: string,
+  desiredIntent: 'keep' | 'terminate',
+): ReconcileProvisionedRunnersResponseDto['runners'][number] {
+  return {
+    provisioned_runner_id: provisionedRunnerId,
+    state: 'running',
+    reservation_id: RESERVATION_ID,
+    runner_session_id: null,
+    bound_job: null,
+    desired_intent: desiredIntent,
+  };
+}
+
+function httpError(status: number): Error {
+  return Object.assign(new Error(`HTTP ${status}`), {response: {status}});
 }

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -1,4 +1,7 @@
-import type {ProvisionedRunnerReportEventDto} from '@shipfox/api-runners-dto';
+import {
+  MAX_RECONCILE_OBSERVED_RUNNERS,
+  type ProvisionedRunnerReportEventDto,
+} from '@shipfox/api-runners-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import type {
   ProvisionedRunnerLaunch,
@@ -7,13 +10,17 @@ import type {
   ProvisionerIdentity,
   ProvisionerTemplate,
 } from '@shipfox/provisioner-core';
+import {ProvisionerAuthenticationError} from '@shipfox/provisioner-core';
 import {buildContainerLabels, parseContainerIdentity} from '#container-identity.js';
 import {type DockerContainerView, type DockerEngine, DockerEngineError} from '#docker-engine.js';
 import {parseMemoryToBytes} from '#memory.js';
 import type {DockerTemplateSpec} from '#templates.js';
 
 const MAX_REPORT_BATCH = 1000;
+const MAX_PENDING_REPORTS = 5000;
 const MAX_REASON_LENGTH = 500;
+const REPORT_BACKLOG_LOG_EVERY_PASSES = 5;
+const EMPTY_TERMINATE_INTENT_IDS = new Set<string>();
 
 type TrackerSeed = {
   provisionedRunnerId: string;
@@ -25,6 +32,7 @@ export interface DockerLifecycle {
   launch(launch: ProvisionedRunnerLaunch<DockerTemplateSpec>): Promise<void>;
   observe(): Promise<void>;
   reconcile(): Promise<void>;
+  terminate(provisionedRunnerIds: readonly string[]): Promise<void>;
   flush(): Promise<void>;
 }
 
@@ -50,6 +58,8 @@ interface DockerLifecycleContext {
   readonly providerKind: string;
   readonly knownLiveIds: Set<string>;
   readonly knownTemplateKeys: Map<string, string>;
+  readonly pendingReports: ProvisionedRunnerReportEventDto[];
+  reportBacklogPasses: number;
 }
 
 interface ObservationPlan {
@@ -59,7 +69,8 @@ interface ObservationPlan {
 }
 
 interface TerminalAction {
-  readonly event: ProvisionedRunnerReportEventDto;
+  readonly provisionedRunnerId: string;
+  readonly event?: ProvisionedRunnerReportEventDto;
   readonly remove?: string;
   readonly killAndRemove?: string;
 }
@@ -83,13 +94,16 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     providerKind: args.providerKind,
     knownLiveIds: new Set<string>(),
     knownTemplateKeys: new Map<string, string>(),
+    pendingReports: [],
+    reportBacklogPasses: 0,
   };
 
   return {
     launch: (runner) => launch(context, runner),
     observe: () => observe(context),
-    reconcile: () => observe(context),
-    flush: () => Promise.resolve(),
+    reconcile: () => reconcile(context),
+    terminate: (ids) => terminate(context, ids),
+    flush: () => flush(context),
   };
 }
 
@@ -139,17 +153,80 @@ async function launch(
 }
 
 async function observe(context: DockerLifecycleContext): Promise<void> {
+  await reportEvents(context, []);
   const containers = await context.engine.listManaged(context.identity.id);
-  const plan = buildObservationPlan(context, containers);
+  await applyObservationPlan(
+    context,
+    buildObservationPlan(context, containers, EMPTY_TERMINATE_INTENT_IDS),
+  );
+  reportBacklogIfNeeded(context);
+}
 
-  context.tracker.replaceAll(plan.trackerRunners);
-  if (plan.liveEvents.length > 0) await reportEvents(context, plan.liveEvents);
-  await applyTerminalActions(context, plan.terminalActions);
+async function reconcile(context: DockerLifecycleContext): Promise<void> {
+  await reportEvents(context, []);
+  const containers = await context.engine.listManaged(context.identity.id);
+  const observedProvisionedRunnerIds = observedRunnerIds(containers);
+  if (observedProvisionedRunnerIds.length > MAX_RECONCILE_OBSERVED_RUNNERS) {
+    logger().error(
+      {
+        observedCount: observedProvisionedRunnerIds.length,
+        maxObserved: MAX_RECONCILE_OBSERVED_RUNNERS,
+      },
+      'Skipping backend reconcile because observed provisioned runner count exceeds the API limit',
+    );
+    await applyObservationPlan(
+      context,
+      buildObservationPlan(context, containers, EMPTY_TERMINATE_INTENT_IDS),
+    );
+    reportBacklogIfNeeded(context);
+    return;
+  }
+
+  const response = await context.client.reconcileProvisionedRunners({
+    observed_provisioned_runner_ids: observedProvisionedRunnerIds,
+  });
+  const terminateIntentIds = new Set(
+    response.runners
+      .filter((runner) => runner.desired_intent === 'terminate')
+      .map((runner) => runner.provisioned_runner_id),
+  );
+
+  if (response.terminated_absent_provisioned_runner_ids.length > 0) {
+    logger().info(
+      {provisionedRunnerIds: response.terminated_absent_provisioned_runner_ids},
+      'Backend terminated provisioned runners absent from Docker',
+    );
+  }
+
+  await applyObservationPlan(
+    context,
+    buildObservationPlan(context, containers, terminateIntentIds),
+  );
+  reportBacklogIfNeeded(context);
+}
+
+async function terminate(
+  context: DockerLifecycleContext,
+  provisionedRunnerIds: readonly string[],
+): Promise<void> {
+  if (provisionedRunnerIds.length === 0) return;
+
+  const ids = new Set(provisionedRunnerIds);
+  const containers = await context.engine.listManaged(context.identity.id);
+  const actions = containers.flatMap((container) => {
+    const parsed = parseContainerIdentity(container);
+    return ids.has(parsed.provisionedRunnerId)
+      ? [terminalActionFor(context, container, 'backend-terminate')]
+      : [];
+  });
+
+  await applyTerminalActions(context, actions);
 }
 
 function buildObservationPlan(
   context: DockerLifecycleContext,
   containers: readonly DockerContainerView[],
+  terminateIntentIds: ReadonlySet<string>,
 ): ObservationPlan {
   const listedIds = new Set<string>();
   const plan: ObservationPlan = {
@@ -159,7 +236,7 @@ function buildObservationPlan(
   };
 
   for (const container of containers) {
-    recordContainerObservation(context, plan, listedIds, container);
+    recordContainerObservation(context, plan, listedIds, container, terminateIntentIds);
   }
   synthesizeVanishedContainers(context, plan, listedIds);
 
@@ -171,9 +248,15 @@ function recordContainerObservation(
   plan: ObservationPlan,
   listedIds: Set<string>,
   container: DockerContainerView,
+  terminateIntentIds: ReadonlySet<string>,
 ): void {
   const parsed = parseContainerIdentity(container);
   listedIds.add(parsed.provisionedRunnerId);
+  if (terminateIntentIds.has(parsed.provisionedRunnerId)) {
+    plan.terminalActions.push(terminalActionFor(context, container, 'backend-terminate'));
+    return;
+  }
+
   const labels = labelsFor(context, parsed.templateKey, parsed.labels);
   if (labels.length === 0) {
     logger().warn(
@@ -187,10 +270,7 @@ function recordContainerObservation(
     container.state === 'created' &&
     isPastDeadline(container.createdAt, context.now(), context.registrationDeadlineMs)
   ) {
-    plan.terminalActions.push({
-      event: eventFor(container, 'terminated', labels, context.providerKind, context.now()),
-      killAndRemove: container.name,
-    });
+    plan.terminalActions.push(terminalActionFor(context, container, 'registration-deadline'));
     return;
   }
 
@@ -205,6 +285,7 @@ function recordContainerObservation(
   }
 
   plan.terminalActions.push({
+    provisionedRunnerId: parsed.provisionedRunnerId,
     event: eventFor(
       container,
       mapped.state,
@@ -254,6 +335,7 @@ function synthesizeVanishedContainers(
     const template = templateKey ? context.templatesByKey.get(templateKey) : undefined;
     if (!template) continue;
     plan.terminalActions.push({
+      provisionedRunnerId,
       event: {
         provisioned_runner_id: provisionedRunnerId,
         template_key: template.key,
@@ -266,17 +348,26 @@ function synthesizeVanishedContainers(
   }
 }
 
+async function applyObservationPlan(
+  context: DockerLifecycleContext,
+  plan: ObservationPlan,
+): Promise<void> {
+  context.tracker.replaceAll(plan.trackerRunners);
+  if (plan.liveEvents.length > 0) await reportEvents(context, plan.liveEvents);
+  await applyTerminalActions(context, plan.terminalActions);
+}
+
 async function applyTerminalActions(
   context: DockerLifecycleContext,
   actions: readonly TerminalAction[],
 ): Promise<void> {
   for (const action of actions) {
-    await reportEvents(context, [action.event]);
+    if (action.event) await reportEvents(context, [action.event]);
     if (action.killAndRemove) await context.engine.killAndRemove(action.killAndRemove);
     if (action.remove) await context.engine.remove(action.remove);
-    context.knownLiveIds.delete(action.event.provisioned_runner_id);
-    context.knownTemplateKeys.delete(action.event.provisioned_runner_id);
-    context.tracker.remove(action.event.provisioned_runner_id);
+    context.knownLiveIds.delete(action.provisionedRunnerId);
+    context.knownTemplateKeys.delete(action.provisionedRunnerId);
+    context.tracker.remove(action.provisionedRunnerId);
   }
 }
 
@@ -284,9 +375,143 @@ async function reportEvents(
   context: DockerLifecycleContext,
   events: readonly ProvisionedRunnerReportEventDto[],
 ): Promise<void> {
-  for (const batch of chunk(events, MAX_REPORT_BATCH)) {
-    await context.client.reportProvisionedRunners({events: batch});
+  const queued = context.pendingReports.splice(0);
+  const reports = [...queued, ...events];
+  if (reports.length === 0) return;
+
+  const batches = chunk(reports, MAX_REPORT_BATCH);
+  for (let index = 0; index < batches.length; index += 1) {
+    const batch = batches[index] ?? [];
+    try {
+      await context.client.reportProvisionedRunners({events: batch});
+    } catch (error) {
+      if (error instanceof ProvisionerAuthenticationError) {
+        bufferReports(context, [...batch, ...batches.slice(index + 1).flat()]);
+        throw error;
+      }
+      if (isPermanentReportError(error)) {
+        logger().error(
+          {err: error, count: batch.length},
+          'Dropping invalid provisioned runner report batch',
+        );
+        continue;
+      }
+      const unsent = [...batch, ...batches.slice(index + 1).flat()];
+      bufferReports(context, unsent);
+      if (isTransientReportError(error)) return;
+      throw error;
+    }
   }
+}
+
+async function flush(context: DockerLifecycleContext): Promise<void> {
+  try {
+    await reportEvents(context, []);
+  } catch (error) {
+    logger().error({err: error}, 'Failed to flush provisioned runner reports on shutdown');
+  }
+}
+
+function terminalActionFor(
+  context: DockerLifecycleContext,
+  container: DockerContainerView,
+  reason: string,
+): TerminalAction {
+  const parsed = parseContainerIdentity(container);
+  const labels = labelsFor(context, parsed.templateKey, parsed.labels);
+  if (labels.length === 0) {
+    logger().warn(
+      {provisionedRunnerId: parsed.provisionedRunnerId},
+      'Skipping provisioned runner report because labels are unavailable',
+    );
+    return {
+      provisionedRunnerId: parsed.provisionedRunnerId,
+      killAndRemove: container.name,
+    };
+  }
+
+  return {
+    provisionedRunnerId: parsed.provisionedRunnerId,
+    event: eventFor(container, 'terminated', labels, context.providerKind, context.now(), reason),
+    killAndRemove: container.name,
+  };
+}
+
+function observedRunnerIds(containers: readonly DockerContainerView[]): string[] {
+  return [
+    ...new Set(
+      containers.map((container) => parseContainerIdentity(container).provisionedRunnerId),
+    ),
+  ];
+}
+
+function bufferReports(
+  context: DockerLifecycleContext,
+  events: readonly ProvisionedRunnerReportEventDto[],
+): void {
+  context.pendingReports.push(...events);
+  if (context.pendingReports.length <= MAX_PENDING_REPORTS) return;
+
+  const overflow = context.pendingReports.length - MAX_PENDING_REPORTS;
+  let dropped = 0;
+  for (let index = 0; index < context.pendingReports.length && dropped < overflow; ) {
+    const event = context.pendingReports[index];
+    if (event && !isTerminalReportEvent(event)) {
+      context.pendingReports.splice(index, 1);
+      dropped += 1;
+      continue;
+    }
+    index += 1;
+  }
+  if (dropped < overflow) {
+    const remaining = overflow - dropped;
+    context.pendingReports.splice(0, remaining);
+    dropped += remaining;
+  }
+
+  if (dropped > 0) {
+    logger().warn(
+      {dropped, pending: context.pendingReports.length},
+      'Dropped buffered provisioned runner reports after retry queue overflow',
+    );
+  }
+}
+
+function reportBacklogIfNeeded(context: DockerLifecycleContext): void {
+  if (context.pendingReports.length === 0) {
+    context.reportBacklogPasses = 0;
+    return;
+  }
+
+  context.reportBacklogPasses += 1;
+  if (
+    context.reportBacklogPasses === 2 ||
+    context.reportBacklogPasses % REPORT_BACKLOG_LOG_EVERY_PASSES === 0
+  ) {
+    logger().error(
+      {pending: context.pendingReports.length},
+      'Provisioned-runner reports backing up',
+    );
+  }
+}
+
+function isTerminalReportEvent(event: ProvisionedRunnerReportEventDto): boolean {
+  return event.state === 'stopped' || event.state === 'failed' || event.state === 'terminated';
+}
+
+function isPermanentReportError(error: unknown): boolean {
+  return responseStatus(error) === 400;
+}
+
+function isTransientReportError(error: unknown): boolean {
+  const status = responseStatus(error);
+  return status === undefined || status >= 500;
+}
+
+function responseStatus(error: unknown): number | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const response = (error as Error & {response?: {status?: unknown}}).response;
+  return typeof response?.status === 'number' ? response.status : undefined;
 }
 
 function labelsFor(

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -362,9 +362,9 @@ async function applyTerminalActions(
   actions: readonly TerminalAction[],
 ): Promise<void> {
   for (const action of actions) {
-    if (action.event) await reportEvents(context, [action.event]);
     if (action.killAndRemove) await context.engine.killAndRemove(action.killAndRemove);
     if (action.remove) await context.engine.remove(action.remove);
+    if (action.event) await reportEvents(context, [action.event]);
     context.knownLiveIds.delete(action.provisionedRunnerId);
     context.knownTemplateKeys.delete(action.provisionedRunnerId);
     context.tracker.remove(action.provisionedRunnerId);
@@ -398,8 +398,7 @@ async function reportEvents(
       }
       const unsent = [...batch, ...batches.slice(index + 1).flat()];
       bufferReports(context, unsent);
-      if (isTransientReportError(error)) return;
-      throw error;
+      return;
     }
   }
 }
@@ -501,11 +500,6 @@ function isTerminalReportEvent(event: ProvisionedRunnerReportEventDto): boolean 
 
 function isPermanentReportError(error: unknown): boolean {
   return responseStatus(error) === 400;
-}
-
-function isTransientReportError(error: unknown): boolean {
-  const status = responseStatus(error);
-  return status === undefined || status >= 500;
 }
 
 function responseStatus(error: unknown): number | undefined {

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -175,7 +175,6 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
       'Skipping backend reconcile because observed provisioned runner count exceeds the API limit',
     );
     await applyObservedContainers(context, containers, EMPTY_TERMINATE_INTENT_IDS);
-    context.backendReconcileSucceeded = true;
     return;
   }
 

--- a/libs/provisioner/docker/src/lifecycle.ts
+++ b/libs/provisioner/docker/src/lifecycle.ts
@@ -32,6 +32,7 @@ export interface DockerLifecycle {
   launch(launch: ProvisionedRunnerLaunch<DockerTemplateSpec>): Promise<void>;
   observe(): Promise<void>;
   reconcile(): Promise<void>;
+  tick(): Promise<void>;
   terminate(provisionedRunnerIds: readonly string[]): Promise<void>;
   flush(): Promise<void>;
 }
@@ -59,6 +60,7 @@ interface DockerLifecycleContext {
   readonly knownLiveIds: Set<string>;
   readonly knownTemplateKeys: Map<string, string>;
   readonly pendingReports: ProvisionedRunnerReportEventDto[];
+  backendReconcileSucceeded: boolean;
   reportBacklogPasses: number;
 }
 
@@ -95,6 +97,7 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     knownLiveIds: new Set<string>(),
     knownTemplateKeys: new Map<string, string>(),
     pendingReports: [],
+    backendReconcileSucceeded: false,
     reportBacklogPasses: 0,
   };
 
@@ -102,6 +105,7 @@ export function createDockerLifecycle(args: DockerLifecycleOptions): DockerLifec
     launch: (runner) => launch(context, runner),
     observe: () => observe(context),
     reconcile: () => reconcile(context),
+    tick: () => tick(context),
     terminate: (ids) => terminate(context, ids),
     flush: () => flush(context),
   };
@@ -155,11 +159,7 @@ async function launch(
 async function observe(context: DockerLifecycleContext): Promise<void> {
   await reportEvents(context, []);
   const containers = await context.engine.listManaged(context.identity.id);
-  await applyObservationPlan(
-    context,
-    buildObservationPlan(context, containers, EMPTY_TERMINATE_INTENT_IDS),
-  );
-  reportBacklogIfNeeded(context);
+  await applyObservedContainers(context, containers, EMPTY_TERMINATE_INTENT_IDS);
 }
 
 async function reconcile(context: DockerLifecycleContext): Promise<void> {
@@ -174,11 +174,8 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
       },
       'Skipping backend reconcile because observed provisioned runner count exceeds the API limit',
     );
-    await applyObservationPlan(
-      context,
-      buildObservationPlan(context, containers, EMPTY_TERMINATE_INTENT_IDS),
-    );
-    reportBacklogIfNeeded(context);
+    await applyObservedContainers(context, containers, EMPTY_TERMINATE_INTENT_IDS);
+    context.backendReconcileSucceeded = true;
     return;
   }
 
@@ -198,11 +195,17 @@ async function reconcile(context: DockerLifecycleContext): Promise<void> {
     );
   }
 
-  await applyObservationPlan(
-    context,
-    buildObservationPlan(context, containers, terminateIntentIds),
-  );
-  reportBacklogIfNeeded(context);
+  await applyObservedContainers(context, containers, terminateIntentIds);
+  context.backendReconcileSucceeded = true;
+}
+
+async function tick(context: DockerLifecycleContext): Promise<void> {
+  if (context.backendReconcileSucceeded) {
+    await observe(context);
+    return;
+  }
+
+  await reconcile(context);
 }
 
 async function terminate(
@@ -355,6 +358,18 @@ async function applyObservationPlan(
   context.tracker.replaceAll(plan.trackerRunners);
   if (plan.liveEvents.length > 0) await reportEvents(context, plan.liveEvents);
   await applyTerminalActions(context, plan.terminalActions);
+}
+
+async function applyObservedContainers(
+  context: DockerLifecycleContext,
+  containers: readonly DockerContainerView[],
+  terminateIntentIds: ReadonlySet<string>,
+): Promise<void> {
+  await applyObservationPlan(
+    context,
+    buildObservationPlan(context, containers, terminateIntentIds),
+  );
+  reportBacklogIfNeeded(context);
 }
 
 async function applyTerminalActions(

--- a/libs/provisioner/docker/src/provisioner.ts
+++ b/libs/provisioner/docker/src/provisioner.ts
@@ -46,7 +46,7 @@ export function startDockerProvisioner(): Promise<void> {
       },
       onTick() {
         if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
-        return lifecycle.observe();
+        return lifecycle.tick();
       },
       onStop() {
         return lifecycle?.flush() ?? Promise.resolve();

--- a/libs/provisioner/docker/src/provisioner.ts
+++ b/libs/provisioner/docker/src/provisioner.ts
@@ -28,6 +28,10 @@ export function startDockerProvisioner(): Promise<void> {
         if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
         return lifecycle.launch(launch);
       },
+      terminate: (ids) => {
+        if (!lifecycle) throw new Error('Docker lifecycle has not been initialized.');
+        return lifecycle.terminate(ids);
+      },
       async onStart(runtime) {
         lifecycle = createDockerLifecycle({
           engine,


### PR DESCRIPTION
Make the Docker provisioner reconcile local containers against backend provisioned-runner intent on startup and during cancellation-driven teardown.

The previous Docker reconcile path was local-only: it could rebuild capacity from labeled containers after restart, but it could not distinguish useful work from containers the backend had already marked terminal or cancelled. This adds the backend reconcile call, consumes terminate intent from demand polling, and converges both paths on the same managed-container teardown flow.

Lifecycle reports now use a bounded in-memory retry queue so transient report outages do not block local cleanup. Authentication failures still propagate, permanent 400 report batches are dropped, and terminal reports are preserved ahead of live reports when the queue overflows.

Reviewers should look closely at the report buffering semantics in `libs/provisioner/docker/src/lifecycle.ts`, especially the decision to continue Docker cleanup after transient report failures.

Closes ENG-657

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles Docker runners with backend intent and hardens lifecycle reporting so transient API failures never block Docker teardown or launch. Implements ENG-657 by terminating backend‑cancelled runners on startup and in the main tick.

- **New Features**
  - Backend-aware reconcile: posts observed IDs; kills terminate‑intent, adopts keep‑intent; skips backend when observed count exceeds `MAX_RECONCILE_OBSERVED_RUNNERS` and keeps retrying until the set fits; retries on each tick until first success, then switches to local observe; new runners use UUIDv7 ids.
  - Cancellation handling: core tick consumes `terminate_provisioned_runner_ids` and calls an optional adapter terminate before mint/launch; adds `TerminateRunners` to `@shipfox/provisioner-core` and wires it to Docker lifecycle.
  - Teardown-first buffered lifecycle reporting in `@shipfox/provisioner-docker-provider`: report terminal states only after kill/remove; non‑auth, non‑400 errors are buffered and retried; 400s are dropped; auth errors propagate; bounded queue (5k) prioritizes terminal events; `flush` drains the queue.
  - Reporting limits and logs: batches chunked at 1000 events; backlog growth is logged; launch “starting” reports are buffered so container creation isn’t blocked.

<sup>Written for commit 6b6a7a258a7ebd22e246cfa66074a82bb54404f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

