### PR TITLE
[react-ui] Add switch component

### DIFF
--- a/.changeset/brisk-switches-toggle.md
+++ b/.changeset/brisk-switches-toggle.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds a Radix-based Switch component with size variants and Storybook coverage.

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -4,7 +4,7 @@ Shared React component library for Shipfox apps. It provides design tokens, Tail
 
 ## What it does
 
-- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, InlineTips, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Modal, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Table, Tabs, ThemeProvider, Toast, Tooltip, and Typography.
+- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, InlineTips, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Modal, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Switch, Table, Tabs, ThemeProvider, Toast, Tooltip, and Typography.
 - **Theme helpers**: `ThemeProvider`, `useTheme()`, and `useResolvedTheme()`.
 - **Hooks**: `useCopyToClipboard`, `useIsTextTruncated`, `useShikiHighlight`, `useShikiStyleInjection`, plus the theme hooks above.
 - **Utilities**: `cn()` for class name merging, `copyTextToClipboard`, `formatBytes`, `formatDate`/`formatTimestamp`, `formatDuration`/`humanDuration`, `formatRelative`, `debounce`, and avatar helpers (`getInitial`, `getPlaceholderImageUrl`).

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -56,6 +56,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.3.1",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@remixicon/react": "^4.6.0",

--- a/libs/shared/react/ui/src/components/index.ts
+++ b/libs/shared/react/ui/src/components/index.ts
@@ -34,6 +34,7 @@ export * from './select/index.js';
 export * from './sheet/index.js';
 export * from './shiny-text/index.js';
 export * from './skeleton/index.js';
+export * from './switch/index.js';
 export * from './table/index.js';
 export * from './tabs/index.js';
 export * from './theme/index.js';

--- a/libs/shared/react/ui/src/components/switch/index.ts
+++ b/libs/shared/react/ui/src/components/switch/index.ts
@@ -1,0 +1,1 @@
+export * from './switch.js';

--- a/libs/shared/react/ui/src/components/switch/switch.stories.tsx
+++ b/libs/shared/react/ui/src/components/switch/switch.stories.tsx
@@ -1,0 +1,103 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import type {ReactNode} from 'react';
+import {Label} from '#components/label/index.js';
+import {Text} from '#components/typography/index.js';
+import {Switch} from './switch.js';
+
+const meta = {
+  title: 'Components/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+    checked: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+  },
+  args: {
+    size: 'md',
+    disabled: false,
+  },
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => <Switch {...args} />,
+};
+
+const sizes = ['sm', 'md', 'lg'] as const;
+
+export const States: Story = {
+  render: () => (
+    <div className="flex flex-col gap-24">
+      {sizes.map((size) => (
+        <div key={size} className="grid grid-cols-[72px_repeat(5,88px)] items-center gap-12">
+          <Text size="sm" bold className="capitalize">
+            {size}
+          </Text>
+          <StatePreview label="Off">
+            <Switch size={size} />
+          </StatePreview>
+          <StatePreview label="On">
+            <Switch size={size} defaultChecked />
+          </StatePreview>
+          <StatePreview label="Focus">
+            <Switch size={size} className="focus" />
+          </StatePreview>
+          <StatePreview label="Disabled">
+            <Switch size={size} disabled />
+          </StatePreview>
+          <StatePreview label="Disabled on">
+            <Switch size={size} defaultChecked disabled />
+          </StatePreview>
+        </div>
+      ))}
+    </div>
+  ),
+  parameters: {
+    pseudo: {
+      focusVisible: '.focus',
+    },
+  },
+};
+
+export const Compositions: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16">
+      <div className="flex items-center gap-8">
+        <Switch id="notifications" />
+        <Label htmlFor="notifications">Enable notifications</Label>
+      </div>
+      <div className="flex items-center gap-8">
+        <Switch id="dark-mode" defaultChecked />
+        <Label htmlFor="dark-mode">Dark mode</Label>
+      </div>
+      <div className="flex items-center gap-8">
+        <Switch id="disabled-switch" disabled />
+        <Label htmlFor="disabled-switch" className="opacity-50">
+          Disabled option
+        </Label>
+      </div>
+    </div>
+  ),
+};
+
+function StatePreview({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <Text size="xs" className="text-foreground-neutral-muted">
+        {label}
+      </Text>
+      {children}
+    </div>
+  );
+}

--- a/libs/shared/react/ui/src/components/switch/switch.tsx
+++ b/libs/shared/react/ui/src/components/switch/switch.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import {cva, type VariantProps} from 'class-variance-authority';
+import type {ComponentProps} from 'react';
+import {cn} from '#utils/cn.js';
+
+export const switchVariants = cva(
+  'peer inline-flex shrink-0 cursor-pointer items-center rounded-full border-none transition-colors duration-200 outline-none',
+  {
+    variants: {
+      size: {
+        sm: 'h-20 w-36',
+        md: 'h-24 w-44',
+        lg: 'h-28 w-52',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+);
+
+export const switchThumbVariants = cva(
+  'pointer-events-none block rounded-full bg-white shadow-button-neutral transition-transform duration-200',
+  {
+    variants: {
+      size: {
+        sm: 'size-16 data-[state=checked]:translate-x-18 data-[state=unchecked]:translate-x-2',
+        md: 'size-20 data-[state=checked]:translate-x-22 data-[state=unchecked]:translate-x-2',
+        lg: 'size-24 data-[state=checked]:translate-x-26 data-[state=unchecked]:translate-x-2',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  },
+);
+
+export type SwitchProps = ComponentProps<typeof SwitchPrimitive.Root> &
+  VariantProps<typeof switchVariants>;
+
+export function Switch({className, size, ...props}: SwitchProps) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        switchVariants({size}),
+        'bg-background-switch-off hover:bg-background-switch-off-hover',
+        'data-[state=checked]:bg-checkbox-checked-bg data-[state=checked]:hover:bg-checkbox-checked-bg-hover',
+        'focus-visible:shadow-checkbox-unchecked-focus data-[state=checked]:focus-visible:shadow-checkbox-checked-focus',
+        'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb className={switchThumbVariants({size})} />
+    </SwitchPrimitive.Root>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4552,6 +4552,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-switch':
+        specifier: ^1.3.1
+        version: 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7831,6 +7834,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.3.1':
+    resolution: {integrity: sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tabs@1.1.15':
@@ -15852,6 +15868,21 @@ snapshots:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@radix-ui/react-switch@1.3.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-tabs@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:


### PR DESCRIPTION
Adds a Radix-based Switch component to the shared React UI package.

This gives client surfaces a reusable toggle primitive that follows the existing Shipfox token conventions for sizing, checked/unchecked state, focus treatment, disabled state, and Storybook visual coverage. The component is exported from the package barrel and includes a changeset for the new public API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Radix-based `Switch` component to `@shipfox/react-ui`, plus README listing. It provides a reusable toggle with size options and token-aligned states.

- **New Features**
  - New `Switch` built on `@radix-ui/react-switch` with `sm`, `md`, `lg` sizes.
  - Styled for on/off, focus, and disabled; smooth thumb transitions.
  - Exported via the package barrel and listed in the README; Storybook includes Playground, States, and Compositions.

- **Dependencies**
  - Add `@radix-ui/react-switch` ^1.3.1.

<sup>Written for commit 33de0eed2ab77798c803441212f291435aa576e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

