### PR TITLE
Add per-job checkout permission scoping

### DIFF
--- a/libs/api/integration/core-dto/src/contracts/index.ts
+++ b/libs/api/integration/core-dto/src/contracts/index.ts
@@ -1,5 +1,6 @@
 export type {
   CheckoutCredentials,
+  CheckoutPermissions,
   CheckoutSpec,
   CreateCheckoutSpecInput,
   FetchFileInput,

--- a/libs/api/integration/core-dto/src/contracts/integrations.ts
+++ b/libs/api/integration/core-dto/src/contracts/integrations.ts
@@ -87,6 +87,10 @@ export interface CheckoutCredentials {
   expiresAt: Date;
 }
 
+export interface CheckoutPermissions {
+  contents: 'read' | 'write';
+}
+
 export interface CheckoutSpec {
   /**
    * Clone URL that must never embed authentication material. Credentials live
@@ -97,12 +101,15 @@ export interface CheckoutSpec {
   repositoryUrl: string;
   ref: string;
   credentials?: CheckoutCredentials | undefined;
+  permissions?: CheckoutPermissions | undefined;
+  ephemeral?: boolean | undefined;
 }
 
 export interface CreateCheckoutSpecInput<
   Connection extends IntegrationConnection = IntegrationConnection,
 > extends ResolveRepositoryInput<Connection> {
   ref?: string | undefined;
+  permissions?: CheckoutPermissions | undefined;
 }
 
 export interface SourceControlProvider<

--- a/libs/api/integration/core/src/core/providers/source-control.ts
+++ b/libs/api/integration/core/src/core/providers/source-control.ts
@@ -1,5 +1,6 @@
 export type {
   CheckoutCredentials,
+  CheckoutPermissions,
   CheckoutSpec,
   CreateCheckoutSpecInput,
   FetchFileInput,

--- a/libs/api/integration/core/src/core/source-control-service.test.ts
+++ b/libs/api/integration/core/src/core/source-control-service.test.ts
@@ -177,6 +177,28 @@ describe('integration source-control service', () => {
     });
   });
 
+  it('forwards checkout permissions to the provider', async () => {
+    const createCheckoutSpec = vi.fn(async (input) => {
+      await Promise.resolve();
+      return {repositoryUrl: repository.cloneUrl, ref: input.ref ?? repository.defaultBranch};
+    });
+    const service = createService({createCheckoutSpec});
+
+    await service.createCheckoutSpec({
+      workspaceId,
+      connectionId: connection.id,
+      externalRepositoryId: 'debug:platform',
+      permissions: {contents: 'write'},
+    });
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      connection,
+      externalRepositoryId: 'debug:platform',
+      ref: undefined,
+      permissions: {contents: 'write'},
+    });
+  });
+
   it('rejects a checkout spec for a connection in another workspace', async () => {
     const service = createService();
 

--- a/libs/api/integration/core/src/core/source-control-service.ts
+++ b/libs/api/integration/core/src/core/source-control-service.ts
@@ -7,6 +7,7 @@ import {
 } from './errors.js';
 import type {IntegrationProviderRegistry} from './providers/registry.js';
 import type {
+  CheckoutPermissions,
   CheckoutSpec,
   FilePage,
   FileSnapshot,
@@ -50,6 +51,7 @@ export interface FetchSourceFileInput extends ResolveSourceRepositoryInput {
 
 export interface CreateSourceCheckoutSpecInput extends ResolveSourceRepositoryInput {
   ref?: string | undefined;
+  permissions?: CheckoutPermissions | undefined;
 }
 
 export interface ResolvedSourceRepository {
@@ -138,7 +140,7 @@ export function createSourceControlIntegrationService({
       });
     },
 
-    async createCheckoutSpec({workspaceId, connectionId, externalRepositoryId, ref}) {
+    async createCheckoutSpec({workspaceId, connectionId, externalRepositoryId, ref, permissions}) {
       const connection = await getConnection(connectionId);
       if (connection.workspaceId !== workspaceId) {
         throw new IntegrationConnectionWorkspaceMismatchError(connectionId);
@@ -152,6 +154,7 @@ export function createSourceControlIntegrationService({
         connection,
         externalRepositoryId,
         ref,
+        permissions,
       });
     },
   };

--- a/libs/api/integration/core/src/index.ts
+++ b/libs/api/integration/core/src/index.ts
@@ -56,6 +56,7 @@ export {redactCheckoutSpec} from '#core/providers/redact-checkout-spec.js';
 export type {IntegrationProviderRegistry} from '#core/providers/registry.js';
 export type {
   CheckoutCredentials,
+  CheckoutPermissions,
   CheckoutSpec,
   CreateCheckoutSpecInput,
   FetchFileInput,

--- a/libs/api/integration/gitea/src/core/source-control.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control.test.ts
@@ -290,7 +290,9 @@ describe('GiteaSourceControlProvider', () => {
           token: 'test-service-token',
           expiresAt: new Date('2026-06-20T00:05:00.000Z'),
         },
+        ephemeral: false,
       });
+      expect(result.permissions).toBeUndefined();
       const url = new URL(result.repositoryUrl);
       expect(url.username).toBe('');
       expect(url.password).toBe('');

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -159,6 +159,7 @@ export class GiteaSourceControlProvider
         token: config.GITEA_SERVICE_TOKEN,
         expiresAt: new Date(Date.now() + config.GITEA_CHECKOUT_TTL_SECONDS * 1000),
       },
+      ephemeral: false,
     };
   }
 }

--- a/libs/api/integration/github/README.md
+++ b/libs/api/integration/github/README.md
@@ -1,0 +1,12 @@
+# GitHub Integration
+
+## GitHub App permissions (self-hosting)
+
+Install the GitHub App with the smallest repository grant your workflows need:
+
+- **Contents**: use **Read-only** unless a workflow requests `checkout.permissions.contents: write`; use **Read and write** only for repositories where jobs must push.
+- **Metadata**: use **Read-only**. GitHub requires metadata access for installed apps.
+
+Do not grant **Workflows**, **Pull requests**, **Administration**, **Secrets**, **Actions**, or **Members** for checkout credentials.
+
+GitHub installation permissions are the ceiling for every per-job token. Shipfox can request a narrower repository-scoped token for a job, but GitHub rejects any requested permission outside the App installation grant. Withholding **Workflows** prevents a leaked checkout token from modifying CI definitions to reach Actions secrets.

--- a/libs/api/integration/github/src/api/client.test.ts
+++ b/libs/api/integration/github/src/api/client.test.ts
@@ -1,3 +1,4 @@
+import {RequestError} from 'octokit';
 import {GithubIntegrationProviderError} from '#core/errors.js';
 import {createGithubApiClient} from './client.js';
 
@@ -20,9 +21,35 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
     createInstallationAccessTokenMock.mockReset();
   });
 
-  it('mints a repository-scoped, read-only installation token', async () => {
+  function githubRequestError(status: number, message = 'GitHub denied the request') {
+    return Object.assign(
+      new RequestError(message, status, {
+        request: {
+          method: 'POST',
+          url: 'https://api.github.com/app/installations/1/access_tokens',
+          headers: {},
+        },
+        response: {
+          url: 'https://api.github.com/app/installations/1/access_tokens',
+          status,
+          headers: {},
+          data: {},
+        },
+      }),
+      {
+        status,
+        response: {headers: {}},
+      },
+    );
+  }
+
+  it('mints a repository-scoped, read-only installation token by default', async () => {
     createInstallationAccessTokenMock.mockResolvedValue({
-      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+      data: {
+        token: 'ghs_installationtoken',
+        expires_at: '2026-06-10T12:00:00.000Z',
+        permissions: {contents: 'read', metadata: 'read'},
+      },
     });
     const client = createGithubApiClient();
 
@@ -34,11 +61,67 @@ describe('OctokitGithubApiClient.createInstallationAccessToken', () => {
     expect(result).toEqual({
       token: 'ghs_installationtoken',
       expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+      permissions: {contents: 'read'},
     });
-    expect(createInstallationAccessTokenMock).toHaveBeenCalledWith({
+    const request = createInstallationAccessTokenMock.mock.calls[0]?.[0];
+    expect(request).toEqual({
       installation_id: 1,
       repository_ids: [42],
-      permissions: {contents: 'read'},
+      permissions: {contents: 'read', metadata: 'read'},
+    });
+    expect(request.permissions).not.toHaveProperty('workflows');
+  });
+
+  it('mints a repository-scoped write installation token when requested', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {
+        token: 'ghs_installationtoken',
+        expires_at: '2026-06-10T12:00:00.000Z',
+        permissions: {contents: 'write', metadata: 'read'},
+      },
+    });
+    const client = createGithubApiClient();
+
+    const result = await client.createInstallationAccessToken({
+      installationId: 1,
+      repositoryId: 42,
+      contents: 'write',
+    });
+
+    expect(result.permissions).toEqual({contents: 'write'});
+    const request = createInstallationAccessTokenMock.mock.calls[0]?.[0];
+    expect(request.permissions).toEqual({contents: 'write', metadata: 'read'});
+    expect(request.permissions).not.toHaveProperty('workflows');
+  });
+
+  it('omits granted permissions when GitHub does not report them', async () => {
+    createInstallationAccessTokenMock.mockResolvedValue({
+      data: {token: 'ghs_installationtoken', expires_at: '2026-06-10T12:00:00.000Z'},
+    });
+    const client = createGithubApiClient();
+
+    const result = await client.createInstallationAccessToken({
+      installationId: 1,
+      repositoryId: 42,
+      contents: 'write',
+    });
+
+    expect(result.permissions).toBeUndefined();
+  });
+
+  it.each([403, 422])('maps GitHub %s write token denial to access-denied', async (status) => {
+    createInstallationAccessTokenMock.mockRejectedValue(githubRequestError(status));
+    const client = createGithubApiClient();
+
+    const result = client.createInstallationAccessToken({
+      installationId: 1,
+      repositoryId: 42,
+      contents: 'write',
+    });
+
+    await expect(result).rejects.toMatchObject({
+      reason: 'access-denied',
+      message: 'GitHub installation does not grant write access to repository contents',
     });
   });
 

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -1,5 +1,8 @@
 import {Buffer} from 'node:buffer';
-import {MAX_REPOSITORY_FILE_BYTES} from '@shipfox/api-integration-core-dto';
+import {
+  type CheckoutPermissions,
+  MAX_REPOSITORY_FILE_BYTES,
+} from '@shipfox/api-integration-core-dto';
 import ky, {HTTPError, TimeoutError} from 'ky';
 import {App, Octokit, RequestError} from 'octokit';
 import {config, normalizedGithubPrivateKey} from '#config.js';
@@ -91,12 +94,14 @@ export interface GithubApiClient {
   createInstallationAccessToken(input: {
     installationId: number;
     repositoryId: number;
+    contents?: CheckoutPermissions['contents'] | undefined;
   }): Promise<GithubInstallationAccessToken>;
 }
 
 export interface GithubInstallationAccessToken {
   token: string;
   expiresAt: Date;
+  permissions?: CheckoutPermissions | undefined;
 }
 
 export function createGithubApiClient(): GithubApiClient {
@@ -341,13 +346,20 @@ class OctokitGithubApiClient implements GithubApiClient {
   async createInstallationAccessToken(input: {
     installationId: number;
     repositoryId: number;
+    contents?: CheckoutPermissions['contents'] | undefined;
   }): Promise<GithubInstallationAccessToken> {
-    const response = await mapGithubError(() =>
-      this.getApp().octokit.rest.apps.createInstallationAccessToken({
-        installation_id: input.installationId,
-        repository_ids: [input.repositoryId],
-        permissions: {contents: 'read'},
-      }),
+    const contents = input.contents ?? 'read';
+    const response = await mapGithubError(
+      () =>
+        this.getApp().octokit.rest.apps.createInstallationAccessToken({
+          installation_id: input.installationId,
+          repository_ids: [input.repositoryId],
+          permissions: {contents, metadata: 'read'},
+        }),
+      'repository-not-found',
+      contents === 'write'
+        ? 'GitHub installation does not grant write access to repository contents'
+        : undefined,
     );
 
     if (typeof response.data.token !== 'string') {
@@ -365,9 +377,12 @@ class OctokitGithubApiClient implements GithubApiClient {
       );
     }
 
+    const grantedPermissions = toCheckoutPermissions(response.data.permissions);
+
     return {
       token: response.data.token,
       expiresAt,
+      ...(grantedPermissions ? {permissions: grantedPermissions} : {}),
     };
   }
 
@@ -415,6 +430,7 @@ async function mapGithubOAuthError<T>(operation: () => Promise<T>): Promise<T> {
 async function mapGithubError<T>(
   operation: () => Promise<T>,
   notFoundReason: 'repository-not-found' | 'file-not-found' = 'repository-not-found',
+  accessDeniedMessage?: string | undefined,
 ): Promise<T> {
   try {
     return await operation();
@@ -431,10 +447,10 @@ async function mapGithubError<T>(
           retryAfterSeconds(error),
         );
       }
-      if (error.status === 401 || error.status === 403) {
+      if (error.status === 401 || error.status === 403 || error.status === 422) {
         throw new GithubIntegrationProviderError(
           'access-denied',
-          error.message,
+          accessDeniedMessage ?? error.message,
           retryAfterSeconds(error),
         );
       }
@@ -447,6 +463,12 @@ async function mapGithubError<T>(
     }
     throw error;
   }
+}
+
+function toCheckoutPermissions(value: unknown): CheckoutPermissions | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const contents = (value as {contents?: unknown}).contents;
+  return contents === 'read' || contents === 'write' ? {contents} : undefined;
 }
 
 function isGithubRateLimitError(error: RequestError): boolean {

--- a/libs/api/integration/github/src/api/client.ts
+++ b/libs/api/integration/github/src/api/client.ts
@@ -447,7 +447,14 @@ async function mapGithubError<T>(
           retryAfterSeconds(error),
         );
       }
-      if (error.status === 401 || error.status === 403 || error.status === 422) {
+      if (error.status === 401) {
+        throw new GithubIntegrationProviderError(
+          'access-denied',
+          error.message,
+          retryAfterSeconds(error),
+        );
+      }
+      if (error.status === 403 || error.status === 422) {
         throw new GithubIntegrationProviderError(
           'access-denied',
           accessDeniedMessage ?? error.message,

--- a/libs/api/integration/github/src/core/source-control.test.ts
+++ b/libs/api/integration/github/src/core/source-control.test.ts
@@ -58,6 +58,7 @@ function githubClient(overrides: Partial<GithubApiClient> = {}): GithubApiClient
       Promise.resolve({
         token: 'ghs_installationtoken',
         expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+        permissions: {contents: 'read' as const},
       }),
     ),
     ...overrides,
@@ -266,12 +267,65 @@ describe('GithubSourceControlProvider', () => {
         token: 'ghs_installationtoken',
         expiresAt: new Date('2026-06-10T12:00:00.000Z'),
       },
+      permissions: {contents: 'read'},
+      ephemeral: true,
     });
     expect(result.repositoryUrl).not.toContain('ghs_installationtoken');
     expect(github.createInstallationAccessToken).toHaveBeenCalledWith({
       installationId,
       repositoryId: 42,
+      contents: 'read',
     });
+  });
+
+  it('requests write checkout credentials when the job asks for contents write', async () => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'ghs_installationtoken',
+          expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+          permissions: {contents: 'write' as const},
+        }),
+      ),
+    });
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = await provider.createCheckoutSpec({
+      connection: connection(),
+      externalRepositoryId: 'github:42',
+      permissions: {contents: 'write'},
+    });
+
+    expect(result.permissions).toEqual({contents: 'write'});
+    expect(result.ephemeral).toBe(true);
+    expect(github.createInstallationAccessToken).toHaveBeenCalledWith({
+      installationId,
+      repositoryId: 42,
+      contents: 'write',
+    });
+  });
+
+  it('omits checkout permissions when the token response did not prove the grant', async () => {
+    await createInstallation();
+    const github = githubClient({
+      createInstallationAccessToken: vi.fn(() =>
+        Promise.resolve({
+          token: 'ghs_installationtoken',
+          expiresAt: new Date('2026-06-10T12:00:00.000Z'),
+        }),
+      ),
+    });
+    const provider = new GithubSourceControlProvider(github);
+
+    const result = await provider.createCheckoutSpec({
+      connection: connection(),
+      externalRepositoryId: 'github:42',
+      permissions: {contents: 'write'},
+    });
+
+    expect(result.permissions).toBeUndefined();
+    expect(result.ephemeral).toBe(true);
   });
 
   it('defaults the checkout ref to the repository default branch', async () => {

--- a/libs/api/integration/github/src/core/source-control.ts
+++ b/libs/api/integration/github/src/core/source-control.ts
@@ -148,15 +148,19 @@ export class GithubSourceControlProvider
     const {repositoryId} = parseGithubRepositoryLocator(input.externalRepositoryId);
     const repository = await this.github.getRepository({installationId, repositoryId});
     const ref = input.ref?.trim() || repository.defaultBranch;
-    const {token, expiresAt} = await this.github.createInstallationAccessToken({
+    const contents = input.permissions?.contents ?? 'read';
+    const {token, expiresAt, permissions} = await this.github.createInstallationAccessToken({
       installationId,
       repositoryId,
+      contents,
     });
 
     return {
       repositoryUrl: repository.cloneUrl,
       ref,
       credentials: {username: 'x-access-token', token, expiresAt},
+      ...(permissions ? {permissions} : {}),
+      ephemeral: true,
     };
   }
 

--- a/libs/api/workflows-dto/src/schemas/checkout-token.test.ts
+++ b/libs/api/workflows-dto/src/schemas/checkout-token.test.ts
@@ -43,6 +43,27 @@ describe('checkoutTokenResponseSchema', () => {
     expect(result.auth).toBeUndefined();
   });
 
+  it('accepts granted checkout permissions and ephemeral metadata', () => {
+    const input = {
+      ...basicResponse,
+      permissions: {contents: 'write'},
+      ephemeral: true,
+    };
+
+    const result = checkoutTokenResponseSchema.parse(input);
+
+    expect(result.permissions).toEqual({contents: 'write'});
+    expect(result.ephemeral).toBe(true);
+  });
+
+  it('rejects an unknown checkout permission level', () => {
+    const input = {...basicResponse, permissions: {contents: 'admin'}};
+
+    const parse = () => checkoutTokenResponseSchema.parse(input);
+
+    expect(parse).toThrow();
+  });
+
   it('rejects basic auth missing a username', () => {
     const {username: _username, ...basicAuthWithoutUsername} = basicResponse.auth;
     const input = {...basicResponse, auth: basicAuthWithoutUsername};

--- a/libs/api/workflows-dto/src/schemas/checkout-token.ts
+++ b/libs/api/workflows-dto/src/schemas/checkout-token.ts
@@ -20,12 +20,18 @@ export const checkoutTokenAuthSchema = z.discriminatedUnion('kind', [
 
 export type CheckoutTokenAuthDto = z.infer<typeof checkoutTokenAuthSchema>;
 
+export const checkoutTokenPermissionsSchema = z.object({
+  contents: z.enum(['read', 'write']),
+});
+
 export const checkoutTokenResponseSchema = z.object({
   repository_url: z.string().min(1),
   ref: z.string().min(1),
   // Optional: credential-free providers (e.g. the debug source control) return a
   // public clone URL with no auth material, so the runner clones without a token.
   auth: checkoutTokenAuthSchema.optional(),
+  permissions: checkoutTokenPermissionsSchema.optional(),
+  ephemeral: z.boolean().optional(),
 });
 
 export type CheckoutTokenResponseDto = z.infer<typeof checkoutTokenResponseSchema>;

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -63,6 +63,7 @@ CREATE TABLE "workflows_jobs" (
 	"listening_until" jsonb,
 	"dependencies" jsonb NOT NULL,
 	"runner" jsonb,
+	"checkout" jsonb,
 	"position" integer NOT NULL,
 	"version" integer DEFAULT 1 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -426,6 +426,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "checkout": {
+          "name": "checkout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "position": {
           "name": "position",
           "type": "integer",

--- a/libs/api/workflows/src/core/checkout.test.ts
+++ b/libs/api/workflows/src/core/checkout.test.ts
@@ -1,5 +1,8 @@
 import type {CheckoutSpec, IntegrationSourceControlService} from '@shipfox/api-integration-core';
 import {getProjectById} from '@shipfox/api-projects';
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {jobs} from '#db/schema/jobs.js';
 import * as workflowRuns from '#db/workflow-runs.js';
 import {jobFactory} from '#test/factories/job.js';
 import {projectFactory} from '#test/factories/project.js';
@@ -25,6 +28,7 @@ describe('resolveCheckoutIntent', () => {
       workspaceId: project.workspaceId,
       connectionId: project.sourceConnectionId,
       externalRepositoryId: project.sourceExternalRepositoryId,
+      permissions: {contents: 'read'},
     });
   });
 
@@ -86,6 +90,73 @@ describe('createJobCheckoutSpec', () => {
       connectionId: project.sourceConnectionId,
       externalRepositoryId: project.sourceExternalRepositoryId,
       ref: undefined,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('passes the persisted job checkout permissions to the service', async () => {
+    const project = projectFactory.build();
+    mockGetProjectById.mockResolvedValue(project);
+    const job = await jobFactory.create({}, {transient: {projectId: project.id}});
+    await db()
+      .update(jobs)
+      .set({checkout: {permissions: {contents: 'write'}, persistCredentials: true}})
+      .where(eq(jobs.id, job.id));
+    const spec: CheckoutSpec = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main'};
+    const createCheckoutSpec = vi.fn().mockResolvedValue(spec);
+    const sourceControl = {createCheckoutSpec} as unknown as IntegrationSourceControlService;
+
+    await createJobCheckoutSpec({jobId: job.id, sourceControl});
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ref: undefined,
+      permissions: {contents: 'write'},
+    });
+  });
+
+  it('defaults null checkout rows to read permissions', async () => {
+    const project = projectFactory.build();
+    mockGetProjectById.mockResolvedValue(project);
+    const job = await jobFactory.create({}, {transient: {projectId: project.id}});
+    await db().update(jobs).set({checkout: null}).where(eq(jobs.id, job.id));
+    const spec: CheckoutSpec = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main'};
+    const createCheckoutSpec = vi.fn().mockResolvedValue(spec);
+    const sourceControl = {createCheckoutSpec} as unknown as IntegrationSourceControlService;
+
+    await createJobCheckoutSpec({jobId: job.id, sourceControl});
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ref: undefined,
+      permissions: {contents: 'read'},
+    });
+  });
+
+  it('fails malformed checkout rows safe to read permissions', async () => {
+    const project = projectFactory.build();
+    mockGetProjectById.mockResolvedValue(project);
+    const job = await jobFactory.create({}, {transient: {projectId: project.id}});
+    await db()
+      .update(jobs)
+      .set({checkout: {permissions: {contents: 'admin'}, persistCredentials: true} as never})
+      .where(eq(jobs.id, job.id));
+    const spec: CheckoutSpec = {repositoryUrl: 'https://github.com/acme/repo.git', ref: 'main'};
+    const createCheckoutSpec = vi.fn().mockResolvedValue(spec);
+    const sourceControl = {createCheckoutSpec} as unknown as IntegrationSourceControlService;
+
+    await createJobCheckoutSpec({jobId: job.id, sourceControl});
+
+    expect(createCheckoutSpec).toHaveBeenCalledWith({
+      workspaceId: project.workspaceId,
+      connectionId: project.sourceConnectionId,
+      externalRepositoryId: project.sourceExternalRepositoryId,
+      ref: undefined,
+      permissions: {contents: 'read'},
     });
   });
 });

--- a/libs/api/workflows/src/core/checkout.ts
+++ b/libs/api/workflows/src/core/checkout.ts
@@ -1,4 +1,8 @@
-import type {CheckoutSpec, IntegrationSourceControlService} from '@shipfox/api-integration-core';
+import type {
+  CheckoutPermissions,
+  CheckoutSpec,
+  IntegrationSourceControlService,
+} from '@shipfox/api-integration-core';
 import {getProjectById} from '@shipfox/api-projects';
 import {getJobById, getWorkflowRunByAttemptId} from '#db/workflow-runs.js';
 import {
@@ -11,12 +15,14 @@ export interface CheckoutIntent {
   workspaceId: string;
   connectionId: string;
   externalRepositoryId: string;
+  permissions: CheckoutPermissions;
 }
 
 /**
  * Resolves what to check out for a job, keyed off the authoritative `jobId`
  * (`workflowRunId`/`workflowRunAttemptId`/`workspaceId` in the lease claim are informational).
- * Chain: job → attempt → run → project source metadata. Credential-free.
+ * Chain: job → attempt → run → project source metadata. Credential-free; the
+ * returned intent carries only the job's requested checkout permission level.
  */
 export async function resolveCheckoutIntent(jobId: string): Promise<CheckoutIntent> {
   const job = await getJobById(jobId);
@@ -32,13 +38,14 @@ export async function resolveCheckoutIntent(jobId: string): Promise<CheckoutInte
     workspaceId: project.workspaceId,
     connectionId: project.sourceConnectionId,
     externalRepositoryId: project.sourceExternalRepositoryId,
+    permissions: job.checkout?.permissions ?? {contents: 'read'},
   };
 }
 
 /**
- * Resolves the job's checkout intent and exchanges it for a short-lived,
- * read-only checkout spec. `ref` is left undefined so the provider defaults to
- * the repository's default branch.
+ * Resolves the job's checkout intent and exchanges it for a provider checkout
+ * spec. `ref` is left undefined so the provider defaults to the repository's
+ * default branch.
  */
 export async function createJobCheckoutSpec({
   jobId,
@@ -53,5 +60,6 @@ export async function createJobCheckoutSpec({
     connectionId: intent.connectionId,
     externalRepositoryId: intent.externalRepositoryId,
     ref: undefined,
+    permissions: intent.permissions,
   });
 }

--- a/libs/api/workflows/src/core/entities/job.ts
+++ b/libs/api/workflows/src/core/entities/job.ts
@@ -1,3 +1,5 @@
+import type {WorkflowModelJobCheckout} from '@shipfox/api-definitions';
+
 export type JobStatus = 'pending' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'skipped';
 
 export type JobMode = 'one_shot' | 'listening';
@@ -44,6 +46,7 @@ export interface Job {
   listeningUntil: JobListeningTrigger[] | null;
   dependencies: string[];
   runner: string[] | null;
+  checkout: WorkflowModelJobCheckout | null;
   position: number;
   version: number;
   createdAt: Date;

--- a/libs/api/workflows/src/db/schema/jobs.ts
+++ b/libs/api/workflows/src/db/schema/jobs.ts
@@ -1,3 +1,4 @@
+import {DEFAULT_JOB_CHECKOUT, type WorkflowModelJobCheckout} from '@shipfox/api-definitions';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {
   bigint,
@@ -74,6 +75,7 @@ export const jobs = pgTable(
     listeningUntil: jsonb('listening_until').$type<JobListeningTrigger[]>(),
     dependencies: jsonb('dependencies').notNull().$type<string[]>(),
     runner: jsonb('runner').$type<string[]>(),
+    checkout: jsonb('checkout').$type<WorkflowModelJobCheckout>(),
     position: integer('position').notNull(),
     version: integer('version').notNull().default(1),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
@@ -109,9 +111,30 @@ export function toJob(row: JobDb): Job {
     listeningUntil: row.listeningUntil,
     dependencies: row.dependencies as string[],
     runner: row.runner as string[] | null,
+    checkout: toJobCheckout(row.checkout),
     position: row.position,
     version: row.version,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+  };
+}
+
+function toJobCheckout(value: unknown): WorkflowModelJobCheckout | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'object') return DEFAULT_JOB_CHECKOUT;
+
+  const checkout = value as {
+    permissions?: {contents?: unknown};
+    persistCredentials?: unknown;
+  };
+  const contents = checkout.permissions?.contents;
+  const persistCredentials = checkout.persistCredentials;
+  if ((contents !== 'read' && contents !== 'write') || typeof persistCredentials !== 'boolean') {
+    return DEFAULT_JOB_CHECKOUT;
+  }
+
+  return {
+    permissions: {contents},
+    persistCredentials,
   };
 }

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -308,6 +308,38 @@ describe('workflow run queries', () => {
       expect(buildSteps.filter((step) => step.type !== 'setup')).toHaveLength(1);
     });
 
+    test('persists job checkout config', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              checkout: {
+                permissions: {contents: 'write'},
+                persistCredentials: false,
+              },
+              steps: [{run: 'echo build'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const [job] = await getJobsByWorkflowRunId(run.id);
+
+      expect(job?.checkout).toEqual({
+        permissions: {contents: 'write'},
+        persistCredentials: false,
+      });
+    });
+
     test('writes workflows.workflow_run_attempt.created outbox event in same transaction', async () => {
       const run = await createWorkflowRun({
         workspaceId,
@@ -1082,6 +1114,51 @@ jobs:
         expect(jobSteps.every((step) => step.status === 'pending')).toBe(true);
         expect(jobSteps.every((step) => step.output === null && step.error === null)).toBe(true);
       }
+    });
+
+    test('reruns preserve job checkout config', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              checkout: {
+                permissions: {contents: 'write'},
+                persistCredentials: false,
+              },
+              steps: [{run: 'echo build'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const sourceJobs = await getJobsByWorkflowRunId(source.id);
+      await markJob(sourceJobs, 'build', 'failed');
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const jobsAfterRerun = await getJobsByWorkflowRunId(source.id);
+      const rerunJob = jobsAfterRerun.find((job) => job.version === 1 && job.status === 'pending');
+      expect(rerunJob?.checkout).toEqual({
+        permissions: {contents: 'write'},
+        persistCredentials: false,
+      });
     });
 
     test('reruns preserve the original resolved agent step config', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -200,6 +200,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
             listeningUntil: job.listening?.until ? [...job.listening.until] : null,
             dependencies: [...job.dependencies],
             runner: job.runner.length === 0 ? null : [...job.runner],
+            checkout: job.checkout,
             position: job.position,
           })),
         )
@@ -451,6 +452,7 @@ export async function createRerunWorkflowRun(
                   listeningUntil: job.listeningUntil ? [...job.listeningUntil] : null,
                   dependencies: [...job.dependencies],
                   runner: job.runner ? [...job.runner] : null,
+                  checkout: job.checkout,
                   position: job.position,
                 };
               }),

--- a/libs/api/workflows/src/presentation/dto/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/dto/checkout-token.test.ts
@@ -11,6 +11,8 @@ describe('toCheckoutTokenDto', () => {
         token: 'ghs-token',
         expiresAt: new Date('2026-06-10T12:00:00.000Z'),
       },
+      permissions: {contents: 'write'},
+      ephemeral: true,
     };
 
     const dto = toCheckoutTokenDto(spec);
@@ -24,6 +26,8 @@ describe('toCheckoutTokenDto', () => {
         token: 'ghs-token',
         expires_at: '2026-06-10T12:00:00.000Z',
       },
+      permissions: {contents: 'write'},
+      ephemeral: true,
     });
   });
 
@@ -34,6 +38,8 @@ describe('toCheckoutTokenDto', () => {
 
     expect(dto).toEqual({repository_url: 'https://example.com/acme/repo.git', ref: 'trunk'});
     expect(dto.auth).toBeUndefined();
+    expect(dto.permissions).toBeUndefined();
+    expect(dto.ephemeral).toBeUndefined();
   });
 
   it('rejects a repository URL that embeds credentials', () => {

--- a/libs/api/workflows/src/presentation/dto/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/dto/checkout-token.ts
@@ -56,5 +56,7 @@ export function toCheckoutTokenDto(spec: CheckoutSpec): CheckoutTokenResponseDto
           },
         }
       : {}),
+    ...(spec.permissions ? {permissions: spec.permissions} : {}),
+    ...(spec.ephemeral === undefined ? {} : {ephemeral: spec.ephemeral}),
   };
 }

--- a/libs/api/workflows/src/presentation/dto/job.test.ts
+++ b/libs/api/workflows/src/presentation/dto/job.test.ts
@@ -65,6 +65,7 @@ function jobEntity(overrides: Partial<Job> = {}): Job {
     listeningUntil: null,
     dependencies: [],
     runner: null,
+    checkout: null,
     position: 0,
     version: 1,
     createdAt: new Date('2026-06-25T00:00:00.000Z'),

--- a/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.test.ts
@@ -27,6 +27,12 @@ const githubSpec = (token: string): CheckoutSpec => ({
   credentials: {username: 'x-access-token', token, expiresAt: new Date('2026-06-10T12:00:00.000Z')},
 });
 
+const githubWriteSpec = (token: string): CheckoutSpec => ({
+  ...githubSpec(token),
+  permissions: {contents: 'write'},
+  ephemeral: true,
+});
+
 describe('POST /runs/jobs/current/checkout-token', () => {
   let app: FastifyInstance;
   const createCheckoutSpec = vi.fn();
@@ -122,6 +128,26 @@ describe('POST /runs/jobs/current/checkout-token', () => {
     });
   });
 
+  test('returns granted checkout permissions and ephemeral metadata', async () => {
+    const project = projectFactory.build();
+    mockGetProjectById.mockResolvedValue(project);
+    const job = await jobFactory.create({}, {transient: {projectId: project.id}});
+    createCheckoutSpec.mockResolvedValue(githubWriteSpec('ghs-secret-token'));
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: URL,
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      permissions: {contents: 'write'},
+      ephemeral: true,
+    });
+  });
+
   test('omits auth for a credential-free (debug) spec', async () => {
     const project = projectFactory.build();
     mockGetProjectById.mockResolvedValue(project);
@@ -143,6 +169,8 @@ describe('POST /runs/jobs/current/checkout-token', () => {
       repository_url: 'https://example.com/acme/repo.git',
       ref: 'trunk',
     });
+    expect(res.json().permissions).toBeUndefined();
+    expect(res.json().ephemeral).toBeUndefined();
   });
 
   test('returns 404 for a token without an active lease', async () => {

--- a/libs/api/workflows/src/presentation/routes/checkout-token.ts
+++ b/libs/api/workflows/src/presentation/routes/checkout-token.ts
@@ -16,7 +16,7 @@ export const checkoutTokenRoute = defineRoute({
   method: 'POST',
   path: '/checkout-token',
   description:
-    "Exchanges the runner's job lease for short-lived, read-only checkout credentials for the job's repository. The job is identified by the access token, so no job ID is needed. The checkout target is resolved server-side from the job's run and project; no credential material is stored on the job or run. Returns the repository URL, ref, and (when the provider needs auth) a short-lived credential that expires soon.",
+    "Exchanges the runner's job lease for checkout credentials for the job's repository, honoring the job's requested contents permission level. The job is identified by the access token, so no job ID is needed. The checkout target is resolved server-side from the job's run and project; no credential material is stored on the job or run. Returns the repository URL, ref, and (when the provider needs auth) a short-lived credential that expires soon.",
   schema: {
     response: {
       200: checkoutTokenResponseSchema,

--- a/libs/api/workflows/test/factories/job.ts
+++ b/libs/api/workflows/test/factories/job.ts
@@ -49,6 +49,7 @@ export const jobFactory = Factory.define<Job, JobTransientParams>(({transientPar
     listeningUntil: null,
     dependencies: [],
     runner: null,
+    checkout: null,
     position: 0,
     version: 1,
     createdAt: new Date(),

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -170,6 +170,8 @@ describe('api-client auth contexts', () => {
         repository_url: 'https://github.com/acme/repo.git',
         ref: 'main',
         auth: {kind: 'bearer', token: 'tok-123', expires_at: '2026-01-01T00:00:00.000Z'},
+        permissions: {contents: 'write'},
+        ephemeral: true,
       }),
     );
     const leaseClient = createLeaseClient('lease-ghi');
@@ -178,6 +180,8 @@ describe('api-client auth contexts', () => {
 
     expect(checkout.repository_url).toBe('https://github.com/acme/repo.git');
     expect(checkout.ref).toBe('main');
+    expect(checkout.permissions).toEqual({contents: 'write'});
+    expect(checkout.ephemeral).toBe(true);
     expect(calls[0]?.url).toContain('runs/jobs/current/checkout-token');
     expect(calls[0]?.authorization).toBe('Bearer lease-ghi');
   });


### PR DESCRIPTION
Add per-job checkout permission scoping for GitHub-backed job checkouts.

Workflow jobs now persist their normalized checkout block, including the requested `contents` permission, so the lease-authenticated checkout-token request can mint the correct capability after the job has been loaded from storage. GitHub installation tokens now request only `contents` plus mandatory `metadata: read`, never `workflows`, and the response reports granted permissions only when GitHub returns them. Reruns preserve the original checkout intent instead of silently downgrading write checkouts to read.

The provider contract also carries optional granted permissions and ephemeral metadata, with Gitea explicitly marked non-ephemeral and unscoped. The checkout-token DTO and runner parser accept the new optional fields, and the GitHub README documents the minimal self-hosted App grants.

All touched workspace packages are marked private, so no changeset is included.

Closes ENG-665

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-job checkout permission scoping for GitHub-backed checkouts. Jobs persist requested `contents` access; the API mints repo-scoped tokens that match the job and returns granted permissions and `ephemeral`, with clearer GitHub auth errors (implements ENG-665).

- **New Features**
  - Persist job checkout config (`checkout.permissions`, `persistCredentials`), defaulting to `contents: read`; preserved on reruns.
  - Thread `permissions` and `ephemeral` through `@shipfox/api-integration-core` services, DTOs, and runner; providers accept requested permissions and may return granted permissions.
  - GitHub: mint repo-scoped installation tokens with requested `contents` and mandatory `metadata: read`; never request `workflows`; surface granted permissions when GitHub returns them; map 403/422 write denials to access-denied with a clear message; keep GitHub’s 401 app-auth error message.
  - Gitea: tokens marked `ephemeral: false`; permissions omitted (unscoped).
  - `/runs/jobs/current/checkout-token` now returns granted `permissions` and `ephemeral` when available.

- **Migration**
  - Self-hosting: grant only what’s needed on your GitHub App—`Contents` (read-only unless jobs need write) and `Metadata: read`; do not grant `Workflows` (see `libs/api/integration/github/README.md`).
  - Runners/clients accept the new optional fields; no action needed if they ignore unknown fields.

<sup>Written for commit d852fb53a4741ccd87e3e95f99488e4bbce9eae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

