### PR TITLE
Stabilize agent provider modal tests

### DIFF
--- a/.changeset/steady-tests-quiet.md
+++ b/.changeset/steady-tests-quiet.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/vitest": patch
+---
+
+Disables Rolldown plugin timing warnings in shared Vitest dependency optimization config.

--- a/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/agent-provider-usage-modal.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, waitFor, within} from '@testing-library/react';
+import {fireEvent, render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {agentProviderEntry} from '#test/fixtures/agent-providers.js';
 import {AgentProviderUsageModal} from './agent-provider-usage-modal.js';
@@ -30,13 +30,11 @@ function renderUsageModal() {
 
 describe('AgentProviderUsageModal', () => {
   test('changes the selected model in the workflow example', async () => {
-    const user = userEvent.setup();
-
     renderUsageModal();
     expect(await screen.findByText('model: claude-opus-4-8')).toBeVisible();
 
-    await user.click(screen.getByRole('button', {name: 'Model'}));
-    await user.click(await screen.findByRole('option', {name: 'Kimi K2.7 Code'}));
+    fireEvent.click(screen.getByRole('button', {name: 'Model'}));
+    fireEvent.click(await screen.findByRole('option', {name: 'Kimi K2.7 Code'}));
 
     await waitFor(() =>
       expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -17,21 +17,43 @@ export type UserConfigFnObject = () => Parameters<typeof vitestDefineConfig>[0];
 export type UserConfig = Parameters<typeof vitestDefineConfig>[0];
 
 type ConfigInput = UserConfig | UserWorkspaceConfig;
+type MergeableConfigInput = ConfigInput & {
+  plugins?: unknown[];
+  optimizeDeps?: {
+    rolldownOptions?: {
+      checks?: Record<string, unknown>;
+    };
+  };
+  test?: {
+    exclude?: string[];
+  };
+};
 
 function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): ConfigInput {
-  const existingPlugins = (resolvedConfig as {plugins?: unknown[]}).plugins || [];
+  const mergeableConfig = resolvedConfig as MergeableConfigInput;
+  const existingPlugins = mergeableConfig.plugins || [];
   const merged = {
     ...resolvedConfig,
     plugins: [...existingPlugins],
+    optimizeDeps: {
+      ...(mergeableConfig.optimizeDeps || {}),
+      rolldownOptions: {
+        ...(mergeableConfig.optimizeDeps?.rolldownOptions || {}),
+        checks: {
+          ...(mergeableConfig.optimizeDeps?.rolldownOptions?.checks || {}),
+          pluginTimings: false,
+        },
+      },
+    },
     test: {
-      ...((resolvedConfig as {test?: {exclude?: string[]}}).test || {}),
+      ...(mergeableConfig.test || {}),
       globals: true,
       exclude: [
         '**/node_modules/**',
         '**/dist/**',
         '**/build/**',
         '**/out/**',
-        ...((resolvedConfig as {test?: {exclude?: string[]}}).test?.exclude || []),
+        ...(mergeableConfig.test?.exclude || []),
       ],
     },
   };


### PR DESCRIPTION
Stabilizes the agent provider usage modal test by using direct DOM clicks for the combobox value-change assertion, avoiding the slower pointer sequence that can stall under CI load.

The shared Vitest config now disables Rolldown plugin timing warnings during dependency optimization so CI logs stay focused on actionable test output. This includes a patch changeset for `@shipfox/vitest`.

During validation, the full changed-graph test run exposed an unrelated `@shipfox/api-workflows` baseline-count failure; rerunning that workflow test file directly passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the agent provider usage modal test and quiets noisy Rolldown plugin timing warnings in Vitest to improve CI reliability and signal-to-noise.

- **Bug Fixes**
  - Use `fireEvent.click` for the combobox button and option to avoid `userEvent` pointer sequence stalls in CI.

- **Dependencies**
  - Disable Rolldown plugin timing warnings via `optimizeDeps.rolldownOptions.checks.pluginTimings = false` in the shared Vitest config.
  - Add a patch changeset for `@shipfox/vitest`.

<sup>Written for commit d71554a076525de30cfdfe77bc09d8b0c8eaa78a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

