### PR TITLE
Add runner provisioner settings

### DIFF
--- a/.changeset/steady-provisioners-connect.md
+++ b/.changeset/steady-provisioners-connect.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/client-runners": patch
+"@shipfox/client-workspace-settings": patch
+"@shipfox/client-router": patch
+---
+
+Adds Runner Provisioners settings with provisioner token management and connection status.

--- a/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
@@ -96,11 +96,14 @@ test('manages workspace manual registration tokens from settings', async ({
   await argosScreenshot(page, 'runners/settings-runners-create-token-success');
 
   await page.keyboard.press('Escape');
-  await expect(page.getByRole('button', {name: 'Revoke E2E runner'})).toBeVisible();
+  await expect(manualRegistrationTokenRow).toBeVisible();
 
-  await page.getByRole('button', {name: 'Revoke E2E runner'}).click();
+  await manualRegistrationTokenRow
+    .getByRole('button', {name: 'Open E2E runner token actions'})
+    .click();
+  await page.getByRole('menuitem', {name: 'Revoke token'}).click();
   await page.getByRole('button', {name: 'Revoke', exact: true}).last().click();
 
-  await expect(page.getByRole('button', {name: 'Revoke E2E runner'})).toHaveCount(0);
+  await expect(manualRegistrationTokenRow).toHaveCount(0);
   await expect(page.getByText('No usable manual registration tokens')).toBeVisible();
 });

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as SetupLayoutWorkspacesNewRouteImport } from './routes/setup/_la
 import { Route as WorkspacesWidLayoutSettingsIndexRouteImport } from './routes/workspaces/$wid/_layout/settings/index'
 import { Route as WorkspacesWidLayoutIntegrationsIndexRouteImport } from './routes/workspaces/$wid/_layout/integrations/index'
 import { Route as WorkspacesWidLayoutSettingsRunnersRouteImport } from './routes/workspaces/$wid/_layout/settings/runners'
+import { Route as WorkspacesWidLayoutSettingsProvisionersRouteImport } from './routes/workspaces/$wid/_layout/settings/provisioners'
 import { Route as WorkspacesWidLayoutSettingsMembersRouteImport } from './routes/workspaces/$wid/_layout/settings/members'
 import { Route as WorkspacesWidLayoutSettingsIntegrationsRouteImport } from './routes/workspaces/$wid/_layout/settings/integrations'
 import { Route as WorkspacesWidLayoutSettingsEventsRouteImport } from './routes/workspaces/$wid/_layout/settings/events'
@@ -132,6 +133,12 @@ const WorkspacesWidLayoutSettingsRunnersRoute =
   WorkspacesWidLayoutSettingsRunnersRouteImport.update({
     id: '/settings/runners',
     path: '/settings/runners',
+    getParentRoute: () => WorkspacesWidLayoutRoute,
+  } as any)
+const WorkspacesWidLayoutSettingsProvisionersRoute =
+  WorkspacesWidLayoutSettingsProvisionersRouteImport.update({
+    id: '/settings/provisioners',
+    path: '/settings/provisioners',
     getParentRoute: () => WorkspacesWidLayoutRoute,
   } as any)
 const WorkspacesWidLayoutSettingsMembersRoute =
@@ -243,6 +250,7 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
+  '/workspaces/$wid/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/integrations/': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/settings/': typeof WorkspacesWidLayoutSettingsIndexRoute
@@ -275,6 +283,7 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
+  '/workspaces/$wid/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/integrations': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/settings': typeof WorkspacesWidLayoutSettingsIndexRoute
@@ -308,6 +317,7 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/settings/events': typeof WorkspacesWidLayoutSettingsEventsRoute
   '/workspaces/$wid/_layout/settings/integrations': typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   '/workspaces/$wid/_layout/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
+  '/workspaces/$wid/_layout/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/_layout/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
   '/workspaces/$wid/_layout/integrations/': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/_layout/settings/': typeof WorkspacesWidLayoutSettingsIndexRoute
@@ -343,6 +353,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/settings/events'
     | '/workspaces/$wid/settings/integrations'
     | '/workspaces/$wid/settings/members'
+    | '/workspaces/$wid/settings/provisioners'
     | '/workspaces/$wid/settings/runners'
     | '/workspaces/$wid/integrations/'
     | '/workspaces/$wid/settings/'
@@ -375,6 +386,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/settings/events'
     | '/workspaces/$wid/settings/integrations'
     | '/workspaces/$wid/settings/members'
+    | '/workspaces/$wid/settings/provisioners'
     | '/workspaces/$wid/settings/runners'
     | '/workspaces/$wid/integrations'
     | '/workspaces/$wid/settings'
@@ -407,6 +419,7 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/settings/events'
     | '/workspaces/$wid/_layout/settings/integrations'
     | '/workspaces/$wid/_layout/settings/members'
+    | '/workspaces/$wid/_layout/settings/provisioners'
     | '/workspaces/$wid/_layout/settings/runners'
     | '/workspaces/$wid/_layout/integrations/'
     | '/workspaces/$wid/_layout/settings/'
@@ -550,6 +563,13 @@ declare module '@tanstack/react-router' {
       path: '/settings/runners'
       fullPath: '/workspaces/$wid/settings/runners'
       preLoaderRoute: typeof WorkspacesWidLayoutSettingsRunnersRouteImport
+      parentRoute: typeof WorkspacesWidLayoutRoute
+    }
+    '/workspaces/$wid/_layout/settings/provisioners': {
+      id: '/workspaces/$wid/_layout/settings/provisioners'
+      path: '/settings/provisioners'
+      fullPath: '/workspaces/$wid/settings/provisioners'
+      preLoaderRoute: typeof WorkspacesWidLayoutSettingsProvisionersRouteImport
       parentRoute: typeof WorkspacesWidLayoutRoute
     }
     '/workspaces/$wid/_layout/settings/members': {
@@ -701,6 +721,7 @@ interface WorkspacesWidLayoutRouteChildren {
   WorkspacesWidLayoutSettingsEventsRoute: typeof WorkspacesWidLayoutSettingsEventsRoute
   WorkspacesWidLayoutSettingsIntegrationsRoute: typeof WorkspacesWidLayoutSettingsIntegrationsRoute
   WorkspacesWidLayoutSettingsMembersRoute: typeof WorkspacesWidLayoutSettingsMembersRoute
+  WorkspacesWidLayoutSettingsProvisionersRoute: typeof WorkspacesWidLayoutSettingsProvisionersRoute
   WorkspacesWidLayoutSettingsRunnersRoute: typeof WorkspacesWidLayoutSettingsRunnersRoute
   WorkspacesWidLayoutIntegrationsIndexRoute: typeof WorkspacesWidLayoutIntegrationsIndexRoute
   WorkspacesWidLayoutSettingsIndexRoute: typeof WorkspacesWidLayoutSettingsIndexRoute
@@ -727,6 +748,8 @@ const WorkspacesWidLayoutRouteChildren: WorkspacesWidLayoutRouteChildren = {
     WorkspacesWidLayoutSettingsIntegrationsRoute,
   WorkspacesWidLayoutSettingsMembersRoute:
     WorkspacesWidLayoutSettingsMembersRoute,
+  WorkspacesWidLayoutSettingsProvisionersRoute:
+    WorkspacesWidLayoutSettingsProvisionersRoute,
   WorkspacesWidLayoutSettingsRunnersRoute:
     WorkspacesWidLayoutSettingsRunnersRoute,
   WorkspacesWidLayoutIntegrationsIndexRoute:

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/settings/provisioners.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/settings/provisioners.tsx
@@ -1,0 +1,6 @@
+import {ProvisionersSettingsPage} from '@shipfox/client-workspace-settings';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/settings/provisioners')({
+  component: ProvisionersSettingsPage,
+});

--- a/libs/client/runners/.storybook/preview.tsx
+++ b/libs/client/runners/.storybook/preview.tsx
@@ -11,6 +11,14 @@ if (typeof document !== 'undefined' && document.fonts) {
   ]);
 }
 
+const STORYBOOK_NOW_MS = Date.parse('2026-06-26T12:00:00.000Z');
+
+Object.defineProperty(Date, 'now', {
+  configurable: true,
+  writable: true,
+  value: () => STORYBOOK_NOW_MS,
+});
+
 const withTheme: Decorator = (Story, context) => {
   const theme = context.globals.theme;
   return (

--- a/libs/client/runners/src/components/create-provisioner-token-form.tsx
+++ b/libs/client/runners/src/components/create-provisioner-token-form.tsx
@@ -1,4 +1,4 @@
-import type {CreateManualRegistrationTokenResponseDto} from '@shipfox/api-runners-dto';
+import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
 import {
   Alert,
   Button,
@@ -19,27 +19,27 @@ import {useForm} from '@tanstack/react-form';
 import {useQueryClient} from '@tanstack/react-query';
 import {useState} from 'react';
 import {
-  manualRegistrationTokenQueryKeys,
-  useCreateManualRegistrationTokenMutation,
-} from '#hooks/api/manual-registration-tokens.js';
-import {manualRegistrationTokenCreateErrorToFormError} from './form-errors.js';
+  provisionerTokenQueryKeys,
+  useCreateProvisionerTokenMutation,
+} from '#hooks/api/provisioner-tokens.js';
+import {provisionerTokenCreateErrorToFormError} from './provisioner-token-form-errors.js';
 import {
   ExpirationSelect,
   expirationHint,
   type TokenExpirationOption,
 } from './token-expiration-select.js';
 
-export const CREATE_MANUAL_REGISTRATION_TOKEN_FORM_ID = 'create-manual-registration-token-form';
+export const CREATE_PROVISIONER_TOKEN_FORM_ID = 'create-provisioner-token-form';
 
-export function CreateManualRegistrationTokenForm({
+export function CreateProvisionerTokenForm({
   workspaceId,
   onCreated,
 }: {
   workspaceId: string;
-  onCreated: (token: CreateManualRegistrationTokenResponseDto) => void;
+  onCreated: (token: CreateProvisionerTokenResponseDto) => void;
 }) {
   const queryClient = useQueryClient();
-  const createToken = useCreateManualRegistrationTokenMutation();
+  const createToken = useCreateProvisionerTokenMutation();
   const [formError, setFormError] = useState<string | undefined>();
 
   const form = useForm({
@@ -55,11 +55,11 @@ export function CreateManualRegistrationTokenForm({
       try {
         const token = await createToken.mutateAsync({workspaceId, body});
         await queryClient.invalidateQueries({
-          queryKey: manualRegistrationTokenQueryKeys.list(workspaceId),
+          queryKey: provisionerTokenQueryKeys.list(workspaceId),
         });
         onCreated(token);
       } catch (error) {
-        const mapped = manualRegistrationTokenCreateErrorToFormError(error);
+        const mapped = provisionerTokenCreateErrorToFormError(error);
         setFormError(mapped.message);
       }
     },
@@ -69,7 +69,7 @@ export function CreateManualRegistrationTokenForm({
     <>
       <ModalBody className="gap-16">
         <form
-          id={CREATE_MANUAL_REGISTRATION_TOKEN_FORM_ID}
+          id={CREATE_PROVISIONER_TOKEN_FORM_ID}
           className="flex w-full flex-col gap-8"
           noValidate
           onSubmit={(event) => {
@@ -90,11 +90,11 @@ export function CreateManualRegistrationTokenForm({
                 <FormField
                   className="flex-1"
                   label="Token name"
-                  id="manual-registration-token-name"
+                  id="provisioner-token-name"
                   error={fieldError(field)}
                 >
                   <FormFieldInput
-                    placeholder="Local runner"
+                    placeholder="Docker provisioner"
                     maxLength={80}
                     value={field.state.value}
                     onChange={(event) => field.handleChange(event.target.value)}
@@ -108,7 +108,7 @@ export function CreateManualRegistrationTokenForm({
                 <FormField
                   className="flex-1"
                   label="Expires"
-                  id="manual-registration-token-expiration"
+                  id="provisioner-token-expiration"
                   error={fieldError(field)}
                 >
                   <ExpirationSelect
@@ -141,7 +141,7 @@ export function CreateManualRegistrationTokenForm({
       <ModalFooter>
         <Button
           type="submit"
-          form={CREATE_MANUAL_REGISTRATION_TOKEN_FORM_ID}
+          form={CREATE_PROVISIONER_TOKEN_FORM_ID}
           isLoading={createToken.isPending}
         >
           Create token
@@ -151,11 +151,7 @@ export function CreateManualRegistrationTokenForm({
   );
 }
 
-export function CreatedManualRegistrationTokenPanel({
-  token,
-}: {
-  token: CreateManualRegistrationTokenResponseDto;
-}) {
+export function CreatedProvisionerTokenPanel({token}: {token: CreateProvisionerTokenResponseDto}) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const {copy} = useCopyToClipboard({
     text: token.raw_token,
@@ -180,7 +176,7 @@ export function CreatedManualRegistrationTokenPanel({
         <div className="flex flex-col gap-2">
           <InlineTipsTitle className="mb-0">Token created</InlineTipsTitle>
           <InlineTipsDescription>
-            Copy this registration token now. It will not be shown again.
+            Copy this provisioner token now. It will not be shown again.
           </InlineTipsDescription>
         </div>
         <div className="flex items-center gap-8 max-[640px]:flex-col max-[640px]:items-stretch">

--- a/libs/client/runners/src/components/manual-registration-token-format.test.ts
+++ b/libs/client/runners/src/components/manual-registration-token-format.test.ts
@@ -1,0 +1,48 @@
+import {
+  formatManualRegistrationTokenDate,
+  formatManualRegistrationTokenTimestamp,
+  manualRegistrationTokenDisplayName,
+} from './manual-registration-token-format.js';
+
+describe('manualRegistrationTokenDisplayName', () => {
+  test('uses the token name when present', () => {
+    const result = manualRegistrationTokenDisplayName({name: 'Deploy runner'});
+
+    expect(result).toBe('Deploy runner');
+  });
+
+  test('falls back for unnamed tokens', () => {
+    const result = manualRegistrationTokenDisplayName({name: null});
+
+    expect(result).toBe('Unnamed token');
+  });
+});
+
+describe('formatManualRegistrationTokenDate', () => {
+  test('formats timestamps as dates', () => {
+    const result = formatManualRegistrationTokenDate('2026-05-08T00:00:00.000Z');
+
+    expect(result).not.toBe('Never');
+    expect(result).not.toContain(':');
+  });
+
+  test('formats null as never', () => {
+    const result = formatManualRegistrationTokenDate(null);
+
+    expect(result).toBe('Never');
+  });
+});
+
+describe('formatManualRegistrationTokenTimestamp', () => {
+  test('formats timestamps with time', () => {
+    const result = formatManualRegistrationTokenTimestamp('2026-05-08T00:00:00.000Z');
+
+    expect(result).toContain(':');
+  });
+
+  test('formats null as undefined', () => {
+    const result = formatManualRegistrationTokenTimestamp(null);
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/libs/client/runners/src/components/manual-registration-token-format.ts
+++ b/libs/client/runners/src/components/manual-registration-token-format.ts
@@ -1,11 +1,18 @@
 import type {ManualRegistrationTokenDto} from '@shipfox/api-runners-dto';
-import {formatTimestamp} from '@shipfox/react-ui';
+import {formatDate, formatTimestamp} from '@shipfox/react-ui';
 
 export function formatManualRegistrationTokenDate(value: string | null): string {
   if (!value) return 'Never';
+  return formatDate(value);
+}
+
+export function formatManualRegistrationTokenTimestamp(value: string | null): string | undefined {
+  if (!value) return undefined;
   return formatTimestamp(value);
 }
 
-export function manualRegistrationTokenDisplayName(token: ManualRegistrationTokenDto): string {
+export function manualRegistrationTokenDisplayName(
+  token: Pick<ManualRegistrationTokenDto, 'name'>,
+): string {
   return token.name || 'Unnamed token';
 }

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -30,6 +30,7 @@ import {
   manualRegistrationTokenDisplayName,
 } from './manual-registration-token-format.js';
 import {TokenDate} from './token-date.js';
+import {TokenName} from './token-name.js';
 
 export function ManualRegistrationTokenList({
   workspaceId,
@@ -41,24 +42,26 @@ export function ManualRegistrationTokenList({
   return (
     <>
       <div className="max-[760px]:hidden">
-        <Table>
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
-              <TableHead>Name</TableHead>
+              <TableHead className="w-[34%]">Name</TableHead>
               <TableHead>Prefix</TableHead>
-              <TableHead>Expires</TableHead>
-              <TableHead>Created</TableHead>
+              <TableHead className="w-128">Expires</TableHead>
+              <TableHead className="w-128">Created</TableHead>
               <TableHead className="w-80 text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {tokens.map((token) => (
               <TableRow key={token.id}>
-                <TableCell className="font-medium">
-                  {manualRegistrationTokenDisplayName(token)}
+                <TableCell>
+                  <TokenName name={manualRegistrationTokenDisplayName(token)} />
                 </TableCell>
                 <TableCell>
-                  <Code variant="paragraph">{token.prefix}</Code>
+                  <Code variant="paragraph" className="block truncate">
+                    {token.prefix}
+                  </Code>
                 </TableCell>
                 <TableCell>
                   <ManualRegistrationTokenDate value={token.expires_at} />
@@ -85,10 +88,8 @@ export function ManualRegistrationTokenList({
           >
             <div className="flex items-start justify-between gap-12">
               <div className="min-w-0 flex-1">
-                <Text size="sm" bold className="truncate">
-                  {manualRegistrationTokenDisplayName(token)}
-                </Text>
-                <Code variant="paragraph" className="text-foreground-neutral-muted">
+                <TokenName name={manualRegistrationTokenDisplayName(token)} />
+                <Code variant="paragraph" className="block truncate text-foreground-neutral-muted">
                   {token.prefix}
                 </Code>
               </div>

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -9,10 +9,12 @@ import {
   DropdownMenuTrigger,
   EmptyState,
   IconButton,
-  Popover,
-  PopoverAnchor,
-  PopoverArrow,
-  PopoverContent,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
   Skeleton,
   Table,
   TableBody,
@@ -151,7 +153,7 @@ function RevokeManualRegistrationTokenButton({
       });
       setOpen(false);
     } catch {
-      // React Query stores the error for the inline popover alert.
+      // React Query stores the error for the inline modal alert.
     }
   }
 
@@ -168,40 +170,37 @@ function RevokeManualRegistrationTokenButton({
   }
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <>
       <DropdownMenu>
-        <PopoverAnchor asChild>
-          <DropdownMenuTrigger asChild>
-            <IconButton
-              type="button"
-              size="sm"
-              variant="transparent"
-              icon="more2Line"
-              aria-label={`Open ${tokenName} token actions`}
-            />
-          </DropdownMenuTrigger>
-        </PopoverAnchor>
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            type="button"
+            size="sm"
+            variant="transparent"
+            icon="more2Line"
+            aria-label={`Open ${tokenName} token actions`}
+          />
+        </DropdownMenuTrigger>
         <DropdownMenuContent align="end" size="sm">
-          <DropdownMenuItem onSelect={openRevokeConfirmation}>Revoke</DropdownMenuItem>
+          <DropdownMenuItem onSelect={openRevokeConfirmation}>Revoke token</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <PopoverContent align="end" className="w-280 p-14">
-        <div className="flex flex-col gap-12">
-          <div className="flex flex-col gap-4">
-            <Text size="sm" bold>
-              Revoke token?
-            </Text>
+      <Modal open={open} onOpenChange={handleOpenChange}>
+        <ModalContent aria-describedby={undefined} className="max-w-[420px]">
+          <ModalTitle className="sr-only">Revoke token</ModalTitle>
+          <ModalHeader title="Revoke token?" />
+          <ModalBody className="gap-16">
             <Text size="sm" className="text-foreground-neutral-muted">
               {tokenName} will stop creating new runner sessions. Existing sessions and job leases
               expire on their own.
             </Text>
-          </div>
-          {revokeToken.isError ? (
-            <Alert variant="error" animated={false}>
-              <Text size="sm">{manualRegistrationTokenErrorMessage(revokeToken.error)}</Text>
-            </Alert>
-          ) : null}
-          <div className="flex justify-end gap-8">
+            {revokeToken.isError ? (
+              <Alert variant="error" animated={false}>
+                <Text size="sm">{manualRegistrationTokenErrorMessage(revokeToken.error)}</Text>
+              </Alert>
+            ) : null}
+          </ModalBody>
+          <ModalFooter>
             <Button size="sm" variant="secondary" onClick={() => setOpen(false)}>
               Cancel
             </Button>
@@ -213,11 +212,10 @@ function RevokeManualRegistrationTokenButton({
             >
               Revoke
             </Button>
-          </div>
-        </div>
-        <PopoverArrow />
-      </PopoverContent>
-    </Popover>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }
 

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -3,11 +3,16 @@ import {
   Alert,
   Button,
   Code,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   EmptyState,
+  IconButton,
   Popover,
+  PopoverAnchor,
   PopoverArrow,
   PopoverContent,
-  PopoverTrigger,
   Skeleton,
   Table,
   TableBody,
@@ -157,19 +162,29 @@ function RevokeManualRegistrationTokenButton({
     }
   }
 
+  function openRevokeConfirmation() {
+    revokeToken.reset();
+    setOpen(true);
+  }
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          size="sm"
-          variant="transparentMuted"
-          iconLeft="deleteBinLine"
-          aria-label={`Revoke ${tokenName}`}
-        >
-          Revoke
-        </Button>
-      </PopoverTrigger>
+      <DropdownMenu>
+        <PopoverAnchor asChild>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              type="button"
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Open ${tokenName} token actions`}
+            />
+          </DropdownMenuTrigger>
+        </PopoverAnchor>
+        <DropdownMenuContent align="end" size="sm">
+          <DropdownMenuItem onSelect={openRevokeConfirmation}>Revoke</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <PopoverContent align="end" className="w-280 p-14">
         <div className="flex flex-col gap-12">
           <div className="flex flex-col gap-4">

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -26,8 +26,10 @@ import {
 import {manualRegistrationTokenErrorMessage} from './manual-registration-token-errors.js';
 import {
   formatManualRegistrationTokenDate,
+  formatManualRegistrationTokenTimestamp,
   manualRegistrationTokenDisplayName,
 } from './manual-registration-token-format.js';
+import {TokenDate} from './token-date.js';
 
 export function ManualRegistrationTokenList({
   workspaceId,
@@ -58,8 +60,12 @@ export function ManualRegistrationTokenList({
                 <TableCell>
                   <Code variant="paragraph">{token.prefix}</Code>
                 </TableCell>
-                <TableCell>{formatManualRegistrationTokenDate(token.expires_at)}</TableCell>
-                <TableCell>{formatManualRegistrationTokenDate(token.created_at)}</TableCell>
+                <TableCell>
+                  <ManualRegistrationTokenDate value={token.expires_at} />
+                </TableCell>
+                <TableCell>
+                  <ManualRegistrationTokenDate value={token.created_at} />
+                </TableCell>
                 <TableCell className="text-right">
                   <RevokeManualRegistrationTokenButton workspaceId={workspaceId} token={token} />
                 </TableCell>
@@ -91,17 +97,31 @@ export function ManualRegistrationTokenList({
             <dl className="mt-12 grid grid-cols-2 gap-10 text-sm">
               <div>
                 <dt className="text-foreground-neutral-muted">Expires</dt>
-                <dd>{formatManualRegistrationTokenDate(token.expires_at)}</dd>
+                <dd>
+                  <ManualRegistrationTokenDate value={token.expires_at} />
+                </dd>
               </div>
               <div>
                 <dt className="text-foreground-neutral-muted">Created</dt>
-                <dd>{formatManualRegistrationTokenDate(token.created_at)}</dd>
+                <dd>
+                  <ManualRegistrationTokenDate value={token.created_at} />
+                </dd>
               </div>
             </dl>
           </li>
         ))}
       </ul>
     </>
+  );
+}
+
+function ManualRegistrationTokenDate({value}: {value: string | null}) {
+  return (
+    <TokenDate
+      value={value}
+      date={formatManualRegistrationTokenDate(value)}
+      timestamp={formatManualRegistrationTokenTimestamp(value)}
+    />
   );
 }
 

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
@@ -139,6 +139,30 @@ describe('WorkspaceManualRegistrationTokensSettingsSection', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
   });
 
+  test('truncates long token names and shows the full name in a tooltip', async () => {
+    const user = userEvent.setup();
+    const tokenName = 'self-hosted-runner-for-production-release-candidate-validation-on-metal';
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        manual_registration_tokens: [manualRegistrationToken({name: tokenName})],
+      }),
+    );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderManualRegistrationTokens(
+      <WorkspaceManualRegistrationTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    const nameTrigger = await screen.findAllByRole('button', {name: tokenName});
+    const visibleNameTrigger = nameTrigger[0];
+    if (!visibleNameTrigger) throw new Error('Token name not rendered');
+
+    expect(screen.getByRole('table')).toHaveClass('table-fixed');
+    expect(visibleNameTrigger).toHaveClass('truncate');
+    await user.hover(visibleNameTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(tokenName);
+  });
+
   test('surfaces create errors without clearing the form', async () => {
     const user = userEvent.setup();
     const fetchImpl = vi

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
@@ -55,10 +55,12 @@ function lastButton(name: string): HTMLElement {
 
 async function chooseTokenAction(user: ReturnType<typeof userEvent.setup>, tokenName: string) {
   await user.click(firstButton(`Open ${tokenName} token actions`));
-  const menuItem = await screen.findByRole('menuitem', {name: 'Revoke'});
+  const menuItem = await screen.findByRole('menuitem', {name: 'Revoke token'});
   expect(menuItem.querySelector('svg')).not.toBeInTheDocument();
 
   await user.click(menuItem);
+  expect(await screen.findByRole('dialog')).toBeVisible();
+  expect(screen.getByText('Revoke token?')).toBeVisible();
 }
 
 describe('WorkspaceManualRegistrationTokensSettingsSection', () => {

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
@@ -53,6 +53,14 @@ function lastButton(name: string): HTMLElement {
   return button;
 }
 
+async function chooseTokenAction(user: ReturnType<typeof userEvent.setup>, tokenName: string) {
+  await user.click(firstButton(`Open ${tokenName} token actions`));
+  const menuItem = await screen.findByRole('menuitem', {name: 'Revoke'});
+  expect(menuItem.querySelector('svg')).not.toBeInTheDocument();
+
+  await user.click(menuItem);
+}
+
 describe('WorkspaceManualRegistrationTokensSettingsSection', () => {
   test('renders an empty usable-token state', async () => {
     const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({manual_registration_tokens: []}));
@@ -205,7 +213,7 @@ describe('WorkspaceManualRegistrationTokensSettingsSection', () => {
       <WorkspaceManualRegistrationTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
     );
     expect((await screen.findAllByText('Deploy runner')).length).toBeGreaterThan(0);
-    await user.click(firstButton('Revoke Deploy runner'));
+    await chooseTokenAction(user, 'Deploy runner');
     await user.click(lastButton('Revoke'));
 
     await waitFor(() => expect(screen.queryByText('Deploy runner')).not.toBeInTheDocument());
@@ -231,7 +239,7 @@ describe('WorkspaceManualRegistrationTokensSettingsSection', () => {
       <WorkspaceManualRegistrationTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
     );
     expect((await screen.findAllByText('Deploy runner')).length).toBeGreaterThan(0);
-    await user.click(firstButton('Revoke Deploy runner'));
+    await chooseTokenAction(user, 'Deploy runner');
     await user.click(lastButton('Revoke'));
 
     expect(await screen.findByText('Manual registration token not found')).toBeVisible();

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {Toaster} from '@shipfox/react-ui';
+import {formatDate, formatTimestamp, Toaster} from '@shipfox/react-ui';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -104,6 +104,39 @@ describe('WorkspaceManualRegistrationTokensSettingsSection', () => {
 
     expect(await screen.findByText('Token created')).toBeVisible();
     expect(screen.getByText('sf_mrt_raw-created-token')).toBeVisible();
+  });
+
+  test('renders compact dates with exact timestamp tooltips', async () => {
+    const user = userEvent.setup();
+    const createdAt = '2026-05-08T00:00:00.000Z';
+    const expiresAt = '2026-05-09T00:00:00.000Z';
+    const fetchImpl = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        manual_registration_tokens: [
+          manualRegistrationToken({created_at: createdAt, expires_at: expiresAt}),
+        ],
+      }),
+    );
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderManualRegistrationTokens(
+      <WorkspaceManualRegistrationTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    const expiresDate = await screen.findAllByText(formatDate(expiresAt));
+    const createdDate = await screen.findAllByText(formatDate(createdAt));
+    const expiresDateTrigger = expiresDate[0];
+    const createdDateTrigger = createdDate[0];
+    if (!expiresDateTrigger || !createdDateTrigger) throw new Error('Token dates not rendered');
+
+    expect(screen.queryByText(formatTimestamp(expiresAt))).not.toBeInTheDocument();
+    await user.hover(expiresDateTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(expiresAt));
+
+    await user.unhover(expiresDateTrigger);
+    await user.hover(createdDateTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
   });
 
   test('surfaces create errors without clearing the form', async () => {

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -50,8 +50,8 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
           <div className="flex flex-col gap-4">
             <Header variant="h3">Runner registration tokens</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
-              Let a machine register itself as a runner in this workspace and run jobs directly.
-              Reusable until revoked.
+              Register individual runner agents that run jobs directly in this workspace. Tokens are
+              reusable until revoked.
             </Text>
           </div>
           <div className="flex items-center gap-12">

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.tsx
@@ -48,9 +48,10 @@ export function WorkspaceManualRegistrationTokensSettingsSection({
       <section className="flex flex-col gap-16">
         <div className="flex items-center justify-between gap-16 max-[640px]:items-start">
           <div className="flex flex-col gap-4">
-            <Header variant="h3">Runners</Header>
+            <Header variant="h3">Runner registration tokens</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
-              Tokens used by machines to request and complete jobs.
+              Let a machine register itself as a runner in this workspace and run jobs directly.
+              Reusable until revoked.
             </Text>
           </div>
           <div className="flex items-center gap-12">

--- a/libs/client/runners/src/components/provisioner-token-errors.ts
+++ b/libs/client/runners/src/components/provisioner-token-errors.ts
@@ -1,0 +1,12 @@
+import {ApiError} from '@shipfox/client-api';
+
+export function provisionerTokenErrorMessage(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.code === 'network-error') {
+      return "We couldn't reach the server. Check your connection and try again.";
+    }
+    return error.message;
+  }
+  if (error instanceof Error) return error.message;
+  return 'Something went wrong. Try again.';
+}

--- a/libs/client/runners/src/components/provisioner-token-form-errors.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-form-errors.test.ts
@@ -10,6 +10,17 @@ describe('provisionerTokenCreateErrorToFormError', () => {
     expect(result).toEqual({kind: 'form', message: 'Try later'});
   });
 
+  test('routes network ApiError to a form-level alert with connection copy', () => {
+    const error = new ApiError({code: 'network-error', message: 'Network failed', status: 0});
+
+    const result = provisionerTokenCreateErrorToFormError(error);
+
+    expect(result).toEqual({
+      kind: 'form',
+      message: "We couldn't reach the server. Check your connection and try again.",
+    });
+  });
+
   test('routes Error to a form-level alert with the error message', () => {
     const result = provisionerTokenCreateErrorToFormError(new Error('boom'));
 

--- a/libs/client/runners/src/components/provisioner-token-form-errors.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-form-errors.test.ts
@@ -1,0 +1,24 @@
+import {ApiError} from '@shipfox/client-api';
+import {provisionerTokenCreateErrorToFormError} from './provisioner-token-form-errors.js';
+
+describe('provisionerTokenCreateErrorToFormError', () => {
+  test('routes ApiError to a form-level alert with the server message', () => {
+    const error = new ApiError({code: 'rate-limited', message: 'Try later', status: 429});
+
+    const result = provisionerTokenCreateErrorToFormError(error);
+
+    expect(result).toEqual({kind: 'form', message: 'Try later'});
+  });
+
+  test('routes Error to a form-level alert with the error message', () => {
+    const result = provisionerTokenCreateErrorToFormError(new Error('boom'));
+
+    expect(result).toEqual({kind: 'form', message: 'boom'});
+  });
+
+  test('falls back to generic copy for non-Error throwables', () => {
+    const result = provisionerTokenCreateErrorToFormError('weird');
+
+    expect(result).toEqual({kind: 'form', message: 'Something went wrong. Try again.'});
+  });
+});

--- a/libs/client/runners/src/components/provisioner-token-form-errors.ts
+++ b/libs/client/runners/src/components/provisioner-token-form-errors.ts
@@ -1,0 +1,9 @@
+import {provisionerTokenErrorMessage} from './provisioner-token-errors.js';
+
+export type ProvisionerTokenCreateFormErrorMapping = {kind: 'form'; message: string};
+
+export function provisionerTokenCreateErrorToFormError(
+  error: unknown,
+): ProvisionerTokenCreateFormErrorMapping {
+  return {kind: 'form', message: provisionerTokenErrorMessage(error)};
+}

--- a/libs/client/runners/src/components/provisioner-token-format.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.test.ts
@@ -1,0 +1,80 @@
+import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
+import {
+  formatProvisionerTokenDate,
+  provisionerConnectionStatus,
+  provisionerTokenDisplayName,
+} from './provisioner-token-format.js';
+
+const token: ProvisionerTokenDto = {
+  id: '33333333-3333-4333-8333-333333333333',
+  workspace_id: '11111111-1111-4111-8111-111111111111',
+  prefix: 'sf_pt_abcde',
+  name: 'Docker provisioner',
+  created_by_user_id: '22222222-2222-4222-8222-222222222222',
+  revoked_by_user_id: null,
+  expires_at: '2026-05-09T00:00:00.000Z',
+  revoked_at: null,
+  last_seen_at: null,
+  created_at: '2026-05-08T00:00:00.000Z',
+  updated_at: '2026-05-08T00:00:00.000Z',
+};
+
+describe('provisionerTokenDisplayName', () => {
+  test('uses the token name when present', () => {
+    const result = provisionerTokenDisplayName(token);
+
+    expect(result).toBe('Docker provisioner');
+  });
+
+  test('falls back for unnamed tokens', () => {
+    const result = provisionerTokenDisplayName({...token, name: null});
+
+    expect(result).toBe('Unnamed provisioner');
+  });
+});
+
+describe('formatProvisionerTokenDate', () => {
+  test('formats timestamps', () => {
+    const result = formatProvisionerTokenDate('2026-05-08T00:00:00.000Z');
+
+    expect(result).not.toBe('Never');
+  });
+
+  test('formats null as never', () => {
+    const result = formatProvisionerTokenDate(null);
+
+    expect(result).toBe('Never');
+  });
+});
+
+describe('provisionerConnectionStatus', () => {
+  test('returns connected when the token id is active', () => {
+    const result = provisionerConnectionStatus(token, new Set([token.id]));
+
+    expect(result).toEqual({kind: 'connected', dotVariant: 'success', label: 'Connected'});
+  });
+
+  test('returns last seen when inactive with a last seen timestamp', () => {
+    const result = provisionerConnectionStatus(
+      {...token, last_seen_at: '2026-05-08T01:00:00.000Z'},
+      new Set(),
+    );
+
+    expect(result).toEqual({
+      kind: 'last-seen',
+      dotVariant: 'neutral',
+      label: 'Last seen',
+      lastSeenAt: '2026-05-08T01:00:00.000Z',
+    });
+  });
+
+  test('returns never connected when inactive with no last seen timestamp', () => {
+    const result = provisionerConnectionStatus(token, new Set());
+
+    expect(result).toEqual({
+      kind: 'never-connected',
+      dotVariant: 'neutral',
+      label: 'Never connected',
+    });
+  });
+});

--- a/libs/client/runners/src/components/provisioner-token-format.test.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.test.ts
@@ -1,6 +1,7 @@
 import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
 import {
   formatProvisionerTokenDate,
+  formatProvisionerTokenTimestamp,
   provisionerConnectionStatus,
   provisionerTokenDisplayName,
 } from './provisioner-token-format.js';
@@ -34,16 +35,31 @@ describe('provisionerTokenDisplayName', () => {
 });
 
 describe('formatProvisionerTokenDate', () => {
-  test('formats timestamps', () => {
+  test('formats timestamps as dates', () => {
     const result = formatProvisionerTokenDate('2026-05-08T00:00:00.000Z');
 
     expect(result).not.toBe('Never');
+    expect(result).not.toContain(':');
   });
 
   test('formats null as never', () => {
     const result = formatProvisionerTokenDate(null);
 
     expect(result).toBe('Never');
+  });
+});
+
+describe('formatProvisionerTokenTimestamp', () => {
+  test('formats timestamps with time', () => {
+    const result = formatProvisionerTokenTimestamp('2026-05-08T00:00:00.000Z');
+
+    expect(result).toContain(':');
+  });
+
+  test('formats null as undefined', () => {
+    const result = formatProvisionerTokenTimestamp(null);
+
+    expect(result).toBeUndefined();
   });
 });
 

--- a/libs/client/runners/src/components/provisioner-token-format.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.ts
@@ -1,6 +1,6 @@
 import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
 import type {DotVariant} from '@shipfox/react-ui';
-import {formatTimestamp} from '@shipfox/react-ui';
+import {formatDate, formatTimestamp} from '@shipfox/react-ui';
 
 export type ProvisionerConnectionStatus =
   | {kind: 'connected'; dotVariant: DotVariant; label: 'Connected'}
@@ -9,6 +9,11 @@ export type ProvisionerConnectionStatus =
 
 export function formatProvisionerTokenDate(value: string | null): string {
   if (!value) return 'Never';
+  return formatDate(value);
+}
+
+export function formatProvisionerTokenTimestamp(value: string | null): string | undefined {
+  if (!value) return undefined;
   return formatTimestamp(value);
 }
 

--- a/libs/client/runners/src/components/provisioner-token-format.ts
+++ b/libs/client/runners/src/components/provisioner-token-format.ts
@@ -1,0 +1,35 @@
+import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
+import type {DotVariant} from '@shipfox/react-ui';
+import {formatTimestamp} from '@shipfox/react-ui';
+
+export type ProvisionerConnectionStatus =
+  | {kind: 'connected'; dotVariant: DotVariant; label: 'Connected'}
+  | {kind: 'last-seen'; dotVariant: DotVariant; label: 'Last seen'; lastSeenAt: string}
+  | {kind: 'never-connected'; dotVariant: DotVariant; label: 'Never connected'};
+
+export function formatProvisionerTokenDate(value: string | null): string {
+  if (!value) return 'Never';
+  return formatTimestamp(value);
+}
+
+export function provisionerTokenDisplayName(token: Pick<ProvisionerTokenDto, 'name'>): string {
+  return token.name || 'Unnamed provisioner';
+}
+
+export function provisionerConnectionStatus(
+  token: Pick<ProvisionerTokenDto, 'id' | 'last_seen_at'>,
+  activeIds: ReadonlySet<string>,
+): ProvisionerConnectionStatus {
+  if (activeIds.has(token.id)) {
+    return {kind: 'connected', dotVariant: 'success', label: 'Connected'};
+  }
+  if (token.last_seen_at) {
+    return {
+      kind: 'last-seen',
+      dotVariant: 'neutral',
+      label: 'Last seen',
+      lastSeenAt: token.last_seen_at,
+    };
+  }
+  return {kind: 'never-connected', dotVariant: 'neutral', label: 'Never connected'};
+}

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -4,11 +4,16 @@ import {
   Button,
   Code,
   Dot,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   EmptyState,
+  IconButton,
   Popover,
+  PopoverAnchor,
   PopoverArrow,
   PopoverContent,
-  PopoverTrigger,
   RelativeTime,
   Skeleton,
   Table,
@@ -195,19 +200,29 @@ function RevokeProvisionerTokenButton({
     }
   }
 
+  function openRevokeConfirmation() {
+    revokeToken.reset();
+    setOpen(true);
+  }
+
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          size="sm"
-          variant="transparentMuted"
-          iconLeft="deleteBinLine"
-          aria-label={`Revoke ${tokenName}`}
-        >
-          Revoke
-        </Button>
-      </PopoverTrigger>
+      <DropdownMenu>
+        <PopoverAnchor asChild>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              type="button"
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Open ${tokenName} token actions`}
+            />
+          </DropdownMenuTrigger>
+        </PopoverAnchor>
+        <DropdownMenuContent align="end" size="sm">
+          <DropdownMenuItem onSelect={openRevokeConfirmation}>Revoke</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <PopoverContent align="end" className="w-280 p-14">
         <div className="flex flex-col gap-12">
           <div className="flex flex-col gap-4">

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -33,6 +33,7 @@ import {
   provisionerTokenDisplayName,
 } from './provisioner-token-format.js';
 import {TokenDate} from './token-date.js';
+import {TokenName} from './token-name.js';
 
 export function ProvisionerTokenList({
   workspaceId,
@@ -46,23 +47,27 @@ export function ProvisionerTokenList({
   return (
     <>
       <div className="max-[760px]:hidden">
-        <Table>
+        <Table className="table-fixed">
           <TableHeader>
             <TableRow>
-              <TableHead>Name</TableHead>
+              <TableHead className="w-[28%]">Name</TableHead>
               <TableHead>Prefix</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Expires</TableHead>
-              <TableHead>Created</TableHead>
+              <TableHead className="w-[18%]">Status</TableHead>
+              <TableHead className="w-112">Expires</TableHead>
+              <TableHead className="w-112">Created</TableHead>
               <TableHead className="w-80 text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {tokens.map((token) => (
               <TableRow key={token.id}>
-                <TableCell className="font-medium">{provisionerTokenDisplayName(token)}</TableCell>
                 <TableCell>
-                  <Code variant="paragraph">{token.prefix}</Code>
+                  <TokenName name={provisionerTokenDisplayName(token)} />
+                </TableCell>
+                <TableCell>
+                  <Code variant="paragraph" className="block truncate">
+                    {token.prefix}
+                  </Code>
                 </TableCell>
                 <TableCell>
                   <ProvisionerStatusCell token={token} activeIds={activeIds} />
@@ -89,10 +94,8 @@ export function ProvisionerTokenList({
           >
             <div className="flex items-start justify-between gap-12">
               <div className="min-w-0 flex-1">
-                <Text size="sm" bold className="truncate">
-                  {provisionerTokenDisplayName(token)}
-                </Text>
-                <Code variant="paragraph" className="text-foreground-neutral-muted">
+                <TokenName name={provisionerTokenDisplayName(token)} />
+                <Code variant="paragraph" className="block truncate text-foreground-neutral-muted">
                   {token.prefix}
                 </Code>
               </div>

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -10,10 +10,12 @@ import {
   DropdownMenuTrigger,
   EmptyState,
   IconButton,
-  Popover,
-  PopoverAnchor,
-  PopoverArrow,
-  PopoverContent,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
   RelativeTime,
   Skeleton,
   Table,
@@ -189,7 +191,7 @@ function RevokeProvisionerTokenButton({
       });
       setOpen(false);
     } catch {
-      // React Query stores the error for the inline popover alert.
+      // React Query stores the error for the inline modal alert.
     }
   }
 
@@ -206,40 +208,37 @@ function RevokeProvisionerTokenButton({
   }
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
+    <>
       <DropdownMenu>
-        <PopoverAnchor asChild>
-          <DropdownMenuTrigger asChild>
-            <IconButton
-              type="button"
-              size="sm"
-              variant="transparent"
-              icon="more2Line"
-              aria-label={`Open ${tokenName} token actions`}
-            />
-          </DropdownMenuTrigger>
-        </PopoverAnchor>
+        <DropdownMenuTrigger asChild>
+          <IconButton
+            type="button"
+            size="sm"
+            variant="transparent"
+            icon="more2Line"
+            aria-label={`Open ${tokenName} token actions`}
+          />
+        </DropdownMenuTrigger>
         <DropdownMenuContent align="end" size="sm">
-          <DropdownMenuItem onSelect={openRevokeConfirmation}>Revoke</DropdownMenuItem>
+          <DropdownMenuItem onSelect={openRevokeConfirmation}>Revoke token</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <PopoverContent align="end" className="w-280 p-14">
-        <div className="flex flex-col gap-12">
-          <div className="flex flex-col gap-4">
-            <Text size="sm" bold>
-              Revoke token?
-            </Text>
+      <Modal open={open} onOpenChange={handleOpenChange}>
+        <ModalContent aria-describedby={undefined} className="max-w-[420px]">
+          <ModalTitle className="sr-only">Revoke token</ModalTitle>
+          <ModalHeader title="Revoke token?" />
+          <ModalBody className="gap-16">
             <Text size="sm" className="text-foreground-neutral-muted">
               {tokenName} will stop authenticating this provisioner. Runners it already provisioned
               keep running until their leases expire.
             </Text>
-          </div>
-          {revokeToken.isError ? (
-            <Alert variant="error" animated={false}>
-              <Text size="sm">{provisionerTokenErrorMessage(revokeToken.error)}</Text>
-            </Alert>
-          ) : null}
-          <div className="flex justify-end gap-8">
+            {revokeToken.isError ? (
+              <Alert variant="error" animated={false}>
+                <Text size="sm">{provisionerTokenErrorMessage(revokeToken.error)}</Text>
+              </Alert>
+            ) : null}
+          </ModalBody>
+          <ModalFooter>
             <Button size="sm" variant="secondary" onClick={() => setOpen(false)}>
               Cancel
             </Button>
@@ -251,11 +250,10 @@ function RevokeProvisionerTokenButton({
             >
               Revoke
             </Button>
-          </div>
-        </div>
-        <PopoverArrow />
-      </PopoverContent>
-    </Popover>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }
 

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -1,0 +1,242 @@
+import type {ProvisionerTokenDto} from '@shipfox/api-runners-dto';
+import {
+  Alert,
+  Button,
+  Code,
+  Dot,
+  EmptyState,
+  Popover,
+  PopoverArrow,
+  PopoverContent,
+  PopoverTrigger,
+  RelativeTime,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+} from '@shipfox/react-ui';
+import {useQueryClient} from '@tanstack/react-query';
+import {useState} from 'react';
+import {
+  provisionerTokenQueryKeys,
+  useRevokeProvisionerTokenMutation,
+} from '#hooks/api/provisioner-tokens.js';
+import {provisionerTokenErrorMessage} from './provisioner-token-errors.js';
+import {
+  formatProvisionerTokenDate,
+  provisionerConnectionStatus,
+  provisionerTokenDisplayName,
+} from './provisioner-token-format.js';
+
+export function ProvisionerTokenList({
+  workspaceId,
+  tokens,
+  activeIds,
+}: {
+  workspaceId: string;
+  tokens: ProvisionerTokenDto[];
+  activeIds: ReadonlySet<string>;
+}) {
+  return (
+    <>
+      <div className="max-[760px]:hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Prefix</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Expires</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead className="w-80 text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {tokens.map((token) => (
+              <TableRow key={token.id}>
+                <TableCell className="font-medium">{provisionerTokenDisplayName(token)}</TableCell>
+                <TableCell>
+                  <Code variant="paragraph">{token.prefix}</Code>
+                </TableCell>
+                <TableCell>
+                  <ProvisionerStatusCell token={token} activeIds={activeIds} />
+                </TableCell>
+                <TableCell>{formatProvisionerTokenDate(token.expires_at)}</TableCell>
+                <TableCell>{formatProvisionerTokenDate(token.created_at)}</TableCell>
+                <TableCell className="text-right">
+                  <RevokeProvisionerTokenButton workspaceId={workspaceId} token={token} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <ul className="hidden flex-col gap-10 max-[760px]:flex" aria-label="Provisioner tokens">
+        {tokens.map((token) => (
+          <li
+            key={token.id}
+            className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-14"
+          >
+            <div className="flex items-start justify-between gap-12">
+              <div className="min-w-0 flex-1">
+                <Text size="sm" bold className="truncate">
+                  {provisionerTokenDisplayName(token)}
+                </Text>
+                <Code variant="paragraph" className="text-foreground-neutral-muted">
+                  {token.prefix}
+                </Code>
+              </div>
+              <RevokeProvisionerTokenButton workspaceId={workspaceId} token={token} />
+            </div>
+            <dl className="mt-12 grid grid-cols-2 gap-10 text-sm">
+              <div>
+                <dt className="text-foreground-neutral-muted">Status</dt>
+                <dd>
+                  <ProvisionerStatusCell token={token} activeIds={activeIds} />
+                </dd>
+              </div>
+              <div>
+                <dt className="text-foreground-neutral-muted">Expires</dt>
+                <dd>{formatProvisionerTokenDate(token.expires_at)}</dd>
+              </div>
+              <div>
+                <dt className="text-foreground-neutral-muted">Created</dt>
+                <dd>{formatProvisionerTokenDate(token.created_at)}</dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function ProvisionerStatusCell({
+  token,
+  activeIds,
+}: {
+  token: ProvisionerTokenDto;
+  activeIds: ReadonlySet<string>;
+}) {
+  const status = provisionerConnectionStatus(token, activeIds);
+
+  return (
+    <span className="inline-flex items-center gap-6">
+      <Dot variant={status.dotVariant} />
+      {status.kind === 'last-seen' ? (
+        <span>
+          {status.label} <RelativeTime value={status.lastSeenAt} />
+        </span>
+      ) : (
+        <span>{status.label}</span>
+      )}
+    </span>
+  );
+}
+
+function RevokeProvisionerTokenButton({
+  workspaceId,
+  token,
+}: {
+  workspaceId: string;
+  token: ProvisionerTokenDto;
+}) {
+  const queryClient = useQueryClient();
+  const revokeToken = useRevokeProvisionerTokenMutation();
+  const [open, setOpen] = useState(false);
+  const tokenName = provisionerTokenDisplayName(token);
+
+  async function handleRevoke() {
+    try {
+      await revokeToken.mutateAsync({workspaceId, tokenId: token.id});
+      await queryClient.invalidateQueries({
+        queryKey: provisionerTokenQueryKeys.list(workspaceId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: provisionerTokenQueryKeys.active(workspaceId),
+      });
+      setOpen(false);
+    } catch {
+      // React Query stores the error for the inline popover alert.
+    }
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      revokeToken.reset();
+    }
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="transparentMuted"
+          iconLeft="deleteBinLine"
+          aria-label={`Revoke ${tokenName}`}
+        >
+          Revoke
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-280 p-14">
+        <div className="flex flex-col gap-12">
+          <div className="flex flex-col gap-4">
+            <Text size="sm" bold>
+              Revoke token?
+            </Text>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              {tokenName} will stop authenticating this provisioner. Runners it already provisioned
+              keep running until their leases expire.
+            </Text>
+          </div>
+          {revokeToken.isError ? (
+            <Alert variant="error" animated={false}>
+              <Text size="sm">{provisionerTokenErrorMessage(revokeToken.error)}</Text>
+            </Alert>
+          ) : null}
+          <div className="flex justify-end gap-8">
+            <Button size="sm" variant="secondary" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              variant="danger"
+              isLoading={revokeToken.isPending}
+              onClick={handleRevoke}
+            >
+              Revoke
+            </Button>
+          </div>
+        </div>
+        <PopoverArrow />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function EmptyProvisionerTokens() {
+  return (
+    <EmptyState
+      icon="key2Line"
+      title="No usable provisioner registration tokens"
+      description="Create a token to connect a provisioner that provisions runners on demand."
+    />
+  );
+}
+
+export function ProvisionerTokenTableSkeleton() {
+  return (
+    <div role="status" aria-label="Loading provisioner tokens" className="flex flex-col gap-8">
+      {[0, 1, 2].map((row) => (
+        <Skeleton key={row} className="h-44 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/libs/client/runners/src/components/provisioner-token-list.tsx
+++ b/libs/client/runners/src/components/provisioner-token-list.tsx
@@ -28,9 +28,11 @@ import {
 import {provisionerTokenErrorMessage} from './provisioner-token-errors.js';
 import {
   formatProvisionerTokenDate,
+  formatProvisionerTokenTimestamp,
   provisionerConnectionStatus,
   provisionerTokenDisplayName,
 } from './provisioner-token-format.js';
+import {TokenDate} from './token-date.js';
 
 export function ProvisionerTokenList({
   workspaceId,
@@ -65,8 +67,12 @@ export function ProvisionerTokenList({
                 <TableCell>
                   <ProvisionerStatusCell token={token} activeIds={activeIds} />
                 </TableCell>
-                <TableCell>{formatProvisionerTokenDate(token.expires_at)}</TableCell>
-                <TableCell>{formatProvisionerTokenDate(token.created_at)}</TableCell>
+                <TableCell>
+                  <ProvisionerTokenDate value={token.expires_at} />
+                </TableCell>
+                <TableCell>
+                  <ProvisionerTokenDate value={token.created_at} />
+                </TableCell>
                 <TableCell className="text-right">
                   <RevokeProvisionerTokenButton workspaceId={workspaceId} token={token} />
                 </TableCell>
@@ -101,17 +107,31 @@ export function ProvisionerTokenList({
               </div>
               <div>
                 <dt className="text-foreground-neutral-muted">Expires</dt>
-                <dd>{formatProvisionerTokenDate(token.expires_at)}</dd>
+                <dd>
+                  <ProvisionerTokenDate value={token.expires_at} />
+                </dd>
               </div>
               <div>
                 <dt className="text-foreground-neutral-muted">Created</dt>
-                <dd>{formatProvisionerTokenDate(token.created_at)}</dd>
+                <dd>
+                  <ProvisionerTokenDate value={token.created_at} />
+                </dd>
               </div>
             </dl>
           </li>
         ))}
       </ul>
     </>
+  );
+}
+
+function ProvisionerTokenDate({value}: {value: string | null}) {
+  return (
+    <TokenDate
+      value={value}
+      date={formatProvisionerTokenDate(value)}
+      timestamp={formatProvisionerTokenTimestamp(value)}
+    />
   );
 }
 

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -71,10 +71,12 @@ function lastButton(name: string): HTMLElement {
 
 async function chooseTokenAction(user: ReturnType<typeof userEvent.setup>, tokenName: string) {
   await user.click(firstButton(`Open ${tokenName} token actions`));
-  const menuItem = await screen.findByRole('menuitem', {name: 'Revoke'});
+  const menuItem = await screen.findByRole('menuitem', {name: 'Revoke token'});
   expect(menuItem.querySelector('svg')).not.toBeInTheDocument();
 
   await user.click(menuItem);
+  expect(await screen.findByRole('dialog')).toBeVisible();
+  expect(screen.getByText('Revoke token?')).toBeVisible();
 }
 
 describe('WorkspaceProvisionerTokensSettingsSection', () => {

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -163,6 +163,32 @@ describe('WorkspaceProvisionerTokensSettingsSection', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
   });
 
+  test('truncates long token names and shows the full name in a tooltip', async () => {
+    const user = userEvent.setup();
+    const tokenName = 'docker-provisioner-for-west-coast-gpu-burst-capacity-and-fallback';
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      return Promise.resolve(jsonResponse({tokens: [provisionerToken({name: tokenName})]}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    const nameTrigger = await screen.findAllByRole('button', {name: tokenName});
+    const visibleNameTrigger = nameTrigger[0];
+    if (!visibleNameTrigger) throw new Error('Token name not rendered');
+
+    expect(screen.getByRole('table')).toHaveClass('table-fixed');
+    expect(visibleNameTrigger).toHaveClass('truncate');
+    await user.hover(visibleNameTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(tokenName);
+  });
+
   test('surfaces create errors without clearing the form', async () => {
     const user = userEvent.setup();
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -69,6 +69,14 @@ function lastButton(name: string): HTMLElement {
   return button;
 }
 
+async function chooseTokenAction(user: ReturnType<typeof userEvent.setup>, tokenName: string) {
+  await user.click(firstButton(`Open ${tokenName} token actions`));
+  const menuItem = await screen.findByRole('menuitem', {name: 'Revoke'});
+  expect(menuItem.querySelector('svg')).not.toBeInTheDocument();
+
+  await user.click(menuItem);
+}
+
 describe('WorkspaceProvisionerTokensSettingsSection', () => {
   test('renders an empty usable-token state', async () => {
     const fetchImpl = vi.fn((input: RequestInfo | URL) => {
@@ -315,7 +323,7 @@ describe('WorkspaceProvisionerTokensSettingsSection', () => {
       <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
     );
     expect((await screen.findAllByText('Docker provisioner')).length).toBeGreaterThan(0);
-    await user.click(firstButton('Revoke Docker provisioner'));
+    await chooseTokenAction(user, 'Docker provisioner');
     await user.click(lastButton('Revoke'));
 
     await waitFor(() => expect(screen.queryByText('Docker provisioner')).not.toBeInTheDocument());
@@ -342,7 +350,7 @@ describe('WorkspaceProvisionerTokensSettingsSection', () => {
       <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
     );
     expect((await screen.findAllByText('Docker provisioner')).length).toBeGreaterThan(0);
-    await user.click(firstButton('Revoke Docker provisioner'));
+    await chooseTokenAction(user, 'Docker provisioner');
     await user.click(lastButton('Revoke'));
 
     expect(await screen.findByText('Provisioner token not found')).toBeVisible();

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -1,0 +1,288 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {ReactElement} from 'react';
+import {WorkspaceProvisionerTokensSettingsSection} from './provisioner-tokens-settings-section.js';
+
+const RUNNERS_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const PROVISIONER_TOKEN_ID = '33333333-3333-4333-8333-333333333333';
+const LAST_SEEN_TEXT = /Last seen/;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function provisionerToken(overrides: Partial<Record<string, string | null>> = {}) {
+  return {
+    id: PROVISIONER_TOKEN_ID,
+    workspace_id: RUNNERS_TEST_WORKSPACE_ID,
+    prefix: 'sf_pt_abcde',
+    name: 'Docker provisioner',
+    created_by_user_id: '22222222-2222-4222-8222-222222222222',
+    revoked_by_user_id: null,
+    expires_at: '2026-05-09T00:00:00.000Z',
+    revoked_at: null,
+    last_seen_at: null,
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function activeProvisioner(overrides: Partial<Record<string, string | null>> = {}) {
+  return {
+    id: PROVISIONER_TOKEN_ID,
+    name: 'Docker provisioner',
+    prefix: 'sf_pt_abcde',
+    last_seen_at: '2026-05-08T01:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function renderProvisionerTokens(element: ReactElement) {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {element}
+      <Toaster />
+    </QueryClientProvider>,
+  );
+}
+
+function firstButton(name: string): HTMLElement {
+  const button = screen.getAllByRole('button', {name})[0];
+  if (!button) throw new Error(`Button not found: ${name}`);
+  return button;
+}
+
+function lastButton(name: string): HTMLElement {
+  const buttons = screen.getAllByRole('button', {name});
+  const button = buttons.at(-1);
+  if (!button) throw new Error(`Button not found: ${name}`);
+  return button;
+}
+
+describe('WorkspaceProvisionerTokensSettingsSection', () => {
+  test('renders an empty usable-token state', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      return Promise.resolve(jsonResponse({tokens: []}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+
+    expect(await screen.findByText('No usable provisioner registration tokens')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Create token'})).toBeVisible();
+  });
+
+  test('creates a token and reveals the raw token inline once', async () => {
+    const user = userEvent.setup();
+    let tokens = [] as ReturnType<typeof provisionerToken>[];
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      if (request.method === 'POST' && request.url.endsWith('/provisioners/tokens')) {
+        tokens = [provisionerToken({name: 'Docker provisioner'})];
+        return Promise.resolve(
+          jsonResponse(
+            {
+              ...provisionerToken({name: 'Docker provisioner'}),
+              raw_token: 'sf_pt_raw-created-token',
+            },
+            {status: 201},
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({tokens}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    await screen.findByText('No usable provisioner registration tokens');
+    await user.click(screen.getByRole('button', {name: 'Create token'}));
+    fireEvent.change(await screen.findByLabelText('Token name'), {
+      target: {value: 'Docker provisioner'},
+    });
+    await user.click(lastButton('Create token'));
+
+    expect(await screen.findByText('Token created')).toBeVisible();
+    expect(screen.getByText('sf_pt_raw-created-token')).toBeVisible();
+  });
+
+  test('surfaces create errors without clearing the form', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      if (request.method === 'POST' && request.url.endsWith('/provisioners/tokens')) {
+        return Promise.resolve(
+          jsonResponse({message: 'Token quota reached', code: 'quota-reached'}, {status: 422}),
+        );
+      }
+      return Promise.resolve(jsonResponse({tokens: []}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    await screen.findByText('No usable provisioner registration tokens');
+    await user.click(screen.getByRole('button', {name: 'Create token'}));
+    fireEvent.change(await screen.findByLabelText('Token name'), {
+      target: {value: 'Docker provisioner'},
+    });
+    await user.click(lastButton('Create token'));
+
+    expect(await screen.findByText('Could not create token')).toBeVisible();
+    expect(screen.getByText('Token quota reached')).toBeVisible();
+    expect(screen.getByLabelText('Token name')).toHaveValue('Docker provisioner');
+  });
+
+  test('renders connected, last-seen, and never-connected statuses', async () => {
+    const activeId = '44444444-4444-4444-8444-444444444444';
+    const staleId = '55555555-5555-4555-8555-555555555555';
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(
+          jsonResponse({
+            provisioners: [activeProvisioner({id: activeId, name: 'Active provisioner'})],
+          }),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse({
+          tokens: [
+            provisionerToken({id: activeId, name: 'Active provisioner'}),
+            provisionerToken({
+              id: staleId,
+              name: 'Stale provisioner',
+              last_seen_at: '2026-05-08T01:00:00.000Z',
+            }),
+            provisionerToken({name: 'New provisioner'}),
+          ],
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+
+    expect((await screen.findAllByText('Connected')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(LAST_SEEN_TEXT).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Never connected').length).toBeGreaterThan(0);
+  });
+
+  test('renders recency when active provisioners cannot load', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(
+          jsonResponse({message: 'Server error', code: 'server-error'}, {status: 500}),
+        );
+      }
+      return Promise.resolve(
+        jsonResponse({
+          tokens: [
+            provisionerToken({
+              last_seen_at: '2026-05-08T01:00:00.000Z',
+            }),
+          ],
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+
+    expect((await screen.findAllByText(LAST_SEEN_TEXT)).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Docker provisioner').length).toBeGreaterThan(0);
+    expect(
+      screen.queryByText('Could not load provisioner registration tokens'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('revokes a token after row confirmation and removes it from the list', async () => {
+    const user = userEvent.setup();
+    let tokens = [provisionerToken()];
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      if (request.method === 'POST' && request.url.includes('/revoke')) {
+        tokens = [];
+        return Promise.resolve(
+          jsonResponse(
+            provisionerToken({
+              revoked_at: '2026-05-08T01:00:00.000Z',
+              revoked_by_user_id: '22222222-2222-4222-8222-222222222222',
+            }),
+          ),
+        );
+      }
+      return Promise.resolve(jsonResponse({tokens}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    expect((await screen.findAllByText('Docker provisioner')).length).toBeGreaterThan(0);
+    await user.click(firstButton('Revoke Docker provisioner'));
+    await user.click(lastButton('Revoke'));
+
+    await waitFor(() => expect(screen.queryByText('Docker provisioner')).not.toBeInTheDocument());
+    expect(screen.getByText('No usable provisioner registration tokens')).toBeVisible();
+  });
+
+  test('shows a recoverable revoke error', async () => {
+    const user = userEvent.setup();
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      if (request.method === 'POST' && request.url.includes('/revoke')) {
+        return Promise.resolve(
+          jsonResponse({message: 'Provisioner token not found', code: 'not-found'}, {status: 404}),
+        );
+      }
+      return Promise.resolve(jsonResponse({tokens: [provisionerToken()]}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    expect((await screen.findAllByText('Docker provisioner')).length).toBeGreaterThan(0);
+    await user.click(firstButton('Revoke Docker provisioner'));
+    await user.click(lastButton('Revoke'));
+
+    expect(await screen.findByText('Provisioner token not found')).toBeVisible();
+    expect(screen.getAllByText('Docker provisioner').length).toBeGreaterThan(0);
+  });
+});

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.test.tsx
@@ -1,5 +1,5 @@
 import {configureApiClient} from '@shipfox/client-api';
-import {Toaster} from '@shipfox/react-ui';
+import {formatDate, formatTimestamp, Toaster} from '@shipfox/react-ui';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -124,6 +124,43 @@ describe('WorkspaceProvisionerTokensSettingsSection', () => {
 
     expect(await screen.findByText('Token created')).toBeVisible();
     expect(screen.getByText('sf_pt_raw-created-token')).toBeVisible();
+  });
+
+  test('renders compact dates with exact timestamp tooltips', async () => {
+    const user = userEvent.setup();
+    const createdAt = '2026-05-08T00:00:00.000Z';
+    const expiresAt = '2026-05-09T00:00:00.000Z';
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      return Promise.resolve(
+        jsonResponse({
+          tokens: [provisionerToken({created_at: createdAt, expires_at: expiresAt})],
+        }),
+      );
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderProvisionerTokens(
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={RUNNERS_TEST_WORKSPACE_ID} />,
+    );
+    const expiresDate = await screen.findAllByText(formatDate(expiresAt));
+    const createdDate = await screen.findAllByText(formatDate(createdAt));
+    const expiresDateTrigger = expiresDate[0];
+    const createdDateTrigger = createdDate[0];
+    if (!expiresDateTrigger || !createdDateTrigger) throw new Error('Token dates not rendered');
+
+    expect(screen.queryByText(formatTimestamp(expiresAt))).not.toBeInTheDocument();
+    await user.hover(expiresDateTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(expiresAt));
+
+    await user.unhover(expiresDateTrigger);
+    await user.hover(createdDateTrigger);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(formatTimestamp(createdAt));
   });
 
   test('surfaces create errors without clearing the form', async () => {

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
@@ -1,0 +1,116 @@
+import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {
+  Button,
+  Header,
+  Icon,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  ModalTrigger,
+  RelativeTimeProvider,
+  Text,
+} from '@shipfox/react-ui';
+import {useMemo, useState} from 'react';
+import {
+  useActiveProvisionersQuery,
+  useProvisionerTokensQuery,
+} from '#hooks/api/provisioner-tokens.js';
+import {
+  CreatedProvisionerTokenPanel,
+  CreateProvisionerTokenForm,
+} from './create-provisioner-token-form.js';
+import {
+  EmptyProvisionerTokens,
+  ProvisionerTokenList,
+  ProvisionerTokenTableSkeleton,
+} from './provisioner-token-list.js';
+
+export function WorkspaceProvisionerTokensSettingsSection({workspaceId}: {workspaceId: string}) {
+  const tokensQuery = useProvisionerTokensQuery(workspaceId);
+  const activeProvisionersQuery = useActiveProvisionersQuery(workspaceId);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [createdToken, setCreatedToken] = useState<CreateProvisionerTokenResponseDto | null>(null);
+  const tokens = tokensQuery.data?.tokens ?? [];
+  const activeIds = useMemo(
+    () => new Set(activeProvisionersQuery.data?.provisioners.map((provisioner) => provisioner.id)),
+    [activeProvisionersQuery.data],
+  );
+
+  function handleOpenChange(nextOpen: boolean) {
+    setIsModalOpen(nextOpen);
+    if (!nextOpen) {
+      setCreatedToken(null);
+    }
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-32">
+      <section className="flex flex-col gap-16">
+        <div className="flex items-center justify-between gap-16 max-[640px]:items-start">
+          <div className="flex flex-col gap-4">
+            <Header variant="h3">Provisioner registration tokens</Header>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Let a provisioner (an autoscaler such as the Docker provisioner) connect to this
+              workspace and provision runners on demand. The provisioner mints its own short-lived
+              runner tokens.
+            </Text>
+          </div>
+          <div className="flex items-center gap-12">
+            {(tokensQuery.isFetching && !tokensQuery.isPending) ||
+            (activeProvisionersQuery.isFetching && !activeProvisionersQuery.isPending) ? (
+              <Icon
+                name="loader4Line"
+                className="mt-2 size-18 text-foreground-neutral-muted"
+                aria-label="Refreshing provisioner tokens"
+              />
+            ) : null}
+            <Modal open={isModalOpen} onOpenChange={handleOpenChange}>
+              <ModalTrigger asChild>
+                <Button>Create token</Button>
+              </ModalTrigger>
+              <ModalContent aria-describedby={undefined}>
+                <ModalTitle className="sr-only">Create provisioner registration token</ModalTitle>
+                <ModalHeader>
+                  <Text
+                    size="lg"
+                    aria-hidden="true"
+                    className="overflow-ellipsis overflow-hidden whitespace-nowrap"
+                  >
+                    Create provisioner registration token
+                  </Text>
+                </ModalHeader>
+                {createdToken ? (
+                  <ModalBody className="gap-16">
+                    <CreatedProvisionerTokenPanel token={createdToken} />
+                  </ModalBody>
+                ) : (
+                  <CreateProvisionerTokenForm
+                    workspaceId={workspaceId}
+                    onCreated={setCreatedToken}
+                  />
+                )}
+              </ModalContent>
+            </Modal>
+          </div>
+        </div>
+
+        {tokensQuery.isPending ? <ProvisionerTokenTableSkeleton /> : null}
+
+        {tokensQuery.isError && tokensQuery.data === undefined ? (
+          <QueryLoadError query={tokensQuery} subject="provisioner registration tokens" />
+        ) : null}
+
+        {tokensQuery.data !== undefined && tokens.length === 0 ? <EmptyProvisionerTokens /> : null}
+
+        {tokens.length > 0 ? (
+          <RelativeTimeProvider>
+            <ProvisionerTokenList workspaceId={workspaceId} tokens={tokens} activeIds={activeIds} />
+          </RelativeTimeProvider>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
+++ b/libs/client/runners/src/components/provisioner-tokens-settings-section.tsx
@@ -51,11 +51,10 @@ export function WorkspaceProvisionerTokensSettingsSection({workspaceId}: {worksp
       <section className="flex flex-col gap-16">
         <div className="flex items-center justify-between gap-16 max-[640px]:items-start">
           <div className="flex flex-col gap-4">
-            <Header variant="h3">Provisioner registration tokens</Header>
+            <Header variant="h3">Runner provisioner registration tokens</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
-              Let a provisioner (an autoscaler such as the Docker provisioner) connect to this
-              workspace and provision runners on demand. The provisioner mints its own short-lived
-              runner tokens.
+              Register runner provisioners that connect to this workspace and create runners
+              dynamically based on demand.
             </Text>
           </div>
           <div className="flex items-center gap-12">

--- a/libs/client/runners/src/components/token-date.tsx
+++ b/libs/client/runners/src/components/token-date.tsx
@@ -1,0 +1,27 @@
+import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
+
+export function TokenDate({
+  value,
+  date,
+  timestamp,
+}: {
+  value: string | null;
+  date: string;
+  timestamp: string | undefined;
+}) {
+  if (!value || !timestamp) return <>{date}</>;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="cursor-help rounded-4 outline-none focus-visible:shadow-button-neutral-focus"
+        >
+          <time dateTime={value}>{date}</time>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{timestamp}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/libs/client/runners/src/components/token-expiration-select.tsx
+++ b/libs/client/runners/src/components/token-expiration-select.tsx
@@ -1,0 +1,64 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  useFormField,
+} from '@shipfox/react-ui';
+
+export type TokenExpirationOption =
+  | '86400'
+  | '604800'
+  | '2592000'
+  | '7776000'
+  | '15552000'
+  | '31536000'
+  | 'never';
+
+export const expirationOptions: Array<{value: TokenExpirationOption; label: string}> = [
+  {value: '86400', label: '1 day'},
+  {value: '604800', label: '7 days'},
+  {value: '2592000', label: '30 days'},
+  {value: '7776000', label: '90 days'},
+  {value: '15552000', label: '180 days'},
+  {value: '31536000', label: '1 year'},
+  {value: 'never', label: 'Never'},
+];
+
+export function expirationHint(expiration: TokenExpirationOption): string {
+  if (expiration === 'never') return 'Token will not expire.';
+  const expiresAt = new Date(Date.now() + Number(expiration) * 1000);
+  const formatted = new Intl.DateTimeFormat(undefined, {dateStyle: 'medium'}).format(expiresAt);
+  return `Expires on ${formatted}.`;
+}
+
+export function ExpirationSelect({
+  value,
+  onValueChange,
+}: {
+  value: TokenExpirationOption;
+  onValueChange: (next: TokenExpirationOption) => void;
+}) {
+  const wiring = useFormField();
+  return (
+    <Select value={value} onValueChange={(next) => onValueChange(next as TokenExpirationOption)}>
+      <SelectTrigger
+        id={wiring.id}
+        aria-invalid={wiring['aria-invalid']}
+        aria-describedby={wiring['aria-describedby']}
+        aria-label="Token expiration"
+        className="w-full"
+      >
+        <SelectValue placeholder="Select expiration" />
+      </SelectTrigger>
+      <SelectContent>
+        {expirationOptions.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/libs/client/runners/src/components/token-name.tsx
+++ b/libs/client/runners/src/components/token-name.tsx
@@ -1,0 +1,19 @@
+import {Tooltip, TooltipContent, TooltipTrigger} from '@shipfox/react-ui';
+
+export function TokenName({name}: {name: string}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="block w-full min-w-0 cursor-help truncate rounded-4 text-left text-sm leading-20 font-medium text-foreground-neutral-base outline-none focus-visible:shadow-button-neutral-focus"
+        >
+          {name}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span className="block max-w-[360px] break-words">{name}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/libs/client/runners/src/components/token-settings-sections.stories.tsx
+++ b/libs/client/runners/src/components/token-settings-sections.stories.tsx
@@ -4,7 +4,7 @@ import {Code, RelativeTimeProvider, Toaster} from '@shipfox/react-ui';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import type {ReactNode} from 'react';
-import {screen, within} from 'storybook/test';
+import {within} from 'storybook/test';
 import {CreatedManualRegistrationTokenPanel} from './create-manual-registration-token-form.js';
 import {CreatedProvisionerTokenPanel} from './create-provisioner-token-form.js';
 import {
@@ -26,7 +26,7 @@ const EIGHT_MINUTES_AGO = '2026-06-26T11:52:00.000Z';
 const EXPIRES_AT = '2026-09-24T12:00:00.000Z';
 const CREATED_AT = '2026-06-20T12:00:00.000Z';
 
-type Scenario = 'populated' | 'empty' | 'loading' | 'manual-error' | 'provisioner-error';
+type Scenario = 'populated' | 'empty' | 'loading' | 'errors';
 
 interface TokenSettingsSectionsStoryProps {
   scenario: Scenario;
@@ -98,7 +98,16 @@ export const DataStates: Story = {
   ),
 };
 
-export const ProvisionerStatuses: Story = {
+export const Errors: Story = {
+  args: {scenario: 'errors'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText("Couldn't load manual registration tokens");
+    await canvas.findByText("Couldn't load provisioner registration tokens");
+  },
+};
+
+export const Statuses: Story = {
   render: () => (
     <StorySurface>
       <ProvisionerTokenList
@@ -124,28 +133,62 @@ export const ProvisionerStatuses: Story = {
       />
     </StorySurface>
   ),
-  play: async () => {
-    await screen.findAllByText('Connected');
-    await screen.findAllByText('Last seen');
-    await screen.findAllByText('Never connected');
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findAllByText('Connected');
+    await canvas.findAllByText('Last seen');
+    await canvas.findAllByText('Never connected');
   },
 };
 
-export const ExistingRunnerTokens: Story = {
+export const Content: Story = {
   render: () => (
     <StorySurface>
-      <ManualRegistrationTokenList
-        workspaceId={WORKSPACE_ID}
-        tokens={[
-          manualToken({name: 'Deploy runner', prefix: 'sf_mrt_deploy'}),
-          manualToken({
-            id: '66666666-6666-4666-8666-666666666666',
-            name: 'macOS build host',
-            prefix: 'sf_mrt_macos',
-            expires_at: null,
-          }),
-        ]}
-      />
+      <StateExample label="Existing tokens">
+        <div className="flex flex-col gap-24">
+          <ManualRegistrationTokenList
+            workspaceId={WORKSPACE_ID}
+            tokens={[
+              manualToken({name: 'Deploy runner', prefix: 'sf_mrt_deploy'}),
+              manualToken({
+                id: '66666666-6666-4666-8666-666666666666',
+                name: 'macOS build host',
+                prefix: 'sf_mrt_macos',
+                expires_at: null,
+              }),
+            ]}
+          />
+          <ProvisionerTokenList
+            workspaceId={WORKSPACE_ID}
+            tokens={provisionerTokens()}
+            activeIds={new Set(['33333333-3333-4333-8333-333333333333'])}
+          />
+        </div>
+      </StateExample>
+      <StateExample label="Long names">
+        <div className="flex flex-col gap-24">
+          <ManualRegistrationTokenList
+            workspaceId={WORKSPACE_ID}
+            tokens={[
+              manualToken({
+                name: 'self-hosted-runner-for-production-release-candidate-validation-on-metal',
+                prefix: 'sf_mrt_release_candidate_validation',
+              }),
+            ]}
+          />
+          <ProvisionerTokenList
+            workspaceId={WORKSPACE_ID}
+            tokens={[
+              provisionerToken({
+                name: 'docker-provisioner-for-west-coast-gpu-burst-capacity-and-fallback',
+                prefix: 'sf_pt_west_coast_gpu_burst',
+                last_seen_at: EIGHT_MINUTES_AGO,
+              }),
+            ]}
+            activeIds={new Set()}
+          />
+        </div>
+      </StateExample>
     </StorySurface>
   ),
 };
@@ -178,51 +221,6 @@ export const CreatedTokenPanels: Story = {
   ),
 };
 
-export const LongNames: Story = {
-  render: () => (
-    <StorySurface>
-      <ManualRegistrationTokenList
-        workspaceId={WORKSPACE_ID}
-        tokens={[
-          manualToken({
-            name: 'self-hosted-runner-for-production-release-candidate-validation-on-metal',
-            prefix: 'sf_mrt_release_candidate_validation',
-          }),
-        ]}
-      />
-      <ProvisionerTokenList
-        workspaceId={WORKSPACE_ID}
-        tokens={[
-          provisionerToken({
-            name: 'docker-provisioner-for-west-coast-gpu-burst-capacity-and-fallback',
-            prefix: 'sf_pt_west_coast_gpu_burst',
-            last_seen_at: EIGHT_MINUTES_AGO,
-          }),
-        ]}
-        activeIds={new Set()}
-      />
-    </StorySurface>
-  ),
-};
-
-export const ManualLoadError: Story = {
-  args: {scenario: 'manual-error'},
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await canvas.findByText("Couldn't load manual registration tokens");
-    await canvas.findAllByText('Docker autoscaler');
-  },
-};
-
-export const ProvisionerLoadError: Story = {
-  args: {scenario: 'provisioner-error'},
-  play: async ({canvasElement}) => {
-    const canvas = within(canvasElement);
-    await canvas.findAllByText('Deploy runner');
-    await canvas.findByText("Couldn't load provisioner registration tokens");
-  },
-};
-
 function StorySurface({children}: {children: ReactNode}) {
   return (
     <div className="min-h-screen bg-background-neutral-background p-24">
@@ -249,7 +247,7 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
     const url = requestUrl(input);
     if (scenario === 'loading') return new Promise<Response>(() => undefined);
     if (url.pathname.endsWith('/runners/manual-registration-tokens')) {
-      if (scenario === 'manual-error') return Promise.resolve(errorResponse());
+      if (scenario === 'errors') return Promise.resolve(errorResponse());
       return Promise.resolve(
         jsonResponse({
           manual_registration_tokens: scenario === 'empty' ? [] : [manualToken()],
@@ -257,7 +255,7 @@ function fetchForScenario(scenario: Scenario): typeof fetch {
       );
     }
     if (url.pathname.endsWith('/provisioners/tokens')) {
-      if (scenario === 'provisioner-error') return Promise.resolve(errorResponse());
+      if (scenario === 'errors') return Promise.resolve(errorResponse());
       return Promise.resolve(
         jsonResponse({
           tokens: scenario === 'empty' ? [] : provisionerTokens(),

--- a/libs/client/runners/src/components/token-settings-sections.stories.tsx
+++ b/libs/client/runners/src/components/token-settings-sections.stories.tsx
@@ -1,0 +1,360 @@
+import type {ManualRegistrationTokenDto, ProvisionerTokenDto} from '@shipfox/api-runners-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {Code, RelativeTimeProvider, Toaster} from '@shipfox/react-ui';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
+import {screen, within} from 'storybook/test';
+import {CreatedManualRegistrationTokenPanel} from './create-manual-registration-token-form.js';
+import {CreatedProvisionerTokenPanel} from './create-provisioner-token-form.js';
+import {
+  EmptyManualRegistrationTokens,
+  ManualRegistrationTokenList,
+  ManualRegistrationTokenTableSkeleton,
+} from './manual-registration-token-list.js';
+import {WorkspaceManualRegistrationTokensSettingsSection} from './manual-registration-tokens-settings-section.js';
+import {
+  EmptyProvisionerTokens,
+  ProvisionerTokenList,
+  ProvisionerTokenTableSkeleton,
+} from './provisioner-token-list.js';
+import {WorkspaceProvisionerTokensSettingsSection} from './provisioner-tokens-settings-section.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const NOW = '2026-06-26T12:00:00.000Z';
+const EIGHT_MINUTES_AGO = '2026-06-26T11:52:00.000Z';
+const EXPIRES_AT = '2026-09-24T12:00:00.000Z';
+const CREATED_AT = '2026-06-20T12:00:00.000Z';
+
+type Scenario = 'populated' | 'empty' | 'loading' | 'manual-error' | 'provisioner-error';
+
+interface TokenSettingsSectionsStoryProps {
+  scenario: Scenario;
+}
+
+const withQueryClient: Decorator = (Story) => {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RelativeTimeProvider>
+        <Story />
+      </RelativeTimeProvider>
+      <Toaster />
+    </QueryClientProvider>
+  );
+};
+
+function TokenSettingsSectionsStory({scenario}: TokenSettingsSectionsStoryProps) {
+  configureApiClient({
+    baseUrl: 'https://api.example.test',
+    fetchImpl: fetchForScenario(scenario),
+  });
+
+  return (
+    <StorySurface>
+      <WorkspaceManualRegistrationTokensSettingsSection workspaceId={WORKSPACE_ID} />
+      <WorkspaceProvisionerTokensSettingsSection workspaceId={WORKSPACE_ID} />
+    </StorySurface>
+  );
+}
+
+const meta = {
+  title: 'Runners/TokenSettingsSections',
+  component: TokenSettingsSectionsStory,
+  parameters: {layout: 'fullscreen'},
+  decorators: [withQueryClient],
+  args: {scenario: 'populated'},
+} satisfies Meta<typeof TokenSettingsSectionsStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findAllByText('Deploy runner');
+    await canvas.findAllByText('Docker autoscaler');
+    await canvas.findAllByText('Connected');
+    await canvas.findAllByText('Never connected');
+  },
+};
+
+export const DataStates: Story = {
+  render: () => (
+    <StorySurface>
+      <StateExample label="Manual empty">
+        <EmptyManualRegistrationTokens />
+      </StateExample>
+      <StateExample label="Manual loading">
+        <ManualRegistrationTokenTableSkeleton />
+      </StateExample>
+      <StateExample label="Provisioner empty">
+        <EmptyProvisionerTokens />
+      </StateExample>
+      <StateExample label="Provisioner loading">
+        <ProvisionerTokenTableSkeleton />
+      </StateExample>
+    </StorySurface>
+  ),
+};
+
+export const ProvisionerStatuses: Story = {
+  render: () => (
+    <StorySurface>
+      <ProvisionerTokenList
+        workspaceId={WORKSPACE_ID}
+        tokens={[
+          provisionerToken({
+            id: '33333333-3333-4333-8333-333333333333',
+            name: 'Docker autoscaler',
+            last_seen_at: NOW,
+          }),
+          provisionerToken({
+            id: '44444444-4444-4444-8444-444444444444',
+            name: 'Kubernetes spot pool',
+            last_seen_at: EIGHT_MINUTES_AGO,
+          }),
+          provisionerToken({
+            id: '55555555-5555-4555-8555-555555555555',
+            name: 'Buildkite migration pool',
+            last_seen_at: null,
+          }),
+        ]}
+        activeIds={new Set(['33333333-3333-4333-8333-333333333333'])}
+      />
+    </StorySurface>
+  ),
+  play: async () => {
+    await screen.findAllByText('Connected');
+    await screen.findAllByText('Last seen');
+    await screen.findAllByText('Never connected');
+  },
+};
+
+export const ExistingRunnerTokens: Story = {
+  render: () => (
+    <StorySurface>
+      <ManualRegistrationTokenList
+        workspaceId={WORKSPACE_ID}
+        tokens={[
+          manualToken({name: 'Deploy runner', prefix: 'sf_mrt_deploy'}),
+          manualToken({
+            id: '66666666-6666-4666-8666-666666666666',
+            name: 'macOS build host',
+            prefix: 'sf_mrt_macos',
+            expires_at: null,
+          }),
+        ]}
+      />
+    </StorySurface>
+  ),
+};
+
+export const CreatedTokenPanels: Story = {
+  render: () => (
+    <StorySurface>
+      <StateExample label="Manual token reveal">
+        <CreatedManualRegistrationTokenPanel
+          token={{
+            id: '77777777-7777-4777-8777-777777777777',
+            raw_token: 'sf_mrt_4nJvNrs23ExampleManualTokenValue',
+            prefix: 'sf_mrt_4nJv',
+            name: 'Deploy runner',
+            workspace_id: WORKSPACE_ID,
+            expires_at: EXPIRES_AT,
+            created_at: CREATED_AT,
+          }}
+        />
+      </StateExample>
+      <StateExample label="Provisioner token reveal">
+        <CreatedProvisionerTokenPanel
+          token={{
+            ...provisionerToken({name: 'Docker autoscaler'}),
+            raw_token: 'sf_pt_Rv8YwrExampleProvisionerTokenValue',
+          }}
+        />
+      </StateExample>
+    </StorySurface>
+  ),
+};
+
+export const LongNames: Story = {
+  render: () => (
+    <StorySurface>
+      <ManualRegistrationTokenList
+        workspaceId={WORKSPACE_ID}
+        tokens={[
+          manualToken({
+            name: 'self-hosted-runner-for-production-release-candidate-validation-on-metal',
+            prefix: 'sf_mrt_release_candidate_validation',
+          }),
+        ]}
+      />
+      <ProvisionerTokenList
+        workspaceId={WORKSPACE_ID}
+        tokens={[
+          provisionerToken({
+            name: 'docker-provisioner-for-west-coast-gpu-burst-capacity-and-fallback',
+            prefix: 'sf_pt_west_coast_gpu_burst',
+            last_seen_at: EIGHT_MINUTES_AGO,
+          }),
+        ]}
+        activeIds={new Set()}
+      />
+    </StorySurface>
+  ),
+};
+
+export const ManualLoadError: Story = {
+  args: {scenario: 'manual-error'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText("Couldn't load manual registration tokens");
+    await canvas.findAllByText('Docker autoscaler');
+  },
+};
+
+export const ProvisionerLoadError: Story = {
+  args: {scenario: 'provisioner-error'},
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await canvas.findAllByText('Deploy runner');
+    await canvas.findByText("Couldn't load provisioner registration tokens");
+  },
+};
+
+function StorySurface({children}: {children: ReactNode}) {
+  return (
+    <div className="min-h-screen bg-background-neutral-background p-24">
+      <div className="mx-auto flex w-full max-w-[920px] flex-col gap-32">{children}</div>
+    </div>
+  );
+}
+
+function StateExample({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <Code variant="label" className="text-foreground-neutral-subtle">
+        {label}
+      </Code>
+      <div className="rounded-8 border border-border-neutral-base bg-background-neutral-base p-16">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return (input) => {
+    const url = requestUrl(input);
+    if (scenario === 'loading') return new Promise<Response>(() => undefined);
+    if (url.pathname.endsWith('/runners/manual-registration-tokens')) {
+      if (scenario === 'manual-error') return Promise.resolve(errorResponse());
+      return Promise.resolve(
+        jsonResponse({
+          manual_registration_tokens: scenario === 'empty' ? [] : [manualToken()],
+        }),
+      );
+    }
+    if (url.pathname.endsWith('/provisioners/tokens')) {
+      if (scenario === 'provisioner-error') return Promise.resolve(errorResponse());
+      return Promise.resolve(
+        jsonResponse({
+          tokens: scenario === 'empty' ? [] : provisionerTokens(),
+        }),
+      );
+    }
+    if (url.pathname.endsWith('/provisioners/active')) {
+      return Promise.resolve(
+        jsonResponse({
+          provisioners:
+            scenario === 'empty'
+              ? []
+              : [
+                  {
+                    id: '33333333-3333-4333-8333-333333333333',
+                    name: 'Docker autoscaler',
+                    prefix: 'sf_pt_docker',
+                    last_seen_at: NOW,
+                  },
+                ],
+        }),
+      );
+    }
+    return Promise.resolve(jsonResponse({}, {status: 404}));
+  };
+}
+
+function provisionerTokens(): ProvisionerTokenDto[] {
+  return [
+    provisionerToken({
+      id: '33333333-3333-4333-8333-333333333333',
+      name: 'Docker autoscaler',
+      prefix: 'sf_pt_docker',
+      last_seen_at: NOW,
+    }),
+    provisionerToken({
+      id: '44444444-4444-4444-8444-444444444444',
+      name: 'Kubernetes spot pool',
+      prefix: 'sf_pt_spot',
+      last_seen_at: EIGHT_MINUTES_AGO,
+    }),
+    provisionerToken({
+      id: '55555555-5555-4555-8555-555555555555',
+      name: 'Buildkite migration pool',
+      prefix: 'sf_pt_migrate',
+      last_seen_at: null,
+    }),
+  ];
+}
+
+function manualToken(
+  overrides: Partial<ManualRegistrationTokenDto> = {},
+): ManualRegistrationTokenDto {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    workspace_id: WORKSPACE_ID,
+    prefix: 'sf_mrt_deploy',
+    name: 'Deploy runner',
+    expires_at: EXPIRES_AT,
+    revoked_at: null,
+    created_at: CREATED_AT,
+    updated_at: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function provisionerToken(overrides: Partial<ProvisionerTokenDto> = {}): ProvisionerTokenDto {
+  return {
+    id: '33333333-3333-4333-8333-333333333333',
+    workspace_id: WORKSPACE_ID,
+    prefix: 'sf_pt_docker',
+    name: 'Docker autoscaler',
+    created_by_user_id: '99999999-9999-4999-8999-999999999999',
+    revoked_by_user_id: null,
+    expires_at: EXPIRES_AT,
+    revoked_at: null,
+    last_seen_at: NOW,
+    created_at: CREATED_AT,
+    updated_at: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function requestUrl(input: RequestInfo | URL): URL {
+  if (typeof input === 'string') return new URL(input);
+  if (input instanceof URL) return input;
+  return new URL(input.url);
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {'content-type': 'application/json'},
+    ...init,
+  });
+}
+
+function errorResponse() {
+  return jsonResponse({code: 'server-error'}, {status: 500, statusText: 'Server error'});
+}

--- a/libs/client/runners/src/hooks/api/provisioner-tokens.test.ts
+++ b/libs/client/runners/src/hooks/api/provisioner-tokens.test.ts
@@ -1,0 +1,127 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {
+  createProvisionerToken,
+  listActiveProvisioners,
+  listProvisionerTokens,
+  revokeProvisionerToken,
+} from './provisioner-tokens.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+const workspaceId = '11111111-1111-4111-8111-111111111111';
+const tokenId = '33333333-3333-4333-8333-333333333333';
+
+describe('provisioner token transports', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('lists provisioner tokens', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({tokens: []}));
+    configureApiClient({fetchImpl});
+
+    const result = await listProvisionerTokens({workspaceId});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.tokens).toEqual([]);
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${workspaceId}/provisioners/tokens`,
+    );
+    expect(request.method).toBe('GET');
+  });
+
+  test('posts token creation body', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse(
+        {
+          id: tokenId,
+          raw_token: 'sf_pt_raw-created-token',
+          prefix: 'sf_pt_raw-c',
+          name: 'Docker provisioner',
+          workspace_id: workspaceId,
+          created_by_user_id: '22222222-2222-4222-8222-222222222222',
+          revoked_by_user_id: null,
+          expires_at: '2026-05-09T00:00:00.000Z',
+          revoked_at: null,
+          last_seen_at: null,
+          created_at: '2026-05-08T00:00:00.000Z',
+          updated_at: '2026-05-08T00:00:00.000Z',
+        },
+        {status: 201},
+      );
+    });
+    configureApiClient({fetchImpl});
+    const body = {name: 'Docker provisioner', ttl_seconds: 86_400};
+
+    const result = await createProvisionerToken({workspaceId, body});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.raw_token).toBe('sf_pt_raw-created-token');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${workspaceId}/provisioners/tokens`,
+    );
+    expect(request.method).toBe('POST');
+    expect(requestBody).toEqual(body);
+  });
+
+  test('posts to the token revoke endpoint', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        id: tokenId,
+        workspace_id: workspaceId,
+        prefix: 'sf_pt_abcde',
+        name: 'Docker provisioner',
+        created_by_user_id: '22222222-2222-4222-8222-222222222222',
+        revoked_by_user_id: '22222222-2222-4222-8222-222222222222',
+        expires_at: '2026-05-09T00:00:00.000Z',
+        revoked_at: '2026-05-08T01:00:00.000Z',
+        last_seen_at: null,
+        created_at: '2026-05-08T00:00:00.000Z',
+        updated_at: '2026-05-08T01:00:00.000Z',
+      }),
+    );
+    configureApiClient({fetchImpl});
+
+    const result = await revokeProvisionerToken({workspaceId, tokenId});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.revoked_at).toBe('2026-05-08T01:00:00.000Z');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${workspaceId}/provisioners/tokens/${tokenId}/revoke`,
+    );
+    expect(request.method).toBe('POST');
+  });
+
+  test('lists active provisioners', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        provisioners: [
+          {
+            id: tokenId,
+            name: 'Docker provisioner',
+            prefix: 'sf_pt_abcde',
+            last_seen_at: '2026-05-08T01:00:00.000Z',
+          },
+        ],
+      }),
+    );
+    configureApiClient({fetchImpl});
+
+    const result = await listActiveProvisioners({workspaceId});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.provisioners).toHaveLength(1);
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${workspaceId}/provisioners/active`,
+    );
+    expect(request.method).toBe('GET');
+  });
+});

--- a/libs/client/runners/src/hooks/api/provisioner-tokens.ts
+++ b/libs/client/runners/src/hooks/api/provisioner-tokens.ts
@@ -1,0 +1,102 @@
+import type {
+  CreateProvisionerTokenBodyDto,
+  CreateProvisionerTokenResponseDto,
+  ListActiveProvisionersResponseDto,
+  ListProvisionerTokensResponseDto,
+  RevokeProvisionerTokenResponseDto,
+} from '@shipfox/api-runners-dto';
+import {apiRequest} from '@shipfox/client-api';
+import {useMutation, useQuery} from '@tanstack/react-query';
+
+const PROVISIONER_TOKEN_REFETCH_INTERVAL_MS = 30_000;
+
+export const provisionerTokenQueryKeys = {
+  all: ['provisioner-tokens'] as const,
+  list: (workspaceId: string) => [...provisionerTokenQueryKeys.all, 'tokens', workspaceId] as const,
+  active: (workspaceId: string) =>
+    [...provisionerTokenQueryKeys.all, 'provisioners', workspaceId] as const,
+};
+
+export async function listProvisionerTokens({
+  workspaceId,
+  signal,
+}: {
+  workspaceId: string;
+  signal?: AbortSignal;
+}) {
+  return await apiRequest<ListProvisionerTokensResponseDto>(
+    `/workspaces/${workspaceId}/provisioners/tokens`,
+    {signal},
+  );
+}
+
+export async function createProvisionerToken({
+  workspaceId,
+  body,
+}: {
+  workspaceId: string;
+  body: CreateProvisionerTokenBodyDto;
+}) {
+  return await apiRequest<CreateProvisionerTokenResponseDto>(
+    `/workspaces/${workspaceId}/provisioners/tokens`,
+    {method: 'POST', body},
+  );
+}
+
+export async function revokeProvisionerToken({
+  workspaceId,
+  tokenId,
+}: {
+  workspaceId: string;
+  tokenId: string;
+}) {
+  return await apiRequest<RevokeProvisionerTokenResponseDto>(
+    `/workspaces/${workspaceId}/provisioners/tokens/${tokenId}/revoke`,
+    {method: 'POST'},
+  );
+}
+
+export async function listActiveProvisioners({
+  workspaceId,
+  signal,
+}: {
+  workspaceId: string;
+  signal?: AbortSignal;
+}) {
+  return await apiRequest<ListActiveProvisionersResponseDto>(
+    `/workspaces/${workspaceId}/provisioners/active`,
+    {signal},
+  );
+}
+
+export function useProvisionerTokensQuery(workspaceId: string | undefined) {
+  return useQuery({
+    queryKey: workspaceId
+      ? provisionerTokenQueryKeys.list(workspaceId)
+      : [...provisionerTokenQueryKeys.all, 'tokens'],
+    enabled: Boolean(workspaceId),
+    queryFn: ({signal}) => listProvisionerTokens({workspaceId: workspaceId ?? '', signal}),
+    refetchInterval: PROVISIONER_TOKEN_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
+}
+
+export function useCreateProvisionerTokenMutation() {
+  return useMutation({mutationFn: createProvisionerToken});
+}
+
+export function useRevokeProvisionerTokenMutation() {
+  return useMutation({mutationFn: revokeProvisionerToken});
+}
+
+export function useActiveProvisionersQuery(workspaceId: string | undefined) {
+  return useQuery({
+    queryKey: workspaceId
+      ? provisionerTokenQueryKeys.active(workspaceId)
+      : [...provisionerTokenQueryKeys.all, 'provisioners'],
+    enabled: Boolean(workspaceId),
+    queryFn: ({signal}) => listActiveProvisioners({workspaceId: workspaceId ?? '', signal}),
+    refetchInterval: PROVISIONER_TOKEN_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/libs/client/runners/src/index.ts
+++ b/libs/client/runners/src/index.ts
@@ -1,2 +1,4 @@
 export * from './components/manual-registration-tokens-settings-section.js';
+export * from './components/provisioner-tokens-settings-section.js';
 export * from './hooks/api/manual-registration-tokens.js';
+export * from './hooks/api/provisioner-tokens.js';

--- a/libs/client/runners/vitest.config.ts
+++ b/libs/client/runners/vitest.config.ts
@@ -1,7 +1,18 @@
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {argosVitestPlugin} from '@argos-ci/storybook/vitest-plugin';
 import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(
   {
+    plugins: [react(), tailwindcss()],
     test: {
       projects: [
         {
@@ -19,6 +30,38 @@ export default defineConfig(
             environment: 'jsdom',
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
+          },
+        },
+        {
+          extends: true,
+          plugins: [
+            storybookTest({configDir: path.join(dirname, '.storybook')}),
+            argosVitestPlugin({
+              uploadToArgos: !!process.env.CI,
+              ...(process.env.ARGOS_TOKEN ? {token: process.env.ARGOS_TOKEN} : {}),
+              buildName: 'client-runners',
+              argosCSS: `
+                *, *::before, *::after {
+                  animation-delay: 0s !important;
+                  animation-duration: 0s !important;
+                  transition-delay: 0s !important;
+                  transition-duration: 0s !important;
+                }
+              `,
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright({
+                launchOptions: {
+                  args: ['--disable-lcd-text', '--font-render-hinting=none'],
+                },
+              }),
+              instances: [{browser: 'chromium'}],
+            },
           },
         },
       ],

--- a/libs/client/workspace-settings/src/components/settings-nav.tsx
+++ b/libs/client/workspace-settings/src/components/settings-nav.tsx
@@ -9,6 +9,9 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
   const isRunnersActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/runners', params: {wid: workspaceId}}),
   );
+  const isProvisionersActive = Boolean(
+    matchRoute({to: '/workspaces/$wid/settings/provisioners', params: {wid: workspaceId}}),
+  );
   const isAgentProvidersActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/agent-providers', params: {wid: workspaceId}}),
   );
@@ -47,6 +50,20 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
         >
           <Icon name="settings3Line" className="size-16" />
           Runners
+        </Link>
+      </Button>
+      <Button
+        asChild
+        variant={isProvisionersActive ? 'secondary' : 'transparent'}
+        className="w-full justify-start"
+      >
+        <Link
+          to="/workspaces/$wid/settings/provisioners"
+          params={{wid: workspaceId}}
+          aria-current={isProvisionersActive ? 'page' : undefined}
+        >
+          <Icon name="serverLine" className="size-16" />
+          Runner Provisioners
         </Link>
       </Button>
       <Button

--- a/libs/client/workspace-settings/src/components/settings-nav.tsx
+++ b/libs/client/workspace-settings/src/components/settings-nav.tsx
@@ -63,7 +63,7 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
           aria-current={isProvisionersActive ? 'page' : undefined}
         >
           <Icon name="serverLine" className="size-16" />
-          Runner Provisioners
+          Runner provisioners
         </Link>
       </Button>
       <Button

--- a/libs/client/workspace-settings/src/index.ts
+++ b/libs/client/workspace-settings/src/index.ts
@@ -2,4 +2,5 @@ export * from './pages/agent-providers-settings-page.js';
 export * from './pages/events-settings-page.js';
 export * from './pages/integrations-settings-page.js';
 export * from './pages/members-settings-page.js';
+export * from './pages/provisioners-settings-page.js';
 export * from './pages/runners-settings-page.js';

--- a/libs/client/workspace-settings/src/pages/provisioners-settings-page.test.tsx
+++ b/libs/client/workspace-settings/src/pages/provisioners-settings-page.test.tsx
@@ -1,0 +1,30 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {screen} from '@testing-library/react';
+import {
+  jsonResponse,
+  renderWorkspaceSettingsPage,
+  WORKSPACE_SETTINGS_TEST_WID,
+} from '#test/pages.js';
+import {ProvisionersSettingsPage} from './provisioners-settings-page.js';
+
+describe('ProvisionersSettingsPage', () => {
+  test('renders the settings shell and provisioner token section', async () => {
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const request = input as Request;
+      if (request.url.endsWith('/provisioners/active')) {
+        return Promise.resolve(jsonResponse({provisioners: []}));
+      }
+      return Promise.resolve(jsonResponse({tokens: []}));
+    });
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+
+    renderWorkspaceSettingsPage(
+      `/workspaces/${WORKSPACE_SETTINGS_TEST_WID}/settings/provisioners`,
+      <ProvisionersSettingsPage />,
+    );
+
+    expect(await screen.findByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+    expect(await screen.findByText('No usable provisioner registration tokens')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'Create token'})).toBeVisible();
+  });
+});

--- a/libs/client/workspace-settings/src/pages/provisioners-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/provisioners-settings-page.tsx
@@ -1,0 +1,14 @@
+import {WorkspaceProvisionerTokensSettingsSection} from '@shipfox/client-runners';
+import {WorkspaceSettingsShell} from '#components/workspace-settings-shell.js';
+
+export function ProvisionersSettingsPage() {
+  return (
+    <WorkspaceSettingsShell>
+      {(workspace) => (
+        <div>
+          <WorkspaceProvisionerTokensSettingsSection workspaceId={workspace.id} />
+        </div>
+      )}
+    </WorkspaceSettingsShell>
+  );
+}

--- a/libs/client/workspace-settings/test/pages.tsx
+++ b/libs/client/workspace-settings/test/pages.tsx
@@ -46,6 +46,11 @@ function createTestRouter(path: string, element: ReactElement) {
     path: '/workspaces/$wid/settings/runners',
     component: () => element,
   });
+  const provisionersRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/settings/provisioners',
+    component: () => element,
+  });
   const agentProvidersRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/settings/agent-providers',
@@ -59,7 +64,12 @@ function createTestRouter(path: string, element: ReactElement) {
 
   return createRouter({
     history: createMemoryHistory({initialEntries: [path]}),
-    routeTree: rootRoute.addChildren([runnersRoute, agentProvidersRoute, integrationsRoute]),
+    routeTree: rootRoute.addChildren([
+      runnersRoute,
+      provisionersRoute,
+      agentProvidersRoute,
+      integrationsRoute,
+    ]),
   });
 }
 


### PR DESCRIPTION
Add a dedicated Runner Provisioners settings page for managing provisioner registration tokens.

Provisioner tokens authenticate autoscalers that connect to a workspace and provision short-lived runners on demand, but this token type previously had no client UI. This PR splits that workflow from manual runner registration tokens so single-machine runner credentials stay on the existing Runners page while provisioner identities get their own health-oriented surface.

The new page lists provisioner tokens, supports create/reveal-once and revoke flows, polls token and active-provisioner state, and shows a merged connection status built from active IDs plus `last_seen_at`. The manual registration token form also now shares the expiration selector and uses the shared clipboard helper.

Reviewers should pay closest attention to the status fallback behavior when `/active` fails and to the settings route/nav split.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Runner Provisioners settings page to manage provisioner registration tokens separately from manual runner tokens. Users can create (reveal-once), list, and revoke tokens; see live connection status; and get compact tables with tooltips.

- **New Features**
  - Route and nav: Settings → Runner Provisioners (`@shipfox/client-router`, `@shipfox/client-workspace-settings`).
  - Provisioner tokens: list with Connected/Last seen/Never connected via `/provisioners/active` + `last_seen_at`, 30s polling, and a fallback when `/active` fails.
  - Tables: compact dates with exact timestamp tooltips, fixed layouts for truncation, and long names with hover tooltips.
  - Create token modal: name + shared expiration select; reveal raw token once; revoke from a per-row actions menu with modal confirmation; loading/empty states; mobile-friendly lists.
  - Errors: clearer messages for provisioner token create/revoke, including friendly copy on network failures.
  - Hooks/components exported from `@shipfox/client-runners`; Storybook stories and browser visual tests use a fixed clock for stable relative times.

- **Refactors**
  - Manual runner token form now uses shared `ExpirationSelect` and `useCopyToClipboard`; header copy clarified (“Runner registration tokens” with clearer description); revoke moved into an actions menu with modal confirmation for consistency.

<sup>Written for commit 0842b30c82a4a5a9c2b9e65654912203b40278fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

