### PR TITLE
[api-workflows] Persist workflow models on run attempts

### DIFF
--- a/.changeset/steady-models-persist.md
+++ b/.changeset/steady-models-persist.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Persists parsed workflow models on run attempts so later workflow phases can materialize from the frozen template.

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -133,6 +133,7 @@ CREATE TABLE "workflows_workflow_run_attempts" (
 	"status" "workflows_run_status" DEFAULT 'pending' NOT NULL,
 	"rerun_mode" "workflows_rerun_mode",
 	"rerun_by_user_id" uuid,
+	"model" jsonb,
 	"version" integer DEFAULT 1 NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -992,6 +992,12 @@
           "primaryKey": false,
           "notNull": false
         },
+        "model": {
+          "name": "model",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
         "version": {
           "name": "version",
           "type": "integer",

--- a/libs/api/workflows/src/core/entities/workflow-run-attempt.ts
+++ b/libs/api/workflows/src/core/entities/workflow-run-attempt.ts
@@ -1,3 +1,4 @@
+import type {WorkflowModel} from '@shipfox/api-definitions';
 import type {WorkflowRunStatus} from './workflow-run.js';
 
 export type RerunMode = 'all' | 'failed';
@@ -9,6 +10,7 @@ export interface WorkflowRunAttempt {
   status: WorkflowRunStatus;
   rerunMode: RerunMode | null;
   rerunByUserId: string | null;
+  model: WorkflowModel | null;
   version: number;
   createdAt: Date;
   updatedAt: Date;

--- a/libs/api/workflows/src/db/schema/workflow-run-attempts.ts
+++ b/libs/api/workflows/src/db/schema/workflow-run-attempts.ts
@@ -1,6 +1,7 @@
+import type {WorkflowModel} from '@shipfox/api-definitions';
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
-import {check, integer, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
+import {check, integer, jsonb, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {WorkflowRunAttempt} from '#core/entities/workflow-run-attempt.js';
 import {pgTable} from './common.js';
 import {workflowRunRerunModeEnum, workflowRunStatusEnum, workflowRuns} from './workflow-runs.js';
@@ -16,6 +17,7 @@ export const workflowRunAttempts = pgTable(
     status: workflowRunStatusEnum('status').notNull().default('pending'),
     rerunMode: workflowRunRerunModeEnum('rerun_mode'),
     rerunByUserId: uuid('rerun_by_user_id'),
+    model: jsonb('model').$type<WorkflowModel>(),
     version: integer('version').notNull().default(1),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
@@ -42,6 +44,7 @@ export function toWorkflowRunAttempt(row: WorkflowRunAttemptDb): WorkflowRunAtte
     status: row.status,
     rerunMode: row.rerunMode ?? null,
     rerunByUserId: row.rerunByUserId,
+    model: row.model ?? null,
     version: row.version,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -7,6 +7,7 @@ import {
   WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
 } from '@shipfox/api-workflows-dto';
+import {createWorkflowExpression} from '@shipfox/expression';
 import * as opentelemetry from '@shipfox/node-opentelemetry';
 import {and, eq, inArray, sql} from 'drizzle-orm';
 import {
@@ -37,6 +38,7 @@ import {
   getStepAttempts,
   getStepsByJobId,
   getWorkflowJobExecutionDepth,
+  getWorkflowRunAttemptById,
   getWorkflowRunById,
   listRunAttempts,
   listWorkflowRunsByProject,
@@ -54,6 +56,10 @@ function buildModel(overrides?: TestWorkflowModelInput) {
 
 function template(source: string): string {
   return `\${{ ${source} }}`;
+}
+
+function expression(source: string) {
+  return createWorkflowExpression({source, check: {mode: 'syntax'}});
 }
 
 function shellRef(name: string): string {
@@ -240,6 +246,41 @@ describe('workflow run queries', () => {
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
     });
 
+    test('persists the parsed model on the run attempt', async () => {
+      const model = buildModel({
+        env: {RUN_ID: template('run.id')},
+        jobs: {
+          build: {
+            name: `Build ${template('event.ref')}`,
+            steps: [
+              {
+                run: 'npm test',
+                env: {REF: template('event.ref')},
+                gate: {successIf: expression('exit_code == 0')},
+              },
+            ],
+          },
+        },
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'github',
+          event: 'push',
+          deliveryId: 'delivery-1',
+          data: {ref: 'refs/heads/main'},
+        },
+      });
+
+      const [attemptSummary] = await listRunAttempts({workflowRunId: run.id, projectId});
+      const attempt = await getWorkflowRunAttemptById(attemptSummary?.id as string);
+      expect(attempt?.model).toEqual(model);
+    });
+
     test('persists listening job config without initial execution or steps', async () => {
       const displayNameSource = ['Review batch $', '{{ execution.index }}'].join('');
       const promptSource = ['Review $', '{{ execution.events[0].data.body }}'].join('');
@@ -306,6 +347,49 @@ describe('workflow run queries', () => {
       const buildSteps = await getStepsByJobId(build?.id as string);
       expect(buildExecutions).toHaveLength(1);
       expect(buildSteps.filter((step) => step.type !== 'setup')).toHaveLength(1);
+    });
+
+    test('persists the listening workflow model on the run attempt', async () => {
+      const displayNameSource = ['Review batch $', '{{ execution.index }}'].join('');
+      const promptSource = ['Review $', '{{ execution.events[0].data.body }}'].join('');
+      const model = normalizeWorkflowDocument({
+        name: 'Listening workflow',
+        runner: 'ubuntu-latest',
+        jobs: {
+          listen: {
+            name: displayNameSource,
+            listening: {
+              on: [{source: 'github', event: 'pull_request_review'}],
+              until: [{source: 'github', event: 'pull_request'}],
+              timeout: '30d',
+              max_executions: 3,
+              batch: {debounce: '5s', max_size: 10, max_wait: '1h'},
+              on_resolve: 'cancel',
+            },
+            steps: [{prompt: promptSource}],
+          },
+          build: {
+            steps: [{run: 'echo build'}],
+          },
+        },
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const [attemptSummary] = await listRunAttempts({workflowRunId: run.id, projectId});
+      const attempt = await getWorkflowRunAttemptById(attemptSummary?.id as string);
+      expect(attempt?.model).toEqual(model);
     });
 
     test('writes workflows.workflow_run_attempt.created outbox event in same transaction', async () => {
@@ -860,12 +944,13 @@ jobs:
       const subscriptionId = crypto.randomUUID();
       const eventId = crypto.randomUUID();
       const idempotencyKey = `${subscriptionId}:${eventId}`;
+      const model = buildModel({name: 'Original idempotent model'});
 
       const first = await createWorkflowRun({
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel(),
+        model,
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -879,7 +964,7 @@ jobs:
         workspaceId,
         projectId,
         definitionId,
-        model: buildModel(),
+        model: buildModel({name: 'Mutated idempotent model'}),
         triggerPayload: {
           source: 'manual',
           event: 'fire',
@@ -899,6 +984,9 @@ jobs:
 
       const allJobs = await getJobsByWorkflowRunId(first.id);
       expect(allJobs).toHaveLength(1);
+      const attempts = await listRunAttempts({workflowRunId: first.id, projectId});
+      expect(attempts).toHaveLength(1);
+      expect(attempts[0]?.model).toEqual(model);
       const outboxRows = await db()
         .select()
         .from(workflowsOutbox)
@@ -1082,6 +1170,22 @@ jobs:
         expect(jobSteps.every((step) => step.status === 'pending')).toBe(true);
         expect(jobSteps.every((step) => step.output === null && step.error === null)).toBe(true);
       }
+    });
+
+    test('reruns clone the parsed model onto the new attempt', async () => {
+      const source = await createTerminalSourceRun();
+
+      await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const attempts = await listRunAttempts({workflowRunId: source.id, projectId});
+      const sourceAttempt = attempts.find((attempt) => attempt.attempt === 1);
+      const rerunAttempt = attempts.find((attempt) => attempt.attempt === 2);
+      const reloadedRerunAttempt = await getWorkflowRunAttemptById(rerunAttempt?.id as string);
+      expect(reloadedRerunAttempt?.model).toEqual(sourceAttempt?.model);
     });
 
     test('reruns preserve the original resolved agent step config', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -159,6 +159,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
         workflowRunId: runRow.id,
         attempt: 1,
         status: 'pending',
+        model: params.model,
       })
       .returning();
     if (!attemptRow) throw new Error('Insert returned no rows');
@@ -390,6 +391,7 @@ export async function createRerunWorkflowRun(
         status: 'pending',
         rerunMode: params.mode,
         rerunByUserId: params.actorUserId,
+        model: sourceAttemptRow.model,
       })
       .returning();
     if (!newAttemptRow) throw new Error('Insert returned no rows');


### PR DESCRIPTION
Persist the parsed workflow model on each workflow run attempt.

Listening executions can fire long after run creation and need access to the frozen workflow template to materialize their steps. This stores the validated `WorkflowModel` as nullable jsonb on `workflow_run_attempts`, writes it during initial run creation, and clones it forward on reruns.

The change is write-only for now; no HTTP DTO exposes the model. ENG-725 tracks the deferred cleanup for avoiding duplicated model serialization in the run-detail fan-out query when a reader lands.

Closes ENG-722

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the parsed `WorkflowModel` on each workflow run attempt so listening executions can materialize from a frozen template; set on creation and cloned on reruns. Write-only change; satisfies ENG-722 (ENG-725 tracks deferred query cleanup).

- **New Features**
  - Store the validated `WorkflowModel` JSON on the attempt at run creation for later phases to read.
  - Clone the `model` to new attempts on reruns; idempotent run creation preserves the original model.

- **Migration**
  - Adds nullable `model` jsonb to `workflows_workflow_run_attempts`.

<sup>Written for commit a77abff5f5dd5f58cddc0533165af30c4feccca0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

