### PR TITLE
[api/workflows] Defer listening job step materialization

### DIFF
--- a/.changeset/eng-724-materialize-steps-per-execution.md
+++ b/.changeset/eng-724-materialize-steps-per-execution.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Materialize listening job steps per execution instead of during workflow run creation.

--- a/libs/api/workflows/src/core/workflow-runtime/index.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/index.ts
@@ -4,8 +4,12 @@ export {
   assembleWorkflowRunContext,
 } from './assemble-run-context.js';
 export {
-  type MaterializedWorkflowJob,
   type MaterializedWorkflowStep,
+  type MaterializeJobExecutionStepsParams,
+  materializeJobExecutionSteps,
+} from './materialize-job-execution-steps.js';
+export {
+  type MaterializedWorkflowJob,
   type MaterializeWorkflowModelParams,
   materializeWorkflowModel,
   modelHasAgentStep,

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.test.ts
@@ -1,0 +1,164 @@
+import {
+  InvalidAgentModelError,
+  UnsupportedAgentProviderError,
+} from '@shipfox/api-agent/core/errors';
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
+import {workflowModel} from '#test/index.js';
+import {materializeJobExecutionSteps} from './materialize-job-execution-steps.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+function template(source: string): string {
+  return `\${{ ${source} }}`;
+}
+
+function shellRef(name: string): string {
+  return `\${${name}}`;
+}
+
+function jobExecutionContext(): WorkflowEvaluationContext {
+  return {
+    phase: 'job-execution-creation',
+    values: {
+      run: {
+        id: 'run-1',
+        name: 'Reviews',
+        definition_id: 'def-1',
+        project_id: 'proj-1',
+        workspace_id: 'workspace-1',
+        created_at: new Date('2026-06-30T12:00:00.000Z'),
+      },
+      trigger: {source: 'manual', event: 'fire'},
+      event: null,
+      inputs: null,
+      execution: {
+        index: 1,
+        name: 'Review batch 2',
+        status: 'pending',
+        started_at: '2026-06-30T12:01:00.000Z',
+        finished_at: null,
+        events: [
+          {
+            source: 'github',
+            event: 'pull_request_review',
+            delivery_id: 'delivery-2',
+            received_at: '2026-06-30T12:01:00.000Z',
+            data: {body: 'LGTM'},
+          },
+        ],
+      },
+      executions: [
+        {
+          index: 0,
+          name: 'Review batch 1',
+          status: 'succeeded',
+          started_at: '2026-06-30T12:00:00.000Z',
+          finished_at: '2026-06-30T12:00:30.000Z',
+          events: [],
+        },
+      ],
+    },
+  };
+}
+
+describe('materializeJobExecutionSteps', () => {
+  it('prepends setup and resolves job-execution context fields', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          steps: [
+            {
+              name: `Review ${template('execution.events[0].data.body')}`,
+              run: `echo "${template('executions[0].name')}"`,
+              env: {BODY: template('execution.events[0].data.body')},
+            },
+          ],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const steps = materializeJobExecutionSteps({model, job, context: jobExecutionContext()});
+
+    expect(steps).toEqual([
+      {
+        key: null,
+        name: 'Set up job',
+        sourceLocation: null,
+        status: 'pending',
+        type: 'setup',
+        config: {},
+        authoredConfig: null,
+        position: 0,
+      },
+      {
+        key: null,
+        name: 'Review LGTM',
+        sourceLocation: null,
+        status: 'pending',
+        type: 'run',
+        config: {
+          run: `echo "${shellRef('__sf_0')}"`,
+          env: {
+            BODY: 'LGTM',
+            __sf_0: 'Review batch 1',
+          },
+        },
+        authoredConfig: {
+          run: `echo "${template('executions[0].name')}"`,
+          env: {BODY: template('execution.events[0].data.body')},
+        },
+        position: 1,
+      },
+    ]);
+  });
+
+  it.each([
+    new UnsupportedAgentProviderError('unknown-provider'),
+    new InvalidAgentModelError('anthropic', 'missing-model'),
+  ])('wraps known resolver errors as permanent agent config errors', (cause) => {
+    const model = workflowModel({
+      jobs: {
+        review: {steps: [{prompt: 'Summarize the review.'}]},
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+    const resolveAgentDefaults = vi.fn<AgentDefaultsResolver>().mockImplementation(() => {
+      throw cause;
+    });
+
+    const materialize = () =>
+      materializeJobExecutionSteps({
+        model,
+        job,
+        context: jobExecutionContext(),
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    expect(materialize).toThrow(AgentConfigUnresolvableError);
+    expect(materialize).toThrow('Agent configuration cannot be resolved for definition def-1');
+  });
+
+  it('throws a permanent interpolation error for unsafe run interpolation', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {steps: [{run: `echo \`${template('execution.index')}\``}]},
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+
+    const materialize = () =>
+      materializeJobExecutionSteps({
+        model,
+        job,
+        context: jobExecutionContext(),
+        definitionId: 'def-1',
+      });
+
+    expect(materialize).toThrow(InterpolationUnresolvableError);
+  });
+});

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.ts
@@ -32,6 +32,10 @@ export interface MaterializeJobExecutionStepsParams {
   readonly definitionId?: string | undefined;
 }
 
+// Synthetic "Set up job" step prepended when a job execution's steps are materialized.
+// The runner prepares the workspace here; failures report through the normal step
+// protocol instead of hanging the job until the lease/timeout fires. Its config is
+// credential-free.
 const SETUP_STEP: MaterializedWorkflowStep = {
   key: null,
   name: 'Set up job',
@@ -57,6 +61,7 @@ export function materializeJobExecutionSteps(
   return [
     SETUP_STEP,
     ...job.steps.map((step, stepPosition) => {
+      // The trusted context exposes the stable job key; the authored display field remains `job.name`.
       const stepContext = {...context.values, job: {key: job.key}};
       const resolved = resolveStepConfig({
         step,

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.ts
@@ -1,0 +1,106 @@
+import {
+  type AgentDefaultsResolver,
+  catalogDefaultAgentResolver,
+} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import {resolveStepConfig, type WorkflowStepTemplateDiagnostic} from './resolve-step-config.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+type WorkflowModelJob = WorkflowModel['jobs'][number];
+type WorkflowModelStep = WorkflowModelJob['steps'][number];
+type WorkflowSourceLocation = NonNullable<WorkflowModelStep['sourceLocation']>;
+
+const FIRST_LINE_PATTERN = /\r?\n/;
+
+export interface MaterializedWorkflowStep {
+  readonly key: string | null;
+  readonly name: string;
+  readonly sourceLocation: WorkflowSourceLocation | null;
+  readonly status: 'pending';
+  readonly type: WorkflowModelStep['kind'] | 'setup';
+  readonly config: Readonly<Record<string, unknown>>;
+  readonly authoredConfig: Readonly<Record<string, unknown>> | null;
+  readonly diagnostics?: readonly WorkflowStepTemplateDiagnostic[];
+  readonly position: number;
+}
+
+export interface MaterializeJobExecutionStepsParams {
+  readonly model: WorkflowModel;
+  readonly job: WorkflowModelJob;
+  readonly context: WorkflowEvaluationContext;
+  readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
+  readonly definitionId?: string | undefined;
+}
+
+const SETUP_STEP: MaterializedWorkflowStep = {
+  key: null,
+  name: 'Set up job',
+  sourceLocation: null,
+  status: 'pending',
+  type: 'setup',
+  config: {},
+  authoredConfig: null,
+  position: 0,
+};
+
+export function materializeJobExecutionSteps(
+  params: MaterializeJobExecutionStepsParams,
+): readonly MaterializedWorkflowStep[] {
+  const {
+    model,
+    job,
+    context,
+    resolveAgentDefaults = catalogDefaultAgentResolver,
+    definitionId = model.name,
+  } = params;
+
+  return [
+    SETUP_STEP,
+    ...job.steps.map((step, stepPosition) => {
+      const stepContext = {...context.values, job: {key: job.key}};
+      const resolved = resolveStepConfig({
+        step,
+        workflowEnv: model.env,
+        workflowEnvTemplates: model.templates?.env,
+        jobEnv: job.env,
+        jobEnvTemplates: job.templates?.env,
+        context: stepContext,
+        phase: context.phase,
+        resolveAgentDefaults,
+        definitionId,
+      });
+      return {
+        key: step.key ?? null,
+        name: resolved.name ?? stepDisplayName(step),
+        sourceLocation: step.sourceLocation ?? null,
+        status: 'pending' as const,
+        type: step.kind,
+        config: resolved.config,
+        authoredConfig: resolved.authoredConfig,
+        ...(resolved.diagnostics.length === 0 ? {} : {diagnostics: resolved.diagnostics}),
+        position: stepPosition + 1,
+      };
+    }),
+  ];
+}
+
+function stepDisplayName(step: WorkflowModelStep): string {
+  switch (step.kind) {
+    case 'run':
+      return firstLine(step.command.value);
+    case 'agent':
+      return step.model === undefined
+        ? firstLine(step.prompt)
+        : `${step.model} · ${firstLine(step.prompt)}`;
+    default:
+      return assertNever(step);
+  }
+}
+
+function firstLine(value: string): string {
+  return value.split(FIRST_LINE_PATTERN, 1)[0]?.trim() || value.trim();
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled workflow step kind: ${JSON.stringify(value)}`);
+}

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -3,10 +3,15 @@ import {
   UnsupportedAgentProviderError,
 } from '@shipfox/api-agent/core/errors';
 import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import {DEFAULT_JOB_CHECKOUT, type WorkflowModel} from '@shipfox/api-definitions';
+import {
+  DEFAULT_JOB_CHECKOUT,
+  normalizeWorkflowDocument,
+  type WorkflowModel,
+} from '@shipfox/api-definitions';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
 import {workflowModel} from '#test/index.js';
 import {materializeWorkflowModel, modelHasAgentStep} from './materialize-workflow-model.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 type TestWorkflowExpression = NonNullable<
   NonNullable<WorkflowModel['jobs'][number]['steps'][number]['gate']>['successIf']
@@ -39,6 +44,12 @@ function runContext(overrides: Record<string, unknown> = {}) {
     event: null,
     inputs: null,
   };
+}
+
+function creationContext(
+  values: Record<string, unknown> = runContext(),
+): WorkflowEvaluationContext {
+  return {phase: 'workflow-run-creation', values};
 }
 
 describe('materializeWorkflowModel', () => {
@@ -422,7 +433,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: runContext()});
+    const rows = materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: `echo "${shellRef('__sf_0')}" && echo "${shellRef('__sf_1')}"`,
@@ -452,7 +463,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: runContext()});
+    const rows = materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: 'echo ok',
@@ -484,7 +495,10 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: {...runContext(), event: {}}});
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext({...runContext(), event: {}}),
+    });
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: 'echo ok',
@@ -510,7 +524,11 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: runContext(), definitionId: 'def-1'});
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext(),
+      definitionId: 'def-1',
+    });
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: 'echo ok',
@@ -536,7 +554,7 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({model, context: runContext()});
+    const rows = materializeWorkflowModel({model, context: creationContext()});
 
     expect(rows[0]?.steps[1]?.config).toEqual({
       run: `echo "${shellRef('__sf_1')}"`,
@@ -566,7 +584,10 @@ describe('materializeWorkflowModel', () => {
 
     const rows = materializeWorkflowModel({
       model,
-      context: {...runContext({name: 'gpt-5.5-pro'}), trigger: {source: 'openai', event: 'fire'}},
+      context: creationContext({
+        ...runContext({name: 'gpt-5.5-pro'}),
+        trigger: {source: 'openai', event: 'fire'},
+      }),
       resolveAgentDefaults,
       definitionId: 'def-1',
     });
@@ -597,7 +618,7 @@ describe('materializeWorkflowModel', () => {
     });
 
     const materialize = () =>
-      materializeWorkflowModel({model, context: runContext(), definitionId: 'def-1'});
+      materializeWorkflowModel({model, context: creationContext(), definitionId: 'def-1'});
 
     expect(materialize).toThrow(InterpolationUnresolvableError);
   });
@@ -609,7 +630,8 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const materialize = () => materializeWorkflowModel({model, context: {}, definitionId: 'def-1'});
+    const materialize = () =>
+      materializeWorkflowModel({model, context: creationContext({}), definitionId: 'def-1'});
 
     expect(materialize).toThrow(InterpolationUnresolvableError);
   });
@@ -629,9 +651,66 @@ describe('materializeWorkflowModel', () => {
     });
 
     const materialize = () =>
-      materializeWorkflowModel({model, context: runContext(), definitionId: 'def-1'});
+      materializeWorkflowModel({model, context: creationContext(), definitionId: 'def-1'});
 
     expect(materialize).toThrow(InterpolationUnresolvableError);
+  });
+
+  it('skips listening job steps at workflow-run creation', () => {
+    const stepNameSource = `Review ${template('execution.index')}`;
+    const model = normalizeWorkflowDocument({
+      name: 'Listening workflow',
+      runner: 'ubuntu-latest',
+      jobs: {
+        review: {
+          listening: {
+            on: [{source: 'github', event: 'pull_request_review'}],
+            max_executions: 3,
+          },
+          steps: [{name: stepNameSource, prompt: 'Summarize the review.'}],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext(),
+      definitionId: 'def-1',
+    });
+
+    expect(rows[0]).toMatchObject({
+      key: 'review',
+      mode: 'listening',
+      steps: [],
+    });
+  });
+
+  it('materializes one-shot siblings while skipping listening steps', () => {
+    const model = normalizeWorkflowDocument({
+      name: 'Mixed workflow',
+      runner: 'ubuntu-latest',
+      jobs: {
+        review: {
+          listening: {
+            on: [{source: 'github', event: 'pull_request_review'}],
+            max_executions: 3,
+          },
+          steps: [{name: `Review ${template('execution.index')}`, prompt: 'Summarize it.'}],
+        },
+        build: {
+          steps: [{run: 'npm test'}],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({model, context: creationContext()});
+
+    const review = rows.find((job) => job.key === 'review');
+    const build = rows.find((job) => job.key === 'build');
+    expect(review?.steps).toEqual([]);
+    expect(build?.steps).toHaveLength(2);
+    expect(build?.steps[0]).toMatchObject({type: 'setup', name: 'Set up job', position: 0});
+    expect(build?.steps[1]).toMatchObject({type: 'run', config: {run: 'npm test'}, position: 1});
   });
 
   it('uses the supplied context for each materialization call', () => {
@@ -641,8 +720,14 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const first = materializeWorkflowModel({model, context: runContext({id: 'run-a'})});
-    const second = materializeWorkflowModel({model, context: runContext({id: 'run-b'})});
+    const first = materializeWorkflowModel({
+      model,
+      context: creationContext(runContext({id: 'run-a'})),
+    });
+    const second = materializeWorkflowModel({
+      model,
+      context: creationContext(runContext({id: 'run-b'})),
+    });
 
     expect(first[0]?.steps[1]?.config).toMatchObject({env: {__sf_0: 'run-a'}});
     expect(second[0]?.steps[1]?.config).toMatchObject({env: {__sf_0: 'run-b'}});

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.ts
@@ -1,16 +1,12 @@
-import {
-  type AgentDefaultsResolver,
-  catalogDefaultAgentResolver,
-} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowModel} from '@shipfox/api-definitions';
-import type {WorkflowContextPhase, WorkflowExpressionEvaluationContext} from '@shipfox/expression';
-import {resolveStepConfig, type WorkflowStepTemplateDiagnostic} from './resolve-step-config.js';
+import {
+  type MaterializedWorkflowStep,
+  materializeJobExecutionSteps,
+} from './materialize-job-execution-steps.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
-type WorkflowModelStep = WorkflowModelJob['steps'][number];
-type WorkflowSourceLocation = NonNullable<WorkflowModelStep['sourceLocation']>;
-
-const FIRST_LINE_PATTERN = /\r?\n/;
 export interface MaterializedWorkflowJob {
   readonly key: string;
   readonly mode: WorkflowModelJob['mode'];
@@ -25,37 +21,9 @@ export interface MaterializedWorkflowJob {
   readonly steps: readonly MaterializedWorkflowStep[];
 }
 
-export interface MaterializedWorkflowStep {
-  readonly key: string | null;
-  readonly name: string;
-  readonly sourceLocation: WorkflowSourceLocation | null;
-  readonly status: 'pending';
-  readonly type: WorkflowModelStep['kind'] | 'setup';
-  readonly config: Readonly<Record<string, unknown>>;
-  readonly authoredConfig: Readonly<Record<string, unknown>> | null;
-  readonly diagnostics?: readonly WorkflowStepTemplateDiagnostic[];
-  readonly position: number;
-}
-
-// Synthetic "Set up job" step prepended to every job at position 0, mirroring
-// GitHub Actions' implicit setup step. The runner prepares the workspace here;
-// failures report through the normal step protocol instead of hanging the job
-// until the lease/timeout fires. Its config is credential-free.
-const SETUP_STEP: MaterializedWorkflowStep = {
-  key: null,
-  name: 'Set up job',
-  sourceLocation: null,
-  status: 'pending',
-  type: 'setup',
-  config: {},
-  authoredConfig: null,
-  position: 0,
-};
-
 export interface MaterializeWorkflowModelParams {
   readonly model: WorkflowModel;
-  readonly context?: WorkflowExpressionEvaluationContext;
-  readonly phase?: WorkflowContextPhase | undefined;
+  readonly context?: WorkflowEvaluationContext | undefined;
   readonly resolveAgentDefaults?: AgentDefaultsResolver | undefined;
   readonly definitionId?: string | undefined;
 }
@@ -65,9 +33,8 @@ export function materializeWorkflowModel(
 ): readonly MaterializedWorkflowJob[] {
   const {
     model,
-    context = {},
-    phase = 'workflow-run-creation',
-    resolveAgentDefaults = catalogDefaultAgentResolver,
+    context = {phase: 'workflow-run-creation', values: {}},
+    resolveAgentDefaults,
     definitionId = model.name,
   } = params;
   const jobsById = new Map(model.jobs.map((job) => [job.id, job]));
@@ -83,37 +50,16 @@ export function materializeWorkflowModel(
     dependencies: dependencySourceNames(job, jobsById),
     runner: job.runner,
     position,
-    // Every job runs on a runner (scheduling never filters on the runner field),
-    // so every job gets a setup step. User steps shift to position 1..n.
-    steps: [
-      SETUP_STEP,
-      ...job.steps.map((step, stepPosition) => {
-        // The trusted context exposes the stable job key; the authored display field remains `job.name`.
-        const stepContext = {...context, job: {key: job.key}};
-        const resolved = resolveStepConfig({
-          step,
-          workflowEnv: model.env,
-          workflowEnvTemplates: model.templates?.env,
-          jobEnv: job.env,
-          jobEnvTemplates: job.templates?.env,
-          context: stepContext,
-          phase,
-          resolveAgentDefaults,
-          definitionId,
-        });
-        return {
-          key: step.key ?? null,
-          name: resolved.name ?? stepDisplayName(step),
-          sourceLocation: step.sourceLocation ?? null,
-          status: 'pending' as const,
-          type: step.kind,
-          config: resolved.config,
-          authoredConfig: resolved.authoredConfig,
-          ...(resolved.diagnostics.length === 0 ? {} : {diagnostics: resolved.diagnostics}),
-          position: stepPosition + 1,
-        };
-      }),
-    ],
+    steps:
+      job.mode === 'listening'
+        ? []
+        : materializeJobExecutionSteps({
+            model,
+            job,
+            context,
+            resolveAgentDefaults,
+            definitionId,
+          }),
   }));
 }
 
@@ -132,25 +78,4 @@ function dependencySourceNames(
     }
     return dependency.key;
   });
-}
-
-function stepDisplayName(step: WorkflowModelStep): string {
-  switch (step.kind) {
-    case 'run':
-      return firstLine(step.command.value);
-    case 'agent':
-      return step.model === undefined
-        ? firstLine(step.prompt)
-        : `${step.model} · ${firstLine(step.prompt)}`;
-    default:
-      return assertNever(step);
-  }
-}
-
-function firstLine(value: string): string {
-  return value.split(FIRST_LINE_PATTERN, 1)[0]?.trim() || value.trim();
-}
-
-function assertNever(value: never): never {
-  throw new Error(`Unhandled workflow step kind: ${JSON.stringify(value)}`);
 }

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -283,6 +283,7 @@ describe('workflow run queries', () => {
 
     test('persists listening job config without initial execution or steps', async () => {
       const displayNameSource = ['Review batch $', '{{ execution.index }}'].join('');
+      const stepNameSource = ['Review $', '{{ execution.index }}'].join('');
       const promptSource = ['Review $', '{{ execution.events[0].data.body }}'].join('');
       const model = normalizeWorkflowDocument({
         name: 'Listening workflow',
@@ -298,7 +299,7 @@ describe('workflow run queries', () => {
               batch: {debounce: '5s', max_size: 10, max_wait: '1h'},
               on_resolve: 'cancel',
             },
-            steps: [{prompt: promptSource}],
+            steps: [{name: stepNameSource, prompt: promptSource}],
           },
           build: {
             steps: [{run: 'echo build'}],
@@ -346,7 +347,9 @@ describe('workflow run queries', () => {
       const buildExecutions = await getJobExecutionsByJobId(build?.id as string);
       const buildSteps = await getStepsByJobId(build?.id as string);
       expect(buildExecutions).toHaveLength(1);
-      expect(buildSteps.filter((step) => step.type !== 'setup')).toHaveLength(1);
+      expect(buildSteps).toHaveLength(2);
+      expect(buildSteps[0]).toMatchObject({type: 'setup', name: 'Set up job', position: 0});
+      expect(buildSteps[1]).toMatchObject({type: 'run', config: {run: 'echo build'}, position: 1});
     });
 
     test('persists the listening workflow model on the run attempt', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -161,8 +161,9 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       .returning();
     if (!attemptRow) throw new Error('Insert returned no rows');
 
-    // Resolving templates here gives interpolation access to the inserted run id.
+    // Resolving one-shot templates here gives interpolation access to the inserted run id.
     // If resolution fails, the transaction rolls back the run, jobs, steps, and outbox event together.
+    // Listening steps are resolved later when a job execution is created.
     const context = assembleCreationContext({
       run,
       triggerPayload: params.triggerPayload,
@@ -170,8 +171,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     });
     const materializedJobs = materializeWorkflowModel({
       model: params.model,
-      context: context.values,
-      phase: context.phase,
+      context,
       resolveAgentDefaults: params.resolveAgentDefaults ?? catalogDefaultAgentResolver,
       definitionId: params.definitionId,
     });


### PR DESCRIPTION
Move workflow step materialization behind a per-job execution seam and skip listening job steps during workflow run creation.

Listening jobs do not have an execution context when a run is created, but their step templates could still be resolved at that point. A listening step name that referenced execution.* would fail creation for the whole run. This keeps one-shot jobs on the existing workflow-run-creation path while deferring listening step resolution until a job execution is created.

The new seam is exported from the workflow runtime internals for the listener firing path to call with a job-execution-creation context. The PR also adds coverage for P2 execution/executions interpolation, validation failure paths, mixed listening/one-shot materialization, and the real Postgres run-creation regression.

Fixes ENG-724

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer materializing listening job steps until a job execution is created, so `execution.*` templates no longer break workflow run creation. One-shot jobs still materialize at run creation. Fixes ENG-724.

- **Bug Fixes**
  - Added a per-execution step materializer and export for the listener path; it runs with a job-execution context. Restored comments explaining setup-step injection and trusted job context.
  - `materializeWorkflowModel` now skips listening job steps during run creation; `createWorkflowRun` materializes only one-shot jobs and still prepends the setup step.
  - Expanded tests for `execution`/`executions` interpolation, permanent error paths, mixed listening/one-shot jobs, and the Postgres run-creation regression in `@shipfox/api-workflows`.

<sup>Written for commit b429817fcf35da57061817721afed31fb6778816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

