### PR TITLE
[react-ui] Add shared textarea component

### DIFF
--- a/.changeset/sharp-fields-expand.md
+++ b/.changeset/sharp-fields-expand.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds a shared Textarea component with Storybook coverage and FormField wiring.

--- a/libs/shared/react/ui/README.md
+++ b/libs/shared/react/ui/README.md
@@ -4,7 +4,7 @@ Shared React component library for Shipfox apps. It provides design tokens, Tail
 
 ## What it does
 
-- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, InlineTips, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Modal, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Switch, Table, Tabs, ThemeProvider, Toast, Tooltip, and Typography.
+- **Components**: Accordion, Alert, Avatar, Badge, Button, Calendar, Card, CodeBlock, Collapsible, Combobox, Command, DatePicker, DateRangePicker, Dot, DropdownMenu, EmptyState, FormField, Icon, InlineTips, Input, Kbd, Label, LoadErrorState, Loader, Log, Logo, Modal, Popover, RadioGroup, RelativeTime, ScrollArea, Search, Select, Sheet, ShinyText, Skeleton, Switch, Table, Tabs, Textarea, ThemeProvider, Toast, Tooltip, and Typography.
 - **Theme helpers**: `ThemeProvider`, `useTheme()`, and `useResolvedTheme()`.
 - **Hooks**: `useCopyToClipboard`, `useIsTextTruncated`, `useShikiHighlight`, `useShikiStyleInjection`, plus the theme hooks above.
 - **Utilities**: `cn()` for class name merging, `copyTextToClipboard`, `formatBytes`, `formatDate`/`formatTimestamp`, `formatDuration`/`humanDuration`, `formatRelative`, `debounce`, and avatar helpers (`getInitial`, `getPlaceholderImageUrl`).
@@ -61,13 +61,17 @@ export function EmptyState() {
 }
 ```
 
-`FormField` wires up label, input, error, and description with the correct `id`, `aria-invalid`, and `aria-describedby` plumbing. Render the input through `FormFieldInput` to inherit those props automatically:
+`FormField` wires up label, input, error, and description with the correct `id`, `aria-invalid`, and `aria-describedby` plumbing. Render controls through `FormFieldInput` or `FormFieldTextarea` to inherit those props automatically:
 
 ```tsx
-import {FormField, FormFieldInput} from '@shipfox/react-ui';
+import {FormField, FormFieldInput, FormFieldTextarea} from '@shipfox/react-ui';
 
 <FormField label="Email" id="email" error={error}>
   <FormFieldInput type="email" value={value} onChange={...} />
+</FormField>
+
+<FormField label="Notes" id="notes" error={error}>
+  <FormFieldTextarea value={value} onChange={...} />
 </FormField>
 ```
 

--- a/libs/shared/react/ui/src/components/form-field/form-field.stories.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {Input} from '#components/input/index.js';
-import {FormField, useFormField} from './form-field.js';
+import {FormField, FormFieldTextarea, useFormField} from './form-field.js';
 
 const meta = {
   title: 'Components/FormField',
@@ -64,6 +64,20 @@ export const ErrorPreemptsDescription: Story = {
     <div className="w-360">
       <FormField {...args}>
         <WiredInput defaultValue="not an email" type="email" />
+      </FormField>
+    </div>
+  ),
+};
+
+export const WithTextarea: Story = {
+  args: {
+    label: 'Notes',
+    description: 'Visible to workspace admins.',
+  },
+  render: (args) => (
+    <div className="w-420">
+      <FormField {...args}>
+        <FormFieldTextarea placeholder="Add deployment context" rows={4} />
       </FormField>
     </div>
   ),

--- a/libs/shared/react/ui/src/components/form-field/form-field.tsx
+++ b/libs/shared/react/ui/src/components/form-field/form-field.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import {Input} from '#components/input/index.js';
 import {Label} from '#components/label/index.js';
+import {Textarea} from '#components/textarea/index.js';
 import {Text} from '#components/typography/index.js';
 import {cn} from '#utils/cn.js';
 
@@ -97,6 +98,15 @@ export const FormFieldInput = forwardRef<HTMLInputElement, ComponentProps<typeof
 );
 
 FormFieldInput.displayName = 'FormFieldInput';
+
+export const FormFieldTextarea = forwardRef<HTMLTextAreaElement, ComponentProps<typeof Textarea>>(
+  (props, ref) => {
+    const wiring = useFormField();
+    return <Textarea ref={ref} {...props} {...wiring} />;
+  },
+);
+
+FormFieldTextarea.displayName = 'FormFieldTextarea';
 
 interface FieldLike {
   state: {meta: {errors: Array<unknown>; isBlurred: boolean}};

--- a/libs/shared/react/ui/src/components/index.ts
+++ b/libs/shared/react/ui/src/components/index.ts
@@ -37,6 +37,7 @@ export * from './skeleton/index.js';
 export * from './switch/index.js';
 export * from './table/index.js';
 export * from './tabs/index.js';
+export * from './textarea/index.js';
 export * from './theme/index.js';
 export * from './time-ticker/index.js';
 export * from './toast/index.js';

--- a/libs/shared/react/ui/src/components/textarea/index.ts
+++ b/libs/shared/react/ui/src/components/textarea/index.ts
@@ -1,0 +1,1 @@
+export * from './textarea.js';

--- a/libs/shared/react/ui/src/components/textarea/textarea.stories.tsx
+++ b/libs/shared/react/ui/src/components/textarea/textarea.stories.tsx
@@ -1,0 +1,94 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {Label} from '#components/label/index.js';
+import {Code} from '#components/typography/index.js';
+import {Textarea} from './textarea.js';
+
+const meta = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['base', 'component'],
+    },
+    size: {
+      control: 'select',
+      options: ['base', 'small'],
+    },
+    rows: {control: 'number'},
+  },
+  args: {
+    placeholder: 'Type a note',
+    variant: 'base',
+    size: 'base',
+    rows: 4,
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const States: Story = {
+  render: (args) => (
+    <div className="grid w-420 gap-16">
+      <div className="grid gap-8">
+        <Label htmlFor="default-textarea">Default</Label>
+        <Textarea {...args} id="default-textarea" />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="filled-textarea">Filled</Label>
+        <Textarea
+          {...args}
+          id="filled-textarea"
+          defaultValue="Summarize the runner failure and include the first failing command."
+        />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="invalid-textarea">Invalid</Label>
+        <Textarea {...args} id="invalid-textarea" aria-invalid defaultValue="Too short" />
+      </div>
+      <div className="grid gap-8">
+        <Label htmlFor="disabled-textarea">Disabled</Label>
+        <Textarea {...args} id="disabled-textarea" disabled defaultValue="Disabled value" />
+      </div>
+    </div>
+  ),
+};
+
+export const Variants: Story = {
+  render: (args) => (
+    <div className="grid w-420 gap-16">
+      {(['base', 'component'] as const).map((variant) => (
+        <div key={variant} className="grid gap-8">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            {variant}
+          </Code>
+          <Textarea
+            {...args}
+            variant={variant}
+            defaultValue="A textarea field with shared form styling."
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="grid w-420 gap-16">
+      {(['base', 'small'] as const).map((size) => (
+        <div key={size} className="grid gap-8">
+          <Code variant="label" className="text-foreground-neutral-subtle">
+            {size}
+          </Code>
+          <Textarea {...args} size={size} />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/libs/shared/react/ui/src/components/textarea/textarea.tsx
+++ b/libs/shared/react/ui/src/components/textarea/textarea.tsx
@@ -22,8 +22,7 @@ export const textareaVariants = cva('', {
   },
 });
 
-export type TextareaProps = Omit<ComponentProps<'textarea'>, 'size'> &
-  VariantProps<typeof textareaVariants>;
+export type TextareaProps = ComponentProps<'textarea'> & VariantProps<typeof textareaVariants>;
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({className, variant, size, ...props}, ref) => {

--- a/libs/shared/react/ui/src/components/textarea/textarea.tsx
+++ b/libs/shared/react/ui/src/components/textarea/textarea.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import {cva, type VariantProps} from 'class-variance-authority';
+import type {ComponentProps} from 'react';
+import {forwardRef} from 'react';
+import {cn} from '#utils/cn.js';
+
+export const textareaVariants = cva('', {
+  variants: {
+    variant: {
+      base: 'bg-background-field-base',
+      component: 'bg-background-field-component',
+    },
+    size: {
+      base: 'py-6',
+      small: 'py-4',
+    },
+  },
+  defaultVariants: {
+    variant: 'base',
+    size: 'base',
+  },
+});
+
+export type TextareaProps = Omit<ComponentProps<'textarea'>, 'size'> &
+  VariantProps<typeof textareaVariants>;
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({className, variant, size, ...props}, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        data-slot="textarea"
+        className={cn(
+          'w-full min-w-0 resize-y rounded-6 px-8 text-sm leading-20 text-foreground-neutral-base shadow-button-neutral transition-[color,box-shadow] outline-none placeholder:text-foreground-neutral-muted',
+          'hover:bg-background-field-hover',
+          'selection:bg-background-accent-neutral-soft selection:text-foreground-neutral-on-inverted',
+          'read-only:cursor-not-allowed read-only:bg-background-neutral-disabled read-only:shadow-none read-only:text-foreground-neutral-disabled read-only:hover:bg-background-neutral-disabled',
+          'disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-background-neutral-disabled disabled:shadow-none disabled:text-foreground-neutral-disabled',
+          'focus-visible:shadow-border-interactive-with-active',
+          'aria-invalid:shadow-border-error',
+          textareaVariants({variant, size}),
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+Textarea.displayName = 'Textarea';


### PR DESCRIPTION
Add a shared Textarea component to `@shipfox/react-ui`.

Multi-line form fields need the same tokenized field styling and accessibility wiring as `Input`, rather than each client surface shaping native `textarea` elements independently. This adds the component, exports it from the library, covers the expected Storybook states, and adds `FormFieldTextarea` so labeled textarea fields inherit `id`, `aria-invalid`, and `aria-describedby` consistently.

The source component was adapted to the current package organization and import aliases, with a minor changeset for the new public API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `Textarea` to `@shipfox/react-ui` for consistent styling and accessibility across apps. Also introduces `FormFieldTextarea` to auto-wire labels and aria props in `FormField`.

- **New Features**
  - New `Textarea` with tokenized styles, `variant` (`base` | `component`) and `size` (`base` | `small`) props, full state styling, and props that extend native textarea attributes.
  - New `FormFieldTextarea` that inherits `id`, `aria-invalid`, and `aria-describedby` from `FormField`.
  - Exported in the package index, updated README usage, and added Storybook stories (states, variants, sizes, FormField example).
  - Minor release via changeset.

<sup>Written for commit 858c3004599feecc5595e8f05d86581a8e465130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

