### PR TITLE
Add Core Concepts docs group

### DIFF
--- a/apps/docs/concepts/gates.mdx
+++ b/apps/docs/concepts/gates.mdx
@@ -1,0 +1,88 @@
+---
+title: "Gates: Conditional Success and Automatic Restart"
+sidebarTitle: "Gates & Retry Loops"
+description: "A gate decides whether a run step succeeded and can restart the job from an earlier step when it fails — building bounded retry loops with no external scripting."
+---
+
+A **gate** turns a step's exit code into a decision: did this step succeed, and
+if not, what should happen? Gates let you build **bounded retry loops** — run a
+step, check a condition, and restart from an earlier step until it passes — without
+any external scripting or orchestration. This is how Shipfox turns an agent into an
+iterating worker: the agent edits, a `run` step judges the result, and the gate
+sends the agent back until the check passes.
+
+## The gate schema
+
+A gate is declared on a **run step** under the `gate` key:
+
+```yaml
+steps:
+  - run: npm test
+    key: test
+  - run: ./flaky-integration.sh
+    gate:
+      success_if: "exit_code == 0"
+      on_failure:
+        restart_from: test
+        output: "Integration check failed; restarting from tests"
+```
+
+<ParamField path="gate.success_if" type="string">
+  A CEL expression that decides success. The only variable available is
+  `exit_code` — the step's process exit code. Examples: `exit_code == 0`,
+  `exit_code < 5`. Required unless `on_failure` is present.
+</ParamField>
+
+<ParamField path="gate.on_failure.restart_from" type="string">
+  The `key` of an earlier step in the same job to restart from when the gate
+  fails (set `key:` on the target step). Execution resumes at that step.
+</ParamField>
+
+<ParamField path="gate.on_failure.output" type="string">
+  An optional message recorded with the restart decision, shown in the run
+  timeline.
+</ParamField>
+
+<Note>
+  Gates are valid on **both run steps and agent steps** — `success_if` always
+  evaluates the step's `exit_code`. The most reliable loop still puts the gate on a
+  `run` step that objectively verifies the agent's work (tests, a linter), with
+  `restart_from` pointing back at the agent.
+</Note>
+
+## How a gate is evaluated
+
+After a gated step finishes, Shipfox evaluates the gate and reaches one of three
+outcomes:
+
+| Outcome | When | Result |
+|---|---|---|
+| **Passed** | `success_if` evaluates true | The step succeeds; the job continues |
+| **Failed** | `success_if` is false | Restart from `restart_from` if the budget allows; otherwise the job fails |
+| **Uncheckable** | No exit code, or the CEL expression errors | The job fails immediately — never restarts |
+
+## Loop bounds
+
+Gates create loops, so Shipfox bounds them for you — there is no way to author an
+unbounded retry.
+
+- **Per-step restart cap.** A gating step is allowed **3 attempts by default** (one
+  initial run plus two restarts). When the cap is exhausted and the gate still
+  fails, the step is marked failed and the **whole job stops**.
+- **Job execution timeout.** Independently, the job-level
+  [`execution_timeout`](/concepts/jobs-steps) bounds total wall-clock time (default
+  6 hours). Whichever bound is reached first ends the loop.
+
+Design loops to converge within a few attempts; the cap is a safety net, not a
+budget to spend.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Gate and retry guide" icon="rotate">
+    A worked example that retries a step until it passes.
+  </Card>
+  <Card title="Jobs & Steps" icon="layer-group" href="/concepts/jobs-steps">
+    Step kinds, job isolation, and `execution_timeout`.
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/jobs-steps.mdx
+++ b/apps/docs/concepts/jobs-steps.mdx
@@ -1,0 +1,182 @@
+---
+title: "Jobs and Steps: Execution Model Inside a Workflow Run"
+sidebarTitle: "Jobs, Steps & Agents"
+description: "Jobs group steps into isolated work units. Steps are shell commands or AI agent calls. Learn how Shipfox executes both inside a workflow run."
+---
+
+Every Shipfox workflow run is a directed acyclic graph of **jobs**. A job is a group of **steps** that run in order on a single runner. Steps are either `run` steps (shell commands) or agent steps (AI model invocations). Jobs run in parallel by default; use `needs` to sequence them.
+
+## Job schema
+
+A job lives under the `jobs:` map in your workflow file, keyed by a unique name. Here is a complete example of a job with all supported fields:
+
+```yaml
+jobs:
+  test:
+    runner: ubuntu-latest     # overrides workflow-level runner
+    needs: [lint]             # wait for the lint job
+    env:
+      NODE_ENV: test
+    steps:
+      - run: npm ci
+      - run: npm test
+```
+
+<ParamField path="steps" type="array" required>
+  List of steps to execute in order. At least one step is required. Steps run sequentially on the same runner instance.
+</ParamField>
+
+<ParamField path="needs" type="string | string[]">
+  Job name or list of job names this job depends on. The job will not start until all listed jobs have completed successfully. Use this to sequence jobs in a pipeline.
+</ParamField>
+
+<ParamField path="runner" type="string | string[]">
+  Runner label or list of labels for this job. Overrides the workflow-level `runner:` value. Shipfox dispatches the job to any online runner whose labels include all required labels.
+</ParamField>
+
+<ParamField path="env" type="object">
+  Environment variables for `run` steps in this job. Merged with workflow-level `env`; a step-level `env` declaration takes the highest precedence. Not applied to agent steps.
+</ParamField>
+
+<ParamField path="execution_timeout" type="string">
+  Maximum duration allowed for the entire job (e.g., `"30m"`, `"2h"`). If the job has not finished by this deadline, Shipfox cancels it.
+</ParamField>
+
+## Job isolation
+
+<Warning>
+  Each job **re-clones the repository** at the start of its execution. Jobs do not share a filesystem — if job A installs dependencies, job B must install them again. Use `needs` to order jobs, not to pass files between them.
+</Warning>
+
+This isolation is intentional. It keeps each job's environment clean and reproducible, and it allows jobs to run on different runners without any shared-state assumptions.
+
+## Run steps
+
+A `run` step executes a shell command on the runner. This is the primary way to run build tools, test suites, linters, and any other CLI-driven work.
+
+```yaml
+steps:
+  - key: install           # optional — identifies the step for restart_from
+    run: npm ci
+    env:
+      CI: "true"
+    gate:
+      success_if: exit_code == 0
+      on_failure:
+        restart_from: install
+```
+
+<ParamField path="run" type="string" required>
+  The shell command to execute. Runs in a POSIX-compatible shell on the runner machine.
+</ParamField>
+
+<ParamField path="name" type="string">
+  A human-readable name for the step, shown in the dashboard. Display-only — to reference this step from `gate.on_failure.restart_from`, give it a `key:`.
+</ParamField>
+
+<ParamField path="key" type="string">
+  A stable identifier for the step. This is what `gate.on_failure.restart_from` matches against — if you want a gate to restart from this step, it must have a `key`.
+</ParamField>
+
+<ParamField path="env" type="object">
+  Environment variables scoped to this step. Merged with job-level and workflow-level `env`; step-level values take highest precedence.
+</ParamField>
+
+<ParamField path="gate" type="object">
+  Optional gate block that controls success evaluation and retry behaviour. See the [Gate schema](#gate-schema) section below.
+</ParamField>
+
+## Agent steps
+
+An agent step invokes an AI model. Instead of `run`, you provide a `prompt`. The model reads the repository context and produces output — edits, reports, suggestions — depending on the prompt.
+
+```yaml
+steps:
+  - key: review
+    model: claude-opus-4-8
+    prompt: Review the latest diff and summarize any issues.
+    thinking: high
+    provider: anthropic
+    gate:
+      success_if: exit_code == 0
+```
+
+<ParamField path="prompt" type="string" required>
+  The instruction sent to the AI model. Supports `${{ }}` interpolation from run and trigger context — see Expressions.
+</ParamField>
+
+<ParamField path="model" type="string">
+  The model identifier to use (e.g., `claude-opus-4-8`, `gpt-5.5-pro`). Defaults to the workspace default model when omitted.
+</ParamField>
+
+<ParamField path="thinking" type="string">
+  Agent reasoning depth. Accepted values: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Defaults to `high`. Higher levels use more tokens and take longer but produce more thorough reasoning.
+</ParamField>
+
+<ParamField path="provider" type="string">
+  Provider identifier (e.g., `anthropic`, `openai`). Pairing `provider` with `model` lets a step target a non-default provider and model combination. Defaults to the workspace default provider when omitted.
+</ParamField>
+
+<ParamField path="name" type="string">
+  Human-readable name for the step, shown in the dashboard. Display-only.
+</ParamField>
+
+<ParamField path="key" type="string">
+  A stable identifier for the step, matched against `gate.on_failure.restart_from`.
+</ParamField>
+
+<ParamField path="gate" type="object">
+  Optional gate block. See the [Gate schema](#gate-schema) section below.
+</ParamField>
+
+<Warning>
+  `env` is not valid on agent steps — the field is rejected by the schema validator. Workflow-level and job-level `env` does not apply to agent steps either.
+</Warning>
+
+## Gate schema
+
+A gate block lets a step evaluate its own success and optionally restart the job from an earlier keyed step on failure.
+
+```yaml
+gate:
+  success_if: exit_code == 0          # CEL expression
+  on_failure:
+    restart_from: install             # must reference an earlier keyed step in the same job
+```
+
+<ParamField path="success_if" type="string">
+  A CEL expression evaluated after the step completes. The most common value is `exit_code == 0`. Either `success_if` or `on_failure` (or both) must be present.
+</ParamField>
+
+<ParamField path="on_failure.restart_from" type="string">
+  The `key` of an earlier step in the same job to restart from when this step's gate is not satisfied. The referenced step must appear before the current step in the `steps` list and must have a `key` field (`name:` is display-only and cannot be referenced).
+</ParamField>
+
+<ParamField path="on_failure.output" type="string">
+  Optional output annotation attached when the gate triggers a restart.
+</ParamField>
+
+The recommended pattern is to pair an agent step with a `run` step that validates the result, using `gate` on the `run` step to drive retries:
+
+```yaml
+steps:
+  - key: fix
+    prompt: Fix the failing tests.
+  - key: verify
+    run: npm test
+    gate:
+      success_if: exit_code == 0
+      on_failure:
+        restart_from: fix
+```
+
+## Related guides
+
+<CardGroup cols={2}>
+  <Card title="Gate & Retry" icon="rotate">
+    Deep dive into writing gate expressions and configuring restart targets.
+  </Card>
+  <Card title="Model Providers" icon="microchip">
+    How to configure provider and model defaults at the workspace level.
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/listening-jobs.mdx
+++ b/apps/docs/concepts/listening-jobs.mdx
@@ -1,0 +1,160 @@
+---
+title: "Listening Jobs (Coming Soon)"
+sidebarTitle: "Listening Jobs (soon)"
+description: "Listening jobs wait on events and react repeatedly inside a single workflow run — an agent handling each batch of PR comments until the PR merges. Coming soon."
+---
+
+<Warning>
+  **Coming soon.** Listening jobs are under active development. The `listening`
+  schema below is accepted and validated today — you can author it and it will
+  parse — but Shipfox does **not execute listening jobs yet**: a listening job
+  currently acts as a scheduling boundary, and jobs that depend on it stay
+  blocked. This page documents the authored shape and what it will do, so you can
+  follow along; details may still evolve before release.
+</Warning>
+
+Today a workflow is a one-shot DAG: a trigger creates a run, every job runs exactly
+once in `needs` order, and the run ends when all jobs end. A **listening job** — a
+job driven by events — changes that: it *listens* for events and runs **one
+execution per event batch**, inside the same run, until a resolution condition is
+met. `needs` still gates when the job activates; from then on, events gate each
+execution.
+
+## What you'll build with it
+
+Two driving use cases shape the design:
+
+**Agentic PR-review loop.** Job A opens a pull request with an agent. Job B
+(`needs: [A]`) listens for new review comments and runs an agent on each batch —
+answering reviewers, applying requested changes — until the PR is closed or merged.
+
+```yaml
+# Illustrative — listening jobs and the PR events they need are coming soon.
+jobs:
+  open_pr:
+    steps:
+      - model: claude-opus-4-8
+        prompt: Implement the fix described in the run context and open a PR.
+      - run: gh pr create --fill
+  address_reviews:
+    needs: [open_pr]
+    listening:
+      on:
+        - source: github_acme
+          event: pull_request_review_comment.created
+      until:
+        - source: github_acme
+          event: pull_request.closed
+      batch:
+        debounce: "30s"
+    steps:
+      - model: claude-opus-4-8
+        prompt: >
+          New review comments arrived on the PR this run opened. Address each one:
+          reply, or apply the requested change and push.
+```
+
+**Issue-watcher loop.** A job listens for new comments on an issue and keeps the
+issue or its spec document up to date — until the issue is closed.
+
+```yaml
+# Illustrative — same caveat.
+jobs:
+  watch_issue:
+    listening:
+      on:
+        - source: github_acme
+          event: issue_comment.created
+      until:
+        - source: github_acme
+          event: issues.closed
+    steps:
+      - model: claude-opus-4-8
+        prompt: Fold the new issue comments into the spec and update the issue body.
+```
+
+<Note>
+  These sketches assume PR-comment and issue events from the GitHub integration,
+  which today delivers `push` — richer event ingestion ships alongside listening
+  jobs.
+</Note>
+
+## The model
+
+A run is a DAG of jobs; a job has one or more **executions**; an execution runs the
+steps. A one-shot job has exactly one execution. A listening job gets **one
+execution per event batch**:
+
+- **`needs` gates the job** — the listener activates only when its dependencies
+  succeed.
+- **`on` events gate each execution** — every matching event (batch) starts one.
+- Executions **serialize** per job; events arriving during an execution coalesce
+  into the next batch (tune with `batch.debounce`, `batch.max_size`,
+  `batch.max_wait`).
+- The job **resolves** when an `until` event arrives, the `timeout` elapses, or
+  `max_executions` is reached.
+
+## The `listening` shape
+
+```yaml
+jobs:
+  address_reviews:
+    needs: [open_pr]
+    listening:
+      on:                      # required — events that start an execution
+        - source: github_acme
+          event: pull_request_review_comment.created
+      until:                   # optional — events that resolve the job
+        - source: github_acme
+          event: pull_request.closed
+      timeout: "24h"           # optional — max wall-clock listening time
+      max_executions: 50       # optional — cap on executions
+      batch:                   # optional — event coalescing
+        debounce: "30s"
+        max_size: 10
+        max_wait: "5m"
+      on_resolve: finish       # 'finish' (default) or 'cancel'
+    steps:
+      - run: ./react.sh
+```
+
+<ParamField path="listening.on" type="trigger[]" required>
+  The events the job listens for. Each entry uses the same `{source, event,
+  filter?, with?}` shape as a workflow [trigger](/concepts/triggers) — one
+  event-selector shape, used at run level (`triggers:`) and at job level
+  (`on`/`until`).
+</ParamField>
+
+<ParamField path="listening.until" type="trigger[]">
+  Events that resolve the listening job.
+</ParamField>
+
+<ParamField path="listening.timeout" type="string">
+  Maximum wall-clock time to keep listening before the job resolves.
+</ParamField>
+
+<ParamField path="listening.max_executions" type="number">
+  Caps how many executions the job runs before it resolves.
+</ParamField>
+
+<ParamField path="listening.batch" type="object">
+  Coalesces bursts of events: `debounce` (quiet window before an execution
+  starts), `max_size` (events per batch), and `max_wait` (longest a batch waits
+  before flushing).
+</ParamField>
+
+<ParamField path="listening.on_resolve" type="'finish' | 'cancel'">
+  What happens when `until` fires: `finish` completes the job normally (default),
+  `cancel` cancels it.
+</ParamField>
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Triggers" icon="bolt" href="/concepts/triggers">
+    The trigger shape reused by `on` and `until`.
+  </Card>
+  <Card title="Integrations" icon="plug">
+    The sources that emit the events a listening job reacts to.
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/logging.mdx
+++ b/apps/docs/concepts/logging.mdx
@@ -1,0 +1,116 @@
+---
+title: "Logging: Live and Persisted Output for Every Step"
+sidebarTitle: "Logs & Agent Sessions"
+description: "Shipfox streams run-step output and structured agent-session events live, then compacts them to object storage. Secrets are masked; logs are retained and bounded."
+---
+
+Every step in a workflow run produces logs. Shipfox streams them **live** while the
+step runs and **persists** them afterwards, so you can watch a run in real time and
+come back to it later. Agent steps get richer treatment than a plain command: their
+model messages, thinking, and tool calls are captured as structured events.
+
+## What gets logged
+
+<Tabs>
+  <Tab title="Agent steps">
+    An agent step captures a structured **session** in addition to any stdout: each
+    model message, thinking block, tool call, and tool result becomes its own entry,
+    along with the provider, model, token usage, and cost. The dashboard expands
+    these into a readable transcript rather than a wall of text — you watch the
+    agent work, not just its stdout.
+  </Tab>
+  <Tab title="Run steps">
+    A `run` step's `stdout` and `stderr` are captured line by line. Output can be
+    organized into named, collapsible [groups](#grouping-output). Secrets known to
+    the runner are masked before the output leaves the machine.
+  </Tab>
+</Tabs>
+
+<Frame caption="An expanded step log on the run page: numbered lines, exact output, and per-step line/byte/duration counts.">
+  <img src="/images/step-logs.png" alt="A run detail page with a step's log expanded, showing numbered log lines and end-of-log metadata" />
+</Frame>
+
+## Grouping output
+
+Inside a `run` step, wrap output in **named groups** with `::group::<name>` and
+`::endgroup::` markers, each on its own line. The dashboard renders every group as a
+collapsible section titled with its name, so a long step reads as a tidy outline
+instead of a wall of text.
+
+```bash
+echo "::group::Install dependencies"
+npm ci
+echo "::endgroup::"
+
+echo "::group::Run tests"
+npm test
+echo "::endgroup::"
+```
+
+Groups **nest** into a tree — open a group inside another and the dashboard shows the
+enclosing structure:
+
+```bash
+echo "::group::Build"
+echo "::group::Compile"
+tsc -b
+echo "::endgroup::"
+echo "::group::Bundle"
+vite build
+echo "::endgroup::"
+echo "::endgroup::"
+```
+
+Nesting is capped at **32 levels deep**; past the cap a group is flattened into plain
+output rather than adding another level. Group names are limited to 1 KiB.
+
+## Live tail, then persisted
+
+Logs move through two phases:
+
+1. **Hot (live).** As a step runs, the runner streams output to the API in chunks.
+   The dashboard tails it with a cursor, so you see output within a couple of
+   seconds of it being produced.
+2. **Cold (persisted).** Once a step's stream closes, Shipfox compacts the logs
+   into a single compressed file in object storage (the garage / S3 bucket from
+   installation). Later reads are served directly from storage.
+
+This is transparent in the dashboard — you don't choose a phase; the run detail
+view reads whichever is current.
+
+## Agent config on the run detail
+
+For agent steps, the run detail also shows the **resolved** provider, model, and
+thinking level that actually ran — after workspace defaults were applied — plus
+targeted guidance when a step failed because a provider wasn't configured, a model
+was unavailable, or credentials were invalid. See
+Model Providers for how that config is resolved.
+
+## Limits and retention
+
+Logs are bounded so a runaway step can't produce unbounded storage or cost:
+
+- **Per-job budget.** Each job has a log budget (32 MiB, growing over time). Past
+  it, further output is dropped and the step is marked truncated rather than failing
+  the run.
+- **Retention.** Persisted logs are kept for a default of 90 days, then deleted from
+  both the database and object storage.
+- **Truncation is explicit.** If output was dropped — because the budget was hit or
+  a runner died mid-step — the stream is flagged truncated so you know the logs are
+  incomplete.
+
+<Note>
+  The budget, retention window, and storage bucket are configurable when you
+  self-host. See Self-Hosting for the object-storage setup.
+</Note>
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Jobs & Steps" icon="layer-group" href="/concepts/jobs-steps">
+    Where run and agent steps are defined.
+  </Card>
+  <Card title="Model Providers" icon="robot">
+    Providers, models, and how agent-step config is resolved.
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/runner-provisioners.mdx
+++ b/apps/docs/concepts/runner-provisioners.mdx
@@ -1,0 +1,112 @@
+---
+title: "Runner Provisioners: Autoscale Runners on Demand"
+sidebarTitle: "Runner Provisioners"
+description: "A provisioner watches job demand and starts ephemeral, single-job runner containers automatically — so you don't hand-start runners or keep a fleet idle."
+---
+
+A **provisioner** watches how many jobs are waiting and starts **ephemeral,
+single-job runner containers** to meet that demand — then lets them exit. It's the
+alternative to [manually starting runners](/concepts/runners): instead of keeping a
+fleet online at idle, you run one provisioner and it scales runners to the work.
+
+<Note>
+  Today Shipfox ships a **Docker** provisioner. The provisioner core is
+  provider-agnostic, so other backends (Kubernetes, cloud VMs) can follow — those
+  are roadmap.
+</Note>
+
+## How it works
+
+The provisioner runs a continuous control loop against the Shipfox API:
+
+<Steps>
+  <Step title="Advertise capacity">
+    For each template it can start, the provisioner reports free slots
+    (`max_concurrency` minus what's already running).
+  </Step>
+  <Step title="Poll for demand">
+    It long-polls the API. When jobs are waiting for labels a template provides, the
+    API grants reservations.
+  </Step>
+  <Step title="Mint ephemeral tokens">
+    For each reservation, the provisioner mints a single-use **ephemeral
+    registration token** (`sf_ert_…`, distinct from the long-lived `sf_mrt_…`
+    manual token) that the new runner uses to register once.
+  </Step>
+  <Step title="Launch and reconcile">
+    It starts a container per reservation, injecting the API URL, the ephemeral
+    token, and the template's labels. It reports each container's lifecycle and
+    reconciles against Docker on startup, reaping containers that never registered.
+    If Docker is unreachable it advertises zero capacity and backs off rather than
+    double-launching.
+  </Step>
+</Steps>
+
+Each provisioned runner claims one job, runs it, and exits — so a burst of work
+spins up runners and quiet periods cost nothing.
+
+## Templates
+
+A **template** maps a label set to the container that provides it. Templates live in
+a YAML file the provisioner loads at startup:
+
+```yaml
+templates:
+  docker-ubuntu22-2vcpu:
+    labels: [ubuntu22, ubuntu22-2vcpu]   # labels the started runner registers with
+    image: shipfox-runner:ubuntu22        # container image to start
+    cpu: 2                                 # vCPUs (also the selection cost)
+    memory: 4GiB                           # memory allocation
+    max_concurrency: 100                   # cap on live containers from this template
+```
+
+When several templates satisfy a job's labels, the provisioner picks the cheapest
+(fewest vCPUs), then the most specific.
+
+## Configuration
+
+The Docker provisioner is a standalone app (`@shipfox/provisioner-docker`)
+configured through environment variables:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `SHIPFOX_API_URL` | yes | Shipfox API base URL |
+| `SHIPFOX_PROVISIONER_TOKEN` | yes | Long-lived token that authenticates the provisioner |
+| `SHIPFOX_PROVISIONER_TEMPLATES_FILE` | yes | Path to the templates YAML |
+| `SHIPFOX_RUNNER_API_URL` | no | API URL injected into runner containers, if they reach the API on a different host |
+| `SHIPFOX_PROVISIONER_DOCKER_HOST` | no | Docker daemon socket or host (defaults to the local socket) |
+| `SHIPFOX_PROVISIONER_DOCKER_NETWORK` | no | Docker network to attach runners to |
+| `SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS` | no | Extra host mappings (e.g. `host.docker.internal:host-gateway`) |
+
+Create the provisioner token (`SHIPFOX_PROVISIONER_TOKEN`) on **Settings → Runner
+Provisioners** in the dashboard — the value is shown once, and you can revoke it
+there.
+
+Poll intervals, reservation limits, token batch size, and the registration deadline
+have sensible defaults and can be tuned with additional `SHIPFOX_PROVISIONER_*`
+variables.
+
+## Deploying it
+
+Run the provisioner as a long-lived process next to a Docker daemon it can control:
+
+```bash
+SHIPFOX_API_URL=https://api.shipfox.io \
+SHIPFOX_PROVISIONER_TOKEN=<YOUR_PROVISIONER_TOKEN> \
+SHIPFOX_PROVISIONER_TEMPLATES_FILE=./templates.yaml \
+pnpm --filter=@shipfox/provisioner-docker start
+```
+
+It authenticates on startup, then enters the control loop until it receives a
+shutdown signal, at which point it stops claiming new work and exits cleanly.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Runners" icon="server" href="/concepts/runners">
+    Manually started runners, labels, and registration.
+  </Card>
+  <Card title="Installation" icon="download">
+    Standing up the API, storage, and your first runner.
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/runners.mdx
+++ b/apps/docs/concepts/runners.mdx
@@ -1,0 +1,57 @@
+---
+title: "Runners: Deploy and Register Your Own Shipfox Runner"
+sidebarTitle: "Runners"
+description: "Runners are processes you deploy on your own infrastructure. They poll Shipfox for jobs matching their labels and execute steps on your machines."
+---
+
+A **runner** is a process you deploy on any machine — a VM, a container, a laptop, or a Kubernetes pod. Runners poll Shipfox for jobs that match their labels, check out the repo, and execute each step. You own the compute; Shipfox owns the orchestration.
+
+## How runners work
+
+The lifecycle of a runner from registration to job execution follows these steps:
+
+1. **Register the runner.** Generate a registration token in the dashboard and start the runner process with that token.
+2. **The runner authenticates and announces its labels** to Shipfox. Its log prints `Runner session registered` and it starts polling for jobs.
+3. **When a workflow run starts a job,** Shipfox dispatches it to any available runner whose labels match the job's `runner:` label.
+4. **The runner re-clones the repository,** then executes each step in the job in order.
+5. **Logs stream back to the dashboard** in real time as each step runs.
+
+## Runner labels
+
+Labels are how Shipfox matches jobs to runners. A runner can carry multiple labels, and a workflow job's `runner:` field specifies which label (or labels) are required.
+
+- A job is dispatched to a runner only if the runner has **all** of the required labels.
+- Labels are set when you start the runner process, as the comma-separated `SHIPFOX_RUNNER_LABELS` environment variable.
+- A single machine can run multiple runner processes with different label sets.
+
+**Example:** A workflow with `runner: ubuntu-latest` is dispatched to any online runner that has the `ubuntu-latest` label. A workflow with `runner: [ubuntu-latest, gpu]` requires a runner that carries both labels simultaneously.
+
+Choose label names that describe the environment the runner provides — OS, architecture, available hardware, or team ownership are common schemes.
+
+## Registration
+
+Registering a new runner takes three steps:
+
+1. In the dashboard, go to **Settings → Runners**.
+2. Click **Create token**, name the token, and copy its value — it is shown only once. Treat it like a secret; it authenticates the runner to your workspace.
+3. Start the runner process with the token. The runner registers itself on first start and begins polling for jobs immediately.
+
+**Settings → Runners** lists the registration tokens you created, with their prefix and expiry. A view of connected runners and their labels is not in the dashboard yet — confirm a runner is connected from its own log.
+
+<Note>
+  Prefer not to hand-start runners? A [runner provisioner](/concepts/runner-provisioners)
+  starts ephemeral, single-job runners automatically based on demand, then lets them
+  exit when idle.
+</Note>
+
+## Agent step requirements
+
+<Note>
+  Runner processes that execute agent steps need network access to the AI provider's API. Set `ANTHROPIC_API_KEY` (or the appropriate provider key, such as `OPENAI_API_KEY`) in the runner's environment before starting it. Without the key, agent steps will fail at execution time.
+</Note>
+
+## Pending runs
+
+<Tip>
+  A run stuck in `pending` state usually means no online runner matches the job's `runner:` label. Check the runner's terminal for `Runner session registered`, and confirm its `SHIPFOX_RUNNER_LABELS` includes the label the workflow asks for. Start a matching runner and the pending job is dispatched automatically.
+</Tip>

--- a/apps/docs/concepts/triggers.mdx
+++ b/apps/docs/concepts/triggers.mdx
@@ -1,0 +1,149 @@
+---
+title: "Triggers: How and When Shipfox Workflow Runs Start"
+sidebarTitle: "Triggers"
+description: "Triggers define when a Shipfox workflow runs — on a push, a Sentry issue, a custom webhook, or on demand. Learn the trigger schema and how sources map to connections."
+---
+
+A **trigger** tells Shipfox when to start a workflow run. Triggers are defined in
+your workflow YAML under the `triggers:` key. You can declare multiple triggers;
+each is a named entry with a `source` and an `event`.
+
+## Trigger schema
+
+Every trigger is a named entry inside the `triggers:` map. The name is an arbitrary
+key you choose — it appears in logs and the dashboard to identify which trigger
+fired a run.
+
+```yaml
+triggers:
+  <name>:              # any unique name
+    source: github_acme  # a connection slug, or "manual"
+    event: push          # an event from that source
+    filter: ""           # optional CEL expression — NOT enforced yet
+    with: {}             # optional extra config
+```
+
+<ParamField path="source" type="string" required>
+  Where the event comes from. For an integration (GitHub, Sentry, a custom
+  webhook), this is the **connection slug** you get after connecting it — for
+  example `github_acme` — **not** the bare provider name. For on-demand runs it is
+  the literal string `manual`. See Integrations for how
+  slugs work.
+</ParamField>
+
+<ParamField path="event" type="string" required>
+  The specific event from that source (for example `push`, `issue.created`,
+  `received`, or `fire`). Must be at least one character. Each integration
+  page lists the events it emits.
+</ParamField>
+
+<ParamField path="filter" type="string">
+  A CEL expression that is parsed but **not yet evaluated**. Reserved for future
+  filtering (for example `event.ref == "refs/heads/main"`). Today the trigger fires on every
+  matching `(source, event)` pair regardless of this field.
+</ParamField>
+
+<ParamField path="with" type="object">
+  Optional extra configuration passed to the trigger source. Contents are
+  source-specific and may be omitted for most sources.
+</ParamField>
+
+<Warning>
+  The `source` of an integration trigger is the **connection slug**, not the
+  provider name. If it doesn't match an existing connection's slug, the trigger is
+  stored but never fires. The slug is `<provider>_<account>`, lowercase — see
+  Finding your connection slug.
+</Warning>
+
+## Manual trigger
+
+The simplest trigger needs no integration. It fires when you click **Run** in the
+dashboard or call the API. Its source is the literal string `manual`.
+
+```yaml
+triggers:
+  on_demand:
+    source: manual
+    event: fire
+```
+
+A workflow can have **at most one** manual trigger. Use it for release workflows or
+one-off automation where you want full control over when the run happens.
+
+## Integration triggers
+
+Integration triggers start a run from an external system's events. Connect the
+integration once, then reference its connection slug:
+
+```yaml
+triggers:
+  on_push:
+    source: github_acme      # GitHub connection slug
+    event: push
+  on_new_issue:
+    source: sentry_acme      # Sentry connection slug
+    event: issue.created
+```
+
+Setup steps and the full event list for each source live on its integration page:
+
+<CardGroup cols={3}>
+  <Card title="GitHub" icon="github">
+    Pushes and other repository events.
+  </Card>
+  <Card title="Sentry" icon="bug">
+    Issue lifecycle events.
+  </Card>
+  <Card title="Custom webhook" icon="webhook">
+    Any system that can POST.
+  </Card>
+</CardGroup>
+
+## Notes
+
+<Note>
+  `event.ref` on a push is the **full Git ref** (for example `refs/heads/main`),
+  exactly as the provider sends it — not the bare branch name.
+</Note>
+
+<Note>
+  `filter` is parsed but not evaluated — a trigger fires on every matching
+  `(source, event)` pair regardless of the filter expression. This changes in a
+  future release when CEL filter evaluation is enabled. GitLab triggers are on the
+  roadmap.
+</Note>
+
+## Coming soon
+
+Two trigger capabilities are under active development:
+
+**Cron triggers** — run a workflow on a recurring schedule, declared in the YAML
+like any other trigger. The design: `source: cron`, `event: tick`, a raw 5-field
+cron `schedule` (minute granularity), and an optional IANA `timezone` (UTC by
+default). A tick fires the latest definition on the default branch; missed ticks
+are skipped, not backfilled.
+
+```yaml
+# Coming soon — syntax may still evolve before release.
+triggers:
+  nightly:
+    source: cron
+    event: tick
+    schedule: "0 2 * * *"
+    timezone: "Europe/Paris"
+```
+
+**Job-level listening** — the same `{source, event}` selector shape, used on a job
+(`listening.on` / `listening.until`) so it reacts to events repeatedly inside one
+run. See [Listening Jobs](/concepts/listening-jobs).
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Integrations" icon="plug">
+    Connections, slugs, and every available integration.
+  </Card>
+  <Card title="Trigger sources reference" icon="book">
+    Sources and events at a glance.
+  </Card>
+</CardGroup>

--- a/apps/docs/concepts/workflows.mdx
+++ b/apps/docs/concepts/workflows.mdx
@@ -1,0 +1,95 @@
+---
+title: "Workflows: Versioned YAML Automation for Your Repo"
+sidebarTitle: "Workflows"
+description: "A Shipfox workflow is a YAML file under .shipfox/workflows/ that defines what runs, when, and on which runner. Versioned and reviewed like any code."
+---
+
+A Shipfox **workflow** is a YAML file stored in your repository under `.shipfox/workflows/`. It defines the automation: what jobs to run, which steps to execute, and what triggers start a run. Because workflows live in your repo, they are versioned, diff-able, and reviewable like any other code.
+
+## Workflow structure
+
+Every workflow file begins with a small set of top-level fields. Here is a complete example showing all supported keys:
+
+```yaml
+name: My workflow          # required — human-readable name
+runner: ubuntu-latest      # default runner label for all jobs
+env:                       # optional — env vars for run steps
+  NODE_ENV: production
+triggers:                  # optional — what starts a run
+  on_push:
+    source: github_acme
+    event: push
+jobs:                      # required — at least one job
+  build:
+    steps:
+      - run: npm test
+```
+
+Each top-level field is described below.
+
+<ParamField path="name" type="string" required>
+  Human-readable name shown in the dashboard. Must be at least one character.
+</ParamField>
+
+<ParamField path="runner" type="string | string[]">
+  Default runner label or list of labels for all jobs in this workflow. Each job can override this value with its own `runner:` field. If omitted, jobs must specify their own runner.
+</ParamField>
+
+<ParamField path="env" type="object">
+  Environment variables available to `run` steps across all jobs. Keys must follow POSIX-style variable naming (`[A-Za-z_][A-Za-z0-9_]*`). Values can be strings, numbers, or booleans — the runtime stringifies numbers and booleans before execution. Not applied to agent steps.
+</ParamField>
+
+<ParamField path="triggers" type="object">
+  Named triggers that start a workflow run. Each entry is a named key with a `source` and `event`. A workflow with no `triggers` block can only be started manually via the API or dashboard. See [Triggers](/concepts/triggers) for the full schema.
+</ParamField>
+
+<ParamField path="jobs" type="object" required>
+  Named jobs that make up the workflow. At least one job is required. Job names are used as identifiers in `needs` references and in the dashboard run view.
+</ParamField>
+
+## Where workflow files live
+
+Shipfox scans `.shipfox/workflows/` in your connected repository for workflow definitions. Each `.yml` file in that directory is treated as one workflow definition — **one file, one workflow**.
+
+A few rules to keep in mind:
+
+- **Any `.yml` or `.yaml` file under `.shipfox/workflows/` is picked up.** Files are matched by path prefix and extension, so nested paths such as `.shipfox/workflows/ci/build.yml` are scanned too.
+- **The filename is not the workflow name.** The human-readable name comes from the top-level `name:` field inside the file. You can name the file anything you like.
+- **Both `.yml` and `.yaml` extensions are accepted.** Pick one and stay consistent for readability.
+
+## Env variables
+
+The `env` block at the workflow level sets environment variables that are inherited by every `run` step in every job. Job-level and step-level `env` blocks follow the same format.
+
+There are a few important constraints:
+
+- **Values may interpolate.** `env` values support `${{ }}` expressions, resolved when the run is created from `run`, `trigger`, `event`, and `inputs` context — for example `${{ trigger.source }}`. See Expressions.
+- **`env` applies only to `run` steps.** Declaring `env` directly on an agent step (`prompt`) is rejected by the schema validator. Workflow-level and job-level `env` is also not forwarded to agent steps.
+- **There is no unset syntax.** Setting `FOO: ""` sets `FOO` to an empty string. An empty `env: {}` block does not remove variables inherited from the runner's process environment.
+- **Do not put secrets in `env`.** Values are stored in the committed workflow file and in the saved step config — they are not masked in logs.
+
+The precedence order when the same variable name is defined at multiple levels is:
+
+> **Step env** > **Job env** > **Workflow env**
+
+The nearest scope wins. A step-level declaration always beats a job or workflow declaration of the same name.
+
+## Roadmap
+
+<Note>
+  `filter` evaluation, `loop`, `matrix`, and `branch` are roadmap features. `${{ }}` template interpolation is supported today — see Expressions.
+</Note>
+
+## Related pages
+
+<CardGroup cols={3}>
+  <Card title="Jobs & Steps" icon="list-check" href="/concepts/jobs-steps">
+    How jobs and steps are structured and executed inside a workflow run.
+  </Card>
+  <Card title="Triggers" icon="bolt" href="/concepts/triggers">
+    The full trigger schema and which sources are supported today.
+  </Card>
+  <Card title="Runners" icon="server" href="/concepts/runners">
+    Where jobs execute and how to register your own runner.
+  </Card>
+</CardGroup>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,19 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "Core Concepts",
+            "pages": [
+              "concepts/workflows",
+              "concepts/jobs-steps",
+              "concepts/gates",
+              "concepts/logging",
+              "concepts/triggers",
+              "concepts/runners",
+              "concepts/runner-provisioners",
+              "concepts/listening-jobs"
+            ]
           }
         ]
       }

--- a/apps/docs/getting-started.mdx
+++ b/apps/docs/getting-started.mdx
@@ -106,7 +106,7 @@ This repository is a small demo service... To run its tests, ...
 
 The agent had your repository checked out — it read real files to answer. Open the step in the dashboard to see the full **agent session**: every message, thinking block, and tool call, plus token usage and cost. Output varies between runs; the step still succeeds or fails based on whether the call completes.
 
-To make the agent *act on your code* — fix failing tests, review a diff — give it a repo-aware prompt and pair it with a gate so it retries until a check passes. Agent steps use your workspace's configured model provider, so configure one before running them.
+To make the agent *act on your code* — fix failing tests, review a diff — give it a repo-aware prompt and pair it with a [gate](/concepts/gates) so it retries until a check passes. Agent steps use your workspace's configured model provider, so configure one before running them.
 
 ## Let your agent write workflows
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -21,7 +21,7 @@ Workflows live in `.shipfox/workflows/` as YAML files, versioned and reviewed al
 Three things set Shipfox apart, and they compound:
 
 - **Agents are first-class steps.** Any step can be an AI agent — pick a `model`, write a `prompt`, choose a `thinking` depth. No plugin, no action, no glue.
-- **Agents iterate until the work is correct.** Pair an agent with a gate: the agent makes a change, a `run` step verifies it, and `restart_from` loops back to the agent until the check passes — bounded automatically.
+- **Agents iterate until the work is correct.** Pair an agent with a [gate](/concepts/gates): the agent makes a change, a `run` step verifies it, and `restart_from` loops back to the agent until the check passes — bounded automatically.
 - **You see the agent think.** Agent steps stream structured events — messages, thinking, tool calls, token usage, and cost — not just raw text.
 
 ```yaml
@@ -41,22 +41,22 @@ jobs:
 ## Key features
 
 <CardGroup cols={2}>
-  <Card title="YAML Workflows in Your Repo" icon="code-branch">
+  <Card title="YAML Workflows in Your Repo" icon="code-branch" href="/concepts/workflows">
     Workflows live under `.shipfox/workflows/`, versioned and reviewed like any code.
   </Card>
-  <Card title="AI Agent Steps" icon="robot">
+  <Card title="AI Agent Steps" icon="robot" href="/concepts/jobs-steps">
     Any step can run an AI agent: pick a model, write a prompt, and Shipfox does the rest.
   </Card>
-  <Card title="Gates & Retry Loops" icon="rotate">
+  <Card title="Gates & Retry Loops" icon="rotate" href="/concepts/gates">
     Gate a step on its exit code and `restart_from` an earlier step — bounded loops, no scripting.
   </Card>
-  <Card title="Live & Agent Logs" icon="terminal">
+  <Card title="Live & Agent Logs" icon="terminal" href="/concepts/logging">
     Tail every step live; agent steps show messages, thinking, and tool calls as structured events.
   </Card>
-  <Card title="Your Own Runners" icon="server">
+  <Card title="Your Own Runners" icon="server" href="/concepts/runners">
     Jobs execute on runners you register and control — no vendor lock-in on compute.
   </Card>
-  <Card title="Autoscaling Provisioners" icon="layer-group">
+  <Card title="Autoscaling Provisioners" icon="layer-group" href="/concepts/runner-provisioners">
     A provisioner starts ephemeral, single-job runners on demand and lets them exit when idle.
   </Card>
   <Card title="Smart Triggers" icon="bolt">

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -62,16 +62,16 @@ The same flow as one picture — note that the runner **polls outbound** (nothin
 ## Core concepts
 
 <CardGroup cols={2}>
-  <Card title="Workflows" icon="code-branch">
+  <Card title="Workflows" icon="code-branch" href="/concepts/workflows">
     The YAML files that define your automation — name, triggers, jobs, steps, and environment variables.
   </Card>
-  <Card title="Jobs, Steps & Agents" icon="layer-group">
+  <Card title="Jobs, Steps & Agents" icon="layer-group" href="/concepts/jobs-steps">
     How work is structured and executed inside a workflow, including shell steps, agent steps, and gate conditions.
   </Card>
-  <Card title="Triggers" icon="bolt">
+  <Card title="Triggers" icon="bolt" href="/concepts/triggers">
     What starts a run — GitHub pushes, Sentry issues, webhooks from any system, manual fires — with more integrations on the way.
   </Card>
-  <Card title="Runners" icon="server">
+  <Card title="Runners" icon="server" href="/concepts/runners">
     The processes you register on your own compute that execute jobs. Runners poll Shipfox and are matched to jobs by label.
   </Card>
 </CardGroup>
@@ -110,7 +110,7 @@ Features listed as roadmap are not yet available and should not be relied upon i
   <Card title="Gate and retry loops" icon="rotate">
     Retry a step until tests pass using `gate` with `success_if` and `on_failure.restart_from` — no custom scripting needed.
   </Card>
-  <Card title="Agents that answer reviews" icon="satellite-dish">
+  <Card title="Agents that answer reviews" icon="satellite-dish" href="/concepts/listening-jobs">
     Coming soon: a job that listens for PR review comments and runs an agent per batch until the PR merges.
   </Card>
 </CardGroup>

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,11 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [Workflows](/concepts/workflows): The YAML workflow file format, top-level fields, env variables, and file location conventions.
+- [Jobs & Steps](/concepts/jobs-steps): How jobs group steps, job isolation, run steps, agent steps, and the gate block.
+- [Gates](/concepts/gates): How gates decide step success and restart a job from an earlier step to build bounded retry loops — valid on run and agent steps.
+- [Logging](/concepts/logging): Live and persisted step logs plus structured agent-session events; masking, retention, and truncation.
+- [Triggers](/concepts/triggers): What starts a run: manual, GitHub push, Sentry issue, and the filter field.
+- [Runners](/concepts/runners): How to register and configure runners that execute your workflow jobs.
+- [Runner Provisioners](/concepts/runner-provisioners): Autoscale ephemeral, single-job runners on demand instead of hand-starting a fleet.
+- [Listening Jobs](/concepts/listening-jobs): Coming soon — jobs that react to a stream of events inside a single run until a terminating condition.


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **Core Concepts** section. Base is `docs/setup-getting-started`, so this diff is just the concepts content; GitHub auto-retargets it to `main` once #476 merges.

## What's here

- **8 concept pages** copied from the docs source (`ShipfoxHQ/docs` @ `d0e33e9`): `workflows`, `jobs-steps`, `gates`, `logging`, `triggers`, `runners`, `runner-provisioners`, `listening-jobs`.
- **Nav** — `Core Concepts` group added to `docs.json` in the source's order (logging after gates; `listening-jobs` last). Sidebar renames ported verbatim: "Jobs, Steps & Agents", "Gates & Retry Loops", "Logs & Agent Sessions", "Listening Jobs (soon)".
- **De-link discipline** (per the trimmed-site model) — cross-references to pages not yet migrated (guides, integrations, reference, installation) are de-linked (inline → plain text; cards → static, `href` stripped for easy re-linking when those groups land). In-group `/concepts/*` links stay live.
- **Base pages re-linked** — the Home feature cards and the Introduction concept cards now point back to the concept pages, and the gate mentions on Home / Getting Started link to `/concepts/gates`.
- **`llms.txt`** — the 8 concept entries appended.

## Correctness notes

- `restart_from` targets a step's **`key:`** (not `name:`) in every example and ParamField — matches the schema (`libs/shared/workflow/document`) and the canonical `gates.yml` seed. (A stale `name:` variant in the source's `jobs-steps.mdx` was caught during porting and fixed upstream in `d0e33e9` before copying.)
- Gates documented as valid on **both run and agent steps**. `source` is the connection **slug**; `event.ref` is the **full Git ref**; `${{ }}` interpolation shown as shipped. Gitea intentionally absent (only appears on `installation/local`). Diagrams are PNG (n/a here — concepts carry only `step-logs.png`).

## Verification

`pnpm docs:check` → **0 broken links**; `pnpm docs:dev` renders all 8 pages and the `step-logs.png` screenshot. No changeset (docs/ is not a `libs/`/`tools/` package).

Refs ENG-475

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Core Concepts docs group with eight pages under `/concepts`, and updates the sidebar plus home/intro/getting-started links. Clarifies trigger and gate behavior and where to create provisioner tokens. Supports ENG-475.

- **New Features**
  - Added pages: workflows, jobs-steps, gates, logging, triggers, runners, runner-provisioners, listening-jobs (coming soon), and a “Core Concepts” nav group.
  - Linked base pages: index/introduction now point to concept pages; getting-started links to `/concepts/gates`.
  - Triggers: custom webhook event is `received`; `source` uses the connection slug; push `event.ref` is the full Git ref; `filter` is parsed but not evaluated yet; manual trigger is `source: manual`, `event: fire`.
  - Gates: `restart_from` targets a step `key`; valid on both run and agent steps.
  - Kept in-group `/concepts/*` links live; de-linked out-of-group refs; appended to `llms.txt`; `pnpm docs:check` shows 0 broken links.

<sup>Written for commit 3227bc21d0d15b787b069fef3882315655fdba85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

