### PR TITLE
Add Integrations docs group

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,17 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "Integrations",
+            "pages": [
+              "integrations/overview",
+              "integrations/github",
+              "integrations/sentry",
+              "integrations/webhooks",
+              "integrations/linear",
+              "integrations/slack"
+            ]
           }
         ]
       }

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -59,7 +59,7 @@ jobs:
   <Card title="Autoscaling Provisioners" icon="layer-group">
     A provisioner starts ephemeral, single-job runners on demand and lets them exit when idle.
   </Card>
-  <Card title="Smart Triggers" icon="bolt">
+  <Card title="Smart Triggers" icon="bolt" href="/integrations/overview">
     GitHub pushes, Sentry issues, webhooks from any system, or on-demand fire — with more integrations on the way.
   </Card>
   <Card title="30+ Model Providers" icon="sparkles">

--- a/apps/docs/integrations/github.mdx
+++ b/apps/docs/integrations/github.mdx
@@ -1,0 +1,102 @@
+---
+title: "GitHub Integration: Trigger Workflows on Repository Events"
+sidebarTitle: "GitHub"
+description: "Connect a GitHub repository to Shipfox with the GitHub App and trigger workflows on pushes and other repository events. Reference the connection by its slug."
+---
+
+The GitHub integration connects a repository or organization to Shipfox through a
+**GitHub App**. Once connected, repository events — pushes and any other event the
+App is subscribed to — can trigger workflow runs.
+
+## Setup
+
+<Steps>
+  <Step title="Start the connection">
+    In your workspace's integration settings, choose **GitHub** and start the
+    connection. Shipfox sends you to GitHub to install its App.
+  </Step>
+  <Step title="Install the GitHub App">
+    On GitHub, pick the account or organization and grant the App access to the
+    repositories you want Shipfox to watch. GitHub redirects you back to Shipfox.
+  </Step>
+  <Step title="Copy the connection slug">
+    Shipfox creates a **connection** for the installation. Its slug defaults to
+    `github_<account>` — for example `github_acme`. This slug is the value you put
+    in a trigger's `source` field.
+  </Step>
+</Steps>
+
+## Triggering a workflow
+
+Use the connection slug as `source` and a GitHub event name as `event`:
+
+```yaml
+triggers:
+  on_push:
+    source: github_acme
+    event: push
+```
+
+`source` is the connection **slug** (`github_acme`), not the word `github` — see
+[Finding your connection slug](/integrations/overview#finding-your-connection-slug).
+
+## Events
+
+The most common event is `push`, which fires on every push to a connected
+repository:
+
+```yaml
+triggers:
+  on_push:
+    source: github_acme
+    event: push
+```
+
+Shipfox forwards any GitHub webhook event the App is subscribed to, named
+`<resource>` or `<resource>.<action>` (for example `pull_request.opened`,
+`issues.opened`, `release.published`), passing the raw payload straight to your run.
+Rather than duplicate GitHub's catalog here, use GitHub's own reference for the full
+list of events and their payload shapes:
+
+<Card title="GitHub webhook events and payloads" icon="github" href="https://docs.github.com/en/webhooks/webhook-events-and-payloads">
+  The authoritative list of every GitHub webhook event and the payload it delivers.
+</Card>
+
+## Event payload
+
+Shipfox passes the raw GitHub webhook payload to the run. For a `push`, that
+includes the pushed ref, the head commit SHA, and the repository's default branch.
+
+The branch ref is exposed to filters as `event.ref` — the **full Git ref** (for
+example `refs/heads/main`), exactly as GitHub sends it.
+
+## Filtering
+
+You can add a `filter` CEL expression to target specific branches or actions — for
+example `event.ref == "refs/heads/main"`:
+
+```yaml
+triggers:
+  on_main_push:
+    source: github_acme
+    event: push
+    filter: event.ref == "refs/heads/main"
+```
+
+<Note>
+  `filter` is parsed but **not yet evaluated** — the trigger fires on every `push`
+  regardless of the expression. Authoring a filter now is safe and takes effect
+  once evaluation ships. To gate behavior on the branch today, branch inside a
+  `run` step.
+</Note>
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Checks on push" icon="circle-check">
+    A worked example that runs tests and an AI review on every push.
+  </Card>
+  <Card title="Triggers" icon="bolt">
+    The trigger schema and how sources and events fit together.
+  </Card>
+</CardGroup>

--- a/apps/docs/integrations/linear.mdx
+++ b/apps/docs/integrations/linear.mdx
@@ -1,0 +1,37 @@
+---
+title: "Linear Integration (Coming Soon)"
+sidebarTitle: "Linear (soon)"
+description: "Trigger Shipfox workflows from Linear issue events — an agent that picks up a ticket, plans, and opens a PR. Coming soon."
+---
+
+<Note>
+  **Coming soon.** The Linear integration is not available yet. This page
+  describes where it is headed.
+</Note>
+
+The Linear integration will connect a Linear workspace to Shipfox so issue events
+can trigger workflow runs — the natural entry point for agentic work that starts
+from a ticket: an issue is created or moved, a workflow fires, and an agent picks
+it up with the issue's context in its prompt.
+
+Like every integration, it will follow the same model as [GitHub](/integrations/github)
+and [Sentry](/integrations/sentry): connect once, get a **connection slug**
+(e.g. `linear_acme`), and reference it as a trigger `source` with the events the
+integration emits.
+
+## Until it ships
+
+Linear can already reach Shipfox through a [custom webhook](/integrations/webhooks):
+create a webhook connection, point a Linear webhook at its ingest URL, and trigger
+on `received` — the run gets Linear's payload as its `event` context.
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Custom webhook" icon="webhook" href="/integrations/webhooks">
+    The working interim path for Linear events today.
+  </Card>
+  <Card title="Integrations overview" icon="plug" href="/integrations/overview">
+    Connections, slugs, and every available integration.
+  </Card>
+</CardGroup>

--- a/apps/docs/integrations/overview.mdx
+++ b/apps/docs/integrations/overview.mdx
@@ -1,0 +1,109 @@
+---
+title: "Integrations: Connect the Tools That Trigger Workflows"
+sidebarTitle: "Overview"
+description: "Connect GitHub, Sentry, and custom webhooks to Shipfox so their events can trigger workflows. Each connection has a slug you reference as a trigger source."
+---
+
+An **integration** connects an external system — GitHub, Sentry, or a custom
+webhook endpoint — to your Shipfox workspace so its events can start workflow
+runs. You connect an integration once in your workspace, and every project in that
+workspace can trigger workflows from it.
+
+## Connections and slugs
+
+Connecting an integration creates a **connection**. Each connection has a **slug**
+— a short, stable identifier that you put in a trigger's `source` field. The slug
+is how a workflow says *which* connection an event must come from.
+
+```yaml
+triggers:
+  on_push:
+    source: github_acme    # <- the connection slug, not the bare word "github"
+    event: push
+```
+
+<Warning>
+  A trigger's `source` is the **connection slug**, not the provider name. Writing
+  `source: github` only works if a connection is literally named `github`. Use the
+  slug shown for your connection after you connect it (for GitHub this defaults to
+  `github_<account>`, for example `github_acme`). If the `source` doesn't match a
+  connection slug, the trigger is stored but never fires.
+</Warning>
+
+Slugs also let one workspace hold **several connections of the same provider** —
+for example a `github_acme` org connection and a `github_acme-labs` connection —
+and target each independently from different workflows.
+
+## Available integrations
+
+| Integration | Status | Events |
+|---|---|---|
+| [GitHub](/integrations/github) | ✅ Shipped | `push` and other repository events |
+| [Sentry](/integrations/sentry) | ✅ Shipped | `issue.created`, `issue.resolved`, `issue.assigned`, `issue.archived`, `issue.unresolved` |
+| [Custom webhook](/integrations/webhooks) | ✅ Shipped | `received` |
+| [Linear](/integrations/linear) | 🚧 Coming soon | — |
+| [Slack](/integrations/slack) | 🚧 Coming soon | — |
+| GitLab | 🔜 Roadmap | — |
+
+The built-in **`manual`** source needs no integration — it fires when you click
+**Run** in the dashboard or call the API. See Triggers for
+its schema.
+
+## The trigger contract
+
+Every integration trigger shares the same two required fields, plus two optional
+ones:
+
+<ParamField path="source" type="string" required>
+  The **connection slug** the event must come from (for example `github_acme`).
+</ParamField>
+
+<ParamField path="event" type="string" required>
+  The event name from that source (for example `push` or `issue.created`). The
+  event names each integration emits are listed on its page.
+</ParamField>
+
+<ParamField path="filter" type="string">
+  A CEL expression intended to narrow which events fire the trigger. **Parsed but
+  not yet evaluated** — today every event matching `(source, event)` fires,
+  regardless of the filter. Authoring one now is safe and forward-compatible.
+</ParamField>
+
+<ParamField path="with" type="object">
+  Optional source-specific configuration. May be omitted for most sources.
+</ParamField>
+
+## Finding your connection slug
+
+The slug is `<provider>_<account>`, lowercase: connecting the GitHub account
+`acme` creates `github_acme`. Your workspace's integration settings
+(**Settings → Integrations**) show each connection's display name — for example
+"GitHub acme" for the slug `github_acme`. The workspace's **Settings → Events**
+page records every event a connection delivers; an event that shows **No
+workflows triggered** usually means the `source` in your workflow does not match
+the connection's slug.
+
+<Frame caption="Settings → Events: every received event, whether it matched, and its raw payload. 'No workflows triggered' usually means a source/slug mismatch.">
+  <img src="/images/events-journal.png" alt="The Events journal listing received trigger events with their match results and payload" />
+</Frame>
+
+## Webhook payloads
+
+Shipfox does not maintain a reference for each provider's webhook payload shape —
+those are owned by the provider and can change. Each integration page links to the
+provider's own webhook documentation for the full payload. Shipfox forwards the
+raw event to the run so your steps can read whatever the provider sent.
+
+## Related pages
+
+<CardGroup cols={3}>
+  <Card title="GitHub" icon="github" href="/integrations/github">
+    Connect a repository and trigger on pushes and other events.
+  </Card>
+  <Card title="Sentry" icon="bug" href="/integrations/sentry">
+    Trigger workflows when Sentry issues change state.
+  </Card>
+  <Card title="Custom webhook" icon="webhook" href="/integrations/webhooks">
+    Trigger from any system that can send an HTTP POST.
+  </Card>
+</CardGroup>

--- a/apps/docs/integrations/sentry.mdx
+++ b/apps/docs/integrations/sentry.mdx
@@ -1,0 +1,106 @@
+---
+title: "Sentry Integration: Trigger Workflows on Issue Events"
+sidebarTitle: "Sentry"
+description: "Connect Sentry to Shipfox and trigger workflows when issues are created, resolved, assigned, archived, or regress. Reference the connection by its slug."
+---
+
+The Sentry integration connects a Sentry organization to Shipfox through a
+**Sentry App**. Once connected, issue lifecycle events can trigger workflow runs —
+for example, kicking off an agent to investigate a newly created issue.
+
+## Setup
+
+<Steps>
+  <Step title="Start the connection">
+    In your workspace's integration settings, choose **Sentry** and start the
+    connection. Shipfox sends you to Sentry to install its App.
+  </Step>
+  <Step title="Install the Sentry App">
+    On Sentry, pick the organization and authorize the App. Sentry redirects you
+    back to Shipfox, which verifies the installation.
+  </Step>
+  <Step title="Copy the connection slug">
+    Shipfox creates a **connection** whose slug defaults to `sentry_<org>` — for
+    example `sentry_acme`. Use this slug in a trigger's `source` field.
+  </Step>
+</Steps>
+
+## Triggering a workflow
+
+Use the connection slug as `source` and a Sentry issue event as `event`:
+
+```yaml
+triggers:
+  on_new_issue:
+    source: sentry_acme
+    event: issue.created
+```
+
+`source` is the connection **slug** (`sentry_acme`), not the word `sentry` — see
+[Finding your connection slug](/integrations/overview#finding-your-connection-slug).
+
+## Events
+
+Shipfox triggers on Sentry **issue** events: `issue.created`, `issue.resolved`,
+`issue.assigned`, `issue.archived`, and `issue.unresolved`. For exactly when each
+action fires and the payload it carries, use Sentry's reference rather than a copy
+here:
+
+<Card title="Sentry issue webhooks" icon="bug" href="https://docs.sentry.io/organization/integrations/integration-platform/webhooks/issues/">
+  When each issue action fires and the payload Sentry sends.
+</Card>
+
+The run receives a normalized version of that payload as its `event` context — the
+issue's `action`, `issueId`, `title`, `level`, `status`, `platform`, `projectUrl`,
+and links back to Sentry (`issueUrl`, `webUrl`).
+
+## Filtering by project or team
+
+Shipfox receives issue events for your **whole connected Sentry organization**. To
+act on a specific project — or a team's projects — key off the project the event
+carries as `event.projectUrl`.
+
+The intended way is a trigger `filter`:
+
+```yaml
+triggers:
+  on_backend_issue:
+    source: sentry_acme
+    event: issue.created
+    filter: event.projectUrl.contains("/backend")
+```
+
+<Warning>
+  `filter` is **parsed but not evaluated yet** (see
+  Expressions), so today it does not stop the run. Until it
+  ships, scope inside the workflow: read `${{ event.projectUrl }}` in a `run` step or
+  agent `prompt` and act only on the projects you care about. Sentry's issue payload
+  has no team field, so filter a team by the set of projects it owns.
+</Warning>
+
+For example, pass the project and issue straight into an agent so it only triages
+what you point it at:
+
+```yaml
+jobs:
+  triage:
+    steps:
+      - model: claude-opus-4-8
+        prompt: >
+          Triage this Sentry issue in project ${{ event.projectUrl }}:
+          "${{ event.title }}" (${{ event.issueUrl }}). Summarize the likely cause.
+```
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Triage Sentry issues" icon="bug">
+    A worked guide: fire on an issue and hand it to an agent that investigates.
+  </Card>
+  <Card title="Agent steps" icon="robot">
+    Have an agent triage or fix the issue that triggered the run.
+  </Card>
+  <Card title="Triggers" icon="bolt">
+    The trigger schema and how sources and events fit together.
+  </Card>
+</CardGroup>

--- a/apps/docs/integrations/slack.mdx
+++ b/apps/docs/integrations/slack.mdx
@@ -1,0 +1,38 @@
+---
+title: "Slack Integration (Coming Soon)"
+sidebarTitle: "Slack (soon)"
+description: "Trigger Shipfox workflows from Slack events and report agent results back to your channels. Coming soon."
+---
+
+<Note>
+  **Coming soon.** The Slack integration is not available yet. This page
+  describes where it is headed.
+</Note>
+
+The Slack integration will connect a Slack workspace to Shipfox so conversations
+and workflows can meet: Slack events triggering workflow runs, and runs reporting
+their results — an agent's summary, a failed check, a finished triage — back into
+your channels.
+
+Like every integration, it will follow the same model as [GitHub](/integrations/github)
+and [Sentry](/integrations/sentry): connect once, get a **connection slug**
+(e.g. `slack_acme`), and reference it as a trigger `source` with the events the
+integration emits.
+
+## Until it ships
+
+Slack can already reach Shipfox through a [custom webhook](/integrations/webhooks):
+create a webhook connection and point a Slack outgoing webhook or automation at its
+ingest URL, then trigger on `received`. For the other direction, a `run`
+step can post to a Slack incoming webhook today (`curl` to your Slack webhook URL).
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Custom webhook" icon="webhook" href="/integrations/webhooks">
+    The working interim path for Slack events today.
+  </Card>
+  <Card title="Integrations overview" icon="plug" href="/integrations/overview">
+    Connections, slugs, and every available integration.
+  </Card>
+</CardGroup>

--- a/apps/docs/integrations/webhooks.mdx
+++ b/apps/docs/integrations/webhooks.mdx
@@ -1,0 +1,78 @@
+---
+title: "Custom Webhooks: Trigger Workflows from Any System"
+sidebarTitle: "Custom webhook"
+description: "Create a Shipfox webhook connection, point any system at its URL, and trigger workflows on the received event. The connection slug is your trigger source."
+---
+
+A **custom webhook** connection gives you a unique URL that any system can POST to.
+Every request that arrives fires the `received` event, which your workflows
+can trigger on. Use it for tools Shipfox doesn't integrate with directly — CI
+systems, monitoring, internal services, or anything that can send an HTTP request.
+
+## Setup
+
+<Steps>
+  <Step title="Create a webhook connection">
+    Create a webhook connection in your workspace. You choose its **slug** — a
+    lowercase identifier matching `^[a-z0-9]+(?:[_-][a-z0-9]+)*$`, unique within
+    the workspace (for example `deploy_hook`). Shipfox returns a unique **ingest
+    URL** for the connection.
+  </Step>
+  <Step title="Send events to the URL">
+    Point any system at the ingest URL with an HTTP `POST`. The body can be JSON,
+    form-encoded, or plain text. An optional `X-Delivery-ID` header lets you
+    deduplicate retries; Shipfox generates one if you omit it.
+
+    ```bash
+    curl -X POST https://<your-shipfox>/webhook/<connection-id> \
+      -H "Content-Type: application/json" \
+      -d '{"environment": "production", "version": "1.4.2"}'
+    ```
+
+    Shipfox responds `202 Accepted` with a `delivery_id`.
+  </Step>
+  <Step title="Trigger a workflow">
+    Author a trigger using the connection slug as `source` and `received`
+    as `event`.
+  </Step>
+</Steps>
+
+## Triggering a workflow
+
+```yaml
+triggers:
+  on_webhook:
+    source: deploy_hook       # your webhook connection slug
+    event: received
+```
+
+`received` is the only event a custom webhook emits — every request to the
+ingest URL fires it.
+
+## Event payload
+
+Shipfox passes the request to the run as structured data:
+
+| Field | Contents |
+|---|---|
+| `method` | The HTTP method (typically `POST`) |
+| `headers` | Request headers, with sensitive ones (authorization, bearer tokens) removed |
+| `query` | Parsed query-string parameters |
+| `body` | Parsed JSON, or the raw body when it isn't JSON |
+
+<Note>
+  A `filter` CEL expression can reference `event.headers`, `event.query`, and
+  `event.body`, but filters are **parsed and not yet evaluated** — every request
+  fires the trigger today.
+</Note>
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Triggers" icon="bolt">
+    The trigger schema shared by every source.
+  </Card>
+  <Card title="Integrations overview" icon="plug" href="/integrations/overview">
+    Connections, slugs, and the other available integrations.
+  </Card>
+</CardGroup>

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,9 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [Integrations](/integrations/overview): Connect GitHub, Sentry, and custom webhooks so their events trigger workflows; each connection has a slug used as the trigger source.
+- [GitHub](/integrations/github): Connect a repository with the GitHub App and trigger workflows on pushes and other repository events.
+- [Sentry](/integrations/sentry): Trigger workflows on Sentry issue events — created, resolved, assigned, archived, regressed.
+- [Custom webhook](/integrations/webhooks): Point any system at a webhook connection URL to trigger workflows on the received event.
+- [Linear](/integrations/linear): Coming soon — trigger workflows from Linear issue events.
+- [Slack](/integrations/slack): Coming soon — trigger workflows from Slack events and report results back to channels.


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **Integrations** section. Base is `docs/setup-getting-started`, so this diff is just the integrations content; GitHub auto-retargets to `main` once #476 merges.

## What's here

- **6 pages** copied from source (`ShipfoxHQ/docs` @ `d0e33e9`): `overview`, `github`, `sentry`, `webhooks`, `linear`, `slack`. Nav group added in source order. Linear and Slack are **"(soon)"** — sidebar markers preserved verbatim, coming-soon with the webhook interim path.
- **De-link discipline** — cross-references to pages not in this branch (`concepts/triggers`, `guides/*`, `reference/expressions`) are de-linked (inline → plain text; cards → static `href` stripped); in-group `/integrations/*` links stay live.
- **Base page re-linked** — Home's "Smart Triggers" feature card now points to `/integrations/overview`.
- **`llms.txt`** — the 6 integration entries appended.

## Correctness notes

- Trigger `source` is the connection **slug** (e.g. `github_acme`) throughout, not the bare provider name.
- **Gitea intentionally absent** — it only appears on `installation/local`; everywhere else says GitHub / webhooks / (roadmap) GitLab.
- `events-journal.png` (Integrations overview journal screenshot) carried and rendering.

## Verification

`pnpm docs:check` → **0 broken links**; `pnpm docs:dev` renders all 6 pages + the screenshot. No changeset (docs/ is not a `libs/`/`tools/` package).

No dedicated Linear issue for integrations — tracked under milestone **"2. OSS and docs"** (referencing ENG-486, the docs-examples issue).

Refs ENG-486

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Integrations docs group with pages for GitHub, Sentry, and custom webhooks, plus “coming soon” stubs for Linear and Slack. Updates navigation, clarifies that triggers use connection slugs, and links the Home “Smart Triggers” card to the new overview. Refs ENG-486.

- **New Features**
  - Added Integrations nav group with six pages: `overview`, `github`, `sentry`, `webhooks`, `linear (soon)`, `slack (soon)`; in-group `/integrations/*` links are live and out-of-group refs are de-linked.
  - Overview explains connections and slugs, lists available events, and includes the Events journal screenshot.
  - GitHub and Sentry pages cover setup, events, payload context, and filter notes; Webhooks documents the ingest URL, payload shape, and trigger usage; Linear/Slack note the interim webhook path.
  - Updated Home “Smart Triggers” card to `/integrations/overview` and appended entries to `docs/llms.txt`.

- **Bug Fixes**
  - Corrected the custom webhook event name to `received` (not `webhook.received`) across docs and examples.

<sup>Written for commit 5eb9c4efe9fe9eb109ba6c28b1052585f61613b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

