### PR TITLE
Add Guides docs group

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,17 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "guides/agent-steps",
+              "guides/gate-and-retry",
+              "guides/triage-sentry-issues",
+              "guides/checks-on-push",
+              "guides/multi-job-pipeline",
+              "guides/model-providers"
+            ]
           }
         ]
       }

--- a/apps/docs/guides/agent-steps.mdx
+++ b/apps/docs/guides/agent-steps.mdx
@@ -1,0 +1,97 @@
+---
+title: "Configure and Use AI Agent Steps in Shipfox Workflows"
+sidebarTitle: "Agent Steps"
+description: "Run AI models inline in your Shipfox workflows using agent steps. Set model, thinking level, and provider, or mix agent and shell steps in a single job."
+---
+
+Shipfox agent steps let you run an AI model as a native workflow step — no glue code, no webhooks. An agent step specifies a `model`, a `prompt`, and optionally a `thinking` level and `provider`. The step executes inline within the job, the model has full access to the repository, and its output appears in the run log alongside any shell step output.
+
+## Basic agent step
+
+At a minimum, an agent step requires a `prompt`. When no `model` or `provider` is specified, Shipfox uses the workspace default provider and model (see [Model Providers](/guides/model-providers)).
+
+```yaml
+jobs:
+  fix:
+    steps:
+      - name: ask-claude
+        model: claude-opus-4-8
+        prompt: Read the repository and summarize what it does in three sentences.
+```
+
+The optional `name` field labels the step in the dashboard. To reference a step from a `restart_from` gate, give it a `key:` — keys identify steps; names are display-only.
+
+## Choosing a model
+
+The `model` field accepts the model ID used by the provider. The `provider` field accepts a provider ID (e.g. `openai`, `deepseek`). When `provider` is omitted, Shipfox resolves the model against your workspace default provider.
+
+To use a non-default provider, specify both fields:
+
+```yaml
+- model: gpt-5.5-pro
+  provider: openai
+  prompt: Review the recent changes for security issues.
+```
+
+Some supported combinations to get you started:
+
+| Provider | `provider` ID | Example `model` |
+|---|---|---|
+| Anthropic | `anthropic` | `claude-opus-4-8` |
+| OpenAI | `openai` | `gpt-5.5-pro` |
+| DeepSeek | `deepseek` | `deepseek-v4-pro` |
+| xAI | `xai` | `grok-4.3` |
+| Google AI Studio | `google` | `gemini-3.1-pro-preview` |
+
+See the [Model Providers](/guides/model-providers) guide for the complete list of supported providers and their model IDs.
+
+## Thinking level
+
+The `thinking` field controls the model's reasoning depth before it produces output. Valid values are `off`, `minimal`, `low`, `medium`, `high`, and `xhigh`. The default is `high`.
+
+Higher thinking levels increase reasoning depth and token usage. Use `low` for straightforward summarization or simple generation tasks. Use `high` or `xhigh` for complex code review, multi-file debugging, or any task where accuracy matters more than speed.
+
+```yaml
+- model: claude-opus-4-8
+  thinking: xhigh
+  prompt: >
+    Trace the root cause of the failing integration test. Check all code paths
+    that touch the payment module and propose a fix.
+```
+
+## Combining run and agent steps
+
+Agent steps and shell steps can be mixed freely within a job. This is the foundation of Shipfox's self-fixing loops: an agent edits the source, a `run` step verifies the result, and a gate retries from the top if verification fails.
+
+```yaml
+jobs:
+  fix-and-verify:
+    steps:
+      - key: install
+        run: npm ci
+      - model: claude-opus-4-8
+        prompt: The tests are failing. Edit the source code to fix them.
+      - run: npm test
+        gate:
+          success_if: exit_code == 0
+          on_failure:
+            restart_from: install
+```
+
+On each iteration, the agent reads the updated codebase and attempts another fix. The gate evaluates `npm test`'s exit code — if the test run still fails, execution jumps back to the `install` step and the loop begins again. See the [Gate & Retry](/guides/gate-and-retry) guide for full details.
+
+## Agent step rules
+
+<Warning>
+  Keep these constraints in mind when authoring agent steps:
+
+  - `env` is not valid on agent steps — it is supported only on `run` steps.
+  - `run` and any of `prompt`, `model`, `thinking`, or `provider` cannot appear on the same step.
+  - `prompt` is required on every agent step — a step with `model` but no `prompt` will be rejected.
+  - The `agent:` key is reserved and will be rejected with an explicit error message.
+</Warning>
+
+## Next steps
+
+- [Gate & Retry](/guides/gate-and-retry) — build self-correcting loops with gate conditions.
+- [Model Providers](/guides/model-providers) — add API keys and configure your default provider.

--- a/apps/docs/guides/checks-on-push.mdx
+++ b/apps/docs/guides/checks-on-push.mdx
@@ -1,0 +1,83 @@
+---
+title: "Run Automated Checks on Every GitHub Push with Shipfox"
+sidebarTitle: "Checks on Push"
+description: "Set up a Shipfox workflow that runs tests, lint, and an AI code review step automatically on every push to your GitHub repository."
+---
+
+This guide walks you through creating a Shipfox workflow that runs your test suite and an AI code review on every push to GitHub. You'll set up a two-job pipeline: one job for automated checks, one for an agent review that runs after tests pass.
+
+## What you'll build
+
+You'll create a workflow with two jobs: `checks` and `review`. The `checks` job runs `npm ci && npm test` to validate the codebase on every push. The `review` job declares `needs: checks`, meaning it only starts once `checks` succeeds, and uses an agent step that reads the repository and flags likely bugs and missing tests — mechanical validation and an agent review, in one workflow that lives with your code.
+
+## The workflow file
+
+Create the following file at `.shipfox/workflows/checks-on-push.yml` in your repository:
+
+```yaml
+name: Checks on push
+runner: ubuntu-latest
+triggers:
+  on_push:
+    source: github_acme
+    event: push
+jobs:
+  checks:
+    steps:
+      - run: npm ci
+      - run: npm test
+  review:
+    needs: checks
+    steps:
+      - model: claude-opus-4-8
+        thinking: high
+        prompt: >
+          Review this repository for likely bugs and missing test coverage.
+          Be concise — summarize the top 3 issues only.
+```
+
+The `triggers` block tells Shipfox to fire this workflow on every GitHub push. The `review` job's `needs: checks` declaration creates a dependency edge — if `checks` fails, `review` is skipped automatically.
+
+## Deploy it
+
+Follow these steps to get the workflow running:
+
+1. Create the directory and file in your repository: `.shipfox/workflows/checks-on-push.yml`.
+2. Paste the YAML above into the file.
+3. Commit the file and push to GitHub.
+
+The workflow appears in the Shipfox dashboard immediately after the push. The next push to any branch fires it.
+
+<Note>
+  Push triggers require a GitHub repository connected to your Shipfox project.
+  GitLab is on the roadmap — use `source: manual, event: fire` if your repo is
+  on GitLab.
+</Note>
+
+## Parallel checks
+
+When lint and tests are independent, running them in parallel cuts wall-clock time. Split `checks` into independent `lint` and `test` jobs that both start immediately, then fan in to the `review` job once both finish:
+
+```yaml
+jobs:
+  lint:
+    steps:
+      - run: npm ci
+      - run: npm run lint
+  test:
+    steps:
+      - run: npm ci
+      - run: npm test
+  review:
+    needs: [lint, test]
+    steps:
+      - model: claude-opus-4-8
+        prompt: Summarize any issues found in the test or lint output.
+```
+
+Because each job runs in its own isolated environment, both `lint` and `test` install dependencies independently. The `review` job waits for both to finish before the agent step executes.
+
+## Next steps
+
+- [Multi-Job Pipeline](/guides/multi-job-pipeline) — learn more about sequencing and fan-out patterns.
+- [Agent Steps](/guides/agent-steps) — configure models, thinking levels, and providers.

--- a/apps/docs/guides/gate-and-retry.mdx
+++ b/apps/docs/guides/gate-and-retry.mdx
@@ -1,0 +1,91 @@
+---
+title: "Use Gate Conditions and Retry Loops in Shipfox Workflows"
+sidebarTitle: "Gate & Retry"
+description: "Use Shipfox gate blocks to evaluate step success with CEL expressions and automatically retry from an earlier keyed step when a condition fails."
+---
+
+A **gate** block on a step lets you define a success condition and a retry strategy. When the condition fails, Shipfox restarts execution from an earlier keyed step in the same job — creating a loop that continues until the condition is met or the job times out. Pair it with an agent step and the loop does real work: the agent edits code, a shell step verifies it, and the gate loops back — no scripting.
+
+## Gate schema
+
+A gate block sits directly on a step and supports two fields:
+
+```yaml
+gate:
+  success_if: exit_code == 0   # CEL expression evaluated against the step outcome
+  on_failure:
+    restart_from: install      # must reference an earlier step that has a `key:` field
+```
+
+`success_if` and `on_failure` are both optional individually, but at least one must be present. A gate with only `success_if` marks the step as failed without retrying. A gate with only `on_failure` always retries. Use both together for a conditional retry loop.
+
+## Basic retry loop
+
+The canonical pattern installs dependencies, runs an agent to fix failing tests, then verifies:
+
+```yaml
+jobs:
+  fix:
+    steps:
+      - key: install
+        run: npm ci
+      - model: claude-opus-4-8
+        prompt: Fix the failing tests in the repository.
+      - run: npm test
+        gate:
+          success_if: exit_code == 0
+          on_failure:
+            restart_from: install
+```
+
+On each iteration, the agent reads the updated codebase and attempts another fix. The loop continues until `npm test` exits `0`. The loop is **bounded automatically**: a gating step gets 3 attempts by default before its restart budget is exhausted and the job stops. The job-level `execution_timeout` adds a second, outer bound — see Loop bounds.
+
+## success_if expressions
+
+The `success_if` field accepts a [CEL (Common Expression Language)](https://cel.dev) expression that is evaluated after the step completes. The only variable available today is `exit_code`, which holds the integer exit code of the step's shell command.
+
+Common patterns:
+
+| Expression | Meaning |
+|---|---|
+| `exit_code == 0` | Step succeeded (standard Unix convention) |
+| `exit_code != 1` | Any exit code except a hard failure |
+
+More CEL variables (stdout content, step duration, etc.) are planned for future releases.
+
+## Rules for restart_from
+
+<Warning>
+  The step referenced by `restart_from` must appear **before** the gate step in the same job. Forward references are not allowed.
+</Warning>
+
+- The target step must have a `key:` field — `restart_from` matches keys, not display names. (`name:` is a separate, display-only label.)
+- The reference is matched by step key, not by position — reordering steps changes which step is targeted.
+- `restart_from` must reference a step within the **same job**. Cross-job retries are not supported; use `needs` to express job dependencies instead.
+
+## Job execution timeout
+
+A gating step already stops after a bounded number of restarts (3 by default). On top of that, `execution_timeout` sets an **outer wall-clock bound** on the whole job — useful when steps are slow and even a few attempts could run long:
+
+```yaml
+jobs:
+  fix:
+    execution_timeout: "30m"
+    steps:
+      - key: install
+        run: npm ci
+      - model: claude-opus-4-8
+        prompt: Fix the failing tests in the repository.
+      - run: npm test
+        gate:
+          success_if: exit_code == 0
+          on_failure:
+            restart_from: install
+```
+
+The value is a duration string. When the timeout is reached, the job is cancelled and marked as failed regardless of where execution is in the loop.
+
+## Next steps
+
+- [Jobs & Steps](/guides/multi-job-pipeline) — understand job isolation, `needs`, and parallel execution.
+- [Agent Steps](/guides/agent-steps) — configure the model, thinking level, and provider for agent steps.

--- a/apps/docs/guides/model-providers.mdx
+++ b/apps/docs/guides/model-providers.mdx
@@ -1,0 +1,59 @@
+---
+title: "Add and Configure AI Model Providers in Shipfox Workflows"
+sidebarTitle: "Model Providers"
+description: "Add API keys for Anthropic, OpenAI, DeepSeek, and 30+ other providers in Shipfox. Set a default provider and reference models by ID in your workflow YAML."
+---
+
+Shipfox agent steps can use any of 31 supported AI model providers. You configure providers once in your workspace settings by adding an API key. Once configured, your workflow YAML can reference any model by its ID and optionally specify the `provider` field — or omit both to fall back to your workspace default.
+
+## Supported providers
+
+Shipfox supports 30+ providers — Anthropic, OpenAI, Azure OpenAI, DeepSeek, Google,
+xAI, Mistral, Groq, OpenRouter, and many more. Each has a `provider` ID and a default
+model used when a step doesn't name one.
+
+See the Model Providers reference for the complete
+table of every provider, its ID, and its default model.
+
+## Configure a provider
+
+1. In the Shipfox dashboard, navigate to **Settings → Agent providers**.
+2. Find the provider you want to use and click **Configure**.
+3. Enter the API key. Azure OpenAI also requires an **Endpoint** URL — paste your Azure deployment endpoint into the additional field.
+4. Click **Save**.
+5. Optionally, click **Set as default** to make this the default provider for agent steps that do not specify a `provider`.
+
+Once saved, any workflow in your workspace can reference that provider immediately — no redeployment required.
+
+## Using a provider in your workflow
+
+If one provider is configured and set as default, you can omit both `provider` and `model` to use the workspace defaults. Otherwise, specify both to be explicit:
+
+```yaml
+steps:
+  - prompt: Review the code for security issues.
+    # Uses workspace default provider + model
+
+  - model: gpt-5.5-pro
+    provider: openai
+    prompt: Rewrite this function to be more readable.
+
+  - model: deepseek-v4-pro
+    provider: deepseek
+    prompt: Optimize this algorithm for performance.
+```
+
+The `model` ID must match an ID recognized by the specified provider. Refer to the provider's own documentation for a full list of available model IDs — Shipfox passes the `model` string directly to the provider's API.
+
+## Unsupported providers
+
+<Note>
+  Amazon Bedrock, Google Vertex AI, OpenAI Codex, and GitHub Copilot appear in
+  the provider list but are not yet supported. They require cloud IAM
+  credentials or OAuth flows that are not available via API key configuration.
+  Support for these providers is planned for a future release.
+</Note>
+
+## Next steps
+
+- [Agent Steps](/guides/agent-steps) — use configured providers in workflow YAML with `model` and `provider`.

--- a/apps/docs/guides/multi-job-pipeline.mdx
+++ b/apps/docs/guides/multi-job-pipeline.mdx
@@ -1,0 +1,123 @@
+---
+title: "Build Multi-Job Pipelines with Shipfox Workflows"
+sidebarTitle: "Multi-Job Pipeline"
+description: "Sequence or parallelize Shipfox jobs with needs. Each job re-clones the repository — no shared filesystem. Learn fan-out, fan-in, and isolation patterns."
+---
+
+Shipfox workflows support multi-job pipelines where jobs run in parallel by default and are sequenced with `needs`. Each job is fully isolated — it re-clones the repository and has its own environment. This page shows you how to design effective pipelines, avoid common isolation pitfalls, and compose fan-out / fan-in patterns that keep total runtime low.
+
+## Parallel jobs (default)
+
+When no `needs` is declared, all jobs in a workflow start at the same time. This is the fastest way to run independent checks:
+
+```yaml
+jobs:
+  lint:
+    steps:
+      - run: npm ci && npm run lint
+  test:
+    steps:
+      - run: npm ci && npm test
+  type-check:
+    steps:
+      - run: npm ci && npx tsc --noEmit
+```
+
+All three jobs run concurrently. The workflow finishes when the last one completes.
+
+## Sequential jobs with `needs`
+
+Use `needs` to declare that a job must wait for one or more other jobs to succeed before it starts:
+
+```yaml
+jobs:
+  lint:
+    steps:
+      - run: npm ci
+      - run: npm run lint
+  test:
+    steps:
+      - run: npm ci
+      - run: npm test
+  deploy:
+    needs: test
+    steps:
+      - run: npm ci
+      - run: ./scripts/deploy.sh
+```
+
+<Warning>
+  **Jobs do not share a filesystem.** Each job re-clones the repository from
+  scratch into a fresh environment. Every job that needs dependencies must run
+  `npm ci` (or your equivalent install step) independently — there is no shared
+  `node_modules` or build cache between jobs.
+</Warning>
+
+`needs` accepts either a single string or a list of strings (see fan-in below).
+
+## Fan-out / fan-in pattern
+
+Run multiple independent jobs in parallel, then converge on a single downstream job that waits for all of them:
+
+```yaml
+jobs:
+  lint:
+    steps:
+      - run: npm ci && npm run lint
+  test:
+    steps:
+      - run: npm ci && npm test
+  review:
+    needs: [lint, test]   # waits for BOTH to finish
+    steps:
+      - model: claude-opus-4-8
+        prompt: Summarize the lint and test results.
+```
+
+`review` will not start until both `lint` and `test` have completed successfully. If either upstream job fails, `review` is skipped.
+
+## Job isolation reminder
+
+<Note>
+  Each job re-clones the repository from scratch. There is no shared volume
+  between jobs. If you need to pass artifacts between jobs — for example, a
+  compiled binary or a test report — upload them to external storage (e.g., S3,
+  a storage bucket) in one job and download them in the next.
+</Note>
+
+This isolation is intentional: it ensures reproducibility and prevents one job's side-effects from contaminating another. Design your jobs so that each one sets up everything it needs independently.
+
+## Example: full CI pipeline
+
+Putting it all together — parallel lint and test jobs, followed by a fan-in agent review, all triggered on push:
+
+```yaml
+name: CI pipeline
+runner: ubuntu-latest
+triggers:
+  on_push:
+    source: github_acme
+    event: push
+jobs:
+  lint:
+    steps:
+      - run: npm ci
+      - run: npm run lint
+  test:
+    steps:
+      - run: npm ci
+      - run: npm test
+  review:
+    needs: [lint, test]
+    steps:
+      - model: claude-opus-4-8
+        thinking: high
+        prompt: Review the repository. Summarize the top 3 issues found.
+```
+
+Lint and test run in parallel on every push, and the AI review step only executes when both pass — giving you fast feedback without wasting agent compute on a broken build.
+
+## Next steps
+
+- [Checks on Push](/guides/checks-on-push) — see a complete push-triggered workflow in action.
+- [Agent Steps](/guides/agent-steps) — configure model, thinking level, and provider for agent steps.

--- a/apps/docs/guides/triage-sentry-issues.mdx
+++ b/apps/docs/guides/triage-sentry-issues.mdx
@@ -1,0 +1,87 @@
+---
+title: "Triage Sentry Issues with an AI Agent in Shipfox"
+sidebarTitle: "Triage Sentry Issues"
+description: "Fire a Shipfox workflow when a Sentry issue is created and hand the issue to an AI agent that investigates your repository and reports the likely cause."
+---
+
+When Sentry reports a new issue, you can fire a Shipfox workflow that hands the issue to an AI agent, which reads your repository and reports the likely cause — turning an alert into a first-pass investigation automatically. This guide sets up a Sentry-triggered workflow with a single agent step that receives the issue details through template interpolation.
+
+## What you'll build
+
+A workflow triggered by the Sentry `issue.created` event. A `triage` job runs one agent step whose prompt embeds the specific issue — its title, culprit, and level — using `${{ event.* }}` interpolation. The agent has your repository checked out, so it can investigate the code behind the error and summarize what a developer should check.
+
+## The workflow file
+
+Create the following file at `.shipfox/workflows/triage-sentry.yml` in your repository:
+
+```yaml
+name: Triage Sentry issues
+runner: ubuntu-latest
+triggers:
+  on_issue:
+    source: sentry_acme
+    event: issue.created
+jobs:
+  triage:
+    steps:
+      - model: claude-opus-4-8
+        thinking: high
+        prompt: |
+          A new Sentry issue was reported for this project:
+          "${{ event.title }}" — culprit ${{ event.culprit }} (level ${{ event.level }}).
+          ${{ event.webUrl }}
+
+          Investigate the repository for the likely cause and summarize what a
+          developer should check first. Be concise.
+```
+
+Each matching Sentry issue starts a run. Shipfox resolves the `${{ event.* }}` expressions when the run is created, so the agent receives the actual issue — its `title`, `culprit`, `level`, and a link back to Sentry (`webUrl`). The agent's summary streams to the step log.
+
+## Deploy it
+
+Follow these steps to get the workflow running:
+
+1. Create the file `.shipfox/workflows/triage-sentry.yml` in your repository.
+2. Paste the YAML above, replacing `sentry_acme` with your Sentry connection slug.
+3. Commit the file and push. The workflow appears in the dashboard and fires on the next matching issue.
+
+<Note>
+  `source` is your **Sentry connection slug** — shown in your integration settings
+  after you connect Sentry (for example `sentry_<org>`), not the literal word
+  `sentry`. Connecting Sentry requires the Sentry integration.
+</Note>
+
+## Scope to a project
+
+Shipfox delivers `issue.created` for **every** project in your connected Sentry organization. The event exposes the issue's project as `event.projectUrl`, so you can point the agent at only what you care about — or name the project in the prompt:
+
+```yaml
+      - model: claude-opus-4-8
+        prompt: |
+          Triage this Sentry issue in ${{ event.projectUrl }}:
+          "${{ event.title }}". Summarize the likely cause.
+```
+
+<Note>
+  Server-side filtering by project or team — `filter: event.projectUrl.contains("...")` —
+  is on the roadmap; the `filter` field is parsed but not evaluated yet. Until then,
+  scope inside the workflow. See Expressions.
+</Note>
+
+## Going further
+
+Turn triage into action by combining it with the other guides:
+
+- **Auto-fix and verify** — follow the agent with a shell step and a gate so it retries until tests pass. See [Gate & Retry](/guides/gate-and-retry).
+- **Open a PR or notify** — add a `run` step that calls `gh pr create` or posts to your chat tool.
+
+<Note>
+  Branching on a structured agent decision (auto-fix vs. escalate) and structured
+  agent `output` are on the roadmap. Today, act with `run` steps and gates.
+</Note>
+
+## Next steps
+
+- Sentry integration — connect Sentry and see every issue event.
+- [Agent Steps](/guides/agent-steps) — configure models, thinking levels, and providers.
+- Expressions — the `${{ }}` context available to prompts.

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -101,13 +101,13 @@ Features listed as roadmap are not yet available and should not be relied upon i
 ## What you can build
 
 <CardGroup cols={2}>
-  <Card title="Checks on every push" icon="circle-check">
+  <Card title="Checks on every push" icon="circle-check" href="/guides/checks-on-push">
     Run tests, lint, and get an AI review on every commit — automatically, in one workflow that lives with your code.
   </Card>
-  <Card title="Agent-powered fixes" icon="wand-magic-sparkles">
+  <Card title="Agent-powered fixes" icon="wand-magic-sparkles" href="/guides/agent-steps">
     Let an agent read your codebase and propose or apply a fix directly from a Sentry issue or a failing test.
   </Card>
-  <Card title="Gate and retry loops" icon="rotate">
+  <Card title="Gate and retry loops" icon="rotate" href="/guides/gate-and-retry">
     Retry a step until tests pass using `gate` with `success_if` and `on_failure.restart_from` — no custom scripting needed.
   </Card>
   <Card title="Agents that answer reviews" icon="satellite-dish">

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,9 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [Agent Steps](/guides/agent-steps): Run AI models inline with agent steps — set model, thinking, and provider, or mix agent and shell steps in one job.
+- [Gate & Retry](/guides/gate-and-retry): Use gate blocks with CEL to evaluate step success and retry from an earlier keyed step on failure.
+- [Triage Sentry Issues](/guides/triage-sentry-issues): Fire a workflow on a new Sentry issue and hand it to an agent that investigates the repo and reports the cause.
+- [Checks on Push](/guides/checks-on-push): Run tests, lint, and an AI review automatically on every push to a GitHub repository.
+- [Multi-Job Pipeline](/guides/multi-job-pipeline): Sequence or parallelize jobs with needs; each job re-clones the repo (no shared filesystem) — fan-out/fan-in patterns.
+- [Model Providers](/guides/model-providers): Add API keys for Anthropic, OpenAI, DeepSeek, and 30+ providers; set a default and reference models by ID.


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **Guides** section. Base is `docs/setup-getting-started`, so this diff is just the guides content; GitHub auto-retargets to `main` once #476 merges.

## What's here

- **6 guides** copied from source (`ShipfoxHQ/docs` @ `d0e33e9`): `agent-steps`, `gate-and-retry`, `triage-sentry-issues` (**new**), `checks-on-push`, `multi-job-pipeline`, `model-providers`. Nav group added in source order (agentic-first).
- **De-link discipline** — cross-references to pages not in this branch (concepts, integrations, reference) de-linked (inline → plain text; cards → static); in-group `/guides/*` links stay live.
- **Base page re-linked** — Introduction's "What you can build" cards (checks on push, agent-powered fixes, gate and retry) now point to the guides.
- **`llms.txt`** — the 6 guide entries appended.

## Correctness notes

- `restart_from` targets a step's **`key:`** throughout — `gate-and-retry` states it explicitly ("matches keys, not display names; `name:` is a separate, display-only label").
- No CI positioning, no Gitea (guides use GitHub / Sentry), `${{ }}` interpolation shown as shipped.

## Verification

`pnpm docs:check` → **0 broken links**; `pnpm docs:dev` renders all 6 pages. No changeset (docs/ is not a `libs/`/`tools/` package).

Refs ENG-486

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Guides docs group with six new pages and wires them into navigation and the Introduction. Aligns with ENG-486.

- **New Features**
  - Added Guides: agent-steps, gate-and-retry, triage-sentry-issues, checks-on-push, multi-job-pipeline, model-providers.
  - Inserted "Guides" group into `apps/docs/docs.json` (source order).
  - Linked Introduction cards to the new guides.
  - De-linked references to pages not in this branch; in-group `/guides/*` links stay live.
  - Appended entries to `apps/docs/llms.txt`; `pnpm docs:check` reports 0 broken links.

<sup>Written for commit 1d37d7e680fec81e267efe9bbeda54e6257476f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

