### PR TITLE
Add AI Assistance docs group

### DIFF
--- a/apps/docs/ai/authoring-prompt.mdx
+++ b/apps/docs/ai/authoring-prompt.mdx
@@ -1,0 +1,102 @@
+---
+title: "Shipfox Workflow Authoring Prompt for Coding Agents"
+sidebarTitle: "Authoring Prompt"
+description: "Copy and paste this compact Shipfox workflow schema cheat sheet into Claude, ChatGPT, Cursor, or any coding agent to get valid workflow YAML every time."
+---
+
+No matter which coding agent you use, you can get valid Shipfox workflow YAML by pasting this prompt into your session. It contains the complete shipped schema, the hard validation rules, the today/roadmap boundary, and two correct examples — the same content as the skills package, in a single paste.
+
+## The prompt
+
+```text Copy this into your coding agent
+You are writing a Shipfox workflow (YAML under .shipfox/workflows/). A trigger
+starts a run; a run is a DAG of jobs; each job runs steps on a runner. Output only
+valid YAML.
+
+Top level: name (required), runner (label or list), env (run-step only), triggers,
+jobs (required). Unknown keys are rejected.
+
+Trigger { source, event, filter?, with? }. For integrations, source is the
+CONNECTION SLUG (e.g. github_<org>, sentry_<org>, or your webhook slug), not the
+bare provider name; for on-demand runs it is literally "manual". Shipped events:
+manual/fire, github push (+ other GitHub events), sentry issue.(created|resolved|
+assigned|archived|unresolved), custom-webhook/received. At most one manual
+trigger.
+
+Job { steps (>=1), needs?, runner?, env? }. Jobs run in parallel; each is isolated
+and re-clones the repo (install deps per job).
+
+Step is a run step { run, key?, name?, env?, gate? } OR an agent step
+{ model, prompt, thinking?, provider?, key?, name?, gate? } — never both; agent
+requires prompt; env is run-only. key identifies a step; name is display-only.
+
+gate (run or agent steps) { success_if: "<CEL over exit_code>", on_failure: {
+restart_from: "<earlier step's key — NOT its name>", output?: "<message>" } }.
+Restarts are capped (3 attempts per gating step) before the job fails.
+
+${{ }} interpolation IS supported in run/env/prompt, resolved at run creation from
+run/trigger/event/inputs context (e.g. ${{ trigger.source }}). Do NOT use (not
+shipped): loop, matrix, branch, structured output, reusable agents. filter isn't
+evaluated yet. event.ref on a push is the full Git ref (e.g. "refs/heads/main").
+```
+
+## How to use it
+
+<Steps>
+  <Step title="Copy the prompt">
+    Click the copy button on the prompt above to copy the full schema cheat sheet to your clipboard.
+  </Step>
+  <Step title="Paste into your session">
+    Paste at the start of a new conversation in Claude, ChatGPT, Cursor, or your preferred coding agent tool.
+  </Step>
+  <Step title="Ask for your workflow">
+    Describe what you want — for example: "Add a Shipfox workflow that runs my tests on every GitHub push and then asks Claude to review the results."
+  </Step>
+  <Step title="Place the output">
+    Save the YAML to `.shipfox/workflows/<name>.yml` in your repo and commit it.
+  </Step>
+</Steps>
+
+## What the prompt covers
+
+The prompt is deliberately compact but complete. It covers every dimension of the shipped schema:
+
+- **Top-level schema fields** — `name`, `runner`, `env`, `triggers`, `jobs`, and which keys are rejected
+- **Trigger sources (shipped today)** — `manual`, plus integration connection slugs for GitHub (`push`), Sentry (`issue.*`), and custom webhooks (`received`)
+- **Job isolation and `needs` ordering** — parallel execution, repo re-cloning, and dependency chaining
+- **Step kinds: run vs. agent** — the two mutually exclusive step shapes and their allowed fields
+- **Gate / restart_from rules** — CEL expressions over `exit_code` and how to wire restart targets
+- **Hard rules** — no `loop`/`matrix`/`branch`, `env` is run-only, at most one manual trigger
+- **The today/roadmap boundary** — an explicit list of features not to use, so the agent doesn't hallucinate roadmap keys
+
+<Tip>
+  For ongoing workflow authoring, install the skills package (`npx skills add shipfox/agent-skills`) so your agent always has the latest schema — no pasting required. See [Skills Package](/ai/skills-package).
+</Tip>
+
+## Example exchange
+
+Here is a sample user prompt and the YAML a well-prompted agent should produce.
+
+**User prompt:** "Add a Shipfox workflow that runs npm test on every push and has an agent step summarize failures."
+
+**Expected output:**
+
+```yaml
+name: Test and triage
+runner: ubuntu-latest
+triggers:
+  on_push:
+    source: github_acme    # your GitHub connection slug
+    event: push
+jobs:
+  test:
+    steps:
+      - run: npm ci
+      - run: npm test
+  triage:
+    needs: test
+    steps:
+      - model: claude-opus-4-8
+        thinking: high
+        prompt: If the tests failed, summarize the failure and suggest a fix.
+```

--- a/apps/docs/ai/overview.mdx
+++ b/apps/docs/ai/overview.mdx
@@ -1,0 +1,39 @@
+---
+title: "AI-Friendly Docs: How Shipfox Supports Coding Agents"
+sidebarTitle: "AI Overview"
+description: "Shipfox workflows are YAML that coding agents write. These docs are AI-ingestible — every page is available as Markdown for agents to browse and cite."
+---
+
+Shipfox is built for AI-forward engineering teams — the workflow YAML your agents write IS the product. These docs are designed to be as useful to a coding agent (Claude Code, Cursor, Codex, etc.) as to a human engineer. Every page is available as Markdown, and a dedicated skills package encodes the workflow schema so your agent always emits valid YAML.
+
+## Three ways to use Shipfox with AI
+
+<CardGroup cols={3}>
+  <Card title="AI-Ingestible Docs" icon="file-lines" href="#ai-ingestible-docs">
+    Every docs page is available as Markdown. Browse `llms.txt` or append `.md` to any URL.
+  </Card>
+  <Card title="Copy/Paste Prompt" icon="clipboard" href="/ai/authoring-prompt">
+    Paste a compact schema cheat sheet into any coding agent.
+  </Card>
+  <Card title="Skills Package" icon="puzzle-piece" href="/ai/skills-package">
+    Install the Shipfox skill in your AI coding tool with one command.
+  </Card>
+</CardGroup>
+
+## Why this matters for Shipfox
+
+The most common mistake when writing Shipfox YAML is using roadmap-only keys (`loop`, `matrix`, `branch`), writing `{{ }}` instead of `${{ }}` for interpolation, mixing `run` and `prompt` on one step, or setting `env` on an agent step. These errors are easy to make when working from memory or incomplete documentation — and they all result in rejected workflows at validation time.
+
+An agent with the Shipfox skill or the copy/paste prompt avoids all of these pitfalls before the YAML ever reaches your repo. The skill encodes the verified schema, the hard validation rules, the today/roadmap boundary, and correct examples — giving your agent a precise, authoritative reference rather than a best guess.
+
+## AI-ingestible docs
+
+Every docs page in this site is available as Markdown. To access the Markdown version of any page, append `.md` to the URL — for example, `/ai/overview.md`. Coding agents can browse these URLs directly, cite specific pages, and pull in schema details on demand without needing a separate API.
+
+The `llms.txt` file at the root of this site lists all pages with short summaries, following the [llms.txt convention](https://llmstxt.org/) for AI indexing. Drop the URL of `llms.txt` into any agent that supports context URLs and it will have a complete map of the Shipfox docs in seconds.
+
+## Roadmap
+
+<Note>
+  A Shipfox plugin for Claude Code, Cursor, and Codex is planned — with slash commands (`/shipfox:new-workflow`, `/shipfox:validate`, `/shipfox:run`), specialist sub-agents, and session activation for repos with `.shipfox/`. An MCP server is also on the roadmap. Ship the skills package today; the plugin and MCP land when the YAML surface stabilizes.
+</Note>

--- a/apps/docs/ai/skills-package.mdx
+++ b/apps/docs/ai/skills-package.mdx
@@ -1,0 +1,57 @@
+---
+title: "Install the Shipfox Agent Skills Package for Coding Agents"
+sidebarTitle: "Skills Package"
+description: "Install the Shipfox skills package to give Claude Code, Cursor, Codex, and 18+ other coding agents the full workflow schema, hard rules, and examples."
+---
+
+The Shipfox skills package encodes the complete workflow YAML schema, the hard validation rules, the shipped-vs-roadmap boundary, and correct examples into your AI coding tool. Install it once and your agent will author valid Shipfox workflows without a copy/paste prompt.
+
+## Install
+
+```bash
+npx skills add shipfox/agent-skills
+```
+
+This installs the skill via [skills.sh](https://skills.sh) and makes it available to Claude Code, Cursor, Codex, and 18+ other agent frameworks automatically — no manual configuration required per tool.
+
+## What the skill includes
+
+Once installed, the skill gives your agent immediate access to:
+
+- The complete shipped workflow YAML schema in compact, agent-optimized form
+- Hard validation rules — strict key allowlists, step kind constraints, `env` restrictions, and the one-manual-trigger limit
+- The today/roadmap boundary — what NOT to use (`loop`, `matrix`, `branch`, trigger `filter` evaluation) and what IS shipped, like `${{ }}` interpolation
+- Two correct examples: a push-triggered checks pipeline and an agent fix-until-green loop
+
+## Usage
+
+Once the skill is installed, just ask your agent in plain language. No schema pasting, no special syntax:
+
+- "Add a Shipfox workflow that runs tests on every push."
+- "Create a Shipfox workflow that triages Sentry issues with an agent."
+- "Add a gate to my workflow that retries until the tests pass."
+
+The skill activates automatically whenever the agent detects a Shipfox context — such as a `.shipfox/` directory in the repo — or whenever you mention Shipfox workflows explicitly.
+
+## Supported tools
+
+<Note>
+  The skills package works with any tool supported by skills.sh, including Claude Code, Cursor, Codex, Grok, Copilot, and 15+ others.
+</Note>
+
+## Skills vs. copy/paste prompt
+
+Both options give your agent the full Shipfox schema. The right choice depends on how often you work with Shipfox workflows.
+
+| | Skills Package | Copy/Paste Prompt |
+|---|---|---|
+| **Installation** | One `npx` command | Manual paste per session |
+| **Stays current** | Re-run install for latest | Must re-paste after schema changes |
+| **Tool support** | 18+ agents via skills.sh | Any agent that accepts a system prompt |
+| **Best for** | Regular Shipfox users | Quick one-off sessions |
+
+<Tip>
+  The skills package is generated from the Shipfox workflow schema source. When you re-run the install command, you get the latest version aligned with the current schema.
+</Tip>
+
+If you prefer not to install the skills package, the [Authoring Prompt](/ai/authoring-prompt) page has a single copy/paste block with the full schema cheat sheet — paste it once at the start of any session.

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,10 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "AI Assistance",
+            "pages": ["ai/overview", "ai/authoring-prompt", "ai/skills-package"]
           }
         ]
       }

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,6 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [AI Overview](/ai/overview): How Shipfox supports coding agents — AI-ingestible docs, every page available as Markdown for agents to browse and cite.
+- [Authoring Prompt](/ai/authoring-prompt): A compact workflow-schema cheat sheet to paste into any coding agent for valid workflow YAML.
+- [Skills Package](/ai/skills-package): Install the Shipfox skills package to give Claude Code, Cursor, Codex, and 18+ agents the full schema, rules, and examples.


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **AI Assistance** section. Base is `docs/setup-getting-started`.

## What's here

- **3 pages** from source (`ShipfoxHQ/docs` @ `d0e33e9`): `overview`, `authoring-prompt`, `skills-package`. Nav group added in source order.
- No cross-references to de-link (self-contained), no base-page changes. `llms.txt` appended.

## Correctness notes

- The authoring cheat sheet keeps `restart_from` pointed at a step's **`key:`** ("earlier step's key — NOT its name").
- `${{ }}` interpolation shown as shipped; no CI positioning.

## Verification

`pnpm docs:check` → **0 broken links**. No changeset (docs/ is not a `libs/`/`tools/` package).

Refs ENG-485

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the AI Assistance docs group to help coding agents author valid Shipfox workflows. Includes an overview, a copy/paste authoring prompt, and a skills package; updates nav and `llms.txt` for discovery (ENG-485).

- **New Features**
  - Added "AI Assistance" nav group with `ai/overview`, `ai/authoring-prompt`, and `ai/skills-package` (source order).
  - Authoring Prompt: compact schema cheat sheet with strict keys, `${{ }}` interpolation, gating; clarifies `restart_from` targets a step `key`.
  - Skills Package: install via `npx skills add shipfox/agent-skills`; includes the full schema, hard rules, and examples; pages indexed in `llms.txt`.

- **Bug Fixes**
  - Use `custom-webhook/received` as the webhook event name in examples and schema text.

<sup>Written for commit 12b01ef44efb36312051a5a9eabe8731e846e2c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

