### PR TITLE
Add Reference docs group

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,18 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "reference/workflow-schema",
+              "reference/trigger-sources",
+              "reference/step-types",
+              "reference/expressions",
+              "reference/model-providers",
+              "reference/rest-api",
+              "reference/glossary"
+            ]
           }
         ]
       }

--- a/apps/docs/getting-started.mdx
+++ b/apps/docs/getting-started.mdx
@@ -106,7 +106,7 @@ This repository is a small demo service... To run its tests, ...
 
 The agent had your repository checked out — it read real files to answer. Open the step in the dashboard to see the full **agent session**: every message, thinking block, and tool call, plus token usage and cost. Output varies between runs; the step still succeeds or fails based on whether the call completes.
 
-To make the agent *act on your code* — fix failing tests, review a diff — give it a repo-aware prompt and pair it with a gate so it retries until a check passes. Agent steps use your workspace's configured model provider, so configure one before running them.
+To make the agent *act on your code* — fix failing tests, review a diff — give it a repo-aware prompt and pair it with a gate so it retries until a check passes. Agent steps use your workspace's configured [model provider](/reference/model-providers), so configure one before running them.
 
 ## Let your agent write workflows
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -62,7 +62,7 @@ jobs:
   <Card title="Smart Triggers" icon="bolt">
     GitHub pushes, Sentry issues, webhooks from any system, or on-demand fire — with more integrations on the way.
   </Card>
-  <Card title="30+ Model Providers" icon="sparkles">
+  <Card title="30+ Model Providers" icon="sparkles" href="/reference/model-providers">
     Anthropic, OpenAI, DeepSeek, xAI, Google, Mistral, and more.
   </Card>
 </CardGroup>

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,10 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [Workflow Schema](/reference/workflow-schema): Complete YAML schema reference — top-level and job fields, step kinds, gate blocks, env, checkout, and validation rules.
+- [Trigger Sources](/reference/trigger-sources): Every trigger source and its events — manual, GitHub, Sentry, custom webhooks; integration source is the connection slug.
+- [Step Types](/reference/step-types): The two step types — run steps (shell) and agent steps (AI models) — fields, constraints, and the gate block.
+- [Expressions (CEL)](/reference/expressions): CEL in gates and job success, and ${{ }} interpolation in run commands, env, and prompts from run/trigger context.
+- [Model Providers](/reference/model-providers): The agent provider catalog — every provider, its ID and default model, and how config and model resolution work.
+- [REST API](/reference/rest-api): The HTTP API — base URL, bearer-token auth, endpoints for projects, definitions, runs, runners, providers, integrations, and the error shape.
+- [Glossary](/reference/glossary): Definitions for every Shipfox term — workspace, project, workflow, run, job, step, trigger, runner, gate, CEL, filter, key.

--- a/apps/docs/reference/expressions.mdx
+++ b/apps/docs/reference/expressions.mdx
@@ -1,0 +1,120 @@
+---
+title: "Expressions and Interpolation (CEL)"
+sidebarTitle: "Expressions (CEL)"
+description: "Shipfox evaluates CEL expressions in gates and job success, and resolves ${{ }} template interpolation in run commands, env, and prompts using run and trigger context."
+---
+
+Shipfox uses [CEL (Common Expression Language)](https://cel.dev) in two places:
+**predicates** that decide an outcome (a gate, a job's success), and **template
+interpolation** — the `${{ }}` syntax that injects run and trigger context into your
+step values. Both are evaluated by the same read-only CEL engine: expressions can
+compute over the data in scope, but they cannot read secrets, the database, the
+network, or the filesystem.
+
+## The CEL engine
+
+Expressions support CEL's standard value types — integers, strings, booleans, lists,
+and maps — and its standard operators (`==`, `!=`, `<`, `>`, `&&`, `||`, `!`, `in`,
+arithmetic) and macros (`.map()`, `.filter()`, `.all()`, `.exists()`) plus string
+helpers like `.contains()`, `.startsWith()`, and `.endsWith()`. There are no custom
+functions and no side effects.
+
+## Predicates
+
+### Gate success — `gate.success_if`
+
+Evaluated on a gated step the moment it finishes. The only variable in scope is
+`exit_code` (an integer). See Gates for the full gate model.
+
+```yaml
+gate:
+  success_if: "exit_code == 0"
+```
+
+### Job success — `success`
+
+A job's optional `success` expression decides whether the job succeeded once all its
+step executions have settled. In scope is `executions` — a list of
+`{index, status}` — so you can express partial-success rules. The default, applied
+when you omit `success`, is:
+
+```yaml
+jobs:
+  build:
+    success: 'executions.all(e, e.status == "succeeded")'
+    steps:
+      - run: ./maybe-flaky.sh
+```
+
+## Template interpolation — `${{ }}`
+
+Interpolation injects run and trigger context into step values. Expressions are
+resolved **when a run is created**, before any runner sees the step, and the
+resolved values are what execute.
+
+```yaml
+jobs:
+  build:
+    env:
+      RUN_ID: "${{ run.id }}"
+      SOURCE: "${{ trigger.source }}"
+    steps:
+      - run: echo "Building for ${{ trigger.event }}"
+      - prompt: "Investigate the event that triggered this run: ${{ event.title }}"
+```
+
+Interpolation is supported in **`run` commands**, **`env` values**, and **agent
+`prompt`s**. To write a literal `${{`, escape it as `$${{`.
+
+### Context available
+
+| Context | Fields | Trust |
+|---|---|---|
+| `run` | `id`, `name`, `definition_id`, `project_id`, `workspace_id`, `created_at` | Trusted |
+| `trigger` | `source`, `event` | Trusted |
+| `job` | `name` | Trusted |
+| `event` | The trigger's raw event payload (open shape — e.g. `event.ref`, `event.action`, `event.body`) | Untrusted |
+| `inputs` | Values passed through a trigger's `with` block (open shape) | Untrusted |
+
+<Note>
+  **Untrusted context can't select infrastructure.** `event` and `inputs` carry
+  data from outside your workspace, so they may be used in `env`, `run`, and
+  `prompt` values but **not** to choose an agent's `model` or `provider`, which
+  accept trusted context only.
+</Note>
+
+### Interpolation inside `run` commands
+
+For safety, values interpolated into a `run` command are passed to the shell through
+generated environment variables rather than spliced into the command text. You write
+`echo "${{ run.id }}"` as normal; Shipfox rewrites it to reference a generated
+variable holding the resolved value, so event-derived data can't inject shell syntax.
+
+## Trigger filters are not evaluated yet
+
+A trigger's `filter` also accepts a CEL expression (over the event, e.g.
+`event.ref == "refs/heads/main"`), but it is **parsed and stored, not evaluated** — every
+matching `(source, event)` fires the trigger today. See
+Triggers. To gate on event data now, branch inside a `run`
+step or interpolate the value and check it there.
+
+## Shipped vs. roadmap
+
+| Feature | Status |
+|---|---|
+| `gate.success_if` (CEL over `exit_code`) | ✅ Shipped |
+| Job `success` (CEL over `executions`) | ✅ Shipped |
+| `${{ }}` interpolation in `run`, `env`, `prompt` | ✅ Shipped |
+| Trigger `filter` evaluation | 🔜 Roadmap |
+| `loop`, `matrix`, `branch` | 🔜 Roadmap |
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Gates" icon="rotate">
+    Where `success_if` decides a step outcome.
+  </Card>
+  <Card title="Workflow schema" icon="code" href="/reference/workflow-schema">
+    The full YAML schema these expressions live in.
+  </Card>
+</CardGroup>

--- a/apps/docs/reference/glossary.mdx
+++ b/apps/docs/reference/glossary.mdx
@@ -1,0 +1,79 @@
+---
+title: "Shipfox Glossary: Key Terms and Concepts"
+sidebarTitle: "Glossary"
+description: "Definitions for every Shipfox term: workspace, project, workflow, run, job, step, trigger, runner, gate, CEL, filter, key, and more. Quick reference."
+---
+
+This glossary defines the core terms used in Shipfox documentation and in the product UI. When a concept is introduced elsewhere in the docs, it links back here.
+
+<AccordionGroup>
+
+  <Accordion title="Agent step">
+    A workflow step that invokes an AI model. Defined with `prompt` (required), plus optional `model`, `thinking`, and `provider` fields. The model reads the repository context and executes the prompt. Agent steps cannot carry `env` — use a run step for environment-dependent shell work. See the [Step Types reference](/reference/step-types#agent-step).
+  </Accordion>
+
+  <Accordion title="CEL">
+    Common Expression Language — a lightweight expression language used in Shipfox for trigger filters (`filter`) and step success conditions (`success_if`). CEL expressions are type-safe, side-effect-free, and sandboxed. In `success_if`, the variable `exit_code` (integer) is available. In `filter`, the variable `event` carries the event payload. See the [CEL specification](https://cel.dev) for syntax details.
+  </Accordion>
+
+  <Accordion title="Filter">
+    An optional CEL expression on a trigger that is intended to narrow which events fire the workflow. For example, `event.ref == "refs/heads/main"` on a GitHub push trigger would restrict to pushes on the `main` branch. Today, `filter` is parsed and stored but is **not yet evaluated at runtime** — the trigger fires on every matching `(source, event)` pair regardless of filter content. Authoring a filter is safe and will take effect once evaluation is enabled. See the [Trigger Sources reference](/reference/trigger-sources#filter-not-enforced).
+  </Accordion>
+
+  <Accordion title="Gate">
+    A condition block attached to a step that controls success evaluation and failure recovery. The `success_if` field accepts a CEL expression over `exit_code`. The `on_failure.restart_from` field names an earlier step in the same job to restart from when the gate fails. The `on_failure.output` field provides a message to surface in the run log on failure. A gate must contain at least one of `success_if` or `on_failure`. See [Gate block](/reference/step-types#gate-block).
+  </Accordion>
+
+  <Accordion title="Job">
+    A group of steps that runs on a single runner. Jobs within a workflow run in parallel by default; use `needs` to declare dependencies and sequence them. Each job re-clones the repository independently. A job must have at least one step. See [Job fields](/reference/workflow-schema#job-fields).
+  </Accordion>
+
+  <Accordion title="Key (step field)">
+    An optional stable identifier on a step, set with the `key` field. Unlike `name` (which is a display label), `key` is intended for programmatic reference — for example, identifying a step when integrating with the Shipfox API. Must be at least one character. Valid on both run steps and agent steps.
+  </Accordion>
+
+  <Accordion title="Model">
+    The AI model used by an agent step (e.g., `claude-opus-4-8`, `gpt-5.5-pro`). Specified with the `model` field on an agent step. When omitted, the model is resolved at runtime from the workspace provider configuration. Model catalog validation happens at runtime, not at parse time.
+  </Accordion>
+
+  <Accordion title="Project">
+    Connects one Git repository to a Shipfox workspace. A project holds all workflow definitions and run history for that repository. Workflow YAML files live at `.shipfox/workflows/*.yml` inside the connected repository.
+  </Accordion>
+
+  <Accordion title="Provider">
+    An AI model provider configured in workspace settings with an API key. Workflows reference providers by their ID string in the `provider` field of an agent step. Supported provider IDs include `anthropic`, `openai`, `deepseek`, `google`, `mistral`, `groq`, and many others. See the full list in the [Workflow Schema reference](/reference/workflow-schema#provider-ids).
+  </Accordion>
+
+  <Accordion title="Run">
+    One execution of a workflow. A run contains one or more jobs, each of which contains one or more steps. Runs are triggered by a trigger event or fired manually from the dashboard. Each run records its jobs, steps, and their outcomes.
+  </Accordion>
+
+  <Accordion title="Runner">
+    A process you deploy on your own infrastructure that polls Shipfox for jobs. Jobs are dispatched to runners whose labels match the job's `runner:` field. Runners execute run steps and coordinate agent steps. Multiple runners can be registered in a workspace.
+  </Accordion>
+
+  <Accordion title="Run step">
+    A workflow step that executes a shell command using the `run` field. Has access to `env` variables from the workflow, job, and step scopes. Cannot be combined with agent step fields (`prompt`, `model`, `thinking`, `provider`) on the same step. See the [Step Types reference](/reference/step-types#run-step).
+  </Accordion>
+
+  <Accordion title="Step">
+    The smallest unit of work in a Shipfox workflow. A step is either a run step (executes a shell command) or an agent step (invokes an AI model). Steps within a job run sequentially. Each step can optionally carry a `gate` block for success evaluation and failure recovery.
+  </Accordion>
+
+  <Accordion title="Thinking level">
+    Controls reasoning depth for agent steps. Set with the `thinking` field on an agent step. Higher levels cause the model to spend more tokens on internal reasoning before producing a response, which can improve quality for complex tasks. Accepted values: `off`, `minimal`, `low`, `medium`, `high` (default), `xhigh`.
+  </Accordion>
+
+  <Accordion title="Trigger">
+    Defines when a workflow run starts. Configured in the `triggers:` section of a workflow YAML. Each trigger has a `source` (the integration) and an `event` (the specific event from that source). An optional `filter` CEL expression narrows which events fire the trigger (not yet evaluated at runtime). See the [Trigger Sources reference](/reference/trigger-sources).
+  </Accordion>
+
+  <Accordion title="Workflow">
+    A YAML file under `.shipfox/workflows/` that defines automation for a project: jobs, steps, triggers, and runner requirements. Versioned in your repository alongside your code. The schema is strict — unknown keys are rejected at parse time. See the [Workflow Schema reference](/reference/workflow-schema).
+  </Accordion>
+
+  <Accordion title="Workspace">
+    The top-level organisational unit in Shipfox. Contains projects, runner settings, AI provider configurations, and members. Provider API keys and default model selections are configured at the workspace level and resolved at run time when not specified in a workflow step.
+  </Accordion>
+
+</AccordionGroup>

--- a/apps/docs/reference/model-providers.mdx
+++ b/apps/docs/reference/model-providers.mdx
@@ -1,0 +1,105 @@
+---
+title: "Model Providers Reference"
+sidebarTitle: "Model Providers"
+description: "The complete Shipfox agent provider catalog: every supported provider, its provider ID, and default model — plus how provider config and model resolution work."
+---
+
+Agent steps run against an **AI provider**. This page is the canonical list of every
+supported provider, the `provider` ID you use in workflow YAML, and the default
+model Shipfox uses when a step doesn't name one. For a step-by-step setup walkthrough
+see the Model Providers guide.
+
+## Supported providers
+
+Each provider is configured per workspace with its credentials. The **default model**
+is used when an agent step names the provider but not a `model`.
+
+| Provider | `provider` ID | Default model |
+|---|---|---|
+| Anthropic | `anthropic` | `claude-opus-4-8` |
+| OpenAI | `openai` | `gpt-5.5-pro` |
+| Azure OpenAI | `azure-openai-responses` | `gpt-5.5-pro` |
+| DeepSeek | `deepseek` | `deepseek-v4-pro` |
+| Google AI Studio | `google` | `gemini-3.1-pro-preview` |
+| xAI | `xai` | `grok-4.3` |
+| Mistral | `mistral` | `mistral-large-latest` |
+| Groq | `groq` | `openai/gpt-oss-120b` |
+| Cerebras | `cerebras` | `gpt-oss-120b` |
+| OpenRouter | `openrouter` | `anthropic/claude-opus-4.8` |
+| Vercel AI Gateway | `vercel-ai-gateway` | `anthropic/claude-opus-4.8` |
+| Cloudflare AI Gateway | `cloudflare-ai-gateway` | `claude-opus-4-8` |
+| Cloudflare Workers AI | `cloudflare-workers-ai` | `@cf/moonshotai/kimi-k2.7-code` |
+| Hugging Face | `huggingface` | `deepseek-ai/DeepSeek-V4-Pro` |
+| Together AI | `together` | `deepseek-ai/DeepSeek-V4-Pro` |
+| Fireworks | `fireworks` | `accounts/fireworks/models/deepseek-v4-pro` |
+| NVIDIA | `nvidia` | `nvidia/nemotron-3-ultra-550b-a55b` |
+| Ant Ling | `ant-ling` | `Ring-2.6-1T` |
+| OpenCode | `opencode` | `claude-opus-4-8` |
+| OpenCode Go | `opencode-go` | `kimi-k2.7-code` |
+| Z.ai | `zai` | `glm-5.2` |
+| Z.ai Coding (CN) | `zai-coding-cn` | `glm-5.2` |
+| Kimi Coding | `kimi-coding` | `k2p7` |
+| MiniMax | `minimax` | `MiniMax-M3` |
+| MiniMax (CN) | `minimax-cn` | `MiniMax-M3` |
+| Moonshot AI | `moonshotai` | `kimi-k2.7-code` |
+| Moonshot AI (CN) | `moonshotai-cn` | `kimi-k2.7-code` |
+| Xiaomi | `xiaomi` | `mimo-v2.5-pro` |
+| Xiaomi Token Plan (CN) | `xiaomi-token-plan-cn` | `mimo-v2.5-pro` |
+| Xiaomi Token Plan (AMS) | `xiaomi-token-plan-ams` | `mimo-v2.5-pro` |
+| Xiaomi Token Plan (SGP) | `xiaomi-token-plan-sgp` | `mimo-v2.5-pro` |
+
+<Note>
+  Most providers need only an **API key**. Azure OpenAI also requires an endpoint;
+  Cloudflare providers require an account ID (and a gateway ID for the AI Gateway).
+  The configuration form shows the fields each provider needs.
+</Note>
+
+### Selecting a model
+
+The `model` you set on an agent step is passed to the provider and **validated
+against that provider's available models** — an unrecognized model ID fails the step
+with a clear error. Each provider's full model list comes from the provider's own
+catalog; the default model above is what Shipfox picks when you omit `model`.
+
+## How configuration works
+
+Providers are configured **per workspace**. For each provider you configure, you
+supply its credentials and can optionally set a **default model** and mark one
+provider as the **workspace default**. Credentials are stored securely — Shipfox
+keeps only fingerprints, never the raw secret. Configuration takes effect
+immediately; no redeploy is needed.
+
+## Resolution and defaults
+
+When an agent step runs, Shipfox resolves the provider, model, and thinking level in
+this order:
+
+- **Provider** — the step's `provider`, else the workspace default provider, else
+  `anthropic`.
+- **Model** — the step's `model`, else the configured default model for the resolved
+  provider, else that provider's catalog default (the table above).
+- **Thinking** — the step's `thinking`, else the provider's configured default, else
+  `high`.
+
+So an agent step with just a `prompt` runs on your workspace default provider and its
+default model; naming a `provider` but no `model` uses that provider's default model.
+
+## Unsupported providers
+
+<Note>
+  **Amazon Bedrock**, **Google Vertex AI**, **OpenAI Codex**, and **GitHub Copilot**
+  appear in the catalog but are **not yet supported** — they require cloud IAM
+  credentials or OAuth flows that API-key configuration can't provide. Support is
+  planned for a future release.
+</Note>
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Model Providers guide" icon="robot">
+    Configure a provider and use it in a workflow, step by step.
+  </Card>
+  <Card title="Agent steps" icon="wand-magic-sparkles">
+    Models, thinking levels, and providers on an agent step.
+  </Card>
+</CardGroup>

--- a/apps/docs/reference/rest-api.mdx
+++ b/apps/docs/reference/rest-api.mdx
@@ -1,0 +1,161 @@
+---
+title: "REST API Reference"
+sidebarTitle: "REST API"
+description: "The Shipfox HTTP API: base URL, bearer-token authentication, the user-facing endpoints for projects, definitions, runs, runners, providers, and integrations, and the error shape."
+---
+
+Shipfox exposes an HTTP API that the dashboard uses and that you can call directly to
+automate projects, definitions, runs, and runners. This page covers the endpoints
+meant for user automation. Endpoints that runners and provisioners use to execute
+jobs are a separate machine protocol — see [Internal protocols](#internal-protocols).
+
+## Base URL
+
+The API is served at the root path — there is no version prefix.
+
+- **Managed:** `https://api.shipfox.io`
+- **Local / self-hosted:** `http://localhost:16101` by default (the port is
+  configurable).
+
+## Authentication
+
+User endpoints authenticate with a **bearer token**. Obtain one by signing in, then
+send it in the `Authorization` header.
+
+```bash
+# Sign in
+curl -X POST https://api.shipfox.io/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "you@example.com", "password": "…"}'
+# → { "token": "<JWT>", "user": {…}, "membership": {…} }
+
+# Call an authenticated endpoint
+curl https://api.shipfox.io/workspaces \
+  -H "Authorization: Bearer <JWT>"
+```
+
+Access tokens are short-lived. `POST /auth/refresh` issues a new one from the
+HttpOnly refresh cookie set at login (a browser flow). Runner registration tokens,
+job lease tokens, and provisioner tokens are **not** general API credentials — they
+belong to the internal protocols below.
+
+## Endpoints
+
+<Note>
+  The tables list the primary endpoints per resource; obvious CRUD sub-routes are
+  omitted. All require `Authorization: Bearer <JWT>` unless the Auth column says
+  otherwise.
+</Note>
+
+### Auth &amp; session
+
+| Method | Path | Purpose | Auth |
+|---|---|---|---|
+| POST | `/auth/signup` | Create an account | None |
+| POST | `/auth/login` | Sign in; returns an access token | None |
+| POST | `/auth/refresh` | Refresh the access token | Cookie |
+| POST | `/auth/logout` | Sign out | User |
+| GET | `/auth/me` | Current signed-in user | User |
+| POST | `/auth/password/reset` | Request a password reset | None |
+
+### Workspaces
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/workspaces` | List your workspace memberships |
+| POST | `/workspaces` | Create a workspace |
+| GET | `/workspaces/{workspaceId}/members` | List members |
+| POST | `/workspaces/{workspaceId}/invitations` | Invite a member |
+
+### Projects
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/projects` | Create a project bound to a repository |
+| GET | `/projects` | List projects (`workspace_id`, pagination, `search`) |
+| GET | `/projects/{projectId}` | Get a project |
+
+### Workflow definitions
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/definitions` | Create or update a definition from YAML |
+| GET | `/definitions` | List definitions (`workspace_id`, `project_id`) |
+| GET | `/definitions/{definitionId}` | Get a definition |
+| POST | `/definitions/validate` | Validate workflow YAML without saving |
+
+### Workflow runs
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/workflow-definitions/{definitionId}/fire-manual` | Fire a manual trigger |
+| GET | `/workflows/runs` | List runs (`project_id`, `status`, `definition_id`, …) |
+| GET | `/workflows/runs/{id}` | Run detail with jobs and steps |
+| POST | `/workflows/runs/{id}/cancel` | Cancel a run |
+| POST | `/workflows/runs/{id}/rerun` | Rerun a run |
+| GET | `/steps/{stepId}/attempts/{attempt}/logs` | Read a page of step logs |
+
+### Runners &amp; provisioners
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/workspaces/{workspaceId}/runners/manual-registration-tokens` | Create a manual registration token |
+| GET | `/workspaces/{workspaceId}/runners/active` | List active runners |
+| POST | `/workspaces/{workspaceId}/provisioners/tokens` | Create a provisioner token |
+| GET | `/workspaces/{workspaceId}/provisioners/active` | List active provisioners |
+
+### Agent providers
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/agent/provider-catalog` | List available providers and models |
+| GET | `/workspaces/{workspaceId}/agent` | List configured providers |
+| PUT | `/workspaces/{workspaceId}/agent` | Configure a provider |
+| POST | `/workspaces/{workspaceId}/agent/{providerId}/default` | Set the default provider |
+
+See [Model Providers](/reference/model-providers) for the catalog and resolution
+rules.
+
+### Integrations &amp; trigger events
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/integration-connections` | List connections (`workspace_id`) |
+| GET | `/integration-providers` | List available integration providers |
+| POST | `/integrations/github/install` | Start a GitHub App installation |
+| GET | `/trigger-events` | List received trigger events (audit log) |
+| GET | `/trigger-events/{eventId}` | Get one trigger event |
+
+## Webhook ingest endpoints
+
+These are **provider callbacks**, not user API endpoints — external providers POST
+to them with a signature. See Integrations.
+
+| Method | Path | Provider |
+|---|---|---|
+| POST | `/webhooks/integrations/github` | GitHub (`X-Hub-Signature-256`) |
+| POST | `/webhooks/integrations/sentry` | Sentry (signed) |
+| POST | `/webhook/{connectionId}` | Custom webhook |
+
+## Errors
+
+Errors return a JSON body with a stable `code`, optional client-safe `details`, and
+an appropriate HTTP status:
+
+```json
+{ "code": "project-already-exists", "details": { "existing_project_id": "…" } }
+```
+
+Common codes include `validation-error` (400), `unauthorized` (401), `forbidden`
+(403), `not-found` (404), and resource conflicts like `project-already-exists`
+(409). Schema-validation failures use `validation-error` with a `message` naming the
+offending field.
+
+## Internal protocols
+
+Runners and provisioners authenticate with their own tokens (runner registration
+`sf_mrt_`/`sf_ert_`, runner session, job lease, provisioner `sf_pt_`) against a
+separate set of endpoints — claiming jobs, fetching steps, reporting results,
+appending logs, and polling for demand. These are an internal machine protocol, not
+part of the user API; don't call them directly. See
+Runners and Runner provisioners.

--- a/apps/docs/reference/step-types.mdx
+++ b/apps/docs/reference/step-types.mdx
@@ -1,0 +1,118 @@
+---
+title: "Step Types Reference: Run Steps and Agent Steps"
+sidebarTitle: "Step Types"
+description: "Detailed reference for Shipfox's two step types: run steps execute shell commands, agent steps invoke AI models. Covers fields, constraints, and the gate block."
+---
+
+Every Shipfox step is one of two kinds: a **run step** executes a shell command on the runner, or an **agent step** invokes an AI model. The kind is determined by which keys are present — `run` marks a run step; `prompt` (or `model`, `thinking`, or `provider`) marks an agent step. Mixing keys from both kinds on the same step is a validation error.
+
+## Run step
+
+A run step executes a shell command on the job's runner. It has access to environment variables from the workflow, job, and step scopes.
+
+<ParamField body="run" type="string" required>
+  The shell command to execute. Must be at least one character.
+</ParamField>
+
+<ParamField body="name" type="string">
+  Displayed in the dashboard log. Display-only — a step referenced by `restart_from` needs a `key:`, not a `name:`.
+</ParamField>
+
+<ParamField body="env" type="object">
+  Environment variables for this step. Merged with job-level and workflow-level env; step-level values take the highest precedence. Keys must follow POSIX-style naming (`[A-Za-z_][A-Za-z0-9_]*`). Values may be strings, numbers, or booleans.
+</ParamField>
+
+<ParamField body="key" type="string">
+  Optional stable identifier for this step. Useful for referencing the step programmatically. Must be at least one character.
+</ParamField>
+
+<ParamField body="gate" type="object">
+  Gate and retry configuration evaluated after the step completes. See [Gate block](#gate-block) below.
+</ParamField>
+
+```yaml
+- key: test
+  run: npm test
+  env:
+    CI: "true"
+  gate:
+    success_if: exit_code == 0
+    on_failure:
+      restart_from: install   # 'install' is an earlier step's key
+```
+
+## Agent step
+
+An agent step invokes an AI model with a text prompt. The model reads the repository context and executes the instruction. The recommended pattern is an agent step that produces a change, followed by a run step whose gate judges the result.
+
+<ParamField body="prompt" type="string" required>
+  The instruction given to the model. Must be at least one character. Required on any step that also sets `model`, `thinking`, or `provider`.
+</ParamField>
+
+<ParamField body="model" type="string">
+  Model ID to use (e.g., `claude-opus-4-8`, `gpt-5.5-pro`). Uses the workspace default if omitted. Model catalog checks are performed at runtime, not at parse time.
+</ParamField>
+
+<ParamField body="provider" type="string">
+  Provider ID for the model (e.g., `anthropic`, `openai`, `deepseek`). Pairing `provider` with `model` lets a step target a specific non-default provider/model combination. Uses the workspace default if omitted.
+</ParamField>
+
+<ParamField body="thinking" type="string">
+  Reasoning depth for the model. Controls how many tokens the model spends on internal reasoning before producing a response. Accepted values: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Default: `high`.
+</ParamField>
+
+<ParamField body="name" type="string">
+  Optional step name, displayed in the dashboard log.
+</ParamField>
+
+<ParamField body="key" type="string">
+  Optional stable identifier for this step. Must be at least one character.
+</ParamField>
+
+<ParamField body="gate" type="object">
+  Gate and retry configuration. See [Gate block](#gate-block) below.
+</ParamField>
+
+```yaml
+- name: review
+  model: claude-opus-4-8
+  provider: anthropic
+  thinking: high
+  prompt: Review the failing test output and fix the code.
+```
+
+## Gate block
+
+A gate block is optional on both run steps and agent steps. It must contain at least one of `success_if` or `on_failure`.
+
+<ParamField body="success_if" type="string">
+  A CEL expression evaluated after the step completes. The variable `exit_code` (integer) is available. Example: `exit_code == 0`. When omitted, the step's default exit behaviour applies.
+</ParamField>
+
+<ParamField body="on_failure.restart_from" type="string">
+  The `key` of an earlier step in the same job to restart from when this step fails. The referenced step must have a `key:` and appear before the current step in the job's step list (`name:` is display-only and cannot be referenced).
+</ParamField>
+
+<ParamField body="on_failure.output" type="string">
+  A message to surface in the run log when this step is considered failed.
+</ParamField>
+
+## Constraints table
+
+The following table summarises which fields are valid on each step kind. Mixing fields across kinds on the same step is a validation error.
+
+| Field | Run step | Agent step |
+|---|---|---|
+| `run` | ✅ Required | ❌ Not allowed |
+| `prompt` | ❌ Not allowed | ✅ Required |
+| `model` | ❌ Not allowed | ✅ Optional |
+| `thinking` | ❌ Not allowed | ✅ Optional |
+| `provider` | ❌ Not allowed | ✅ Optional |
+| `env` | ✅ Optional | ❌ Not allowed |
+| `name` | ✅ Optional | ✅ Optional |
+| `key` | ✅ Optional | ✅ Optional |
+| `gate` | ✅ Optional | ✅ Optional |
+
+<Warning>
+  The `agent:` key is reserved for a future step kind. Using it today results in a validation error with a clear message. It is not a valid alias or shorthand for an agent step — use `prompt` instead.
+</Warning>

--- a/apps/docs/reference/trigger-sources.mdx
+++ b/apps/docs/reference/trigger-sources.mdx
@@ -1,0 +1,60 @@
+---
+title: "Trigger Sources and Events Reference"
+sidebarTitle: "Trigger Sources"
+description: "Every Shipfox trigger source and its events at a glance: manual fire, GitHub, Sentry, and custom webhooks. For integration triggers, source is the connection slug."
+---
+
+A trigger has a `source` and an `event`. This page lists every source and its
+events at a glance. For **integration** sources, the `source` you write is the
+**connection slug** (for example `github_acme`), not the provider name — see
+Integrations. Setup and payloads live on each
+integration page.
+
+## Sources at a glance
+
+| Source | `source` value | Events | Setup |
+|---|---|---|---|
+| Manual | `manual` (literal) | `fire` | None — Triggers |
+| GitHub | connection slug, e.g. `github_acme` | `push` and other repository events | GitHub |
+| Sentry | connection slug, e.g. `sentry_acme` | `issue.created`, `issue.resolved`, `issue.assigned`, `issue.archived`, `issue.unresolved` | Sentry |
+| Custom webhook | connection slug you choose | `received` | Custom webhook |
+| Cron | 🚧 Coming soon — `cron` (literal) | `tick` | Triggers |
+| Linear | 🚧 Coming soon | — | Linear |
+| Slack | 🚧 Coming soon | — | Slack |
+| GitLab | 🔜 Roadmap | — | — |
+
+## manual
+
+The built-in on-demand source. Use `manual` to start a workflow from the dashboard
+or API without an external integration. At most one `manual` trigger per workflow.
+
+```yaml
+triggers:
+  on_demand:
+    source: manual
+    event: fire
+```
+
+## Integration sources
+
+For GitHub, Sentry, and custom webhooks, the `source` is the **connection slug**
+created when you connect the integration. A single workspace can hold several
+connections of the same provider, disambiguated by slug.
+
+```yaml
+triggers:
+  on_push:
+    source: github_acme
+    event: push
+```
+
+See the Integrations section for setup, the full event
+list per source, and payload details.
+
+## filter (not enforced)
+
+The `filter` field accepts a CEL expression intended to narrow which events fire a
+trigger — for example `event.ref == "refs/heads/main"` on a GitHub push. Today `filter` is
+parsed and stored but **not evaluated**: the trigger fires on every matching
+`(source, event)` pair regardless of the expression. Authoring a filter is safe and
+takes effect once evaluation is enabled — no schema change will be required.

--- a/apps/docs/reference/workflow-schema.mdx
+++ b/apps/docs/reference/workflow-schema.mdx
@@ -1,0 +1,213 @@
+---
+title: "Workflow YAML Schema Reference for Shipfox"
+sidebarTitle: "Workflow Schema"
+description: "Complete reference for the Shipfox workflow YAML schema: top-level fields, job fields, step kinds, gate blocks, env variables, and validation rules."
+---
+
+This page is the authoritative reference for the Shipfox workflow YAML schema. Workflow files live at `.shipfox/workflows/*.yml`. The schema is strict — unknown keys are rejected everywhere. Use this reference when authoring or debugging workflow files.
+
+## Top-level fields
+
+<ParamField body="name" type="string" required>
+  Human-readable workflow name. Must be at least one character.
+</ParamField>
+
+<ParamField body="runner" type="string | string[]">
+  Default runner label or list of labels for all jobs in this workflow. Individual jobs can override this value with their own `runner` field.
+</ParamField>
+
+<ParamField body="env" type="object">
+  Environment variables applied to `run` steps across the entire workflow. Keys must follow POSIX-style naming (`[A-Za-z_][A-Za-z0-9_]*`). Values may be a string, number, or boolean. Numbers and booleans are stringified before a run is saved. This field is applied to run steps only — it has no effect on agent steps.
+</ParamField>
+
+<ParamField body="triggers" type="object">
+  Named trigger entries that define when this workflow runs. Each key is a user-chosen trigger name; each value is a trigger object (see [Trigger fields](#trigger-fields) below). If present, at least one entry is required.
+</ParamField>
+
+<ParamField body="jobs" type="object" required>
+  Named job entries that define the work to perform. Each key is a user-chosen job name; each value is a job object (see [Job fields](#job-fields) below). At least one entry is required.
+</ParamField>
+
+## Trigger fields
+
+<ParamField body="source" type="string" required>
+  Where the event comes from. For an integration this is the **connection slug** (e.g., `github_acme`, `sentry_acme`) — not the bare provider name; a `source` that matches no connection slug is stored but never fires. For on-demand runs it is the literal string `manual`. See the [Trigger Sources reference](/reference/trigger-sources).
+</ParamField>
+
+<ParamField body="event" type="string" required>
+  The event name from the named source (e.g., `push`, `issue.created`, `fire`).
+</ParamField>
+
+<ParamField body="filter" type="string">
+  A CEL expression that narrows which events fire this trigger (e.g., `event.ref == "refs/heads/main"`). The expression is parsed and stored but **not yet evaluated** — the trigger fires on every matching `(source, event)` pair regardless of filter content.
+</ParamField>
+
+<ParamField body="with" type="object">
+  Extra source-specific configuration. The shape is source-defined; Shipfox stores it verbatim and passes it to the integration.
+</ParamField>
+
+## Job fields
+
+<ParamField body="steps" type="array" required>
+  The ordered list of steps this job executes. At least one step is required. Each step is either a run step or an agent step — see [Step fields](#step-fields) below.
+</ParamField>
+
+<ParamField body="needs" type="string | string[]">
+  Name(s) of other jobs that must complete successfully before this job starts. Jobs without `needs` run in parallel by default.
+</ParamField>
+
+<ParamField body="runner" type="string | string[]">
+  Runner label(s) for this specific job. Overrides the workflow-level `runner` if set.
+</ParamField>
+
+<ParamField body="env" type="object">
+  Environment variables scoped to this job's run steps. Merged with workflow-level `env`; job-level values take precedence over workflow-level values for the same key.
+</ParamField>
+
+<ParamField body="execution_timeout" type="string">
+  Maximum duration allowed for this job before it is cancelled (e.g., `"30m"`, `"2h"`).
+</ParamField>
+
+<ParamField body="success" type="string">
+  A CEL expression that decides whether the job succeeded once all its executions settle, with `executions` (a list of `{index, status}`) in scope. Defaults to all executions succeeding. See [Expressions](/reference/expressions#job-success--success).
+</ParamField>
+
+<ParamField body="checkout" type="object">
+  Declares the job's repository-checkout intent: `permissions.contents` (`read` or `write`, default `read`) and `persist-credentials` (boolean, default `true` — keep the checkout credential available to later steps). Omit the block for a read-only checkout with persisted credentials.
+</ParamField>
+
+<ParamField body="listening" type="object">
+  Turns the job into a listening job that reacts to events inside the run (🚧 coming soon — the field parses and validates, but listening jobs do not execute yet).
+</ParamField>
+
+<ParamField body="name" type="string">
+  Optional display name for this job, shown in the dashboard run view.
+</ParamField>
+
+## Step fields
+
+A step is either a **run step** or an **agent step**. The two kinds share one strict object so unknown keys are always rejected. See [Constraints](#validation-rules) for which keys are mutually exclusive.
+
+### Run step fields
+
+<ParamField body="run" type="string" required>
+  The shell command to execute on the runner. Must be at least one character.
+</ParamField>
+
+<ParamField body="name" type="string">
+  Displayed in the dashboard log. Display-only — to reference a step from `restart_from`, give it a `key:`.
+</ParamField>
+
+<ParamField body="key" type="string">
+  Optional stable identifier for this step. Useful for referencing the step programmatically. Must be at least one character.
+</ParamField>
+
+<ParamField body="env" type="object">
+  Step-level environment variables. Merged with job and workflow env; step-level values take the highest precedence.
+</ParamField>
+
+<ParamField body="gate" type="object">
+  Gate and retry configuration. See [Gate fields](#gate-fields) below.
+</ParamField>
+
+### Agent step fields
+
+<ParamField body="prompt" type="string" required>
+  The instruction given to the AI model. Must be at least one character. Required on any step that also sets `model`, `thinking`, or `provider`.
+</ParamField>
+
+<ParamField body="model" type="string">
+  Model ID to use for this step (e.g., `claude-opus-4-8`, `gpt-5.5-pro`). Uses the workspace default if omitted.
+</ParamField>
+
+<ParamField body="thinking" type="string">
+  Reasoning depth for the model. Accepted values: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Default: `high`.
+</ParamField>
+
+<ParamField body="provider" type="string">
+  Provider ID for the model (e.g., `anthropic`, `openai`, `deepseek`). Uses the workspace default if omitted. See the [Provider IDs reference](/reference/workflow-schema#provider-ids) for all supported values.
+</ParamField>
+
+<ParamField body="name" type="string">
+  Optional step name, displayed in the dashboard log.
+</ParamField>
+
+<ParamField body="key" type="string">
+  Optional stable identifier for this step. Must be at least one character.
+</ParamField>
+
+<ParamField body="gate" type="object">
+  Gate and retry configuration. See [Gate fields](#gate-fields) below.
+</ParamField>
+
+## Gate fields
+
+A gate block must contain at least one of `success_if` or `on_failure`.
+
+<ParamField body="success_if" type="string">
+  A CEL expression evaluated after the step completes. The variable `exit_code` (integer) is available. Example: `exit_code == 0`.
+</ParamField>
+
+<ParamField body="on_failure.restart_from" type="string">
+  The `key` of an earlier step in the same job to restart from when this step fails. The referenced step must have a `key:` and appear before this step in the job's step list (`name:` is display-only and cannot be referenced).
+</ParamField>
+
+<ParamField body="on_failure.output" type="string">
+  A message to surface in the run log when the step fails.
+</ParamField>
+
+## Validation rules
+
+<Warning>
+  The schema is strict. Every one of these rules is enforced at parse time — violating any of them produces a typed validation error.
+
+  - **Unknown keys are rejected everywhere.** The schema is strict; any unrecognised key is an error.
+  - **A step must define `run` OR `prompt` — never both, never neither.** A step with none of `run`, `prompt`, `model`, `thinking`, or `provider` is invalid.
+  - **`model`, `thinking`, and `provider` are invalid on a run step.** They may only appear alongside `prompt`.
+  - **`env` is invalid on an agent step.** Workflow-level and job-level env is not applied to agent steps either.
+  - **`prompt` is required on any step that sets `model`, `thinking`, or `provider`.** Declaring those fields without `prompt` is a validation error.
+  - **At most one `manual` trigger per workflow.** Multiple `source: manual` entries are not permitted.
+  - **`restart_from` must reference an earlier keyed step in the same job.** The referenced step must appear before the gate-bearing step in the step list and must have a `key`.
+  - **The `agent:` key is reserved and rejected.** Using `agent:` on a step produces a clear error message. It is not a valid alias for an agent step.
+  - **`jobs` and `triggers` objects must have at least one entry.** An empty object for either field is invalid.
+</Warning>
+
+## Provider IDs
+
+The following provider IDs are supported in the `provider` field of an agent step:
+
+`anthropic`, `ant-ling`, `azure-openai-responses`, `openai`, `deepseek`, `nvidia`, `google`, `mistral`, `groq`, `cerebras`, `cloudflare-ai-gateway`, `cloudflare-workers-ai`, `xai`, `openrouter`, `vercel-ai-gateway`, `zai`, `zai-coding-cn`, `opencode`, `opencode-go`, `huggingface`, `fireworks`, `together`, `kimi-coding`, `minimax`, `minimax-cn`, `moonshotai`, `moonshotai-cn`, `xiaomi`, `xiaomi-token-plan-cn`, `xiaomi-token-plan-ams`, `xiaomi-token-plan-sgp`
+
+The following IDs are recognised but not currently supported: `amazon-bedrock`, `google-vertex`, `openai-codex`, `github-copilot`.
+
+## Full example
+
+```yaml
+name: Full example
+runner: ubuntu-latest
+env:
+  NODE_ENV: test
+triggers:
+  on_push:
+    source: github_acme
+    event: push
+  on_demand:
+    source: manual
+    event: fire
+jobs:
+  test:
+    steps:
+      - key: install
+        run: npm ci
+      - run: npm test
+        gate:
+          success_if: exit_code == 0
+          on_failure:
+            restart_from: install
+  review:
+    needs: test
+    steps:
+      - model: claude-opus-4-8
+        thinking: high
+        prompt: Summarize the test results and suggest improvements.
+```


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **Reference** section. Base is `docs/setup-getting-started`.

## What's here

- **7 pages** from source (`ShipfoxHQ/docs` @ `d0e33e9`): `workflow-schema`, `trigger-sources`, `step-types`, `expressions`, `model-providers`, `rest-api`, `glossary`. Nav group in source order.
- **De-link discipline** — cross-references to pages not in this branch (concepts, guides, integrations) de-linked; in-group `/reference/*` links stay live.
- **Base pages re-linked** — Home's "30+ Model Providers" card and Getting Started's "model provider" mention now point to `/reference/model-providers`.
- **`llms.txt`** — the 7 reference entries appended.

## Correctness notes

- `event.ref` documented as the **full Git ref** (`refs/heads/main`); the job **`checkout`** field is in the schema reference; `restart_from`→**`key:`**; CEL `${{ }}` interpolation shown as shipped.

## Verification

`pnpm docs:check` → **0 broken links**. No changeset. No dedicated Linear issue for reference — tracked under milestone "2. OSS and docs" (ENG-486).

Refs ENG-486

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Reference docs section with seven pages, updates navigation and key links, and fixes the custom webhook event name. Completes the Reference scope for ENG-486.

- **New Features**
  - Adds `/reference` group (nav order): `workflow-schema`, `trigger-sources`, `step-types`, `expressions`, `model-providers`, `rest-api`, `glossary`.
  - Keeps in-group `/reference/*` links; de-links refs outside this branch.
  - Re-links Home card and Getting Started to `/reference/model-providers`; appends seven entries to `docs/llms.txt`.
  - Documents verified behavior: `filter` is parsed but not evaluated yet; `event.ref` is the full Git ref; job `checkout`; `restart_from` targets `key:`; `${{ }}` interpolation scopes/timing. `pnpm docs:check` reports 0 broken links.

- **Bug Fixes**
  - Corrects custom webhook event name to `received` in Trigger Sources.

<sup>Written for commit 593108cb0dbb10e114b8a1bb5d75ff62c5f76339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

