### PR TITLE
Add Installation docs group

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,17 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "Installation",
+            "pages": [
+              "installation",
+              "installation/local",
+              "installation/self-hosting",
+              "installation/aws",
+              "installation/kubernetes",
+              "installation/cloud"
+            ]
           }
         ]
       }

--- a/apps/docs/installation.mdx
+++ b/apps/docs/installation.mdx
@@ -1,0 +1,45 @@
+---
+title: "Installing Shipfox"
+sidebarTitle: "Overview"
+description: "How to run Shipfox: evaluate locally, self-host on your own infrastructure, or use managed cloud. An overview of the components and the setup paths."
+---
+
+Shipfox has two parts to stand up: a **control plane** — the API and dashboard, backed
+by PostgreSQL, Temporal, and S3-compatible object storage — and one or more **runners**
+that execute jobs on compute you own. This section is for whoever operates that
+infrastructure, typically a platform, DevEx, or SRE team.
+
+<Info>
+  Configuring projects and authoring workflows needs none of this. If Shipfox is
+  already running for your team, head to [Quick Start](/getting-started).
+</Info>
+
+## Components
+
+| Component | What it is |
+|---|---|
+| API + dashboard | Stateless control-plane processes you deploy as containers |
+| PostgreSQL | Primary datastore for Shipfox state |
+| Temporal | Workflow orchestration engine used internally |
+| Object storage | S3-compatible storage for step-log artifacts |
+| Runners | Processes on your compute that execute jobs — see Runners |
+
+## Choose a path
+
+<CardGroup cols={2}>
+  <Card title="Local evaluation" icon="laptop" href="/installation/local">
+    Run the whole stack on your machine with Docker Compose to try Shipfox out.
+  </Card>
+  <Card title="Self-hosting" icon="server" href="/installation/self-hosting">
+    Deploy the control plane and runners on your own infrastructure.
+  </Card>
+  <Card title="AWS" icon="aws" href="/installation/aws">
+    A reference deployment on AWS. Coming soon.
+  </Card>
+  <Card title="Kubernetes" icon="dharmachakra" href="/installation/kubernetes">
+    Deploy on a Kubernetes cluster. Coming soon.
+  </Card>
+  <Card title="Managed cloud" icon="cloud" href="/installation/cloud">
+    Shipfox runs the control plane; you only configure and connect runners. Coming soon.
+  </Card>
+</CardGroup>

--- a/apps/docs/installation/aws.mdx
+++ b/apps/docs/installation/aws.mdx
@@ -1,0 +1,17 @@
+---
+title: "Self-Hosting Shipfox on AWS"
+sidebarTitle: "AWS (soon)"
+description: "A reference deployment of Shipfox on AWS — RDS, S3, and container compute. Coming soon."
+---
+
+<Note>
+  **Coming soon.** A step-by-step reference deployment on AWS is in progress.
+</Note>
+
+This guide will cover a reference deployment of the Shipfox control plane on AWS,
+including RDS for PostgreSQL, S3 for object storage, a Temporal option, and running
+the API, dashboard, and runners on container compute (ECS or EKS).
+
+In the meantime, follow the platform-agnostic [Self-Hosting](/installation/self-hosting)
+guide — its external-service requirements map directly onto AWS managed services (RDS,
+S3, and Temporal Cloud or a self-managed cluster).

--- a/apps/docs/installation/cloud.mdx
+++ b/apps/docs/installation/cloud.mdx
@@ -1,0 +1,19 @@
+---
+title: "Shipfox Managed Cloud"
+sidebarTitle: "Managed Cloud (soon)"
+description: "Use Shipfox managed cloud — Shipfox runs the control plane and you only configure your workspace and connect runners. Coming soon."
+---
+
+<Note>
+  **Coming soon.** Managed cloud onboarding documentation is in progress.
+</Note>
+
+With managed cloud, Shipfox operates the control plane — the API, database, and
+orchestration — so there is no infrastructure for you to stand up. Setup is
+configuration rather than deployment: create a workspace, connect your
+integrations, configure model providers,
+and connect runners on compute you control (your jobs still run
+on your own runners).
+
+This page will walk through that configuration. For access today, reach out to the
+Shipfox team.

--- a/apps/docs/installation/kubernetes.mdx
+++ b/apps/docs/installation/kubernetes.mdx
@@ -1,0 +1,17 @@
+---
+title: "Self-Hosting Shipfox on Kubernetes"
+sidebarTitle: "Kubernetes (soon)"
+description: "Deploy the Shipfox control plane and runners on a Kubernetes cluster. Coming soon."
+---
+
+<Note>
+  **Coming soon.** A Kubernetes deployment guide (with manifests) is in progress.
+</Note>
+
+This guide will cover deploying the Shipfox control plane on a Kubernetes cluster —
+the stateless API and dashboard as Deployments, connecting to PostgreSQL, Temporal,
+and S3-compatible object storage, and running runners in-cluster.
+
+In the meantime, the [Self-Hosting](/installation/self-hosting) guide describes the
+components and external services to provision; the API and dashboard are stateless
+containers that run on any orchestrator, including Kubernetes.

--- a/apps/docs/installation/local.mdx
+++ b/apps/docs/installation/local.mdx
@@ -1,0 +1,175 @@
+---
+title: "Local Evaluation"
+sidebarTitle: "Local Evaluation"
+description: "Run the full Shipfox stack on your machine with Docker Compose — API, dashboard, PostgreSQL, Temporal, Gitea, and object storage — to explore the platform."
+---
+
+Evaluation mode runs the full Shipfox stack — API, dashboard, PostgreSQL, Temporal,
+Gitea, and object storage — locally with Docker Compose, so you can explore the
+platform without any cloud account. For a production deployment, see
+[Self-Hosting](/installation/self-hosting).
+
+<Steps>
+  <Step title="Prerequisites">
+    Make sure the following are installed and available on your `PATH` before continuing:
+
+    - [Docker](https://docs.docker.com/get-docker/) (with Compose v2)
+    - [mise](https://mise.jdx.dev/) — installs the pinned Node.js, pnpm, and turbo versions
+    - [Git](https://git-scm.com/)
+
+    Clone the Shipfox repository to your local machine:
+
+    ```bash
+    git clone https://github.com/ShipfoxHQ/shipfox.git
+    cd shipfox
+    ```
+  </Step>
+  <Step title="Install dependencies">
+    Install runtime tooling with `mise` and then install Node dependencies with `pnpm`:
+
+    ```bash
+    mise install && pnpm install
+    ```
+
+    `mise` installs the exact Node, pnpm, and turbo versions pinned in `mise.toml` (run `mise trust` if prompted). If you don't use `mise`, install Node, pnpm, and turbo yourself at the versions listed in that file.
+  </Step>
+  <Step title="Build packages">
+    Build the packages the API and dashboard depend on. Run these two commands in order:
+
+    ```bash
+    turbo build --filter=@shipfox/vite
+    turbo build --filter=@shipfox/api...
+    ```
+
+    The first command builds shared UI primitives; the second builds everything the API transitively depends on. Both are incremental — re-running after a code change only rebuilds what changed.
+  </Step>
+  <Step title="Start infrastructure services">
+    Bring up the Docker Compose stack:
+
+    ```bash
+    docker compose up -d
+    ```
+
+    This starts the following services in the background:
+
+    | Service | Purpose |
+    |---|---|
+    | PostgreSQL | Primary database for Shipfox state |
+    | Temporal | Workflow orchestration engine used internally by Shipfox |
+    | Gitea | Local Git hosting (simulates GitHub for local push triggers) |
+    | Object storage (garage) | S3-compatible storage for step-log artifacts |
+
+    A demo repository `shipfox/demo` is seeded automatically. You can connect this repository to a project for your first run without needing a real GitHub repo.
+
+    <Note>
+      The stack binds fixed host ports: 5432 (PostgreSQL), 7233 (Temporal), 3000
+      (Gitea HTTP), 2222 (Gitea SSH), and 3900 (object storage S3). If
+      `docker compose up` fails with "port is already allocated", override the
+      conflicting port with the matching variable — `SHIPFOX_POSTGRES_PORT`,
+      `SHIPFOX_TEMPORAL_PORT`, `SHIPFOX_GITEA_HTTP_PORT`, `SHIPFOX_GITEA_SSH_PORT`,
+      or `SHIPFOX_GARAGE_S3_PORT` — before running the command again.
+    </Note>
+  </Step>
+  <Step title="Start the API and dashboard">
+    Open two terminal windows and start the API and dashboard processes:
+
+    ```bash
+    # Terminal 1 — API on port 16101
+    pnpm --filter=@shipfox/api dev
+
+    # Terminal 2 — Dashboard on port 5173
+    pnpm --filter=@shipfox/client dev
+    ```
+
+    Wait until both processes are ready before proceeding. The API prints `Server listening at http://127.0.0.1:16101`; the dashboard prints `VITE ready`. The dashboard is available at `http://localhost:5173` and the API at `http://localhost:16101`.
+  </Step>
+  <Step title="Create your account and workspace">
+    Open `http://localhost:5173` and sign up with any name, email, and password.
+
+    <Note>
+      Signup asks you to verify your email. In evaluation mode there is no mail
+      server — the API prints every email to its terminal. Find the line containing
+      `Verify your email` in the API logs and open the verification link it
+      contains.
+    </Note>
+
+    After verification, the dashboard walks you through setup:
+
+    1. **Create your workspace** — pick any name.
+    2. **Install source control** — choose **Gitea** and enter the organization `shipfox` (the org seeded by Docker Compose).
+    3. **Configure agent provider** — skip this unless you want to run agent steps immediately.
+    4. **Create project** — pick a seeded repository such as `shipfox/demo`. The project name is pre-filled from the repository.
+
+    <Frame caption="Create project: pick the source connection, then the repository — the name is pre-filled.">
+      <img src="/images/create-project.png" alt="The create-project form showing the source connection, repository picker, and pre-filled project name" />
+    </Frame>
+  </Step>
+  <Step title="Register a runner">
+    A runner is required to execute jobs. Follow these steps to register one:
+
+    1. Go to **Settings → Runners** and click **Create token**. Name the token, pick an expiry, and copy the token — it is shown only once.
+    2. Start a runner in a third terminal, passing your token and labels as environment variables:
+
+    ```bash
+    SHIPFOX_API_URL=http://localhost:16101 \
+    SHIPFOX_RUNNER_REGISTRATION_TOKEN=<YOUR_REGISTRATION_TOKEN> \
+    SHIPFOX_RUNNER_LABELS=ubuntu-latest,node-22 \
+    pnpm --filter=@shipfox/runner dev
+    ```
+
+    The runner reads `SHIPFOX_API_URL`, `SHIPFOX_RUNNER_REGISTRATION_TOKEN`, and `SHIPFOX_RUNNER_LABELS` from its environment. Within a few seconds its terminal prints `Runner session registered` — the runner is now polling for jobs. The dashboard does not list connected runners yet; the runner's own log is the place to confirm it is connected.
+
+    <Frame caption="Creating a registration token — the value is shown once, with a copy button.">
+      <img src="/images/runner-registration-token.png" alt="The create registration token dialog on Settings → Runners, showing the one-time token value and copy button" />
+    </Frame>
+
+    <Note>
+      A runner exits after a default idle window (about 5 minutes). To keep it polling indefinitely during evaluation, add `SHIPFOX_POLL_MAX_DURATION_MS=0` to its environment.
+    </Note>
+  </Step>
+  <Step title="Fire your first run">
+    Create a workflow file in the `shipfox/demo` repository that uses a manual trigger — for example:
+
+    ```yaml
+    name: First run
+    runner: ubuntu-latest
+    triggers:
+      on_demand:
+        source: manual
+        event: fire
+    jobs:
+      hello:
+        steps:
+          - run: echo "Shipfox is running!"
+    ```
+
+    Clone the seeded repo from the local Gitea, add the file, and push. The seeded admin account is `gitea-admin` / `gitea-admin-dev-password`, and the Gitea web UI is at `http://localhost:3000`:
+
+    ```bash
+    git clone http://gitea-admin:gitea-admin-dev-password@localhost:3000/shipfox/demo.git
+    ```
+
+    Shipfox picks the workflow up within seconds. Open the project's **Workflows** page and click **Run** next to the workflow. Watch the logs stream live in the run detail view.
+  </Step>
+</Steps>
+
+<Note>
+  In evaluation mode, **GitHub** push triggers will not fire because the local API is not reachable from GitHub's webhook infrastructure. **Gitea** push triggers do fire: the compose stack registers a webhook from the seeded `shipfox` org to your local API. Add a push trigger with the Gitea connection's slug as its source:
+
+  ```yaml
+  triggers:
+    on_push:
+      source: gitea_shipfox   # <provider>_<organization>
+      event: push
+  ```
+
+  Then `git push` to the connected repository and watch the run start.
+
+  Gitea is the evaluation stack's local stand-in for GitHub — it exists only in
+  this Docker Compose setup. Deployed installations (self-hosted or cloud) connect
+  **GitHub**; GitLab support is on the roadmap.
+</Note>
+
+<Note>
+  Agent steps (`model` + `prompt`) require the appropriate provider API key to be set in the runner's environment. For Anthropic models, set `ANTHROPIC_API_KEY` before starting the runner process. Other providers use their own key environment variables.
+</Note>

--- a/apps/docs/installation/self-hosting.mdx
+++ b/apps/docs/installation/self-hosting.mdx
@@ -1,0 +1,78 @@
+---
+title: "Self-Hosting Shipfox"
+sidebarTitle: "Self-Hosting"
+description: "Deploy the Shipfox control plane and runners on your own infrastructure: PostgreSQL, Temporal, S3-compatible object storage, and runner registration."
+---
+
+For a production self-hosted deployment you run the Shipfox control plane on your own
+compute and connect it to managed dependencies. This page covers the external
+services to provision and how to register runners. For a reference deployment on a
+specific platform, see [AWS](/installation/aws) or [Kubernetes](/installation/kubernetes)
+(both coming soon).
+
+## What you run, and what talks to what
+
+{/* Source: images/diagrams/deployment-topology.mmd — regenerate with:
+    npx -y @mermaid-js/mermaid-cli -b white -i images/diagrams/deployment-topology.mmd -s 3 -o images/diagrams/deployment-topology.png */}
+<Frame caption="Deployment topology — click to enlarge.">
+  <img src="/images/diagrams/deployment-topology.png" alt="Deployment topology: event sources send webhooks into the Shipfox API; the control plane containers connect to PostgreSQL, Temporal, and S3-compatible object storage; runners and an optional provisioner on your compute connect outbound only, clone the repository, and call model providers with your API keys" />
+</Frame>
+
+Two directions matter: **runners only connect outward** — you never open an inbound
+port into your compute — and **agent traffic to model providers leaves from your
+runners**, with your API keys, not from the control plane.
+
+## External services
+
+Provision and connect the following:
+
+| Service | Recommended options |
+|---|---|
+| PostgreSQL | Any managed PostgreSQL 15+ instance (RDS, Cloud SQL, Supabase, self-managed) |
+| Temporal | Self-hosted Temporal cluster or Temporal Cloud |
+| Object storage | Any S3-compatible service (AWS S3, GCS with interop, MinIO, Cloudflare R2) |
+
+The Shipfox API and dashboard are stateless processes that can be deployed as
+containers on any compute platform (Kubernetes, ECS, Fly.io, bare VMs). The runner is
+a separate process you deploy on the compute where jobs should execute — it does not
+need to be co-located with the API.
+
+## Runner registration
+
+A runner is a lightweight process you start on any machine — a VM, a bare-metal
+server, or a container. Runners poll Shipfox for jobs that match their labels and
+execute them locally, streaming logs back to the API in real time.
+
+To register a new runner:
+
+1. In the Shipfox dashboard, create a **registration token** in the runner settings.
+2. Copy the generated token — it is shown only once.
+3. Start the runner on your target machine. The runner ships as a Docker image and is configured entirely through environment variables — the API URL, the registration token, and the labels this runner advertises:
+
+```bash
+docker run --rm \
+  -e SHIPFOX_API_URL=<YOUR_SHIPFOX_API_URL> \
+  -e SHIPFOX_RUNNER_REGISTRATION_TOKEN=<YOUR_REGISTRATION_TOKEN> \
+  -e SHIPFOX_RUNNER_LABELS=<LABEL_1>,<LABEL_2> \
+  <shipfox-runner-image>
+```
+
+`SHIPFOX_RUNNER_LABELS` is a comma-separated list (e.g. `linux,x64,self-hosted`). A job
+is dispatched to a runner only when the runner has **all** the labels listed in the
+workflow's `runner:` field. Make sure your runner's labels match exactly what your
+workflows declare — a mismatch is the most common cause of runs sticking in `pending`.
+
+By default a runner exits after an idle window. For a long-lived runner that keeps
+polling, set `SHIPFOX_POLL_MAX_DURATION_MS=0` in its environment.
+
+<Tip>
+  To scale runners automatically instead of starting each one by hand, run a
+  runner provisioner — it starts ephemeral,
+  single-job runners on demand and lets them exit when idle.
+</Tip>
+
+## Managed hosting
+
+Prefer not to operate the control plane yourself? With [managed cloud](/installation/cloud),
+Shipfox runs the API, database, and orchestration, and you only deploy and connect
+runners. Reach out to the Shipfox team for access.

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,9 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [Installation](/installation): How to run Shipfox — evaluate locally, self-host, or use managed cloud; components and setup paths.
+- [Local Evaluation](/installation/local): Run the full stack on your machine with Docker Compose — API, dashboard, PostgreSQL, Temporal, Gitea, object storage.
+- [Self-Hosting](/installation/self-hosting): Deploy the control plane and runners on your own infrastructure — PostgreSQL, Temporal, S3-compatible storage, runner registration.
+- [AWS](/installation/aws): Coming soon — a reference Shipfox deployment on AWS (RDS, S3, container compute).
+- [Kubernetes](/installation/kubernetes): Coming soon — deploy the control plane and runners on a Kubernetes cluster.
+- [Managed Cloud](/installation/cloud): Coming soon — Shipfox runs the control plane; you configure your workspace and connect runners.


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **Installation** section. Base is `docs/setup-getting-started`.

## What's here

- **6 pages** from source (`ShipfoxHQ/docs` @ `d0e33e9`): overview (`installation`), `local`, `self-hosting`, `aws`, `kubernetes`, `cloud`. Nav group in source order. AWS / Kubernetes / Managed Cloud are **"(soon)"** — sidebar markers verbatim.
- **De-link discipline** — cross-references to pages not in this branch (concepts, integrations, reference) de-linked; in-group `/installation/*` links stay live.
- No base-page re-links (the Installation mention was reworded out of Getting Started during the PR1 trim). `llms.txt` appended.

## Correctness notes

- **Gitea appears only on Local Evaluation** (the Docker Compose stack) — every other page uses your own infra / managed cloud.
- The self-hosting **deployment-topology diagram is the pre-rendered PNG** (`-s 3`), not SVG — mermaid `foreignObject` labels don't render through `<img>`. Regen command preserved in the MDX comment.

## Verification

`pnpm docs:check` → **0 broken links**. No changeset.

Refs ENG-476

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Installation docs section with six pages and sidebar navigation to help teams run Shipfox locally or self-host. Aligns with ENG-476 by enabling immediate evaluation and self-hosting; AWS/Kubernetes/Managed Cloud are marked “coming soon”.

- **New Features**
  - Added Installation nav group and six pages: overview, local, self-hosting, aws, kubernetes, cloud (last three marked “(soon)”).
  - Local Evaluation: Docker Compose stack (API, dashboard, PostgreSQL, Temporal, object storage, Gitea) with a seeded `shipfox/demo` repo; build/start steps using `mise`, `pnpm`, and `turbo`; fixed ports with env overrides (e.g., `SHIPFOX_POSTGRES_PORT`); runner setup with keep-alive option.
  - Self-Hosting: external services (PostgreSQL, Temporal, S3-compatible storage), runner registration via env/Docker; uses a pre-rendered PNG topology diagram for reliable rendering.
  - Kept in-group `/installation/*` links live; de-linked out-of-branch pages; `pnpm docs:check` shows 0 broken links; updated `llms.txt` with the new entries.

<sup>Written for commit 5a4b5ff34e9963ba230461c2487fa20276f739e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

