### PR TITLE
Add Help docs group

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -20,6 +20,10 @@
           {
             "group": "Get Started",
             "pages": ["introduction", "getting-started"]
+          },
+          {
+            "group": "Help",
+            "pages": ["troubleshooting", "faq"]
           }
         ]
       }

--- a/apps/docs/faq.mdx
+++ b/apps/docs/faq.mdx
@@ -1,0 +1,53 @@
+---
+title: "Frequently Asked Questions About Shipfox"
+sidebarTitle: "FAQ"
+description: "Answers to common questions about Shipfox: workflow YAML, runners, AI agent steps, supported providers, self-hosting, triggers, and roadmap features."
+---
+
+Quick answers to the most common questions about Shipfox. For more depth on any topic, follow the links to the relevant guide or reference page.
+
+<AccordionGroup>
+  <Accordion title="Can I use GitLab or Bitbucket as a trigger source?">
+    Only GitHub push triggers are supported today. GitLab and Bitbucket are on the roadmap. For non-GitHub repositories, use `source: manual, event: fire` to trigger runs on demand.
+  </Accordion>
+
+  <Accordion title="How do I pass secrets to my workflow?">
+    Secrets should be set as environment variables in your runner's process environment — not in the workflow YAML `env:` block (those values are committed to your repo). Your runner inherits the environment from the process that starts it; set secrets there.
+  </Accordion>
+
+  <Accordion title="Can I share files between jobs?">
+    Not directly — each job re-clones the repository and runs in isolation. To pass build artifacts between jobs, upload them to external storage (S3, R2, etc.) in one job and download them in the next.
+  </Accordion>
+
+  <Accordion title="What AI providers are supported?">
+    Shipfox supports 30+ providers including Anthropic, OpenAI, DeepSeek, Google AI Studio, xAI, Mistral, Groq, OpenRouter, Vercel AI Gateway, Cloudflare AI Gateway, Hugging Face, Together AI, Fireworks, and more. See the Model Providers guide for the full list.
+  </Accordion>
+
+  <Accordion title="Can I use `${{ }}` template expressions in my workflow?">
+    Yes. `${{ }}` interpolation is supported in `run` commands, `env` values, and agent `prompt`s, resolved when the run is created from `run`, `trigger`, `event`, and `inputs` context. Trigger `filter` expressions are the exception — still parsed but not evaluated. See Expressions.
+  </Accordion>
+
+  <Accordion title="What does `filter:` do today?">
+    The `filter` field is parsed and stored but not yet evaluated. Your trigger fires on every matching `(source, event)` regardless of the filter. This will change in a future release.
+  </Accordion>
+
+  <Accordion title="How do I run Shipfox locally to test?">
+    Use the Docker Compose evaluation stack. See Local Evaluation for step-by-step instructions. GitHub push triggers don't fire locally because GitHub can't reach your local API; the evaluation stack ships its own local Git hosting so you can still test push triggers — the local guide covers it.
+  </Accordion>
+
+  <Accordion title="Can my coding agent write Shipfox workflows?">
+    Yes — and it's encouraged. Install the skills package (`npx skills add shipfox/agent-skills`) or paste the authoring prompt into your agent's context. The schema has non-obvious rules that the skill encodes, preventing the most common authoring mistakes.
+  </Accordion>
+
+  <Accordion title="Is self-hosting supported?">
+    Yes. Shipfox requires PostgreSQL, Temporal, and S3-compatible object storage. The runner is a separate process you deploy on your compute. See Self-Hosting for details. Managed hosting is also available.
+  </Accordion>
+
+  <Accordion title="What happens when a gate's `restart_from` loops infinitely?">
+    It can't loop infinitely — a gating step gets **3 attempts by default**, then the job fails. The job-level `execution_timeout` adds an outer wall-clock bound (default 6 hours). See Loop bounds.
+  </Accordion>
+
+  <Accordion title="Why is my run showing `exit_code != 0` on an agent step?">
+    Agent steps that fail to connect to the provider or encounter an API error may surface a non-zero exit code. Check the step log for the specific error, verify your API key is set on the runner, and confirm the model and provider IDs are valid.
+  </Accordion>
+</AccordionGroup>

--- a/apps/docs/llms.txt
+++ b/apps/docs/llms.txt
@@ -6,3 +6,5 @@
 
 - [Introduction](/introduction): What Shipfox is, how it works, and what you can build with agentic workflows.
 - [Quick Start](/getting-started): Connect a project, add a workflow YAML, register a runner, and fire your first run.
+- [Troubleshooting](/troubleshooting): Fix common issues — pending runs, runner connection problems, workflow validation errors, agent step failures, trigger setup.
+- [FAQ](/faq): Common questions about workflow YAML, runners, agent steps, providers, self-hosting, triggers, and roadmap features.

--- a/apps/docs/troubleshooting.mdx
+++ b/apps/docs/troubleshooting.mdx
@@ -1,0 +1,82 @@
+---
+title: "Troubleshooting Shipfox Workflows and Runners"
+sidebarTitle: "Troubleshooting"
+description: "Fix common Shipfox issues: pending runs, runner connection problems, workflow validation errors, agent step failures, and trigger setup issues."
+---
+
+This page covers the most common issues teams encounter with Shipfox and how to resolve them quickly. For each symptom, you'll find the likely cause and the steps to fix it.
+
+<AccordionGroup>
+  <Accordion title="Run is stuck in `pending`">
+    **Cause:** No online runner with a matching label.
+
+    **Fix:**
+    - Check the runner process's log for `Runner session registered` — the dashboard does not list connected runners yet.
+    - Verify your workflow's `runner:` label exactly matches a runner label (case-sensitive).
+    - Ensure the runner process is running; a runner exits after its idle window unless `SHIPFOX_POLL_MAX_DURATION_MS=0` is set.
+    - In evaluation mode, remember the compose services do not execute jobs — a separate runner process must be started.
+  </Accordion>
+
+  <Accordion title="Workflow file not detected">
+    **Cause:** File is not in the correct location or has a YAML syntax error.
+
+    **Fix:**
+    - Confirm the file is under `.shipfox/workflows/` and has a `.yml` or `.yaml` extension.
+    - Run the file through a YAML linter (`npx js-yaml your-file.yml`).
+    - Check that the file extension is `.yml` or `.yaml`.
+  </Accordion>
+
+  <Accordion title="Validation error on push">
+    **Cause:** Workflow YAML contains invalid or unsupported keys.
+
+    **Common mistakes:**
+    - Using `loop`, `matrix`, or `branch` — these are roadmap features not yet shipped. (`${{ }}` interpolation **is** shipped; writing `{{ }}` instead of `${{ }}` is the common mistake.)
+    - Setting `env` on an agent step — `env` is run-step only.
+    - Using `model`, `thinking`, or `provider` on a `run` step.
+    - No `prompt` on an agent step.
+    - Using the reserved `agent:` key.
+
+    **Fix:** Review the Workflow Schema reference. Use the Authoring Prompt or Skills Package to get valid YAML from your coding agent.
+  </Accordion>
+
+  <Accordion title="Agent step fails or produces no output">
+    **Cause:** Missing API key on the runner, or model/provider mismatch.
+
+    **Fix:**
+    - Verify the AI provider is configured in **Settings → Agent providers** with a valid API key.
+    - Check that `ANTHROPIC_API_KEY` (or the relevant provider key) is set in the runner's environment.
+    - Confirm `model` and `provider` IDs are valid (see Model Providers).
+    - Check the step log in the dashboard for error messages from the provider.
+  </Accordion>
+
+  <Accordion title="Push trigger not firing">
+    **Cause:** GitHub integration not connected, wrong trigger `source`, or repository is on GitLab.
+
+    **Fix:**
+    - Open **Settings → Events**. It lists every trigger event the workspace received. If your push appears with **No workflows triggered**, the workflow's `source` does not match the connection's slug (see Integrations). If the push does not appear at all, the webhook never reached Shipfox.
+    - In the project settings, verify the GitHub repository is connected.
+    - Push triggers only work with GitHub — GitLab is roadmap. Use `source: manual, event: fire` for non-GitHub repos.
+    - Verify the GitHub webhook is registered (visible in your GitHub repo's **Settings → Webhooks**).
+  </Accordion>
+
+  <Accordion title="`restart_from` validation error">
+    **Cause:** The step referenced by `restart_from` doesn't exist, appears after the gate step, or has no `key:`.
+
+    **Fix:**
+    - Add a `key:` field to the step you want to restart from (`restart_from` matches keys, not `name:` labels).
+    - Ensure the keyed step appears **before** the gate step in the same job.
+    - Use the exact `name` string — it's case-sensitive.
+  </Accordion>
+
+  <Accordion title="Sentry trigger not firing">
+    **Cause:** Sentry integration not configured.
+
+    **Fix:**
+    - Go to **Settings → Integrations → Sentry** and complete the setup.
+    - Verify the `event` value is one of: `issue.created`, `issue.resolved`, `issue.assigned`, `issue.archived`, `issue.unresolved`.
+  </Accordion>
+</AccordionGroup>
+
+<Note>
+  If you're still stuck, check the run's step log in the dashboard — it often contains the exact error message. Still need help? Reach out to the Shipfox team.
+</Note>


### PR DESCRIPTION
Phase 3 group PR (stacked on [#476](https://github.com/ShipfoxHQ/shipfox/pull/476)) — adds the **Help** section (the final group). Base is `docs/setup-getting-started`.

## What's here

- **2 pages** from source (`ShipfoxHQ/docs` @ `d0e33e9`): `troubleshooting`, `faq`. Nav group added.
- **De-link discipline** — cross-references to pages not in this branch de-linked to plain text; no base-page changes. `llms.txt` appended.

## Verification

`pnpm docs:check` → **0 broken links**. No changeset.

Refs ENG-482

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Help docs group with Troubleshooting and FAQ to complete the docs navigation and make support content easy to find. Fulfills ENG-482 by introducing the final docs group.

- **New Features**
  - Added `troubleshooting.mdx` and `faq.mdx`; added a new "Help" group to `apps/docs/docs.json`.
  - Appended `llms.txt` with Help entries; de-linked cross-references to out-of-branch pages.
  - Verified with `pnpm docs:check` (0 broken links).

<sup>Written for commit a3a392d554c0cbe82909ade23b87fbb013e22b74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

