### PR TITLE
Add secrets and variables workspace settings UI

### DIFF
--- a/.changeset/secrets-variables-settings-ui.md
+++ b/.changeset/secrets-variables-settings-ui.md
@@ -1,0 +1,20 @@
+---
+"@shipfox/client-secrets": minor
+"@shipfox/client-workspace-settings": minor
+"@shipfox/api-secrets-dto": patch
+"@shipfox/client-router": patch
+---
+
+Add the Secrets & Variables workspace settings UI (S1b).
+
+- New `@shipfox/client-secrets` package: transport + React Query hooks (a shared
+  `createStoreApi` factory), a write-only secret form and a readable variable form
+  (TanStack Form + Zod, multiline `Textarea` values, live short-value / sensitive-name
+  advisories), and the workspace secrets/variables sections (single-call list, masked
+  secret values, copy-name, delete with blast-radius warning).
+- `@shipfox/client-workspace-settings`: new Secrets and Variables settings pages and nav
+  entries.
+- `@shipfox/api-secrets-dto`: export `SECRETS_MAX_LIST_LIMIT` and raise the list `limit`
+  cap so the settings UI can fetch the whole bounded set in one request.
+- `@shipfox/client-router`: register the `/workspaces/$wid/settings/secrets` and
+  `/variables` routes.

--- a/.changeset/secrets-variables-settings-ui.md
+++ b/.changeset/secrets-variables-settings-ui.md
@@ -1,6 +1,7 @@
 ---
 "@shipfox/client-secrets": minor
 "@shipfox/client-workspace-settings": minor
+"@shipfox/api-secrets": patch
 "@shipfox/api-secrets-dto": patch
 "@shipfox/client-router": patch
 ---
@@ -15,6 +16,11 @@ Add the Secrets & Variables workspace settings UI (S1b).
 - `@shipfox/client-workspace-settings`: new Secrets and Variables settings pages and nav
   entries.
 - `@shipfox/api-secrets-dto`: export `SECRETS_MAX_LIST_LIMIT` and raise the list `limit`
-  cap so the settings UI can fetch the whole bounded set in one request.
+  cap so the settings UI can fetch the whole bounded set in one request; the variable
+  list item now carries `value_truncated`.
+- `@shipfox/api-secrets`: the variable list returns a bounded single-line preview of each
+  value (the full value is read via `GET /variables/:key` when editing) so a single-call
+  list cannot materialize very large responses; startup fails if `SECRETS_MAX_PER_WORKSPACE`
+  exceeds the list limit.
 - `@shipfox/client-router`: register the `/workspaces/$wid/settings/secrets` and
   `/variables` routes.

--- a/libs/api/secrets-dto/src/schemas/management.ts
+++ b/libs/api/secrets-dto/src/schemas/management.ts
@@ -30,6 +30,15 @@ export const variableDtoSchema = secretDtoSchema.extend({
 });
 export type VariableDto = z.infer<typeof variableDtoSchema>;
 
+// List responses return a bounded preview of each value (the store allows large
+// values, so returning every full value in one call is an availability risk).
+// `value_truncated` tells the client the stored value is longer than the preview,
+// so editing must fetch the full value via GET /variables/:key.
+export const variableListItemDtoSchema = variableDtoSchema.extend({
+  value_truncated: z.boolean(),
+});
+export type VariableListItemDto = z.infer<typeof variableListItemDtoSchema>;
+
 export const listSecretsQuerySchema = z.object({
   project_id: optionalProjectIdSchema,
   limit: listLimitSchema,
@@ -52,7 +61,7 @@ export const listSecretsResponseSchema = z.object({
 export type ListSecretsResponseDto = z.infer<typeof listSecretsResponseSchema>;
 
 export const listVariablesResponseSchema = z.object({
-  variables: z.array(variableDtoSchema),
+  variables: z.array(variableListItemDtoSchema),
   next_cursor: cursorSchema.nullable(),
 });
 export type ListVariablesResponseDto = z.infer<typeof listVariablesResponseSchema>;

--- a/libs/api/secrets-dto/src/schemas/management.ts
+++ b/libs/api/secrets-dto/src/schemas/management.ts
@@ -5,7 +5,12 @@ import {secretWriteWarningSchema} from './warnings.js';
 const timestampSchema = z.string().datetime();
 const projectIdSchema = z.string().uuid().nullable();
 const optionalProjectIdSchema = z.string().uuid().optional();
-const listLimitSchema = z.coerce.number().int().min(1).max(100).default(50);
+
+// The settings UI fetches every key in one call rather than paginating, so the list
+// limit ceiling matches the per-workspace cap (SECRETS_MAX_PER_WORKSPACE default). A
+// client asking for the whole bounded set passes limit=SECRETS_MAX_LIST_LIMIT.
+export const SECRETS_MAX_LIST_LIMIT = 10000;
+const listLimitSchema = z.coerce.number().int().min(1).max(SECRETS_MAX_LIST_LIMIT).default(50);
 const cursorSchema = z
   .string()
   .min(1)

--- a/libs/api/secrets/src/config.ts
+++ b/libs/api/secrets/src/config.ts
@@ -1,3 +1,4 @@
+import {SECRETS_MAX_LIST_LIMIT} from '@shipfox/api-secrets-dto';
 import {createConfig, num, str} from '@shipfox/config';
 import {decodeBase64Key} from '#core/crypto.js';
 
@@ -27,6 +28,13 @@ if (config.SECRETS_ENCRYPTION_KEK_PREVIOUS) {
 }
 if (config.SECRETS_MAX_PER_WORKSPACE < 1) {
   throw new Error('SECRETS_MAX_PER_WORKSPACE must be greater than 0.');
+}
+if (config.SECRETS_MAX_PER_WORKSPACE > SECRETS_MAX_LIST_LIMIT) {
+  // The settings UI lists the whole bounded set in one call (limit = SECRETS_MAX_LIST_LIMIT).
+  // A cap above that would let the list silently truncate, so fail fast instead.
+  throw new Error(
+    `SECRETS_MAX_PER_WORKSPACE (${config.SECRETS_MAX_PER_WORKSPACE}) cannot exceed SECRETS_MAX_LIST_LIMIT (${SECRETS_MAX_LIST_LIMIT}).`,
+  );
 }
 if (config.SECRETS_SHORT_VALUE_WARN_LENGTH < 1) {
   throw new Error('SECRETS_SHORT_VALUE_WARN_LENGTH must be greater than 0.');

--- a/libs/api/secrets/src/db/index.ts
+++ b/libs/api/secrets/src/db/index.ts
@@ -20,6 +20,7 @@ export {
   listSecretManagementRows,
   listVariableManagementRows,
   type SecretManagementRow,
+  type VariableManagementListRow,
 } from './management.js';
 export {secretDataKeys} from './schema/data-keys.js';
 export {secretsOutbox} from './schema/outbox.js';

--- a/libs/api/secrets/src/db/management.ts
+++ b/libs/api/secrets/src/db/management.ts
@@ -1,4 +1,4 @@
-import {and, asc, eq, gt, inArray, isNull, type SQL} from 'drizzle-orm';
+import {and, asc, eq, gt, inArray, isNull, type SQL, sql} from 'drizzle-orm';
 import type {AnyPgColumn} from 'drizzle-orm/pg-core';
 import type {Tx} from './db.js';
 import {db} from './db.js';
@@ -14,13 +14,24 @@ export interface ManagementListParams extends StoreScope {
 
 export type SecretManagementRow = Omit<SecretValue, 'ciphertext' | 'fingerprint'>;
 
+// Values can be large and multi-line, so the list returns only a bounded, single-line
+// preview (the value's first line, capped at this many characters). The full value is
+// fetched on demand via getVariableManagementRow. This keeps a single-call list of the
+// whole bounded set from materializing hundreds of MB server-side.
+export const VARIABLE_LIST_VALUE_PREVIEW_LENGTH = 256;
+
+/** A variable list row whose `value` is a preview; `valueTruncated` flags that more exists. */
+export interface VariableManagementListRow extends SecretVariable {
+  valueTruncated: boolean;
+}
+
 export interface SecretManagementListResult {
   secrets: SecretManagementRow[];
   nextCursor: string | null;
 }
 
 export interface VariableManagementListResult {
-  variables: SecretVariable[];
+  variables: VariableManagementListRow[];
   nextCursor: string | null;
 }
 
@@ -51,8 +62,22 @@ export async function listVariableManagementRows(
   tx?: Tx,
 ): Promise<VariableManagementListResult> {
   const executor = tx ?? db();
+  // Preview = the value's first line, capped at the preview length. `valueTruncated`
+  // is true whenever the stored value differs from that preview (longer, or multi-line).
+  const valuePreview = sql<string>`left(split_part(${secretVariables.value}, chr(10), 1), ${VARIABLE_LIST_VALUE_PREVIEW_LENGTH})`;
   const rows = await executor
-    .select()
+    .select({
+      id: secretVariables.id,
+      workspaceId: secretVariables.workspaceId,
+      projectId: secretVariables.projectId,
+      namespace: secretVariables.namespace,
+      key: secretVariables.key,
+      createdAt: secretVariables.createdAt,
+      updatedAt: secretVariables.updatedAt,
+      lastEditedBy: secretVariables.lastEditedBy,
+      valuePreview,
+      valueTruncated: sql<boolean>`${secretVariables.value} <> ${valuePreview}`,
+    })
     .from(secretVariables)
     .where(and(...managementFilters(secretVariables, params)))
     .orderBy(asc(secretVariables.key))
@@ -63,7 +88,18 @@ export async function listVariableManagementRows(
   const last = pageRows.at(-1);
 
   return {
-    variables: pageRows.map(toSecretVariable),
+    variables: pageRows.map((row) => ({
+      id: row.id,
+      workspaceId: row.workspaceId,
+      projectId: row.projectId,
+      namespace: row.namespace,
+      key: row.key,
+      value: row.valuePreview,
+      valueTruncated: row.valueTruncated,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      lastEditedBy: row.lastEditedBy,
+    })),
     nextCursor: hasMore && last ? last.key : null,
   };
 }

--- a/libs/api/secrets/src/presentation/dto/index.ts
+++ b/libs/api/secrets/src/presentation/dto/index.ts
@@ -1,1 +1,1 @@
-export {toSecretDto, toVariableDto} from './management.js';
+export {toSecretDto, toVariableDto, toVariableListItemDto} from './management.js';

--- a/libs/api/secrets/src/presentation/dto/management.ts
+++ b/libs/api/secrets/src/presentation/dto/management.ts
@@ -1,5 +1,5 @@
-import type {SecretDto, VariableDto} from '@shipfox/api-secrets-dto';
-import type {SecretManagementRow} from '#db/index.js';
+import type {SecretDto, VariableDto, VariableListItemDto} from '@shipfox/api-secrets-dto';
+import type {SecretManagementRow, VariableManagementListRow} from '#db/index.js';
 import type {SecretVariable} from '#db/schema/variables.js';
 
 export function toSecretDto(secret: SecretManagementRow): SecretDto {
@@ -17,6 +17,18 @@ export function toVariableDto(variable: SecretVariable): VariableDto {
     key: variable.key,
     project_id: variable.projectId,
     value: variable.value,
+    created_at: variable.createdAt.toISOString(),
+    updated_at: variable.updatedAt.toISOString(),
+    last_edited_by: variable.lastEditedBy,
+  };
+}
+
+export function toVariableListItemDto(variable: VariableManagementListRow): VariableListItemDto {
+  return {
+    key: variable.key,
+    project_id: variable.projectId,
+    value: variable.value,
+    value_truncated: variable.valueTruncated,
     created_at: variable.createdAt.toISOString(),
     updated_at: variable.updatedAt.toISOString(),
     last_edited_by: variable.lastEditedBy,

--- a/libs/api/secrets/src/presentation/routes/list-variables.ts
+++ b/libs/api/secrets/src/presentation/routes/list-variables.ts
@@ -2,7 +2,7 @@ import {listVariablesQuerySchema, listVariablesResponseSchema} from '@shipfox/ap
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {listManagedVariables} from '#core/index.js';
-import {toVariableDto} from '#presentation/dto/index.js';
+import {toVariableListItemDto} from '#presentation/dto/index.js';
 import {requireManagementRead} from './auth.js';
 import {decodeManagementCursor, encodeManagementCursor} from './cursor.js';
 import {translateManagementError} from './errors.js';
@@ -34,7 +34,7 @@ export const listVariablesRoute = defineRoute({
     });
 
     return {
-      variables: result.variables.map(toVariableDto),
+      variables: result.variables.map(toVariableListItemDto),
       next_cursor: result.nextCursor ? encodeManagementCursor(result.nextCursor) : null,
     };
   },

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -267,6 +267,33 @@ describe('secrets management routes', () => {
     expect(second.json().secrets.map((secret: {key: string}) => secret.key)).toEqual(['BRAVO']);
   });
 
+  it('accepts a limit above 100 and returns the whole set in one call', async () => {
+    await app.inject({
+      method: 'POST',
+      url: `/workspaces/${workspaceId}/secrets:batch`,
+      headers: {authorization: 'Bearer user'},
+      payload: {
+        entries: [
+          {key: 'ALPHA', value: 'alpha-value'},
+          {key: 'BRAVO', value: 'bravo-value'},
+        ],
+      },
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/secrets?limit=10000`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().secrets.map((secret: {key: string}) => secret.key)).toEqual([
+      'ALPHA',
+      'BRAVO',
+    ]);
+    expect(res.json().next_cursor).toBeNull();
+  });
+
   it('rejects malformed management cursors', async () => {
     const res = await app.inject({
       method: 'GET',

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -238,6 +238,42 @@ describe('secrets management routes', () => {
     expect(get.json().variable.value).toBe('not-secret-but-sensitive-name');
   });
 
+  it('returns a bounded single-line preview for variable list values', async () => {
+    await app.inject({
+      method: 'PUT',
+      url: `/workspaces/${workspaceId}/variables/MULTILINE`,
+      headers: {authorization: 'Bearer user'},
+      payload: {value: 'first line\nsecond line'},
+    });
+    await app.inject({
+      method: 'PUT',
+      url: `/workspaces/${workspaceId}/variables/SHORT`,
+      headers: {authorization: 'Bearer user'},
+      payload: {value: 'debug'},
+    });
+
+    const list = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/variables?limit=10000`,
+      headers: {authorization: 'Bearer user'},
+    });
+    const full = await app.inject({
+      method: 'GET',
+      url: `/workspaces/${workspaceId}/variables/MULTILINE`,
+      headers: {authorization: 'Bearer user'},
+    });
+
+    const byKey = Object.fromEntries(
+      (list.json().variables as Array<{key: string; value: string; value_truncated: boolean}>).map(
+        (variable) => [variable.key, variable],
+      ),
+    );
+    expect(byKey.MULTILINE).toMatchObject({value: 'first line', value_truncated: true});
+    expect(byKey.SHORT).toMatchObject({value: 'debug', value_truncated: false});
+    // The full value is still available through the single-item read used for editing.
+    expect(full.json().variable.value).toBe('first line\nsecond line');
+  });
+
   it('supports paginated secret lists', async () => {
     await app.inject({
       method: 'POST',

--- a/libs/client/router/src/routeTree.gen.ts
+++ b/libs/client/router/src/routeTree.gen.ts
@@ -25,6 +25,8 @@ import { Route as WorkspacesWidLayoutAgentProviderRouteImport } from './routes/w
 import { Route as SetupLayoutWorkspacesNewRouteImport } from './routes/setup/_layout/workspaces/new'
 import { Route as WorkspacesWidLayoutSettingsIndexRouteImport } from './routes/workspaces/$wid/_layout/settings/index'
 import { Route as WorkspacesWidLayoutIntegrationsIndexRouteImport } from './routes/workspaces/$wid/_layout/integrations/index'
+import { Route as WorkspacesWidLayoutSettingsVariablesRouteImport } from './routes/workspaces/$wid/_layout/settings/variables'
+import { Route as WorkspacesWidLayoutSettingsSecretsRouteImport } from './routes/workspaces/$wid/_layout/settings/secrets'
 import { Route as WorkspacesWidLayoutSettingsRunnersRouteImport } from './routes/workspaces/$wid/_layout/settings/runners'
 import { Route as WorkspacesWidLayoutSettingsProvisionersRouteImport } from './routes/workspaces/$wid/_layout/settings/provisioners'
 import { Route as WorkspacesWidLayoutSettingsMembersRouteImport } from './routes/workspaces/$wid/_layout/settings/members'
@@ -127,6 +129,18 @@ const WorkspacesWidLayoutIntegrationsIndexRoute =
   WorkspacesWidLayoutIntegrationsIndexRouteImport.update({
     id: '/integrations/',
     path: '/integrations/',
+    getParentRoute: () => WorkspacesWidLayoutRoute,
+  } as any)
+const WorkspacesWidLayoutSettingsVariablesRoute =
+  WorkspacesWidLayoutSettingsVariablesRouteImport.update({
+    id: '/settings/variables',
+    path: '/settings/variables',
+    getParentRoute: () => WorkspacesWidLayoutRoute,
+  } as any)
+const WorkspacesWidLayoutSettingsSecretsRoute =
+  WorkspacesWidLayoutSettingsSecretsRouteImport.update({
+    id: '/settings/secrets',
+    path: '/settings/secrets',
     getParentRoute: () => WorkspacesWidLayoutRoute,
   } as any)
 const WorkspacesWidLayoutSettingsRunnersRoute =
@@ -252,6 +266,8 @@ export interface FileRoutesByFullPath {
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
   '/workspaces/$wid/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
+  '/workspaces/$wid/settings/secrets': typeof WorkspacesWidLayoutSettingsSecretsRoute
+  '/workspaces/$wid/settings/variables': typeof WorkspacesWidLayoutSettingsVariablesRoute
   '/workspaces/$wid/integrations/': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/settings/': typeof WorkspacesWidLayoutSettingsIndexRoute
   '/workspaces/$wid/projects/$pid': typeof WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren
@@ -285,6 +301,8 @@ export interface FileRoutesByTo {
   '/workspaces/$wid/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
   '/workspaces/$wid/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
+  '/workspaces/$wid/settings/secrets': typeof WorkspacesWidLayoutSettingsSecretsRoute
+  '/workspaces/$wid/settings/variables': typeof WorkspacesWidLayoutSettingsVariablesRoute
   '/workspaces/$wid/integrations': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/settings': typeof WorkspacesWidLayoutSettingsIndexRoute
   '/workspaces/$wid/projects/$pid/runs': typeof WorkspacesWidLayoutProjectsPidLayoutRunsRoute
@@ -319,6 +337,8 @@ export interface FileRoutesById {
   '/workspaces/$wid/_layout/settings/members': typeof WorkspacesWidLayoutSettingsMembersRoute
   '/workspaces/$wid/_layout/settings/provisioners': typeof WorkspacesWidLayoutSettingsProvisionersRoute
   '/workspaces/$wid/_layout/settings/runners': typeof WorkspacesWidLayoutSettingsRunnersRoute
+  '/workspaces/$wid/_layout/settings/secrets': typeof WorkspacesWidLayoutSettingsSecretsRoute
+  '/workspaces/$wid/_layout/settings/variables': typeof WorkspacesWidLayoutSettingsVariablesRoute
   '/workspaces/$wid/_layout/integrations/': typeof WorkspacesWidLayoutIntegrationsIndexRoute
   '/workspaces/$wid/_layout/settings/': typeof WorkspacesWidLayoutSettingsIndexRoute
   '/workspaces/$wid/_layout/projects/$pid/_layout': typeof WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren
@@ -355,6 +375,8 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/settings/members'
     | '/workspaces/$wid/settings/provisioners'
     | '/workspaces/$wid/settings/runners'
+    | '/workspaces/$wid/settings/secrets'
+    | '/workspaces/$wid/settings/variables'
     | '/workspaces/$wid/integrations/'
     | '/workspaces/$wid/settings/'
     | '/workspaces/$wid/projects/$pid'
@@ -388,6 +410,8 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/settings/members'
     | '/workspaces/$wid/settings/provisioners'
     | '/workspaces/$wid/settings/runners'
+    | '/workspaces/$wid/settings/secrets'
+    | '/workspaces/$wid/settings/variables'
     | '/workspaces/$wid/integrations'
     | '/workspaces/$wid/settings'
     | '/workspaces/$wid/projects/$pid/runs'
@@ -421,6 +445,8 @@ export interface FileRouteTypes {
     | '/workspaces/$wid/_layout/settings/members'
     | '/workspaces/$wid/_layout/settings/provisioners'
     | '/workspaces/$wid/_layout/settings/runners'
+    | '/workspaces/$wid/_layout/settings/secrets'
+    | '/workspaces/$wid/_layout/settings/variables'
     | '/workspaces/$wid/_layout/integrations/'
     | '/workspaces/$wid/_layout/settings/'
     | '/workspaces/$wid/_layout/projects/$pid/_layout'
@@ -556,6 +582,20 @@ declare module '@tanstack/react-router' {
       path: '/integrations'
       fullPath: '/workspaces/$wid/integrations/'
       preLoaderRoute: typeof WorkspacesWidLayoutIntegrationsIndexRouteImport
+      parentRoute: typeof WorkspacesWidLayoutRoute
+    }
+    '/workspaces/$wid/_layout/settings/variables': {
+      id: '/workspaces/$wid/_layout/settings/variables'
+      path: '/settings/variables'
+      fullPath: '/workspaces/$wid/settings/variables'
+      preLoaderRoute: typeof WorkspacesWidLayoutSettingsVariablesRouteImport
+      parentRoute: typeof WorkspacesWidLayoutRoute
+    }
+    '/workspaces/$wid/_layout/settings/secrets': {
+      id: '/workspaces/$wid/_layout/settings/secrets'
+      path: '/settings/secrets'
+      fullPath: '/workspaces/$wid/settings/secrets'
+      preLoaderRoute: typeof WorkspacesWidLayoutSettingsSecretsRouteImport
       parentRoute: typeof WorkspacesWidLayoutRoute
     }
     '/workspaces/$wid/_layout/settings/runners': {
@@ -723,6 +763,8 @@ interface WorkspacesWidLayoutRouteChildren {
   WorkspacesWidLayoutSettingsMembersRoute: typeof WorkspacesWidLayoutSettingsMembersRoute
   WorkspacesWidLayoutSettingsProvisionersRoute: typeof WorkspacesWidLayoutSettingsProvisionersRoute
   WorkspacesWidLayoutSettingsRunnersRoute: typeof WorkspacesWidLayoutSettingsRunnersRoute
+  WorkspacesWidLayoutSettingsSecretsRoute: typeof WorkspacesWidLayoutSettingsSecretsRoute
+  WorkspacesWidLayoutSettingsVariablesRoute: typeof WorkspacesWidLayoutSettingsVariablesRoute
   WorkspacesWidLayoutIntegrationsIndexRoute: typeof WorkspacesWidLayoutIntegrationsIndexRoute
   WorkspacesWidLayoutSettingsIndexRoute: typeof WorkspacesWidLayoutSettingsIndexRoute
   WorkspacesWidLayoutProjectsPidLayoutRoute: typeof WorkspacesWidLayoutProjectsPidLayoutRouteWithChildren
@@ -752,6 +794,10 @@ const WorkspacesWidLayoutRouteChildren: WorkspacesWidLayoutRouteChildren = {
     WorkspacesWidLayoutSettingsProvisionersRoute,
   WorkspacesWidLayoutSettingsRunnersRoute:
     WorkspacesWidLayoutSettingsRunnersRoute,
+  WorkspacesWidLayoutSettingsSecretsRoute:
+    WorkspacesWidLayoutSettingsSecretsRoute,
+  WorkspacesWidLayoutSettingsVariablesRoute:
+    WorkspacesWidLayoutSettingsVariablesRoute,
   WorkspacesWidLayoutIntegrationsIndexRoute:
     WorkspacesWidLayoutIntegrationsIndexRoute,
   WorkspacesWidLayoutSettingsIndexRoute: WorkspacesWidLayoutSettingsIndexRoute,

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/settings/secrets.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/settings/secrets.tsx
@@ -1,0 +1,6 @@
+import {SecretsSettingsPage} from '@shipfox/client-workspace-settings';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/settings/secrets')({
+  component: SecretsSettingsPage,
+});

--- a/libs/client/router/src/routes/workspaces/$wid/_layout/settings/variables.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout/settings/variables.tsx
@@ -1,0 +1,6 @@
+import {VariablesSettingsPage} from '@shipfox/client-workspace-settings';
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/workspaces/$wid/_layout/settings/variables')({
+  component: VariablesSettingsPage,
+});

--- a/libs/client/secrets/.storybook/main.ts
+++ b/libs/client/secrets/.storybook/main.ts
@@ -1,0 +1,1 @@
+export {default} from '../../.storybook/main.ts';

--- a/libs/client/secrets/.storybook/preview.css
+++ b/libs/client/secrets/.storybook/preview.css
@@ -1,0 +1,4 @@
+@import "@shipfox/react-ui/index.css";
+
+@source "../src";
+@source "../../../shared/react/ui/src";

--- a/libs/client/secrets/.storybook/preview.tsx
+++ b/libs/client/secrets/.storybook/preview.tsx
@@ -1,0 +1,55 @@
+import './preview.css';
+import {ThemeProvider} from '@shipfox/react-ui';
+import type {Decorator, Preview} from '@storybook/react';
+
+if (typeof document !== 'undefined' && document.fonts) {
+  void Promise.all([
+    document.fonts.load("16px 'Inter'"),
+    document.fonts.load("italic 16px 'Inter'"),
+    document.fonts.load("16px 'Commit Mono'"),
+    document.fonts.load("bold 16px 'Commit Mono'"),
+  ]);
+}
+
+const withTheme: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  return (
+    <ThemeProvider key={theme} defaultTheme={theme} storageKey={`shipfox-theme-${theme}`}>
+      <Story />
+    </ThemeProvider>
+  );
+};
+
+const preview: Preview = {
+  decorators: [withTheme],
+  parameters: {
+    argos: {
+      modes: {
+        light: {theme: 'light'},
+        dark: {theme: 'dark'},
+      },
+      fitToContent: false,
+    },
+    options: {
+      storySort: {method: 'alphabetical'},
+    },
+  },
+  globalTypes: {
+    theme: {
+      name: 'Theme',
+      description: 'Global theme for components',
+      defaultValue: 'dark',
+      toolbar: {
+        icon: 'sun',
+        items: [
+          {value: 'light', icon: 'sun', title: 'Light'},
+          {value: 'dark', icon: 'moon', title: 'Dark'},
+          {value: 'system', icon: 'info', title: 'System'},
+        ],
+        showName: true,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/libs/client/secrets/package.json
+++ b/libs/client/secrets/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@shipfox/client-workspace-settings",
+  "name": "@shipfox/client-secrets",
   "license": "MIT",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "libs/client/workspace-settings"
+    "directory": "libs/client/secrets"
   },
   "private": true,
   "type": "module",
@@ -31,20 +31,16 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "storybook": "storybook dev -p 6013",
+    "storybook:build": "storybook build -o storybook-static",
     "test": "shipfox-vitest-run",
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/api-workspaces-dto": "workspace:*",
-    "@shipfox/client-agent": "workspace:*",
+    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/client-api": "workspace:*",
-    "@shipfox/client-auth": "workspace:*",
-    "@shipfox/client-integrations": "workspace:*",
-    "@shipfox/client-runners": "workspace:*",
-    "@shipfox/client-secrets": "workspace:*",
-    "@shipfox/client-triggers": "workspace:*",
     "@shipfox/client-ui": "workspace:*",
     "@shipfox/react-ui": "workspace:*",
     "@swc/helpers": "^0.5.17",
@@ -52,26 +48,36 @@
     "@tanstack/react-query": "^5.101.0"
   },
   "peerDependencies": {
-    "@tanstack/react-router": "^1.170.16",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@argos-ci/cli": "^5.0.0",
+    "@argos-ci/storybook": "^6.0.0",
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",
     "@shipfox/vite": "workspace:*",
     "@shipfox/vitest": "workspace:*",
-    "@tanstack/react-router": "^1.170.16",
+    "@storybook/addon-vitest": "^10.3.6",
+    "@storybook/react": "^10.0.0",
+    "@storybook/react-vite": "^10.0.0",
+    "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^6.0.0",
+    "@vitest/browser-playwright": "^4.1.5",
     "jsdom": "^29.0.0",
-    "jotai": "^2.19.1",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "storybook": "^10.0.0",
+    "storybook-addon-pseudo-states": "^10.0.0",
+    "tailwindcss": "^4.1.13",
+    "vite": "^8.0.3",
+    "vitest": "^4.1.5"
   }
 }

--- a/libs/client/secrets/src/components/copy-key.test.ts
+++ b/libs/client/secrets/src/components/copy-key.test.ts
@@ -1,0 +1,44 @@
+import {toast} from '@shipfox/react-ui';
+import {copyKeyName} from './copy-key.js';
+
+vi.mock('@shipfox/react-ui', () => ({
+  toast: {success: vi.fn(), error: vi.fn()},
+}));
+
+describe('copyKeyName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('writes the bare key name to the clipboard and toasts success', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', {clipboard: {writeText}});
+
+    await copyKeyName('MY_TOKEN');
+
+    expect(writeText).toHaveBeenCalledExactlyOnceWith('MY_TOKEN');
+    expect(toast.success).toHaveBeenCalledOnce();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  test('no-ops safely and warns when the clipboard API is unavailable', async () => {
+    vi.stubGlobal('navigator', {});
+
+    await copyKeyName('MY_TOKEN');
+
+    expect(toast.error).toHaveBeenCalledOnce();
+  });
+
+  test('surfaces a toast when the clipboard write rejects', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    vi.stubGlobal('navigator', {clipboard: {writeText}});
+
+    await copyKeyName('MY_TOKEN');
+
+    expect(toast.error).toHaveBeenCalledOnce();
+  });
+});

--- a/libs/client/secrets/src/components/copy-key.test.ts
+++ b/libs/client/secrets/src/components/copy-key.test.ts
@@ -21,7 +21,7 @@ describe('copyKeyName', () => {
     await copyKeyName('MY_TOKEN');
 
     expect(writeText).toHaveBeenCalledExactlyOnceWith('MY_TOKEN');
-    expect(toast.success).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledExactlyOnceWith('Copied MY_TOKEN');
     expect(toast.error).not.toHaveBeenCalled();
   });
 

--- a/libs/client/secrets/src/components/copy-key.ts
+++ b/libs/client/secrets/src/components/copy-key.ts
@@ -1,0 +1,21 @@
+import {toast} from '@shipfox/react-ui';
+
+/**
+ * Copies a bare key name (e.g. `MY_TOKEN`) to the clipboard. Guarded because
+ * `navigator.clipboard` is undefined in insecure contexts and older browsers —
+ * a missing API or a rejected write surfaces a toast instead of an unhandled
+ * rejection.
+ */
+export async function copyKeyName(key: string): Promise<void> {
+  const clipboard = typeof navigator === 'undefined' ? undefined : navigator.clipboard;
+  if (!clipboard?.writeText) {
+    toast.error('Clipboard is not available in this browser.');
+    return;
+  }
+  try {
+    await clipboard.writeText(key);
+    toast.success(`Copied ${key}`);
+  } catch {
+    toast.error('Could not copy to the clipboard.');
+  }
+}

--- a/libs/client/secrets/src/components/delete-entry-dialog.tsx
+++ b/libs/client/secrets/src/components/delete-entry-dialog.tsx
@@ -1,0 +1,74 @@
+import {
+  Alert,
+  Button,
+  Code,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Text,
+} from '@shipfox/react-ui';
+
+export type StoreEntryKind = 'secret' | 'variable';
+
+function referenceExpression(kind: StoreEntryKind, key: string): string {
+  // Built by concatenation, not a template literal, because `${{` cannot appear
+  // inside a JS template string.
+  return kind === 'secret' ? `\${{ secrets.${key} }}` : `\${{ vars.${key} }}`;
+}
+
+export function DeleteEntryDialog({
+  open,
+  onOpenChange,
+  entryKey,
+  kind,
+  isLoading,
+  errorMessage,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  entryKey: string;
+  kind: StoreEntryKind;
+  isLoading: boolean;
+  errorMessage?: string | undefined;
+  onConfirm: () => void;
+}) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>Delete {kind}</ModalTitle>
+        </ModalHeader>
+        <ModalBody className="gap-16">
+          <Text size="sm">
+            Delete{' '}
+            <Code as="span" variant="label">
+              {entryKey}
+            </Code>
+            ? Workflows that reference{' '}
+            <Code as="span" variant="label">
+              {referenceExpression(kind, entryKey)}
+            </Code>{' '}
+            will fail at their next run.
+          </Text>
+          {errorMessage ? (
+            <Alert variant="error" animated={false}>
+              <Text size="sm">{errorMessage}</Text>
+            </Alert>
+          ) : null}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="danger" isLoading={isLoading} onClick={onConfirm}>
+            Delete
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/libs/client/secrets/src/components/form-errors.test.ts
+++ b/libs/client/secrets/src/components/form-errors.test.ts
@@ -1,0 +1,67 @@
+import {ApiError} from '@shipfox/client-api';
+import {type SecretsFormErrorMapping, secretsErrorToFormError} from './form-errors.js';
+
+function apiError(code: string, message = 'server message'): ApiError {
+  return new ApiError({code, message, status: 400});
+}
+
+describe('secretsErrorToFormError', () => {
+  test.each<[string, SecretsFormErrorMapping]>([
+    [
+      'invalid-key',
+      {
+        kind: 'field',
+        field: 'key',
+        message:
+          'Invalid name. Use uppercase letters, digits and underscores; start with a letter or underscore.',
+      },
+    ],
+    [
+      'duplicate-key',
+      {kind: 'field', field: 'key', message: 'A key with this name already exists.'},
+    ],
+    ['invalid-namespace', {kind: 'form', message: 'Invalid namespace.'}],
+    ['value-too-large', {kind: 'form', message: 'This value is too large to store.'}],
+    [
+      'workspace-secret-cap-exceeded',
+      {kind: 'form', message: 'This workspace has reached its secrets and variables limit.'},
+    ],
+    [
+      'batch-scope-mismatch',
+      {kind: 'form', message: 'All entries in a batch must share the same scope.'},
+    ],
+    ['secret-not-found', {kind: 'form', message: 'This secret no longer exists.'}],
+    ['variable-not-found', {kind: 'form', message: 'This variable no longer exists.'}],
+    ['unknown-secret-store', {kind: 'form', message: 'Unknown secret store.'}],
+    ['project-not-found', {kind: 'form', message: 'This project no longer exists.'}],
+    [
+      'forbidden',
+      {
+        kind: 'form',
+        message: 'You need the workspace admin role to manage secrets and variables.',
+      },
+    ],
+  ])('maps the %s ApiError code', (code, expected) => {
+    const result = secretsErrorToFormError(apiError(code));
+
+    expect(result).toEqual(expected);
+  });
+
+  test('falls back to the server message for an unknown ApiError code', () => {
+    const result = secretsErrorToFormError(apiError('some-new-code', 'raw server message'));
+
+    expect(result).toEqual({kind: 'form', message: 'raw server message'});
+  });
+
+  test('maps a plain Error to a form-level alert with its message', () => {
+    const result = secretsErrorToFormError(new Error('boom'));
+
+    expect(result).toEqual({kind: 'form', message: 'boom'});
+  });
+
+  test('falls back to generic copy for a non-Error throwable', () => {
+    const result = secretsErrorToFormError('weird');
+
+    expect(result).toEqual({kind: 'form', message: 'Something went wrong. Try again.'});
+  });
+});

--- a/libs/client/secrets/src/components/form-errors.ts
+++ b/libs/client/secrets/src/components/form-errors.ts
@@ -1,0 +1,59 @@
+import {ApiError} from '@shipfox/client-api';
+
+export type SecretsFormField = 'key';
+
+/**
+ * Classifies a management error into either a field-level message (routed to
+ * the `key` field via `errorMap.onServer`) or a form-level message (rendered
+ * in an `<Alert>`). Shared by the secret and variable forms because both hit
+ * the same management routes / `ClientError` codes.
+ */
+export type SecretsFormErrorMapping =
+  | {kind: 'field'; field: SecretsFormField; message: string}
+  | {kind: 'form'; message: string};
+
+export function secretsErrorToFormError(error: unknown): SecretsFormErrorMapping {
+  if (error instanceof ApiError) {
+    switch (error.code) {
+      case 'invalid-key':
+        return {
+          kind: 'field',
+          field: 'key',
+          message:
+            'Invalid name. Use uppercase letters, digits and underscores; start with a letter or underscore.',
+        };
+      case 'duplicate-key':
+        return {kind: 'field', field: 'key', message: 'A key with this name already exists.'};
+      case 'invalid-namespace':
+        return {kind: 'form', message: 'Invalid namespace.'};
+      case 'value-too-large':
+        return {kind: 'form', message: 'This value is too large to store.'};
+      case 'workspace-secret-cap-exceeded':
+        return {
+          kind: 'form',
+          message: 'This workspace has reached its secrets and variables limit.',
+        };
+      case 'batch-scope-mismatch':
+        return {kind: 'form', message: 'All entries in a batch must share the same scope.'};
+      case 'secret-not-found':
+        return {kind: 'form', message: 'This secret no longer exists.'};
+      case 'variable-not-found':
+        return {kind: 'form', message: 'This variable no longer exists.'};
+      case 'unknown-secret-store':
+        return {kind: 'form', message: 'Unknown secret store.'};
+      case 'project-not-found':
+        return {kind: 'form', message: 'This project no longer exists.'};
+      case 'forbidden':
+        return {
+          kind: 'form',
+          message: 'You need the workspace admin role to manage secrets and variables.',
+        };
+      default:
+        return {kind: 'form', message: error.message};
+    }
+  }
+  if (error instanceof Error) {
+    return {kind: 'form', message: error.message};
+  }
+  return {kind: 'form', message: 'Something went wrong. Try again.'};
+}

--- a/libs/client/secrets/src/components/form-shell.tsx
+++ b/libs/client/secrets/src/components/form-shell.tsx
@@ -1,0 +1,31 @@
+import {cn} from '@shipfox/react-ui';
+import type {ReactNode} from 'react';
+
+/**
+ * Modal-agnostic body/footer layout matching `ModalBody`/`ModalFooter` so the
+ * forms render the same inside a `ModalContent` and standalone (stories, RTL
+ * tests) without a Modal context.
+ */
+export function FormBody({children, className}: {children: ReactNode; className?: string}) {
+  return (
+    <div
+      className={cn(
+        'flex w-full flex-col items-start gap-16 bg-background-neutral-base px-24 pt-16 pb-24',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function FormFooter({children}: {children: ReactNode}) {
+  return (
+    <div className="flex w-full shrink-0 flex-col">
+      <div className="h-[1px] w-full bg-border-neutral-strong" />
+      <div className="flex w-full items-center justify-end gap-16 bg-background-neutral-base px-24 py-16">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/libs/client/secrets/src/components/secret-form.stories.tsx
+++ b/libs/client/secrets/src/components/secret-form.stories.tsx
@@ -1,0 +1,58 @@
+import {Toaster} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
+import {useMemo} from 'react';
+import {userEvent, within} from 'storybook/test';
+import {SecretForm} from './secret-form.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+function Wrapper({children}: {children: ReactNode}) {
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}, mutations: {retry: false}}}),
+    [],
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="w-[520px] overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+        {children}
+      </div>
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+const meta: Meta<typeof SecretForm> = {
+  title: 'Secrets/SecretForm',
+  component: SecretForm,
+  args: {
+    workspaceId: WORKSPACE_ID,
+    mode: 'create',
+    onSaved: () => undefined,
+    onCancel: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof SecretForm>;
+
+export const Playground: Story = {};
+
+export const Edit: Story = {
+  args: {mode: 'edit', existingKey: 'API_TOKEN'},
+};
+
+export const ShortValueWarning: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText('Value'), 'abc');
+  },
+};

--- a/libs/client/secrets/src/components/secret-form.test.tsx
+++ b/libs/client/secrets/src/components/secret-form.test.tsx
@@ -1,0 +1,37 @@
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {render, screen} from '@testing-library/react';
+import {SecretForm} from './secret-form.js';
+
+function renderEditForm() {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SecretForm
+        workspaceId="11111111-1111-4111-8111-111111111111"
+        mode="edit"
+        existingKey="API_TOKEN"
+        onSaved={() => undefined}
+        onCancel={() => undefined}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('SecretForm write-only invariant', () => {
+  test('never prefills the value when editing an existing secret', () => {
+    renderEditForm();
+
+    const value = screen.getByLabelText('Value') as HTMLTextAreaElement;
+
+    expect(value.value).toBe('');
+  });
+
+  test('locks the name and keeps it uneditable when editing', () => {
+    renderEditForm();
+
+    const name = screen.getByLabelText('Name') as HTMLInputElement;
+
+    expect(name.value).toBe('API_TOKEN');
+    expect(name).toBeDisabled();
+  });
+});

--- a/libs/client/secrets/src/components/secret-form.tsx
+++ b/libs/client/secrets/src/components/secret-form.tsx
@@ -1,0 +1,167 @@
+import {isShortSecretValue} from '@shipfox/api-secrets-dto';
+import {
+  Alert,
+  Button,
+  FormField,
+  FormFieldInput,
+  FormFieldTextarea,
+  fieldError,
+  IconButton,
+  Text,
+} from '@shipfox/react-ui';
+import {useForm} from '@tanstack/react-form';
+import {useState} from 'react';
+import {usePutSecretMutation} from '#hooks/api/secrets.js';
+import {secretsErrorToFormError} from './form-errors.js';
+import {FormBody, FormFooter} from './form-shell.js';
+import {STORE_KEY_HELP, validateStoreKey} from './store-key.js';
+
+export const SECRET_FORM_ID = 'secret-form';
+
+// Client-side mirror of the server default SECRETS_SHORT_VALUE_WARN_LENGTH. The
+// advisory is best-effort UX, so drift from a self-hosted override is cosmetic.
+const SHORT_VALUE_THRESHOLD = 12;
+
+export function SecretForm({
+  workspaceId,
+  mode,
+  existingKey,
+  onSaved,
+  onCancel,
+}: {
+  workspaceId: string;
+  mode: 'create' | 'edit';
+  existingKey?: string | undefined;
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const putSecret = usePutSecretMutation();
+  const [formError, setFormError] = useState<string | undefined>();
+  const [showValue, setShowValue] = useState(false);
+
+  const form = useForm({
+    defaultValues: {key: existingKey ?? '', value: ''},
+    onSubmit: async ({value}) => {
+      setFormError(undefined);
+      try {
+        await putSecret.mutateAsync({workspaceId, key: value.key, body: {value: value.value}});
+        onSaved();
+      } catch (error) {
+        const mapped = secretsErrorToFormError(error);
+        if (mapped.kind === 'field') {
+          form.setFieldMeta(mapped.field, (prev) => ({
+            ...prev,
+            errorMap: {...prev.errorMap, onServer: mapped.message},
+          }));
+        } else {
+          setFormError(mapped.message);
+        }
+      }
+    },
+  });
+
+  return (
+    <>
+      <FormBody>
+        <form
+          id={SECRET_FORM_ID}
+          className="flex w-full flex-col gap-16"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="key"
+            validators={{
+              onBlur: ({value}) => validateStoreKey(value),
+              onSubmit: ({value}) => validateStoreKey(value),
+            }}
+          >
+            {(field) => (
+              <FormField
+                label="Name"
+                id="secret-key"
+                description={STORE_KEY_HELP}
+                error={fieldError(field)}
+              >
+                <FormFieldInput
+                  className="font-code"
+                  autoComplete="off"
+                  spellCheck={false}
+                  disabled={mode === 'edit'}
+                  placeholder="MY_TOKEN"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value.toUpperCase())}
+                  onBlur={field.handleBlur}
+                />
+              </FormField>
+            )}
+          </form.Field>
+
+          <form.Field
+            name="value"
+            validators={{
+              onBlur: ({value}) => (value.length > 0 ? undefined : 'A value is required.'),
+              onSubmit: ({value}) => (value.length > 0 ? undefined : 'A value is required.'),
+            }}
+          >
+            {(field) => (
+              <FormField label="Value" id="secret-value" error={fieldError(field)}>
+                <div className="relative">
+                  <FormFieldTextarea
+                    className={
+                      showValue ? 'pr-32 font-code' : 'pr-32 font-code [-webkit-text-security:disc]'
+                    }
+                    autoComplete="off"
+                    spellCheck={false}
+                    rows={3}
+                    placeholder={
+                      mode === 'edit'
+                        ? 'Enter a new value to replace the current one'
+                        : 'Paste the secret value'
+                    }
+                    value={field.state.value}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    onBlur={field.handleBlur}
+                  />
+                  <IconButton
+                    type="button"
+                    variant="transparent"
+                    size="xs"
+                    className="absolute top-6 right-6"
+                    icon={showValue ? 'eyeOffLine' : 'eyeLine'}
+                    aria-label={showValue ? 'Hide value' : 'Show value'}
+                    onClick={() => setShowValue((prev) => !prev)}
+                  />
+                </div>
+                {isShortSecretValue(field.state.value, SHORT_VALUE_THRESHOLD) ? (
+                  <Alert variant="warning" animated={false}>
+                    <Text size="sm">
+                      This value is short; log redaction is weaker for very short values.
+                    </Text>
+                  </Alert>
+                ) : null}
+              </FormField>
+            )}
+          </form.Field>
+        </form>
+        {formError ? (
+          <Alert variant="error" animated={false}>
+            <Text size="sm">{formError}</Text>
+          </Alert>
+        ) : null}
+      </FormBody>
+      <FormFooter>
+        <Button variant="secondary" type="button" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" form={SECRET_FORM_ID} isLoading={putSecret.isPending}>
+          {mode === 'edit' ? 'Update secret' : 'Add secret'}
+        </Button>
+      </FormFooter>
+    </>
+  );
+}

--- a/libs/client/secrets/src/components/secret-form.tsx
+++ b/libs/client/secrets/src/components/secret-form.tsx
@@ -14,7 +14,7 @@ import {useState} from 'react';
 import {usePutSecretMutation} from '#hooks/api/secrets.js';
 import {secretsErrorToFormError} from './form-errors.js';
 import {FormBody, FormFooter} from './form-shell.js';
-import {STORE_KEY_HELP, validateStoreKey} from './store-key.js';
+import {STORE_KEY_HELP, validateNewStoreKey} from './store-key.js';
 
 export const SECRET_FORM_ID = 'secret-form';
 
@@ -26,12 +26,14 @@ export function SecretForm({
   workspaceId,
   mode,
   existingKey,
+  reservedKeys = [],
   onSaved,
   onCancel,
 }: {
   workspaceId: string;
   mode: 'create' | 'edit';
   existingKey?: string | undefined;
+  reservedKeys?: readonly string[] | undefined;
   onSaved: () => void;
   onCancel: () => void;
 }) {
@@ -76,8 +78,9 @@ export function SecretForm({
           <form.Field
             name="key"
             validators={{
-              onBlur: ({value}) => validateStoreKey(value),
-              onSubmit: ({value}) => validateStoreKey(value),
+              onBlur: ({value}) => validateNewStoreKey(value, {mode, reservedKeys, kind: 'secret'}),
+              onSubmit: ({value}) =>
+                validateNewStoreKey(value, {mode, reservedKeys, kind: 'secret'}),
             }}
           >
             {(field) => (

--- a/libs/client/secrets/src/components/store-key.test.ts
+++ b/libs/client/secrets/src/components/store-key.test.ts
@@ -1,0 +1,53 @@
+import {STORE_KEY_HELP, validateNewStoreKey, validateStoreKey} from './store-key.js';
+
+describe('validateStoreKey', () => {
+  test('accepts a valid uppercase identifier', () => {
+    expect(validateStoreKey('MY_TOKEN')).toBeUndefined();
+  });
+
+  test('rejects a malformed key', () => {
+    expect(validateStoreKey('my token')).toBe(STORE_KEY_HELP);
+  });
+});
+
+describe('validateNewStoreKey', () => {
+  test('blocks a create that collides with an existing key', () => {
+    const error = validateNewStoreKey('API_TOKEN', {
+      mode: 'create',
+      reservedKeys: ['API_TOKEN', 'DATABASE_URL'],
+      kind: 'secret',
+    });
+
+    expect(error).toBe('A secret with this name already exists. Edit it instead.');
+  });
+
+  test('allows a create with a fresh key', () => {
+    const error = validateNewStoreKey('NEW_KEY', {
+      mode: 'create',
+      reservedKeys: ['API_TOKEN'],
+      kind: 'secret',
+    });
+
+    expect(error).toBeUndefined();
+  });
+
+  test('does not treat the locked key as a collision in edit mode', () => {
+    const error = validateNewStoreKey('LOG_LEVEL', {
+      mode: 'edit',
+      reservedKeys: ['LOG_LEVEL'],
+      kind: 'variable',
+    });
+
+    expect(error).toBeUndefined();
+  });
+
+  test('enforces the format before the collision check', () => {
+    const error = validateNewStoreKey('bad key', {
+      mode: 'create',
+      reservedKeys: [],
+      kind: 'secret',
+    });
+
+    expect(error).toBe(STORE_KEY_HELP);
+  });
+});

--- a/libs/client/secrets/src/components/store-key.ts
+++ b/libs/client/secrets/src/components/store-key.ts
@@ -1,0 +1,13 @@
+import {secretKeySchema} from '@shipfox/api-secrets-dto';
+
+export const STORE_KEY_HELP =
+  'Uppercase letters, digits and underscores; must start with a letter or underscore.';
+
+/**
+ * Validates a store key against the shared `secretKeySchema` and returns a
+ * human-readable message (not Zod's default) when it fails. The name input is
+ * also auto-uppercased at the call site, so the common case never trips this.
+ */
+export function validateStoreKey(value: string): string | undefined {
+  return secretKeySchema.safeParse(value).success ? undefined : STORE_KEY_HELP;
+}

--- a/libs/client/secrets/src/components/store-key.ts
+++ b/libs/client/secrets/src/components/store-key.ts
@@ -11,3 +11,26 @@ export const STORE_KEY_HELP =
 export function validateStoreKey(value: string): string | undefined {
   return secretKeySchema.safeParse(value).success ? undefined : STORE_KEY_HELP;
 }
+
+/**
+ * Format validation plus a create-mode collision guard. `PUT /:key` is an
+ * upsert and single writes never return a duplicate-key error, so without this
+ * a create with an existing name would silently overwrite the current value —
+ * unrecoverable for write-only secrets. Edit mode locks the key, so it skips
+ * the collision check.
+ */
+export function validateNewStoreKey(
+  value: string,
+  {
+    mode,
+    reservedKeys,
+    kind,
+  }: {mode: 'create' | 'edit'; reservedKeys: readonly string[]; kind: 'secret' | 'variable'},
+): string | undefined {
+  const formatError = validateStoreKey(value);
+  if (formatError) return formatError;
+  if (mode === 'create' && reservedKeys.includes(value)) {
+    return `A ${kind} with this name already exists. Edit it instead.`;
+  }
+  return undefined;
+}

--- a/libs/client/secrets/src/components/store-section-shell.tsx
+++ b/libs/client/secrets/src/components/store-section-shell.tsx
@@ -1,0 +1,31 @@
+import {cn, Skeleton} from '@shipfox/react-ui';
+
+export const STORE_SURFACE_CLASS =
+  'overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base';
+
+/** Placeholder rows shown while the store list loads. */
+export function StoreRowsSkeleton({label}: {label: string}) {
+  return (
+    <div role="status" aria-label={label} className={STORE_SURFACE_CLASS}>
+      <ul className="divide-y divide-border-neutral-base">
+        {[0, 1, 2].map((row) => (
+          <li key={row} className="flex items-center gap-12 px-16 py-12">
+            <Skeleton className="h-16 w-140" />
+            <Skeleton className="h-16 w-96" />
+            <Skeleton className="ml-auto h-14 w-80 shrink-0" />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function StoreSurface({
+  className,
+  children,
+}: {
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return <div className={cn(STORE_SURFACE_CLASS, className)}>{children}</div>;
+}

--- a/libs/client/secrets/src/components/variable-form.stories.tsx
+++ b/libs/client/secrets/src/components/variable-form.stories.tsx
@@ -1,0 +1,58 @@
+import {Toaster} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
+import {useMemo} from 'react';
+import {userEvent, within} from 'storybook/test';
+import {VariableForm} from './variable-form.js';
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+function Wrapper({children}: {children: ReactNode}) {
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}, mutations: {retry: false}}}),
+    [],
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="w-[520px] overflow-hidden rounded-8 border border-border-neutral-base bg-background-neutral-base">
+        {children}
+      </div>
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+const meta: Meta<typeof VariableForm> = {
+  title: 'Secrets/VariableForm',
+  component: VariableForm,
+  args: {
+    workspaceId: WORKSPACE_ID,
+    mode: 'create',
+    onSaved: () => undefined,
+    onCancel: () => undefined,
+  },
+  decorators: [
+    (Story) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof VariableForm>;
+
+export const Playground: Story = {};
+
+export const Edit: Story = {
+  args: {mode: 'edit', existingKey: 'LOG_LEVEL', existingValue: 'debug'},
+};
+
+export const SensitiveNameWarning: Story = {
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText('Name'), 'MY_TOKEN');
+  },
+};

--- a/libs/client/secrets/src/components/variable-form.test.tsx
+++ b/libs/client/secrets/src/components/variable-form.test.tsx
@@ -1,0 +1,60 @@
+import {configureApiClient} from '@shipfox/client-api';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {render, screen, waitFor} from '@testing-library/react';
+import {variable} from '#test/fixtures/secrets.js';
+import {VariableForm} from './variable-form.js';
+
+const FULL_VALUE_ERROR = /Could not load the current value/;
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+function renderTruncatedEdit(fetchImpl: typeof fetch) {
+  configureApiClient({baseUrl: 'https://api.example.test', fetchImpl});
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <VariableForm
+        workspaceId="11111111-1111-4111-8111-111111111111"
+        mode="edit"
+        existingKey="TLS_CERT"
+        existingValue="-----BEGIN CERTIFICATE-----"
+        existingValueTruncated
+        onSaved={() => undefined}
+        onCancel={() => undefined}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('VariableForm truncated edit', () => {
+  test('loads the full value and enables the update button', async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(
+        jsonResponse({variable: variable({value: 'full-certificate-body'})}),
+      )) as unknown as typeof fetch;
+
+    renderTruncatedEdit(fetchImpl);
+
+    const value = (await screen.findByLabelText('Value')) as HTMLTextAreaElement;
+    await waitFor(() => expect(value.value).toBe('full-certificate-body'));
+    expect(screen.getByRole('button', {name: 'Update variable'})).toBeEnabled();
+  });
+
+  test('keeps the update button disabled and surfaces an error when the full value fails to load', async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(
+        jsonResponse({code: 'server-error', message: 'boom'}, {status: 500}),
+      )) as unknown as typeof fetch;
+
+    renderTruncatedEdit(fetchImpl);
+
+    await screen.findByText(FULL_VALUE_ERROR);
+    expect(screen.getByRole('button', {name: 'Update variable'})).toBeDisabled();
+  });
+});

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -1,0 +1,141 @@
+import {isSensitiveSecretName} from '@shipfox/api-secrets-dto';
+import {
+  Alert,
+  Button,
+  FormField,
+  FormFieldInput,
+  FormFieldTextarea,
+  fieldError,
+  Text,
+} from '@shipfox/react-ui';
+import {useForm} from '@tanstack/react-form';
+import {useState} from 'react';
+import {usePutVariableMutation} from '#hooks/api/variables.js';
+import {secretsErrorToFormError} from './form-errors.js';
+import {FormBody, FormFooter} from './form-shell.js';
+import {STORE_KEY_HELP, validateStoreKey} from './store-key.js';
+
+export const VARIABLE_FORM_ID = 'variable-form';
+
+export function VariableForm({
+  workspaceId,
+  mode,
+  existingKey,
+  existingValue,
+  onSaved,
+  onCancel,
+}: {
+  workspaceId: string;
+  mode: 'create' | 'edit';
+  existingKey?: string | undefined;
+  existingValue?: string | undefined;
+  onSaved: () => void;
+  onCancel: () => void;
+}) {
+  const putVariable = usePutVariableMutation();
+  const [formError, setFormError] = useState<string | undefined>();
+
+  const form = useForm({
+    defaultValues: {key: existingKey ?? '', value: existingValue ?? ''},
+    onSubmit: async ({value}) => {
+      setFormError(undefined);
+      try {
+        await putVariable.mutateAsync({workspaceId, key: value.key, body: {value: value.value}});
+        onSaved();
+      } catch (error) {
+        const mapped = secretsErrorToFormError(error);
+        if (mapped.kind === 'field') {
+          form.setFieldMeta(mapped.field, (prev) => ({
+            ...prev,
+            errorMap: {...prev.errorMap, onServer: mapped.message},
+          }));
+        } else {
+          setFormError(mapped.message);
+        }
+      }
+    },
+  });
+
+  return (
+    <>
+      <FormBody>
+        <form
+          id={VARIABLE_FORM_ID}
+          className="flex w-full flex-col gap-16"
+          noValidate
+          onSubmit={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            void form.handleSubmit();
+          }}
+        >
+          <form.Field
+            name="key"
+            validators={{
+              onBlur: ({value}) => validateStoreKey(value),
+              onSubmit: ({value}) => validateStoreKey(value),
+            }}
+          >
+            {(field) => (
+              <FormField
+                label="Name"
+                id="variable-key"
+                description={STORE_KEY_HELP}
+                error={fieldError(field)}
+              >
+                <FormFieldInput
+                  className="font-code"
+                  autoComplete="off"
+                  spellCheck={false}
+                  disabled={mode === 'edit'}
+                  placeholder="LOG_LEVEL"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value.toUpperCase())}
+                  onBlur={field.handleBlur}
+                />
+                {isSensitiveSecretName(field.state.value) ? (
+                  <Alert variant="warning" animated={false}>
+                    <Text size="sm" aria-live="polite">
+                      Variables are stored in plaintext and are not redacted from logs. Store this
+                      as a Secret instead.
+                    </Text>
+                  </Alert>
+                ) : null}
+              </FormField>
+            )}
+          </form.Field>
+
+          <form.Field name="value">
+            {(field) => (
+              <FormField label="Value" id="variable-value" error={fieldError(field)}>
+                <FormFieldTextarea
+                  className="font-code"
+                  autoComplete="off"
+                  spellCheck={false}
+                  rows={3}
+                  placeholder="debug"
+                  value={field.state.value}
+                  onChange={(event) => field.handleChange(event.target.value)}
+                  onBlur={field.handleBlur}
+                />
+              </FormField>
+            )}
+          </form.Field>
+        </form>
+        {formError ? (
+          <Alert variant="error" animated={false}>
+            <Text size="sm">{formError}</Text>
+          </Alert>
+        ) : null}
+      </FormBody>
+      <FormFooter>
+        <Button variant="secondary" type="button" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" form={VARIABLE_FORM_ID} isLoading={putVariable.isPending}>
+          {mode === 'edit' ? 'Update variable' : 'Add variable'}
+        </Button>
+      </FormFooter>
+    </>
+  );
+}

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -73,6 +73,10 @@ export function VariableForm({
     }
   }, [needsFullValue, fullValueQuery.data, form]);
 
+  // The full value must be loaded before a save is allowed, otherwise submitting would
+  // overwrite the stored value with the truncated preview. Block until it arrives —
+  // whether the fetch is still pending or has failed.
+  const awaitingFullValue = needsFullValue && fullValueQuery.data === undefined;
   const loadingFullValue = needsFullValue && fullValueQuery.isPending;
 
   return (
@@ -139,7 +143,7 @@ export function VariableForm({
                   autoComplete="off"
                   spellCheck={false}
                   rows={3}
-                  disabled={loadingFullValue}
+                  disabled={awaitingFullValue}
                   placeholder="debug"
                   value={field.state.value}
                   onChange={(event) => field.handleChange(event.target.value)}
@@ -149,7 +153,7 @@ export function VariableForm({
             )}
           </form.Field>
         </form>
-        {needsFullValue && fullValueQuery.isError ? (
+        {awaitingFullValue && fullValueQuery.isError ? (
           <Alert variant="error" animated={false}>
             <Text size="sm">Could not load the current value. Close and try again.</Text>
           </Alert>
@@ -168,7 +172,7 @@ export function VariableForm({
           type="submit"
           form={VARIABLE_FORM_ID}
           isLoading={putVariable.isPending}
-          disabled={loadingFullValue}
+          disabled={awaitingFullValue}
         >
           {mode === 'edit' ? 'Update variable' : 'Add variable'}
         </Button>

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -9,11 +9,11 @@ import {
   Text,
 } from '@shipfox/react-ui';
 import {useForm} from '@tanstack/react-form';
-import {useState} from 'react';
-import {usePutVariableMutation} from '#hooks/api/variables.js';
+import {useEffect, useRef, useState} from 'react';
+import {usePutVariableMutation, useVariableQuery} from '#hooks/api/variables.js';
 import {secretsErrorToFormError} from './form-errors.js';
 import {FormBody, FormFooter} from './form-shell.js';
-import {STORE_KEY_HELP, validateStoreKey} from './store-key.js';
+import {STORE_KEY_HELP, validateNewStoreKey} from './store-key.js';
 
 export const VARIABLE_FORM_ID = 'variable-form';
 
@@ -22,6 +22,8 @@ export function VariableForm({
   mode,
   existingKey,
   existingValue,
+  existingValueTruncated = false,
+  reservedKeys = [],
   onSaved,
   onCancel,
 }: {
@@ -29,11 +31,18 @@ export function VariableForm({
   mode: 'create' | 'edit';
   existingKey?: string | undefined;
   existingValue?: string | undefined;
+  existingValueTruncated?: boolean | undefined;
+  reservedKeys?: readonly string[] | undefined;
   onSaved: () => void;
   onCancel: () => void;
 }) {
   const putVariable = usePutVariableMutation();
   const [formError, setFormError] = useState<string | undefined>();
+
+  // The list value is only a preview, so a truncated variable must load its full
+  // value before editing to avoid saving the truncated preview back.
+  const needsFullValue = mode === 'edit' && existingValueTruncated;
+  const fullValueQuery = useVariableQuery(workspaceId, needsFullValue ? existingKey : undefined);
 
   const form = useForm({
     defaultValues: {key: existingKey ?? '', value: existingValue ?? ''},
@@ -56,6 +65,16 @@ export function VariableForm({
     },
   });
 
+  const populatedRef = useRef(false);
+  useEffect(() => {
+    if (needsFullValue && fullValueQuery.data && !populatedRef.current) {
+      populatedRef.current = true;
+      form.setFieldValue('value', fullValueQuery.data.value);
+    }
+  }, [needsFullValue, fullValueQuery.data, form]);
+
+  const loadingFullValue = needsFullValue && fullValueQuery.isPending;
+
   return (
     <>
       <FormBody>
@@ -72,8 +91,10 @@ export function VariableForm({
           <form.Field
             name="key"
             validators={{
-              onBlur: ({value}) => validateStoreKey(value),
-              onSubmit: ({value}) => validateStoreKey(value),
+              onBlur: ({value}) =>
+                validateNewStoreKey(value, {mode, reservedKeys, kind: 'variable'}),
+              onSubmit: ({value}) =>
+                validateNewStoreKey(value, {mode, reservedKeys, kind: 'variable'}),
             }}
           >
             {(field) => (
@@ -107,12 +128,18 @@ export function VariableForm({
 
           <form.Field name="value">
             {(field) => (
-              <FormField label="Value" id="variable-value" error={fieldError(field)}>
+              <FormField
+                label="Value"
+                id="variable-value"
+                error={fieldError(field)}
+                description={loadingFullValue ? 'Loading the current value…' : undefined}
+              >
                 <FormFieldTextarea
                   className="font-code"
                   autoComplete="off"
                   spellCheck={false}
                   rows={3}
+                  disabled={loadingFullValue}
                   placeholder="debug"
                   value={field.state.value}
                   onChange={(event) => field.handleChange(event.target.value)}
@@ -122,6 +149,11 @@ export function VariableForm({
             )}
           </form.Field>
         </form>
+        {needsFullValue && fullValueQuery.isError ? (
+          <Alert variant="error" animated={false}>
+            <Text size="sm">Could not load the current value. Close and try again.</Text>
+          </Alert>
+        ) : null}
         {formError ? (
           <Alert variant="error" animated={false}>
             <Text size="sm">{formError}</Text>
@@ -132,7 +164,12 @@ export function VariableForm({
         <Button variant="secondary" type="button" onClick={onCancel}>
           Cancel
         </Button>
-        <Button type="submit" form={VARIABLE_FORM_ID} isLoading={putVariable.isPending}>
+        <Button
+          type="submit"
+          form={VARIABLE_FORM_ID}
+          isLoading={putVariable.isPending}
+          disabled={loadingFullValue}
+        >
           {mode === 'edit' ? 'Update variable' : 'Add variable'}
         </Button>
       </FormFooter>

--- a/libs/client/secrets/src/components/workspace-secrets-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.stories.tsx
@@ -1,15 +1,26 @@
 import type {SecretDto} from '@shipfox/api-secrets-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui';
-import type {Meta, StoryObj} from '@storybook/react';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {within} from 'storybook/test';
 import {WorkspaceSecretsSection} from './workspace-secrets-section.js';
 
-// Freeze the clock so RelativeTime renders a stable string in argos snapshots.
+// Freeze the clock only while a story is mounted so RelativeTime renders a stable
+// string in argos snapshots, without leaking the override to other stories.
 const FROZEN_NOW = Date.parse('2026-07-02T00:00:00.000Z');
-Date.now = () => FROZEN_NOW;
+const realDateNow = Date.now;
+const withFrozenClock: Decorator = (Story) => {
+  Date.now = () => FROZEN_NOW;
+  useEffect(
+    () => () => {
+      Date.now = realDateNow;
+    },
+    [],
+  );
+  return <Story />;
+};
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const EDITOR_ID = '22222222-2222-4222-8222-222222222222';
@@ -82,6 +93,7 @@ function SectionStory({scenario}: {scenario: Scenario}) {
 const meta: Meta<typeof SectionStory> = {
   title: 'Secrets/WorkspaceSecretsSection',
   component: SectionStory,
+  decorators: [withFrozenClock],
 };
 export default meta;
 

--- a/libs/client/secrets/src/components/workspace-secrets-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.stories.tsx
@@ -1,0 +1,113 @@
+import type {SecretDto} from '@shipfox/api-secrets-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import {within} from 'storybook/test';
+import {WorkspaceSecretsSection} from './workspace-secrets-section.js';
+
+// Freeze the clock so RelativeTime renders a stable string in argos snapshots.
+const FROZEN_NOW = Date.parse('2026-07-02T00:00:00.000Z');
+Date.now = () => FROZEN_NOW;
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const EDITOR_ID = '22222222-2222-4222-8222-222222222222';
+
+const SECRETS: SecretDto[] = [
+  {
+    key: 'API_TOKEN',
+    project_id: null,
+    created_at: '2026-05-01T10:00:00.000Z',
+    updated_at: '2026-06-30T12:00:00.000Z',
+    last_edited_by: EDITOR_ID,
+  },
+  {
+    key: 'DATABASE_URL',
+    project_id: null,
+    created_at: '2026-04-01T10:00:00.000Z',
+    updated_at: '2026-06-25T12:00:00.000Z',
+    last_edited_by: EDITOR_ID,
+  },
+  {
+    key: 'STRIPE_SECRET_KEY',
+    project_id: null,
+    created_at: '2026-03-01T10:00:00.000Z',
+    updated_at: '2026-06-20T12:00:00.000Z',
+    last_edited_by: null,
+  },
+];
+
+type Scenario = 'loaded' | 'empty' | 'loading' | 'error';
+
+const RETRY_BUTTON = /retry/i;
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return (() => {
+    if (scenario === 'loading') return new Promise<Response>(() => undefined);
+    if (scenario === 'error') {
+      return Promise.resolve(
+        new Response(JSON.stringify({code: 'server-error', message: 'Something failed'}), {
+          status: 500,
+          headers: {'content-type': 'application/json'},
+        }),
+      );
+    }
+    const secrets = scenario === 'empty' ? [] : SECRETS;
+    return Promise.resolve(
+      new Response(JSON.stringify({secrets, next_cursor: null}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      }),
+    );
+  }) as unknown as typeof fetch;
+}
+
+function SectionStory({scenario}: {scenario: Scenario}) {
+  configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: fetchForScenario(scenario)});
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="w-[720px] p-24">
+        <WorkspaceSecretsSection workspaceId={WORKSPACE_ID} />
+      </div>
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+const meta: Meta<typeof SectionStory> = {
+  title: 'Secrets/WorkspaceSecretsSection',
+  component: SectionStory,
+};
+export default meta;
+
+type Story = StoryObj<typeof SectionStory>;
+
+export const Loaded: Story = {
+  args: {scenario: 'loaded'},
+  play: async ({canvasElement}) => {
+    await within(canvasElement).findByText('API_TOKEN');
+  },
+};
+
+export const Empty: Story = {
+  args: {scenario: 'empty'},
+  play: async ({canvasElement}) => {
+    await within(canvasElement).findByText('No secrets yet');
+  },
+};
+
+export const Loading: Story = {
+  args: {scenario: 'loading'},
+};
+
+export const LoadError: Story = {
+  args: {scenario: 'error'},
+  play: async ({canvasElement}) => {
+    await within(canvasElement).findByRole('button', {name: RETRY_BUTTON});
+  },
+};

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -1,0 +1,232 @@
+import type {SecretDto} from '@shipfox/api-secrets-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {
+  Button,
+  Code,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyState,
+  Header,
+  IconButton,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  RelativeTime,
+  RelativeTimeProvider,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+  toast,
+} from '@shipfox/react-ui';
+import {useMemo, useState} from 'react';
+import {useDeleteSecretMutation, useSecretsQuery} from '#hooks/api/secrets.js';
+import {copyKeyName} from './copy-key.js';
+import {DeleteEntryDialog} from './delete-entry-dialog.js';
+import {secretsErrorToFormError} from './form-errors.js';
+import {SecretForm} from './secret-form.js';
+import {StoreRowsSkeleton, StoreSurface} from './store-section-shell.js';
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${{ secrets.NAME }} reference syntax is shown to users.
+const SECRET_REFERENCE = '${{ secrets.NAME }}';
+
+type FormState = {mode: 'create'} | {mode: 'edit'; key: string} | null;
+
+export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
+  const secretsQuery = useSecretsQuery(workspaceId);
+  const deleteSecret = useDeleteSecretMutation();
+  const [formState, setFormState] = useState<FormState>(null);
+  const [deleteKey, setDeleteKey] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
+
+  const secrets = useMemo(
+    () => [...(secretsQuery.data ?? [])].sort((a, b) => a.key.localeCompare(b.key)),
+    [secretsQuery.data],
+  );
+
+  function closeDelete() {
+    setDeleteKey(null);
+    setDeleteError(undefined);
+  }
+
+  return (
+    <RelativeTimeProvider>
+      <section className="flex flex-col gap-16" aria-label="Secrets">
+        <div className="flex items-start justify-between gap-16">
+          <div className="flex flex-col gap-4">
+            <Header variant="h3">Secrets</Header>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Encrypted, write-only values. Reference them from workflows as{' '}
+              <Code as="span" variant="label">
+                {SECRET_REFERENCE}
+              </Code>
+              .
+            </Text>
+          </div>
+          <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
+            Add secret
+          </Button>
+        </div>
+
+        {secretsQuery.isPending ? <StoreRowsSkeleton label="Loading secrets" /> : null}
+
+        {secretsQuery.isError && secretsQuery.data === undefined ? (
+          <StoreSurface className="px-16">
+            <QueryLoadError query={secretsQuery} subject="secrets" />
+          </StoreSurface>
+        ) : null}
+
+        {secretsQuery.data !== undefined && secrets.length === 0 ? (
+          <StoreSurface className="px-16">
+            <EmptyState
+              icon="keyLine"
+              title="No secrets yet"
+              description={`Secrets are encrypted and write-only. Reference them from workflows as ${SECRET_REFERENCE}.`}
+              action={
+                <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
+                  Add secret
+                </Button>
+              }
+            />
+          </StoreSurface>
+        ) : null}
+
+        {secrets.length > 0 ? (
+          <StoreSurface>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead>Last edited</TableHead>
+                  <TableHead className="w-40 text-right">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {secrets.map((secret) => (
+                  <SecretRow
+                    key={secret.key}
+                    secret={secret}
+                    onEdit={() => setFormState({mode: 'edit', key: secret.key})}
+                    onDelete={() => setDeleteKey(secret.key)}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </StoreSurface>
+        ) : null}
+      </section>
+
+      <Modal
+        open={formState !== null}
+        onOpenChange={(open) => {
+          if (!open) setFormState(null);
+        }}
+      >
+        <ModalContent>
+          <ModalHeader>
+            <ModalTitle>{formState?.mode === 'edit' ? 'Update secret' : 'Add secret'}</ModalTitle>
+          </ModalHeader>
+          {formState ? (
+            <SecretForm
+              workspaceId={workspaceId}
+              mode={formState.mode}
+              existingKey={formState.mode === 'edit' ? formState.key : undefined}
+              onSaved={() => {
+                const wasEdit = formState.mode === 'edit';
+                setFormState(null);
+                toast.success(wasEdit ? 'Secret updated' : 'Secret added');
+              }}
+              onCancel={() => setFormState(null)}
+            />
+          ) : null}
+        </ModalContent>
+      </Modal>
+
+      <DeleteEntryDialog
+        open={deleteKey !== null}
+        onOpenChange={(open) => {
+          if (!open) closeDelete();
+        }}
+        entryKey={deleteKey ?? ''}
+        kind="secret"
+        isLoading={deleteSecret.isPending}
+        errorMessage={deleteError}
+        onConfirm={async () => {
+          if (deleteKey === null) return;
+          setDeleteError(undefined);
+          try {
+            await deleteSecret.mutateAsync({workspaceId, key: deleteKey});
+            toast.success('Secret deleted');
+            closeDelete();
+          } catch (error) {
+            setDeleteError(secretsErrorToFormError(error).message);
+          }
+        }}
+      />
+    </RelativeTimeProvider>
+  );
+}
+
+function SecretRow({
+  secret,
+  onEdit,
+  onDelete,
+}: {
+  secret: SecretDto;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <TableRow>
+      <TableCell>
+        <Code as="span" variant="paragraph">
+          {secret.key}
+        </Code>
+      </TableCell>
+      <TableCell>
+        <span
+          role="img"
+          aria-label="Value hidden"
+          className="font-code text-foreground-neutral-muted"
+        >
+          ••••••••
+        </span>
+      </TableCell>
+      <TableCell className="text-foreground-neutral-muted">
+        <RelativeTime value={secret.updated_at} />
+      </TableCell>
+      <TableCell className="text-right">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Actions for ${secret.key}`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem icon="fileCopyLine" onSelect={() => void copyKeyName(secret.key)}>
+              Copy name
+            </DropdownMenuItem>
+            <DropdownMenuItem icon="editLine" onSelect={onEdit}>
+              Edit value
+            </DropdownMenuItem>
+            <DropdownMenuItem icon="deleteBinLine" onSelect={onDelete}>
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -140,6 +140,7 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
               workspaceId={workspaceId}
               mode={formState.mode}
               existingKey={formState.mode === 'edit' ? formState.key : undefined}
+              reservedKeys={secrets.map((secret) => secret.key)}
               onSaved={() => {
                 const wasEdit = formState.mode === 'edit';
                 setFormState(null);

--- a/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
@@ -1,0 +1,94 @@
+import type {VariableDto} from '@shipfox/api-secrets-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {Toaster} from '@shipfox/react-ui';
+import type {Meta, StoryObj} from '@storybook/react';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {useMemo} from 'react';
+import {within} from 'storybook/test';
+import {WorkspaceVariablesSection} from './workspace-variables-section.js';
+
+// Freeze the clock so RelativeTime renders a stable string in argos snapshots.
+const FROZEN_NOW = Date.parse('2026-07-02T00:00:00.000Z');
+Date.now = () => FROZEN_NOW;
+
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+const EDITOR_ID = '22222222-2222-4222-8222-222222222222';
+
+const VARIABLES: VariableDto[] = [
+  {
+    key: 'LOG_LEVEL',
+    value: 'debug',
+    project_id: null,
+    created_at: '2026-05-01T10:00:00.000Z',
+    updated_at: '2026-06-30T12:00:00.000Z',
+    last_edited_by: EDITOR_ID,
+  },
+  {
+    key: 'FEATURE_FLAG',
+    value: '',
+    project_id: null,
+    created_at: '2026-04-01T10:00:00.000Z',
+    updated_at: '2026-06-25T12:00:00.000Z',
+    last_edited_by: EDITOR_ID,
+  },
+  {
+    key: 'REGION',
+    value: 'eu-west-1',
+    project_id: null,
+    created_at: '2026-03-01T10:00:00.000Z',
+    updated_at: '2026-06-20T12:00:00.000Z',
+    last_edited_by: null,
+  },
+];
+
+type Scenario = 'loaded' | 'empty';
+
+function fetchForScenario(scenario: Scenario): typeof fetch {
+  return (() => {
+    const variables = scenario === 'empty' ? [] : VARIABLES;
+    return Promise.resolve(
+      new Response(JSON.stringify({variables, next_cursor: null}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      }),
+    );
+  }) as unknown as typeof fetch;
+}
+
+function SectionStory({scenario}: {scenario: Scenario}) {
+  configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: fetchForScenario(scenario)});
+  const queryClient = useMemo(
+    () => new QueryClient({defaultOptions: {queries: {retry: false}}}),
+    [],
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div className="w-[720px] p-24">
+        <WorkspaceVariablesSection workspaceId={WORKSPACE_ID} />
+      </div>
+      <Toaster />
+    </QueryClientProvider>
+  );
+}
+
+const meta: Meta<typeof SectionStory> = {
+  title: 'Secrets/WorkspaceVariablesSection',
+  component: SectionStory,
+};
+export default meta;
+
+type Story = StoryObj<typeof SectionStory>;
+
+export const Loaded: Story = {
+  args: {scenario: 'loaded'},
+  play: async ({canvasElement}) => {
+    await within(canvasElement).findByText('LOG_LEVEL');
+  },
+};
+
+export const Empty: Story = {
+  args: {scenario: 'empty'},
+  play: async ({canvasElement}) => {
+    await within(canvasElement).findByText('No variables yet');
+  },
+};

--- a/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
@@ -1,4 +1,4 @@
-import type {VariableDto} from '@shipfox/api-secrets-dto';
+import type {VariableListItemDto} from '@shipfox/api-secrets-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui';
 import type {Meta, StoryObj} from '@storybook/react';
@@ -14,10 +14,11 @@ Date.now = () => FROZEN_NOW;
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const EDITOR_ID = '22222222-2222-4222-8222-222222222222';
 
-const VARIABLES: VariableDto[] = [
+const VARIABLES: VariableListItemDto[] = [
   {
     key: 'LOG_LEVEL',
     value: 'debug',
+    value_truncated: false,
     project_id: null,
     created_at: '2026-05-01T10:00:00.000Z',
     updated_at: '2026-06-30T12:00:00.000Z',
@@ -26,14 +27,25 @@ const VARIABLES: VariableDto[] = [
   {
     key: 'FEATURE_FLAG',
     value: '',
+    value_truncated: false,
     project_id: null,
     created_at: '2026-04-01T10:00:00.000Z',
     updated_at: '2026-06-25T12:00:00.000Z',
     last_edited_by: EDITOR_ID,
   },
   {
+    key: 'TLS_CERT',
+    value: '-----BEGIN CERTIFICATE-----',
+    value_truncated: true,
+    project_id: null,
+    created_at: '2026-03-15T10:00:00.000Z',
+    updated_at: '2026-06-22T12:00:00.000Z',
+    last_edited_by: EDITOR_ID,
+  },
+  {
     key: 'REGION',
     value: 'eu-west-1',
+    value_truncated: false,
     project_id: null,
     created_at: '2026-03-01T10:00:00.000Z',
     updated_at: '2026-06-20T12:00:00.000Z',

--- a/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
@@ -1,15 +1,26 @@
 import type {VariableListItemDto} from '@shipfox/api-secrets-dto';
 import {configureApiClient} from '@shipfox/client-api';
 import {Toaster} from '@shipfox/react-ui';
-import type {Meta, StoryObj} from '@storybook/react';
+import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {useMemo} from 'react';
+import {useEffect, useMemo} from 'react';
 import {within} from 'storybook/test';
 import {WorkspaceVariablesSection} from './workspace-variables-section.js';
 
-// Freeze the clock so RelativeTime renders a stable string in argos snapshots.
+// Freeze the clock only while a story is mounted so RelativeTime renders a stable
+// string in argos snapshots, without leaking the override to other stories.
 const FROZEN_NOW = Date.parse('2026-07-02T00:00:00.000Z');
-Date.now = () => FROZEN_NOW;
+const realDateNow = Date.now;
+const withFrozenClock: Decorator = (Story) => {
+  Date.now = () => FROZEN_NOW;
+  useEffect(
+    () => () => {
+      Date.now = realDateNow;
+    },
+    [],
+  );
+  return <Story />;
+};
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const EDITOR_ID = '22222222-2222-4222-8222-222222222222';
@@ -86,6 +97,7 @@ function SectionStory({scenario}: {scenario: Scenario}) {
 const meta: Meta<typeof SectionStory> = {
   title: 'Secrets/WorkspaceVariablesSection',
   component: SectionStory,
+  decorators: [withFrozenClock],
 };
 export default meta;
 

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -1,0 +1,239 @@
+import type {VariableDto} from '@shipfox/api-secrets-dto';
+import {QueryLoadError} from '@shipfox/client-ui';
+import {
+  Button,
+  Code,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyState,
+  Header,
+  IconButton,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  RelativeTime,
+  RelativeTimeProvider,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+  toast,
+} from '@shipfox/react-ui';
+import {useMemo, useState} from 'react';
+import {useDeleteVariableMutation, useVariablesQuery} from '#hooks/api/variables.js';
+import {copyKeyName} from './copy-key.js';
+import {DeleteEntryDialog} from './delete-entry-dialog.js';
+import {secretsErrorToFormError} from './form-errors.js';
+import {StoreRowsSkeleton, StoreSurface} from './store-section-shell.js';
+import {VariableForm} from './variable-form.js';
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${{ vars.NAME }} reference syntax is shown to users.
+const VARS_REFERENCE = '${{ vars.NAME }}';
+
+type FormState = {mode: 'create'} | {mode: 'edit'; variable: VariableDto} | null;
+
+export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) {
+  const variablesQuery = useVariablesQuery(workspaceId);
+  const deleteVariable = useDeleteVariableMutation();
+  const [formState, setFormState] = useState<FormState>(null);
+  const [deleteKey, setDeleteKey] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
+
+  const variables = useMemo(
+    () => [...(variablesQuery.data ?? [])].sort((a, b) => a.key.localeCompare(b.key)),
+    [variablesQuery.data],
+  );
+
+  function closeDelete() {
+    setDeleteKey(null);
+    setDeleteError(undefined);
+  }
+
+  return (
+    <RelativeTimeProvider>
+      <section className="flex flex-col gap-16" aria-label="Variables">
+        <div className="flex items-start justify-between gap-16">
+          <div className="flex flex-col gap-4">
+            <Header variant="h3">Variables</Header>
+            <Text size="sm" className="text-foreground-neutral-muted">
+              Plaintext config, not redacted from logs. Use a Secret for sensitive values. Reference
+              them from workflows as{' '}
+              <Code as="span" variant="label">
+                {VARS_REFERENCE}
+              </Code>
+              .
+            </Text>
+          </div>
+          <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
+            Add variable
+          </Button>
+        </div>
+
+        {variablesQuery.isPending ? <StoreRowsSkeleton label="Loading variables" /> : null}
+
+        {variablesQuery.isError && variablesQuery.data === undefined ? (
+          <StoreSurface className="px-16">
+            <QueryLoadError query={variablesQuery} subject="variables" />
+          </StoreSurface>
+        ) : null}
+
+        {variablesQuery.data !== undefined && variables.length === 0 ? (
+          <StoreSurface className="px-16">
+            <EmptyState
+              icon="bracesLine"
+              title="No variables yet"
+              description={`Variables are plaintext config. Reference them from workflows as ${VARS_REFERENCE}.`}
+              action={
+                <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
+                  Add variable
+                </Button>
+              }
+            />
+          </StoreSurface>
+        ) : null}
+
+        {variables.length > 0 ? (
+          <StoreSurface>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Value</TableHead>
+                  <TableHead>Last edited</TableHead>
+                  <TableHead className="w-40 text-right">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {variables.map((variable) => (
+                  <VariableRow
+                    key={variable.key}
+                    variable={variable}
+                    onEdit={() => setFormState({mode: 'edit', variable})}
+                    onDelete={() => setDeleteKey(variable.key)}
+                  />
+                ))}
+              </TableBody>
+            </Table>
+          </StoreSurface>
+        ) : null}
+      </section>
+
+      <Modal
+        open={formState !== null}
+        onOpenChange={(open) => {
+          if (!open) setFormState(null);
+        }}
+      >
+        <ModalContent>
+          <ModalHeader>
+            <ModalTitle>
+              {formState?.mode === 'edit' ? 'Update variable' : 'Add variable'}
+            </ModalTitle>
+          </ModalHeader>
+          {formState ? (
+            <VariableForm
+              workspaceId={workspaceId}
+              mode={formState.mode}
+              existingKey={formState.mode === 'edit' ? formState.variable.key : undefined}
+              existingValue={formState.mode === 'edit' ? formState.variable.value : undefined}
+              onSaved={() => {
+                const wasEdit = formState.mode === 'edit';
+                setFormState(null);
+                toast.success(wasEdit ? 'Variable updated' : 'Variable added');
+              }}
+              onCancel={() => setFormState(null)}
+            />
+          ) : null}
+        </ModalContent>
+      </Modal>
+
+      <DeleteEntryDialog
+        open={deleteKey !== null}
+        onOpenChange={(open) => {
+          if (!open) closeDelete();
+        }}
+        entryKey={deleteKey ?? ''}
+        kind="variable"
+        isLoading={deleteVariable.isPending}
+        errorMessage={deleteError}
+        onConfirm={async () => {
+          if (deleteKey === null) return;
+          setDeleteError(undefined);
+          try {
+            await deleteVariable.mutateAsync({workspaceId, key: deleteKey});
+            toast.success('Variable deleted');
+            closeDelete();
+          } catch (error) {
+            setDeleteError(secretsErrorToFormError(error).message);
+          }
+        }}
+      />
+    </RelativeTimeProvider>
+  );
+}
+
+function VariableRow({
+  variable,
+  onEdit,
+  onDelete,
+}: {
+  variable: VariableDto;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <TableRow>
+      <TableCell>
+        <Code as="span" variant="paragraph">
+          {variable.key}
+        </Code>
+      </TableCell>
+      <TableCell>
+        <span
+          title={variable.value}
+          className="block max-w-[280px] truncate font-code text-foreground-neutral-base"
+        >
+          {variable.value === '' ? (
+            <span className="text-foreground-neutral-muted">(empty)</span>
+          ) : (
+            variable.value
+          )}
+        </span>
+      </TableCell>
+      <TableCell className="text-foreground-neutral-muted">
+        <RelativeTime value={variable.updated_at} />
+      </TableCell>
+      <TableCell className="text-right">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              size="sm"
+              variant="transparent"
+              icon="more2Line"
+              aria-label={`Actions for ${variable.key}`}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem icon="fileCopyLine" onSelect={() => void copyKeyName(variable.key)}>
+              Copy name
+            </DropdownMenuItem>
+            <DropdownMenuItem icon="editLine" onSelect={onEdit}>
+              Edit value
+            </DropdownMenuItem>
+            <DropdownMenuItem icon="deleteBinLine" onSelect={onDelete}>
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -1,4 +1,4 @@
-import type {VariableDto} from '@shipfox/api-secrets-dto';
+import type {VariableListItemDto} from '@shipfox/api-secrets-dto';
 import {QueryLoadError} from '@shipfox/client-ui';
 import {
   Button,
@@ -36,7 +36,7 @@ import {VariableForm} from './variable-form.js';
 // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${{ vars.NAME }} reference syntax is shown to users.
 const VARS_REFERENCE = '${{ vars.NAME }}';
 
-type FormState = {mode: 'create'} | {mode: 'edit'; variable: VariableDto} | null;
+type FormState = {mode: 'create'} | {mode: 'edit'; variable: VariableListItemDto} | null;
 
 export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) {
   const variablesQuery = useVariablesQuery(workspaceId);
@@ -144,6 +144,10 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
               mode={formState.mode}
               existingKey={formState.mode === 'edit' ? formState.variable.key : undefined}
               existingValue={formState.mode === 'edit' ? formState.variable.value : undefined}
+              existingValueTruncated={
+                formState.mode === 'edit' ? formState.variable.value_truncated : undefined
+              }
+              reservedKeys={variables.map((variable) => variable.key)}
               onSaved={() => {
                 const wasEdit = formState.mode === 'edit';
                 setFormState(null);
@@ -185,7 +189,7 @@ function VariableRow({
   onEdit,
   onDelete,
 }: {
-  variable: VariableDto;
+  variable: VariableListItemDto;
   onEdit: () => void;
   onDelete: () => void;
 }) {

--- a/libs/client/secrets/src/hooks/api/create-store-api.ts
+++ b/libs/client/secrets/src/hooks/api/create-store-api.ts
@@ -92,8 +92,10 @@ export function createStoreApi<
     const queryClient = useQueryClient();
     return useMutation({
       mutationFn: put,
-      onSuccess: async (_result, variables) => {
-        await queryClient.invalidateQueries({queryKey: queryKeys.list(variables.workspaceId)});
+      // Invalidate the whole resource namespace so the per-item detail cache
+      // (full variable values) is refreshed too, not just the list.
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({queryKey: queryKeys.all});
       },
     });
   }
@@ -102,8 +104,8 @@ export function createStoreApi<
     const queryClient = useQueryClient();
     return useMutation({
       mutationFn: remove,
-      onSuccess: async (_result, variables) => {
-        await queryClient.invalidateQueries({queryKey: queryKeys.list(variables.workspaceId)});
+      onSuccess: async () => {
+        await queryClient.invalidateQueries({queryKey: queryKeys.all});
       },
     });
   }

--- a/libs/client/secrets/src/hooks/api/create-store-api.ts
+++ b/libs/client/secrets/src/hooks/api/create-store-api.ts
@@ -1,0 +1,112 @@
+import {SECRETS_MAX_LIST_LIMIT, type SecretWriteWarningDto} from '@shipfox/api-secrets-dto';
+import {apiRequest} from '@shipfox/client-api';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+/**
+ * Secrets and variables share an identical management surface (list / put /
+ * delete under `/workspaces/:id/{resource}`); only the response envelope keys
+ * and DTO types differ. This factory builds the typed transport functions,
+ * query keys, and React Query hooks for one resource so `secrets.ts` and
+ * `variables.ts` stay thin instantiations. The forms and sections diverge
+ * (write-only vs readable) and are kept separate on purpose.
+ */
+export interface CreateStoreApiConfig<TItem, TListResponse, TPutResponse> {
+  /** URL segment and query-key namespace, e.g. `'secrets'` or `'variables'`. */
+  resource: string;
+  /** Pulls the item array out of a list response. */
+  listItems: (response: TListResponse) => TItem[];
+  /** Pulls the single item out of a put response. */
+  putItem: (response: TPutResponse) => TItem;
+}
+
+export interface PutResult<TItem> {
+  item: TItem;
+  warnings: SecretWriteWarningDto[];
+}
+
+export function createStoreApi<
+  TItem,
+  TListResponse,
+  TPutBody,
+  TPutResponse extends {warnings: SecretWriteWarningDto[]},
+>(config: CreateStoreApiConfig<TItem, TListResponse, TPutResponse>) {
+  const {resource, listItems, putItem} = config;
+
+  const queryKeys = {
+    all: [resource] as const,
+    list: (workspaceId: string) => [resource, 'list', workspaceId] as const,
+  };
+
+  // The store is a bounded set (per-workspace cap), so the UI fetches every key
+  // in one call rather than paginating: request the max limit and ignore the
+  // cursor. See SECRETS_MAX_LIST_LIMIT / the S1a list route.
+  async function listAll(params: {
+    workspaceId: string;
+    projectId?: string | undefined;
+    signal?: AbortSignal | undefined;
+  }): Promise<TItem[]> {
+    const search = new URLSearchParams({limit: String(SECRETS_MAX_LIST_LIMIT)});
+    if (params.projectId) search.set('project_id', params.projectId);
+    const response = await apiRequest<TListResponse>(
+      `/workspaces/${params.workspaceId}/${resource}?${search.toString()}`,
+      {signal: params.signal},
+    );
+    return listItems(response);
+  }
+
+  async function put(params: {
+    workspaceId: string;
+    key: string;
+    body: TPutBody;
+  }): Promise<PutResult<TItem>> {
+    const response = await apiRequest<TPutResponse>(
+      `/workspaces/${params.workspaceId}/${resource}/${encodeURIComponent(params.key)}`,
+      {method: 'PUT', body: params.body},
+    );
+    return {item: putItem(response), warnings: response.warnings};
+  }
+
+  async function remove(params: {
+    workspaceId: string;
+    key: string;
+    projectId?: string | undefined;
+  }): Promise<void> {
+    const search = params.projectId
+      ? `?${new URLSearchParams({project_id: params.projectId}).toString()}`
+      : '';
+    await apiRequest<void>(
+      `/workspaces/${params.workspaceId}/${resource}/${encodeURIComponent(params.key)}${search}`,
+      {method: 'DELETE'},
+    );
+  }
+
+  function useListQuery(workspaceId: string | undefined) {
+    return useQuery({
+      queryKey: workspaceId ? queryKeys.list(workspaceId) : [resource, 'list'],
+      enabled: Boolean(workspaceId),
+      queryFn: ({signal}) => listAll({workspaceId: workspaceId ?? '', signal}),
+    });
+  }
+
+  function usePutMutation() {
+    const queryClient = useQueryClient();
+    return useMutation({
+      mutationFn: put,
+      onSuccess: async (_result, variables) => {
+        await queryClient.invalidateQueries({queryKey: queryKeys.list(variables.workspaceId)});
+      },
+    });
+  }
+
+  function useDeleteMutation() {
+    const queryClient = useQueryClient();
+    return useMutation({
+      mutationFn: remove,
+      onSuccess: async (_result, variables) => {
+        await queryClient.invalidateQueries({queryKey: queryKeys.list(variables.workspaceId)});
+      },
+    });
+  }
+
+  return {queryKeys, listAll, put, remove, useListQuery, usePutMutation, useDeleteMutation};
+}

--- a/libs/client/secrets/src/hooks/api/secrets.test.ts
+++ b/libs/client/secrets/src/hooks/api/secrets.test.ts
@@ -1,0 +1,140 @@
+import {SECRETS_MAX_LIST_LIMIT} from '@shipfox/api-secrets-dto';
+import {configureApiClient} from '@shipfox/client-api';
+import {
+  SECRETS_TEST_WORKSPACE_ID,
+  secret,
+  secretsListResponse,
+  variable,
+  variablesListResponse,
+} from '#test/fixtures/secrets.js';
+import {deleteSecret, listSecrets, putSecret} from './secrets.js';
+import {deleteVariable, listVariables, putVariable} from './variables.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {'content-type': 'application/json'},
+    status: 200,
+    ...init,
+  });
+}
+
+describe('store transport', () => {
+  beforeEach(() => {
+    configureApiClient({baseUrl: 'https://api.example.test', fetchImpl: undefined});
+  });
+
+  test('lists the whole secret set in a single call at the max limit', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(secretsListResponse()));
+    configureApiClient({fetchImpl});
+
+    const result = await listSecrets({workspaceId: SECRETS_TEST_WORKSPACE_ID});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([secret()]);
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/secrets?limit=${SECRETS_MAX_LIST_LIMIT}`,
+    );
+  });
+
+  test('returns an empty array when the store is empty', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(secretsListResponse({secrets: [], next_cursor: null})));
+    configureApiClient({fetchImpl});
+
+    const result = await listSecrets({workspaceId: SECRETS_TEST_WORKSPACE_ID});
+
+    expect(result).toEqual([]);
+  });
+
+  test('puts a secret, encodes the key, and passes warnings through', async () => {
+    let requestBody: unknown;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      requestBody = await (input as Request).clone().json();
+      return jsonResponse({
+        secret: secret({key: 'MY_TOKEN'}),
+        warnings: [{code: 'short-secret-value', key: 'MY_TOKEN'}],
+      });
+    });
+    configureApiClient({fetchImpl});
+
+    const result = await putSecret({
+      workspaceId: SECRETS_TEST_WORKSPACE_ID,
+      key: 'MY_TOKEN',
+      body: {value: 'short'},
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(request.method).toBe('PUT');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/secrets/MY_TOKEN`,
+    );
+    expect(requestBody).toEqual({value: 'short'});
+    expect(result.warnings).toEqual([{code: 'short-secret-value', key: 'MY_TOKEN'}]);
+    expect(result.item.key).toBe('MY_TOKEN');
+  });
+
+  test('deletes a secret with a 204 and no project scope by default', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, {status: 204}));
+    configureApiClient({fetchImpl});
+
+    const result = await deleteSecret({workspaceId: SECRETS_TEST_WORKSPACE_ID, key: 'MY_TOKEN'});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result).toBeUndefined();
+    expect(request.method).toBe('DELETE');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/secrets/MY_TOKEN`,
+    );
+  });
+
+  test('lists variables (values included) via the same factory', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(variablesListResponse()));
+    configureApiClient({fetchImpl});
+
+    const result = await listVariables({workspaceId: SECRETS_TEST_WORKSPACE_ID});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result).toEqual([variable()]);
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/variables?limit=${SECRETS_MAX_LIST_LIMIT}`,
+    );
+  });
+
+  test('puts a variable and returns the sensitive-name warning', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      jsonResponse({
+        variable: variable({key: 'MY_KEY', value: 'v'}),
+        warnings: [{code: 'sensitive-variable-name', key: 'MY_KEY'}],
+      }),
+    );
+    configureApiClient({fetchImpl});
+
+    const result = await putVariable({
+      workspaceId: SECRETS_TEST_WORKSPACE_ID,
+      key: 'MY_KEY',
+      body: {value: 'v'},
+    });
+
+    expect(result.warnings).toEqual([{code: 'sensitive-variable-name', key: 'MY_KEY'}]);
+    expect(result.item.value).toBe('v');
+  });
+
+  test('deletes a variable within a project scope via project_id query', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, {status: 204}));
+    configureApiClient({fetchImpl});
+
+    await deleteVariable({
+      workspaceId: SECRETS_TEST_WORKSPACE_ID,
+      key: 'LOG_LEVEL',
+      projectId: '33333333-3333-4333-8333-333333333333',
+    });
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/variables/LOG_LEVEL?project_id=33333333-3333-4333-8333-333333333333`,
+    );
+  });
+});

--- a/libs/client/secrets/src/hooks/api/secrets.test.ts
+++ b/libs/client/secrets/src/hooks/api/secrets.test.ts
@@ -5,10 +5,11 @@ import {
   secret,
   secretsListResponse,
   variable,
+  variableListItem,
   variablesListResponse,
 } from '#test/fixtures/secrets.js';
 import {deleteSecret, listSecrets, putSecret} from './secrets.js';
-import {deleteVariable, listVariables, putVariable} from './variables.js';
+import {deleteVariable, getVariable, listVariables, putVariable} from './variables.js';
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -97,9 +98,25 @@ describe('store transport', () => {
     const result = await listVariables({workspaceId: SECRETS_TEST_WORKSPACE_ID});
 
     const request = fetchImpl.mock.calls[0]?.[0] as Request;
-    expect(result).toEqual([variable()]);
+    expect(result).toEqual([variableListItem()]);
     expect(request.url).toBe(
       `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/variables?limit=${SECRETS_MAX_LIST_LIMIT}`,
+    );
+  });
+
+  test('reads a single variable with its full value for editing', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({variable: variable({value: 'first line\nsecond line'})}));
+    configureApiClient({fetchImpl});
+
+    const result = await getVariable({workspaceId: SECRETS_TEST_WORKSPACE_ID, key: 'LOG_LEVEL'});
+
+    const request = fetchImpl.mock.calls[0]?.[0] as Request;
+    expect(result.value).toBe('first line\nsecond line');
+    expect(request.method).toBe('GET');
+    expect(request.url).toBe(
+      `https://api.example.test/workspaces/${SECRETS_TEST_WORKSPACE_ID}/variables/LOG_LEVEL`,
     );
   });
 

--- a/libs/client/secrets/src/hooks/api/secrets.ts
+++ b/libs/client/secrets/src/hooks/api/secrets.ts
@@ -1,0 +1,26 @@
+import type {
+  ListSecretsResponseDto,
+  PutSecretBodyDto,
+  PutSecretResponseDto,
+  SecretDto,
+} from '@shipfox/api-secrets-dto';
+import {createStoreApi} from './create-store-api.js';
+
+const secretsApi = createStoreApi<
+  SecretDto,
+  ListSecretsResponseDto,
+  PutSecretBodyDto,
+  PutSecretResponseDto
+>({
+  resource: 'secrets',
+  listItems: (response) => response.secrets,
+  putItem: (response) => response.secret,
+});
+
+export const secretsQueryKeys = secretsApi.queryKeys;
+export const listSecrets = secretsApi.listAll;
+export const putSecret = secretsApi.put;
+export const deleteSecret = secretsApi.remove;
+export const useSecretsQuery = secretsApi.useListQuery;
+export const usePutSecretMutation = secretsApi.usePutMutation;
+export const useDeleteSecretMutation = secretsApi.useDeleteMutation;

--- a/libs/client/secrets/src/hooks/api/variables.ts
+++ b/libs/client/secrets/src/hooks/api/variables.ts
@@ -1,0 +1,26 @@
+import type {
+  ListVariablesResponseDto,
+  PutVariableBodyDto,
+  PutVariableResponseDto,
+  VariableDto,
+} from '@shipfox/api-secrets-dto';
+import {createStoreApi} from './create-store-api.js';
+
+const variablesApi = createStoreApi<
+  VariableDto,
+  ListVariablesResponseDto,
+  PutVariableBodyDto,
+  PutVariableResponseDto
+>({
+  resource: 'variables',
+  listItems: (response) => response.variables,
+  putItem: (response) => response.variable,
+});
+
+export const variablesQueryKeys = variablesApi.queryKeys;
+export const listVariables = variablesApi.listAll;
+export const putVariable = variablesApi.put;
+export const deleteVariable = variablesApi.remove;
+export const useVariablesQuery = variablesApi.useListQuery;
+export const usePutVariableMutation = variablesApi.usePutMutation;
+export const useDeleteVariableMutation = variablesApi.useDeleteMutation;

--- a/libs/client/secrets/src/hooks/api/variables.ts
+++ b/libs/client/secrets/src/hooks/api/variables.ts
@@ -1,20 +1,25 @@
 import type {
+  GetVariableResponseDto,
   ListVariablesResponseDto,
   PutVariableBodyDto,
   PutVariableResponseDto,
   VariableDto,
+  VariableListItemDto,
 } from '@shipfox/api-secrets-dto';
+import {apiRequest} from '@shipfox/client-api';
+import {useQuery} from '@tanstack/react-query';
 import {createStoreApi} from './create-store-api.js';
 
 const variablesApi = createStoreApi<
-  VariableDto,
+  VariableListItemDto,
   ListVariablesResponseDto,
   PutVariableBodyDto,
   PutVariableResponseDto
 >({
   resource: 'variables',
   listItems: (response) => response.variables,
-  putItem: (response) => response.variable,
+  // The list carries only a preview; a freshly-written value is the full value.
+  putItem: (response) => ({...response.variable, value_truncated: false}),
 });
 
 export const variablesQueryKeys = variablesApi.queryKeys;
@@ -24,3 +29,33 @@ export const deleteVariable = variablesApi.remove;
 export const useVariablesQuery = variablesApi.useListQuery;
 export const usePutVariableMutation = variablesApi.usePutMutation;
 export const useDeleteVariableMutation = variablesApi.useDeleteMutation;
+
+/**
+ * Reads a single variable including its full value. The list only returns a
+ * bounded preview, so editing a truncated variable fetches the full value here.
+ */
+export async function getVariable(params: {
+  workspaceId: string;
+  key: string;
+  projectId?: string | undefined;
+  signal?: AbortSignal | undefined;
+}): Promise<VariableDto> {
+  const search = params.projectId
+    ? `?${new URLSearchParams({project_id: params.projectId}).toString()}`
+    : '';
+  const response = await apiRequest<GetVariableResponseDto>(
+    `/workspaces/${params.workspaceId}/variables/${encodeURIComponent(params.key)}${search}`,
+    {signal: params.signal},
+  );
+  return response.variable;
+}
+
+export function useVariableQuery(workspaceId: string, key: string | undefined) {
+  return useQuery({
+    queryKey: key
+      ? [...variablesQueryKeys.all, 'detail', workspaceId, key]
+      : [...variablesQueryKeys.all, 'detail'],
+    enabled: Boolean(key),
+    queryFn: ({signal}) => getVariable({workspaceId, key: key ?? '', signal}),
+  });
+}

--- a/libs/client/secrets/src/index.ts
+++ b/libs/client/secrets/src/index.ts
@@ -1,0 +1,5 @@
+export {type SecretsFormErrorMapping, secretsErrorToFormError} from './components/form-errors.js';
+export {WorkspaceSecretsSection} from './components/workspace-secrets-section.js';
+export {WorkspaceVariablesSection} from './components/workspace-variables-section.js';
+export * from './hooks/api/secrets.js';
+export * from './hooks/api/variables.js';

--- a/libs/client/secrets/test/fixtures/secrets.ts
+++ b/libs/client/secrets/test/fixtures/secrets.ts
@@ -1,0 +1,48 @@
+import type {
+  ListSecretsResponseDto,
+  ListVariablesResponseDto,
+  SecretDto,
+  VariableDto,
+} from '@shipfox/api-secrets-dto';
+
+export const SECRETS_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
+
+export function secret(overrides: Partial<SecretDto> = {}): SecretDto {
+  return {
+    key: 'MY_TOKEN',
+    project_id: null,
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    last_edited_by: '22222222-2222-4222-8222-222222222222',
+    ...overrides,
+  };
+}
+
+export function variable(overrides: Partial<VariableDto> = {}): VariableDto {
+  return {
+    ...secret(),
+    key: 'LOG_LEVEL',
+    value: 'debug',
+    ...overrides,
+  };
+}
+
+export function secretsListResponse(
+  overrides: Partial<ListSecretsResponseDto> = {},
+): ListSecretsResponseDto {
+  return {
+    secrets: [secret()],
+    next_cursor: null,
+    ...overrides,
+  };
+}
+
+export function variablesListResponse(
+  overrides: Partial<ListVariablesResponseDto> = {},
+): ListVariablesResponseDto {
+  return {
+    variables: [variable()],
+    next_cursor: null,
+    ...overrides,
+  };
+}

--- a/libs/client/secrets/test/fixtures/secrets.ts
+++ b/libs/client/secrets/test/fixtures/secrets.ts
@@ -3,6 +3,7 @@ import type {
   ListVariablesResponseDto,
   SecretDto,
   VariableDto,
+  VariableListItemDto,
 } from '@shipfox/api-secrets-dto';
 
 export const SECRETS_TEST_WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
@@ -27,6 +28,16 @@ export function variable(overrides: Partial<VariableDto> = {}): VariableDto {
   };
 }
 
+export function variableListItem(
+  overrides: Partial<VariableListItemDto> = {},
+): VariableListItemDto {
+  return {
+    ...variable(),
+    value_truncated: false,
+    ...overrides,
+  };
+}
+
 export function secretsListResponse(
   overrides: Partial<ListSecretsResponseDto> = {},
 ): ListSecretsResponseDto {
@@ -41,7 +52,7 @@ export function variablesListResponse(
   overrides: Partial<ListVariablesResponseDto> = {},
 ): ListVariablesResponseDto {
   return {
-    variables: [variable()],
+    variables: [variableListItem()],
     next_cursor: null,
     ...overrides,
   };

--- a/libs/client/secrets/test/setup.ts
+++ b/libs/client/secrets/test/setup.ts
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom/vitest';
 
-// Pure-logic tests run in the node environment (the package default), where
-// there is no window; the browser stubs only apply to jsdom test files
-// (those carrying the `@vitest-environment jsdom` pragma).
+// This setup file is shared by the node and jsdom vitest projects. The `.test.ts`
+// files run in the node environment (no window), so the browser stubs below only
+// apply to the jsdom project, which selects `.test.tsx` files via vitest.config.ts.
 if (typeof window !== 'undefined') {
   class ResizeObserverStub {
     observe(): void {

--- a/libs/client/secrets/test/setup.ts
+++ b/libs/client/secrets/test/setup.ts
@@ -1,0 +1,47 @@
+import '@testing-library/jest-dom/vitest';
+
+// Pure-logic tests run in the node environment (the package default), where
+// there is no window; the browser stubs only apply to jsdom test files
+// (those carrying the `@vitest-environment jsdom` pragma).
+if (typeof window !== 'undefined') {
+  class ResizeObserverStub {
+    observe(): void {
+      /* no-op */
+    }
+    unobserve(): void {
+      /* no-op */
+    }
+    disconnect(): void {
+      /* no-op */
+    }
+  }
+
+  Object.defineProperty(window, 'ResizeObserver', {
+    configurable: true,
+    value: ResizeObserverStub,
+  });
+
+  Object.defineProperty(window, 'scrollTo', {
+    configurable: true,
+    value: () => undefined,
+  });
+
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: () => undefined,
+  });
+
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    value: (query: string) => ({
+      addEventListener: () => undefined,
+      addListener: () => undefined,
+      dispatchEvent: () => false,
+      matches: false,
+      media: query,
+      onchange: null,
+      removeEventListener: () => undefined,
+      removeListener: () => undefined,
+    }),
+  });
+}

--- a/libs/client/secrets/tsconfig.build.json
+++ b/libs/client/secrets/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/react",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/client/secrets/tsconfig.json
+++ b/libs/client/secrets/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/client/secrets/tsconfig.test.json
+++ b/libs/client/secrets/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/client/secrets/vitest.config.ts
+++ b/libs/client/secrets/vitest.config.ts
@@ -1,0 +1,72 @@
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {argosVitestPlugin} from '@argos-ci/storybook/vitest-plugin';
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+import {storybookTest} from '@storybook/addon-vitest/vitest-plugin';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import {playwright} from '@vitest/browser-playwright';
+
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig(
+  {
+    plugins: [react(), tailwindcss()],
+    test: {
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: 'node',
+            environment: 'node',
+            include: ['src/**/*.test.ts'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: 'dom',
+            environment: 'jsdom',
+            include: ['src/**/*.test.tsx'],
+            setupFiles: ['test/setup.ts'],
+          },
+        },
+        {
+          extends: true,
+          plugins: [
+            storybookTest({configDir: path.join(dirname, '.storybook')}),
+            argosVitestPlugin({
+              uploadToArgos: !!process.env.CI,
+              ...(process.env.ARGOS_TOKEN ? {token: process.env.ARGOS_TOKEN} : {}),
+              buildName: 'client-secrets',
+              argosCSS: `
+                *, *::before, *::after {
+                  animation-delay: 0s !important;
+                  animation-duration: 0s !important;
+                  transition-delay: 0s !important;
+                  transition-duration: 0s !important;
+                }
+              `,
+            }),
+          ],
+          test: {
+            name: 'storybook',
+            browser: {
+              enabled: true,
+              headless: true,
+              provider: playwright({
+                launchOptions: {
+                  args: ['--disable-lcd-text', '--font-render-hinting=none'],
+                },
+              }),
+              instances: [{browser: 'chromium'}],
+            },
+          },
+        },
+      ],
+    },
+  },
+  import.meta.url,
+) as UserConfigExport;

--- a/libs/client/workspace-settings/src/components/settings-nav.tsx
+++ b/libs/client/workspace-settings/src/components/settings-nav.tsx
@@ -15,6 +15,12 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
   const isAgentProvidersActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/agent-providers', params: {wid: workspaceId}}),
   );
+  const isSecretsActive = Boolean(
+    matchRoute({to: '/workspaces/$wid/settings/secrets', params: {wid: workspaceId}}),
+  );
+  const isVariablesActive = Boolean(
+    matchRoute({to: '/workspaces/$wid/settings/variables', params: {wid: workspaceId}}),
+  );
   const isIntegrationsActive = Boolean(
     matchRoute({to: '/workspaces/$wid/settings/integrations', params: {wid: workspaceId}}),
   );
@@ -78,6 +84,34 @@ export function SettingsNav({workspaceId}: {workspaceId: string}) {
         >
           <Icon name="robot2Line" className="size-16" />
           Agent providers
+        </Link>
+      </Button>
+      <Button
+        asChild
+        variant={isSecretsActive ? 'secondary' : 'transparent'}
+        className="w-full justify-start"
+      >
+        <Link
+          to="/workspaces/$wid/settings/secrets"
+          params={{wid: workspaceId}}
+          aria-current={isSecretsActive ? 'page' : undefined}
+        >
+          <Icon name="keyLine" className="size-16" />
+          Secrets
+        </Link>
+      </Button>
+      <Button
+        asChild
+        variant={isVariablesActive ? 'secondary' : 'transparent'}
+        className="w-full justify-start"
+      >
+        <Link
+          to="/workspaces/$wid/settings/variables"
+          params={{wid: workspaceId}}
+          aria-current={isVariablesActive ? 'page' : undefined}
+        >
+          <Icon name="bracesLine" className="size-16" />
+          Variables
         </Link>
       </Button>
       <Button

--- a/libs/client/workspace-settings/src/index.ts
+++ b/libs/client/workspace-settings/src/index.ts
@@ -4,3 +4,5 @@ export * from './pages/integrations-settings-page.js';
 export * from './pages/members-settings-page.js';
 export * from './pages/provisioners-settings-page.js';
 export * from './pages/runners-settings-page.js';
+export * from './pages/secrets-settings-page.js';
+export * from './pages/variables-settings-page.js';

--- a/libs/client/workspace-settings/src/pages/secrets-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/secrets-settings-page.tsx
@@ -1,0 +1,14 @@
+import {WorkspaceSecretsSection} from '@shipfox/client-secrets';
+import {WorkspaceSettingsShell} from '#components/workspace-settings-shell.js';
+
+export function SecretsSettingsPage() {
+  return (
+    <WorkspaceSettingsShell>
+      {(workspace) => (
+        <div>
+          <WorkspaceSecretsSection workspaceId={workspace.id} />
+        </div>
+      )}
+    </WorkspaceSettingsShell>
+  );
+}

--- a/libs/client/workspace-settings/src/pages/variables-settings-page.tsx
+++ b/libs/client/workspace-settings/src/pages/variables-settings-page.tsx
@@ -1,0 +1,14 @@
+import {WorkspaceVariablesSection} from '@shipfox/client-secrets';
+import {WorkspaceSettingsShell} from '#components/workspace-settings-shell.js';
+
+export function VariablesSettingsPage() {
+  return (
+    <WorkspaceSettingsShell>
+      {(workspace) => (
+        <div>
+          <WorkspaceVariablesSection workspaceId={workspace.id} />
+        </div>
+      )}
+    </WorkspaceSettingsShell>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3320,6 +3320,112 @@ importers:
         specifier: ^4.1.5
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  libs/client/secrets:
+    dependencies:
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../../api/secrets-dto
+      '@shipfox/client-api':
+        specifier: workspace:*
+        version: link:../api
+      '@shipfox/client-ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@shipfox/react-ui':
+        specifier: workspace:*
+        version: link:../../shared/react/ui
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.23
+      '@tanstack/react-form':
+        specifier: ^1.32.0
+        version: 1.33.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
+    devDependencies:
+      '@argos-ci/cli':
+        specifier: ^5.0.0
+        version: 5.0.5
+      '@argos-ci/storybook':
+        specifier: ^6.0.0
+        version: 6.0.7
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vite':
+        specifier: workspace:*
+        version: link:../../../tools/vite
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+      '@storybook/addon-vitest':
+        specifier: ^10.3.6
+        version: 10.4.6(@vitest/browser-playwright@4.1.9)(@vitest/browser@4.1.9(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9))(@vitest/runner@4.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.9)
+      '@storybook/react':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)
+      '@storybook/react-vite':
+        specifier: ^10.0.0
+        version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.107.2(esbuild@0.28.1))
+      '@tailwindcss/vite':
+        specifier: ^4.1.13
+        version: 4.3.1(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.1.11
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.1.7
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.0
+        version: 6.0.2(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      jsdom:
+        specifier: ^29.0.0
+        version: 29.1.1
+      react:
+        specifier: ^19.1.1
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.7(react@19.2.7)
+      storybook:
+        specifier: ^10.0.0
+        version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      storybook-addon-pseudo-states:
+        specifier: ^10.0.0
+        version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      tailwindcss:
+        specifier: ^4.1.13
+        version: 4.3.1
+      vite:
+        specifier: ^8.0.3
+        version: 8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(jsdom@29.1.1)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   libs/client/triggers:
     dependencies:
       '@shipfox/api-triggers-dto':
@@ -3616,6 +3722,9 @@ importers:
       '@shipfox/client-runners':
         specifier: workspace:*
         version: link:../runners
+      '@shipfox/client-secrets':
+        specifier: workspace:*
+        version: link:../secrets
       '@shipfox/client-triggers':
         specifier: workspace:*
         version: link:../triggers


### PR DESCRIPTION
Builds the client transport, hooks, and workspace settings UI (S1b) on top of the
already-merged secrets & variables management API.

## What

- **`@shipfox/client-secrets`** (new): a `createStoreApi` factory for the shared
  secret/variable transport + React Query hooks; `secretsErrorToFormError`; a
  write-only `SecretForm` and a readable `VariableForm` (TanStack Form + Zod,
  multiline `Textarea` values, live short-value / sensitive-name advisories,
  auto-uppercased keys); and the workspace secrets/variables sections (`Table`,
  masked secret values, copy-name, delete dialog with blast-radius copy).
- **`client-workspace-settings`**: Secrets and Variables settings pages + nav entries.
- **`client-router`**: `/workspaces/$wid/settings/secrets` and `/variables` routes.
- **`api-secrets-dto`**: export `SECRETS_MAX_LIST_LIMIT` and raise the list `limit`
  cap (with a matching `api-secrets` route test).

## Why

Secrets are **write-only**: values are never fetched back or prefilled (a masked
`••••` communicates a value exists), so the UI never re-displays a secret after
entry. The store is a bounded per-workspace set, so instead of paginating the
settings list, the client fetches it in a single call — hence the small S1a limit
cap bump. Variables are readable/plaintext, so their forms carry a live
sensitive-name advisory pointing users to Secrets when a name looks like a
credential.

## Scope decisions (from design + eng review)

- No fingerprint (the shipped DTO exposes none), never-reveal, workspace-scope only.
- Deferred to follow-up issues: project-scoped store + scope selector, editor
  attribution, batch/bulk entry, fingerprint display, and render virtualization if a
  workspace ever approaches the 10k cap.

## Review notes

- The `createStoreApi` factory backs both resources; the forms/sections stay separate
  because write-only vs readable genuinely diverge.
- Tests: `form-errors` enumeration, transport (incl. the single-call limit),
  write-only-invariant RTL, copy-key behavior, and form/section stories (argos,
  light + dark).

Closes ENG-694

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace Secrets and Variables settings UI and a shared client transport via `@shipfox/client-secrets`. Implements ENG-694 (S1b), fetches the whole store in one call, bounds variable list values, and hardens the variable edit flow and caching.

- **New Features**
  - New `@shipfox/client-secrets`: shared `createStoreApi` + React Query hooks, Secret and Variable forms.
  - Secrets are write-only with masked values, short‑value advisory, and auto‑uppercased keys; editing never prefills the value.
  - Variables are plaintext with a sensitive-name warning.
  - Workspace sections: single-call list, copy name, edit, and delete with blast-radius warning; wired into settings pages, nav, and `/workspaces/$wid/settings/secrets` and `/workspaces/$wid/settings/variables` routes.

- **Bug Fixes**
  - Variable list returns a single-line, length-capped preview with `value_truncated`; editing a truncated entry fetches the full value. Startup now fails if `SECRETS_MAX_PER_WORKSPACE` exceeds the list limit; `@shipfox/api-secrets-dto` exports `SECRETS_MAX_LIST_LIMIT` and raises the cap.
  - Variable edit: the Update button stays disabled until the full value loads; the load-error alert only shows if the full value never loaded.
  - Cache: invalidate the entire secrets/variables query namespace on write/delete to avoid stale per-variable detail data.
  - Guard create-mode overwrites: new entries cannot reuse existing names; edit mode locks the key.

<sup>Written for commit 5ce32846b5233e03692751c979b4fd8e4bda607b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

