### PR TITLE
[api/gitea] Add clone URL override

### DIFF
--- a/libs/api/integration/gitea/README.md
+++ b/libs/api/integration/gitea/README.md
@@ -1,0 +1,61 @@
+# Shipfox API Integration Gitea
+
+Shipfox API Integration Gitea connects a Gitea organization to a Shipfox
+workspace, receives organization push webhooks, and lets workflow runners check
+out repositories through Gitea's git HTTP endpoint.
+
+## Setup
+
+Configure the provider in the API environment:
+
+```sh
+GITEA_BASE_URL=https://gitea.example.com
+GITEA_SERVICE_USERNAME=shipfox-bot
+GITEA_SERVICE_TOKEN=
+GITEA_WEBHOOK_SECRET=
+GITEA_CHECKOUT_TTL_SECONDS=300
+```
+
+`GITEA_BASE_URL` is the URL the API uses for Gitea REST calls and webhook
+setup.
+
+`GITEA_SERVICE_USERNAME` and `GITEA_SERVICE_TOKEN` are handed to runners as
+checkout credentials. The checkout spec keeps these credentials separate from
+the repository URL.
+
+`GITEA_WEBHOOK_SECRET` must match the secret configured on the Gitea
+organization webhook.
+
+## Clone URL Override
+
+By default, checkout uses the clone URL reported by Gitea for each repository.
+Set `GITEA_CLONE_BASE_URL` when runners reach Gitea through a different scheme,
+host, or port than the API does:
+
+```sh
+GITEA_BASE_URL=http://localhost:3000
+GITEA_CLONE_BASE_URL=http://gitea:3000
+```
+
+When set, the provider rewrites only the clone URL origin and keeps the
+repository path reported by Gitea. Repository listing, `htmlUrl`, REST API calls,
+and webhooks continue to use `GITEA_BASE_URL`.
+
+## Development
+
+Run checks for this package:
+
+```sh
+turbo check --filter=@shipfox/api-integration-gitea
+turbo type --filter=@shipfox/api-integration-gitea
+turbo test --filter=@shipfox/api-integration-gitea
+```
+
+Tests use Vitest and a real PostgreSQL database. Start local services before
+running the test suite:
+
+```sh
+docker compose up -d
+```
+
+The test environment uses the `api_test` database, set in `test/env.ts`.

--- a/libs/api/integration/gitea/src/config.ts
+++ b/libs/api/integration/gitea/src/config.ts
@@ -4,6 +4,10 @@ export const config = createConfig({
   GITEA_BASE_URL: url({
     desc: 'Base URL of the Gitea instance the provider connects to, including the scheme (for example https://gitea.example.com). Required.',
   }),
+  GITEA_CLONE_BASE_URL: str({
+    desc: 'Base URL runners use when cloning Gitea repositories. Leave it unset to use clone URLs reported by Gitea, or set it when runners reach Gitea through a different scheme, host, or port.',
+    default: undefined,
+  }),
   GITEA_SERVICE_USERNAME: str({
     desc: 'Username of the Gitea service account the provider authenticates as. Required.',
   }),
@@ -22,3 +26,17 @@ export const config = createConfig({
     default: 10_000,
   }),
 });
+
+export const giteaCloneBaseOrigin = parseGiteaCloneBaseOrigin(config.GITEA_CLONE_BASE_URL);
+
+function parseGiteaCloneBaseOrigin(value: string | undefined): URL | undefined {
+  if (!value) return undefined;
+
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error(
+      'GITEA_CLONE_BASE_URL must be an absolute URL with a scheme, host, and optional port.',
+    );
+  }
+}

--- a/libs/api/integration/gitea/src/core/source-control-clone-url.test.ts
+++ b/libs/api/integration/gitea/src/core/source-control-clone-url.test.ts
@@ -1,0 +1,83 @@
+import type {IntegrationConnection} from '@shipfox/api-integration-core-dto';
+import type {GiteaApiClient, GiteaRepository} from '#api/client.js';
+
+const REPOSITORY: GiteaRepository = {
+  ownerLogin: 'shipfox',
+  name: 'platform',
+  fullName: 'shipfox/platform',
+  defaultBranch: 'main',
+  private: true,
+  cloneUrl: 'https://gitea.example.com/shipfox/platform.git',
+  htmlUrl: 'https://gitea.example.com/shipfox/platform',
+};
+
+function giteaClient(repository: GiteaRepository): GiteaApiClient {
+  return {
+    listOrgRepositories: vi.fn(),
+    getRepository: vi.fn(() => Promise.resolve(repository)),
+    resolveRef: vi.fn(),
+    listTree: vi.fn(),
+    fetchFileContent: vi.fn(),
+    organizationExists: vi.fn(),
+  };
+}
+
+function connection(): IntegrationConnection<'gitea'> {
+  return {
+    id: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    provider: 'gitea',
+    externalAccountId: 'shipfox',
+    slug: 'gitea_shipfox',
+    displayName: 'Gitea shipfox',
+    lifecycleStatus: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+async function createCheckoutSpec(repository: GiteaRepository) {
+  const {GiteaSourceControlProvider} = await import('./source-control.js');
+  const provider = new GiteaSourceControlProvider(giteaClient(repository));
+
+  return provider.createCheckoutSpec({
+    connection: connection(),
+    externalRepositoryId: 'gitea:shipfox/platform',
+  });
+}
+
+describe('GiteaSourceControlProvider clone URL override', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses the provider clone URL when GITEA_CLONE_BASE_URL is unset', async () => {
+    vi.resetModules();
+
+    const result = await createCheckoutSpec(REPOSITORY);
+
+    expect(result.repositoryUrl).toBe('https://gitea.example.com/shipfox/platform.git');
+  });
+
+  it('replaces the checkout clone URL origin when GITEA_CLONE_BASE_URL is set', async () => {
+    vi.stubEnv('GITEA_CLONE_BASE_URL', 'http://gitea:3000');
+    vi.resetModules();
+
+    const result = await createCheckoutSpec(REPOSITORY);
+
+    expect(result.repositoryUrl).toBe('http://gitea:3000/shipfox/platform.git');
+  });
+
+  it('keeps a non-root repository path prefix from the provider clone URL', async () => {
+    vi.stubEnv('GITEA_CLONE_BASE_URL', 'http://gitea:3000');
+    vi.resetModules();
+
+    const result = await createCheckoutSpec({
+      ...REPOSITORY,
+      cloneUrl: 'https://gitea.example.com/git/shipfox/platform.git',
+    });
+
+    expect(result.repositoryUrl).toBe('http://gitea:3000/git/shipfox/platform.git');
+  });
+});

--- a/libs/api/integration/gitea/src/core/source-control.ts
+++ b/libs/api/integration/gitea/src/core/source-control.ts
@@ -19,7 +19,7 @@ import {
 } from '@shipfox/api-integration-core-dto';
 import {giteaProviderKind} from '@shipfox/api-integration-gitea-dto';
 import type {GiteaApiClient, GiteaRepository} from '#api/client.js';
-import {config} from '#config.js';
+import {config, giteaCloneBaseOrigin} from '#config.js';
 import {GiteaIntegrationProviderError} from './errors.js';
 
 type GiteaIntegrationConnection = IntegrationConnection<'gitea'>;
@@ -145,10 +145,7 @@ export class GiteaSourceControlProvider
     const ref = input.ref?.trim() || repository.defaultBranch;
 
     return {
-      // The provider's own clone URL respects a Gitea instance whose external
-      // clone host differs from the API base; it is credential-free, so the
-      // CheckoutSpec "no auth material in repositoryUrl" contract still holds.
-      repositoryUrl: repository.cloneUrl,
+      repositoryUrl: createCheckoutRepositoryUrl(repository.cloneUrl),
       ref,
       // Gitea has no per-repo, auto-expiring token like a GitHub App installation
       // token, so checkout reuses the long-lived service credential. `expiresAt`
@@ -161,6 +158,17 @@ export class GiteaSourceControlProvider
       },
     };
   }
+}
+
+function createCheckoutRepositoryUrl(cloneUrl: string): string {
+  if (!giteaCloneBaseOrigin) return cloneUrl;
+
+  const repositoryUrl = new URL(cloneUrl);
+
+  repositoryUrl.protocol = giteaCloneBaseOrigin.protocol;
+  repositoryUrl.host = giteaCloneBaseOrigin.host;
+
+  return repositoryUrl.toString();
 }
 
 function toRepositorySnapshot(repository: GiteaRepository): RepositorySnapshot {


### PR DESCRIPTION
[api/gitea] Add a runner-facing clone URL override

Some deployments expose Gitea to the API and to runner containers through different network origins. This adds optional `GITEA_CLONE_BASE_URL` support so checkout specs can replace the scheme, host, and port of Gitea-reported clone URLs while preserving the repository path.

Repository listing, `htmlUrl`, REST API calls, and webhooks continue to use `GITEA_BASE_URL`. The setting is documented in the Gitea package README and covered by unset, set, and non-root path-prefix unit tests.

No changeset is included because `@shipfox/api-integration-gitea` is a private package.

Fixes ENG-728

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a runner-facing clone URL override to `@shipfox/api-integration-gitea` so checkouts can use a different Gitea origin than the API while keeping repository paths. Fixes ENG-728.

- **New Features**
  - Added `GITEA_CLONE_BASE_URL` to replace the scheme/host/port of clone URLs used in checkout; preserves the repository path.
  - Repository listing, `htmlUrl`, REST calls, and webhooks continue to use `GITEA_BASE_URL`.
  - Validates the override as an absolute URL and documents the setting with tests for unset, set, and non-root path prefixes.

<sup>Written for commit c75924c854c4440fe962400b578feed62e7d81df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

