### PR TITLE
[e2e/helpers] Add integrations-gitea helper for workflow E2E suite

### DIFF
--- a/e2e/helpers/integrations-gitea/README.md
+++ b/e2e/helpers/integrations-gitea/README.md
@@ -20,8 +20,14 @@ Instance side (admin-credentialed, against `E2E_GITEA_URL`):
   cloneUrl, defaultBranch}`.
 - `commitFiles({org, repo, message, files, branch?})` — one commit for the whole batch
   through Gitea's change-files contents API. Returns the commit SHA. File `content` is
-  UTF-8 text; the helper base64-encodes it.
-- `deleteRepo({org, repo})`, `deleteOrg({org})` — teardown.
+  UTF-8 text; the helper base64-encodes it. `operation` defaults to `create`; `update`
+  and `delete` need the file's current blob `sha`.
+- `deleteRepo({org, repo})`, `deleteOrg({org})` — teardown. Delete an org's repos before
+  the org: Gitea's `DELETE /orgs/{org}` fails while the org still owns repositories.
+
+`createOrg` and `createConnectedOrg` are self-cleaning: if a step fails after the org is
+created (team, webhook, or the connect call), they delete the half-built org before
+rethrowing, so a failed run leaves no orphan org in the shared instance.
 
 Platform side (through the product route):
 

--- a/e2e/helpers/integrations-gitea/README.md
+++ b/e2e/helpers/integrations-gitea/README.md
@@ -1,0 +1,61 @@
+# @shipfox/e2e-helper-integrations-gitea
+
+The integration/gitea domain end to end for E2E suites. It drives the external Gitea
+instance with admin credentials (org, team, webhook, repos, commits) and links the org
+to a workspace through the product route. One import gives a scenario a connected org.
+
+Calling Gitea's REST API directly is on purpose: Gitea is the external system under
+integration, exactly like the browser is for client E2E. Everything else goes through
+the platform's public HTTP surface.
+
+## Public API
+
+Instance side (admin-credentialed, against `E2E_GITEA_URL`):
+
+- `createOrg(params?)` — org + read-only team (`includes_all_repositories`) + bot
+  membership + org push webhook, mirroring `dev/gitea/bootstrap.sh`. Returns
+  `{org, teamId, webhookId}`. A fresh org per suite run is required because an org can
+  only ever be linked to one workspace.
+- `createRepo({org, name, ...})` — create a repo in the org. Returns `{name, fullName,
+  cloneUrl, defaultBranch}`.
+- `commitFiles({org, repo, message, files, branch?})` — one commit for the whole batch
+  through Gitea's change-files contents API. Returns the commit SHA. File `content` is
+  UTF-8 text; the helper base64-encodes it.
+- `deleteRepo({org, repo})`, `deleteOrg({org})` — teardown.
+
+Platform side (through the product route):
+
+- `connectGiteaOrg({workspaceId, org, sessionToken})` — `POST
+  /integrations/gitea/connections`, authenticated with the suite user's session token.
+  Returns the connection DTO.
+
+Convenience:
+
+- `createConnectedOrg({workspaceId, sessionToken, name?})` — `createOrg` then
+  `connectGiteaOrg`, returning `{org, teamId, webhookId, connection}`.
+- `createGiteaHelper()` / `giteaHelper` — the factory and the Playwright fixture
+  (`gitea`). Compose it with the other helpers:
+
+  ```ts
+  import {test as base, expect} from '@shipfox/e2e-core/playwright';
+  import {type GiteaFixtures, giteaHelper} from '@shipfox/e2e-helper-integrations-gitea';
+
+  export const test = base.extend<GiteaFixtures>({...giteaHelper});
+  ```
+
+## Configuration
+
+Defaults match `dev/gitea/bootstrap.sh`, so the helper works against local compose Gitea
+with no environment set.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `E2E_GITEA_URL` | `http://localhost:3000` | Gitea instance, seen from the test host. |
+| `E2E_GITEA_ADMIN_USERNAME` | `gitea-admin` | Site admin the helper authenticates as. |
+| `E2E_GITEA_ADMIN_PASSWORD` | `gitea-admin-dev-password` | Site admin password (Basic auth). |
+| `E2E_GITEA_BOT_USERNAME` | `shipfox-bot` | Read-only bot added to each run org's team. |
+| `E2E_GITEA_WEBHOOK_SECRET` | `shipfox-gitea-dev-webhook-secret` | Secret on the org push webhook; must match the API's `GITEA_WEBHOOK_SECRET`. |
+| `E2E_API_HOST_FROM_CONTAINER` | `host.docker.internal` | Host the Gitea container uses to reach the API when delivering webhooks. |
+
+The webhook target URL is derived from the API URL (`@shipfox/e2e-core`'s `API_URL`),
+swapping the host for `E2E_API_HOST_FROM_CONTAINER` and keeping the scheme and port.

--- a/e2e/helpers/integrations-gitea/README.md
+++ b/e2e/helpers/integrations-gitea/README.md
@@ -22,8 +22,8 @@ Instance side (admin-credentialed, against `E2E_GITEA_URL`):
   through Gitea's change-files contents API. Returns the commit SHA. File `content` is
   UTF-8 text; the helper base64-encodes it. `operation` defaults to `create`; `update`
   and `delete` need the file's current blob `sha`.
-- `deleteRepo({org, repo})`, `deleteOrg({org})` — teardown. Delete an org's repos before
-  the org: Gitea's `DELETE /orgs/{org}` fails while the org still owns repositories.
+- `deleteRepo({org, repo})`, `deleteOrg({org})` — teardown. `deleteOrg` deletes the org's
+  repositories first, then the org (Gitea rejects deleting an org that still owns repos).
 
 `createOrg` and `createConnectedOrg` are self-cleaning: if a step fails after the org is
 created (team, webhook, or the connect call), they delete the half-built org before

--- a/e2e/helpers/integrations-gitea/package.json
+++ b/e2e/helpers/integrations-gitea/package.json
@@ -34,7 +34,6 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/api-integration-gitea": "workspace:*",
     "@shipfox/api-integration-gitea-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",

--- a/e2e/helpers/integrations-gitea/package.json
+++ b/e2e/helpers/integrations-gitea/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shipfox/e2e-helper-integrations-gitea",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/helpers/integrations-gitea"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-integration-gitea": "workspace:*",
+    "@shipfox/api-integration-gitea-dto": "workspace:*",
+    "@shipfox/config": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/helpers/integrations-gitea/src/config.ts
+++ b/e2e/helpers/integrations-gitea/src/config.ts
@@ -1,0 +1,39 @@
+import {createConfig, str} from '@shipfox/config';
+import {config as e2eCoreConfig} from '@shipfox/e2e-core';
+
+export const config = createConfig({
+  E2E_GITEA_URL: str({
+    desc: 'Base URL of the Gitea instance the helper drives with admin credentials, seen from the host running the tests (for example http://localhost:3000).',
+    default: 'http://localhost:3000',
+  }),
+  E2E_GITEA_ADMIN_USERNAME: str({
+    desc: 'Username of the Gitea site admin the helper authenticates as over Basic auth. Matches the value dev/gitea/bootstrap.sh creates.',
+    default: 'gitea-admin',
+  }),
+  E2E_GITEA_ADMIN_PASSWORD: str({
+    desc: 'Password of the Gitea site admin, used for Basic auth against the Gitea REST API. Matches the value dev/gitea/bootstrap.sh creates.',
+    default: 'gitea-admin-dev-password',
+  }),
+  E2E_GITEA_BOT_USERNAME: str({
+    desc: "Username of the read-only bot added to each run org's team, so the platform service account can read the org's repositories. Matches the value dev/gitea/bootstrap.sh creates.",
+    default: 'shipfox-bot',
+  }),
+  E2E_GITEA_WEBHOOK_SECRET: str({
+    desc: "Secret registered on each run org's push webhook. Must match the API GITEA_WEBHOOK_SECRET so deliveries verify.",
+    default: 'shipfox-gitea-dev-webhook-secret',
+  }),
+  E2E_API_HOST_FROM_CONTAINER: str({
+    desc: 'Host the Gitea container uses to reach the API when delivering webhooks. Defaults to host.docker.internal, which resolves to the host running the API from inside a container.',
+    default: 'host.docker.internal',
+  }),
+});
+
+// Gitea delivers push webhooks from inside a container, so the target host is the
+// container-reachable API host (host.docker.internal), while the scheme and port
+// stay those of the API the tests already talk to.
+export function defaultWebhookTargetUrl(): string {
+  const url = new URL(e2eCoreConfig.API_URL);
+  url.hostname = config.E2E_API_HOST_FROM_CONTAINER;
+  url.pathname = '/webhooks/integrations/gitea';
+  return url.toString();
+}

--- a/e2e/helpers/integrations-gitea/src/connect.ts
+++ b/e2e/helpers/integrations-gitea/src/connect.ts
@@ -1,0 +1,28 @@
+import type {
+  CreateGiteaConnectionBodyDto,
+  CreateGiteaConnectionResponseDto,
+} from '@shipfox/api-integration-gitea-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+export interface ConnectGiteaOrgParams {
+  workspaceId: string;
+  org: string;
+  sessionToken: string;
+}
+
+// Links the org to the workspace through the product route, authenticated with the
+// suite user's session token instead of the E2E admin key the core client defaults to.
+export async function connectGiteaOrg(
+  params: ConnectGiteaOrgParams,
+): Promise<CreateGiteaConnectionResponseDto> {
+  const body: CreateGiteaConnectionBodyDto = {
+    workspace_id: params.workspaceId,
+    org: params.org,
+  };
+
+  return await requestJson<CreateGiteaConnectionResponseDto>(
+    'post',
+    '/integrations/gitea/connections',
+    {json: body, headers: {authorization: `Bearer ${params.sessionToken}`}},
+  );
+}

--- a/e2e/helpers/integrations-gitea/src/gitea-client.ts
+++ b/e2e/helpers/integrations-gitea/src/gitea-client.ts
@@ -1,0 +1,90 @@
+import {Buffer} from 'node:buffer';
+import {config} from './config.js';
+
+const TRAILING_SLASHES_RE = /\/+$/;
+
+export class GiteaInstanceError extends Error {
+  readonly status: number;
+  readonly details: unknown;
+
+  constructor(params: {message: string; status: number; details: unknown}) {
+    super(params.message);
+    this.name = 'GiteaInstanceError';
+    this.status = params.status;
+    this.details = params.details;
+  }
+}
+
+export interface GiteaRequestOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  json?: unknown;
+}
+
+function baseApiUrl(): string {
+  return `${config.E2E_GITEA_URL.replace(TRAILING_SLASHES_RE, '')}/api/v1`;
+}
+
+function authHeader(): string {
+  const credentials = `${config.E2E_GITEA_ADMIN_USERNAME}:${config.E2E_GITEA_ADMIN_PASSWORD}`;
+  return `Basic ${Buffer.from(credentials).toString('base64')}`;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+export async function giteaFetch(
+  path: string,
+  options: GiteaRequestOptions = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    authorization: authHeader(),
+    accept: 'application/json',
+  };
+  const init: RequestInit = {method: options.method ?? 'GET', headers};
+  if (options.json !== undefined) {
+    headers['content-type'] = 'application/json';
+    init.body = JSON.stringify(options.json);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseApiUrl()}/${path}`, init);
+  } catch (error) {
+    throw new GiteaInstanceError({
+      message: `Gitea request to ${path} failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      status: 0,
+      details: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw new GiteaInstanceError({
+      message: `Gitea request to ${path} failed with ${response.status}`,
+      status: response.status,
+      details: await parseBody(response),
+    });
+  }
+
+  return response;
+}
+
+export async function giteaFetchJson<T>(
+  path: string,
+  options: GiteaRequestOptions = {},
+): Promise<T> {
+  const response = await giteaFetch(path, options);
+  return (await response.json()) as T;
+}
+
+export function encodeSegment(segment: string): string {
+  return encodeURIComponent(segment);
+}

--- a/e2e/helpers/integrations-gitea/src/index.ts
+++ b/e2e/helpers/integrations-gitea/src/index.ts
@@ -1,0 +1,76 @@
+import type {CreateGiteaConnectionResponseDto} from '@shipfox/api-integration-gitea-dto';
+import {connectGiteaOrg} from './connect.js';
+import {type CreatedOrg, createOrg} from './instance.js';
+
+export type {CreateGiteaConnectionResponseDto} from '@shipfox/api-integration-gitea-dto';
+export {type ConnectGiteaOrgParams, connectGiteaOrg} from './connect.js';
+export {GiteaInstanceError} from './gitea-client.js';
+export {
+  type CommitFile,
+  type CommitFileOperation,
+  type CommitFilesParams,
+  type CreatedOrg,
+  type CreatedRepo,
+  type CreateOrgParams,
+  type CreateRepoParams,
+  commitFiles,
+  createOrg,
+  createRepo,
+  deleteOrg,
+  deleteRepo,
+  generateOrgName,
+} from './instance.js';
+
+export interface CreateConnectedOrgParams {
+  workspaceId: string;
+  sessionToken: string;
+  name?: string;
+}
+
+export interface ConnectedOrg extends CreatedOrg {
+  connection: CreateGiteaConnectionResponseDto;
+}
+
+// The one-import path: a fresh org (team, bot, webhook) linked to the workspace,
+// ready for a scenario to push into.
+export async function createConnectedOrg(params: CreateConnectedOrgParams): Promise<ConnectedOrg> {
+  const org = await createOrg({name: params.name});
+  const connection = await connectGiteaOrg({
+    workspaceId: params.workspaceId,
+    org: org.org,
+    sessionToken: params.sessionToken,
+  });
+
+  return {...org, connection};
+}
+
+export function createGiteaHelper() {
+  return {
+    createOrg,
+    createRepo,
+    commitFiles,
+    deleteRepo,
+    deleteOrg,
+    connectOrg: connectGiteaOrg,
+    createConnectedOrg,
+    have: {
+      org: createOrg,
+      connectedOrg: createConnectedOrg,
+    },
+  };
+}
+
+export type GiteaHelper = ReturnType<typeof createGiteaHelper>;
+
+export interface GiteaFixtures {
+  gitea: GiteaHelper;
+}
+
+export const giteaHelper = {
+  gitea: async (
+    {request: _request}: {request: unknown},
+    use: (helper: GiteaHelper) => Promise<void>,
+  ) => {
+    await use(createGiteaHelper());
+  },
+};

--- a/e2e/helpers/integrations-gitea/src/index.ts
+++ b/e2e/helpers/integrations-gitea/src/index.ts
@@ -1,6 +1,6 @@
 import type {CreateGiteaConnectionResponseDto} from '@shipfox/api-integration-gitea-dto';
 import {connectGiteaOrg} from './connect.js';
-import {type CreatedOrg, createOrg} from './instance.js';
+import {bestEffortDeleteOrg, type CreatedOrg, createOrg} from './instance.js';
 
 export type {CreateGiteaConnectionResponseDto} from '@shipfox/api-integration-gitea-dto';
 export {type ConnectGiteaOrgParams, connectGiteaOrg} from './connect.js';
@@ -35,13 +35,21 @@ export interface ConnectedOrg extends CreatedOrg {
 // ready for a scenario to push into.
 export async function createConnectedOrg(params: CreateConnectedOrgParams): Promise<ConnectedOrg> {
   const org = await createOrg({name: params.name});
-  const connection = await connectGiteaOrg({
-    workspaceId: params.workspaceId,
-    org: org.org,
-    sessionToken: params.sessionToken,
-  });
 
-  return {...org, connection};
+  // If linking fails, the org (with its live webhook) is not returned, so undo it
+  // here rather than leak it into the shared instance.
+  try {
+    const connection = await connectGiteaOrg({
+      workspaceId: params.workspaceId,
+      org: org.org,
+      sessionToken: params.sessionToken,
+    });
+
+    return {...org, connection};
+  } catch (error) {
+    await bestEffortDeleteOrg(org.org);
+    throw error;
+  }
 }
 
 export function createGiteaHelper() {

--- a/e2e/helpers/integrations-gitea/src/instance.ts
+++ b/e2e/helpers/integrations-gitea/src/instance.ts
@@ -70,34 +70,42 @@ export async function createOrg(params: CreateOrgParams = {}): Promise<CreatedOr
     json: {username: org, visibility: params.visibility ?? 'public'},
   });
 
-  const team = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/teams`, {
-    method: 'POST',
-    json: {
-      name: READ_TEAM_NAME,
-      permission: 'read',
-      includes_all_repositories: true,
-      units: ['repo.code'],
-    },
-  });
-
-  const botUsername = params.botUsername ?? config.E2E_GITEA_BOT_USERNAME;
-  await giteaFetch(`teams/${team.id}/members/${encodeSegment(botUsername)}`, {method: 'PUT'});
-
-  const hook = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/hooks`, {
-    method: 'POST',
-    json: {
-      type: 'gitea',
-      active: true,
-      events: ['push'],
-      config: {
-        url: params.webhookTargetUrl ?? defaultWebhookTargetUrl(),
-        content_type: 'json',
-        secret: params.webhookSecret ?? config.E2E_GITEA_WEBHOOK_SECRET,
+  // A failure after the org exists (team, membership, or webhook) would strand it
+  // in the shared instance with no handle for the caller to clean up, so undo the
+  // half-built org here. It owns no repos yet, so deleteOrg always succeeds.
+  try {
+    const team = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/teams`, {
+      method: 'POST',
+      json: {
+        name: READ_TEAM_NAME,
+        permission: 'read',
+        includes_all_repositories: true,
+        units: ['repo.code'],
       },
-    },
-  });
+    });
 
-  return {org, teamId: team.id, webhookId: hook.id};
+    const botUsername = params.botUsername ?? config.E2E_GITEA_BOT_USERNAME;
+    await giteaFetch(`teams/${team.id}/members/${encodeSegment(botUsername)}`, {method: 'PUT'});
+
+    const hook = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/hooks`, {
+      method: 'POST',
+      json: {
+        type: 'gitea',
+        active: true,
+        events: ['push'],
+        config: {
+          url: params.webhookTargetUrl ?? defaultWebhookTargetUrl(),
+          content_type: 'json',
+          secret: params.webhookSecret ?? config.E2E_GITEA_WEBHOOK_SECRET,
+        },
+      },
+    });
+
+    return {org, teamId: team.id, webhookId: hook.id};
+  } catch (error) {
+    await bestEffortDeleteOrg(org);
+    throw error;
+  }
 }
 
 export async function createRepo(params: CreateRepoParams): Promise<CreatedRepo> {
@@ -158,6 +166,19 @@ export async function deleteRepo(params: {org: string; repo: string}): Promise<v
   });
 }
 
+// Gitea's DELETE /orgs/{org} rejects an org that still owns repositories, so
+// delete the org's repos first.
 export async function deleteOrg(params: {org: string}): Promise<void> {
   await giteaFetch(`orgs/${encodeSegment(params.org)}`, {method: 'DELETE'});
+}
+
+// Removes an org on a failure path, where surfacing the original error matters
+// more than a cleanup that itself fails; used to keep half-built orgs out of the
+// shared instance.
+export async function bestEffortDeleteOrg(org: string): Promise<void> {
+  try {
+    await deleteOrg({org});
+  } catch {
+    // Swallowed on purpose: the caller is already rethrowing the root cause.
+  }
 }

--- a/e2e/helpers/integrations-gitea/src/instance.ts
+++ b/e2e/helpers/integrations-gitea/src/instance.ts
@@ -166,10 +166,27 @@ export async function deleteRepo(params: {org: string; repo: string}): Promise<v
   });
 }
 
-// Gitea's DELETE /orgs/{org} rejects an org that still owns repositories, so
-// delete the org's repos first.
+// Deletes the org and every repo it owns. Gitea's DELETE /orgs/{org} rejects an
+// org that still owns repositories, so the repos go first.
 export async function deleteOrg(params: {org: string}): Promise<void> {
+  for (const repo of await listOrgRepoNames(params.org)) {
+    await deleteRepo({org: params.org, repo});
+  }
   await giteaFetch(`orgs/${encodeSegment(params.org)}`, {method: 'DELETE'});
+}
+
+const ORG_REPOS_PAGE_SIZE = 50;
+
+async function listOrgRepoNames(org: string): Promise<string[]> {
+  const names: string[] = [];
+  for (let page = 1; ; page++) {
+    const repos = await giteaFetchJson<Array<{name: string}>>(
+      `orgs/${encodeSegment(org)}/repos?page=${page}&limit=${ORG_REPOS_PAGE_SIZE}`,
+    );
+    for (const repo of repos) names.push(repo.name);
+    if (repos.length < ORG_REPOS_PAGE_SIZE) break;
+  }
+  return names;
 }
 
 // Removes an org on a failure path, where surfacing the original error matters

--- a/e2e/helpers/integrations-gitea/src/instance.ts
+++ b/e2e/helpers/integrations-gitea/src/instance.ts
@@ -1,0 +1,163 @@
+import {Buffer} from 'node:buffer';
+import {config, defaultWebhookTargetUrl} from './config.js';
+import {encodeSegment, GiteaInstanceError, giteaFetch, giteaFetchJson} from './gitea-client.js';
+
+// A read-only team that includes every repo, current and future, mirroring
+// dev/gitea/bootstrap.sh: it is the bot's only membership, so a leaked bot
+// credential is bounded to read access on the run's repos.
+const READ_TEAM_NAME = 'shipfox-readers';
+
+export interface CreateOrgParams {
+  name?: string;
+  visibility?: 'public' | 'private' | 'limited';
+  botUsername?: string;
+  webhookTargetUrl?: string;
+  webhookSecret?: string;
+}
+
+export interface CreatedOrg {
+  org: string;
+  teamId: number;
+  webhookId: number;
+}
+
+export interface CreateRepoParams {
+  org: string;
+  name: string;
+  private?: boolean;
+  autoInit?: boolean;
+  defaultBranch?: string;
+}
+
+export interface CreatedRepo {
+  name: string;
+  fullName: string;
+  cloneUrl: string;
+  defaultBranch: string;
+}
+
+export type CommitFileOperation = 'create' | 'update' | 'delete';
+
+export interface CommitFile {
+  path: string;
+  content?: string;
+  operation?: CommitFileOperation;
+  sha?: string;
+}
+
+export interface CommitFilesParams {
+  org: string;
+  repo: string;
+  message: string;
+  files: CommitFile[];
+  branch?: string;
+}
+
+export function generateOrgName(): string {
+  return `e2e-${crypto.randomUUID().replaceAll('-', '').slice(0, 20)}`;
+}
+
+// Org + read-only team + bot membership + push webhook, mirroring
+// dev/gitea/bootstrap.sh. A fresh org per suite run is required because an org
+// can only ever be linked to one workspace (GiteaOrgAlreadyLinkedError). The org
+// is public so the platform service account can see it exists while its repos
+// stay private, exercising the checkout path's Basic auth.
+export async function createOrg(params: CreateOrgParams = {}): Promise<CreatedOrg> {
+  const org = params.name ?? generateOrgName();
+
+  await giteaFetch('orgs', {
+    method: 'POST',
+    json: {username: org, visibility: params.visibility ?? 'public'},
+  });
+
+  const team = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/teams`, {
+    method: 'POST',
+    json: {
+      name: READ_TEAM_NAME,
+      permission: 'read',
+      includes_all_repositories: true,
+      units: ['repo.code'],
+    },
+  });
+
+  const botUsername = params.botUsername ?? config.E2E_GITEA_BOT_USERNAME;
+  await giteaFetch(`teams/${team.id}/members/${encodeSegment(botUsername)}`, {method: 'PUT'});
+
+  const hook = await giteaFetchJson<{id: number}>(`orgs/${encodeSegment(org)}/hooks`, {
+    method: 'POST',
+    json: {
+      type: 'gitea',
+      active: true,
+      events: ['push'],
+      config: {
+        url: params.webhookTargetUrl ?? defaultWebhookTargetUrl(),
+        content_type: 'json',
+        secret: params.webhookSecret ?? config.E2E_GITEA_WEBHOOK_SECRET,
+      },
+    },
+  });
+
+  return {org, teamId: team.id, webhookId: hook.id};
+}
+
+export async function createRepo(params: CreateRepoParams): Promise<CreatedRepo> {
+  const repo = await giteaFetchJson<{
+    name: string;
+    full_name: string;
+    clone_url: string;
+    default_branch: string;
+  }>(`orgs/${encodeSegment(params.org)}/repos`, {
+    method: 'POST',
+    json: {
+      name: params.name,
+      private: params.private ?? true,
+      auto_init: params.autoInit ?? true,
+      default_branch: params.defaultBranch ?? 'main',
+    },
+  });
+
+  return {
+    name: repo.name,
+    fullName: repo.full_name,
+    cloneUrl: repo.clone_url,
+    defaultBranch: repo.default_branch,
+  };
+}
+
+// One commit for the whole batch through Gitea's change-files contents API,
+// returning the resulting commit SHA (the push correlation key in the suite).
+export async function commitFiles(params: CommitFilesParams): Promise<string> {
+  const files = params.files.map((file) => ({
+    operation: file.operation ?? 'create',
+    path: file.path,
+    content:
+      file.content === undefined ? undefined : Buffer.from(file.content, 'utf8').toString('base64'),
+    sha: file.sha,
+  }));
+
+  const response = await giteaFetchJson<{commit?: {sha?: string}}>(
+    `repos/${encodeSegment(params.org)}/${encodeSegment(params.repo)}/contents`,
+    {method: 'POST', json: {branch: params.branch ?? 'main', message: params.message, files}},
+  );
+
+  const sha = response.commit?.sha;
+  if (!sha) {
+    throw new GiteaInstanceError({
+      message: 'Gitea change-files response did not include a commit SHA',
+      status: 200,
+      details: response,
+    });
+  }
+
+  return sha;
+}
+
+export async function deleteRepo(params: {org: string; repo: string}): Promise<void> {
+  await giteaFetch(`repos/${encodeSegment(params.org)}/${encodeSegment(params.repo)}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function deleteOrg(params: {org: string}): Promise<void> {
+  await giteaFetch(`orgs/${encodeSegment(params.org)}`, {method: 'DELETE'});
+}

--- a/e2e/helpers/integrations-gitea/tsconfig.build.json
+++ b/e2e/helpers/integrations-gitea/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/integrations-gitea/tsconfig.json
+++ b/e2e/helpers/integrations-gitea/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,9 +434,6 @@ importers:
 
   e2e/helpers/integrations-gitea:
     dependencies:
-      '@shipfox/api-integration-gitea':
-        specifier: workspace:*
-        version: link:../../../libs/api/integration/gitea
       '@shipfox/api-integration-gitea-dto':
         specifier: workspace:*
         version: link:../../../libs/api/integration/gitea-dto

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,37 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/helpers/integrations-gitea:
+    dependencies:
+      '@shipfox/api-integration-gitea':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/gitea
+      '@shipfox/api-integration-gitea-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/gitea-dto
+      '@shipfox/config':
+        specifier: workspace:*
+        version: link:../../../libs/shared/common/config
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/helpers/runners:
     dependencies:
       '@shipfox/api-runners':


### PR DESCRIPTION
Add `@shipfox/e2e-helper-integrations-gitea` (`e2e/helpers/integrations-gitea`): the integration/gitea domain end to end for the Platform workflow E2E suite (WS2 in the [spec](https://linear.app/shipfox/document/platform-workflow-e2e-suite-spec-and-design-v1-850a2afe3712)). It is named after the domain plus provider, matching `e2e-client-integrations` on the client side, and follows the existing helper conventions (`e2e-helper-auth`, `e2e-helper-workspaces`, `e2e-core`).

**Instance side** (admin-credentialed, against `E2E_GITEA_URL`):
- `createOrg` — org + read-only team (`includes_all_repositories`) + `shipfox-bot` membership + org push webhook, mirroring `dev/gitea/bootstrap.sh`. A fresh org per run is required because an org can only ever be linked to one workspace (`GiteaOrgAlreadyLinkedError`).
- `createRepo`, `commitFiles` (batch change-files contents API, one commit per call, returns the commit SHA), `deleteRepo`, `deleteOrg`.

**Platform side**: `connectGiteaOrg` → `POST /integrations/gitea/connections`, authenticated with the suite user's session token (overriding the E2E admin key the core client defaults to).

`createConnectedOrg` and the `gitea` Playwright fixture give a scenario a connected org from one import.

Calling Gitea's API directly is consistent with the HTTP-first E2E rule: Gitea is the external system under integration, exactly like the browser is for client E2E. Config defaults match the dev bootstrap, so the instance side is verifiable against local compose Gitea alone.

### Notes for reviewers
- Internal cross-file imports are **relative** (`./config.js`), not `#`-subpath, matching `e2e-core`: the package `imports` map (`#*` → `./src/*`) would otherwise resolve the consumed `dist` back to TS source.
- Verified against local compose Gitea: `createOrg` → `createRepo` → seed + trigger `commitFiles` (both returned real SHAs) → `deleteRepo` → `deleteOrg`, leaving no leaked orgs. `connectGiteaOrg` was verified statically (route auth reads `Authorization: Bearer <token>`; path has no extra prefix) but not live-tested, as it needs the API running.
- No changeset: private `e2e/` package, not a published `libs/`/`tools/` package.

Closes ENG-729

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@shipfox/e2e-helper-integrations-gitea` for the Platform workflow E2E suite (ENG-729). It provisions a fresh Gitea org, links it to a workspace, and cleans up on failures so tests can push and verify webhooks without leaking orgs.

- **New Features**
  - Instance-side: `createOrg` (read-only team + `shipfox-bot` + push webhook; self-cleans on partial failures), `createRepo`, `commitFiles` (batch; returns commit SHA; `update`/`delete` need blob `sha`), `deleteRepo`, `deleteOrg` (cascades by deleting repos first).
  - Platform-side: `connectGiteaOrg` (`POST /integrations/gitea/connections`) using the suite user’s `sessionToken`.
  - Convenience: `createConnectedOrg` (self-cleans if connect fails) and Playwright fixture `gitea`.
  - Defaults match dev bootstrap; webhook target derives from `@shipfox/e2e-core`’s `API_URL` + `E2E_API_HOST_FROM_CONTAINER`.

- **Dependencies**
  - Removed unused `@shipfox/api-integration-gitea`; only `@shipfox/api-integration-gitea-dto` is used.

<sup>Written for commit 7d3e5faac962c5c359d58061f361d1a01efd1877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

