### PR TITLE
[client-projects] Stabilize page test auth seeding

### DIFF
--- a/libs/client/projects/test/pages.tsx
+++ b/libs/client/projects/test/pages.tsx
@@ -12,8 +12,8 @@ import {
   useParams,
 } from '@tanstack/react-router';
 import {type RenderResult, render} from '@testing-library/react';
-import {Provider as JotaiProvider, useSetAtom} from 'jotai';
-import {type ReactElement, useEffect} from 'react';
+import {createStore, Provider as JotaiProvider} from 'jotai';
+import type {ReactElement} from 'react';
 import {CreateProjectPage} from '#pages/create-project-page.js';
 import {ProjectWorkflowsPage} from '#pages/project-workflows-page.js';
 import {ProjectsHubPage} from '#pages/projects-hub-page.js';
@@ -132,26 +132,17 @@ function createTestRouter(path: string, element: ReactElement) {
   });
 }
 
-function AuthSeed() {
-  const setAuth = useSetAtom(authStateAtom);
-
-  useEffect(() => {
-    setAuth(authState);
-  }, [setAuth]);
-
-  return null;
-}
-
 export function renderProjectPage(path: string, element: ReactElement): RenderResult {
   const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
   const router = createTestRouter(path, element);
+  const store = createStore();
+  store.set(authStateAtom, authState);
 
   configureApiClient({baseUrl: 'https://api.example.test'});
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <JotaiProvider>
-        <AuthSeed />
+      <JotaiProvider store={store}>
         <RouterProvider router={router} />
         <Toaster />
       </JotaiProvider>


### PR DESCRIPTION
[client-projects] Stabilize page test auth seeding

The client projects page test helper seeded authenticated workspace state from a sibling React effect. That let the router render workspace pages before `authStateAtom` contained the route workspace, so `useActiveWorkspace()` could fail before the page mounted and cause flaky timeouts waiting for static page content.

This seeds a fresh Jotai store synchronously before mounting `RouterProvider`, which also keeps auth state isolated per render.

This is a test-only helper change in a private client package, so no release changeset is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized client projects page tests by seeding auth state synchronously with a fresh `jotai` store before mounting the router. This removes the race where pages rendered before `authStateAtom` was set, eliminating flaky timeouts.

- **Bug Fixes**
  - Seed `authStateAtom` in a new `jotai` store and pass it to `JotaiProvider` before `RouterProvider`.
  - Removed effect-based `AuthSeed`, isolating auth per render and preventing `useActiveWorkspace()` failures.

<sup>Written for commit c0892087ed6a37cf068d6846473c6ae9bca5c8a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

