### PR TITLE
[e2e/helper-runners] Add provisioner token and child-process helper

### DIFF
--- a/e2e/helpers/runners/README.md
+++ b/e2e/helpers/runners/README.md
@@ -1,0 +1,109 @@
+# @shipfox/e2e-helper-runners
+
+Runner capacity for an end-to-end suite. It mints a provisioner token and runs
+`@shipfox/provisioner-docker` as a child process, so a suite can provision real
+Docker runners the same way production does.
+
+This package owns the `@shipfox/provisioner-docker` workspace dependency. Other
+helpers (gitea, workflows) do not depend on it, so they never pull the provisioner
+and its Docker client into their graph.
+
+## API
+
+### `mintProvisionerToken(params)`
+
+Calls `POST /workspaces/:workspaceId/provisioners/tokens` and returns the created
+token. The `raw_token` field is the value to pass to `startProvisioner`; the API
+returns it only once.
+
+The provisioner-token route is user-authed, so `params.userToken` must be a user
+session bearer (the `token` from an E2E session), not the shared E2E admin key.
+
+```ts
+const token = await mintProvisionerToken({
+  workspaceId,
+  userToken: session.token,
+});
+```
+
+### `startProvisioner(params)`
+
+Spawns the provisioner dist (`node .../provisioner-docker/dist/index.js`), appends
+its stdout and stderr to `logFile` (keep this file as a CI artifact), and resolves
+once the provisioner reports as active for the workspace. It rejects, after killing
+the child, if the process exits before it becomes active or the readiness budget
+(default 30s) runs out.
+
+```ts
+const handle = await startProvisioner({
+  workspaceId,
+  userToken: session.token,
+  provisionerToken: token.raw_token,
+  templatesFile: '/abs/path/to/templates.e2e.yaml',
+  logFile: '/abs/path/to/provisioner.log',
+  tokenPrefix: token.prefix, // match this provisioner in the active list
+  // Optional, for the compose topology the platform suite uses:
+  runnerApiUrl: 'http://host.docker.internal:16101',
+  dockerNetwork: 'shipfox_default',
+  dockerExtraHosts: 'host.docker.internal:host-gateway',
+});
+```
+
+The provisioner dist must be built first. Under Turbo this is automatic: `test:e2e`
+depends on `^build`, and this package depends on `@shipfox/provisioner-docker`.
+
+### `stopProvisioner(handle, options?)`
+
+Sends `SIGTERM` (then `SIGKILL` after a grace period, default 15s) so the
+provisioner reaps its own containers, then removes any container still carrying the
+`shipfox.workspace_id=<workspaceId>` label as a backstop. The backstop is
+best-effort: a Docker failure is written to stderr, not thrown.
+
+```ts
+await stopProvisioner(handle);
+```
+
+## Manual verification
+
+Automated coverage lands with the platform workflow E2E suite, which composes these
+functions in its `global-setup` / `global-teardown`. To verify this package on its
+own:
+
+```sh
+# 1. Infra + a runner image the templates file references, then the API with E2E routes on.
+docker compose up -d
+turbo image --filter=@shipfox/runner        # loads runner:ci locally
+E2E_ENABLED=true pnpm --filter=@shipfox/api dev
+
+# 2. Build the provisioner dist this helper spawns.
+turbo build --filter=@shipfox/provisioner-docker
+```
+
+Then, from a scratch script (run with the workspace conditions, e.g. `tsx`):
+
+```ts
+import {createUser, createSession} from '@shipfox/e2e-helper-auth';
+import {createWorkspace} from '@shipfox/e2e-helper-workspaces';
+import {mintProvisionerToken, startProvisioner, stopProvisioner} from '@shipfox/e2e-helper-runners';
+
+const user = await createUser();
+const session = await createSession({user_id: user.user.id});
+const workspace = await createWorkspace({userId: user.user.id});
+
+const token = await mintProvisionerToken({workspaceId: workspace.workspace.id, userToken: session.token});
+const handle = await startProvisioner({
+  workspaceId: workspace.workspace.id,
+  userToken: session.token,
+  provisionerToken: token.raw_token,
+  tokenPrefix: token.prefix,
+  templatesFile: new URL('../../../apps/provisioner-docker/templates.example.yaml', import.meta.url).pathname,
+  logFile: '/tmp/provisioner.log',
+});
+console.log('active provisioner:', handle.provisioner);
+
+await stopProvisioner(handle);
+```
+
+Confirm the provisioner appeared in the resolved `handle.provisioner`, that
+`/tmp/provisioner.log` filled with output, and that after teardown
+`docker ps -a --filter label=shipfox.workspace_id=<workspaceId>` lists nothing.

--- a/e2e/helpers/runners/package.json
+++ b/e2e/helpers/runners/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-helper-runners",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/helpers/runners"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-runners": "workspace:*",
+    "@shipfox/api-runners-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/provisioner-docker": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/helpers/runners/src/index.ts
+++ b/e2e/helpers/runners/src/index.ts
@@ -1,0 +1,13 @@
+export type {
+  ActiveProvisionerDto,
+  CreateProvisionerTokenResponseDto,
+  ListActiveProvisionersResponseDto,
+} from '@shipfox/api-runners-dto';
+export {
+  type ProvisionerHandle,
+  type StartProvisionerParams,
+  type StopProvisionerOptions,
+  startProvisioner,
+  stopProvisioner,
+} from './provisioner-process.js';
+export {type MintProvisionerTokenParams, mintProvisionerToken} from './provisioner-token.js';

--- a/e2e/helpers/runners/src/poll.ts
+++ b/e2e/helpers/runners/src/poll.ts
@@ -1,0 +1,73 @@
+export interface PollOptions {
+  timeoutMs: number;
+  intervalMs?: number;
+  maxIntervalMs?: number;
+  describe: () => string;
+  /** Stops polling early (used to fail fast when the polled process dies). */
+  signal?: AbortSignal;
+}
+
+const DEFAULT_INTERVAL_MS = 500;
+const DEFAULT_MAX_INTERVAL_MS = 2_000;
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, {once: true});
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Polls `probe` with exponential backoff until it returns a non-null value or the
+ * budget runs out. On timeout it throws an error that ends with `describe()`, so
+ * callers surface the last state they observed rather than a bare deadline. An
+ * aborted signal also ends the poll with that same descriptive error.
+ */
+export async function pollUntil<T>(
+  options: PollOptions,
+  probe: () => Promise<T | null>,
+): Promise<T> {
+  const deadline = Date.now() + options.timeoutMs;
+  let delay = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const maxIntervalMs = options.maxIntervalMs ?? DEFAULT_MAX_INTERVAL_MS;
+  let lastError: unknown;
+
+  for (;;) {
+    if (options.signal?.aborted) {
+      throw new Error(`Stopped waiting for ${options.describe()}`);
+    }
+
+    try {
+      const result = await probe();
+      if (result !== null) return result;
+    } catch (error) {
+      lastError = error;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      const suffix = lastError === undefined ? '' : `; last error: ${errorMessage(lastError)}`;
+      throw new Error(
+        `Timed out after ${options.timeoutMs}ms waiting for ${options.describe()}${suffix}`,
+      );
+    }
+
+    await sleep(Math.min(delay, remaining), options.signal);
+    delay = Math.min(delay * 2, maxIntervalMs);
+  }
+}

--- a/e2e/helpers/runners/src/provisioner-process.ts
+++ b/e2e/helpers/runners/src/provisioner-process.ts
@@ -1,0 +1,240 @@
+import {type ChildProcess, execFile, spawn} from 'node:child_process';
+import {closeSync, openSync} from 'node:fs';
+import {createRequire} from 'node:module';
+import {dirname, join} from 'node:path';
+import {promisify} from 'node:util';
+import type {
+  ActiveProvisionerDto,
+  ListActiveProvisionersResponseDto,
+} from '@shipfox/api-runners-dto';
+import {config, requestJson} from '@shipfox/e2e-core';
+import {pollUntil} from './poll.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Label stamped on every runner container the provisioner launches
+ * (libs/provisioner/docker container identity). Used only as a teardown backstop,
+ * so it is duplicated here rather than imported from the provider internals.
+ */
+const WORKSPACE_ID_LABEL = 'shipfox.workspace_id';
+
+const DEFAULT_READINESS_TIMEOUT_MS = 30_000;
+const DEFAULT_SIGTERM_TIMEOUT_MS = 15_000;
+
+export interface StartProvisionerParams {
+  workspaceId: string;
+  /** User session bearer used to poll the workspace's active provisioners. */
+  userToken: string;
+  /** `raw_token` from `mintProvisionerToken`. */
+  provisionerToken: string;
+  /** Path to the provisioner templates YAML. */
+  templatesFile: string;
+  /** File that the child's stdout and stderr are appended to (a CI artifact). */
+  logFile: string;
+  /** Provisioner control-plane URL. Defaults to the E2E API URL. */
+  apiUrl?: string;
+  /** URL injected into runner containers when they reach the API on a different host. */
+  runnerApiUrl?: string;
+  /** Docker network runner containers join. */
+  dockerNetwork?: string;
+  /** Comma-separated extra host mappings for runner containers. */
+  dockerExtraHosts?: string;
+  /** Token prefix to match in the active list; falls back to the first provisioner. */
+  tokenPrefix?: string;
+  readinessTimeoutMs?: number;
+  /** Overrides the resolved `@shipfox/provisioner-docker` dist entry. */
+  entryPath?: string;
+}
+
+export interface ProvisionerHandle {
+  process: ChildProcess;
+  pid: number;
+  logFile: string;
+  workspaceId: string;
+  provisioner: ActiveProvisionerDto;
+}
+
+export interface StopProvisionerOptions {
+  sigtermTimeoutMs?: number;
+}
+
+function buildProvisionerEnv(params: StartProvisionerParams): Record<string, string> {
+  const env: Record<string, string> = {
+    SHIPFOX_API_URL: params.apiUrl ?? config.API_URL,
+    SHIPFOX_PROVISIONER_TOKEN: params.provisionerToken,
+    SHIPFOX_PROVISIONER_TEMPLATES_FILE: params.templatesFile,
+  };
+  if (params.runnerApiUrl !== undefined) env.SHIPFOX_RUNNER_API_URL = params.runnerApiUrl;
+  if (params.dockerNetwork !== undefined)
+    env.SHIPFOX_PROVISIONER_DOCKER_NETWORK = params.dockerNetwork;
+  if (params.dockerExtraHosts !== undefined) {
+    env.SHIPFOX_PROVISIONER_DOCKER_EXTRA_HOSTS = params.dockerExtraHosts;
+  }
+  return env;
+}
+
+function resolveProvisionerEntry(): string {
+  const require = createRequire(import.meta.url);
+  const packageJsonPath = require.resolve('@shipfox/provisioner-docker/package.json');
+  return join(dirname(packageJsonPath), 'dist/index.js');
+}
+
+async function waitForActiveProvisioner(params: {
+  workspaceId: string;
+  userToken: string;
+  tokenPrefix: string | undefined;
+  timeoutMs: number;
+  child: ChildProcess;
+}): Promise<ActiveProvisionerDto> {
+  let lastSeen: ActiveProvisionerDto[] = [];
+  const abortController = new AbortController();
+
+  let onError: ((error: Error) => void) | undefined;
+  let onExit: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  const failed = new Promise<never>((_, reject) => {
+    onError = (error) => {
+      abortController.abort();
+      reject(new Error(`Provisioner process error: ${error.message}`));
+    };
+    onExit = (code, signal) => {
+      abortController.abort();
+      reject(
+        new Error(
+          `Provisioner process exited before becoming active (code ${code}, signal ${signal})`,
+        ),
+      );
+    };
+    params.child.once('error', onError);
+    params.child.once('exit', onExit);
+  });
+
+  const poll = pollUntil<ActiveProvisionerDto>(
+    {
+      timeoutMs: params.timeoutMs,
+      signal: abortController.signal,
+      describe: () =>
+        `provisioner ${params.tokenPrefix ?? '(any)'} to become active for workspace ${params.workspaceId} (last active list: ${JSON.stringify(lastSeen)})`,
+    },
+    async () => {
+      const {provisioners} = await requestJson<ListActiveProvisionersResponseDto>(
+        'get',
+        `/workspaces/${params.workspaceId}/provisioners/active`,
+        {headers: {authorization: `Bearer ${params.userToken}`}},
+      );
+      lastSeen = provisioners;
+      const match =
+        params.tokenPrefix === undefined
+          ? provisioners[0]
+          : provisioners.find((provisioner) => provisioner.prefix === params.tokenPrefix);
+      return match ?? null;
+    },
+  );
+
+  try {
+    return await Promise.race([poll, failed]);
+  } finally {
+    if (onError) params.child.removeListener('error', onError);
+    if (onExit) params.child.removeListener('exit', onExit);
+  }
+}
+
+/**
+ * Spawns the `@shipfox/provisioner-docker` dist as a child process, streams its
+ * output to `logFile`, and resolves once the provisioner reports as active for the
+ * workspace. Rejects (after killing the child) if it exits before becoming active.
+ */
+export async function startProvisioner(params: StartProvisionerParams): Promise<ProvisionerHandle> {
+  const entryPath = params.entryPath ?? resolveProvisionerEntry();
+
+  const logFd = openSync(params.logFile, 'a');
+  let child: ChildProcess;
+  try {
+    child = spawn(process.execPath, [entryPath], {
+      stdio: ['ignore', logFd, logFd],
+      env: {...process.env, ...buildProvisionerEnv(params)},
+    });
+  } finally {
+    // The child inherits its own copy of the fd during spawn; the parent's is done.
+    closeSync(logFd);
+  }
+
+  const {pid} = child;
+  if (pid === undefined) {
+    child.kill('SIGKILL');
+    throw new Error('Provisioner child process failed to start (no pid)');
+  }
+
+  try {
+    const provisioner = await waitForActiveProvisioner({
+      workspaceId: params.workspaceId,
+      userToken: params.userToken,
+      tokenPrefix: params.tokenPrefix,
+      timeoutMs: params.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS,
+      child,
+    });
+    return {
+      process: child,
+      pid,
+      logFile: params.logFile,
+      workspaceId: params.workspaceId,
+      provisioner,
+    };
+  } catch (error) {
+    child.kill('SIGKILL');
+    throw error;
+  }
+}
+
+function terminate(child: ChildProcess, sigtermTimeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+
+  const exited = new Promise<void>((resolve) => child.once('exit', () => resolve()));
+  child.kill('SIGTERM');
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      exited.then(resolve);
+    }, sigtermTimeoutMs);
+    exited.then(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function removeContainersByWorkspace(workspaceId: string): Promise<void> {
+  try {
+    const {stdout} = await execFileAsync('docker', [
+      'ps',
+      '-aq',
+      '--filter',
+      `label=${WORKSPACE_ID_LABEL}=${workspaceId}`,
+    ]);
+    const ids = stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    if (ids.length === 0) return;
+    await execFileAsync('docker', ['rm', '-f', ...ids]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `e2e-helper-runners: container backstop cleanup failed for workspace ${workspaceId}: ${message}\n`,
+    );
+  }
+}
+
+/**
+ * Stops a provisioner started by `startProvisioner`: SIGTERM (then SIGKILL after a
+ * grace period) so it reaps its own containers, then removes any container that
+ * still carries the workspace label as a backstop.
+ */
+export async function stopProvisioner(
+  handle: ProvisionerHandle,
+  options: StopProvisionerOptions = {},
+): Promise<void> {
+  await terminate(handle.process, options.sigtermTimeoutMs ?? DEFAULT_SIGTERM_TIMEOUT_MS);
+  await removeContainersByWorkspace(handle.workspaceId);
+}

--- a/e2e/helpers/runners/src/provisioner-token.ts
+++ b/e2e/helpers/runners/src/provisioner-token.ts
@@ -1,0 +1,31 @@
+import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+export interface MintProvisionerTokenParams {
+  workspaceId: string;
+  /**
+   * User session bearer (the `token` from an E2E session). The provisioner-token
+   * route is user-authed and workspace-scoped, so the shared E2E admin key that
+   * `@shipfox/e2e-core` sends by default does not satisfy it.
+   */
+  userToken: string;
+  name?: string;
+  ttlSeconds?: number;
+}
+
+/**
+ * Mints a workspace provisioner token. The `raw_token` on the response is returned
+ * once by the API and is the value to hand to `startProvisioner`.
+ */
+export async function mintProvisionerToken(
+  params: MintProvisionerTokenParams,
+): Promise<CreateProvisionerTokenResponseDto> {
+  return await requestJson<CreateProvisionerTokenResponseDto>(
+    'post',
+    `/workspaces/${params.workspaceId}/provisioners/tokens`,
+    {
+      headers: {authorization: `Bearer ${params.userToken}`},
+      json: {name: params.name, ttl_seconds: params.ttlSeconds},
+    },
+  );
+}

--- a/e2e/helpers/runners/tsconfig.build.json
+++ b/e2e/helpers/runners/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/runners/tsconfig.json
+++ b/e2e/helpers/runners/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,6 +432,34 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/helpers/runners:
+    dependencies:
+      '@shipfox/api-runners':
+        specifier: workspace:*
+        version: link:../../../libs/api/runners
+      '@shipfox/api-runners-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/runners-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/provisioner-docker':
+        specifier: workspace:*
+        version: link:../../../apps/provisioner-docker
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/helpers/workspaces:
     dependencies:
       '@shipfox/api-workspaces':


### PR DESCRIPTION
New private `@shipfox/e2e-helper-runners` package (`e2e/helpers/runners`) that gives an E2E suite runner capacity, matching the runners domain (`libs/api/runners`, `apps/provisioner-docker`). This is WS3 of the Platform workflow E2E suite; the suite skeleton (ENG-731) will compose it in global setup/teardown.

## What it provides

- **`mintProvisionerToken`** — `POST /workspaces/:workspaceId/provisioners/tokens`, keeps the one-time `raw_token` from the 201. The route is user-authed (`requireUserContext` + `requireMembership`), so the helper overrides `@shipfox/e2e-core`'s default admin-key header with `Bearer ${session.token}`, following the existing pattern in `e2e/api/auth/tests/auth-api.e2e.ts`. `e2e-core` has no user-authed client.
- **`startProvisioner` / `stopProvisioner`** — spawn the `@shipfox/provisioner-docker` dist as a child process with the minted token and a templates file, stream stdout/stderr to a log file (a CI artifact), poll `GET /workspaces/:workspaceId/provisioners/active` for readiness (matching the token prefix), and tear down with `SIGTERM` → `SIGKILL`-after-grace plus a `shipfox.workspace_id` container-label backstop.

The package **owns the `@shipfox/provisioner-docker` workspace dependency** so consumers of the other suite helpers do not drag the provisioner (and its Docker client) into their graph. The provisioner dist entry is resolved via `require.resolve('@shipfox/provisioner-docker/package.json')`, and `turbo test:e2e` `dependsOn: ["^build"]` guarantees it is built before the suite spawns it.

## Notes for review

- Readiness wires an `AbortController` to the child's `exit`/`error` events, so a provisioner that dies before becoming active fails fast and stops the poll immediately instead of hitting the API for the full 30s budget.
- No unit tests, matching the sibling helpers (`e2e-helper-auth`/`workspaces`); real coverage lands with the WS5 suite. A manual verification runbook is in the package README.
- No changeset: the package is `private` and lives under `e2e/`, so there is no npm-consumer impact (the `pnpm-lock.yaml` delta is just its dependencies).

Closes ENG-730

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new private `@shipfox/e2e-helper-runners` package to mint workspace provisioner tokens and run `@shipfox/provisioner-docker` as a child process for E2E tests. Enables the Platform workflow suite (ENG-730) to provision real Docker runners.

- **New Features**
  - `mintProvisionerToken`: calls `POST /workspaces/:workspaceId/provisioners/tokens` with a user bearer, returns the one-time `raw_token`.
  - `startProvisioner`: spawns the provisioner dist, appends stdout/stderr to a `logFile`, supports `runnerApiUrl`/`dockerNetwork`/`dockerExtraHosts`, polls `GET /workspaces/:workspaceId/provisioners/active` for readiness (match `tokenPrefix` or first), configurable timeout, and aborts early if the child exits.
  - `stopProvisioner`: sends SIGTERM→SIGKILL with a configurable grace and removes any container labeled `shipfox.workspace_id=<workspaceId>` as a backstop.

- **Dependencies**
  - The helper owns `@shipfox/provisioner-docker` so other E2E helpers don’t pull the provisioner or Docker client into their graphs.

<sup>Written for commit 8245008c5b101b57522cc491492e3e1376dca25c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

