### PR TITLE
Evaluate step gate and job success over the unified context

### DIFF
--- a/.changeset/swift-gates-unify.md
+++ b/.changeset/swift-gates-unify.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/expression": patch
+"@shipfox/api-definitions": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-integration-debug": patch
+---
+
+Evaluate the step gate `success_if` over the `step` self-root (`step.exit_code`, `step.status`) and job `success` over the full typed executions context, both validated against the shared context registry; authored gate expressions move from `exit_code` to `step.exit_code` and job-success now fails closed on a runtime evaluation error.

--- a/libs/api/definitions/src/core/parse-definition.test.ts
+++ b/libs/api/definitions/src/core/parse-definition.test.ts
@@ -76,7 +76,7 @@ jobs:
           pnpm test
           pnpm build
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
   deploy:
     needs: build
     steps:

--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -8,9 +8,10 @@ Code that turns a checked workflow document into the model used by definitions.
   parsing.
 - **`normalizeWorkflowDocument(document)`**: Expands shorthand fields, assigns
   stable ids, validates explicit providers, and builds graph edges.
-- **Step gates**: Parse run-step `gate.success_if` as CEL with `exit_code` in
-  scope and check `gate.on_failure.restart_from` against earlier named steps in
-  the same job.
+- **Step gates**: Parse run-step `gate.success_if` as CEL against the `step`
+  self-root (`step.exit_code`, `step.status`) from the shared context registry,
+  and check `gate.on_failure.restart_from` against earlier named steps in the
+  same job.
 - **`InvalidWorkflowModelError`**: Reports semantic workflow errors found during
   normalization.
 
@@ -91,8 +92,9 @@ before execution. Explicit providers are checked against the shared provider
 catalog; explicit model ids are preserved because the shared seed catalog does
 not yet carry each provider's full model list.
 
-For now, run-step gates can use `exit_code`. Fields such as `step.output.pass`
-need a declared output schema, so they belong to later agent-step work.
+For now, run-step gates can use `step.exit_code` and `step.status`. Fields such
+as `step.output.pass` need a declared output schema, so they belong to later
+agent-step work.
 
 `on_failure.restart_from` must name an earlier step in the same job. The runtime
 host does not execute restart semantics yet. This module only records the

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-success.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-success.ts
@@ -1,4 +1,8 @@
-import {createWorkflowExpression, InvalidWorkflowExpressionError} from '@shipfox/expression';
+import {
+  createWorkflowExpression,
+  getWorkflowContextTypeEnvironment,
+  InvalidWorkflowExpressionError,
+} from '@shipfox/expression';
 import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
 import {issue} from './validation-issue.js';
 
@@ -16,19 +20,7 @@ export function normalizeJobSuccess(params: {
       source: params.source,
       check: {
         mode: 'typed',
-        // Runtime success evaluation intentionally exposes only execution index/status today.
-        typeEnvironment: {
-          executions: {
-            kind: 'list',
-            element: {
-              kind: 'object',
-              fields: {
-                index: 'int',
-                status: 'string',
-              },
-            },
-          },
-        },
+        typeEnvironment: getWorkflowContextTypeEnvironment('executions') ?? {},
         expectedResultType: 'bool',
       },
     });

--- a/libs/api/definitions/src/core/workflow-model/normalize-step-gate.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-step-gate.ts
@@ -1,5 +1,6 @@
 import {
   createWorkflowExpression,
+  getWorkflowContextTypeEnvironment,
   InvalidWorkflowExpressionError,
   type WorkflowExpression,
 } from '@shipfox/expression';
@@ -65,9 +66,7 @@ function normalizeGateSuccessIf(params: {
       source: params.source,
       check: {
         mode: 'typed',
-        typeEnvironment: {
-          exit_code: 'int',
-        },
+        typeEnvironment: getWorkflowContextTypeEnvironment('step') ?? {},
         expectedResultType: 'bool',
       },
     });

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -96,7 +96,7 @@ describe('normalizeWorkflowDocument', () => {
               provider: 'openai',
               prompt: 'Review the fix.',
               thinking: 'low',
-              gate: {success_if: 'exit_code == 0', on_failure: {restart_from: 'implement'}},
+              gate: {success_if: 'step.exit_code == 0', on_failure: {restart_from: 'implement'}},
             },
           ],
         },
@@ -700,7 +700,7 @@ describe('normalizeWorkflowDocument', () => {
               key: 'reviewer',
               run: 'npm run review',
               gate: {
-                success_if: 'exit_code == 0',
+                success_if: 'step.exit_code == 0',
                 on_failure: {
                   restart_from: 'producer',
                   output: reviewOutput,
@@ -720,7 +720,7 @@ describe('normalizeWorkflowDocument', () => {
       gate: {
         successIf: {
           language: 'cel',
-          source: 'exit_code == 0',
+          source: 'step.exit_code == 0',
           check: 'typed',
         },
         onFailure: {
@@ -736,7 +736,7 @@ describe('normalizeWorkflowDocument', () => {
       name: 'simple build',
       jobs: {
         build: {
-          steps: [{name: 'build', run: 'npm run build', gate: {success_if: 'exit_code == 0'}}],
+          steps: [{name: 'build', run: 'npm run build', gate: {success_if: 'step.exit_code == 0'}}],
         },
       },
     };
@@ -745,9 +745,68 @@ describe('normalizeWorkflowDocument', () => {
 
     expect(model.jobs[0]?.steps[0]?.gate?.successIf).toEqual({
       language: 'cel',
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
       check: 'typed',
     });
+  });
+
+  it('accepts step.status in a gate success_if', () => {
+    const document: WorkflowDocument = {
+      name: 'status gate',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build', gate: {success_if: 'step.status == "succeeded"'}}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]?.gate?.successIf).toEqual({
+      language: 'cel',
+      source: 'step.status == "succeeded"',
+      check: 'typed',
+    });
+  });
+
+  it('rejects a gate success_if referencing a root outside the step self-context', () => {
+    const document: WorkflowDocument = {
+      name: 'out-of-scope gate',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build', gate: {success_if: 'run.id == "x"'}}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid-step-gate-success-if',
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
+        details: expect.objectContaining({source: 'run.id == "x"'}),
+      }),
+    ]);
+  });
+
+  it('accepts execution fields and event data in job success expressions', () => {
+    const document: WorkflowDocument = {
+      name: 'full-shape job success',
+      jobs: {
+        build: {
+          success:
+            'executions.all(e, e.name != "") && executions.all(e, e.events.all(ev, ev.data.ok == true))',
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.success).toBe(
+      'executions.all(e, e.name != "") && executions.all(e, e.events.all(ev, ev.data.ok == true))',
+    );
   });
 
   it('reports invalid job success expressions', () => {
@@ -960,7 +1019,7 @@ describe('normalizeWorkflowDocument', () => {
       name: 'non-boolean gate',
       jobs: {
         build: {
-          steps: [{run: 'npm run build', gate: {success_if: 'exit_code + 1'}}],
+          steps: [{run: 'npm run build', gate: {success_if: 'step.exit_code + 1'}}],
         },
       },
     };
@@ -972,7 +1031,7 @@ describe('normalizeWorkflowDocument', () => {
         code: 'invalid-step-gate-success-if',
         path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
         details: expect.objectContaining({
-          source: 'exit_code + 1',
+          source: 'step.exit_code + 1',
           reason: expect.stringContaining('must return bool'),
         }),
       }),

--- a/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.document.json
+++ b/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.document.json
@@ -17,7 +17,7 @@
           "name": "build",
           "run": "npm run build",
           "gate": {
-            "success_if": "exit_code == 0"
+            "success_if": "step.exit_code == 0"
           }
         }
       ]

--- a/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.yaml
+++ b/libs/api/definitions/test/fixtures/workflow-yaml/valid/simple-build.yaml
@@ -11,4 +11,4 @@ jobs:
       - name: build
         run: npm run build
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0

--- a/libs/api/integration/debug/src/core/source-control.ts
+++ b/libs/api/integration/debug/src/core/source-control.ts
@@ -84,7 +84,7 @@ jobs:
       - name: test
         run: pnpm test
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
 `,
       '.shipfox/workflows/build-and-deploy.yaml': `
 name: Build and deploy
@@ -122,12 +122,12 @@ jobs:
         prompt: Review the fix.
         thinking: low
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
           on_failure:
             restart_from: implement
       - run: pnpm test
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
 `,
       'README.md': '# Debug platform\n',
     },

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -666,7 +666,7 @@ describe('gate evaluation', () => {
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const stepId = steps[0]?.id as string;
     await attachGate(stepId, {
-      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 1'},
+      success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 1'},
     });
     await nextStepForJob(jobId);
 
@@ -688,7 +688,7 @@ describe('gate evaluation', () => {
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const stepId = steps[0]?.id as string;
     await attachGate(stepId, {
-      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+      success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
     });
     await nextStepForJob(jobId);
 
@@ -708,7 +708,7 @@ describe('gate evaluation', () => {
     const {jobId, steps} = await arrangeJobWithSteps(1);
     const stepId = steps[0]?.id as string;
     await attachGate(stepId, {
-      success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+      success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
       on_failure: {restart_from: 'producer'},
     });
     await nextStepForJob(jobId);
@@ -795,7 +795,7 @@ describe('durable gate restart', () => {
   }
 
   test('a failing gate rewinds the job to the restart_from step, keeping it running', async () => {
-    const {jobId, producer, reviewer} = await arrangeGatedJob('exit_code == 0');
+    const {jobId, producer, reviewer} = await arrangeGatedJob('step.exit_code == 0');
 
     await runStep(jobId, producer, 0); // producer succeeds, attempt 1
     const restart = await runStep(jobId, reviewer, 1); // reviewer gate fails → restart
@@ -816,7 +816,7 @@ describe('durable gate restart', () => {
   });
 
   test('restart event identifies the failed gate attempt and restart target', async () => {
-    const {jobId, producer, reviewer} = await arrangeGatedJob('exit_code == 0');
+    const {jobId, producer, reviewer} = await arrangeGatedJob('step.exit_code == 0');
 
     await runStep(jobId, producer, 0);
     await runStep(jobId, reviewer, 1);
@@ -830,7 +830,7 @@ describe('durable gate restart', () => {
   });
 
   test('a passing rerun after a restart completes the job', async () => {
-    const {jobId, producer, reviewer} = await arrangeGatedJob('exit_code == 0');
+    const {jobId, producer, reviewer} = await arrangeGatedJob('step.exit_code == 0');
 
     await runStep(jobId, producer, 0);
     await runStep(jobId, reviewer, 1); // restart
@@ -854,7 +854,7 @@ describe('durable gate restart', () => {
   });
 
   test('a permanently-failing gate terminates via the attempt cap (no infinite loop)', async () => {
-    const {jobId, producer, reviewer} = await arrangeGatedJob('exit_code == 0');
+    const {jobId, producer, reviewer} = await arrangeGatedJob('step.exit_code == 0');
 
     // Default cap is 3: reviewer attempts 1 and 2 restart; attempt 3 exhausts.
     await runStep(jobId, producer, 0);
@@ -871,7 +871,7 @@ describe('durable gate restart', () => {
   });
 
   test('a duplicate report of a superseded attempt does not restart twice', async () => {
-    const {jobId, producer, reviewer} = await arrangeGatedJob('exit_code == 0');
+    const {jobId, producer, reviewer} = await arrangeGatedJob('step.exit_code == 0');
 
     await runStep(jobId, producer, 0);
     await runStep(jobId, reviewer, 1); // restart (reviewer now pending at attempt 2)
@@ -904,7 +904,7 @@ describe('durable gate restart', () => {
         config: {
           run: 'review',
           gate: {
-            success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+            success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
             on_failure: {restart_from: 'producer'},
           },
         },
@@ -937,7 +937,7 @@ describe('durable gate restart', () => {
     const gatedToProducer = {
       run: 'x',
       gate: {
-        success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+        success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
         on_failure: {restart_from: 'producer'},
       },
     };
@@ -969,7 +969,7 @@ describe('durable gate restart', () => {
         config: {
           run: 'x',
           gate: {
-            success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+            success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
             on_failure: {restart_from: 'does-not-exist'},
           },
         },

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -16,8 +16,8 @@ describe('readStepGate', () => {
   });
 
   test('parses success_if and on_failure', () => {
-    const gate = readStepGate(gateConfig('exit_code == 0', 'producer'));
-    expect(gate?.successIf?.source).toBe('exit_code == 0');
+    const gate = readStepGate(gateConfig('step.exit_code == 0', 'producer'));
+    expect(gate?.successIf?.source).toBe('step.exit_code == 0');
     expect(gate?.onFailure).toEqual({restartFrom: 'producer'});
   });
 });
@@ -31,51 +31,57 @@ describe('evaluateGate', () => {
     });
   });
 
-  test('exit_code == 0 passes for exit 0', () => {
-    const gate = readStepGate(gateConfig('exit_code == 0'));
+  test('step.exit_code == 0 passes for exit 0', () => {
+    const gate = readStepGate(gateConfig('step.exit_code == 0'));
     expect(evaluateGate(gate, {status: 'succeeded', exitCode: 0})).toEqual({
       kind: 'passed',
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
     });
   });
 
-  test('exit_code == 0 fails for a non-zero exit', () => {
-    const gate = readStepGate(gateConfig('exit_code == 0'));
+  test('step.exit_code == 0 fails for a non-zero exit', () => {
+    const gate = readStepGate(gateConfig('step.exit_code == 0'));
     expect(evaluateGate(gate, {status: 'failed', exitCode: 1})).toEqual({
       kind: 'failed',
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
     });
   });
 
-  test('a passing gate can succeed a non-zero exit (success_if: exit_code == 1)', () => {
-    const gate = readStepGate(gateConfig('exit_code == 1'));
+  test('a passing gate can succeed a non-zero exit (success_if: step.exit_code == 1)', () => {
+    const gate = readStepGate(gateConfig('step.exit_code == 1'));
     expect(evaluateGate(gate, {status: 'failed', exitCode: 1})).toMatchObject({kind: 'passed'});
   });
 
   test('exit_code arithmetic can pass using CEL int values at runtime', () => {
-    const gate = readStepGate(gateConfig('exit_code % 2 == 0'));
+    const gate = readStepGate(gateConfig('step.exit_code % 2 == 0'));
 
     const result = evaluateGate(gate, {status: 'succeeded', exitCode: 2});
 
     expect(result).toEqual({
       kind: 'passed',
-      source: 'exit_code % 2 == 0',
+      source: 'step.exit_code % 2 == 0',
     });
   });
 
   test('exit_code arithmetic can fail using CEL int values at runtime', () => {
-    const gate = readStepGate(gateConfig('exit_code % 2 == 0'));
+    const gate = readStepGate(gateConfig('step.exit_code % 2 == 0'));
 
     const result = evaluateGate(gate, {status: 'failed', exitCode: 3});
 
     expect(result).toEqual({
       kind: 'failed',
-      source: 'exit_code % 2 == 0',
+      source: 'step.exit_code % 2 == 0',
     });
   });
 
+  test('step.status gates on the reported step status', () => {
+    const gate = readStepGate(gateConfig('step.status == "succeeded"'));
+    expect(evaluateGate(gate, {status: 'succeeded', exitCode: 0})).toMatchObject({kind: 'passed'});
+    expect(evaluateGate(gate, {status: 'failed', exitCode: 0})).toMatchObject({kind: 'failed'});
+  });
+
   test('a missing exit code is uncheckable (never evaluated)', () => {
-    const gate = readStepGate(gateConfig('exit_code == 0'));
+    const gate = readStepGate(gateConfig('step.exit_code == 0'));
     expect(evaluateGate(gate, {status: 'failed', exitCode: null})).toMatchObject({
       kind: 'uncheckable',
     });
@@ -95,17 +101,17 @@ describe('gateResultPayload', () => {
   });
 
   test('passed records the source and evaluated exit code', () => {
-    expect(gateResultPayload({kind: 'passed', source: 'exit_code == 0'}, 0)).toEqual({
+    expect(gateResultPayload({kind: 'passed', source: 'step.exit_code == 0'}, 0)).toEqual({
       passed: true,
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
       exit_code: 0,
     });
   });
 
   test('failed records the source and evaluated exit code', () => {
-    expect(gateResultPayload({kind: 'failed', source: 'exit_code == 0'}, 1)).toEqual({
+    expect(gateResultPayload({kind: 'failed', source: 'step.exit_code == 0'}, 1)).toEqual({
       passed: false,
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
       exit_code: 1,
     });
   });

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -54,10 +54,11 @@ export function readStepGate(config: Record<string, unknown>): StepGate | undefi
 // could trigger a restart.
 //
 // NOTE: callers run this inside the FOR UPDATE transaction, so the eval holds the
-// job's step-row locks. The context is a single scalar (`exit_code`), so this is
-// cheap; do not widen the context or add CEL call sites inside the lock without
-// an eval budget. `language` is assumed CEL because the materializer writes only
-// that language, and the evaluator reads only `.source`.
+// job's step-row locks. The context is a small `step` self-root object
+// (`exit_code`, `status`), so this is cheap; do not widen the context or add CEL
+// call sites inside the lock without an eval budget. `language` is assumed CEL
+// because the materializer writes only that language, and the evaluator reads only
+// `.source`.
 export function evaluateGate(gate: StepGate | undefined, result: StepResult): GateOutcome {
   if (!gate?.successIf) return {kind: 'no-gate'};
   const source = gate.successIf.source;
@@ -67,7 +68,12 @@ export function evaluateGate(gate: StepGate | undefined, result: StepResult): Ga
   }
 
   try {
-    const passed = evaluateWorkflowPredicate(gate.successIf, {exit_code: BigInt(result.exitCode)});
+    const passed = evaluateWorkflowPredicate(gate.successIf, {
+      step: {
+        exit_code: BigInt(result.exitCode),
+        status: result.status,
+      },
+    });
     return passed ? {kind: 'passed', source} : {kind: 'failed', source};
   } catch (error) {
     if (error instanceof WorkflowExpressionEvaluationError) {

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -48,17 +48,14 @@ export function readStepGate(config: Record<string, unknown>): StepGate | undefi
   };
 }
 
-// Evaluate a step's gate against the run-step result. This is the ONLY place that
-// runs the CEL engine. It fails closed: a missing exit code or an evaluation
-// error is `uncheckable` (a plain command failure), never a gate-failure that
-// could trigger a restart.
-//
-// NOTE: callers run this inside the FOR UPDATE transaction, so the eval holds the
-// job's step-row locks. The context is a small `step` self-root object
-// (`exit_code`, `status`), so this is cheap; do not widen the context or add CEL
-// call sites inside the lock without an eval budget. `language` is assumed CEL
-// because the materializer writes only that language, and the evaluator reads only
-// `.source`.
+/**
+ * Gate evaluation fails closed: a missing exit code or CEL evaluation error is
+ * `uncheckable` (a plain command failure), never a gate failure that can restart.
+ *
+ * Callers hold step-row locks while this runs. Keep the CEL context bounded
+ * unless evaluation gets a budget outside the lock. The materializer only
+ * persists CEL expressions, and this evaluator only needs the validated source.
+ */
 export function evaluateGate(gate: StepGate | undefined, result: StepResult): GateOutcome {
   if (!gate?.successIf) return {kind: 'no-gate'};
   const source = gate.successIf.source;

--- a/libs/api/workflows/src/core/workflow-runtime/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/assemble-run-context.ts
@@ -1,4 +1,5 @@
 import type {WorkflowExpressionEvaluationContext} from '@shipfox/expression';
+import type {JobExecution} from '#core/entities/job-execution.js';
 import type {TriggerPayload, WorkflowRun} from '#core/entities/workflow-run.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
@@ -38,5 +39,24 @@ export function assembleCreationContext(
   return {
     phase: 'workflow-run-creation',
     values: assembleWorkflowRunContext(params),
+  };
+}
+
+// Assemble the `executions` root for job-resolution predicates (job `success`).
+// Mirrors the registry `executions` type environment field-for-field: `index` is the
+// position in the resolution-ordered list, and `events` passes the execution's trigger
+// events through unchanged (they already share the executionEvent shape).
+export function assembleExecutionsContext(
+  executions: readonly JobExecution[],
+): WorkflowExpressionEvaluationContext {
+  return {
+    executions: executions.map((execution, index) => ({
+      index,
+      name: execution.name,
+      status: execution.status,
+      started_at: execution.startedAt,
+      finished_at: execution.finishedAt,
+      events: execution.triggerEvents,
+    })),
   };
 }

--- a/libs/api/workflows/src/core/workflow-runtime/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/assemble-run-context.ts
@@ -42,10 +42,10 @@ export function assembleCreationContext(
   };
 }
 
-// Assemble the `executions` root for job-resolution predicates (job `success`).
-// Mirrors the registry `executions` type environment field-for-field: `index` is the
-// position in the resolution-ordered list, and `events` passes the execution's trigger
-// events through unchanged (they already share the executionEvent shape).
+/**
+ * Keeps job-success predicate values aligned with the registry's `executions`
+ * type environment.
+ */
 export function assembleExecutionsContext(
   executions: readonly JobExecution[],
 ): WorkflowExpressionEvaluationContext {

--- a/libs/api/workflows/src/core/workflow-runtime/index.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/index.ts
@@ -1,6 +1,7 @@
 export {
   type AssembleWorkflowRunContextParams,
   assembleCreationContext,
+  assembleExecutionsContext,
   assembleWorkflowRunContext,
 } from './assemble-run-context.js';
 export {

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -69,7 +69,7 @@ describe('materializeWorkflowModel', () => {
               run: 'npm run build',
               sourceLocation: {startLine: 7, endLine: 14},
               gate: {
-                successIf: expression('exit_code == 0'),
+                successIf: expression('step.exit_code == 0'),
                 onFailure: {restartFrom: 'install', output: 'Build failed'},
               },
             },
@@ -125,7 +125,7 @@ describe('materializeWorkflowModel', () => {
             config: {
               run: 'npm run build',
               gate: {
-                success_if: {language: 'cel', check: 'typed', source: 'exit_code == 0'},
+                success_if: {language: 'cel', check: 'typed', source: 'step.exit_code == 0'},
                 on_failure: {restart_from: 'install', output: 'Build failed'},
               },
             },
@@ -178,7 +178,7 @@ describe('materializeWorkflowModel', () => {
               thinking: 'low',
               prompt: 'Review it.',
               gate: {
-                successIf: expression('exit_code == 0'),
+                successIf: expression('step.exit_code == 0'),
                 onFailure: {restartFrom: 'implement'},
               },
             },
@@ -216,7 +216,7 @@ describe('materializeWorkflowModel', () => {
         thinking: 'low',
         prompt: 'Review it.',
         gate: {
-          success_if: {language: 'cel', check: 'typed', source: 'exit_code == 0'},
+          success_if: {language: 'cel', check: 'typed', source: 'step.exit_code == 0'},
           on_failure: {restart_from: 'implement'},
         },
       },

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1899,8 +1899,13 @@ jobs:
       });
 
       const resolved = await resolveJobStatusFromJobExecutions({jobId: job.id});
+      const resolvedJob = (await getJobsByWorkflowRunId(run.id))[0];
 
       expect(resolved.status).toBe('failed');
+      expect(resolvedJob).toMatchObject({
+        status: 'failed',
+        statusReason: 'unknown',
+      });
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -256,7 +256,7 @@ describe('workflow run queries', () => {
               {
                 run: 'npm test',
                 env: {REF: template('event.ref')},
-                gate: {successIf: expression('exit_code == 0')},
+                gate: {successIf: expression('step.exit_code == 0')},
               },
             ],
           },
@@ -1830,6 +1830,80 @@ jobs:
         status: 'succeeded',
         statusReason: null,
       });
+    });
+
+    test('resolves a custom success expression over the full execution shape', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              // `e.name` is only reachable now that job success evaluates over the full
+              // assembled executions context, not the old `{index, status}` reduction.
+              success: 'executions.all(e, e.status == "succeeded" && e.name == e.name)',
+              steps: [{run: 'npm test'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const job = (await getJobsByWorkflowRunId(run.id))[0];
+      if (!job) throw new Error('Expected workflow job');
+      const jobExecution = await getFirstJobExecutionByJobId(job.id);
+      if (!jobExecution) throw new Error('Expected workflow job execution');
+      await updateJobExecutionStatus({
+        jobExecutionId: jobExecution.id,
+        status: 'succeeded',
+        expectedVersion: jobExecution.version,
+      });
+
+      const resolved = await resolveJobStatusFromJobExecutions({jobId: job.id});
+
+      expect(resolved.status).toBe('succeeded');
+    });
+
+    test('fails closed when the success expression throws at runtime', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            build: {
+              // Type-checks at authoring (int / int == int) but throws at runtime; stands in
+              // for any runtime eval error (e.g. timestamp math on a null finished_at).
+              success: 'executions.all(e, 1 / 0 == 0)',
+              steps: [{run: 'npm test'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+      const job = (await getJobsByWorkflowRunId(run.id))[0];
+      if (!job) throw new Error('Expected workflow job');
+      const jobExecution = await getFirstJobExecutionByJobId(job.id);
+      if (!jobExecution) throw new Error('Expected workflow job execution');
+      await updateJobExecutionStatus({
+        jobExecutionId: jobExecution.id,
+        status: 'succeeded',
+        expectedVersion: jobExecution.version,
+      });
+
+      const resolved = await resolveJobStatusFromJobExecutions({jobId: job.id});
+
+      expect(resolved.status).toBe('failed');
     });
   });
 

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -1840,9 +1840,8 @@ jobs:
         model: buildModel({
           jobs: {
             build: {
-              // `e.name` is only reachable now that job success evaluates over the full
-              // assembled executions context, not the old `{index, status}` reduction.
-              success: 'executions.all(e, e.status == "succeeded" && e.name == e.name)',
+              name: 'Build',
+              success: 'executions.all(e, e.status == "succeeded" && e.name == "Build")',
               steps: [{run: 'npm test'}],
             },
           },
@@ -1877,8 +1876,6 @@ jobs:
         model: buildModel({
           jobs: {
             build: {
-              // Type-checks at authoring (int / int == int) but throws at runtime; stands in
-              // for any runtime eval error (e.g. timestamp math on a null finished_at).
               success: 'executions.all(e, 1 / 0 == 0)',
               steps: [{run: 'npm test'}],
             },

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1746,21 +1746,24 @@ export async function resolveJobStatusFromJobExecutions(params: {
       check: {mode: 'syntax'},
     });
     const context = assembleExecutionsContext(jobExecutionRows.map(toJobExecution));
-    // Fail-closed: a success predicate that throws at runtime (e.g. timestamp math on a
-    // null finished_at) resolves the job to failed rather than aborting resolution. Mirrors
-    // the gate's fail-closed handling of evaluation errors.
+    // Fail closed so a runtime-only predicate error cannot abort job resolution.
     let passed: boolean;
+    let predicateEvaluationFailed = false;
     try {
       passed = evaluateWorkflowPredicate(expression, context);
     } catch (error) {
       if (!(error instanceof WorkflowExpressionEvaluationError)) throw error;
       passed = false;
+      predicateEvaluationFailed = true;
     }
     const status: RuntimeCompletionStatus = passed ? 'succeeded' : 'failed';
+    // A thrown predicate is a job-level failure, not evidence that any execution failed.
     const statusReason =
       status === 'failed'
-        ? (jobExecutionRows.find((jobExecution) => jobExecution.statusReason)?.statusReason ??
-          'step_failed')
+        ? predicateEvaluationFailed
+          ? 'unknown'
+          : (jobExecutionRows.find((jobExecution) => jobExecution.statusReason)?.statusReason ??
+            'step_failed')
         : null;
 
     const updated = await updateJobStatusAtVersion(tx, {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -15,7 +15,11 @@ import {
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMapDto,
 } from '@shipfox/api-workflows-dto';
-import {createWorkflowExpression, evaluateWorkflowPredicate} from '@shipfox/expression';
+import {
+  createWorkflowExpression,
+  evaluateWorkflowPredicate,
+  WorkflowExpressionEvaluationError,
+} from '@shipfox/expression';
 import {
   paginateTimestampIdRows,
   type TimestampIdCursor,
@@ -67,7 +71,11 @@ import {
 } from '#core/errors.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import type {WorkflowStepTemplateDiagnostic} from '#core/workflow-runtime/index.js';
-import {assembleCreationContext, materializeWorkflowModel} from '#core/workflow-runtime/index.js';
+import {
+  assembleCreationContext,
+  assembleExecutionsContext,
+  materializeWorkflowModel,
+} from '#core/workflow-runtime/index.js';
 import type {MaterializedWorkflowJob} from '#core/workflow-runtime/materialize-workflow-model.js';
 import type {RuntimeCompletionStatus} from '#core/workflow-runtime/runtime-dag.js';
 import {
@@ -1737,12 +1745,17 @@ export async function resolveJobStatusFromJobExecutions(params: {
       source: jobRow.success ?? DEFAULT_JOB_SUCCESS,
       check: {mode: 'syntax'},
     });
-    const passed = evaluateWorkflowPredicate(expression, {
-      executions: jobExecutionRows.map((jobExecution, index) => ({
-        index,
-        status: jobExecution.status,
-      })),
-    });
+    const context = assembleExecutionsContext(jobExecutionRows.map(toJobExecution));
+    // Fail-closed: a success predicate that throws at runtime (e.g. timestamp math on a
+    // null finished_at) resolves the job to failed rather than aborting resolution. Mirrors
+    // the gate's fail-closed handling of evaluation errors.
+    let passed: boolean;
+    try {
+      passed = evaluateWorkflowPredicate(expression, context);
+    } catch (error) {
+      if (!(error instanceof WorkflowExpressionEvaluationError)) throw error;
+      passed = false;
+    }
     const status: RuntimeCompletionStatus = passed ? 'succeeded' : 'failed';
     const statusReason =
       status === 'failed'

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -133,7 +133,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
           provider: 'anthropic',
           thinking: 'high',
           prompt: 'Fix the tests.',
-          gate: {successIf: expression('exit_code == 0')},
+          gate: {successIf: expression('step.exit_code == 0')},
         },
       ],
     });

--- a/libs/api/workflows/src/presentation/routes/get-run.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-run.test.ts
@@ -471,7 +471,7 @@ jobs:
         config: {
           run: 'review',
           gate: {
-            success_if: {language: 'cel', check: 'syntax', source: 'exit_code == 0'},
+            success_if: {language: 'cel', check: 'syntax', source: 'step.exit_code == 0'},
             on_failure: {restart_from: 'producer'},
           },
         },
@@ -514,7 +514,7 @@ jobs:
     expect(reviewerAttempts[0]?.gate_result).toEqual({
       kind: 'failed',
       passed: false,
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
       exit_code: 1,
     });
     expect(reviewerAttempts[0]?.restart_reason).toBe('gate condition not met');
@@ -527,7 +527,7 @@ jobs:
     expect(reviewerAttempts[1]?.gate_result).toEqual({
       kind: 'passed',
       passed: true,
-      source: 'exit_code == 0',
+      source: 'step.exit_code == 0',
       exit_code: 0,
     });
     expect(reviewerAttempts[1]?.restart_result).toBeNull();

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -395,10 +395,7 @@ describe('workflow context registry', () => {
     expect(gateExpression.check).toBe('typed');
   });
 
-  it('allows dynamic access into untrusted event data on the executions root', () => {
-    // Deep event-data access type-checks as `dyn` because the executions -> events
-    // list-of-objects collapses to `list<dyn>`. Job success relies on this; guard it
-    // against a future converter change.
+  it('keeps executions event data dynamic after type conversion', () => {
     const eventDataExpression = createWorkflowExpression({
       source: 'executions.all(e, e.events.all(ev, ev.data.ok == true))',
       check: {

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -29,16 +29,16 @@ describe('workflow context registry', () => {
       'job',
       'executions',
       'execution',
+      'step',
     ]);
   });
 
   it('keeps future phase roots reserved out of the referenceable registry', () => {
     expect(workflowContextReservedRoots).toEqual({
-      step: 'step-completion',
       steps: 'step-completion',
       jobs: 'job-resolution',
     });
-    expect(workflowContextNames).not.toContain('step');
+    expect(workflowContextNames).toContain('step');
     expect(workflowContextNames).not.toContain('steps');
     expect(workflowContextNames).not.toContain('jobs');
   });
@@ -55,7 +55,14 @@ describe('workflow context registry', () => {
       },
     );
 
-    expect(contextsByTrust.trusted).toEqual(['run', 'trigger', 'job', 'executions', 'execution']);
+    expect(contextsByTrust.trusted).toEqual([
+      'run',
+      'trigger',
+      'job',
+      'executions',
+      'execution',
+      'step',
+    ]);
     expect(contextsByTrust.untrusted).toEqual(['event', 'inputs']);
   });
 
@@ -81,6 +88,12 @@ describe('workflow context registry', () => {
       shape: 'known',
       checkMode: 'typed',
       untrustedPaths: ['events'],
+    });
+    expect(workflowContextDefinitions.step).toMatchObject({
+      availability: 'step-completion',
+      trustTier: 'trusted',
+      shape: 'known',
+      checkMode: 'typed',
     });
     expect(workflowContextDefinitions.event).toMatchObject({
       shape: 'open',
@@ -123,6 +136,15 @@ describe('workflow context registry', () => {
         },
       },
     });
+    expect(getWorkflowContextTypeEnvironment('step')).toEqual({
+      step: {
+        kind: 'object',
+        fields: {
+          exit_code: 'int',
+          status: 'string',
+        },
+      },
+    });
   });
 
   it('does not expose type environments for open contexts', () => {
@@ -155,6 +177,7 @@ describe('workflow context registry', () => {
       'job',
       'executions',
       'execution',
+      'step',
     ]);
     expect(rootsAvailableAt('job-resolution')).toEqual([
       'run',
@@ -164,6 +187,7 @@ describe('workflow context registry', () => {
       'job',
       'executions',
       'execution',
+      'step',
     ]);
   });
 
@@ -299,7 +323,7 @@ describe('workflow context registry', () => {
             "step-completion": true,
             "workflow-run-creation": false,
           },
-          "reserved": true,
+          "reserved": false,
           "root": "step",
         },
         {
@@ -356,6 +380,35 @@ describe('workflow context registry', () => {
     expect(triggerExpression.check).toBe('typed');
     expect(jobExpression.check).toBe('typed');
     expect(executionsExpression.check).toBe('typed');
+  });
+
+  it('type-checks step self-root gate expressions', () => {
+    const gateExpression = createWorkflowExpression({
+      source: 'step.exit_code == 0 && step.status == "succeeded"',
+      check: {
+        mode: 'typed',
+        typeEnvironment: workflowContextDefinitions.step.typeEnvironment,
+        expectedResultType: 'bool',
+      },
+    });
+
+    expect(gateExpression.check).toBe('typed');
+  });
+
+  it('allows dynamic access into untrusted event data on the executions root', () => {
+    // Deep event-data access type-checks as `dyn` because the executions -> events
+    // list-of-objects collapses to `list<dyn>`. Job success relies on this; guard it
+    // against a future converter change.
+    const eventDataExpression = createWorkflowExpression({
+      source: 'executions.all(e, e.events.all(ev, ev.data.ok == true))',
+      check: {
+        mode: 'typed',
+        typeEnvironment: workflowContextDefinitions.executions.typeEnvironment,
+        expectedResultType: 'bool',
+      },
+    });
+
+    expect(eventDataExpression.check).toBe('typed');
   });
 
   it('rejects unknown fields from known context type environments', () => {

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -8,6 +8,7 @@ export const workflowContextNames = [
   'job',
   'executions',
   'execution',
+  'step',
 ] as const;
 export type WorkflowContextName = (typeof workflowContextNames)[number];
 
@@ -20,7 +21,6 @@ export const workflowContextPhases = [
 export type WorkflowContextPhase = (typeof workflowContextPhases)[number];
 
 export const workflowContextReservedRoots = {
-  step: 'step-completion',
   steps: 'step-completion',
   jobs: 'job-resolution',
 } as const satisfies Record<string, WorkflowContextPhase>;
@@ -124,6 +124,16 @@ const executionTypeEnvironment = {
   execution: executionType,
 } as const satisfies ExpressionTypeEnvironment;
 
+const stepTypeEnvironment = {
+  step: {
+    kind: 'object',
+    fields: {
+      exit_code: 'int',
+      status: 'string',
+    },
+  },
+} as const satisfies ExpressionTypeEnvironment;
+
 export const workflowContextDefinitions = {
   run: {
     availability: 'workflow-run-creation',
@@ -173,6 +183,13 @@ export const workflowContextDefinitions = {
     checkMode: 'typed',
     typeEnvironment: executionTypeEnvironment,
     untrustedPaths: ['events'],
+  },
+  step: {
+    availability: 'step-completion',
+    trustTier: 'trusted',
+    shape: 'known',
+    checkMode: 'typed',
+    typeEnvironment: stepTypeEnvironment,
   },
 } as const satisfies Record<WorkflowContextName, WorkflowContextDefinition>;
 

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -49,7 +49,7 @@ try {
         },
         env: {NODE_ENV: 'test'},
         runner: 'ubuntu-latest',
-        steps: [{run: 'npm run build', env: {CI: true}, gate: {success_if: 'exit_code == 0'}}],
+        steps: [{run: 'npm run build', env: {CI: true}, gate: {success_if: 'step.exit_code == 0'}}],
       },
     },
   });
@@ -81,7 +81,7 @@ parseWorkflowDocument({
       steps: [
         {prompt: 'Fix the failing tests.'},
         {model: 'gpt-5.5-pro', provider: 'openai', prompt: 'Review the fix.'},
-        {run: 'npm test', gate: {success_if: 'exit_code == 0'}},
+        {run: 'npm test', gate: {success_if: 'step.exit_code == 0'}},
       ],
     },
   },

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -359,7 +359,7 @@ describe('workflowDocumentSchema', () => {
     ['agent step with name', {name: 'fix', model: 'claude-opus-4-8', prompt: 'Fix it.'}],
     [
       'agent step with gate',
-      {model: 'claude-opus-4-8', prompt: 'Fix it.', gate: {success_if: 'exit_code == 0'}},
+      {model: 'claude-opus-4-8', prompt: 'Fix it.', gate: {success_if: 'step.exit_code == 0'}},
     ],
     ['custom-model-provider model string', {model: 'openrouter/anthropic/claude', prompt: 'Hi.'}],
   ])('accepts %s', (_label, step) => {

--- a/libs/shared/workflow/document/test/data/simple-build.json
+++ b/libs/shared/workflow/document/test/data/simple-build.json
@@ -17,7 +17,7 @@
           "name": "build",
           "run": "npm run build",
           "gate": {
-            "success_if": "exit_code == 0"
+            "success_if": "step.exit_code == 0"
           }
         }
       ]


### PR DESCRIPTION
Migrate the two remaining bespoke runtime predicates — the step gate (`success_if`) and job `success` — onto the shared, phase-aware context registry introduced in ENG-721. Authoring types and runtime values now come from one source of truth, so they cannot drift.

## Why

The gate type-checked against an inline `{exit_code: 'int'}` environment and evaluated a bare `{exit_code}` scalar; job success type-checked against an inline `{index, status}` shape and evaluated a hand-reduced context, even though the registry already defined a fuller `executions` schema. Two hand-maintained shapes per predicate is exactly the drift this project set out to remove.

## What changed

- **`@shipfox/expression`** — promote `step` to a first-class typed root (`step.exit_code`, `step.status`); `steps`/`jobs` stay reserved.
- **`@shipfox/api-definitions`** — `normalize-step-gate` / `normalize-job-success` pull their type environments from the registry (`getWorkflowContextTypeEnvironment`), dropping the inline shapes.
- **`@shipfox/api-workflows`** — the gate evaluates over the `step` self-root; job success evaluates over the full assembled `executions` context via a new `assembleExecutionsContext`, wrapped in a fail-closed guard (a predicate that throws at runtime resolves the job to `failed`, mirroring the gate's `uncheckable`).
- **`@shipfox/api-integration-debug`** — debug workflow templates updated to the new gate form.

## Breaking change (pre-deployment, no shim)

Authored gate expressions move from `exit_code == 0` to `step.exit_code == 0`. All fixtures, tests, and the shipped debug templates are migrated.

## Notes for review

- The `{kind:'map'}` expression-type extension was intentionally dropped: event-`data` deep access already type-checks as `dyn` (the `executions[] -> events[]` list-of-objects collapse), verified against `@marcbachmann/cel-js@7.6.1`. `step.output.*` is the only depth-1 case that needs the open-map type, and it is deferred to ENG-735.
- Gate authoring is scoped to the single `step` root (not `rootsAvailableAt(phase)`) so authoring and runtime stay in lockstep.
- Promoting `step` into the registry also makes `${{ step.* }}` interpolations type-check at authoring even though they only resolve at step-completion; phase-aware interpolation validation is ENG-726's scope (consistent with how `execution`/`executions` already behave).

Closes ENG-723

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves step gate (`success_if`) and job `success` to the shared, phase-aware workflow context. Adds a typed `step` root and evaluates job success over the full `executions` context via `assembleExecutionsContext`, failing closed and recording `unknown` when a predicate throws. Closes ENG-723.

- **New Features**
  - `@shipfox/expression`: added typed `step` root (`step.exit_code`, `step.status`).
  - Gates validate/run against `step`; job success validates/runs over full `executions`, failing closed on runtime errors and setting status reason to `unknown`.

- **Migration**
  - Update gate expressions from `exit_code == 0` to `step.exit_code == 0`.
  - Examples, fixtures, and debug templates updated; no shim provided.

<sup>Written for commit 487b9a5cfcc91b8e02a0b70a6f6a28531cad42c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

