### PR TITLE
[client-integrations] Fix flaky gallery tests

### DIFF
--- a/libs/client/integrations/src/components/integration-gallery.test.tsx
+++ b/libs/client/integrations/src/components/integration-gallery.test.tsx
@@ -5,7 +5,6 @@ import {configureApiClient} from '@shipfox/client-api';
 import {fireEvent, screen, waitFor, within} from '@testing-library/react';
 import {INTEGRATIONS_TEST_WID, jsonResponse, renderIntegrationsPage} from '#test/render.js';
 import {IntegrationGallery} from './integration-gallery.js';
-import {usageEventsForConnection} from './integration-usage-events.js';
 
 if (!HTMLElement.prototype.hasPointerCapture) {
   Object.defineProperty(HTMLElement.prototype, 'hasPointerCapture', {
@@ -192,7 +191,7 @@ function renderGallery(
   return renderIntegrationsPage({
     path: `/workspaces/${INTEGRATIONS_TEST_WID}/integrations`,
     routePath: '/workspaces/$wid/integrations',
-    element: <IntegrationGallery {...props} />,
+    element: <IntegrationGallery workspaceId={INTEGRATIONS_TEST_WID} {...props} />,
     extraRoutes: SETUP_ROUTES,
   });
 }
@@ -325,22 +324,19 @@ describe('IntegrationGallery — installed section', () => {
     expect(screen.getByText(webhookConnectionDto.inbound_url)).toBeVisible();
   });
 
-  test('shows GitHub webhook events in the usage selector', async () => {
-    const githubEventValues = usageEventsForConnection(githubConnection).map(
-      (event) => event.value,
-    );
-    expect(githubEventValues).toEqual(expect.arrayContaining(['pull_request', 'workflow_run']));
-
+  test('opens the usage modal with a GitHub event selector', async () => {
     renderGallery({}, {connections: [githubConnection]});
 
     await openActions('Open acme-corp integration actions');
     fireEvent.click(screen.getByRole('menuitem', {name: 'Use this integration'}));
 
     expect(await screen.findByText('Usage')).toBeVisible();
-    expect(screen.getAllByText('github_acme_corp')[0]).toBeVisible();
-    expect(screen.getAllByText('push')[0]).toBeVisible();
-    const eventSelect = screen.getByRole('combobox', {name: 'Event'});
+    const eventSelect = await screen.findByRole('combobox', {name: 'Event'});
+
     expect(eventSelect).toBeVisible();
+    await waitFor(() => {
+      expect(eventSelect).toHaveTextContent('push');
+    });
   });
 
   test('toggles integration lifecycle status from the actions menu', async () => {

--- a/libs/client/integrations/src/components/integration-usage-events.test.ts
+++ b/libs/client/integrations/src/components/integration-usage-events.test.ts
@@ -1,0 +1,68 @@
+import type {IntegrationConnectionDto} from '@shipfox/api-integration-core-dto';
+import {WEBHOOK_RECEIVED_EVENT} from '@shipfox/api-integration-webhook-dto';
+import {usageEventsForConnection} from './integration-usage-events.js';
+
+const baseConnection = {
+  id: '44444444-4444-4444-8444-444444444444',
+  workspace_id: '11111111-1111-4111-8111-111111111111',
+  provider: 'github',
+  external_account_id: 'installation-1',
+  slug: 'github_acme_corp',
+  display_name: 'acme-corp',
+  lifecycle_status: 'active',
+  capabilities: [],
+  created_at: '2026-03-12T00:00:00.000Z',
+  updated_at: '2026-03-12T00:00:00.000Z',
+} satisfies IntegrationConnectionDto;
+
+describe('usageEventsForConnection', () => {
+  it('lists the GitHub webhook events used by workflow triggers', () => {
+    const connection = {
+      ...baseConnection,
+      provider: 'github',
+      capabilities: ['source_control'],
+    } satisfies IntegrationConnectionDto;
+
+    const events = usageEventsForConnection(connection);
+    const values = events.map((event) => event.value);
+
+    expect(values[0]).toBe('push');
+    expect(values).toEqual(expect.arrayContaining(['pull_request', 'workflow_run']));
+    expect(events.find((event) => event.value === 'workflow_run')?.label).toBe('workflow_run');
+  });
+
+  it('uses the webhook received event for webhook connections', () => {
+    const connection = {
+      ...baseConnection,
+      provider: 'webhook',
+      slug: 'stripe-prod',
+    } satisfies IntegrationConnectionDto;
+
+    const events = usageEventsForConnection(connection);
+
+    expect(events).toEqual([{value: WEBHOOK_RECEIVED_EVENT, label: WEBHOOK_RECEIVED_EVENT}]);
+  });
+
+  it('uses source-control push for uncataloged source-control providers', () => {
+    const connection = {
+      ...baseConnection,
+      provider: 'gitea',
+      capabilities: ['source_control'],
+    } satisfies IntegrationConnectionDto;
+
+    const events = usageEventsForConnection(connection);
+
+    expect(events).toEqual([{value: 'push', label: 'push'}]);
+  });
+
+  it('falls back to a generic received event for uncataloged providers', () => {
+    const connection = {
+      ...baseConnection,
+      provider: 'mystery',
+    } satisfies IntegrationConnectionDto;
+
+    const events = usageEventsForConnection(connection);
+
+    expect(events).toEqual([{value: 'received', label: 'received'}]);
+  });
+});


### PR DESCRIPTION
[client-integrations] Fix flaky gallery tests

The gallery DOM test for GitHub usage mixed pure event-list assertions with modal rendering and exact text queries inside an asynchronously highlighted code block. Under CI load, the test could wait on Shiki timing or exceed the 5s per-test budget while affected Storybook browser tests were also running.

This moves provider event mapping coverage into a fast Node test for `usageEventsForConnection`, keeps the gallery DOM assertion focused on the visible Event selector, and passes the workspace ID directly in gallery tests so they do not wait on active-workspace auth setup.

No changeset: this is test-only coverage and setup for a private client package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the integration gallery tests by moving provider-event mapping to a fast unit test and narrowing the DOM test to the Usage modal’s event selector. Passes `workspaceId` directly to skip auth/setup waits.

- **Bug Fixes**
  - Added a Node unit test for `usageEventsForConnection` (GitHub with `source_control`, webhook via `WEBHOOK_RECEIVED_EVENT`, uncataloged providers) asserting events like 'push', 'pull_request', 'workflow_run', and a 'received' fallback.
  - Simplified the gallery DOM test to open "Use this integration", ensure the "Usage" modal, and await the Event combobox showing 'push', removing timing-sensitive code-highlighting checks.

<sup>Written for commit 051686cd93ad987f40848e20e7d79c128b399350. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

