### PR TITLE
Cap CI test concurrency from workflow env

### DIFF
--- a/.changeset/quiet-workers-cap.md
+++ b/.changeset/quiet-workers-cap.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/vitest": patch
+---
+
+Adds an environment-controlled Vitest worker cap to reduce CI CPU contention.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
       # Only approved code on main may publish remote cache artifacts. Pull
       # requests can restore trusted artifacts from main, but cannot poison cache.
       TURBO_CACHE: ${{ github.ref == 'refs/heads/main' && 'local:rw,remote:rw' || 'local:rw,remote:r' }}
+      SHIPFOX_TURBO_CONCURRENCY: "2"
+      SHIPFOX_VITEST_MAX_WORKERS: "2"
 
     steps:
       - name: Check out repository
@@ -42,7 +44,7 @@ jobs:
       - name: Run verification
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
-        run: turbo check type test build depcruise
+        run: turbo check type test build depcruise --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
       - name: Run E2E tests
         id: e2e

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -29,6 +29,20 @@ type MergeableConfigInput = ConfigInput & {
   };
 };
 
+const maxWorkers = parseMaxWorkers(process.env.SHIPFOX_VITEST_MAX_WORKERS);
+const workerPoolConfig = maxWorkers === undefined ? {} : {maxWorkers};
+
+function parseMaxWorkers(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+
+  const maxWorkers = Number(value);
+  if (!Number.isInteger(maxWorkers) || maxWorkers < 1) {
+    throw new Error('SHIPFOX_VITEST_MAX_WORKERS must be a positive integer.');
+  }
+
+  return maxWorkers;
+}
+
 function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): ConfigInput {
   const mergeableConfig = resolvedConfig as MergeableConfigInput;
   const existingPlugins = mergeableConfig.plugins || [];
@@ -48,6 +62,7 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
     test: {
       ...(mergeableConfig.test || {}),
       globals: true,
+      ...workerPoolConfig,
       exclude: [
         '**/node_modules/**',
         '**/dist/**',

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -37,7 +37,7 @@ function parseMaxWorkers(value: string | undefined): number | undefined {
 
   const maxWorkers = Number(value);
   if (!Number.isInteger(maxWorkers) || maxWorkers < 1) {
-    throw new Error('SHIPFOX_VITEST_MAX_WORKERS must be a positive integer.');
+    throw new Error(`SHIPFOX_VITEST_MAX_WORKERS must be a positive integer, got "${value}".`);
   }
 
   return maxWorkers;

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -9,6 +9,7 @@
     "API_URL",
     "CLIENT_URL",
     "ARGOS_TOKEN",
+    "SHIPFOX_VITEST_MAX_WORKERS",
     "CI"
   ],
   "tasks": {


### PR DESCRIPTION
Cap CI test concurrency from explicit workflow environment variables.

The verification job currently lets Turbo and each Vitest process size themselves independently, which can oversubscribe standard GitHub runners when many packages run at once. This adds CI-owned knobs for both layers: `SHIPFOX_TURBO_CONCURRENCY` drives Turbo's task concurrency, and `SHIPFOX_VITEST_MAX_WORKERS` is passed through Turbo's strict task environment and read by the shared `@shipfox/vitest` config.

The Vitest wrapper only applies a worker cap when the env var is set, so local defaults and package configs stay unchanged. The Storybook browser projects inherit the same shared Vitest config through their existing project setup.

Validation: changed-graph build, test, and check passed locally. An earlier broad test run hit a transient `@shipfox/api-workflows` assertion that passed when rerun directly and then passed in the full changed-graph test rerun.

Closes ENG-736

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap CI test concurrency to prevent oversubscribing GitHub runners and stabilize test times. CI now controls Turbo task parallelism and Vitest worker count via env, with no change to local defaults (ENG-736).

- **New Features**
  - CI sets SHIPFOX_TURBO_CONCURRENCY=2 and SHIPFOX_VITEST_MAX_WORKERS=2, and runs turbo with --concurrency="$SHIPFOX_TURBO_CONCURRENCY".
  - `@shipfox/vitest` reads SHIPFOX_VITEST_MAX_WORKERS and applies maxWorkers only when set; invalid values throw a clear error that includes the provided value.
  - Exposed SHIPFOX_VITEST_MAX_WORKERS in turbo.jsonc so tasks can read it; Storybook test projects inherit the shared config.

<sup>Written for commit 175950c5ffdb8c1e7da95da77b39e7ac242bc13a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

