### PR TITLE
[react-ui] Add fixed clock for relative time

### DIFF
--- a/.changeset/steady-clocks-freeze.md
+++ b/.changeset/steady-clocks-freeze.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": minor
+---
+
+Adds a fixed clock option to relative time rendering for deterministic visual captures.

--- a/libs/client/triggers/src/components/events-list.stories.tsx
+++ b/libs/client/triggers/src/components/events-list.stories.tsx
@@ -3,17 +3,22 @@ import type {
   TriggerEventListItemDto,
   TriggerEventOutcomeDto,
 } from '@shipfox/api-triggers-dto';
-import {Code} from '@shipfox/react-ui';
+import {Code, RelativeTimeProvider} from '@shipfox/react-ui';
 import type {Decorator, Meta, StoryObj} from '@storybook/react';
 import type {ReactNode} from 'react';
 import {EventsList} from './events-list.js';
 import type {TriggerEventsListQuery} from './types.js';
 
+const STORY_NOW = '2026-06-25T20:00:00.000Z';
+const STORY_NOW_MS = Date.parse(STORY_NOW);
+
 // Typed so meta's inferred type stays nameable (TS2883) under the package's tsconfig.
 const withWidth: Decorator = (Story) => (
-  <div className="w-[900px]">
-    <Story />
-  </div>
+  <RelativeTimeProvider now={STORY_NOW}>
+    <div className="w-[900px]">
+      <Story />
+    </div>
+  </RelativeTimeProvider>
 );
 
 function makeQuery(overrides: Partial<TriggerEventsListQuery> = {}): TriggerEventsListQuery {
@@ -50,9 +55,9 @@ function makeEvent(
     connection_id: 'conn-demo',
     outcome,
     matched_count: matchedCount,
-    received_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
-    processed_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
-    created_at: new Date(Date.now() - minutesAgo * 60_000).toISOString(),
+    received_at: new Date(STORY_NOW_MS - minutesAgo * 60_000).toISOString(),
+    processed_at: new Date(STORY_NOW_MS - minutesAgo * 60_000).toISOString(),
+    created_at: new Date(STORY_NOW_MS - minutesAgo * 60_000).toISOString(),
   };
 }
 

--- a/libs/shared/react/ui/src/components/relative-time/relative-time.tsx
+++ b/libs/shared/react/ui/src/components/relative-time/relative-time.tsx
@@ -1,14 +1,23 @@
-import type {ReactNode} from 'react';
+import {createContext, type ReactNode, useContext} from 'react';
 import {useMediaQuery} from '#hooks/useMediaQuery.js';
 import {formatTimestamp} from '#utils/datetime.js';
-import {formatRelative} from '#utils/relative-time.js';
+import {formatRelative, type RelativeNow} from '#utils/relative-time.js';
 import {TimeTickerProvider, useTimeTick} from '../time-ticker/index.js';
 import {Tooltip, TooltipContent, TooltipTrigger} from '../tooltip/index.js';
 
 const TICK_MS = 30_000;
+const RelativeTimeContext = createContext<{now?: RelativeNow}>({});
 
-export function RelativeTimeProvider({children}: {children: ReactNode}) {
-  return <TimeTickerProvider intervalMs={TICK_MS}>{children}</TimeTickerProvider>;
+export function RelativeTimeProvider({children, now}: {children: ReactNode; now?: RelativeNow}) {
+  const content = (
+    <RelativeTimeContext.Provider value={now === undefined ? {} : {now}}>
+      {children}
+    </RelativeTimeContext.Provider>
+  );
+
+  if (now !== undefined) return content;
+
+  return <TimeTickerProvider intervalMs={TICK_MS}>{content}</TimeTickerProvider>;
 }
 
 /**
@@ -23,8 +32,9 @@ export function RelativeTimeProvider({children}: {children: ReactNode}) {
 export function RelativeTime({value, className}: {value: string; className?: string}) {
   useTimeTick();
   const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  const {now} = useContext(RelativeTimeContext);
 
-  const display = formatRelative(value, {reducedMotion});
+  const display = formatRelative(value, now === undefined ? {reducedMotion} : {reducedMotion, now});
 
   // Skip the Tooltip entirely for unparseable input so consumers see a
   // clean empty render instead of a tooltip exposing a thrown Intl call.

--- a/libs/shared/react/ui/src/utils/relative-time.test.ts
+++ b/libs/shared/react/ui/src/utils/relative-time.test.ts
@@ -42,6 +42,15 @@ describe('formatRelative', () => {
     expect(result).toBe('2d ago');
   });
 
+  test('renders relative to an explicit now value', () => {
+    const result = formatRelative('2026-05-13T00:00:00.000Z', {
+      reducedMotion: false,
+      now: '2026-05-13T00:05:00.000Z',
+    });
+
+    expect(result).toBe('5m ago');
+  });
+
   test('renders "in Ns" for future timestamps', () => {
     freezeNow('2026-05-13T00:00:00.000Z');
 

--- a/libs/shared/react/ui/src/utils/relative-time.ts
+++ b/libs/shared/react/ui/src/utils/relative-time.ts
@@ -1,5 +1,13 @@
 import {intlFormatDistance} from 'date-fns';
 
+export type RelativeNow = Date | number | string;
+
+function timestamp(value: RelativeNow): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'number') return value;
+  return Date.parse(value);
+}
+
 /**
  * Formats the signed distance between `iso` and now as a short relative
  * string ("12s ago", "3m ago", "in 2h"). Returns '' for unparseable input
@@ -9,10 +17,15 @@ import {intlFormatDistance} from 'date-fns';
  * Under `reducedMotion`, sub-minute distances collapse to a steady
  * "just now" / "in <1m" rather than ticking every second.
  */
-export function formatRelative(iso: string, {reducedMotion}: {reducedMotion: boolean}): string {
+export function formatRelative(
+  iso: string,
+  {reducedMotion, now}: {reducedMotion: boolean; now?: RelativeNow},
+): string {
   const ts = Date.parse(iso);
   if (!Number.isFinite(ts)) return '';
-  const diffMs = Date.now() - ts;
+  const nowTs = now === undefined ? Date.now() : timestamp(now);
+  if (!Number.isFinite(nowTs)) return '';
+  const diffMs = nowTs - ts;
   const past = diffMs >= 0;
   const absMs = Math.abs(diffMs);
 
@@ -20,7 +33,7 @@ export function formatRelative(iso: string, {reducedMotion}: {reducedMotion: boo
     if (reducedMotion) return past ? 'just now' : 'in <1m';
   }
 
-  return intlFormatDistance(new Date(ts), Date.now(), {
+  return intlFormatDistance(new Date(ts), nowTs, {
     numeric: 'always',
     style: 'narrow',
   });


### PR DESCRIPTION
Add a fixed clock option to `RelativeTimeProvider` and use it in the trigger events list story.

The `triggers-eventslist--playground` visual capture used sample event timestamps derived from `Date.now()`, while the received column rendered relative labels against the live clock. That made Argos screenshots drift depending on when the story rendered. Freezing the story clock keeps the received column deterministic while preserving live relative-time behavior for production callers.

The new `now` option is intentionally scoped to the relative-time provider/formatter so other Storybook captures can opt into deterministic clocks without stubbing global time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional fixed clock for relative time so Storybook screenshots are stable. The triggers events list story now freezes “now” to stop drifting “Received” labels.

- **New Features**
  - `RelativeTimeProvider` accepts `now`; when set, it skips ticking and provides the clock via context.
  - `formatRelative` adds `now?: RelativeNow` (`Date` | `number` | `string`) and includes a test for explicit `now`.
  - Updated `triggers-eventslist--playground` to wrap in `RelativeTimeProvider now="2026-06-25T20:00:00.000Z"` and derive sample timestamps from it for deterministic Argos captures.

<sup>Written for commit c792724520c195cac9023c27386ebddd1fdd9007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

