### PR TITLE
[react-ui] Stabilize badge avatar snapshots

### DIFF
--- a/.changeset/steady-badges-load.md
+++ b/.changeset/steady-badges-load.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/react-ui": patch
+---
+
+Stabilizes Badge story visual snapshots by using a deterministic user avatar fixture.

--- a/libs/shared/react/ui/src/components/badge/badge.stories.tsx
+++ b/libs/shared/react/ui/src/components/badge/badge.stories.tsx
@@ -1,4 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
+import {waitFor} from 'storybook/test';
 import {Code} from '#components/typography/index.js';
 import {Badge} from './badge.js';
 import {IconBadge} from './icon-badge.js';
@@ -8,6 +9,25 @@ import {UserBadge} from './user-badge.js';
 const variants = ['neutral', 'info', 'feature', 'success', 'warning', 'error'] as const;
 const iconBadgeVariants = ['neutral', 'info', 'feature', 'success', 'warning', 'error'] as const;
 const sizes = ['2xs', 'xs'] as const;
+const userBadgeAvatarSrc = `data:image/svg+xml,${encodeURIComponent(`
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="16" fill="#e3e6ea"/>
+  <circle cx="16" cy="12" r="6" fill="#6b7280"/>
+  <path d="M6 29c1.5-6.2 5.2-9.3 10-9.3S24.5 22.8 26 29" fill="#6b7280"/>
+</svg>
+`)}`;
+
+const waitForStoryImages = async (canvasElement: HTMLElement) => {
+  const images = Array.from(canvasElement.querySelectorAll('img'));
+
+  await waitFor(() => {
+    for (const image of images) {
+      if (!image.complete || image.naturalWidth === 0) {
+        throw new Error('Waiting for badge story images to load');
+      }
+    }
+  });
+};
 
 const meta = {
   title: 'Components/Badge',
@@ -76,7 +96,11 @@ export const AllVariants: Story = {
           User badge
         </Code>
         <div className="flex gap-16">
-          <UserBadge name="Ada Lovelace" avatarFallback="Ada Lovelace" />
+          <UserBadge
+            name="Ada Lovelace"
+            avatarSrc={userBadgeAvatarSrc}
+            avatarFallback="Ada Lovelace"
+          />
         </div>
       </div>
 
@@ -112,6 +136,9 @@ export const AllVariants: Story = {
       ))}
     </div>
   ),
+  play: async ({canvasElement}) => {
+    await waitForStoryImages(canvasElement);
+  },
 };
 
 export const InteractiveBadges: Story = {


### PR DESCRIPTION
Stabilize the Badge `AllVariants` story by replacing the network-backed avatar placeholder with an inline SVG fixture and waiting for story images to finish loading.

The visual regression snapshot could capture either the avatar fallback or the loaded DiceBear image depending on network and decode timing. Keeping the fixture local makes the story deterministic while preserving the user-badge visual coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Badge visual snapshots by making the `AllVariants` story deterministic. Prevents flakiness from network and image decode timing in CI.

- **Bug Fixes**
  - Replaced network avatar with an inline SVG `data:` URL fixture via `avatarSrc` for `UserBadge` in `AllVariants`.
  - Added a `play` step that waits for all story images to finish loading using `waitFor` from `storybook/test`.

<sup>Written for commit 87445d2e49c572f96cf7ef3e044060d6d6a4d972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

