### PR TITLE
[client-workflows] Move presentational component tests off the page harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -278,6 +278,29 @@ export default defineConfig(
 The target shape is many fast Node tests for branch-heavy behavior, a small RTL
 suite for React integration, and Playwright for user-visible journeys.
 
+### Render at the lowest altitude that proves the behavior
+
+A page-level harness (memory router + `QueryClient` + configured API client, e.g.
+`renderProjectPage` in `libs/client/*/test/pages.tsx`) is the heaviest way to
+mount a component, and every import re-evaluates that provider stack. Pick the
+lightest tier that can still exercise what the test asserts:
+
+| Tier | Use it for | How |
+| --- | --- | --- |
+| `node` test | Pure decisions: filtering, formatting, URL/search-param shaping, status mapping. | Extract a helper, test it in the `node` project (`*.test.ts`, no DOM). |
+| `render()` | A presentational component that takes all its data through props and renders no router-aware child. | `render(<Component {...props} />)` from `@testing-library/react`, no providers. |
+| `renderWithRouter()` | A component that needs a router in context (its rows render `<Link>`, or it calls `useNavigate`) but fetches nothing. | A router-only helper (e.g. `libs/client/workflows/test/render.tsx`): memory router, no `QueryClient` or API client. |
+| Page harness | A page, or a component that genuinely fetches and navigates (React Query hooks + `useNavigate`). | `renderProjectPage` / the package's `test/pages.tsx`. |
+
+A page keeps a handful of harness-based smoke tests; it should not carry dozens of
+assertions that each remount the world when a lower tier proves the same branch.
+
+**Enforcement.** Harness usage must be justified in review, and a package that
+uses the page harness pins its harness importers with an allowlist guard test (see
+`libs/client/workflows/src/page-harness-budget.test.ts`). A new `#test/pages`
+import fails the guard until it is added to the allowlist, which is the moment a
+reviewer asks whether the test needs page wiring or should drop an altitude.
+
 ## Visual Regression Testing
 
 Visual drift is caught on every PR via [Argos](https://argos-ci.com/). One Argos

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -2,10 +2,11 @@ import {screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {WorkflowRunListItem, WorkflowRunStatus} from '#core/workflow-run.js';
 import {workflowRunListItem} from '#test/fixtures/workflow-run.js';
-import {PROJECT_TEST_WID, renderProjectPage} from '#test/pages.js';
+import {renderWithRouter} from '#test/render.js';
 import type {WorkflowRunListQuery} from './types.js';
 import {WorkflowRunListView} from './workflow-run-list-view.js';
 
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const PROJECT_ID = '44444444-4444-4444-8444-444444444444';
 
 function loadedQuery(): WorkflowRunListQuery {
@@ -144,14 +145,17 @@ describe('WorkflowRunListView', () => {
 });
 
 function renderListView(runs: WorkflowRunListItem[]) {
-  renderProjectPage(`/workspaces/${PROJECT_TEST_WID}/projects/${PROJECT_ID}/runs`, () => (
+  // The list view fetches nothing (its rows are fed via props); it only needs a
+  // router so the row `<Link>`s resolve, so it uses the router-only helper rather
+  // than the page harness.
+  renderWithRouter(
     <WorkflowRunListView
       runs={runs}
       query={loadedQuery()}
-      workspaceId={PROJECT_TEST_WID}
+      workspaceId={WORKSPACE_ID}
       projectId={PROJECT_ID}
-    />
-  ));
+    />,
+  );
 }
 
 function run(

--- a/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-list/workflow-run-list-view.test.tsx
@@ -145,9 +145,7 @@ describe('WorkflowRunListView', () => {
 });
 
 function renderListView(runs: WorkflowRunListItem[]) {
-  // The list view fetches nothing (its rows are fed via props); it only needs a
-  // router so the row `<Link>`s resolve, so it uses the router-only helper rather
-  // than the page harness.
+  // Row links need router context; the query and data stay injected by props.
   renderWithRouter(
     <WorkflowRunListView
       runs={runs}

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -1,8 +1,7 @@
-import {screen, within} from '@testing-library/react';
+import {render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {workflowRunDetailDto} from '#test/fixtures/workflow-run.js';
 import {workflowJobDto, workflowRunDetail} from '#test/fixtures/workflow-run.js';
-import {renderProjectPage} from '#test/pages.js';
 import {WorkflowRunSummary} from './workflow-run-summary.js';
 
 const {useIsTextTruncatedMock} = vi.hoisted(() => ({
@@ -330,7 +329,8 @@ function renderSummary(
     ...overrides,
   });
 
-  renderProjectPage('/workspaces/ws-demo/projects/proj-demo/runs/run-demo', () => (
-    <WorkflowRunSummary run={run} {...props} />
-  ));
+  // The summary takes all its data through props and renders no router-aware child
+  // (the attempt switcher only mounts when `latestAttempt > 1`, which these tests
+  // never set), so a plain render is enough: no router, QueryClient, or API client.
+  render(<WorkflowRunSummary run={run} {...props} />);
 }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -329,8 +329,6 @@ function renderSummary(
     ...overrides,
   });
 
-  // The summary takes all its data through props and renders no router-aware child
-  // (the attempt switcher only mounts when `latestAttempt > 1`, which these tests
-  // never set), so a plain render is enough: no router, QueryClient, or API client.
+  // These cases never mount the attempt switcher links, so no router is needed.
   render(<WorkflowRunSummary run={run} {...props} />);
 }

--- a/libs/client/workflows/src/page-harness-budget.test.ts
+++ b/libs/client/workflows/src/page-harness-budget.test.ts
@@ -2,15 +2,8 @@ import {readdirSync, readFileSync} from 'node:fs';
 import {dirname, join, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-// Altitude guard for the page-level RTL harness (`test/pages.tsx`), which mounts a
-// memory router + QueryClient + API client. That weight is justified for a page
-// test or a component that genuinely fetches and navigates; it is pure overhead
-// for a presentational component (use a plain `render()`) or a router-only
-// component (use `renderWithRouter` from `test/render.tsx`).
-//
-// This is a soft cap, not a ban: a new harness user must be added here on purpose,
-// which is the point at which a reviewer asks whether the test needs page wiring.
-// See CONTRIBUTING.md "Unit Testing Strategy (Client Apps)".
+// Keeps page-harness imports intentional because each one mounts router, query,
+// and API-client providers around the test.
 const PAGE_HARNESS_ALLOWLIST = [
   'src/components/workflow-run-summary/workflow-run-attempt-switcher.test.tsx',
   'src/components/workflow-run-view/workflow-run-view.test.tsx',

--- a/libs/client/workflows/src/page-harness-budget.test.ts
+++ b/libs/client/workflows/src/page-harness-budget.test.ts
@@ -1,0 +1,40 @@
+import {readdirSync, readFileSync} from 'node:fs';
+import {dirname, join, relative} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+// Altitude guard for the page-level RTL harness (`test/pages.tsx`), which mounts a
+// memory router + QueryClient + API client. That weight is justified for a page
+// test or a component that genuinely fetches and navigates; it is pure overhead
+// for a presentational component (use a plain `render()`) or a router-only
+// component (use `renderWithRouter` from `test/render.tsx`).
+//
+// This is a soft cap, not a ban: a new harness user must be added here on purpose,
+// which is the point at which a reviewer asks whether the test needs page wiring.
+// See CONTRIBUTING.md "Unit Testing Strategy (Client Apps)".
+const PAGE_HARNESS_ALLOWLIST = [
+  'src/components/workflow-run-summary/workflow-run-attempt-switcher.test.tsx',
+  'src/components/workflow-run-view/workflow-run-view.test.tsx',
+  'src/pages/workflow-run-page.test.tsx',
+];
+
+const srcDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = dirname(srcDir);
+
+function collectTestFiles(dir: string): string[] {
+  return readdirSync(dir, {withFileTypes: true}).flatMap((entry) => {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) return collectTestFiles(entryPath);
+    return entry.isFile() && entry.name.endsWith('.test.tsx') ? [entryPath] : [];
+  });
+}
+
+describe('page harness budget', () => {
+  it('is imported only by the allowlisted page-wiring tests', () => {
+    const harnessImporters = collectTestFiles(srcDir)
+      .filter((file) => readFileSync(file, 'utf8').includes("'#test/pages"))
+      .map((file) => relative(packageRoot, file))
+      .sort();
+
+    expect(harnessImporters).toEqual(PAGE_HARNESS_ALLOWLIST);
+  });
+});

--- a/libs/client/workflows/test/render.tsx
+++ b/libs/client/workflows/test/render.tsx
@@ -1,0 +1,47 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import {type RenderResult, render} from '@testing-library/react';
+import type {ReactElement} from 'react';
+
+// The lightweight middle tier between a plain `render()` and the page harness
+// (`test/pages.tsx`). Use it for a component that only needs a router in context
+// (its rows render `<Link>`, or it calls `useNavigate`) but does not fetch: it
+// mounts the element with a memory router and no QueryClient or API client.
+//
+// The run-detail route is registered so `<Link to=".../runs/$workflowRunId">`
+// resolves to a real href. Add more link-target routes here as router-only
+// components need them, rather than reaching for the page harness.
+function createComponentRouter(element: ReactElement) {
+  const rootRoute = createRootRoute({component: Outlet});
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => element,
+  });
+  const runDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/workspaces/$wid/projects/$pid/runs/$workflowRunId',
+    component: () => null,
+  });
+
+  return createRouter({
+    history: createMemoryHistory({initialEntries: ['/']}),
+    routeTree: rootRoute.addChildren([indexRoute, runDetailRoute]),
+  });
+}
+
+export function renderWithRouter(
+  element: ReactElement,
+): RenderResult & {router: ReturnType<typeof createComponentRouter>} {
+  const router = createComponentRouter(element);
+
+  const result = render(<RouterProvider router={router} />);
+
+  return Object.assign(result, {router});
+}

--- a/libs/client/workflows/test/render.tsx
+++ b/libs/client/workflows/test/render.tsx
@@ -9,14 +9,6 @@ import {
 import {type RenderResult, render} from '@testing-library/react';
 import type {ReactElement} from 'react';
 
-// The lightweight middle tier between a plain `render()` and the page harness
-// (`test/pages.tsx`). Use it for a component that only needs a router in context
-// (its rows render `<Link>`, or it calls `useNavigate`) but does not fetch: it
-// mounts the element with a memory router and no QueryClient or API client.
-//
-// The run-detail route is registered so `<Link to=".../runs/$workflowRunId">`
-// resolves to a real href. Add more link-target routes here as router-only
-// components need them, rather than reaching for the page harness.
 function createComponentRouter(element: ReactElement) {
   const rootRoute = createRootRoute({component: Outlet});
   const indexRoute = createRoute({
@@ -24,6 +16,7 @@ function createComponentRouter(element: ReactElement) {
     path: '/',
     component: () => element,
   });
+  // Workflow run rows link here; TanStack Router needs the target route to build hrefs.
   const runDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/workspaces/$wid/projects/$pid/runs/$workflowRunId',


### PR DESCRIPTION
Enforce test altitude in the RTL suite: stop simple checks from paying for full page mounting.

## Why

CONTRIBUTING already prescribes the pyramid (pure behavior in `node` tests, RTL only for genuinely rendered behavior, journeys in Playwright), but nothing enforced it. Many "very simple checks" went through the heaviest harness available: `renderProjectPage` in `test/pages.tsx`, which spins up a memory router + `QueryClient` + configured API client. That provider stack is re-evaluated on every test-file import and is pure overhead for a component that receives all its data through props and never fetches.

`@shipfox/client-workflows` was the clear outlier (70 harness-mounted tests across 5 files), carrying two presentational components on the page harness:

- `WorkflowRunSummary` (20 tests) takes `run` + callbacks as props and renders no router-aware child in these tests. Now rendered with a plain `render()`, no context.
- `WorkflowRunListView` (7 tests) fetches nothing (rows are fed via props); it only needs a router so its row `<Link>`s resolve. Now uses a new lightweight `renderWithRouter` helper (`test/render.tsx`): memory router only, no `QueryClient` or API client.

The three genuinely page-wired tests keep the harness because they fetch via React Query and navigate: `workflow-run-view`, `workflow-run-attempt-switcher`, `workflow-run-page`.

Net: harness-mounted tests in the package drop 70 to 43, with 20 now fully context-free.

## Enforcement (not just prose)

- `src/page-harness-budget.test.ts` — a per-package soft cap: it scans `src/**/*.test.tsx` for `#test/pages` imports and asserts they equal an allowlist. A new harness import fails the guard until it is added, which is the moment a reviewer asks whether the test needs page wiring or should drop an altitude.
- `CONTRIBUTING.md` — a render-tier table (`node` test -> `render()` -> `renderWithRouter()` -> page harness) and a review-checklist line: harness usage must be justified.

## Audit of the other client packages

I checked every client `.test.tsx`. `client-workflows` was the only package with props-fed presentational components on the page harness. The other heavy tests are legitimately integration-level (they self-fetch via React Query and/or navigate): `integration-gallery`, `workspace-setup-guard`, `agent-providers-section`, the runners token-settings sections, `redirect-install-page`, `project-switcher`. The remaining page-harness tests are actual page tests, and the rest already use a plain `render()`.

No changeset: `@shipfox/client-workflows` is private and the change is test-only plus docs.

Closes ENG-741

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move presentational tests in `@shipfox/client-workflows` off the page harness to faster, lower-altitude renders and add a soft guard to enforce it. Aligns with ENG-741 and reduces harness-mounted tests from 70 to 43, with 20 now context-free.

- **Refactors**
  - Use plain `render()` for `WorkflowRunSummary`; add `renderWithRouter()` in `test/render.tsx` for `WorkflowRunListView` (router-only, no `QueryClient` or API client).
  - Keep the page harness only for page-wired tests: `workflow-run-view`, `workflow-run-attempt-switcher`, `workflow-run-page`.
  - Add `src/page-harness-budget.test.ts` to allowlist page-harness importers and fail new ones until justified.
  - Update `CONTRIBUTING.md` with tier guidelines (`node` -> `render()` -> `renderWithRouter()` -> page harness) and a review checklist line to justify harness usage.
  - Tighten test comments to clarify when router context is needed.

<sup>Written for commit e48e9610056f0f09057c22e191ad649d5073282d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

