### PR TITLE
Split CI verification and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,28 @@ env:
 # Parallel jobs cannot share PR-written remote cache artifacts, so each job
 # rebuilds what its own Turbo graph needs.
 jobs:
-  ci:
-    name: Check, test, type, and build
+  static-verification:
+    name: Check, type, build, and depcruise
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      SHIPFOX_TURBO_CONCURRENCY: "2"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run static verification
+        run: turbo check type build depcruise --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
+
+  tests:
+    name: Unit and story tests
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -40,15 +60,15 @@ jobs:
       - name: Start test services
         run: docker compose up --wait -d postgres temporal garage garage-init
 
-      # `turbo test` includes client Vitest browser tests, so Chromium is
-      # required in the verification job too.
+      # Client Vitest browser tests run under `turbo test`, so this non-E2E
+      # job still needs Chromium.
       - name: Install Playwright browsers
         run: pnpm --filter=@shipfox/playwright exec playwright install --with-deps chromium
 
-      - name: Run verification
+      - name: Run tests
         env:
           ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
-        run: turbo check type test build depcruise --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
+        run: turbo test --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
 
   e2e:
     name: E2E tests
@@ -146,7 +166,7 @@ jobs:
   # cache instead of inheriting artifacts from less-privileged jobs.
   publish-images:
     name: Publish app images
-    needs: [ci, e2e]
+    needs: [static-verification, tests, e2e]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     # Multi-arch: linux/arm64 builds under QEMU emulation, slow on a cold gha BuildKit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 # rebuilds what its own Turbo graph needs.
 jobs:
   static-verification:
-    name: Check, type, build, and depcruise
+    name: Static verification
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:


### PR DESCRIPTION
Split the combined CI verification job into separate static verification and test jobs.

The workflow was doing check, type, test, build, and dependency cruising in one job. Separating static verification from unit and Storybook tests lets GitHub schedule those paths independently while keeping image builds gated on static verification, tests, and E2E.

Reviewers should check the new job dependency graph: PR image builds now wait for all verification jobs, and main image publishing still waits for the same gates before receiving package write permission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the monolithic CI job into `static-verification` and `tests` to improve parallelism and speed up feedback. Aligns with ENG-737 by keeping the `static-verification` check name stable; image publishing on `main` still waits for all verification and E2E gates.

- **Refactors**
  - Added `static-verification` job with a stable label; runs `turbo check type build depcruise` after `pnpm install` via `jdx/mise-action`.
  - Added `tests` job for unit and Storybook: starts services, installs Playwright Chromium via `@shipfox/playwright`, runs `turbo test`.
  - Updated `publish-images` to depend on `[static-verification, tests, e2e]` to keep gating unchanged on `main`.

<sup>Written for commit 0ae0781fedb06e2b7b79218770b4ddd4fea1c80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

