### PR TITLE
[client-projects] Harden projects hub flaky test

### DIFF
--- a/libs/client/projects/src/pages/projects-hub-page.test.tsx
+++ b/libs/client/projects/src/pages/projects-hub-page.test.tsx
@@ -16,19 +16,20 @@ describe('ProjectsHubPage', () => {
     configureApiClient({
       fetchImpl: createHubFetch({
         projects: jsonResponse({projects: [], next_cursor: null}),
+        agentProviders: jsonResponse(agentProviderConfigsDto()),
       }),
     });
 
     renderProjectPage(`/workspaces/${PROJECT_TEST_WID}`, <ProjectsHubPage />);
 
+    expect(await screen.findByText('Create your first project')).toBeInTheDocument();
     // The page-level "Projects" title belongs in content because the top nav owns
     // workspace identity.
-    expect(await screen.findByRole('heading', {name: 'Projects'})).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Projects'})).toBeInTheDocument();
     expect(screen.getByRole('link', {name: NEW_PROJECT_REGEX})).toHaveAttribute(
       'href',
       WORKSPACE_PROJECTS_NEW_HREF,
     );
-    expect(await screen.findByText('Create your first project')).toBeInTheDocument();
     expect(
       (screen.getAllByRole('link', {name: 'Create project'})[0] as HTMLAnchorElement).getAttribute(
         'href',
@@ -52,7 +53,9 @@ describe('ProjectsHubPage', () => {
     );
     fireEvent.click(screen.getByRole('button', {name: 'Close'}));
 
-    expect(screen.queryByText('Finish setting up an agent provider')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('Finish setting up an agent provider')).not.toBeInTheDocument();
+    });
   });
 
   test('hides the agent provider reminder when a provider is configured', async () => {


### PR DESCRIPTION
Hardens the ProjectsHubPage tests that were timing out under CI load.

The empty-state test now waits on the actual async page condition once, then checks the heading synchronously. It also seeds the agent-provider response explicitly so the page's background reminder query cannot depend on helper defaults. The reminder dismissal test now waits for the React state update after closing, which removes the act warning seen beside the timeout.

No changeset is included because the touched package is private and this is test-only hardening.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened ProjectsHubPage tests to eliminate CI timeouts and act warnings by waiting on the right async states and making API mocks explicit. No runtime changes.

- **Bug Fixes**
  - Empty state: wait for “Create your first project” once, then assert “Projects” heading synchronously.
  - Seed `agentProviders` in the test API mock to avoid reliance on helper defaults.
  - Wrap reminder dismissal check in `waitFor` to await the React state update.

<sup>Written for commit 824e95c410b120953033b2f832b21d01e25c00e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

