### PR TITLE
Add domain-split E2E observation helpers

### DIFF
--- a/e2e/core/src/api/client.test.ts
+++ b/e2e/core/src/api/client.test.ts
@@ -1,0 +1,86 @@
+import {type ApiFetch, createApiClient, type E2eApiError} from './client.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return Response.json(body, init);
+}
+
+describe('createApiClient', () => {
+  test('builds URLs from the configured API URL and sends the bearer token', async () => {
+    let input: URL | undefined;
+    let init: RequestInit | undefined;
+    const fetchImpl: ApiFetch = (url, requestInit) => {
+      input = url;
+      init = requestInit;
+      return jsonResponse({ok: true});
+    };
+    const client = createApiClient({
+      apiUrl: 'https://api.example.test/base/',
+      fetch: fetchImpl,
+      token: 'user-token',
+    });
+
+    const result = await client.requestJson<{ok: boolean}>('get', '/workflows/runs?limit=1');
+
+    expect(result).toEqual({ok: true});
+    expect(input?.toString()).toBe('https://api.example.test/workflows/runs?limit=1');
+    expect(init?.method).toBe('GET');
+    expect(new Headers(init?.headers).get('authorization')).toBe('Bearer user-token');
+  });
+
+  test('serializes JSON bodies', async () => {
+    let init: RequestInit | undefined;
+    const fetchImpl: ApiFetch = (_url, requestInit) => {
+      init = requestInit;
+      return jsonResponse({ok: true});
+    };
+    const client = createApiClient({fetch: fetchImpl, token: 'user-token'});
+
+    await client.requestJson('post', '/workflow-definitions/id/fire-manual', {
+      json: {inputs: {name: 'Ada'}},
+    });
+
+    expect(new Headers(init?.headers).get('content-type')).toBe('application/json');
+    expect(init?.body).toBe(JSON.stringify({inputs: {name: 'Ada'}}));
+  });
+
+  test('wraps non-2xx responses with parsed details', async () => {
+    const client = createApiClient({
+      fetch: async () => jsonResponse({code: 'not-found'}, {status: 404}),
+      token: 'user-token',
+    });
+
+    await expect(client.requestJson('get', '/workflows/runs/nope')).rejects.toMatchObject({
+      name: 'E2eApiError',
+      status: 404,
+      details: {code: 'not-found'},
+    } satisfies Partial<E2eApiError>);
+  });
+
+  test('passes abort signals to fetch', async () => {
+    let signal: AbortSignal | null | undefined;
+    const controller = new AbortController();
+    const client = createApiClient({
+      fetch: (_url, requestInit) => {
+        signal = requestInit?.signal;
+        return jsonResponse({ok: true});
+      },
+      token: 'user-token',
+    });
+
+    await client.requestJson('get', '/definitions', {signal: controller.signal});
+
+    expect(signal).toBe(controller.signal);
+  });
+
+  test('does not wrap fetch abort errors', async () => {
+    const abortError = new DOMException('Cancelled', 'AbortError');
+    const client = createApiClient({
+      fetch: () => {
+        throw abortError;
+      },
+      token: 'user-token',
+    });
+
+    await expect(client.requestJson('get', '/definitions')).rejects.toBe(abortError);
+  });
+});

--- a/e2e/core/src/api/client.test.ts
+++ b/e2e/core/src/api/client.test.ts
@@ -51,8 +51,24 @@ describe('createApiClient', () => {
 
     await expect(client.requestJson('get', '/workflows/runs/nope')).rejects.toMatchObject({
       name: 'E2eApiError',
+      message: 'E2E API request failed for GET /workflows/runs/nope: 404',
       status: 404,
       details: {code: 'not-found'},
+    } satisfies Partial<E2eApiError>);
+  });
+
+  test('wraps fetch failures with request context', async () => {
+    const client = createApiClient({
+      fetch: () => {
+        throw new Error('socket closed');
+      },
+      token: 'user-token',
+    });
+
+    await expect(client.requestJson('get', '/definitions?limit=1')).rejects.toMatchObject({
+      name: 'E2eApiError',
+      message: 'E2E API request failed for GET /definitions?limit=1: socket closed',
+      status: 0,
     } satisfies Partial<E2eApiError>);
   });
 

--- a/e2e/core/src/api/client.ts
+++ b/e2e/core/src/api/client.ts
@@ -1,6 +1,9 @@
 import ky, {HTTPError, type Options as KyOptions, type ResponsePromise as KyResponse} from 'ky';
 import {config} from '../config.js';
 
+export type ApiMethod = 'get' | 'post' | 'put' | 'delete' | 'patch';
+export type ApiFetch = (input: URL, init?: RequestInit) => Promise<Response> | Response;
+
 export class E2eApiError extends Error {
   readonly status: number;
   readonly details: unknown;
@@ -13,6 +16,19 @@ export class E2eApiError extends Error {
   }
 }
 
+export interface ApiClientRequestOptions {
+  body?: RequestInit['body'] | undefined;
+  headers?: RequestInit['headers'] | undefined;
+  json?: unknown;
+  signal?: AbortSignal | undefined;
+}
+
+export interface ApiClientOptions {
+  apiUrl?: string | undefined;
+  fetch?: ApiFetch | undefined;
+  token: string;
+}
+
 const api = ky.create({
   headers: {
     authorization: `Bearer ${config.E2E_ADMIN_API_KEY}`,
@@ -21,8 +37,8 @@ const api = ky.create({
   timeout: false,
 });
 
-function e2eUrl(path: string): URL {
-  return new URL(path, config.API_URL);
+function e2eUrl(path: string, apiUrl = config.API_URL): URL {
+  return new URL(path, apiUrl);
 }
 
 async function parseErrorDetails(response: Response): Promise<unknown> {
@@ -34,6 +50,10 @@ async function parseErrorDetails(response: Response): Promise<unknown> {
   } catch {
     return text;
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
 }
 
 async function toE2eApiError(error: unknown): Promise<E2eApiError> {
@@ -52,8 +72,77 @@ async function toE2eApiError(error: unknown): Promise<E2eApiError> {
   });
 }
 
+function appendHeaders(headers: Headers, source: RequestInit['headers'] | undefined): void {
+  if (!source) return;
+  new Headers(source).forEach((value, key) => {
+    headers.set(key, value);
+  });
+}
+
+export function createApiClient(options: ApiClientOptions) {
+  const fetchImpl = options.fetch ?? fetch;
+  const apiUrl = options.apiUrl ?? config.API_URL;
+
+  async function clientRequest(
+    method: ApiMethod,
+    path: string,
+    params: ApiClientRequestOptions = {},
+  ): Promise<Response> {
+    const headers = new Headers();
+    headers.set('authorization', `Bearer ${options.token}`);
+    appendHeaders(headers, params.headers);
+
+    let body = params.body;
+    if (params.json !== undefined) {
+      headers.set('content-type', 'application/json');
+      body = JSON.stringify(params.json);
+    }
+
+    const requestInit: RequestInit = {
+      headers,
+      method: method.toUpperCase(),
+    };
+    if (body !== undefined) requestInit.body = body;
+    if (params.signal) requestInit.signal = params.signal;
+
+    let response: Response;
+    try {
+      response = await fetchImpl(e2eUrl(path, apiUrl), requestInit);
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      throw new E2eApiError({
+        message: error instanceof Error ? error.message : 'E2E API request failed',
+        status: 0,
+        details: error,
+      });
+    }
+
+    if (!response.ok) {
+      throw new E2eApiError({
+        message: `E2E API request failed: ${response.status}`,
+        status: response.status,
+        details: await parseErrorDetails(response),
+      });
+    }
+
+    return response;
+  }
+
+  return {
+    request: clientRequest,
+    requestJson: async <T>(
+      method: ApiMethod,
+      path: string,
+      params: ApiClientRequestOptions = {},
+    ): Promise<T> => {
+      const response = await clientRequest(method, path, params);
+      return (await response.json()) as T;
+    },
+  };
+}
+
 export async function request<T>(
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
+  method: ApiMethod,
   path: string,
   params: KyOptions,
 ): Promise<Awaited<KyResponse<T>>> {
@@ -65,7 +154,7 @@ export async function request<T>(
 }
 
 export async function requestJson<T>(
-  method: 'get' | 'post' | 'put' | 'delete' | 'patch',
+  method: ApiMethod,
   path: string,
   params: KyOptions,
 ): Promise<T> {

--- a/e2e/core/src/api/client.ts
+++ b/e2e/core/src/api/client.ts
@@ -88,6 +88,7 @@ export function createApiClient(options: ApiClientOptions) {
     path: string,
     params: ApiClientRequestOptions = {},
   ): Promise<Response> {
+    const requestLabel = `${method.toUpperCase()} ${path}`;
     const headers = new Headers();
     headers.set('authorization', `Bearer ${options.token}`);
     appendHeaders(headers, params.headers);
@@ -111,7 +112,10 @@ export function createApiClient(options: ApiClientOptions) {
     } catch (error) {
       if (isAbortError(error)) throw error;
       throw new E2eApiError({
-        message: error instanceof Error ? error.message : 'E2E API request failed',
+        message:
+          error instanceof Error
+            ? `E2E API request failed for ${requestLabel}: ${error.message}`
+            : `E2E API request failed for ${requestLabel}`,
         status: 0,
         details: error,
       });
@@ -119,7 +123,7 @@ export function createApiClient(options: ApiClientOptions) {
 
     if (!response.ok) {
       throw new E2eApiError({
-        message: `E2E API request failed: ${response.status}`,
+        message: `E2E API request failed for ${requestLabel}: ${response.status}`,
         status: response.status,
         details: await parseErrorDetails(response),
       });

--- a/e2e/core/src/api/index.ts
+++ b/e2e/core/src/api/index.ts
@@ -1,4 +1,9 @@
 export {
+  type ApiClientOptions,
+  type ApiClientRequestOptions,
+  type ApiFetch,
+  type ApiMethod,
+  createApiClient,
   E2eApiError,
   request,
   requestJson,

--- a/e2e/core/src/index.ts
+++ b/e2e/core/src/index.ts
@@ -1,4 +1,9 @@
 export {
+  type ApiClientOptions,
+  type ApiClientRequestOptions,
+  type ApiFetch,
+  type ApiMethod,
+  createApiClient,
   E2eApiError,
   request,
   requestJson,

--- a/e2e/core/tsconfig.test.json
+++ b/e2e/core/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/core/vitest.config.ts
+++ b/e2e/core/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/e2e/helpers/definitions/package.json
+++ b/e2e/helpers/definitions/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@shipfox/e2e-core",
+  "name": "@shipfox/e2e-helper-definitions",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "e2e/core"
+    "directory": "e2e/helpers/definitions"
   },
   "license": "MIT",
   "private": true,
@@ -24,26 +24,6 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
-    },
-    "./api": {
-      "development": {
-        "types": "./src/api/index.ts",
-        "default": "./src/api/index.ts"
-      },
-      "default": {
-        "types": "./dist/api/index.d.ts",
-        "default": "./dist/api/index.js"
-      }
-    },
-    "./playwright": {
-      "development": {
-        "types": "./src/playwright.ts",
-        "default": "./src/playwright.ts"
-      },
-      "default": {
-        "types": "./dist/playwright.d.ts",
-        "default": "./dist/playwright.js"
-      }
     }
   },
   "scripts": {
@@ -56,9 +36,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/config": "workspace:*",
-    "@shipfox/playwright": "workspace:*",
-    "ky": "^2.0.0"
+    "@shipfox/api-definitions-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/e2e/helpers/definitions/src/index.test.ts
+++ b/e2e/helpers/definitions/src/index.test.ts
@@ -1,0 +1,176 @@
+import type {DefinitionDto, DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
+import {waitForDefinition} from './index.js';
+
+const projectId = '11111111-1111-4111-8111-111111111111';
+const definitionId = '22222222-2222-4222-8222-222222222222';
+const DEFINITION_SYNC_FAILED_RE =
+  /Definition sync failed.*syncStatus=failed.*syncErrorCode=no-workflow-files/u;
+const DEFINITION_TIMEOUT_RE =
+  /Timed out waiting for definition: configPath=.shipfox\/workflows\/missing.yml/u;
+const DEFINITION_TIMEOUT_OBSERVED_RE = /definitions=\[id=22222222/u;
+
+function definition(params: Partial<DefinitionDto> = {}): DefinitionDto {
+  return {
+    id: params.id ?? definitionId,
+    project_id: params.project_id ?? projectId,
+    config_path: params.config_path ?? '.shipfox/workflows/build.yml',
+    source: params.source ?? 'vcs',
+    sha: params.sha ?? 'abc123',
+    ref: params.ref ?? 'main',
+    name: params.name ?? 'Build',
+    workflow_document: params.workflow_document ?? {},
+    workflow_model: params.workflow_model ?? {},
+    manual_trigger: params.manual_trigger ?? null,
+    fetched_at: params.fetched_at ?? '2026-07-02T08:00:00.000Z',
+    created_at: params.created_at ?? '2026-07-02T08:00:00.000Z',
+    updated_at: params.updated_at ?? '2026-07-02T08:00:00.000Z',
+  };
+}
+
+function listResponse(params: Partial<DefinitionListResponseDto> = {}): DefinitionListResponseDto {
+  return {
+    definitions: params.definitions ?? [],
+    sync:
+      params.sync === undefined
+        ? {
+            ref: 'main',
+            status: 'succeeded',
+            last_sync_at: '2026-07-02T08:00:00.000Z',
+            started_at: '2026-07-02T08:00:00.000Z',
+            finished_at: '2026-07-02T08:00:01.000Z',
+            last_error_code: null,
+            last_error_message: null,
+          }
+        : params.sync,
+    next_cursor: params.next_cursor ?? null,
+  };
+}
+
+function response(body: unknown): Response {
+  return Response.json(body);
+}
+
+describe('waitForDefinition', () => {
+  test('requires an explicit selector', async () => {
+    const result = waitForDefinition({
+      projectId,
+      token: 'user-token',
+    } as never);
+
+    await expect(result).rejects.toThrow('requires configPath or definitionId');
+  });
+
+  test('polls until the selected definition appears by config path', async () => {
+    let calls = 0;
+
+    const result = await waitForDefinition({
+      configPath: '.shipfox/workflows/build.yml',
+      fetch: () => {
+        calls += 1;
+        return Promise.resolve(
+          response(calls === 1 ? listResponse() : listResponse({definitions: [definition()]})),
+        );
+      },
+      initialDelayMs: 1,
+      projectId,
+      token: 'user-token',
+    });
+
+    expect(result.id).toBe(definitionId);
+    expect(calls).toBe(2);
+  });
+
+  test('polls until the selected definition appears by id', async () => {
+    const result = await waitForDefinition({
+      definitionId,
+      fetch: () => response(listResponse({definitions: [definition()]})),
+      projectId,
+      token: 'user-token',
+    });
+
+    expect(result.config_path).toBe('.shipfox/workflows/build.yml');
+  });
+
+  test('fails immediately when sync fails', async () => {
+    const result = waitForDefinition({
+      configPath: '.shipfox/workflows/missing.yml',
+      fetch: () =>
+        response(
+          listResponse({
+            sync: {
+              ref: 'main',
+              status: 'failed',
+              last_sync_at: '2026-07-02T08:00:00.000Z',
+              started_at: '2026-07-02T08:00:00.000Z',
+              finished_at: '2026-07-02T08:00:01.000Z',
+              last_error_code: 'no-workflow-files',
+              last_error_message: 'No workflow files found',
+            },
+          }),
+        ),
+      projectId,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(DEFINITION_SYNC_FAILED_RE);
+  });
+
+  test('does not return a stale matching definition when sync fails', async () => {
+    const result = waitForDefinition({
+      configPath: '.shipfox/workflows/build.yml',
+      fetch: () =>
+        response(
+          listResponse({
+            definitions: [definition()],
+            sync: {
+              ref: 'main',
+              status: 'failed',
+              last_sync_at: '2026-07-02T08:00:00.000Z',
+              started_at: '2026-07-02T08:00:00.000Z',
+              finished_at: '2026-07-02T08:00:01.000Z',
+              last_error_code: 'no-workflow-files',
+              last_error_message: 'No workflow files found',
+            },
+          }),
+        ),
+      projectId,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(DEFINITION_SYNC_FAILED_RE);
+  });
+
+  test('times out with a bounded observation summary', async () => {
+    const result = waitForDefinition({
+      configPath: '.shipfox/workflows/missing.yml',
+      fetch: () =>
+        response(
+          listResponse({
+            definitions: [definition({config_path: '.shipfox/workflows/other.yml'})],
+          }),
+        ),
+      initialDelayMs: 1,
+      projectId,
+      timeoutMs: 1,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(DEFINITION_TIMEOUT_RE);
+    await expect(result).rejects.toThrow(DEFINITION_TIMEOUT_OBSERVED_RE);
+  });
+
+  test('passes abort signals through polling', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = waitForDefinition({
+      configPath: '.shipfox/workflows/build.yml',
+      fetch: () => response(listResponse()),
+      projectId,
+      signal: controller.signal,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toMatchObject({name: 'AbortError'});
+  });
+});

--- a/e2e/helpers/definitions/src/index.test.ts
+++ b/e2e/helpers/definitions/src/index.test.ts
@@ -151,7 +151,7 @@ describe('waitForDefinition', () => {
         ),
       initialDelayMs: 1,
       projectId,
-      timeoutMs: 1,
+      timeoutMs: 10,
       token: 'user-token',
     });
 

--- a/e2e/helpers/definitions/src/index.ts
+++ b/e2e/helpers/definitions/src/index.ts
@@ -1,0 +1,144 @@
+import {setTimeout as sleep} from 'node:timers/promises';
+import type {DefinitionDto, DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
+import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_INITIAL_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 4_000;
+const DEFAULT_BACKOFF_FACTOR = 1.5;
+
+type DefinitionSelector =
+  | {
+      configPath: string;
+      definitionId?: never;
+    }
+  | {
+      configPath?: never;
+      definitionId: string;
+    };
+
+export type WaitForDefinitionOptions = DefinitionSelector & {
+  apiUrl?: string | undefined;
+  backoffFactor?: number | undefined;
+  fetch?: ApiFetch | undefined;
+  initialDelayMs?: number | undefined;
+  maxDelayMs?: number | undefined;
+  projectId: string;
+  signal?: AbortSignal | undefined;
+  timeoutMs?: number | undefined;
+  token: string;
+};
+
+function nextDelay(currentDelayMs: number, options: WaitForDefinitionOptions): number {
+  const factor = options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  return Math.min(Math.ceil(currentDelayMs * factor), maxDelayMs);
+}
+
+function assertDefinitionSelector(options: WaitForDefinitionOptions): void {
+  if (!options.configPath && !options.definitionId) {
+    throw new Error('waitForDefinition requires configPath or definitionId');
+  }
+}
+
+function matchesDefinition(definition: DefinitionDto, selector: DefinitionSelector): boolean {
+  if (selector.definitionId) return definition.id === selector.definitionId;
+  return definition.config_path === selector.configPath;
+}
+
+function selectorLabel(selector: DefinitionSelector): string {
+  if (selector.definitionId) return `definitionId=${selector.definitionId}`;
+  return `configPath=${selector.configPath}`;
+}
+
+function formatObserved(response: DefinitionListResponseDto | null, selector: DefinitionSelector) {
+  if (!response) return 'no definitions response observed';
+  const definitions = response.definitions
+    .slice(0, 5)
+    .map((definition) =>
+      [
+        `id=${definition.id}`,
+        `configPath=${definition.config_path ?? 'null'}`,
+        `source=${definition.source}`,
+        `fetchedAt=${definition.fetched_at}`,
+      ].join(' '),
+    );
+  const more = response.definitions.length > definitions.length ? ', ...' : '';
+  const sync = response.sync
+    ? [
+        `syncStatus=${response.sync.status}`,
+        `syncRef=${response.sync.ref ?? 'null'}`,
+        `syncErrorCode=${response.sync.last_error_code ?? 'null'}`,
+        `syncErrorMessage=${response.sync.last_error_message ?? 'null'}`,
+      ].join(' ')
+    : 'sync=null';
+  return `${selectorLabel(selector)} ${sync} definitions=[${definitions.join(', ')}${more}]`;
+}
+
+async function waitForNextPoll(params: {
+  delayMs: number;
+  deadline: number;
+  signal?: AbortSignal | undefined;
+}): Promise<void> {
+  const remainingMs = params.deadline - Date.now();
+  if (remainingMs <= 0) return;
+  await sleep(Math.min(params.delayMs, remainingMs), undefined, {signal: params.signal});
+}
+
+export async function waitForDefinition(options: WaitForDefinitionOptions): Promise<DefinitionDto> {
+  assertDefinitionSelector(options);
+  const selector = {
+    configPath: options.configPath,
+    definitionId: options.definitionId,
+  } as DefinitionSelector;
+  const client = createApiClient({
+    apiUrl: options.apiUrl,
+    fetch: options.fetch,
+    token: options.token,
+  });
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let delayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  let lastResponse: DefinitionListResponseDto | null = null;
+
+  while (Date.now() <= deadline) {
+    options.signal?.throwIfAborted();
+    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
+    lastResponse = await client.requestJson<DefinitionListResponseDto>(
+      'get',
+      `/definitions?${params}`,
+      {
+        signal: options.signal,
+      },
+    );
+
+    if (lastResponse.sync?.status === 'failed') {
+      throw new Error(
+        `Definition sync failed while waiting: ${formatObserved(lastResponse, selector)}`,
+      );
+    }
+
+    const definition = lastResponse.definitions.find((candidate) =>
+      matchesDefinition(candidate, selector),
+    );
+    if (definition) return definition;
+
+    await waitForNextPoll({deadline, delayMs, signal: options.signal});
+    delayMs = nextDelay(delayMs, options);
+  }
+
+  throw new Error(`Timed out waiting for definition: ${formatObserved(lastResponse, selector)}`);
+}
+
+export function createDefinitionsHelper(options: {
+  apiUrl?: string | undefined;
+  fetch?: ApiFetch | undefined;
+  token: string;
+}) {
+  return {
+    waitForDefinition: (params: Omit<WaitForDefinitionOptions, 'apiUrl' | 'fetch' | 'token'>) =>
+      waitForDefinition({...options, ...params} as WaitForDefinitionOptions),
+  };
+}
+
+export type DefinitionsHelper = ReturnType<typeof createDefinitionsHelper>;

--- a/e2e/helpers/definitions/tsconfig.build.json
+++ b/e2e/helpers/definitions/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/definitions/tsconfig.json
+++ b/e2e/helpers/definitions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/helpers/definitions/tsconfig.test.json
+++ b/e2e/helpers/definitions/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/helpers/definitions/vitest.config.ts
+++ b/e2e/helpers/definitions/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/e2e/helpers/logs/package.json
+++ b/e2e/helpers/logs/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@shipfox/e2e-core",
+  "name": "@shipfox/e2e-helper-logs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "e2e/core"
+    "directory": "e2e/helpers/logs"
   },
   "license": "MIT",
   "private": true,
@@ -24,26 +24,6 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
-    },
-    "./api": {
-      "development": {
-        "types": "./src/api/index.ts",
-        "default": "./src/api/index.ts"
-      },
-      "default": {
-        "types": "./dist/api/index.d.ts",
-        "default": "./dist/api/index.js"
-      }
-    },
-    "./playwright": {
-      "development": {
-        "types": "./src/playwright.ts",
-        "default": "./src/playwright.ts"
-      },
-      "default": {
-        "types": "./dist/playwright.d.ts",
-        "default": "./dist/playwright.js"
-      }
     }
   },
   "scripts": {
@@ -56,9 +36,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/config": "workspace:*",
-    "@shipfox/playwright": "workspace:*",
-    "ky": "^2.0.0"
+    "@shipfox/api-logs-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/e2e/helpers/logs/src/index.test.ts
+++ b/e2e/helpers/logs/src/index.test.ts
@@ -1,0 +1,116 @@
+import type {LogRecord, ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import {fetchStepLogs} from './index.js';
+
+const stepId = '11111111-1111-4111-8111-111111111111';
+
+const output = (data: string, ts = 1): LogRecord => ({
+  v: 1,
+  ts,
+  type: 'output',
+  stream: 'stdout',
+  data,
+});
+
+function line(record: LogRecord): string {
+  return `${JSON.stringify(record)}\n`;
+}
+
+function inline(params: {
+  hasMore?: boolean;
+  ndjson: string;
+  nextCursor?: number;
+  truncated?: boolean;
+}): ReadLogsResponseDto {
+  return {
+    mode: 'inline',
+    ndjson: params.ndjson,
+    next_cursor: params.nextCursor ?? 1,
+    has_more: params.hasMore ?? false,
+    state: 'closed',
+    truncated: params.truncated ?? false,
+  };
+}
+
+function presigned(params: {truncated?: boolean; url?: string} = {}): ReadLogsResponseDto {
+  return {
+    mode: 'presigned',
+    url: params.url ?? 'https://storage.example.test/logs/object?sig=1',
+    expires_at: '2026-07-02T08:00:00.000Z',
+    total_bytes: 128,
+    truncated: params.truncated ?? false,
+  };
+}
+
+describe('fetchStepLogs', () => {
+  test('drains inline pages and parses records', async () => {
+    const urls: string[] = [];
+    const result = await fetchStepLogs({
+      attempt: 1,
+      fetch: (url) => {
+        urls.push(url.toString());
+        return Promise.resolve(
+          Response.json(
+            urls.length === 1
+              ? inline({hasMore: true, ndjson: line(output('first\n')), nextCursor: 7})
+              : inline({ndjson: line(output('second\n', 2)), nextCursor: 8, truncated: true}),
+          ),
+        );
+      },
+      stepId,
+      token: 'user-token',
+    });
+
+    expect(urls).toEqual([
+      `http://localhost:16101/steps/${stepId}/attempts/1/logs?cursor=0`,
+      `http://localhost:16101/steps/${stepId}/attempts/1/logs?cursor=7`,
+    ]);
+    expect(result.ndjson).toBe(`${line(output('first\n'))}${line(output('second\n', 2))}`);
+    expect(result.records).toEqual([output('first\n'), output('second\n', 2)]);
+    expect(result.truncated).toBe(true);
+  });
+
+  test('reads presigned log objects without sending the API authorization header', async () => {
+    const authorizationHeaders: Array<string | null> = [];
+    const result = await fetchStepLogs({
+      attempt: 1,
+      fetch: (url, init) => {
+        authorizationHeaders.push(new Headers(init?.headers).get('authorization'));
+        if (url.hostname === 'storage.example.test') {
+          return Promise.resolve(new Response(line(output('from object\n'))));
+        }
+        return Promise.resolve(Response.json(presigned()));
+      },
+      stepId,
+      token: 'user-token',
+    });
+
+    expect(result.records).toEqual([output('from object\n')]);
+    expect(authorizationHeaders).toEqual(['Bearer user-token', null]);
+  });
+
+  test('throws when a log record line is malformed', async () => {
+    const result = fetchStepLogs({
+      attempt: 1,
+      fetch: () => Response.json(inline({ndjson: '{"v":1,"ts":1,"type":"nope"}\n'})),
+      stepId,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow();
+  });
+
+  test('passes abort signals through reads', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = fetchStepLogs({
+      attempt: 1,
+      fetch: () => Response.json(inline({ndjson: ''})),
+      signal: controller.signal,
+      stepId,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toMatchObject({name: 'AbortError'});
+  });
+});

--- a/e2e/helpers/logs/src/index.ts
+++ b/e2e/helpers/logs/src/index.ts
@@ -1,0 +1,97 @@
+import {type LogRecord, parseLogRecordLine, type ReadLogsResponseDto} from '@shipfox/api-logs-dto';
+import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+
+const NDJSON_LINE_SPLIT_RE = /\r?\n/u;
+
+export interface FetchStepLogsOptions {
+  apiUrl?: string | undefined;
+  attempt: number;
+  fetch?: ApiFetch | undefined;
+  signal?: AbortSignal | undefined;
+  stepId: string;
+  token: string;
+}
+
+export interface StepLogs {
+  ndjson: string;
+  records: LogRecord[];
+  truncated: boolean;
+}
+
+function parseLogNdjson(ndjson: string): LogRecord[] {
+  return ndjson
+    .split(NDJSON_LINE_SPLIT_RE)
+    .filter((line) => line.length > 0)
+    .map((line) => parseLogRecordLine(line));
+}
+
+async function readPresignedLogObject(params: {
+  fetchImpl: ApiFetch;
+  signal?: AbortSignal | undefined;
+  url: string;
+}): Promise<string> {
+  const requestInit: RequestInit = {};
+  if (params.signal) requestInit.signal = params.signal;
+  const response = await params.fetchImpl(new URL(params.url), requestInit);
+  if (!response.ok) {
+    throw new Error(`Could not read presigned step logs: ${response.status}`);
+  }
+  return await response.text();
+}
+
+export async function fetchStepLogs(options: FetchStepLogsOptions): Promise<StepLogs> {
+  options.signal?.throwIfAborted();
+  const fetchImpl = options.fetch ?? fetch;
+  const client = createApiClient({
+    apiUrl: options.apiUrl,
+    fetch: fetchImpl,
+    token: options.token,
+  });
+  let cursor = 0;
+  let ndjson = '';
+  let truncated = false;
+
+  while (true) {
+    options.signal?.throwIfAborted();
+    const params = new URLSearchParams({cursor: String(cursor)});
+    const response = await client.requestJson<ReadLogsResponseDto>(
+      'get',
+      `/steps/${encodeURIComponent(options.stepId)}/attempts/${options.attempt}/logs?${params}`,
+      {signal: options.signal},
+    );
+
+    truncated ||= response.truncated;
+
+    if (response.mode === 'presigned') {
+      ndjson += await readPresignedLogObject({
+        fetchImpl,
+        signal: options.signal,
+        url: response.url,
+      });
+      break;
+    }
+
+    ndjson += response.ndjson;
+    cursor = response.next_cursor;
+    if (!response.has_more) break;
+  }
+
+  return {
+    ndjson,
+    records: parseLogNdjson(ndjson),
+    truncated,
+  };
+}
+
+export function createLogsHelper(options: {
+  apiUrl?: string | undefined;
+  fetch?: ApiFetch | undefined;
+  token: string;
+}) {
+  return {
+    fetchStepLogs: (params: Omit<FetchStepLogsOptions, 'apiUrl' | 'fetch' | 'token'>) =>
+      fetchStepLogs({...options, ...params}),
+  };
+}
+
+export type LogsHelper = ReturnType<typeof createLogsHelper>;

--- a/e2e/helpers/logs/tsconfig.build.json
+++ b/e2e/helpers/logs/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/logs/tsconfig.json
+++ b/e2e/helpers/logs/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/helpers/logs/tsconfig.test.json
+++ b/e2e/helpers/logs/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/helpers/logs/vitest.config.ts
+++ b/e2e/helpers/logs/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/e2e/helpers/workflows/package.json
+++ b/e2e/helpers/workflows/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@shipfox/e2e-core",
+  "name": "@shipfox/e2e-helper-workflows",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "e2e/core"
+    "directory": "e2e/helpers/workflows"
   },
   "license": "MIT",
   "private": true,
@@ -24,26 +24,6 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
-    },
-    "./api": {
-      "development": {
-        "types": "./src/api/index.ts",
-        "default": "./src/api/index.ts"
-      },
-      "default": {
-        "types": "./dist/api/index.d.ts",
-        "default": "./dist/api/index.js"
-      }
-    },
-    "./playwright": {
-      "development": {
-        "types": "./src/playwright.ts",
-        "default": "./src/playwright.ts"
-      },
-      "default": {
-        "types": "./dist/playwright.d.ts",
-        "default": "./dist/playwright.js"
-      }
     }
   },
   "scripts": {
@@ -56,9 +36,8 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
-    "@shipfox/config": "workspace:*",
-    "@shipfox/playwright": "workspace:*",
-    "ky": "^2.0.0"
+    "@shipfox/api-workflows-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/e2e/helpers/workflows/src/index.test.ts
+++ b/e2e/helpers/workflows/src/index.test.ts
@@ -1,0 +1,179 @@
+import type {
+  WorkflowRunDetailResponseDto,
+  WorkflowRunDto,
+  WorkflowRunListResponseDto,
+  WorkflowRunStatusDto,
+} from '@shipfox/api-workflows-dto';
+import {waitForRunByCommit, waitForRunTerminal} from './index.js';
+
+const projectId = '11111111-1111-4111-8111-111111111111';
+const definitionId = '22222222-2222-4222-8222-222222222222';
+const runId = '33333333-3333-4333-8333-333333333333';
+const attemptId = '44444444-4444-4444-8444-444444444444';
+const RUN_BY_COMMIT_TIMEOUT_RE =
+  /Timed out waiting for workflow run by commit: expectedHeadCommitSha=abc123/u;
+const RUN_BY_COMMIT_OBSERVED_RE = /headCommitSha=other/u;
+const RUN_TERMINAL_TIMEOUT_RE =
+  /Timed out waiting for workflow run terminal status: runId=33333333/u;
+const RUN_TERMINAL_OBSERVED_RE = /status=running/u;
+
+function run(params: Partial<WorkflowRunDto> = {}): WorkflowRunDto {
+  return {
+    id: params.id ?? runId,
+    project_id: params.project_id ?? projectId,
+    definition_id: params.definition_id ?? definitionId,
+    name: params.name ?? 'Build',
+    status: params.status ?? 'pending',
+    current_attempt: params.current_attempt ?? 1,
+    latest_attempt: params.latest_attempt ?? 1,
+    trigger_provider: params.trigger_provider ?? 'gitea',
+    trigger_source: params.trigger_source ?? 'gitea_e2e',
+    trigger_event: params.trigger_event ?? 'push',
+    trigger_payload: params.trigger_payload ?? {
+      provider: 'gitea',
+      source: 'gitea_e2e',
+      event: 'push',
+      deliveryId: 'delivery-1',
+      data: {headCommitSha: 'abc123', ref: 'main'},
+    },
+    inputs: params.inputs ?? null,
+    source_snapshot: params.source_snapshot ?? null,
+    created_at: params.created_at ?? '2026-07-02T08:00:00.000Z',
+    updated_at: params.updated_at ?? '2026-07-02T08:00:00.000Z',
+    started_at: params.started_at ?? null,
+    finished_at: params.finished_at ?? null,
+  };
+}
+
+function listResponse(
+  params: Partial<WorkflowRunListResponseDto> = {},
+): WorkflowRunListResponseDto {
+  return {
+    runs: params.runs ?? [],
+    next_cursor: params.next_cursor ?? null,
+    filtered_total_count: params.filtered_total_count ?? null,
+  };
+}
+
+function detail(params: Partial<WorkflowRunDetailResponseDto> = {}): WorkflowRunDetailResponseDto {
+  return {
+    ...run(params),
+    run_attempt: params.run_attempt ?? {
+      id: attemptId,
+      workflow_run_id: params.id ?? runId,
+      attempt: 1,
+      status: params.status ?? 'pending',
+      created_at: '2026-07-02T08:00:00.000Z',
+      started_at: null,
+      finished_at: null,
+      rerun_mode: null,
+    },
+    jobs: params.jobs ?? [],
+  };
+}
+
+function response(body: unknown): Response {
+  return Response.json(body);
+}
+
+describe('waitForRunByCommit', () => {
+  test('polls until a run with the matching head commit appears', async () => {
+    let calls = 0;
+
+    const result = await waitForRunByCommit({
+      fetch: () => {
+        calls += 1;
+        return Promise.resolve(
+          response(
+            calls === 1
+              ? listResponse({runs: [run({trigger_payload: {data: {headCommitSha: 'other'}}})]})
+              : listResponse({runs: [run()]}),
+          ),
+        );
+      },
+      headCommitSha: 'abc123',
+      initialDelayMs: 1,
+      projectId,
+      token: 'user-token',
+    });
+
+    expect(result.id).toBe(runId);
+    expect(calls).toBe(2);
+  });
+
+  test('times out with a bounded run list summary', async () => {
+    const result = waitForRunByCommit({
+      fetch: () =>
+        response(listResponse({runs: [run({trigger_payload: {data: {headCommitSha: 'other'}}})]})),
+      headCommitSha: 'abc123',
+      initialDelayMs: 1,
+      projectId,
+      timeoutMs: 1,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(RUN_BY_COMMIT_TIMEOUT_RE);
+    await expect(result).rejects.toThrow(RUN_BY_COMMIT_OBSERVED_RE);
+  });
+
+  test('passes abort signals through polling', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = waitForRunByCommit({
+      fetch: () => response(listResponse()),
+      headCommitSha: 'abc123',
+      projectId,
+      signal: controller.signal,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toMatchObject({name: 'AbortError'});
+  });
+});
+
+describe('waitForRunTerminal', () => {
+  test.each([
+    'succeeded',
+    'failed',
+    'cancelled',
+  ] satisfies WorkflowRunStatusDto[])('returns %s runs as terminal', async (status) => {
+    const result = await waitForRunTerminal({
+      fetch: () => response(detail({status})),
+      runId,
+      token: 'user-token',
+    });
+
+    expect(result.status).toBe(status);
+  });
+
+  test('polls until the run reaches a terminal status', async () => {
+    let calls = 0;
+
+    const result = await waitForRunTerminal({
+      fetch: () => {
+        calls += 1;
+        return Promise.resolve(response(detail({status: calls === 1 ? 'running' : 'succeeded'})));
+      },
+      initialDelayMs: 1,
+      runId,
+      token: 'user-token',
+    });
+
+    expect(result.status).toBe('succeeded');
+    expect(calls).toBe(2);
+  });
+
+  test('times out with the last run status', async () => {
+    const result = waitForRunTerminal({
+      fetch: () => response(detail({status: 'running'})),
+      initialDelayMs: 1,
+      runId,
+      timeoutMs: 1,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(RUN_TERMINAL_TIMEOUT_RE);
+    await expect(result).rejects.toThrow(RUN_TERMINAL_OBSERVED_RE);
+  });
+});

--- a/e2e/helpers/workflows/src/index.ts
+++ b/e2e/helpers/workflows/src/index.ts
@@ -1,0 +1,183 @@
+import {setTimeout as sleep} from 'node:timers/promises';
+import type {
+  WorkflowRunDetailResponseDto,
+  WorkflowRunDto,
+  WorkflowRunListResponseDto,
+  WorkflowRunStatusDto,
+} from '@shipfox/api-workflows-dto';
+import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+
+const DEFAULT_LIST_TIMEOUT_MS = 60_000;
+const DEFAULT_TERMINAL_TIMEOUT_MS = 180_000;
+const DEFAULT_INITIAL_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 4_000;
+const DEFAULT_BACKOFF_FACTOR = 1.5;
+const TERMINAL_STATUSES = new Set<WorkflowRunStatusDto>(['succeeded', 'failed', 'cancelled']);
+
+interface PollingOptions {
+  apiUrl?: string | undefined;
+  backoffFactor?: number | undefined;
+  fetch?: ApiFetch | undefined;
+  initialDelayMs?: number | undefined;
+  maxDelayMs?: number | undefined;
+  signal?: AbortSignal | undefined;
+  timeoutMs?: number | undefined;
+  token: string;
+}
+
+export interface WaitForRunByCommitOptions extends PollingOptions {
+  headCommitSha: string;
+  projectId: string;
+}
+
+export interface WaitForRunTerminalOptions extends PollingOptions {
+  runId: string;
+}
+
+function nextDelay(currentDelayMs: number, options: PollingOptions): number {
+  const factor = options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  return Math.min(Math.ceil(currentDelayMs * factor), maxDelayMs);
+}
+
+async function waitForNextPoll(params: {
+  delayMs: number;
+  deadline: number;
+  signal?: AbortSignal | undefined;
+}): Promise<void> {
+  const remainingMs = params.deadline - Date.now();
+  if (remainingMs <= 0) return;
+  await sleep(Math.min(params.delayMs, remainingMs), undefined, {signal: params.signal});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function headCommitSha(run: WorkflowRunDto): string | null {
+  const payload = run.trigger_payload;
+  if (!isRecord(payload) || !isRecord(payload.data)) return null;
+  return typeof payload.data.headCommitSha === 'string' ? payload.data.headCommitSha : null;
+}
+
+function formatRunListObserved(
+  response: WorkflowRunListResponseDto | null,
+  expectedHeadCommitSha: string,
+): string {
+  if (!response) return 'no workflow run list response observed';
+  const runs = response.runs
+    .slice(0, 5)
+    .map((run) =>
+      [
+        `id=${run.id}`,
+        `status=${run.status}`,
+        `trigger=${run.trigger_source}/${run.trigger_event}`,
+        `headCommitSha=${headCommitSha(run) ?? 'null'}`,
+        `updatedAt=${run.updated_at}`,
+      ].join(' '),
+    );
+  const more = response.runs.length > runs.length ? ', ...' : '';
+  return `expectedHeadCommitSha=${expectedHeadCommitSha} runs=[${runs.join(', ')}${more}]`;
+}
+
+function formatRunDetailObserved(
+  response: WorkflowRunDetailResponseDto | null,
+  runId: string,
+): string {
+  if (!response) return 'no workflow run detail response observed';
+  return [
+    `runId=${runId}`,
+    `status=${response.status}`,
+    `currentAttempt=${response.current_attempt}`,
+    `latestAttempt=${response.latest_attempt}`,
+    `updatedAt=${response.updated_at}`,
+  ].join(' ');
+}
+
+export async function waitForRunByCommit(
+  options: WaitForRunByCommitOptions,
+): Promise<WorkflowRunDto> {
+  const client = createApiClient({
+    apiUrl: options.apiUrl,
+    fetch: options.fetch,
+    token: options.token,
+  });
+  const timeoutMs = options.timeoutMs ?? DEFAULT_LIST_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let delayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  let lastResponse: WorkflowRunListResponseDto | null = null;
+
+  while (Date.now() <= deadline) {
+    options.signal?.throwIfAborted();
+    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
+    lastResponse = await client.requestJson<WorkflowRunListResponseDto>(
+      'get',
+      `/workflows/runs?${params}`,
+      {signal: options.signal},
+    );
+
+    const run = lastResponse.runs.find(
+      (candidate) => headCommitSha(candidate) === options.headCommitSha,
+    );
+    if (run) return run;
+
+    await waitForNextPoll({deadline, delayMs, signal: options.signal});
+    delayMs = nextDelay(delayMs, options);
+  }
+
+  throw new Error(
+    `Timed out waiting for workflow run by commit: ${formatRunListObserved(
+      lastResponse,
+      options.headCommitSha,
+    )}`,
+  );
+}
+
+export async function waitForRunTerminal(
+  options: WaitForRunTerminalOptions,
+): Promise<WorkflowRunDetailResponseDto> {
+  const client = createApiClient({
+    apiUrl: options.apiUrl,
+    fetch: options.fetch,
+    token: options.token,
+  });
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TERMINAL_TIMEOUT_MS;
+  const deadline = Date.now() + timeoutMs;
+  let delayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  let lastResponse: WorkflowRunDetailResponseDto | null = null;
+
+  while (Date.now() <= deadline) {
+    options.signal?.throwIfAborted();
+    lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
+      'get',
+      `/workflows/runs/${encodeURIComponent(options.runId)}`,
+      {signal: options.signal},
+    );
+    if (TERMINAL_STATUSES.has(lastResponse.status)) return lastResponse;
+
+    await waitForNextPoll({deadline, delayMs, signal: options.signal});
+    delayMs = nextDelay(delayMs, options);
+  }
+
+  throw new Error(
+    `Timed out waiting for workflow run terminal status: ${formatRunDetailObserved(
+      lastResponse,
+      options.runId,
+    )}`,
+  );
+}
+
+export function createWorkflowsHelper(options: {
+  apiUrl?: string | undefined;
+  fetch?: ApiFetch | undefined;
+  token: string;
+}) {
+  return {
+    waitForRunByCommit: (params: Omit<WaitForRunByCommitOptions, 'apiUrl' | 'fetch' | 'token'>) =>
+      waitForRunByCommit({...options, ...params}),
+    waitForRunTerminal: (params: Omit<WaitForRunTerminalOptions, 'apiUrl' | 'fetch' | 'token'>) =>
+      waitForRunTerminal({...options, ...params}),
+  };
+}
+
+export type WorkflowsHelper = ReturnType<typeof createWorkflowsHelper>;

--- a/e2e/helpers/workflows/tsconfig.build.json
+++ b/e2e/helpers/workflows/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/workflows/tsconfig.json
+++ b/e2e/helpers/workflows/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/helpers/workflows/tsconfig.test.json
+++ b/e2e/helpers/workflows/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/helpers/workflows/vitest.config.ts
+++ b/e2e/helpers/workflows/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../tools/vitest
 
   e2e/helpers/auth:
     dependencies:
@@ -459,6 +462,81 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+
+  e2e/helpers/definitions:
+    dependencies:
+      '@shipfox/api-definitions-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/definitions-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
+  e2e/helpers/logs:
+    dependencies:
+      '@shipfox/api-logs-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/logs-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
+  e2e/helpers/workflows:
+    dependencies:
+      '@shipfox/api-workflows-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/workflows-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
 
   e2e/helpers/workspaces:
     dependencies:


### PR DESCRIPTION
Add domain-split E2E observation helpers for definitions, workflows, and logs.

E2E observation helpers previously risked grouping workflow runs and logs into one cross-domain surface. This adds a shared session-auth API client in `@shipfox/e2e-core`, then exposes separate helper packages for definition sync polling, workflow run polling, and step attempt log reads so tests follow the backend/API package boundaries.

The helpers use normal user bearer tokens against public API routes instead of E2E-only observation endpoints. Logs stay in the logs helper, workflows stay in the workflows helper, and definitions stay in the definitions helper.

Closes ENG-734

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add domain-scoped E2E observation helpers and a session-auth API client so tests poll real public APIs per domain (definitions, workflows, logs) instead of a single cross-domain surface. Fulfills ENG-734 by enforcing backend/API boundaries and removing E2E-only observation endpoints.

- **New Features**
  - `@shipfox/e2e-core`: `createApiClient` with bearer auth, JSON serialization, abort passthrough, and request-context error messages with parsed details; supports custom API base URL and injectable `fetch`. Added `@shipfox/vitest` test setup.
  - `@shipfox/e2e-helper-definitions`: `waitForDefinition` with backoff, early failure on sync errors, and bounded timeout summaries.
  - `@shipfox/e2e-helper-workflows`: `waitForRunByCommit`, `waitForRunTerminal` with backoff and bounded timeout summaries.
  - `@shipfox/e2e-helper-logs`: `fetchStepLogs` drains inline pages or reads presigned objects (no auth header to storage) and returns parsed records with a `truncated` flag.
  - All helpers use user tokens, accept abort signals, and keep logs/workflows/definitions isolated.

- **Migration**
  - Replace previous cross-domain E2E observers with the new helpers above.
  - Use standard user bearer tokens in tests; stop calling E2E-only observation endpoints.

<sup>Written for commit b849696bbfc842ca5a60c35d7b46cd46a3255fba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

