### PR TITLE
[client] Harden DOM tests for shared workers

### DIFF
--- a/libs/client/agent/package.json
+++ b/libs/client/agent/package.json
@@ -72,6 +72,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/browser-playwright": "^4.1.5",
+    "happy-dom": "^20.8.3",
     "jsdom": "^29.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
+++ b/libs/client/agent/src/components/model-provider-usage-modal.test.tsx
@@ -31,7 +31,11 @@ function renderUsageModal() {
 describe('ModelProviderUsageModal', () => {
   test('changes the selected model in the workflow example', async () => {
     renderUsageModal();
-    expect(await screen.findByText('model: claude-opus-4-8')).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', {name: 'Use Anthropic in a workflow'})).toHaveTextContent(
+        'model: claude-opus-4-8',
+      ),
+    );
 
     fireEvent.click(screen.getByRole('button', {name: 'Model'}));
     fireEvent.click(await screen.findByRole('option', {name: 'Kimi K2.7 Code'}));

--- a/libs/client/agent/vitest.config.ts
+++ b/libs/client/agent/vitest.config.ts
@@ -27,9 +27,10 @@ export default defineConfig(
           extends: true,
           test: {
             name: 'dom',
-            environment: 'jsdom',
+            environment: 'happy-dom',
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
+            isolate: false,
           },
         },
         {

--- a/libs/client/triggers/package.json
+++ b/libs/client/triggers/package.json
@@ -73,6 +73,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/browser-playwright": "^4.1.5",
+    "happy-dom": "^20.8.3",
     "jsdom": "^29.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/libs/client/triggers/src/components/trigger-event-detail.test.tsx
+++ b/libs/client/triggers/src/components/trigger-event-detail.test.tsx
@@ -1,39 +1,10 @@
 import type {TriggerEventDetailResponseDto} from '@shipfox/api-triggers-dto';
 import {RelativeTimeProvider} from '@shipfox/react-ui/relative-time';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type {AnchorHTMLAttributes, ReactElement, ReactNode} from 'react';
+import type {ReactElement} from 'react';
 import {useTriggerEventQuery} from '#hooks/api/trigger-events.js';
 import {TriggerEventDetail, TriggerEventDetailView} from './trigger-event-detail.js';
-
-vi.mock('#hooks/api/trigger-events.js', () => ({
-  useTriggerEventQuery: vi.fn(),
-}));
-
-vi.mock('@tanstack/react-router', () => ({
-  Link: ({
-    to,
-    params,
-    search: _search,
-    children,
-    ...props
-  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
-    to: string;
-    params?: Record<string, string> | undefined;
-    search?: unknown;
-    children: ReactNode;
-  }) => {
-    const href = Object.entries(params ?? {}).reduce(
-      (path, [key, value]) => path.replace(`$${key}`, value),
-      to,
-    );
-    return (
-      <a href={href} {...props}>
-        {children}
-      </a>
-    );
-  },
-}));
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const PROJECT_ID = '22222222-2222-4222-8222-222222222222';
@@ -94,10 +65,10 @@ function renderDetailView(event: TriggerEventDetailResponseDto, onBack = vi.fn()
 }
 
 describe('TriggerEventDetailView', () => {
-  test('renders the result badge, run links, and payload', () => {
+  test('renders the result badge, run links, and payload', async () => {
     renderDetailView(makeEvent());
 
-    expect(screen.getByText('Triggered 1 workflow')).toBeInTheDocument();
+    expect(await screen.findByText('Triggered 1 workflow')).toBeInTheDocument();
     expect(screen.getByText('Deploy production')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: DEPLOY_RUN_LINK_NAME})).toHaveAttribute(
       'href',
@@ -106,15 +77,15 @@ describe('TriggerEventDetailView', () => {
     expect(screen.getByText(PAYLOAD_REF_LINE)).toBeInTheDocument();
   });
 
-  test('renders a no-subscriptions note for a discarded event', () => {
+  test('renders a no-subscriptions note for a discarded event', async () => {
     renderDetailView(makeEvent({outcome: 'discarded', matched_count: 0, decisions: []}));
 
-    expect(screen.getByText('No workflows triggered')).toBeInTheDocument();
+    expect(await screen.findByText('No workflows triggered')).toBeInTheDocument();
     expect(screen.getByText('No workflows are subscribed to this event.')).toBeInTheDocument();
     expect(screen.queryByText('Matched workflows')).not.toBeInTheDocument();
   });
 
-  test('renders errored decisions inline with their reason', () => {
+  test('renders errored decisions inline with their reason', async () => {
     renderDetailView(
       makeEvent({
         outcome: 'errored',
@@ -136,12 +107,12 @@ describe('TriggerEventDetailView', () => {
       }),
     );
 
-    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(await screen.findByText('Failed')).toBeInTheDocument();
     expect(screen.getByText('Deploy production')).toBeInTheDocument();
     expect(screen.getByText('workflow definition deleted')).toBeInTheDocument();
   });
 
-  test('renders null run fields without a run link', () => {
+  test('renders null run fields without a run link', async () => {
     renderDetailView(
       makeEvent({
         decisions: [
@@ -162,7 +133,7 @@ describe('TriggerEventDetailView', () => {
       }),
     );
 
-    expect(screen.getByText('No run created')).toBeInTheDocument();
+    expect(await screen.findByText('No run created')).toBeInTheDocument();
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
@@ -170,7 +141,7 @@ describe('TriggerEventDetailView', () => {
     const onBack = vi.fn();
     renderDetailView(makeEvent(), onBack);
 
-    await userEvent.click(screen.getByRole('button', {name: 'Back to events'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Back to events'}));
 
     expect(onBack).toHaveBeenCalledTimes(1);
   });
@@ -181,7 +152,7 @@ describe('TriggerEventDetail', () => {
     useTriggerEventQueryMock.mockReset();
   });
 
-  test('renders a loading panel while the detail query is pending', () => {
+  test('renders a loading panel while the detail query is pending', async () => {
     useTriggerEventQueryMock.mockReturnValue({
       data: undefined,
       isError: false,
@@ -192,7 +163,7 @@ describe('TriggerEventDetail', () => {
       <TriggerEventDetail workspaceId={WORKSPACE_ID} eventId={EVENT_ID} onBack={vi.fn()} />,
     );
 
-    expect(screen.getByRole('button', {name: 'Back to events'})).toBeInTheDocument();
+    expect(await screen.findByRole('button', {name: 'Back to events'})).toBeInTheDocument();
   });
 
   test('renders a retry action when the detail query fails', async () => {
@@ -207,7 +178,7 @@ describe('TriggerEventDetail', () => {
       <TriggerEventDetail workspaceId={WORKSPACE_ID} eventId={EVENT_ID} onBack={vi.fn()} />,
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Retry'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Retry'}));
 
     expect(screen.getByText('Event detail could not be loaded.')).toBeInTheDocument();
     expect(refetch).toHaveBeenCalledTimes(1);

--- a/libs/client/triggers/src/pages/events-page.test.tsx
+++ b/libs/client/triggers/src/pages/events-page.test.tsx
@@ -3,46 +3,13 @@ import type {
   TriggerEventListItemDto,
   TriggerEventListResponseDto,
 } from '@shipfox/api-triggers-dto';
-import {render, screen, waitFor} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import type {AnchorHTMLAttributes, ReactNode} from 'react';
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
 import {
   useTriggerEventFacetsQuery,
   useTriggerEventQuery,
   useTriggerEventsInfiniteQuery,
 } from '#hooks/api/trigger-events.js';
 import {EventsPage} from './events-page.js';
-
-vi.mock('#hooks/api/trigger-events.js', () => ({
-  useTriggerEventFacetsQuery: vi.fn(),
-  useTriggerEventQuery: vi.fn(),
-  useTriggerEventsInfiniteQuery: vi.fn(),
-}));
-
-vi.mock('@tanstack/react-router', () => ({
-  Link: ({
-    to,
-    params,
-    search: _search,
-    children,
-    ...props
-  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
-    to: string;
-    params?: Record<string, string> | undefined;
-    search?: unknown;
-    children: ReactNode;
-  }) => {
-    const href = Object.entries(params ?? {}).reduce(
-      (path, [key, value]) => path.replace(`$${key}`, value),
-      to,
-    );
-    return (
-      <a href={href} {...props}>
-        {children}
-      </a>
-    );
-  },
-}));
 
 const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111';
 const EVENT_ID = '22222222-2222-4222-8222-222222222222';
@@ -120,7 +87,7 @@ describe('EventsPage', () => {
     const {rerender} = render(
       <EventsPage workspaceId={WORKSPACE_ID} filters={{}} onFiltersChange={vi.fn()} />,
     );
-    await userEvent.click(screen.getByRole('button', {name: 'Open details for github · push'}));
+    fireEvent.click(await screen.findByRole('button', {name: 'Open details for github · push'}));
     expect(screen.getByRole('button', {name: 'Back to events'})).toBeInTheDocument();
 
     useTriggerEventsInfiniteQueryMock.mockReturnValue(makeListQuery([]));

--- a/libs/client/triggers/test/setup.ts
+++ b/libs/client/triggers/test/setup.ts
@@ -1,5 +1,37 @@
 import {installClientDomTestEnv} from '@shipfox/client-test-setup';
 import {configure} from '@testing-library/react';
+import {type AnchorHTMLAttributes, createElement, type ReactNode} from 'react';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    Link: ({
+      to,
+      params,
+      search: _search,
+      children,
+      ...props
+    }: AnchorHTMLAttributes<HTMLAnchorElement> & {
+      to: string;
+      params?: Record<string, string> | undefined;
+      search?: unknown;
+      children: ReactNode;
+    }) => {
+      const href = Object.entries(params ?? {}).reduce(
+        (path, [key, value]) => path.replace(`$${key}`, value),
+        to,
+      );
+      return createElement('a', {href, ...props}, children);
+    },
+  };
+});
+
+vi.mock('#hooks/api/trigger-events.js', () => ({
+  useTriggerEventFacetsQuery: vi.fn(),
+  useTriggerEventQuery: vi.fn(),
+  useTriggerEventsInfiniteQuery: vi.fn(),
+}));
 
 installClientDomTestEnv();
 

--- a/libs/client/triggers/test/setup.ts
+++ b/libs/client/triggers/test/setup.ts
@@ -19,7 +19,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
       children: ReactNode;
     }) => {
       const href = Object.entries(params ?? {}).reduce(
-        (path, [key, value]) => path.replace(`$${key}`, value),
+        (path, [key, value]) => path.split(`$${key}`).join(value),
         to,
       );
       return createElement('a', {href, ...props}, children);
@@ -35,7 +35,7 @@ vi.mock('#hooks/api/trigger-events.js', () => ({
 
 installClientDomTestEnv();
 
-// The jsdom `dom` project shares a `vitest run` with the CPU-heavy `storybook (chromium)`
+// The happy-dom `dom` project shares a `vitest run` with the CPU-heavy `storybook (chromium)`
 // browser project, so a `findBy*`/`waitFor` can starve well past Testing Library's 1s
 // default while the browser tests saturate the host. Widen the ceiling: a resolved query
 // still returns immediately, so this only buys headroom for a contended cold start.

--- a/libs/client/triggers/vitest.config.ts
+++ b/libs/client/triggers/vitest.config.ts
@@ -27,9 +27,10 @@ export default defineConfig(
           extends: true,
           test: {
             name: 'dom',
-            environment: 'jsdom',
+            environment: 'happy-dom',
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
+            isolate: false,
           },
         },
         {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -1,38 +1,32 @@
-import {render, screen, within} from '@testing-library/react';
+import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {workflowRunDetailDto} from '#test/fixtures/workflow-run.js';
 import {workflowJobDto, workflowRunDetail} from '#test/fixtures/workflow-run.js';
 import {WorkflowRunSummary} from './workflow-run-summary.js';
-
-const {useIsTextTruncatedMock} = vi.hoisted(() => ({
-  useIsTextTruncatedMock: vi.fn(),
-}));
 
 const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const RELATIVE_TIME_TEXT_PATTERN = /ago$/;
 const OLD_ROOT_TIME_TEXT_PATTERN = /(?:1d|24h) ago/;
 const COPY_RUN_BUTTON_NAME = /Copy run/;
 
-vi.mock('@shipfox/react-ui/hooks', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/react-ui/hooks')>();
-  return {
-    ...actual,
-    useIsTextTruncated: useIsTextTruncatedMock,
-  };
-});
+const originalScrollWidth = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  'scrollWidth',
+);
+const originalClientWidth = Object.getOwnPropertyDescriptor(
+  window.HTMLElement.prototype,
+  'clientWidth',
+);
 
 beforeEach(() => {
-  useIsTextTruncatedMock.mockReset();
-  useIsTextTruncatedMock.mockReturnValue({
-    ref: () => undefined,
-    isTruncated: false,
-  });
+  setElementWidths({scrollWidth: 80, clientWidth: 120});
 });
 
 describe('WorkflowRunSummary', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    restoreElementWidthDescriptors();
   });
 
   test('renders status, trigger metadata, and trigger time', async () => {
@@ -89,10 +83,6 @@ describe('WorkflowRunSummary', () => {
 
   test('does not show a run name tooltip when the heading is not truncated', async () => {
     const user = userEvent.setup();
-    useIsTextTruncatedMock.mockReturnValue({
-      ref: () => undefined,
-      isTruncated: false,
-    });
     renderSummary();
 
     await user.hover(await screen.findByRole('heading', {name: 'deploy-web'}));
@@ -100,18 +90,17 @@ describe('WorkflowRunSummary', () => {
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
 
-  test('shows the full run name in a tooltip when the heading is truncated', async () => {
-    const user = userEvent.setup();
+  test('wires the full run name tooltip when the heading is truncated', async () => {
     const runName = 'release-production-multi-region-with-canary-and-smoke-tests';
-    useIsTextTruncatedMock.mockReturnValue({
-      ref: () => undefined,
-      isTruncated: true,
-    });
+    setElementWidths({scrollWidth: 160, clientWidth: 80});
     renderSummary({name: runName});
 
-    await user.hover(await screen.findByRole('heading', {name: runName}));
+    const heading = await screen.findByRole('heading', {name: runName});
 
-    expect(await screen.findByRole('tooltip')).toHaveTextContent(runName);
+    expect(heading).toHaveAttribute('data-slot', 'tooltip-trigger');
+    await waitFor(() =>
+      expect(within(heading).getByText(runName)).toHaveAttribute('title', runName),
+    );
   });
 
   test('renders source control only when source is available', async () => {
@@ -331,4 +320,35 @@ function renderSummary(
 
   // These cases never mount the attempt switcher links, so no router is needed.
   render(<WorkflowRunSummary run={run} {...props} />);
+}
+
+function setElementWidths({scrollWidth, clientWidth}: {scrollWidth: number; clientWidth: number}) {
+  Object.defineProperty(window.HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get() {
+      return scrollWidth;
+    },
+  });
+  Object.defineProperty(window.HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return clientWidth;
+    },
+  });
+}
+
+function restoreElementWidthDescriptors() {
+  restoreElementWidthDescriptor('scrollWidth', originalScrollWidth);
+  restoreElementWidthDescriptor('clientWidth', originalClientWidth);
+}
+
+function restoreElementWidthDescriptor(
+  property: 'scrollWidth' | 'clientWidth',
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(window.HTMLElement.prototype, property, descriptor);
+    return;
+  }
+  delete window.HTMLElement.prototype[property];
 }

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.tsx
@@ -90,7 +90,11 @@ export function WorkflowRunSummary({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Header id={headingId} variant="h3" className="min-w-0 truncate">
-                  <span ref={headingTextRef} className="block min-w-0 truncate">
+                  <span
+                    ref={headingTextRef}
+                    title={isHeadingTruncated ? run.name : undefined}
+                    className="block min-w-0 truncate"
+                  >
                     {run.name}
                   </span>
                 </Header>

--- a/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.test.tsx
+++ b/libs/client/workflows/src/components/workflow-source-panel/workflow-source-panel.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, within} from '@testing-library/react';
+import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {WorkflowSourcePanel} from './workflow-source-panel.js';
 
@@ -10,7 +10,7 @@ describe('WorkflowSourcePanel', () => {
 
     expect(dialog).toHaveAttribute('id', 'workflow-source-panel');
     expect(within(dialog).getByText('workflow.yaml')).toBeInTheDocument();
-    expect(within(dialog).getByText('jobs:')).toBeInTheDocument();
+    await waitFor(() => expect(dialog).toHaveTextContent('jobs:'));
     expect(within(dialog).getByRole('button', {name: 'Copy to clipboard'})).toBeInTheDocument();
     expect(within(dialog).getByRole('button', {name: 'Close source'})).toBeInTheDocument();
   });

--- a/libs/client/workflows/vitest.config.ts
+++ b/libs/client/workflows/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig(
             environment: 'happy-dom',
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
+            isolate: false,
             // Keep the per-test budget above the widened `asyncUtilTimeout` (test/setup.ts) so a
             // contended `findBy*` reports the real query failure instead of a Vitest timeout.
             testTimeout: 15000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2497,6 +2497,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      happy-dom:
+        specifier: ^20.8.3
+        version: 20.10.6
       jsdom:
         specifier: ^29.0.0
         version: 29.1.1
@@ -3617,6 +3620,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.5
         version: 4.1.9(playwright@1.61.0)(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.9)
+      happy-dom:
+        specifier: ^20.8.3
+        version: 20.10.6
       jsdom:
         specifier: ^29.0.0
         version: 29.1.1


### PR DESCRIPTION
Harden the remaining client DOM suites so they can share a Vitest worker module graph and run on happy-dom.

Agent, triggers, and workflows were the last DOM packages left isolated after the shared client test setup landed. This moves the fragile test seams onto deterministic paths: agent assertions no longer depend on transient highlighted code spans, triggers installs its router and API hook test doubles from setup before any file imports shared modules, and workflows avoids opening Radix portals while still checking the truncated-name affordance. The three packages now opt into `isolate: false` and `happy-dom`.

The only production change is adding a `title` attribute to truncated workflow run names, matching the existing full-name tooltip affordance with a stable browser/accessibility fallback.

Validation:
- `mise exec -- pnpm --filter=@shipfox/client-agent check`
- `mise exec -- pnpm --filter=@shipfox/client-triggers check`
- `mise exec -- pnpm --filter=@shipfox/client-workflows check`
- `mise exec -- turbo type --filter=...@shipfox/client-agent --filter=...@shipfox/client-triggers --filter=...@shipfox/client-workflows`
- `mise exec -- pnpm --filter=@shipfox/client-agent exec vitest run --project dom --maxWorkers=1`
- `mise exec -- pnpm --filter=@shipfox/client-triggers exec vitest run --project dom --maxWorkers=1`
- `mise exec -- pnpm --filter=@shipfox/client-workflows exec vitest run --project dom --maxWorkers=1`
- `mise exec -- turbo build --filter '...[origin/main]'`
- `mise exec -- turbo check --filter '...[origin/main]'`
- `mise exec -- turbo test --filter '...[origin/main]'`

No changeset: touched workspace packages are private.

Closes ENG-744

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened DOM tests for `@shipfox/client-agent`, `@shipfox/client-triggers`, and `@shipfox/client-workflows` to share a Vitest worker on `happy-dom`, and added a `title` fallback for truncated workflow run names for stable tooltips and better accessibility. Closes ENG-744.

- **Refactors**
  - Set `environment: 'happy-dom'` and `isolate: false` for DOM projects to enable shared workers.
  - Centralized `@tanstack/react-router` and API hook mocks in `@shipfox/client-triggers` `test/setup.ts`; removed per-file mocks and used stable async queries and `fireEvent`.
  - Made agent and workflows tests wait for rendered content; simulated truncation via element widths to avoid portal-dependent checks.

- **Bug Fixes**
  - Fixed `Link` mock href replacement in `@shipfox/client-triggers` tests using literal split/join so param values with replacement-pattern characters are preserved.

<sup>Written for commit 67665d864e7168c81e0c29bdd06c213adc7dd71d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

