### PR TITLE
Resolve Vitest workspace deps through dist

### DIFF
--- a/.changeset/quiet-paths-resolve.md
+++ b/.changeset/quiet-paths-resolve.md
@@ -1,0 +1,23 @@
+---
+"@shipfox/biome": patch
+"@shipfox/config": patch
+"@shipfox/depcruise": patch
+"@shipfox/docker": patch
+"@shipfox/node-email": patch
+"@shipfox/node-error-monitoring": patch
+"@shipfox/node-fastify": patch
+"@shipfox/node-log": patch
+"@shipfox/node-mailer": patch
+"@shipfox/node-opentelemetry": patch
+"@shipfox/node-postgres": patch
+"@shipfox/node-temporal": patch
+"@shipfox/playwright": patch
+"@shipfox/react-ui": patch
+"@shipfox/regex": patch
+"@shipfox/swc": patch
+"@shipfox/typescript": patch
+"@shipfox/vitest": patch
+"@shipfox/workflow-document": patch
+---
+
+Resolves CI Vitest workspace imports through built package output while preserving source-based TypeScript checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,10 +413,12 @@ Packages use Node.js [subpath imports](https://nodejs.org/api/packages.html#subp
 
 | Pattern | Maps to | Example |
 | --- | --- | --- |
-| `#*` | `./src/*` | `import {foo} from '#core/foo.js'` |
+| `#*` | `./src/*` (`types`, `development`), `./dist/*` (`default`) | `import {foo} from '#core/foo.js'` |
 | `#test/*` | `./test/*` | `import {bar} from '#test/factories/bar.js'` |
 
-Node, TypeScript, and [Vitest](https://vitest.dev/) resolve these natively; no build-time rewriting needed.
+Node, TypeScript, and [Vitest](https://vitest.dev/) resolve these natively. `#*`
+resolves to source for editor, pnpm development, and local Vitest workflows, and
+to built output by default for CI and production.
 
 ## Development Workflow
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,7 +9,11 @@
   "private": true,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "scripts": {
     "build": "shipfox-swc",

--- a/apps/provisioner-docker/package.json
+++ b/apps/provisioner-docker/package.json
@@ -9,7 +9,11 @@
   "private": true,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "scripts": {
     "build": "shipfox-swc",

--- a/e2e/core/package.json
+++ b/e2e/core/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/auth/package.json
+++ b/e2e/helpers/auth/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/definitions/package.json
+++ b/e2e/helpers/definitions/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/integrations-gitea/package.json
+++ b/e2e/helpers/integrations-gitea/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/logs/package.json
+++ b/e2e/helpers/logs/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/runners/package.json
+++ b/e2e/helpers/runners/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/workflows/package.json
+++ b/e2e/helpers/workflows/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/e2e/helpers/workspaces/package.json
+++ b/e2e/helpers/workspaces/package.json
@@ -12,7 +12,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/agent-dto/package.json
+++ b/libs/api/agent-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/agent/package.json
+++ b/libs/api/agent/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/auth-dto/package.json
+++ b/libs/api/auth-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/auth/package.json
+++ b/libs/api/auth/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/common-dto/package.json
+++ b/libs/api/common-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/definitions-dto/package.json
+++ b/libs/api/definitions-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/dispatcher/package.json
+++ b/libs/api/dispatcher/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/core-dto/package.json
+++ b/libs/api/integration/core-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/core/package.json
+++ b/libs/api/integration/core/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/debug-dto/package.json
+++ b/libs/api/integration/debug-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/debug/package.json
+++ b/libs/api/integration/debug/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/gitea-dto/package.json
+++ b/libs/api/integration/gitea-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/gitea/package.json
+++ b/libs/api/integration/gitea/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/github-dto/package.json
+++ b/libs/api/integration/github-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/github/package.json
+++ b/libs/api/integration/github/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/sentry-dto/package.json
+++ b/libs/api/integration/sentry-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/sentry/package.json
+++ b/libs/api/integration/sentry/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/webhook-dto/package.json
+++ b/libs/api/integration/webhook-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/integration/webhook/package.json
+++ b/libs/api/integration/webhook/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/logs-dto/package.json
+++ b/libs/api/logs-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/logs/package.json
+++ b/libs/api/logs/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/logs/src/config.ts
+++ b/libs/api/logs/src/config.ts
@@ -111,12 +111,14 @@ if (!Number.isInteger(config.LOG_RETENTION_DAYS) || config.LOG_RETENTION_DAYS < 
 // truncate live logs. Validate against the real lease TTL read from auth's config (not a
 // hardcoded floor), so raising AUTH_JOB_LEASE_TOKEN_EXPIRES_IN can never silently outrun the
 // reaper window.
-const jobLeaseTtlSeconds = durationToSeconds(authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN);
+const authJobLeaseTokenExpiresIn =
+  process.env.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN ?? authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN;
+const jobLeaseTtlSeconds = durationToSeconds(authJobLeaseTokenExpiresIn);
 if (
   !Number.isFinite(config.LOG_STREAM_REAP_AFTER_SECONDS) ||
   config.LOG_STREAM_REAP_AFTER_SECONDS <= jobLeaseTtlSeconds
 ) {
   throw new Error(
-    `LOG_STREAM_REAP_AFTER_SECONDS (${config.LOG_STREAM_REAP_AFTER_SECONDS}) must be greater than the job lease TTL (${jobLeaseTtlSeconds}s, from AUTH_JOB_LEASE_TOKEN_EXPIRES_IN=${authConfig.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN}); a smaller value would let the reaper force-close a stream a still-valid lease is appending to and silently truncate live logs.`,
+    `LOG_STREAM_REAP_AFTER_SECONDS (${config.LOG_STREAM_REAP_AFTER_SECONDS}) must be greater than the job lease TTL (${jobLeaseTtlSeconds}s, from AUTH_JOB_LEASE_TOKEN_EXPIRES_IN=${authJobLeaseTokenExpiresIn}); a smaller value would let the reaper force-close a stream a still-valid lease is appending to and silently truncate live logs.`,
   );
 }

--- a/libs/api/projects-dto/package.json
+++ b/libs/api/projects-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/projects/package.json
+++ b/libs/api/projects/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/runners-dto/package.json
+++ b/libs/api/runners-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/secrets-dto/package.json
+++ b/libs/api/secrets-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/secrets/package.json
+++ b/libs/api/secrets/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/triggers-dto/package.json
+++ b/libs/api/triggers-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/workflows-dto/package.json
+++ b/libs/api/workflows-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -8,7 +8,6 @@ import {
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
 } from '@shipfox/api-workflows-dto';
 import {createWorkflowExpression} from '@shipfox/expression';
-import * as opentelemetry from '@shipfox/node-opentelemetry';
 import {and, eq, inArray, sql} from 'drizzle-orm';
 import {
   JobNotFoundError,
@@ -528,7 +527,6 @@ describe('workflow run queries', () => {
 
     test('logs enriched diagnostics for missing untrusted interpolation paths', async () => {
       const warn = vi.fn();
-      vi.spyOn(opentelemetry, 'logger').mockReturnValue({warn} as never);
       const model = normalizeWorkflowDocument({
         name: 'Diagnostic workflow',
         runner: 'ubuntu-latest',
@@ -545,6 +543,7 @@ describe('workflow run queries', () => {
         projectId,
         definitionId,
         model,
+        diagnosticsLogger: {warn} as never,
         triggerPayload: {
           source: 'github',
           event: 'push',

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -102,6 +102,8 @@ const TERMINAL_WORKFLOW_RUN_STATUSES: WorkflowRunStatus[] = ['succeeded', 'faile
 const TERMINAL_JOB_STATUSES: JobStatus[] = ['succeeded', 'failed', 'cancelled', 'skipped'];
 const TERMINAL_EXECUTION_STATUSES: JobExecutionStatus[] = ['succeeded', 'failed', 'cancelled'];
 
+type WorkflowDiagnosticsLogger = Pick<ReturnType<typeof logger>, 'warn'>;
+
 export interface CreateWorkflowRunParams {
   workspaceId: string;
   projectId: string;
@@ -113,6 +115,7 @@ export interface CreateWorkflowRunParams {
   sourceSnapshot?: WorkflowSourceSnapshot | null | undefined;
   triggerIdempotencyKey?: string | undefined;
   resolveAgentDefaults?: AgentDefaultsResolver | undefined;
+  diagnosticsLogger?: WorkflowDiagnosticsLogger | undefined;
 }
 
 export async function createWorkflowRun(params: CreateWorkflowRunParams): Promise<WorkflowRun> {
@@ -274,6 +277,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
 
     logTemplateDiagnostics({
       workflowRunId: runRow.id,
+      diagnosticsLogger: params.diagnosticsLogger,
       diagnostics: materializedJobs.flatMap((job) =>
         job.steps.flatMap((step) =>
           (step.diagnostics ?? []).map((diagnostic) => ({
@@ -573,6 +577,7 @@ function workflowTemplateSource(template: MaterializedWorkflowJob['name']): stri
 
 function logTemplateDiagnostics(params: {
   readonly workflowRunId: string;
+  readonly diagnosticsLogger?: WorkflowDiagnosticsLogger | undefined;
   readonly diagnostics: readonly (WorkflowStepTemplateDiagnostic & {
     readonly jobKey: string;
     readonly stepName: string;
@@ -580,7 +585,8 @@ function logTemplateDiagnostics(params: {
 }): void {
   if (params.diagnostics.length === 0) return;
 
-  logger().warn(
+  const diagnosticsLogger = params.diagnosticsLogger ?? logger();
+  diagnosticsLogger.warn(
     {workflowRunId: params.workflowRunId, diagnostics: params.diagnostics},
     'Workflow interpolation resolved with diagnostics',
   );

--- a/libs/api/workspaces-dto/package.json
+++ b/libs/api/workspaces-dto/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/.storybook/main.ts
+++ b/libs/client/.storybook/main.ts
@@ -1,5 +1,5 @@
-import type {StorybookConfig} from '@storybook/react-vite';
 import {createRequire} from 'node:module';
+import type {StorybookConfig} from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   framework: '@storybook/react-vite',
@@ -14,6 +14,14 @@ const config: StorybookConfig = {
 
     config.plugins = config.plugins ?? [];
     config.plugins.push(tailwindcss());
+    if (process.env.CI === 'true') {
+      const {createWorkspaceDistInternalImportResolverPlugin} = await import(
+        require.resolve('@shipfox/vitest')
+      );
+      // Storybook owns its browser Vite server, so CI needs the same built-dist
+      // internal import resolver that @shipfox/vitest installs for Vitest projects.
+      config.plugins.push(createWorkspaceDistInternalImportResolverPlugin(process.cwd()));
+    }
 
     return config;
   },

--- a/libs/client/agent/package.json
+++ b/libs/client/agent/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/app-shell/package.json
+++ b/libs/client/app-shell/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/app-shell/src/components/main-layout.test.tsx
+++ b/libs/client/app-shell/src/components/main-layout.test.tsx
@@ -20,15 +20,11 @@ vi.mock('@shipfox/client-projects', () => ({
   useProjectQuery: () => ({data: {id: 'project-1', name: 'Platform'}}),
 }));
 
-vi.mock('@shipfox/react-ui/logo', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/react-ui/logo')>();
-  return {
-    ...actual,
-    Logo: ({variant = 'wordmark', className}: {variant?: string; className?: string}) => (
-      <span data-testid={`logo:${variant}`} className={className} />
-    ),
-  };
-});
+vi.mock('@shipfox/react-ui/logo', () => ({
+  Logo: ({variant = 'wordmark', className}: {variant?: string; className?: string}) => (
+    <span data-testid={`logo:${variant}`} className={className} />
+  ),
+}));
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({

--- a/libs/client/auth/package.json
+++ b/libs/client/auth/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/auth/src/pages/login-page.tsx
+++ b/libs/client/auth/src/pages/login-page.tsx
@@ -8,7 +8,7 @@ import {useForm} from '@tanstack/react-form';
 import {Link, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
+import {AuthShell} from '#components/auth-shell.js';
 import {useLoginAuth} from '#hooks/api/login-auth.js';
 import {authFormDraftAtom, initialAuthFormDraft} from '#state/auth.js';
 import {loginErrorToFormError} from './form-errors.js';

--- a/libs/client/auth/src/pages/logout-page.tsx
+++ b/libs/client/auth/src/pages/logout-page.tsx
@@ -1,8 +1,8 @@
 import {Text} from '@shipfox/react-ui/typography';
 import {useNavigate, useRouter, useSearch} from '@tanstack/react-router';
 import {useEffect} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
-import {sanitizeRedirectPath} from '#/components/redirect-target.js';
+import {AuthShell} from '#components/auth-shell.js';
+import {sanitizeRedirectPath} from '#components/redirect-target.js';
 import {useLogoutAuth} from '#hooks/api/logout-auth.js';
 
 export function LogoutPage() {

--- a/libs/client/auth/src/pages/password-reset-page.tsx
+++ b/libs/client/auth/src/pages/password-reset-page.tsx
@@ -11,7 +11,7 @@ import {useForm} from '@tanstack/react-form';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
+import {AuthShell} from '#components/auth-shell.js';
 import {
   useConfirmPasswordResetAuth,
   useRequestPasswordResetAuth,

--- a/libs/client/auth/src/pages/signup-page.tsx
+++ b/libs/client/auth/src/pages/signup-page.tsx
@@ -10,7 +10,7 @@ import {useForm} from '@tanstack/react-form';
 import {Link, useNavigate, useSearch} from '@tanstack/react-router';
 import {useAtom} from 'jotai';
 import {useEffect, useRef, useState} from 'react';
-import {AuthShell} from '#/components/auth-shell.js';
+import {AuthShell} from '#components/auth-shell.js';
 import {useRefreshAuth} from '#hooks/api/refresh-auth.js';
 import {useSignupAuth} from '#hooks/api/signup-auth.js';
 import {useResendEmailVerificationAuth} from '#hooks/api/verify-email-auth.js';

--- a/libs/client/config/package.json
+++ b/libs/client/config/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/integrations/package.json
+++ b/libs/client/integrations/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/invitations/package.json
+++ b/libs/client/invitations/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/logs/package.json
+++ b/libs/client/logs/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/projects/package.json
+++ b/libs/client/projects/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/runners/package.json
+++ b/libs/client/runners/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/secrets/package.json
+++ b/libs/client/secrets/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/test-setup/package.json
+++ b/libs/client/test-setup/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/triggers/package.json
+++ b/libs/client/triggers/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/ui/package.json
+++ b/libs/client/ui/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/client/workflows/package.json
+++ b/libs/client/workflows/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
+++ b/libs/client/workflows/src/components/workflow-run-summary/workflow-run-summary.test.tsx
@@ -8,7 +8,6 @@ const RUN_ID = '66666666-6666-4666-8666-666666666666';
 const RELATIVE_TIME_TEXT_PATTERN = /ago$/;
 const OLD_ROOT_TIME_TEXT_PATTERN = /(?:1d|24h) ago/;
 const COPY_RUN_BUTTON_NAME = /Copy run/;
-
 const originalScrollWidth = Object.getOwnPropertyDescriptor(
   window.HTMLElement.prototype,
   'scrollWidth',
@@ -24,7 +23,6 @@ beforeEach(() => {
 
 describe('WorkflowRunSummary', () => {
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
     restoreElementWidthDescriptors();
   });

--- a/libs/client/workspace-settings/package.json
+++ b/libs/client/workspace-settings/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "exports": {

--- a/libs/provisioner/core/package.json
+++ b/libs/provisioner/core/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/provisioner/docker/package.json
+++ b/libs/provisioner/docker/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/agent/package.json
+++ b/libs/runner/agent/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/execution/package.json
+++ b/libs/runner/execution/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/logs/package.json
+++ b/libs/runner/logs/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/orchestration/package.json
+++ b/libs/runner/orchestration/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/protocol/package.json
+++ b/libs/runner/protocol/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/runner/workspace/package.json
+++ b/libs/runner/workspace/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/common/config/package.json
+++ b/libs/shared/common/config/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/common/redact/package.json
+++ b/libs/shared/common/redact/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/common/regex/package.json
+++ b/libs/shared/common/regex/package.json
@@ -15,7 +15,11 @@
     "dist"
   ],
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/common/runner-labels/package.json
+++ b/libs/shared/common/runner-labels/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/drizzle/package.json
+++ b/libs/shared/node/drizzle/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/email/package.json
+++ b/libs/shared/node/email/package.json
@@ -17,7 +17,11 @@
   ],
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/error-monitoring/package.json
+++ b/libs/shared/node/error-monitoring/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/fastify/package.json
+++ b/libs/shared/node/fastify/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/jwt/package.json
+++ b/libs/shared/node/jwt/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/log/package.json
+++ b/libs/shared/node/log/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/mailer/package.json
+++ b/libs/shared/node/mailer/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/module/package.json
+++ b/libs/shared/node/module/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/opentelemetry/package.json
+++ b/libs/shared/node/opentelemetry/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/outbox/package.json
+++ b/libs/shared/node/outbox/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/postgres/package.json
+++ b/libs/shared/node/postgres/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/temporal/package.json
+++ b/libs/shared/node/temporal/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/node/tokens/package.json
+++ b/libs/shared/node/tokens/package.json
@@ -13,7 +13,11 @@
   "types": "dist/index.d.ts",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/libs/shared/react/ui/package.json
+++ b/libs/shared/react/ui/package.json
@@ -11,7 +11,11 @@
   "type": "module",
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "style": "dist/styles.css",
   "sideEffects": [

--- a/libs/shared/workflow/document/package.json
+++ b/libs/shared/workflow/document/package.json
@@ -12,7 +12,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "imports": {
-    "#*": "./src/*",
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    },
     "#test/*": "./test/*"
   },
   "files": [

--- a/tools/biome/package.json
+++ b/tools/biome/package.json
@@ -10,7 +10,11 @@
   "private": false,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "bin": {
     "shipfox-biome-lint": "./bin/biome-lint.js",

--- a/tools/depcruise/package.json
+++ b/tools/depcruise/package.json
@@ -10,7 +10,11 @@
   "private": false,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "bin": {
     "shipfox-depcruise": "./bin/depcruise.js"

--- a/tools/docker/package.json
+++ b/tools/docker/package.json
@@ -10,7 +10,11 @@
   "private": false,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "bin": {
     "shipfox-docker": "./bin/docker.js"

--- a/tools/playwright/package.json
+++ b/tools/playwright/package.json
@@ -16,7 +16,11 @@
   },
   "imports": {
     "#test/*": "./test/*",
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "exports": {
     ".": {

--- a/tools/swc/package.json
+++ b/tools/swc/package.json
@@ -10,7 +10,11 @@
   "private": false,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "bin": {
     "shipfox-swc": "./bin/swc.js"

--- a/tools/typescript/package.json
+++ b/tools/typescript/package.json
@@ -10,7 +10,11 @@
   "private": false,
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "bin": {
     "shipfox-tsc-check": "./bin/tsc-check.js",

--- a/tools/vitest/package.json
+++ b/tools/vitest/package.json
@@ -29,7 +29,11 @@
   },
   "type": "module",
   "imports": {
-    "#*": "./src/*"
+    "#*": {
+      "types": "./src/*",
+      "development": "./src/*",
+      "default": "./dist/*"
+    }
   },
   "bin": {
     "shipfox-vitest-run": "./bin/vitest-run.js",
@@ -37,6 +41,7 @@
   },
   "scripts": {
     "build": "shipfox-swc",
+    "test": "vitest run",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },

--- a/tools/vitest/src/config-merge.ts
+++ b/tools/vitest/src/config-merge.ts
@@ -1,0 +1,71 @@
+import {join} from 'node:path';
+import type {ResolveAlias} from './config-types.js';
+
+const projectRootSlashImportPattern = /^#\/(.+)$/;
+const projectRootImportPattern = /^#(?!test\/)(.+)$/;
+
+export function withoutConditions(conditions: string[], excludedConditions: string[]): string[] {
+  return conditions.filter(
+    (condition) =>
+      condition !== 'development' &&
+      condition !== 'development|production' &&
+      !excludedConditions.includes(condition),
+  );
+}
+
+export function mergeConditions(
+  existing: string[] | undefined,
+  fallback: string[],
+  excludedConditions: string[] = [],
+): string[] {
+  return Array.from(
+    new Set([
+      ...withoutConditions(existing ?? [], excludedConditions),
+      ...withoutConditions(fallback, excludedConditions),
+    ]),
+  );
+}
+
+export function mergeExternalPackages(
+  existing: string[] | true | undefined,
+  packageNames: string[],
+) {
+  if (existing === true) return true;
+  return Array.from(new Set([...(existing || []), ...packageNames]));
+}
+
+export function mergeInlineDeps(
+  existing: (string | RegExp)[] | true | undefined,
+  deps: Array<string | RegExp>,
+) {
+  if (existing === true) return true;
+  return [...(existing || []), ...deps];
+}
+
+export function mergeStringList(existing: string[] | undefined, values: string[]): string[] {
+  return Array.from(new Set([...(existing || []), ...values]));
+}
+
+function normalizeAlias(alias: ResolveAlias | undefined): Array<{
+  find: string | RegExp;
+  replacement: string;
+}> {
+  if (!alias) return [];
+  if (Array.isArray(alias)) return alias;
+  return Object.entries(alias).map(([find, replacement]) => ({find, replacement}));
+}
+
+export function mergeProjectSourceAliases(
+  alias: ResolveAlias | undefined,
+  projectRoot: string | undefined,
+) {
+  const existingAliases = normalizeAlias(alias);
+  if (!projectRoot) return existingAliases;
+
+  const projectSrc = join(projectRoot, 'src');
+  return [
+    {find: projectRootSlashImportPattern, replacement: `${projectSrc}/$1`},
+    {find: projectRootImportPattern, replacement: `${projectSrc}/$1`},
+    ...existingAliases,
+  ];
+}

--- a/tools/vitest/src/config-types.ts
+++ b/tools/vitest/src/config-types.ts
@@ -26,6 +26,7 @@ export type MergeableConfigInput = ConfigInput & {
   optimizeDeps?: {
     rolldownOptions?: {
       checks?: Record<string, unknown>;
+      plugins?: unknown[];
     };
   };
   test?: {
@@ -48,6 +49,14 @@ export type MergeableConfigInput = ConfigInput & {
       debug?: unknown;
     };
   };
+};
+
+export type MergeableConfigFragment = {
+  plugins?: unknown[];
+  resolve?: MergeableConfigInput['resolve'];
+  ssr?: MergeableConfigInput['ssr'];
+  optimizeDeps?: MergeableConfigInput['optimizeDeps'];
+  test?: MergeableConfigInput['test'];
 };
 
 export type EnvironmentConfig = {

--- a/tools/vitest/src/config-types.ts
+++ b/tools/vitest/src/config-types.ts
@@ -1,0 +1,67 @@
+import type {UserWorkspaceConfig, defineConfig as vitestDefineConfig} from 'vitest/config';
+
+type VitestUserConfig = Parameters<typeof vitestDefineConfig>[0];
+
+export type ConfigInput = VitestUserConfig | UserWorkspaceConfig;
+
+export type ResolveAlias =
+  | Array<{find: string | RegExp; replacement: string}>
+  | Record<string, string>;
+
+export type MergeableConfigInput = ConfigInput & {
+  plugins?: unknown[];
+  resolve?: {
+    alias?: ResolveAlias;
+    conditions?: string[];
+    externalConditions?: string[];
+    external?: string[] | true;
+  };
+  ssr?: {
+    external?: string[] | true;
+    resolve?: {
+      conditions?: string[];
+      externalConditions?: string[];
+    };
+  };
+  optimizeDeps?: {
+    rolldownOptions?: {
+      checks?: Record<string, unknown>;
+    };
+  };
+  test?: {
+    deps?: {
+      optimizer?: Record<
+        string,
+        {
+          enabled?: boolean;
+          include?: string[];
+        }
+      >;
+    };
+    exclude?: string[];
+    server?: {
+      deps?: {
+        external?: (string | RegExp)[];
+        inline?: (string | RegExp)[] | true;
+        fallbackCJS?: boolean;
+      };
+      debug?: unknown;
+    };
+  };
+};
+
+export type EnvironmentConfig = {
+  resolve?: {
+    alias?: ResolveAlias;
+    conditions?: string[];
+    externalConditions?: string[];
+    external?: string[] | true;
+  };
+};
+
+export type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -1,4 +1,6 @@
-import {getProjectRootPath} from '@shipfox/tool-utils';
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {getProjectRootPath, getWorkspaceRootPath} from '@shipfox/tool-utils';
 import {
   type TestProjectConfiguration,
   type UserWorkspaceConfig,
@@ -19,18 +21,78 @@ export type UserConfig = Parameters<typeof vitestDefineConfig>[0];
 type ConfigInput = UserConfig | UserWorkspaceConfig;
 type MergeableConfigInput = ConfigInput & {
   plugins?: unknown[];
+  resolve?: {
+    alias?: ResolveAlias;
+    conditions?: string[];
+    externalConditions?: string[];
+    external?: string[] | true;
+  };
+  ssr?: {
+    external?: string[] | true;
+    resolve?: {
+      conditions?: string[];
+      externalConditions?: string[];
+    };
+  };
   optimizeDeps?: {
     rolldownOptions?: {
       checks?: Record<string, unknown>;
     };
   };
   test?: {
+    deps?: {
+      optimizer?: Record<
+        string,
+        {
+          enabled?: boolean;
+          include?: string[];
+        }
+      >;
+    };
     exclude?: string[];
+    server?: {
+      deps?: {
+        external?: (string | RegExp)[];
+        inline?: (string | RegExp)[] | true;
+        fallbackCJS?: boolean;
+      };
+      debug?: unknown;
+    };
   };
 };
 
-const maxWorkers = parseMaxWorkers(process.env.SHIPFOX_VITEST_MAX_WORKERS);
-const workerPoolConfig = maxWorkers === undefined ? {} : {maxWorkers};
+const workspacePackagePattern = /^@shipfox\/.+/;
+const workspaceDistFilePattern = /\/(?:apps|e2e|infra|libs|tools|turbo)\/.*\/dist\/.*\.m?js$/;
+const clientDistConditions = ['module', 'browser'];
+const serverDistConditions = ['node'];
+const serverModuleDistConditions = ['module', 'node'];
+const externalDistConditions = ['node', 'module-sync'];
+const workspacePackageRoots = ['apps', 'e2e', 'libs', 'tools', 'infra', 'turbo'];
+const projectRootSlashImportPattern = /^#\/(.+)$/;
+const projectRootImportPattern = /^#(?!test\/)(.+)$/;
+const esmOptimizerPackages = [
+  {dependencyName: '@opentelemetry/api', optimizerName: '@opentelemetry/api'},
+  {dependencyName: '@opentelemetry/core', optimizerName: '@opentelemetry/core'},
+];
+const esmOptimizerInlinePattern = /@opentelemetry\/(?:api|core)/;
+let cachedWorkspacePackageNames: string[] | undefined;
+
+type ResolveAlias = Array<{find: string | RegExp; replacement: string}> | Record<string, string>;
+type PackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+type EnvironmentConfig = {
+  resolve?: {
+    alias?: ResolveAlias;
+    conditions?: string[];
+    externalConditions?: string[];
+    external?: string[] | true;
+  };
+};
 
 function parseMaxWorkers(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -43,12 +105,247 @@ function parseMaxWorkers(value: string | undefined): number | undefined {
   return maxWorkers;
 }
 
+function createWorkerPoolConfig(): {maxWorkers?: number} {
+  const maxWorkers = parseMaxWorkers(process.env.SHIPFOX_VITEST_MAX_WORKERS);
+  return maxWorkers === undefined ? {} : {maxWorkers};
+}
+
+function withoutConditions(conditions: string[], excludedConditions: string[]): string[] {
+  return conditions.filter(
+    (condition) =>
+      condition !== 'development' &&
+      condition !== 'development|production' &&
+      !excludedConditions.includes(condition),
+  );
+}
+
+function mergeConditions(
+  existing: string[] | undefined,
+  fallback: string[],
+  excludedConditions: string[] = [],
+): string[] {
+  return Array.from(
+    new Set([
+      ...withoutConditions(existing ?? [], excludedConditions),
+      ...withoutConditions(fallback, excludedConditions),
+    ]),
+  );
+}
+
+function mergeExternalPackages(existing: string[] | true | undefined, packageNames: string[]) {
+  if (existing === true) return true;
+  return Array.from(new Set([...(existing || []), ...packageNames]));
+}
+
+function mergeInlineDeps(
+  existing: (string | RegExp)[] | true | undefined,
+  deps: Array<string | RegExp>,
+) {
+  if (existing === true) return true;
+  return [...(existing || []), ...deps];
+}
+
+function mergeStringList(existing: string[] | undefined, values: string[]): string[] {
+  return Array.from(new Set([...(existing || []), ...values]));
+}
+
+function getDirectDependencyNames(projectRoot: string | undefined): Set<string> {
+  if (!projectRoot) return new Set();
+
+  const packageJsonPath = join(projectRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) return new Set();
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+  return new Set([
+    ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.devDependencies || {}),
+    ...Object.keys(packageJson.optionalDependencies || {}),
+    ...Object.keys(packageJson.peerDependencies || {}),
+  ]);
+}
+
+function getResolvableEsmOptimizerPackageNames(projectRoot: string | undefined): string[] {
+  const directDependencyNames = getDirectDependencyNames(projectRoot);
+  return esmOptimizerPackages.flatMap(({dependencyName, optimizerName}) =>
+    directDependencyNames.has(dependencyName) ? [optimizerName] : [],
+  );
+}
+
+function getServerExcludedConditions(projectRoot: string | undefined): string[] {
+  const directDependencyNames = getDirectDependencyNames(projectRoot);
+  return directDependencyNames.has('@opentelemetry/api') ||
+    directDependencyNames.has('@opentelemetry/core')
+    ? []
+    : ['module'];
+}
+
+function getServerFallbackConditions(serverExcludedConditions: string[]): string[] {
+  return serverExcludedConditions.includes('module')
+    ? serverDistConditions
+    : serverModuleDistConditions;
+}
+
+function mergeServerConditions(
+  conditions: string[] | undefined,
+  fallbackConditions: string[],
+  excludedConditions: string[],
+): string[] {
+  return mergeConditions(conditions, fallbackConditions, excludedConditions);
+}
+
+function normalizeAlias(alias: ResolveAlias | undefined): Array<{
+  find: string | RegExp;
+  replacement: string;
+}> {
+  if (!alias) return [];
+  if (Array.isArray(alias)) return alias;
+  return Object.entries(alias).map(([find, replacement]) => ({find, replacement}));
+}
+
+function mergeProjectSourceAliases(
+  alias: ResolveAlias | undefined,
+  projectRoot: string | undefined,
+) {
+  const existingAliases = normalizeAlias(alias);
+  if (!projectRoot) return existingAliases;
+
+  const projectSrc = join(projectRoot, 'src');
+  return [
+    {find: projectRootSlashImportPattern, replacement: `${projectSrc}/$1`},
+    {find: projectRootImportPattern, replacement: `${projectSrc}/$1`},
+    ...existingAliases,
+  ];
+}
+
+function collectWorkspacePackageNames(dir: string, names: Set<string>): void {
+  const packageJsonPath = join(dir, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {name?: string};
+    if (packageJson.name?.startsWith('@shipfox/')) names.add(packageJson.name);
+    return;
+  }
+
+  if (!existsSync(dir)) return;
+
+  for (const entry of readdirSync(dir, {withFileTypes: true})) {
+    if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+    collectWorkspacePackageNames(join(dir, entry.name), names);
+  }
+}
+
+function getWorkspacePackageNames(): string[] {
+  if (cachedWorkspacePackageNames) return cachedWorkspacePackageNames;
+
+  const names = new Set<string>();
+  const workspaceRoot = getWorkspaceRootPath();
+  for (const packageRoot of workspacePackageRoots) {
+    collectWorkspacePackageNames(join(workspaceRoot, packageRoot), names);
+  }
+
+  cachedWorkspacePackageNames = Array.from(names).sort();
+  return cachedWorkspacePackageNames;
+}
+
+function createWorkspaceDistResolutionPlugin(
+  packageNames: string[],
+  projectRoot: string | undefined,
+  serverExcludedConditions: string[],
+) {
+  return {
+    name: 'shipfox-vitest-workspace-dist-resolution',
+    configEnvironment(name: string, environmentConfig: EnvironmentConfig) {
+      const resolveConfig = environmentConfig.resolve || {};
+      const fallbackConditions =
+        name === 'client'
+          ? clientDistConditions
+          : getServerFallbackConditions(serverExcludedConditions);
+
+      environmentConfig.resolve = {
+        ...resolveConfig,
+        alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),
+        conditions:
+          name === 'client'
+            ? mergeConditions(resolveConfig.conditions, fallbackConditions)
+            : mergeServerConditions(
+                resolveConfig.conditions,
+                fallbackConditions,
+                serverExcludedConditions,
+              ),
+        externalConditions: mergeConditions(
+          resolveConfig.externalConditions,
+          externalDistConditions,
+        ),
+        external: mergeExternalPackages(resolveConfig.external, packageNames),
+      };
+    },
+  };
+}
+
 function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): ConfigInput {
   const mergeableConfig = resolvedConfig as MergeableConfigInput;
+  const useBuiltWorkspaceDeps = process.env.CI === 'true';
+  const workerPoolConfig = createWorkerPoolConfig();
+  const workspacePackageNames = useBuiltWorkspaceDeps ? getWorkspacePackageNames() : [];
+  const esmOptimizerIncludes = useBuiltWorkspaceDeps
+    ? getResolvableEsmOptimizerPackageNames(projectRoot)
+    : [];
+  const serverExcludedConditions = useBuiltWorkspaceDeps
+    ? getServerExcludedConditions(projectRoot)
+    : [];
+  const serverFallbackConditions = getServerFallbackConditions(serverExcludedConditions);
   const existingPlugins = mergeableConfig.plugins || [];
+  const workspaceDistPlugin = useBuiltWorkspaceDeps
+    ? [
+        createWorkspaceDistResolutionPlugin(
+          workspacePackageNames,
+          projectRoot,
+          serverExcludedConditions,
+        ),
+      ]
+    : [];
+  const resolveConfig = mergeableConfig.resolve || {};
+  const ssrConfig = mergeableConfig.ssr || {};
+  const ssrResolveConfig = ssrConfig.resolve || {};
+  const testConfig = mergeableConfig.test || {};
+  const testDepsConfig = testConfig.deps || {};
+  const testDepsOptimizerConfig = testDepsConfig.optimizer || {};
+  const testDepsSsrOptimizerConfig = testDepsOptimizerConfig.ssr || {};
+  const testServerConfig = testConfig.server || {};
+  const testServerDepsConfig = testServerConfig.deps || {};
+  const workspaceDistConfig = useBuiltWorkspaceDeps
+    ? {
+        resolve: {
+          ...resolveConfig,
+          alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),
+          conditions: mergeConditions(resolveConfig.conditions, clientDistConditions),
+          externalConditions: mergeConditions(
+            resolveConfig.externalConditions,
+            externalDistConditions,
+          ),
+          external: mergeExternalPackages(resolveConfig.external, workspacePackageNames),
+        },
+        ssr: {
+          ...ssrConfig,
+          external: mergeExternalPackages(ssrConfig.external, workspacePackageNames),
+          resolve: {
+            ...ssrResolveConfig,
+            conditions: mergeServerConditions(
+              ssrResolveConfig.conditions,
+              serverFallbackConditions,
+              serverExcludedConditions,
+            ),
+            externalConditions: mergeConditions(
+              ssrResolveConfig.externalConditions,
+              externalDistConditions,
+            ),
+          },
+        },
+      }
+    : {};
   const merged = {
     ...resolvedConfig,
-    plugins: [...existingPlugins],
+    plugins: [...existingPlugins, ...workspaceDistPlugin],
+    ...workspaceDistConfig,
     optimizeDeps: {
       ...(mergeableConfig.optimizeDeps || {}),
       rolldownOptions: {
@@ -60,9 +357,41 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
       },
     },
     test: {
-      ...(mergeableConfig.test || {}),
+      ...testConfig,
       globals: true,
       ...workerPoolConfig,
+      ...(useBuiltWorkspaceDeps
+        ? {
+            deps: {
+              ...testDepsConfig,
+              optimizer: {
+                ...testDepsOptimizerConfig,
+                ssr: {
+                  ...testDepsSsrOptimizerConfig,
+                  enabled: true,
+                  include: mergeStringList(
+                    testDepsSsrOptimizerConfig.include,
+                    esmOptimizerIncludes,
+                  ),
+                },
+              },
+            },
+            server: {
+              ...testServerConfig,
+              deps: {
+                ...testServerDepsConfig,
+                external: [
+                  ...(testServerDepsConfig.external || []),
+                  workspacePackagePattern,
+                  workspaceDistFilePattern,
+                ],
+                inline: mergeInlineDeps(testServerDepsConfig.inline, [
+                  esmOptimizerInlinePattern,
+                ]),
+              },
+            },
+          }
+        : {}),
       exclude: [
         '**/node_modules/**',
         '**/dist/**',

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -34,26 +34,53 @@ function createWorkerPoolConfig(): {maxWorkers?: number} {
   return maxWorkers === undefined ? {} : {maxWorkers};
 }
 
+function mergeProjectPlugins(projects: unknown, plugins: unknown[]): unknown {
+  if (!Array.isArray(projects) || plugins.length === 0) return projects;
+
+  return projects.map((project) => {
+    if (!project || typeof project !== 'object' || Array.isArray(project)) return project;
+
+    const projectConfig = project as {plugins?: unknown[]};
+    return {
+      ...projectConfig,
+      plugins: [...(projectConfig.plugins || []), ...plugins],
+    };
+  });
+}
+
 function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): ConfigInput {
   const mergeableConfig = resolvedConfig as MergeableConfigInput;
   const useBuiltWorkspaceDeps = process.env.CI === 'true';
   const workerPoolConfig = createWorkerPoolConfig();
   const existingPlugins = mergeableConfig.plugins || [];
   const testConfig = mergeableConfig.test || {};
+  const optimizeDepsConfig = mergeableConfig.optimizeDeps || {};
+  const optimizeDepsRolldownOptionsConfig = optimizeDepsConfig.rolldownOptions || {};
   const workspaceDistConfig = useBuiltWorkspaceDeps
     ? createWorkspaceDistConfig(mergeableConfig, projectRoot)
     : undefined;
+  const workspaceOptimizeDepsConfig = workspaceDistConfig?.optimizeDeps;
+  const workspaceOptimizeDepsRolldownOptionsConfig =
+    workspaceOptimizeDepsConfig?.rolldownOptions || {};
+  const workspacePlugins = workspaceDistConfig?.plugins || [];
+  const testProjects = mergeProjectPlugins(
+    (testConfig as {projects?: unknown[]}).projects,
+    workspacePlugins,
+  );
   const merged = {
     ...resolvedConfig,
-    plugins: [...existingPlugins, ...(workspaceDistConfig?.plugins || [])],
+    plugins: [...existingPlugins, ...workspacePlugins],
     ...(workspaceDistConfig?.resolve ? {resolve: workspaceDistConfig.resolve} : {}),
     ...(workspaceDistConfig?.ssr ? {ssr: workspaceDistConfig.ssr} : {}),
     optimizeDeps: {
-      ...(mergeableConfig.optimizeDeps || {}),
+      ...optimizeDepsConfig,
+      ...(workspaceOptimizeDepsConfig || {}),
       rolldownOptions: {
-        ...(mergeableConfig.optimizeDeps?.rolldownOptions || {}),
+        ...optimizeDepsRolldownOptionsConfig,
+        ...workspaceOptimizeDepsRolldownOptionsConfig,
         checks: {
-          ...(mergeableConfig.optimizeDeps?.rolldownOptions?.checks || {}),
+          ...(optimizeDepsRolldownOptionsConfig.checks || {}),
+          ...(workspaceOptimizeDepsRolldownOptionsConfig.checks || {}),
           pluginTimings: false,
         },
       },
@@ -63,6 +90,7 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
       globals: true,
       ...workerPoolConfig,
       ...(workspaceDistConfig?.test || {}),
+      ...(testProjects ? {projects: testProjects} : {}),
       exclude: [
         '**/node_modules/**',
         '**/dist/**',

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -1,12 +1,12 @@
-import {existsSync, readdirSync, readFileSync} from 'node:fs';
-import {join} from 'node:path';
-import {getProjectRootPath, getWorkspaceRootPath} from '@shipfox/tool-utils';
+import {getProjectRootPath} from '@shipfox/tool-utils';
 import {
   type TestProjectConfiguration,
   type UserWorkspaceConfig,
   defineConfig as vitestDefineConfig,
   defineProject as vitestDefineProject,
 } from 'vitest/config';
+import type {ConfigInput, MergeableConfigInput} from './config-types.js';
+import {createWorkspaceDistConfig} from './workspace-dist-resolution.js';
 
 export type {
   TestProjectConfiguration,
@@ -17,82 +17,6 @@ export type UserConfigExport = ReturnType<typeof vitestDefineConfig>;
 export type UserConfigFnObject = () => Parameters<typeof vitestDefineConfig>[0];
 
 export type UserConfig = Parameters<typeof vitestDefineConfig>[0];
-
-type ConfigInput = UserConfig | UserWorkspaceConfig;
-type MergeableConfigInput = ConfigInput & {
-  plugins?: unknown[];
-  resolve?: {
-    alias?: ResolveAlias;
-    conditions?: string[];
-    externalConditions?: string[];
-    external?: string[] | true;
-  };
-  ssr?: {
-    external?: string[] | true;
-    resolve?: {
-      conditions?: string[];
-      externalConditions?: string[];
-    };
-  };
-  optimizeDeps?: {
-    rolldownOptions?: {
-      checks?: Record<string, unknown>;
-    };
-  };
-  test?: {
-    deps?: {
-      optimizer?: Record<
-        string,
-        {
-          enabled?: boolean;
-          include?: string[];
-        }
-      >;
-    };
-    exclude?: string[];
-    server?: {
-      deps?: {
-        external?: (string | RegExp)[];
-        inline?: (string | RegExp)[] | true;
-        fallbackCJS?: boolean;
-      };
-      debug?: unknown;
-    };
-  };
-};
-
-const workspacePackagePattern = /^@shipfox\/.+/;
-const workspaceDistFilePattern = /\/(?:apps|e2e|infra|libs|tools|turbo)\/.*\/dist\/.*\.m?js$/;
-const clientDistConditions = ['module', 'browser'];
-const serverDistConditions = ['node'];
-const serverModuleDistConditions = ['module', 'node'];
-const externalDistConditions = ['node', 'module-sync'];
-const workspacePackageRoots = ['apps', 'e2e', 'libs', 'tools', 'infra', 'turbo'];
-const projectRootSlashImportPattern = /^#\/(.+)$/;
-const projectRootImportPattern = /^#(?!test\/)(.+)$/;
-const esmOptimizerPackages = [
-  {dependencyName: '@opentelemetry/api', optimizerName: '@opentelemetry/api'},
-  {dependencyName: '@opentelemetry/core', optimizerName: '@opentelemetry/core'},
-];
-const esmOptimizerInlinePattern = /@opentelemetry\/(?:api|core)/;
-let cachedWorkspacePackageNames: string[] | undefined;
-
-type ResolveAlias = Array<{find: string | RegExp; replacement: string}> | Record<string, string>;
-type PackageJson = {
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-};
-
-type EnvironmentConfig = {
-  resolve?: {
-    alias?: ResolveAlias;
-    conditions?: string[];
-    externalConditions?: string[];
-    external?: string[] | true;
-  };
-};
 
 function parseMaxWorkers(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -110,242 +34,20 @@ function createWorkerPoolConfig(): {maxWorkers?: number} {
   return maxWorkers === undefined ? {} : {maxWorkers};
 }
 
-function withoutConditions(conditions: string[], excludedConditions: string[]): string[] {
-  return conditions.filter(
-    (condition) =>
-      condition !== 'development' &&
-      condition !== 'development|production' &&
-      !excludedConditions.includes(condition),
-  );
-}
-
-function mergeConditions(
-  existing: string[] | undefined,
-  fallback: string[],
-  excludedConditions: string[] = [],
-): string[] {
-  return Array.from(
-    new Set([
-      ...withoutConditions(existing ?? [], excludedConditions),
-      ...withoutConditions(fallback, excludedConditions),
-    ]),
-  );
-}
-
-function mergeExternalPackages(existing: string[] | true | undefined, packageNames: string[]) {
-  if (existing === true) return true;
-  return Array.from(new Set([...(existing || []), ...packageNames]));
-}
-
-function mergeInlineDeps(
-  existing: (string | RegExp)[] | true | undefined,
-  deps: Array<string | RegExp>,
-) {
-  if (existing === true) return true;
-  return [...(existing || []), ...deps];
-}
-
-function mergeStringList(existing: string[] | undefined, values: string[]): string[] {
-  return Array.from(new Set([...(existing || []), ...values]));
-}
-
-function getDirectDependencyNames(projectRoot: string | undefined): Set<string> {
-  if (!projectRoot) return new Set();
-
-  const packageJsonPath = join(projectRoot, 'package.json');
-  if (!existsSync(packageJsonPath)) return new Set();
-
-  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
-  return new Set([
-    ...Object.keys(packageJson.dependencies || {}),
-    ...Object.keys(packageJson.devDependencies || {}),
-    ...Object.keys(packageJson.optionalDependencies || {}),
-    ...Object.keys(packageJson.peerDependencies || {}),
-  ]);
-}
-
-function getResolvableEsmOptimizerPackageNames(projectRoot: string | undefined): string[] {
-  const directDependencyNames = getDirectDependencyNames(projectRoot);
-  return esmOptimizerPackages.flatMap(({dependencyName, optimizerName}) =>
-    directDependencyNames.has(dependencyName) ? [optimizerName] : [],
-  );
-}
-
-function getServerExcludedConditions(projectRoot: string | undefined): string[] {
-  const directDependencyNames = getDirectDependencyNames(projectRoot);
-  return directDependencyNames.has('@opentelemetry/api') ||
-    directDependencyNames.has('@opentelemetry/core')
-    ? []
-    : ['module'];
-}
-
-function getServerFallbackConditions(serverExcludedConditions: string[]): string[] {
-  return serverExcludedConditions.includes('module')
-    ? serverDistConditions
-    : serverModuleDistConditions;
-}
-
-function mergeServerConditions(
-  conditions: string[] | undefined,
-  fallbackConditions: string[],
-  excludedConditions: string[],
-): string[] {
-  return mergeConditions(conditions, fallbackConditions, excludedConditions);
-}
-
-function normalizeAlias(alias: ResolveAlias | undefined): Array<{
-  find: string | RegExp;
-  replacement: string;
-}> {
-  if (!alias) return [];
-  if (Array.isArray(alias)) return alias;
-  return Object.entries(alias).map(([find, replacement]) => ({find, replacement}));
-}
-
-function mergeProjectSourceAliases(
-  alias: ResolveAlias | undefined,
-  projectRoot: string | undefined,
-) {
-  const existingAliases = normalizeAlias(alias);
-  if (!projectRoot) return existingAliases;
-
-  const projectSrc = join(projectRoot, 'src');
-  return [
-    {find: projectRootSlashImportPattern, replacement: `${projectSrc}/$1`},
-    {find: projectRootImportPattern, replacement: `${projectSrc}/$1`},
-    ...existingAliases,
-  ];
-}
-
-function collectWorkspacePackageNames(dir: string, names: Set<string>): void {
-  const packageJsonPath = join(dir, 'package.json');
-  if (existsSync(packageJsonPath)) {
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {name?: string};
-    if (packageJson.name?.startsWith('@shipfox/')) names.add(packageJson.name);
-    return;
-  }
-
-  if (!existsSync(dir)) return;
-
-  for (const entry of readdirSync(dir, {withFileTypes: true})) {
-    if (!entry.isDirectory() || entry.name === 'node_modules') continue;
-    collectWorkspacePackageNames(join(dir, entry.name), names);
-  }
-}
-
-function getWorkspacePackageNames(): string[] {
-  if (cachedWorkspacePackageNames) return cachedWorkspacePackageNames;
-
-  const names = new Set<string>();
-  const workspaceRoot = getWorkspaceRootPath();
-  for (const packageRoot of workspacePackageRoots) {
-    collectWorkspacePackageNames(join(workspaceRoot, packageRoot), names);
-  }
-
-  cachedWorkspacePackageNames = Array.from(names).sort();
-  return cachedWorkspacePackageNames;
-}
-
-function createWorkspaceDistResolutionPlugin(
-  packageNames: string[],
-  projectRoot: string | undefined,
-  serverExcludedConditions: string[],
-) {
-  return {
-    name: 'shipfox-vitest-workspace-dist-resolution',
-    configEnvironment(name: string, environmentConfig: EnvironmentConfig) {
-      const resolveConfig = environmentConfig.resolve || {};
-      const fallbackConditions =
-        name === 'client'
-          ? clientDistConditions
-          : getServerFallbackConditions(serverExcludedConditions);
-
-      environmentConfig.resolve = {
-        ...resolveConfig,
-        alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),
-        conditions:
-          name === 'client'
-            ? mergeConditions(resolveConfig.conditions, fallbackConditions)
-            : mergeServerConditions(
-                resolveConfig.conditions,
-                fallbackConditions,
-                serverExcludedConditions,
-              ),
-        externalConditions: mergeConditions(
-          resolveConfig.externalConditions,
-          externalDistConditions,
-        ),
-        external: mergeExternalPackages(resolveConfig.external, packageNames),
-      };
-    },
-  };
-}
-
 function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): ConfigInput {
   const mergeableConfig = resolvedConfig as MergeableConfigInput;
   const useBuiltWorkspaceDeps = process.env.CI === 'true';
   const workerPoolConfig = createWorkerPoolConfig();
-  const workspacePackageNames = useBuiltWorkspaceDeps ? getWorkspacePackageNames() : [];
-  const esmOptimizerIncludes = useBuiltWorkspaceDeps
-    ? getResolvableEsmOptimizerPackageNames(projectRoot)
-    : [];
-  const serverExcludedConditions = useBuiltWorkspaceDeps
-    ? getServerExcludedConditions(projectRoot)
-    : [];
-  const serverFallbackConditions = getServerFallbackConditions(serverExcludedConditions);
   const existingPlugins = mergeableConfig.plugins || [];
-  const workspaceDistPlugin = useBuiltWorkspaceDeps
-    ? [
-        createWorkspaceDistResolutionPlugin(
-          workspacePackageNames,
-          projectRoot,
-          serverExcludedConditions,
-        ),
-      ]
-    : [];
-  const resolveConfig = mergeableConfig.resolve || {};
-  const ssrConfig = mergeableConfig.ssr || {};
-  const ssrResolveConfig = ssrConfig.resolve || {};
   const testConfig = mergeableConfig.test || {};
-  const testDepsConfig = testConfig.deps || {};
-  const testDepsOptimizerConfig = testDepsConfig.optimizer || {};
-  const testDepsSsrOptimizerConfig = testDepsOptimizerConfig.ssr || {};
-  const testServerConfig = testConfig.server || {};
-  const testServerDepsConfig = testServerConfig.deps || {};
   const workspaceDistConfig = useBuiltWorkspaceDeps
-    ? {
-        resolve: {
-          ...resolveConfig,
-          alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),
-          conditions: mergeConditions(resolveConfig.conditions, clientDistConditions),
-          externalConditions: mergeConditions(
-            resolveConfig.externalConditions,
-            externalDistConditions,
-          ),
-          external: mergeExternalPackages(resolveConfig.external, workspacePackageNames),
-        },
-        ssr: {
-          ...ssrConfig,
-          external: mergeExternalPackages(ssrConfig.external, workspacePackageNames),
-          resolve: {
-            ...ssrResolveConfig,
-            conditions: mergeServerConditions(
-              ssrResolveConfig.conditions,
-              serverFallbackConditions,
-              serverExcludedConditions,
-            ),
-            externalConditions: mergeConditions(
-              ssrResolveConfig.externalConditions,
-              externalDistConditions,
-            ),
-          },
-        },
-      }
-    : {};
+    ? createWorkspaceDistConfig(mergeableConfig, projectRoot)
+    : undefined;
   const merged = {
     ...resolvedConfig,
-    plugins: [...existingPlugins, ...workspaceDistPlugin],
-    ...workspaceDistConfig,
+    plugins: [...existingPlugins, ...(workspaceDistConfig?.plugins || [])],
+    ...(workspaceDistConfig?.resolve ? {resolve: workspaceDistConfig.resolve} : {}),
+    ...(workspaceDistConfig?.ssr ? {ssr: workspaceDistConfig.ssr} : {}),
     optimizeDeps: {
       ...(mergeableConfig.optimizeDeps || {}),
       rolldownOptions: {
@@ -360,38 +62,7 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
       ...testConfig,
       globals: true,
       ...workerPoolConfig,
-      ...(useBuiltWorkspaceDeps
-        ? {
-            deps: {
-              ...testDepsConfig,
-              optimizer: {
-                ...testDepsOptimizerConfig,
-                ssr: {
-                  ...testDepsSsrOptimizerConfig,
-                  enabled: true,
-                  include: mergeStringList(
-                    testDepsSsrOptimizerConfig.include,
-                    esmOptimizerIncludes,
-                  ),
-                },
-              },
-            },
-            server: {
-              ...testServerConfig,
-              deps: {
-                ...testServerDepsConfig,
-                external: [
-                  ...(testServerDepsConfig.external || []),
-                  workspacePackagePattern,
-                  workspaceDistFilePattern,
-                ],
-                inline: mergeInlineDeps(testServerDepsConfig.inline, [
-                  esmOptimizerInlinePattern,
-                ]),
-              },
-            },
-          }
-        : {}),
+      ...(workspaceDistConfig?.test || {}),
       exclude: [
         '**/node_modules/**',
         '**/dist/**',

--- a/tools/vitest/src/index.ts
+++ b/tools/vitest/src/index.ts
@@ -1,1 +1,2 @@
 export * from './config.js';
+export {createWorkspaceDistInternalImportResolverPlugin} from './workspace-dist-resolution.js';

--- a/tools/vitest/src/workspace-dist-resolution.ts
+++ b/tools/vitest/src/workspace-dist-resolution.ts
@@ -1,0 +1,228 @@
+import {existsSync, readdirSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {getWorkspaceRootPath} from '@shipfox/tool-utils';
+import {
+  mergeConditions,
+  mergeExternalPackages,
+  mergeInlineDeps,
+  mergeProjectSourceAliases,
+  mergeStringList,
+} from './config-merge.js';
+import type {EnvironmentConfig, MergeableConfigInput, PackageJson} from './config-types.js';
+
+const workspacePackagePattern = /^@shipfox\/.+/;
+const workspaceDistFilePattern = /\/(?:apps|e2e|infra|libs|tools|turbo)\/.*\/dist\/.*\.m?js$/;
+const clientDistConditions = ['module', 'browser'];
+const serverDistConditions = ['node'];
+const serverModuleDistConditions = ['module', 'node'];
+const externalDistConditions = ['node', 'module-sync'];
+const workspacePackageRoots = ['apps', 'e2e', 'libs', 'tools', 'infra', 'turbo'];
+const esmOptimizerPackages = [
+  {dependencyName: '@opentelemetry/api', optimizerName: '@opentelemetry/api'},
+  {dependencyName: '@opentelemetry/core', optimizerName: '@opentelemetry/core'},
+];
+const esmOptimizerInlinePattern = /@opentelemetry\/(?:api|core)/;
+let cachedWorkspacePackageNames: string[] | undefined;
+
+function getDirectDependencyNames(projectRoot: string | undefined): Set<string> {
+  if (!projectRoot) return new Set();
+
+  const packageJsonPath = join(projectRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) return new Set();
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as PackageJson;
+  return new Set([
+    ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.devDependencies || {}),
+    ...Object.keys(packageJson.optionalDependencies || {}),
+    ...Object.keys(packageJson.peerDependencies || {}),
+  ]);
+}
+
+function collectWorkspacePackageNames(dir: string, names: Set<string>): void {
+  const packageJsonPath = join(dir, 'package.json');
+  if (existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {name?: string};
+    if (packageJson.name?.startsWith('@shipfox/')) names.add(packageJson.name);
+    return;
+  }
+
+  if (!existsSync(dir)) return;
+
+  for (const entry of readdirSync(dir, {withFileTypes: true})) {
+    if (!entry.isDirectory() || entry.name === 'node_modules') continue;
+    collectWorkspacePackageNames(join(dir, entry.name), names);
+  }
+}
+
+function getWorkspacePackageNames(): string[] {
+  if (cachedWorkspacePackageNames) return cachedWorkspacePackageNames;
+
+  const names = new Set<string>();
+  const workspaceRoot = getWorkspaceRootPath();
+  for (const packageRoot of workspacePackageRoots) {
+    collectWorkspacePackageNames(join(workspaceRoot, packageRoot), names);
+  }
+
+  cachedWorkspacePackageNames = Array.from(names).sort();
+  return cachedWorkspacePackageNames;
+}
+
+function getResolvableEsmOptimizerPackageNames(directDependencyNames: Set<string>): string[] {
+  return esmOptimizerPackages.flatMap(({dependencyName, optimizerName}) =>
+    directDependencyNames.has(dependencyName) ? [optimizerName] : [],
+  );
+}
+
+function getServerExcludedConditions(directDependencyNames: Set<string>): string[] {
+  return directDependencyNames.has('@opentelemetry/api') ||
+    directDependencyNames.has('@opentelemetry/core')
+    ? []
+    : ['module'];
+}
+
+function getServerFallbackConditions(serverExcludedConditions: string[]): string[] {
+  return serverExcludedConditions.includes('module')
+    ? serverDistConditions
+    : serverModuleDistConditions;
+}
+
+function mergeServerConditions(
+  conditions: string[] | undefined,
+  fallbackConditions: string[],
+  excludedConditions: string[],
+): string[] {
+  return mergeConditions(conditions, fallbackConditions, excludedConditions);
+}
+
+// Vite owns separate resolvers for environments such as `client` and `ssr`, so
+// top-level `resolve`/`ssr.resolve` settings are not enough for workspace projects.
+function createWorkspaceDistResolutionPlugin(
+  packageNames: string[],
+  projectRoot: string | undefined,
+  serverExcludedConditions: string[],
+) {
+  return {
+    name: 'shipfox-vitest-workspace-dist-resolution',
+    configEnvironment(name: string, environmentConfig: EnvironmentConfig) {
+      const resolveConfig = environmentConfig.resolve || {};
+      const fallbackConditions =
+        name === 'client'
+          ? clientDistConditions
+          : getServerFallbackConditions(serverExcludedConditions);
+
+      environmentConfig.resolve = {
+        ...resolveConfig,
+        alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),
+        conditions:
+          name === 'client'
+            ? mergeConditions(resolveConfig.conditions, fallbackConditions)
+            : mergeServerConditions(
+                resolveConfig.conditions,
+                fallbackConditions,
+                serverExcludedConditions,
+              ),
+        externalConditions: mergeConditions(
+          resolveConfig.externalConditions,
+          externalDistConditions,
+        ),
+        external: mergeExternalPackages(resolveConfig.external, packageNames),
+      };
+    },
+  };
+}
+
+// OpenTelemetry's `module` entry currently reaches extensionless ESM imports
+// that Node cannot load directly. Direct dependants can let Vite optimize that
+// ESM graph, but downstream packages need the Node/default condition instead.
+function createOpenTelemetrySsrPolicy(projectRoot: string | undefined) {
+  const directDependencyNames = getDirectDependencyNames(projectRoot);
+  const optimizerIncludes = getResolvableEsmOptimizerPackageNames(directDependencyNames);
+  const serverExcludedConditions = getServerExcludedConditions(directDependencyNames);
+
+  return {
+    optimizerIncludes,
+    serverExcludedConditions,
+    serverFallbackConditions: getServerFallbackConditions(serverExcludedConditions),
+  };
+}
+
+// CI points Shipfox workspace dependencies at built `dist` exports so package
+// tests catch the same public-contract breakages that downstream consumers see.
+export function createWorkspaceDistConfig(
+  config: MergeableConfigInput,
+  projectRoot: string | undefined,
+) {
+  const workspacePackageNames = getWorkspacePackageNames();
+  const openTelemetrySsrPolicy = createOpenTelemetrySsrPolicy(projectRoot);
+  const resolveConfig = config.resolve || {};
+  const ssrConfig = config.ssr || {};
+  const ssrResolveConfig = ssrConfig.resolve || {};
+  const testConfig = config.test || {};
+  const testDepsConfig = testConfig.deps || {};
+  const testDepsOptimizerConfig = testDepsConfig.optimizer || {};
+  const testDepsSsrOptimizerConfig = testDepsOptimizerConfig.ssr || {};
+  const testServerConfig = testConfig.server || {};
+  const testServerDepsConfig = testServerConfig.deps || {};
+
+  return {
+    plugins: [
+      createWorkspaceDistResolutionPlugin(
+        workspacePackageNames,
+        projectRoot,
+        openTelemetrySsrPolicy.serverExcludedConditions,
+      ),
+    ],
+    resolve: {
+      ...resolveConfig,
+      alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),
+      conditions: mergeConditions(resolveConfig.conditions, clientDistConditions),
+      externalConditions: mergeConditions(resolveConfig.externalConditions, externalDistConditions),
+      external: mergeExternalPackages(resolveConfig.external, workspacePackageNames),
+    },
+    ssr: {
+      ...ssrConfig,
+      external: mergeExternalPackages(ssrConfig.external, workspacePackageNames),
+      resolve: {
+        ...ssrResolveConfig,
+        conditions: mergeServerConditions(
+          ssrResolveConfig.conditions,
+          openTelemetrySsrPolicy.serverFallbackConditions,
+          openTelemetrySsrPolicy.serverExcludedConditions,
+        ),
+        externalConditions: mergeConditions(
+          ssrResolveConfig.externalConditions,
+          externalDistConditions,
+        ),
+      },
+    },
+    test: {
+      deps: {
+        ...testDepsConfig,
+        optimizer: {
+          ...testDepsOptimizerConfig,
+          ssr: {
+            ...testDepsSsrOptimizerConfig,
+            enabled: true,
+            include: mergeStringList(
+              testDepsSsrOptimizerConfig.include,
+              openTelemetrySsrPolicy.optimizerIncludes,
+            ),
+          },
+        },
+      },
+      server: {
+        ...testServerConfig,
+        deps: {
+          ...testServerDepsConfig,
+          external: [
+            ...(testServerDepsConfig.external || []),
+            workspacePackagePattern,
+            workspaceDistFilePattern,
+          ],
+          inline: mergeInlineDeps(testServerDepsConfig.inline, [esmOptimizerInlinePattern]),
+        },
+      },
+    },
+  };
+}

--- a/tools/vitest/src/workspace-dist-resolution.ts
+++ b/tools/vitest/src/workspace-dist-resolution.ts
@@ -1,5 +1,5 @@
 import {existsSync, readdirSync, readFileSync} from 'node:fs';
-import {join} from 'node:path';
+import {dirname, isAbsolute, join, relative, resolve} from 'node:path';
 import {getWorkspaceRootPath} from '@shipfox/tool-utils';
 import {
   mergeConditions,
@@ -8,10 +8,18 @@ import {
   mergeProjectSourceAliases,
   mergeStringList,
 } from './config-merge.js';
-import type {EnvironmentConfig, MergeableConfigInput, PackageJson} from './config-types.js';
+import type {
+  EnvironmentConfig,
+  MergeableConfigFragment,
+  MergeableConfigInput,
+  PackageJson,
+} from './config-types.js';
 
 const workspacePackagePattern = /^@shipfox\/.+/;
 const workspaceDistFilePattern = /\/(?:apps|e2e|infra|libs|tools|turbo)\/.*\/dist\/.*\.m?js$/;
+const workspaceDistInternalImportPattern = /^#\/?(.+)$/;
+const workspaceDistInternalImportSpecifierPattern = /(['"])#\/?([^'"]+)\1/g;
+const viteFsPrefix = '/@fs';
 const clientDistConditions = ['module', 'browser'];
 const serverDistConditions = ['node'];
 const serverModuleDistConditions = ['module', 'node'];
@@ -23,6 +31,13 @@ const esmOptimizerPackages = [
 ];
 const esmOptimizerInlinePattern = /@opentelemetry\/(?:api|core)/;
 let cachedWorkspacePackageNames: string[] | undefined;
+
+type WorkspaceDistInternalImportResolverPlugin = {
+  name: string;
+  enforce: 'pre';
+  resolveId(source: string, importer?: string): string | undefined;
+  transform(code: string, id: string): string | undefined;
+};
 
 function getDirectDependencyNames(projectRoot: string | undefined): Set<string> {
   if (!projectRoot) return new Set();
@@ -95,6 +110,100 @@ function mergeServerConditions(
   return mergeConditions(conditions, fallbackConditions, excludedConditions);
 }
 
+function normalizeImporterPath(
+  importer: string | undefined,
+  projectRoot: string | undefined,
+): string | undefined {
+  const importerPath = importer?.split('?')[0];
+  if (!importerPath) return undefined;
+
+  const filePath = importerPath.startsWith(`${viteFsPrefix}/`)
+    ? importerPath.slice(viteFsPrefix.length)
+    : importerPath;
+
+  return isAbsolute(filePath) || !projectRoot ? filePath : resolve(projectRoot, filePath);
+}
+
+function findWorkspacePackageRoot(filePath: string): string | undefined {
+  const workspaceRoot = getWorkspaceRootPath();
+  let currentDir = dirname(filePath);
+
+  while (currentDir.startsWith(workspaceRoot)) {
+    if (existsSync(join(currentDir, 'package.json'))) return currentDir;
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) return undefined;
+    currentDir = parentDir;
+  }
+
+  return undefined;
+}
+
+function resolveWorkspaceDistInternalImport(
+  source: string,
+  importer: string | undefined,
+  projectRoot: string | undefined,
+): string | undefined {
+  if (source.startsWith('#test/')) return undefined;
+
+  const sourceMatch = workspaceDistInternalImportPattern.exec(source);
+  const importerPath = normalizeImporterPath(importer, projectRoot);
+  if (!sourceMatch || !importerPath || !workspaceDistFilePattern.test(importerPath)) {
+    return undefined;
+  }
+
+  const importPath = sourceMatch[1];
+  if (!importPath) return undefined;
+
+  const packageRoot = findWorkspacePackageRoot(importerPath);
+  if (!packageRoot) return undefined;
+
+  return join(packageRoot, 'dist', importPath);
+}
+
+function toRelativeImportPath(importerPath: string, resolvedPath: string): string {
+  const importPath = relative(dirname(importerPath), resolvedPath).replaceAll('\\', '/');
+  return importPath.startsWith('.') ? importPath : `./${importPath}`;
+}
+
+function rewriteWorkspaceDistInternalImports(
+  code: string,
+  id: string,
+  projectRoot: string | undefined,
+): string | undefined {
+  const importerPath = normalizeImporterPath(id, projectRoot);
+  if (!importerPath || !workspaceDistFilePattern.test(importerPath)) return undefined;
+
+  let rewritten = false;
+  const output = code.replace(
+    workspaceDistInternalImportSpecifierPattern,
+    (match, quote: string, importPath: string) => {
+      const resolvedPath = resolveWorkspaceDistInternalImport(`#${importPath}`, id, projectRoot);
+      if (!resolvedPath) return match;
+
+      rewritten = true;
+      return `${quote}${toRelativeImportPath(importerPath, resolvedPath)}${quote}`;
+    },
+  );
+
+  return rewritten ? output : undefined;
+}
+
+export function createWorkspaceDistInternalImportResolverPlugin(
+  projectRoot: string | undefined,
+): WorkspaceDistInternalImportResolverPlugin {
+  return {
+    name: 'shipfox-vitest-workspace-dist-internal-imports',
+    enforce: 'pre',
+    resolveId(source: string, importer: string | undefined) {
+      return resolveWorkspaceDistInternalImport(source, importer, projectRoot);
+    },
+    transform(code: string, id: string) {
+      return rewriteWorkspaceDistInternalImports(code, id, projectRoot);
+    },
+  };
+}
+
 // Vite owns separate resolvers for environments such as `client` and `ssr`, so
 // top-level `resolve`/`ssr.resolve` settings are not enough for workspace projects.
 function createWorkspaceDistResolutionPlugin(
@@ -104,6 +213,13 @@ function createWorkspaceDistResolutionPlugin(
 ) {
   return {
     name: 'shipfox-vitest-workspace-dist-resolution',
+    enforce: 'pre',
+    resolveId(source: string, importer: string | undefined) {
+      return resolveWorkspaceDistInternalImport(source, importer, projectRoot);
+    },
+    transform(code: string, id: string) {
+      return rewriteWorkspaceDistInternalImports(code, id, projectRoot);
+    },
     configEnvironment(name: string, environmentConfig: EnvironmentConfig) {
       const resolveConfig = environmentConfig.resolve || {};
       const fallbackConditions =
@@ -132,6 +248,10 @@ function createWorkspaceDistResolutionPlugin(
   };
 }
 
+function mergeRolldownPlugins(existing: unknown[] | undefined, plugins: unknown[]): unknown[] {
+  return [...(existing || []), ...plugins];
+}
+
 // OpenTelemetry's `module` entry currently reaches extensionless ESM imports
 // that Node cannot load directly. Direct dependants can let Vite optimize that
 // ESM graph, but downstream packages need the Node/default condition instead.
@@ -152,7 +272,7 @@ function createOpenTelemetrySsrPolicy(projectRoot: string | undefined) {
 export function createWorkspaceDistConfig(
   config: MergeableConfigInput,
   projectRoot: string | undefined,
-) {
+): MergeableConfigFragment {
   const workspacePackageNames = getWorkspacePackageNames();
   const openTelemetrySsrPolicy = createOpenTelemetrySsrPolicy(projectRoot);
   const resolveConfig = config.resolve || {};
@@ -164,6 +284,8 @@ export function createWorkspaceDistConfig(
   const testDepsSsrOptimizerConfig = testDepsOptimizerConfig.ssr || {};
   const testServerConfig = testConfig.server || {};
   const testServerDepsConfig = testServerConfig.deps || {};
+  const optimizeDepsConfig = config.optimizeDeps || {};
+  const optimizeDepsRolldownOptionsConfig = optimizeDepsConfig.rolldownOptions || {};
 
   return {
     plugins: [
@@ -173,6 +295,15 @@ export function createWorkspaceDistConfig(
         openTelemetrySsrPolicy.serverExcludedConditions,
       ),
     ],
+    optimizeDeps: {
+      ...optimizeDepsConfig,
+      rolldownOptions: {
+        ...optimizeDepsRolldownOptionsConfig,
+        plugins: mergeRolldownPlugins(optimizeDepsRolldownOptionsConfig.plugins, [
+          createWorkspaceDistInternalImportResolverPlugin(projectRoot),
+        ]),
+      },
+    },
     resolve: {
       ...resolveConfig,
       alias: mergeProjectSourceAliases(resolveConfig.alias, projectRoot),

--- a/tools/vitest/src/workspace-dist-resolution.ts
+++ b/tools/vitest/src/workspace-dist-resolution.ts
@@ -84,16 +84,20 @@ function getWorkspacePackageNames(): string[] {
 }
 
 function getResolvableEsmOptimizerPackageNames(directDependencyNames: Set<string>): string[] {
-  return esmOptimizerPackages.flatMap(({dependencyName, optimizerName}) =>
-    directDependencyNames.has(dependencyName) ? [optimizerName] : [],
-  );
+  if (!hasDirectOpenTelemetryEsmGraph(directDependencyNames)) return [];
+
+  return esmOptimizerPackages.map(({optimizerName}) => optimizerName);
 }
 
 function getServerExcludedConditions(directDependencyNames: Set<string>): string[] {
-  return directDependencyNames.has('@opentelemetry/api') ||
+  return hasDirectOpenTelemetryEsmGraph(directDependencyNames) ? [] : ['module'];
+}
+
+function hasDirectOpenTelemetryEsmGraph(directDependencyNames: Set<string>): boolean {
+  return (
+    directDependencyNames.has('@opentelemetry/api') &&
     directDependencyNames.has('@opentelemetry/core')
-    ? []
-    : ['module'];
+  );
 }
 
 function getServerFallbackConditions(serverExcludedConditions: string[]): string[] {

--- a/tools/vitest/test/config.test.ts
+++ b/tools/vitest/test/config.test.ts
@@ -1,3 +1,4 @@
+import {fileURLToPath} from 'node:url';
 import {afterEach, describe, expect, it} from 'vitest';
 import {defineConfig} from '../src/config.js';
 
@@ -8,6 +9,9 @@ const esmOptimizerInlinePattern = /@opentelemetry\/(?:api|core)/;
 const projectRootSlashImportPattern = /^#\/(.+)$/;
 const projectRootImportPattern = /^#(?!test\/)(.+)$/;
 const vitestSrcReplacementPattern = /\/tools\/vitest\/src\/\$1$/;
+const reactUiDistThemePathPattern = /\/libs\/shared\/react\/ui\/dist\/state\/theme\.js$/;
+const existingProjectPlugin = {name: 'existing-project-plugin'};
+const existingRolldownPlugin = {name: 'existing-rolldown-plugin'};
 const nodeOpentelemetryConfigUrl = new URL(
   '../../../libs/shared/node/opentelemetry/vitest.config.ts',
   import.meta.url,
@@ -16,6 +20,13 @@ const runnerProtocolConfigUrl = new URL(
   '../../../libs/runner/protocol/vitest.config.ts',
   import.meta.url,
 ).href;
+const clientLogsConfigUrl = new URL('../../../libs/client/logs/vitest.config.ts', import.meta.url)
+  .href;
+const reactUiDistThemeProviderPath = fileURLToPath(
+  new URL('../../../libs/shared/react/ui/dist/components/theme/theme-provider.js', import.meta.url),
+);
+const relativeReactUiDistThemeProviderPath =
+  '../../shared/react/ui/dist/components/theme/theme-provider.js';
 
 describe('defineConfig', () => {
   const originalCi = process.env.CI;
@@ -66,7 +77,21 @@ describe('defineConfig', () => {
             conditions: ['module', 'node', 'development|production', 'custom-ssr'],
           },
         },
+        optimizeDeps: {
+          rolldownOptions: {
+            plugins: [existingRolldownPlugin],
+          },
+        },
         test: {
+          projects: [
+            {
+              extends: true,
+              plugins: [existingProjectPlugin],
+              test: {
+                name: 'storybook',
+              },
+            },
+          ],
           deps: {
             optimizer: {
               ssr: {
@@ -86,6 +111,8 @@ describe('defineConfig', () => {
     ) as {
       plugins?: Array<{
         name?: string;
+        resolveId?: (source: string, importer?: string) => string | undefined;
+        transform?: (code: string, id: string) => string | undefined;
         configEnvironment?: (
           name: string,
           config: {resolve?: {alias?: Array<{find: RegExp}>; conditions?: string[]}},
@@ -104,8 +131,23 @@ describe('defineConfig', () => {
           externalConditions?: string[];
         };
       };
+      optimizeDeps?: {
+        rolldownOptions?: {
+          checks?: Record<string, unknown>;
+          plugins?: Array<{
+            name?: string;
+            resolveId?: (source: string, importer?: string) => string | undefined;
+            transform?: (code: string, id: string) => string | undefined;
+          }>;
+        };
+      };
       test?: {
         maxWorkers?: number;
+        projects?: Array<{
+          plugins?: Array<{
+            name?: string;
+          }>;
+        }>;
         deps?: {
           optimizer?: {
             ssr?: {
@@ -119,6 +161,9 @@ describe('defineConfig', () => {
     };
     const workspaceDistPlugin = config.plugins?.find(
       (plugin) => plugin.name === 'shipfox-vitest-workspace-dist-resolution',
+    );
+    const optimizerResolverPlugin = config.optimizeDeps?.rolldownOptions?.plugins?.find(
+      (plugin) => plugin.name === 'shipfox-vitest-workspace-dist-internal-imports',
     );
     const environmentConfig: {
       resolve: {alias?: Array<{find: RegExp}>; conditions: string[]};
@@ -141,6 +186,17 @@ describe('defineConfig', () => {
     expect(config.ssr?.external).toContain('existing-ssr-package');
     expect(config.ssr?.external).toContain('@shipfox/vitest');
     expect(config.ssr?.external).toContain('@shipfox/react-ui');
+    expect(config.optimizeDeps?.rolldownOptions?.checks).toEqual({
+      pluginTimings: false,
+    });
+    expect(config.optimizeDeps?.rolldownOptions?.plugins?.[0]).toBe(existingRolldownPlugin);
+    expect(optimizerResolverPlugin).toBeDefined();
+    expect(config.test?.projects?.[0]?.plugins?.[0]).toBe(existingProjectPlugin);
+    expect(
+      config.test?.projects?.[0]?.plugins?.some(
+        (plugin) => plugin.name === 'shipfox-vitest-workspace-dist-resolution',
+      ),
+    ).toBe(true);
     expect(config.test?.server?.deps?.external).toEqual([
       existingExternalPattern,
       workspaceExternalPattern,
@@ -151,14 +207,53 @@ describe('defineConfig', () => {
       esmOptimizerInlinePattern,
     ]);
     expect(config.test?.deps?.optimizer?.ssr?.enabled).toBe(true);
-    expect(config.test?.deps?.optimizer?.ssr?.include).toEqual([
-      'existing-optimizer-package',
-    ]);
+    expect(config.test?.deps?.optimizer?.ssr?.include).toEqual(['existing-optimizer-package']);
     expect(config.test?.maxWorkers).toBe(2);
     workspaceDistPlugin?.configEnvironment?.('ssr', environmentConfig);
     expect(environmentConfig.resolve.alias?.[0]?.find).toEqual(projectRootSlashImportPattern);
     expect(environmentConfig.resolve.alias?.[1]?.find).toEqual(projectRootImportPattern);
     expect(environmentConfig.resolve.conditions).toEqual(['custom-env', 'node']);
+    expect(
+      workspaceDistPlugin?.resolveId?.('#state/theme.js', reactUiDistThemeProviderPath),
+    ).toMatch(reactUiDistThemePathPattern);
+    expect(
+      workspaceDistPlugin?.resolveId?.('#state/theme.js', `/@fs${reactUiDistThemeProviderPath}`),
+    ).toMatch(reactUiDistThemePathPattern);
+    expect(
+      workspaceDistPlugin?.transform?.(
+        'import { ThemeProviderContext } from "#state/theme.js";',
+        reactUiDistThemeProviderPath,
+      ),
+    ).toBe('import { ThemeProviderContext } from "../../state/theme.js";');
+  });
+
+  it('resolves built workspace package internals during optimizer scans', () => {
+    process.env.CI = 'true';
+
+    const config = defineConfig({}, clientLogsConfigUrl) as {
+      optimizeDeps?: {
+        rolldownOptions?: {
+          plugins?: Array<{
+            name?: string;
+            resolveId?: (source: string, importer?: string) => string | undefined;
+            transform?: (code: string, id: string) => string | undefined;
+          }>;
+        };
+      };
+    };
+    const optimizerResolverPlugin = config.optimizeDeps?.rolldownOptions?.plugins?.find(
+      (plugin) => plugin.name === 'shipfox-vitest-workspace-dist-internal-imports',
+    );
+
+    expect(
+      optimizerResolverPlugin?.resolveId?.('#state/theme.js', relativeReactUiDistThemeProviderPath),
+    ).toMatch(reactUiDistThemePathPattern);
+    expect(
+      optimizerResolverPlugin?.transform?.(
+        'import { ThemeProviderContext } from "#state/theme.js";',
+        relativeReactUiDistThemeProviderPath,
+      ),
+    ).toBe('import { ThemeProviderContext } from "../../state/theme.js";');
   });
 
   it('optimizes direct OpenTelemetry dependencies when a package lists them', () => {

--- a/tools/vitest/test/config.test.ts
+++ b/tools/vitest/test/config.test.ts
@@ -1,0 +1,210 @@
+import {afterEach, describe, expect, it} from 'vitest';
+import {defineConfig} from '../src/config.js';
+
+const existingExternalPattern = /^existing$/;
+const workspaceExternalPattern = /^@shipfox\/.+/;
+const workspaceDistFilePattern = /\/(?:apps|e2e|infra|libs|tools|turbo)\/.*\/dist\/.*\.m?js$/;
+const esmOptimizerInlinePattern = /@opentelemetry\/(?:api|core)/;
+const projectRootSlashImportPattern = /^#\/(.+)$/;
+const projectRootImportPattern = /^#(?!test\/)(.+)$/;
+const vitestSrcReplacementPattern = /\/tools\/vitest\/src\/\$1$/;
+const nodeOpentelemetryConfigUrl = new URL(
+  '../../../libs/shared/node/opentelemetry/vitest.config.ts',
+  import.meta.url,
+).href;
+const runnerProtocolConfigUrl = new URL(
+  '../../../libs/runner/protocol/vitest.config.ts',
+  import.meta.url,
+).href;
+
+describe('defineConfig', () => {
+  const originalCi = process.env.CI;
+  const originalMaxWorkers = process.env.SHIPFOX_VITEST_MAX_WORKERS;
+
+  afterEach(() => {
+    if (originalCi === undefined) delete process.env.CI;
+    else process.env.CI = originalCi;
+
+    if (originalMaxWorkers === undefined) delete process.env.SHIPFOX_VITEST_MAX_WORKERS;
+    else process.env.SHIPFOX_VITEST_MAX_WORKERS = originalMaxWorkers;
+  });
+
+  it('keeps local runs on the default workspace source resolution path', () => {
+    delete process.env.CI;
+
+    const config = defineConfig({
+      test: {
+        server: {
+          deps: {
+            external: [existingExternalPattern],
+          },
+        },
+      },
+    }) as {
+      resolve?: {alias?: unknown; conditions?: string[]; external?: string[] | true};
+      test?: {server?: {deps?: {external?: unknown[]}}};
+    };
+
+    expect(config.resolve?.alias).toBeUndefined();
+    expect(config.resolve?.conditions).toBeUndefined();
+    expect(config.resolve?.external).toBeUndefined();
+    expect(config.test?.server?.deps?.external).toEqual([existingExternalPattern]);
+  });
+
+  it('resolves Shipfox workspace dependencies through built package exports on CI', () => {
+    process.env.CI = 'true';
+    process.env.SHIPFOX_VITEST_MAX_WORKERS = '2';
+
+    const config = defineConfig(
+      {
+        resolve: {
+          conditions: ['module', 'browser', 'development', 'custom'],
+        },
+        ssr: {
+          external: ['existing-ssr-package'],
+          resolve: {
+            conditions: ['module', 'node', 'development|production', 'custom-ssr'],
+          },
+        },
+        test: {
+          deps: {
+            optimizer: {
+              ssr: {
+                include: ['existing-optimizer-package'],
+              },
+            },
+          },
+          server: {
+            deps: {
+              external: [existingExternalPattern],
+              inline: ['existing-inline-package'],
+            },
+          },
+        },
+      },
+      import.meta.url,
+    ) as {
+      plugins?: Array<{
+        name?: string;
+        configEnvironment?: (
+          name: string,
+          config: {resolve?: {alias?: Array<{find: RegExp}>; conditions?: string[]}},
+        ) => void;
+      }>;
+      resolve?: {
+        alias?: Array<{find: RegExp; replacement: string}>;
+        conditions?: string[];
+        externalConditions?: string[];
+        external?: string[] | true;
+      };
+      ssr?: {
+        external?: string[] | true;
+        resolve?: {
+          conditions?: string[];
+          externalConditions?: string[];
+        };
+      };
+      test?: {
+        maxWorkers?: number;
+        deps?: {
+          optimizer?: {
+            ssr?: {
+              enabled?: boolean;
+              include?: string[];
+            };
+          };
+        };
+        server?: {deps?: {external?: unknown[]; inline?: unknown[] | true}};
+      };
+    };
+    const workspaceDistPlugin = config.plugins?.find(
+      (plugin) => plugin.name === 'shipfox-vitest-workspace-dist-resolution',
+    );
+    const environmentConfig: {
+      resolve: {alias?: Array<{find: RegExp}>; conditions: string[]};
+    } = {
+      resolve: {
+        conditions: ['custom-env', 'development|production'],
+      },
+    };
+
+    expect(config.resolve?.alias?.[0]?.find).toEqual(projectRootSlashImportPattern);
+    expect(config.resolve?.alias?.[0]?.replacement).toMatch(vitestSrcReplacementPattern);
+    expect(config.resolve?.alias?.[1]?.find).toEqual(projectRootImportPattern);
+    expect(config.resolve?.alias?.[1]?.replacement).toMatch(vitestSrcReplacementPattern);
+    expect(config.resolve?.conditions).toEqual(['module', 'browser', 'custom']);
+    expect(config.resolve?.externalConditions).toEqual(['node', 'module-sync']);
+    expect(config.resolve?.external).toContain('@shipfox/vitest');
+    expect(config.resolve?.external).toContain('@shipfox/react-ui');
+    expect(config.ssr?.resolve?.conditions).toEqual(['node', 'custom-ssr']);
+    expect(config.ssr?.resolve?.externalConditions).toEqual(['node', 'module-sync']);
+    expect(config.ssr?.external).toContain('existing-ssr-package');
+    expect(config.ssr?.external).toContain('@shipfox/vitest');
+    expect(config.ssr?.external).toContain('@shipfox/react-ui');
+    expect(config.test?.server?.deps?.external).toEqual([
+      existingExternalPattern,
+      workspaceExternalPattern,
+      workspaceDistFilePattern,
+    ]);
+    expect(config.test?.server?.deps?.inline).toEqual([
+      'existing-inline-package',
+      esmOptimizerInlinePattern,
+    ]);
+    expect(config.test?.deps?.optimizer?.ssr?.enabled).toBe(true);
+    expect(config.test?.deps?.optimizer?.ssr?.include).toEqual([
+      'existing-optimizer-package',
+    ]);
+    expect(config.test?.maxWorkers).toBe(2);
+    workspaceDistPlugin?.configEnvironment?.('ssr', environmentConfig);
+    expect(environmentConfig.resolve.alias?.[0]?.find).toEqual(projectRootSlashImportPattern);
+    expect(environmentConfig.resolve.alias?.[1]?.find).toEqual(projectRootImportPattern);
+    expect(environmentConfig.resolve.conditions).toEqual(['custom-env', 'node']);
+  });
+
+  it('optimizes direct OpenTelemetry dependencies when a package lists them', () => {
+    process.env.CI = 'true';
+
+    const config = defineConfig({}, nodeOpentelemetryConfigUrl) as {
+      test?: {
+        deps?: {
+          optimizer?: {
+            ssr?: {
+              enabled?: boolean;
+              include?: string[];
+            };
+          };
+        };
+        server?: {deps?: {inline?: unknown[] | true}};
+      };
+    };
+
+    expect(config.test?.server?.deps?.inline).toEqual([esmOptimizerInlinePattern]);
+    expect(config.test?.deps?.optimizer?.ssr?.enabled).toBe(true);
+    expect(config.test?.deps?.optimizer?.ssr?.include).toEqual([
+      '@opentelemetry/api',
+      '@opentelemetry/core',
+    ]);
+  });
+
+  it('does not optimize transitive OpenTelemetry dependencies from downstream packages', () => {
+    process.env.CI = 'true';
+
+    const config = defineConfig({}, runnerProtocolConfigUrl) as {
+      test?: {
+        deps?: {
+          optimizer?: {
+            ssr?: {
+              enabled?: boolean;
+              include?: string[];
+            };
+          };
+        };
+        server?: {deps?: {inline?: unknown[] | true}};
+      };
+    };
+
+    expect(config.test?.server?.deps?.inline).toEqual([esmOptimizerInlinePattern]);
+    expect(config.test?.deps?.optimizer?.ssr?.enabled).toBe(true);
+    expect(config.test?.deps?.optimizer?.ssr?.include).toEqual([]);
+  });
+});

--- a/tools/vitest/test/config.test.ts
+++ b/tools/vitest/test/config.test.ts
@@ -20,6 +20,7 @@ const runnerProtocolConfigUrl = new URL(
   '../../../libs/runner/protocol/vitest.config.ts',
   import.meta.url,
 ).href;
+const apiAgentConfigUrl = new URL('../../../libs/api/agent/vitest.config.ts', import.meta.url).href;
 const clientLogsConfigUrl = new URL('../../../libs/client/logs/vitest.config.ts', import.meta.url)
   .href;
 const reactUiDistThemeProviderPath = fileURLToPath(
@@ -298,6 +299,34 @@ describe('defineConfig', () => {
       };
     };
 
+    expect(config.test?.server?.deps?.inline).toEqual([esmOptimizerInlinePattern]);
+    expect(config.test?.deps?.optimizer?.ssr?.enabled).toBe(true);
+    expect(config.test?.deps?.optimizer?.ssr?.include).toEqual([]);
+  });
+
+  it('keeps partial direct OpenTelemetry dependencies on Node conditions', () => {
+    process.env.CI = 'true';
+
+    const config = defineConfig({}, apiAgentConfigUrl) as {
+      ssr?: {
+        resolve?: {
+          conditions?: string[];
+        };
+      };
+      test?: {
+        deps?: {
+          optimizer?: {
+            ssr?: {
+              enabled?: boolean;
+              include?: string[];
+            };
+          };
+        };
+        server?: {deps?: {inline?: unknown[] | true}};
+      };
+    };
+
+    expect(config.ssr?.resolve?.conditions).toEqual(['node']);
     expect(config.test?.server?.deps?.inline).toEqual([esmOptimizerInlinePattern]);
     expect(config.test?.deps?.optimizer?.ssr?.enabled).toBe(true);
     expect(config.test?.deps?.optimizer?.ssr?.include).toEqual([]);


### PR DESCRIPTION
Resolve CI Vitest workspace dependency imports through built package output instead of re-importing source for each test file.

The client RTL suites were paying most of their time in repeated workspace source imports. Turbo already builds package dependencies before test tasks, so CI can use the built `dist` package graph and externalize `@shipfox/*` packages for native Node loading. Local runs keep the existing source-first path for watch-mode cross-package editing.

Package `#*` import maps now route TypeScript and development resolution to `src`, while default runtime resolution points to `dist`. The shared Vitest config strips Vite's development conditions on CI, externalizes workspace packages, and patches Vite environment defaults that otherwise reintroduce source resolution. `@shipfox/client-workflows` also opts its DOM project into `isolate: false`, with the affected order-dependent tests hardened.

Representative CI-mode `@shipfox/client-workflows` DOM run now reports `142 passed` with `import 2.71s`.

Review the shared resolver and package import-map shape carefully; those are the broadest behavioral surfaces in this PR.

Fixes ENG-738

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CI Vitest by resolving workspace deps from built `dist` and externalizing `@shipfox/*` and workspace `dist` for native Node. Local runs keep source-first; Storybook CI uses the same resolver for internal `#` imports. Fixes ENG-738.

- **Refactors**
  - Converted `"#*"` import maps to conditional: `types`/`development` -> `./src/*`, `default` -> `./dist/*`; aligned remaining e2e helpers and updated CONTRIBUTING; added project-root `#`/`#/` aliases and updated `@shipfox/client-auth` imports to `#components/*`.
  - CI-only `@shipfox/vitest` externalizes workspace packages, merges client/SSR resolve conditions, and is split into focused helpers; packages that only depend on `@opentelemetry/api` stay on Node/default resolution.
  - Storybook on CI installs the same workspace-dist internal import resolver so browser Vite servers resolve `#` imports to built output.
  - Hardened CI dist mode: keep asset-heavy `@shipfox/react-ui/logo` mocked, inject a diagnostics logger in workflow tests, read live `AUTH_JOB_LEASE_TOKEN_EXPIRES_IN` for logs TTL validation, stabilize order-sensitive DOM tests by mocking element widths, and add `SHIPFOX_VITEST_MAX_WORKERS`.

<sup>Written for commit adcbaa88ee98631935b5be27e6ec1fbaeda862fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

