### PR TITLE
Fix demo gate workflow expressions

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/gates.yml
@@ -25,7 +25,7 @@ jobs:
           fi
           echo "First gate passed"
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
           on_failure:
             restart_from: first-setup
             output: First gate failed once; retrying from first setup.
@@ -43,7 +43,7 @@ jobs:
           fi
           echo "Second gate passed"
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
           on_failure:
             restart_from: second-setup
             output: Second gate failed once; retrying from second setup.
@@ -63,7 +63,7 @@ jobs:
           fi
           echo "Third gate passed on attempt $attempts"
         gate:
-          success_if: exit_code == 0
+          success_if: step.exit_code == 0
           on_failure:
             restart_from: second-setup
             output: Third gate failed; retrying from second setup.


### PR DESCRIPTION
Fix the bundled Gitea demo gate workflow so its `success_if` expressions match the step gate CEL context.

The workflow used `exit_code == 0`, but gate expressions are type-checked against the `step` root. This caused the demo seed workflow to fail validation with `Step gate success_if must be a valid CEL boolean expression`. Updating the expressions to `step.exit_code == 0` keeps the demo aligned with the workflow model contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Gitea demo gate workflow to use `step.exit_code` in `success_if` expressions. This resolves CEL validation errors and aligns the demo with the step gate context.

<sup>Written for commit b11a4216c63a1e4a15e7f6b22f48c3d056bac9fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

