### PR TITLE
[client-secrets] Add Vercel Storybook config

### DIFF
--- a/libs/client/secrets/vercel.json
+++ b/libs/client/secrets/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo build && pnpm run storybook:build",
+  "devCommand": "pnpm run storybook",
+  "installCommand": "pnpm install",
+  "framework": null,
+  "outputDirectory": "./storybook-static"
+}


### PR DESCRIPTION
Add a package-level Vercel config for `@shipfox/client-secrets` so its Storybook can be deployed the same way as the other client feature packages.

The config uses the existing client package pattern: install with pnpm, build the Turbo package graph, build Storybook, and serve `storybook-static` from Vercel.

No changeset is included because this is deploy configuration for a private package and does not change the package API or runtime behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Vercel config to deploy Storybook for `@shipfox/client-secrets`, consistent with other client packages. Installs with `pnpm`, runs `turbo build` then `pnpm run storybook:build`, and serves `./storybook-static`; no runtime or API changes.

<sup>Written for commit 214ce92ff6f4966466637bbb1dcaad40edfd779f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

