### PR TITLE
[client-secrets] Improve secrets settings copy

### DIFF
--- a/libs/client/secrets/src/components/delete-entry-dialog.tsx
+++ b/libs/client/secrets/src/components/delete-entry-dialog.tsx
@@ -8,21 +8,12 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@shipfox/react-ui/modal';
-import {Code, Text} from '@shipfox/react-ui/typography';
-
-export type StoreEntryKind = 'secret' | 'variable';
-
-function referenceExpression(kind: StoreEntryKind, key: string): string {
-  // Built by concatenation, not a template literal, because `${{` cannot appear
-  // inside a JS template string.
-  return kind === 'secret' ? `\${{ secrets.${key} }}` : `\${{ vars.${key} }}`;
-}
+import {Text} from '@shipfox/react-ui/typography';
 
 export function DeleteEntryDialog({
   open,
   onOpenChange,
   entryKey,
-  kind,
   isLoading,
   errorMessage,
   onConfirm,
@@ -30,7 +21,6 @@ export function DeleteEntryDialog({
   open: boolean;
   onOpenChange: (next: boolean) => void;
   entryKey: string;
-  kind: StoreEntryKind;
   isLoading: boolean;
   errorMessage?: string | undefined;
   onConfirm: () => void;
@@ -39,19 +29,13 @@ export function DeleteEntryDialog({
     <Modal open={open} onOpenChange={onOpenChange}>
       <ModalContent>
         <ModalHeader>
-          <ModalTitle>Delete {kind}</ModalTitle>
+          <ModalTitle>
+            Delete <strong>{entryKey}</strong>?
+          </ModalTitle>
         </ModalHeader>
         <ModalBody className="gap-16">
           <Text size="sm">
-            Delete{' '}
-            <Code as="span" variant="label">
-              {entryKey}
-            </Code>
-            ? Workflows that reference{' '}
-            <Code as="span" variant="label">
-              {referenceExpression(kind, entryKey)}
-            </Code>{' '}
-            will fail at their next run.
+            Workflows that reference <strong>{entryKey}</strong> will fail at their next run.
           </Text>
           {errorMessage ? (
             <Alert variant="error" animated={false}>

--- a/libs/client/secrets/src/components/secret-form.tsx
+++ b/libs/client/secrets/src/components/secret-form.tsx
@@ -142,7 +142,8 @@ export function SecretForm({
                 {isShortSecretValue(field.state.value, SHORT_VALUE_THRESHOLD) ? (
                   <Alert variant="warning" animated={false}>
                     <Text size="sm">
-                      This value is short; log redaction is weaker for very short values.
+                      Very short secrets can match ordinary log text and redact unrelated output. If
+                      this value is not sensitive, store it as a Variable instead.
                     </Text>
                   </Alert>
                 ) : null}
@@ -161,7 +162,7 @@ export function SecretForm({
           Cancel
         </Button>
         <Button type="submit" form={SECRET_FORM_ID} isLoading={putSecret.isPending}>
-          {mode === 'edit' ? 'Update secret' : 'Add secret'}
+          {mode === 'edit' ? 'Update secret' : 'Create secret'}
         </Button>
       </FormFooter>
     </>

--- a/libs/client/secrets/src/components/variable-form.tsx
+++ b/libs/client/secrets/src/components/variable-form.tsx
@@ -121,8 +121,8 @@ export function VariableForm({
                 {isSensitiveSecretName(field.state.value) ? (
                   <Alert variant="warning" animated={false}>
                     <Text size="sm" aria-live="polite">
-                      Variables are stored in plaintext and are not redacted from logs. Store this
-                      as a Secret instead.
+                      This looks like it may be sensitive. Variables are stored in plaintext and are
+                      not redacted from logs. Use a Secret if this value contains private data.
                     </Text>
                   </Alert>
                 ) : null}
@@ -174,7 +174,7 @@ export function VariableForm({
           isLoading={putVariable.isPending}
           disabled={awaitingFullValue}
         >
-          {mode === 'edit' ? 'Update variable' : 'Add variable'}
+          {mode === 'edit' ? 'Update variable' : 'Create variable'}
         </Button>
       </FormFooter>
     </>

--- a/libs/client/secrets/src/components/workspace-secrets-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.stories.tsx
@@ -102,7 +102,10 @@ type Story = StoryObj<typeof SectionStory>;
 export const Loaded: Story = {
   args: {scenario: 'loaded'},
   play: async ({canvasElement}) => {
-    await within(canvasElement).findByText('API_TOKEN');
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('API_TOKEN');
+    await canvas.findByRole('button', {name: 'Copy secret name API_TOKEN'});
   },
 };
 

--- a/libs/client/secrets/src/components/workspace-secrets-section.tsx
+++ b/libs/client/secrets/src/components/workspace-secrets-section.tsx
@@ -28,8 +28,10 @@ import {secretsErrorToFormError} from './form-errors.js';
 import {SecretForm} from './secret-form.js';
 import {StoreRowsSkeleton, StoreSurface} from './store-section-shell.js';
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${{ secrets.NAME }} reference syntax is shown to users.
-const SECRET_REFERENCE = '${{ secrets.NAME }}';
+const SECRETS_DESCRIPTION =
+  'Encrypted, write-only values for sensitive data like API keys, tokens, and passwords.';
+const EMPTY_SECRETS_DESCRIPTION =
+  'Create a secret to store sensitive values like API keys, tokens, and passwords.';
 
 type FormState = {mode: 'create'} | {mode: 'edit'; key: string} | null;
 
@@ -57,15 +59,11 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
           <div className="flex flex-col gap-4">
             <Header variant="h3">Secrets</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
-              Encrypted, write-only values. Reference them from workflows as{' '}
-              <Code as="span" variant="label">
-                {SECRET_REFERENCE}
-              </Code>
-              .
+              {SECRETS_DESCRIPTION}
             </Text>
           </div>
           <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
-            Add secret
+            Create secret
           </Button>
         </div>
 
@@ -82,10 +80,10 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
             <EmptyState
               icon="keyLine"
               title="No secrets yet"
-              description={`Secrets are encrypted and write-only. Reference them from workflows as ${SECRET_REFERENCE}.`}
+              description={EMPTY_SECRETS_DESCRIPTION}
               action={
                 <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
-                  Add secret
+                  Create secret
                 </Button>
               }
             />
@@ -128,7 +126,9 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
       >
         <ModalContent>
           <ModalHeader>
-            <ModalTitle>{formState?.mode === 'edit' ? 'Update secret' : 'Add secret'}</ModalTitle>
+            <ModalTitle>
+              {formState?.mode === 'edit' ? 'Update secret' : 'Create secret'}
+            </ModalTitle>
           </ModalHeader>
           {formState ? (
             <SecretForm
@@ -139,7 +139,7 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
               onSaved={() => {
                 const wasEdit = formState.mode === 'edit';
                 setFormState(null);
-                toast.success(wasEdit ? 'Secret updated' : 'Secret added');
+                toast.success(wasEdit ? 'Secret updated' : 'Secret created');
               }}
               onCancel={() => setFormState(null)}
             />
@@ -153,7 +153,6 @@ export function WorkspaceSecretsSection({workspaceId}: {workspaceId: string}) {
           if (!open) closeDelete();
         }}
         entryKey={deleteKey ?? ''}
-        kind="secret"
         isLoading={deleteSecret.isPending}
         errorMessage={deleteError}
         onConfirm={async () => {
@@ -184,9 +183,16 @@ function SecretRow({
   return (
     <TableRow>
       <TableCell>
-        <Code as="span" variant="paragraph">
-          {secret.key}
-        </Code>
+        <button
+          type="button"
+          className="inline-flex min-w-0 cursor-pointer rounded-4 border-none bg-transparent p-0 text-left text-foreground-neutral-base outline-none transition-colors hover:text-foreground-highlight-interactive focus-visible:shadow-border-interactive-with-active"
+          aria-label={`Copy secret name ${secret.key}`}
+          onClick={() => void copyKeyName(secret.key)}
+        >
+          <Code as="span" variant="paragraph" className="truncate">
+            {secret.key}
+          </Code>
+        </button>
       </TableCell>
       <TableCell>
         <span
@@ -211,9 +217,6 @@ function SecretRow({
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem icon="fileCopyLine" onSelect={() => void copyKeyName(secret.key)}>
-              Copy name
-            </DropdownMenuItem>
             <DropdownMenuItem icon="editLine" onSelect={onEdit}>
               Edit value
             </DropdownMenuItem>

--- a/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.stories.tsx
@@ -106,7 +106,10 @@ type Story = StoryObj<typeof SectionStory>;
 export const Loaded: Story = {
   args: {scenario: 'loaded'},
   play: async ({canvasElement}) => {
-    await within(canvasElement).findByText('LOG_LEVEL');
+    const canvas = within(canvasElement);
+
+    await canvas.findByText('LOG_LEVEL');
+    await canvas.findByRole('button', {name: 'Copy variable name LOG_LEVEL'});
   },
 };
 

--- a/libs/client/secrets/src/components/workspace-variables-section.tsx
+++ b/libs/client/secrets/src/components/workspace-variables-section.tsx
@@ -28,8 +28,10 @@ import {secretsErrorToFormError} from './form-errors.js';
 import {StoreRowsSkeleton, StoreSurface} from './store-section-shell.js';
 import {VariableForm} from './variable-form.js';
 
-// biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${{ vars.NAME }} reference syntax is shown to users.
-const VARS_REFERENCE = '${{ vars.NAME }}';
+const VARIABLES_DESCRIPTION =
+  'Plaintext configuration values for non-sensitive data like regions, flags, and log levels.';
+const EMPTY_VARIABLES_DESCRIPTION =
+  'Create a variable to store non-sensitive configuration like regions, flags, and log levels.';
 
 type FormState = {mode: 'create'} | {mode: 'edit'; variable: VariableListItemDto} | null;
 
@@ -57,16 +59,11 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
           <div className="flex flex-col gap-4">
             <Header variant="h3">Variables</Header>
             <Text size="sm" className="text-foreground-neutral-muted">
-              Plaintext config, not redacted from logs. Use a Secret for sensitive values. Reference
-              them from workflows as{' '}
-              <Code as="span" variant="label">
-                {VARS_REFERENCE}
-              </Code>
-              .
+              {VARIABLES_DESCRIPTION}
             </Text>
           </div>
           <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
-            Add variable
+            Create variable
           </Button>
         </div>
 
@@ -83,10 +80,10 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
             <EmptyState
               icon="bracesLine"
               title="No variables yet"
-              description={`Variables are plaintext config. Reference them from workflows as ${VARS_REFERENCE}.`}
+              description={EMPTY_VARIABLES_DESCRIPTION}
               action={
                 <Button size="sm" onClick={() => setFormState({mode: 'create'})}>
-                  Add variable
+                  Create variable
                 </Button>
               }
             />
@@ -130,7 +127,7 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
         <ModalContent>
           <ModalHeader>
             <ModalTitle>
-              {formState?.mode === 'edit' ? 'Update variable' : 'Add variable'}
+              {formState?.mode === 'edit' ? 'Update variable' : 'Create variable'}
             </ModalTitle>
           </ModalHeader>
           {formState ? (
@@ -146,7 +143,7 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
               onSaved={() => {
                 const wasEdit = formState.mode === 'edit';
                 setFormState(null);
-                toast.success(wasEdit ? 'Variable updated' : 'Variable added');
+                toast.success(wasEdit ? 'Variable updated' : 'Variable created');
               }}
               onCancel={() => setFormState(null)}
             />
@@ -160,7 +157,6 @@ export function WorkspaceVariablesSection({workspaceId}: {workspaceId: string}) 
           if (!open) closeDelete();
         }}
         entryKey={deleteKey ?? ''}
-        kind="variable"
         isLoading={deleteVariable.isPending}
         errorMessage={deleteError}
         onConfirm={async () => {
@@ -191,9 +187,16 @@ function VariableRow({
   return (
     <TableRow>
       <TableCell>
-        <Code as="span" variant="paragraph">
-          {variable.key}
-        </Code>
+        <button
+          type="button"
+          className="inline-flex min-w-0 cursor-pointer rounded-4 border-none bg-transparent p-0 text-left text-foreground-neutral-base outline-none transition-colors hover:text-foreground-highlight-interactive focus-visible:shadow-border-interactive-with-active"
+          aria-label={`Copy variable name ${variable.key}`}
+          onClick={() => void copyKeyName(variable.key)}
+        >
+          <Code as="span" variant="paragraph" className="truncate">
+            {variable.key}
+          </Code>
+        </button>
       </TableCell>
       <TableCell>
         <span
@@ -221,9 +224,6 @@ function VariableRow({
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem icon="fileCopyLine" onSelect={() => void copyKeyName(variable.key)}>
-              Copy name
-            </DropdownMenuItem>
             <DropdownMenuItem icon="editLine" onSelect={onEdit}>
               Edit value
             </DropdownMenuItem>


### PR DESCRIPTION
Improve the Secrets and Variables settings UI copy so it explains what each value type is, when to create one, and what risks users should consider.

The previous copy leaned on workflow reference syntax and a few warnings that sounded either too implementation-specific or too certain about the user's intent. This updates the language to be more educational and conditional, simplifies delete confirmations, and makes table names directly copyable so the action is closer to the value users want.

The row action menus now focus on edit and delete, while copy-name behavior is exposed through the name itself with accessible button labels and Storybook coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Secrets and Variables settings with clearer, more helpful copy and a faster way to copy names by clicking them directly.

- **New Features**
  - Clear, educational descriptions for Secrets and Variables; empty states updated. Buttons and modals now say “Create,” and success toasts say “created.”
  - Delete dialog simplified to “Delete <name>?” with a concise warning; removed workflow reference syntax from UI.
  - Copy names by clicking the name itself with accessible labels; row menus focus on Edit/Delete. Storybook updated to assert copy buttons.
  - Refined warnings: guidance for very short secrets and when a variable name looks sensitive.

<sup>Written for commit 0e96553ed95c98281f253b3624dd2e7d88cf8d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

