### PR TITLE
Add agent repair loop demo workflow

### DIFF
--- a/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
+++ b/dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml
@@ -1,0 +1,48 @@
+name: Agent repair loop
+runner:
+  - ubuntu-latest
+  - node-22
+triggers:
+  on_demand:
+    source: manual
+    event: fire
+  on_push:
+    source: gitea
+    event: push
+    filter: 'event.ref == "refs/heads/main"'
+jobs:
+  repair-checkout-pricing:
+    name: Repair checkout pricing
+    execution_timeout: 15m
+    steps:
+      - key: inspect
+        name: Inspect failing checkout tests
+        run: node scripts/demo-step.mjs repair inspect
+      - key: implement
+        name: Agent implements the fix
+        provider: openrouter
+        model: meta-llama/llama-3.1-8b-instruct
+        prompt: |
+          Fix the checkout pricing bug in this repository.
+
+          Read .shipfox/demo-feedback.md before editing. It contains the latest
+          gate failure context. The regression contract is documented in
+          fixtures/checkout-regression.test.js.fixture.
+
+          Make the smallest useful change to src/checkout.js. The checkout total
+          must include line-item discounts, apply taxable discounts before tax,
+          round tax with Math.round, and return subtotal_cents, discount_cents,
+          tax_cents, and total_cents.
+
+          After editing, summarize the files changed and the behavior fixed.
+      - key: test-gate
+        name: Run checkout regression gate
+        run: node scripts/demo-step.mjs repair test-gate
+        gate:
+          success_if: step.exit_code == 0
+          on_failure:
+            restart_from: implement
+            output: Checkout regression gate failed. Sending failure context back to the agent.
+      - key: package
+        name: Package verified change
+        run: node scripts/demo-step.mjs repair package

--- a/dev/gitea/seed/demo/fixtures/cart.json
+++ b/dev/gitea/seed/demo/fixtures/cart.json
@@ -1,0 +1,22 @@
+{
+  "currency": "USD",
+  "tax_rate_bps": 875,
+  "items": [
+    {
+      "sku": "mug-black",
+      "name": "Black ceramic mug",
+      "quantity": 2,
+      "unit_price_cents": 2599,
+      "discount_cents": 500,
+      "taxable": true
+    },
+    {
+      "sku": "sticker-pack",
+      "name": "Sticker pack",
+      "quantity": 3,
+      "unit_price_cents": 399,
+      "discount_cents": 0,
+      "taxable": false
+    }
+  ]
+}

--- a/dev/gitea/seed/demo/fixtures/checkout-regression.test.js.fixture
+++ b/dev/gitea/seed/demo/fixtures/checkout-regression.test.js.fixture
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import {test} from 'node:test';
+import {calculateCheckoutTotal} from '../src/checkout.js';
+import cart from './cart.json' with {type: 'json'};
+
+test('applies item-level discounts before tax', () => {
+  const total = calculateCheckoutTotal(cart);
+
+  assert.equal(total.subtotal_cents, 6395);
+  assert.equal(total.discount_cents, 500);
+  assert.equal(total.tax_cents, 411);
+  assert.equal(total.total_cents, 6306);
+});
+
+test('rounds tax after removing discounts from taxable items only', () => {
+  const total = calculateCheckoutTotal({
+    tax_rate_bps: 825,
+    items: [
+      {
+        sku: 'hoodie',
+        quantity: 1,
+        unit_price_cents: 6200,
+        discount_cents: 775,
+        taxable: true,
+      },
+      {
+        sku: 'gift-card',
+        quantity: 1,
+        unit_price_cents: 2500,
+        discount_cents: 0,
+        taxable: false,
+      },
+    ],
+  });
+
+  assert.equal(total.discount_cents, 775);
+  assert.equal(total.tax_cents, 448);
+  assert.equal(total.total_cents, 8373);
+});

--- a/dev/gitea/seed/demo/scripts/demo-step.mjs
+++ b/dev/gitea/seed/demo/scripts/demo-step.mjs
@@ -1,0 +1,177 @@
+import {mkdir, readFile, writeFile} from 'node:fs/promises';
+import {dirname, join} from 'node:path';
+
+const [, , scenario, action] = process.argv;
+const scale = Number.parseFloat(process.env.DEMO_TIME_SCALE ?? '1');
+const stateDir = join('.shipfox', 'demo-state');
+const feedbackPath = join('.shipfox', 'demo-feedback.md');
+
+if (scenario !== 'repair') {
+  await failUsage();
+}
+
+switch (action) {
+  case 'inspect':
+    await inspectRepair();
+    break;
+  case 'test-gate':
+    await runTestGate();
+    break;
+  case 'package':
+    await packageRepair();
+    break;
+  default:
+    await failUsage();
+}
+
+async function failUsage() {
+  console.error('Usage: node scripts/demo-step.mjs repair <inspect|test-gate|package>');
+  process.exit(2);
+}
+
+async function inspectRepair() {
+  await line('::group::Read failure summary');
+  await line('Pull request: checkout-pricing-discounts');
+  await line('Changed files: src/checkout.js, fixtures/cart.json');
+  await line('Customer report: discounted taxable items are overcharged by 6-8%.');
+  await line('::endgroup::');
+  await line('::group::Replay failing regression');
+  await line('node --test fixtures/checkout-regression.test.js');
+  await line('not ok 1 - applies item-level discounts before tax', 'stderr');
+  await line('  Expected values to be strictly equal:', 'stderr');
+  await line('  0 !== 500', 'stderr');
+  await line('not ok 2 - rounds tax after removing discounts from taxable items only', 'stderr');
+  await line('  Expected values to be strictly equal:', 'stderr');
+  await line('  512 !== 448', 'stderr');
+  await line('::endgroup::');
+  await line('Seeded repair context for the agent.');
+  await writeFeedback(`\
+# Checkout pricing repair context
+
+The regression suite is failing because item-level discounts are ignored.
+
+Expected behavior:
+
+- Sum every line item into subtotal_cents before discounts.
+- Sum item.discount_cents into discount_cents.
+- For taxable items, apply the discount before calculating tax.
+- Round tax with Math.round after multiplying by tax_rate_bps / 10000.
+- total_cents is subtotal_cents - discount_cents + tax_cents.
+
+The contract example lives in fixtures/checkout-regression.test.js.fixture.
+`);
+}
+
+async function runTestGate() {
+  await mkdir(stateDir, {recursive: true});
+  const attemptPath = join(stateDir, 'repair-test-gate-attempt');
+  const attempt = (await readAttempt(attemptPath)) + 1;
+  await writeFile(attemptPath, `${attempt}\n`);
+
+  await line(`::group::Checkout regression gate attempt ${attempt}`);
+  await line('node --test fixtures/checkout-regression.test.js');
+
+  if (attempt === 1) {
+    await line('TAP version 13');
+    await line('# Subtest: applies item-level discounts before tax', 'stderr');
+    await line('not ok 1 - applies item-level discounts before tax', 'stderr');
+    await line('  failureType: testCodeFailure', 'stderr');
+    await line('  expected: 500', 'stderr');
+    await line('  actual: 0', 'stderr');
+    await line('# Subtest: rounds tax after removing discounts from taxable items only', 'stderr');
+    await line('not ok 2 - rounds tax after removing discounts from taxable items only', 'stderr');
+    await line('  expected: 448', 'stderr');
+    await line('  actual: 512', 'stderr');
+    await line('1..2');
+    await line('# tests 2');
+    await line('# fail 2', 'stderr');
+    await line('::endgroup::');
+    await writeFeedback(`\
+# Checkout pricing repair feedback
+
+Attempt 1 failed.
+
+The implementation still ignores item.discount_cents. Update src/checkout.js so
+discount_cents is the sum of all line-item discounts.
+
+The tax calculation must also use the taxable amount after discounts, not the
+original taxable subtotal.
+`);
+    process.exit(1);
+  }
+
+  if (attempt === 2) {
+    await line('TAP version 13');
+    await line('# Subtest: applies item-level discounts before tax');
+    await line('ok 1 - applies item-level discounts before tax');
+    await line('# Subtest: rounds tax after removing discounts from taxable items only', 'stderr');
+    await line('not ok 2 - rounds tax after removing discounts from taxable items only', 'stderr');
+    await line('  failureType: testCodeFailure', 'stderr');
+    await line('  expected: 448', 'stderr');
+    await line('  actual: 512', 'stderr');
+    await line('1..2');
+    await line('# tests 2');
+    await line('# pass 1');
+    await line('# fail 1', 'stderr');
+    await line('::endgroup::');
+    await writeFeedback(`\
+# Checkout pricing repair feedback
+
+Attempt 2 fixed discount_cents, but tax is still calculated before taxable
+discounts are removed.
+
+For taxable items, subtract the item's discount from that item's extended price
+before summing the taxable base. Do not subtract discounts from non-taxable items
+when calculating tax.
+`);
+    process.exit(1);
+  }
+
+  await line('TAP version 13');
+  await line('# Subtest: applies item-level discounts before tax');
+  await line('ok 1 - applies item-level discounts before tax');
+  await line('# Subtest: rounds tax after removing discounts from taxable items only');
+  await line('ok 2 - rounds tax after removing discounts from taxable items only');
+  await line('1..2');
+  await line('# tests 2');
+  await line('# pass 2');
+  await line('# fail 0');
+  await line('::endgroup::');
+  await line('Checkout pricing contract verified after agent repair loop.');
+}
+
+async function packageRepair() {
+  await line('::group::Prepare verified change');
+  await line('Writing repair summary');
+  await line('Collecting changed files');
+  await line('src/checkout.js');
+  await line('.shipfox/demo-feedback.md');
+  await line('::endgroup::');
+  await line('Ready for review: checkout pricing repair passed all gates.');
+}
+
+async function readAttempt(path) {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = Number.parseInt(raw.trim(), 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  } catch {
+    return 0;
+  }
+}
+
+async function writeFeedback(content) {
+  await mkdir(dirname(feedbackPath), {recursive: true});
+  await writeFile(feedbackPath, content);
+}
+
+async function line(text, stream = 'stdout', delayMs = 350) {
+  await sleep(delayMs);
+  const target = stream === 'stderr' ? process.stderr : process.stdout;
+  target.write(`${text}\n`);
+}
+
+function sleep(delayMs) {
+  const scaled = Math.max(0, Math.round(delayMs * scale));
+  return new Promise((resolve) => setTimeout(resolve, scaled));
+}

--- a/dev/gitea/seed/demo/src/checkout.js
+++ b/dev/gitea/seed/demo/src/checkout.js
@@ -1,0 +1,18 @@
+export function calculateCheckoutTotal(cart) {
+  const subtotalCents = cart.items.reduce(
+    (sum, item) => sum + item.unit_price_cents * item.quantity,
+    0,
+  );
+  const discountCents = 0;
+  const taxableSubtotalCents = cart.items
+    .filter((item) => item.taxable)
+    .reduce((sum, item) => sum + item.unit_price_cents * item.quantity, 0);
+  const taxCents = Math.round((taxableSubtotalCents * cart.tax_rate_bps) / 10_000);
+
+  return {
+    subtotal_cents: subtotalCents,
+    discount_cents: discountCents,
+    tax_cents: taxCents,
+    total_cents: subtotalCents - discountCents + taxCents,
+  };
+}

--- a/dev/gitea/seed/demo/src/index.js
+++ b/dev/gitea/seed/demo/src/index.js
@@ -1,3 +1,5 @@
 export function greet(name) {
   return `Hello, ${name}!`;
 }
+
+export {calculateCheckoutTotal} from './checkout.js';


### PR DESCRIPTION
Add a seeded demo workflow that shows an agent repairing code under deterministic regression gates.

Prospect demos previously relied on workflows that were technically useful but did not show the higher-value loop of agent work being verified by executable checks. This adds a checkout-pricing repair scenario where the agent receives failure context, the gate fails twice with realistic logs, and the workflow rewinds back to the agent before eventually passing.

The demo uses a small intentionally flawed checkout module plus a deterministic script for staged stdout/stderr, feedback files, and fixed timing. The workflow still runs through the normal runner path, so checkout, log streaming, step gates, and restart behavior are exercised as they would be in a real workflow.

Review the balance between realism and determinism in the fake logs and feedback text; the script is intentionally demo-oriented rather than a reusable runner utility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic demo workflow that shows an agent repairing checkout pricing code under executable regression gates. It runs on the normal runner path and demonstrates gate restarts, log streaming, and packaging.

- **New Features**
  - Added `dev/gitea/seed/demo/.shipfox/workflows/agent-repair-loop.yaml` with on-demand and main-branch triggers; steps: inspect, implement (provider `openrouter`, model `meta-llama/llama-3.1-8b-instruct`), test gate with restart, and package.
  - Added `scripts/demo-step.mjs` to simulate three gate attempts with staged stdout/stderr, write `.shipfox/demo-feedback.md`, and support `DEMO_TIME_SCALE`.
  - Seeded fixtures `fixtures/cart.json` and `fixtures/checkout-regression.test.js.fixture`; included a small intentionally flawed `src/checkout.js` and exported `calculateCheckoutTotal` from `src/index.js` to drive the repair loop.

<sup>Written for commit a9c640510d44f4f28b96e99b0f27d64afce44a63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

