### PR TITLE
Add secrets settings E2E coverage

### DIFF
--- a/.changeset/quiet-secrets-setup.md
+++ b/.changeset/quiet-secrets-setup.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-secrets": patch
+"@shipfox/api-secrets-dto": patch
+---
+
+Add E2E setup contracts and routes for creating managed secrets and variables.

--- a/.changeset/quiet-secrets-setup.md
+++ b/.changeset/quiet-secrets-setup.md
@@ -3,4 +3,4 @@
 "@shipfox/api-secrets-dto": patch
 ---
 
-Add E2E setup contracts and routes for creating managed secrets and variables.
+Test suites can create managed secrets and variables through protected setup APIs.

--- a/e2e/client/secrets/package.json
+++ b/e2e/client/secrets/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@shipfox/e2e-client-secrets",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/client/secrets"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./tests/*"
+  },
+  "scripts": {
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test:e2e": "shipfox-playwright-test",
+    "type": "shipfox-tsc-check"
+  },
+  "devDependencies": {
+    "@shipfox/api-secrets": "workspace:*",
+    "@shipfox/api-secrets-dto": "workspace:*",
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/client-router": "workspace:*",
+    "@shipfox/client-secrets": "workspace:*",
+    "@shipfox/client-workspace-settings": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-secrets": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/client/secrets/package.json
+++ b/e2e/client/secrets/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@shipfox/api-secrets": "workspace:*",
-    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/biome": "workspace:*",
     "@shipfox/client-router": "workspace:*",
     "@shipfox/client-secrets": "workspace:*",

--- a/e2e/client/secrets/playwright.config.ts
+++ b/e2e/client/secrets/playwright.config.ts
@@ -1,0 +1,32 @@
+import {config} from '@shipfox/e2e-core';
+import {defineConfig, devices} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  globalSetup: './tests/global-setup.ts',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        [
+          '@argos-ci/playwright/reporter',
+          {
+            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
+            buildName: 'e2e-client-secrets',
+            ignoreUploadFailures: true,
+          },
+        ],
+      ]
+    : 'list',
+  use: {
+    baseURL: config.CLIENT_URL,
+    trace: 'retain-on-failure',
+    contextOptions: {reducedMotion: 'reduce'},
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/e2e/client/secrets/tests/global-setup.ts
+++ b/e2e/client/secrets/tests/global-setup.ts
@@ -1,0 +1,5 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck();
+}

--- a/e2e/client/secrets/tests/secrets-settings.e2e.ts
+++ b/e2e/client/secrets/tests/secrets-settings.e2e.ts
@@ -1,0 +1,274 @@
+import type {AuthHelper} from '@shipfox/e2e-helper-auth';
+import type {WorkspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import type {Page} from '@shipfox/playwright';
+import {expect, test} from './test.js';
+
+const SECRET_CREATE_KEY = 'E2E_SECRET_CREATE';
+const SECRET_EDIT_KEY = 'E2E_SECRET_EDIT';
+const SECRET_DELETE_KEY = 'E2E_SECRET_DELETE';
+const VARIABLE_CREATE_KEY = 'E2E_VARIABLE_CREATE';
+const VARIABLE_EDIT_KEY = 'E2E_VARIABLE_EDIT';
+const VARIABLE_DELETE_KEY = 'E2E_VARIABLE_DELETE';
+
+interface ReadyWorkspace {
+  userId: string;
+  workspaceId: string;
+}
+
+async function stubProjectExists(page: Page, workspaceId: string): Promise<void> {
+  await page.route('**/projects?*', async (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get('workspace_id') !== workspaceId) {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        projects: [
+          {
+            id: '00000000-0000-4000-8000-000000000001',
+            workspace_id: workspaceId,
+            name: 'Platform',
+            source: {
+              connection_id: '00000000-0000-4000-8000-000000000002',
+              external_repository_id: 'debug:platform',
+            },
+            created_at: '2026-01-15T12:00:00.000Z',
+            updated_at: '2026-01-15T12:00:00.000Z',
+          },
+        ],
+        next_cursor: null,
+      }),
+    });
+  });
+}
+
+async function createReadyWorkspace(params: {
+  auth: AuthHelper;
+  page: Page;
+  workspaces: WorkspacesHelper;
+  name: string;
+}): Promise<ReadyWorkspace> {
+  const user = await params.auth.createUser();
+  const workspace = await params.workspaces.create({
+    userId: user.user.id,
+    name: params.name,
+  });
+  await params.auth.loginAs(params.page, user);
+  await stubProjectExists(params.page, workspace.id);
+
+  return {userId: user.user.id, workspaceId: workspace.id};
+}
+
+function secretsSection(page: Page) {
+  return page.locator('section[aria-label="Secrets"]');
+}
+
+function variablesSection(page: Page) {
+  return page.locator('section[aria-label="Variables"]');
+}
+
+function rowByKey(section: ReturnType<typeof secretsSection>, key: string) {
+  return section.locator('tr', {hasText: key});
+}
+
+async function gotoSecrets(page: Page, workspaceId: string) {
+  await page.goto(`/workspaces/${workspaceId}/settings/secrets`);
+  await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/settings/secrets/?$`, 'u'));
+  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+}
+
+async function gotoVariables(page: Page, workspaceId: string) {
+  await page.goto(`/workspaces/${workspaceId}/settings/variables`);
+  await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/settings/variables/?$`, 'u'));
+  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+}
+
+async function createSecretFromSettings(page: Page, key: string, value: string) {
+  const section = secretsSection(page);
+  await section.getByRole('button', {name: 'Create secret'}).first().click();
+  const dialog = page.getByRole('dialog', {name: 'Create secret'});
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel('Name').fill(key);
+  await dialog.getByRole('textbox', {name: 'Value'}).fill(value);
+  await dialog.getByRole('button', {name: 'Create secret'}).click();
+
+  await expect(page.getByText('Secret created')).toBeVisible();
+  await expect(rowByKey(section, key)).toBeVisible();
+}
+
+async function createVariableFromSettings(page: Page, key: string, value: string) {
+  const section = variablesSection(page);
+  await section.getByRole('button', {name: 'Create variable'}).first().click();
+  const dialog = page.getByRole('dialog', {name: 'Create variable'});
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel('Name').fill(key);
+  await dialog.getByRole('textbox', {name: 'Value'}).fill(value);
+  await dialog.getByRole('button', {name: 'Create variable'}).click();
+
+  await expect(page.getByText('Variable created')).toBeVisible();
+  await expect(rowByKey(section, key)).toBeVisible();
+}
+
+test('creates a workspace secret from settings', async ({page, auth, workspaces}) => {
+  const {workspaceId} = await createReadyWorkspace({
+    page,
+    auth,
+    workspaces,
+    name: 'Secrets Create Workspace',
+  });
+  const value = 'secret-create-value-e2e';
+
+  await gotoSecrets(page, workspaceId);
+  await expect(secretsSection(page).getByText('No secrets yet')).toBeVisible();
+  await createSecretFromSettings(page, SECRET_CREATE_KEY, value);
+
+  const row = rowByKey(secretsSection(page), SECRET_CREATE_KEY);
+  await expect(row.getByLabel('Value hidden')).toBeVisible();
+  await expect(secretsSection(page)).not.toContainText(value);
+});
+
+test('edits a workspace secret from settings', async ({page, auth, workspaces, secrets}) => {
+  const {userId, workspaceId} = await createReadyWorkspace({
+    page,
+    auth,
+    workspaces,
+    name: 'Secrets Edit Workspace',
+  });
+  const oldValue = 'secret-edit-old-value-e2e';
+  const newValue = 'secret-edit-new-value-e2e';
+  await secrets.createSecret({
+    workspaceId,
+    actorId: userId,
+    key: SECRET_EDIT_KEY,
+    value: oldValue,
+  });
+
+  await gotoSecrets(page, workspaceId);
+  const row = rowByKey(secretsSection(page), SECRET_EDIT_KEY);
+  await row.getByRole('button', {name: `Actions for ${SECRET_EDIT_KEY}`}).click();
+  await page.getByRole('menuitem', {name: 'Edit value'}).click();
+  const dialog = page.getByRole('dialog', {name: 'Update secret'});
+  await expect(dialog.getByLabel('Name')).toBeDisabled();
+  await expect(dialog.getByLabel('Name')).toHaveValue(SECRET_EDIT_KEY);
+
+  await dialog.getByRole('textbox', {name: 'Value'}).fill(newValue);
+  await dialog.getByRole('button', {name: 'Update secret'}).click();
+
+  await expect(page.getByText('Secret updated')).toBeVisible();
+  await expect(row).toBeVisible();
+  await expect(secretsSection(page)).not.toContainText(oldValue);
+  await expect(secretsSection(page)).not.toContainText(newValue);
+});
+
+test('deletes a workspace secret from settings', async ({page, auth, workspaces, secrets}) => {
+  const {userId, workspaceId} = await createReadyWorkspace({
+    page,
+    auth,
+    workspaces,
+    name: 'Secrets Delete Workspace',
+  });
+  await secrets.createSecret({
+    workspaceId,
+    actorId: userId,
+    key: SECRET_DELETE_KEY,
+    value: 'secret-delete-value-e2e',
+  });
+
+  await gotoSecrets(page, workspaceId);
+  const section = secretsSection(page);
+  const row = rowByKey(section, SECRET_DELETE_KEY);
+  await row.getByRole('button', {name: `Actions for ${SECRET_DELETE_KEY}`}).click();
+  await page.getByRole('menuitem', {name: 'Delete'}).click();
+  const dialog = page.getByRole('dialog', {name: new RegExp(`Delete ${SECRET_DELETE_KEY}`, 'u')});
+  await dialog.getByRole('button', {name: 'Delete'}).click();
+
+  await expect(page.getByText('Secret deleted')).toBeVisible();
+  await expect(row).toHaveCount(0);
+  await expect(section.getByText('No secrets yet')).toBeVisible();
+});
+
+test('creates a workspace variable from settings', async ({page, auth, workspaces}) => {
+  const {workspaceId} = await createReadyWorkspace({
+    page,
+    auth,
+    workspaces,
+    name: 'Variables Create Workspace',
+  });
+  const value = 'debug';
+
+  await gotoVariables(page, workspaceId);
+  await expect(variablesSection(page).getByText('No variables yet')).toBeVisible();
+  await createVariableFromSettings(page, VARIABLE_CREATE_KEY, value);
+
+  const row = rowByKey(variablesSection(page), VARIABLE_CREATE_KEY);
+  await expect(row.getByText(value, {exact: true})).toBeVisible();
+});
+
+test('edits a workspace variable from settings', async ({page, auth, workspaces, secrets}) => {
+  const {userId, workspaceId} = await createReadyWorkspace({
+    page,
+    auth,
+    workspaces,
+    name: 'Variables Edit Workspace',
+  });
+  const oldValue = 'info';
+  const newValue = 'debug';
+  await secrets.createVariable({
+    workspaceId,
+    actorId: userId,
+    key: VARIABLE_EDIT_KEY,
+    value: oldValue,
+  });
+
+  await gotoVariables(page, workspaceId);
+  const section = variablesSection(page);
+  const row = rowByKey(section, VARIABLE_EDIT_KEY);
+  await expect(row.getByText(oldValue, {exact: true})).toBeVisible();
+  await row.getByRole('button', {name: `Actions for ${VARIABLE_EDIT_KEY}`}).click();
+  await page.getByRole('menuitem', {name: 'Edit value'}).click();
+  const dialog = page.getByRole('dialog', {name: 'Update variable'});
+  await expect(dialog.getByLabel('Name')).toBeDisabled();
+  await expect(dialog.getByLabel('Name')).toHaveValue(VARIABLE_EDIT_KEY);
+
+  await dialog.getByRole('textbox', {name: 'Value'}).fill(newValue);
+  await dialog.getByRole('button', {name: 'Update variable'}).click();
+
+  await expect(page.getByText('Variable updated')).toBeVisible();
+  await expect(row.getByText(newValue, {exact: true})).toBeVisible();
+  await expect(row).not.toContainText(oldValue);
+});
+
+test('deletes a workspace variable from settings', async ({page, auth, workspaces, secrets}) => {
+  const {userId, workspaceId} = await createReadyWorkspace({
+    page,
+    auth,
+    workspaces,
+    name: 'Variables Delete Workspace',
+  });
+  await secrets.createVariable({
+    workspaceId,
+    actorId: userId,
+    key: VARIABLE_DELETE_KEY,
+    value: 'trace',
+  });
+
+  await gotoVariables(page, workspaceId);
+  const section = variablesSection(page);
+  const row = rowByKey(section, VARIABLE_DELETE_KEY);
+  await row.getByRole('button', {name: `Actions for ${VARIABLE_DELETE_KEY}`}).click();
+  await page.getByRole('menuitem', {name: 'Delete'}).click();
+  const dialog = page.getByRole('dialog', {
+    name: new RegExp(`Delete ${VARIABLE_DELETE_KEY}`, 'u'),
+  });
+  await dialog.getByRole('button', {name: 'Delete'}).click();
+
+  await expect(page.getByText('Variable deleted')).toBeVisible();
+  await expect(row).toHaveCount(0);
+  await expect(section.getByText('No variables yet')).toBeVisible();
+});

--- a/e2e/client/secrets/tests/test.ts
+++ b/e2e/client/secrets/tests/test.ts
@@ -1,0 +1,11 @@
+import {test as base, expect} from '@shipfox/e2e-core/playwright';
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type SecretsFixtures, secretsHelper} from '@shipfox/e2e-helper-secrets';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+export const test = base.extend<AuthFixtures & WorkspacesFixtures & SecretsFixtures>({
+  ...authHelper,
+  ...workspacesHelper,
+  ...secretsHelper,
+});
+export {expect};

--- a/e2e/client/secrets/tsconfig.json
+++ b/e2e/client/secrets/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/e2e/helpers/secrets/package.json
+++ b/e2e/helpers/secrets/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shipfox/e2e-helper-secrets",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/helpers/secrets"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-secrets-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/e2e/helpers/secrets/src/index.test.ts
+++ b/e2e/helpers/secrets/src/index.test.ts
@@ -1,0 +1,58 @@
+import {beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+
+const requestJson = vi.fn();
+
+const workspaceId = '11111111-1111-4111-8111-111111111111';
+const actorId = '22222222-2222-4222-8222-222222222222';
+
+describe('secrets e2e helper', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    requestJson.mockReset();
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+  });
+
+  it('creates secrets through the admin setup route', async () => {
+    requestJson.mockResolvedValueOnce({key: 'API_TOKEN'});
+    const {createSecret} = await import('./index.js');
+
+    await createSecret({
+      workspaceId,
+      actorId,
+      key: 'API_TOKEN',
+      value: 'seeded-secret',
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/secrets/secret', {
+      json: {
+        workspace_id: workspaceId,
+        actor_id: actorId,
+        key: 'API_TOKEN',
+        value: 'seeded-secret',
+      },
+    });
+  });
+
+  it('creates variables through the admin setup route', async () => {
+    requestJson.mockResolvedValueOnce({key: 'REGION'});
+    const {createVariable} = await import('./index.js');
+
+    await createVariable({
+      workspaceId,
+      actorId,
+      projectId: '33333333-3333-4333-8333-333333333333',
+      key: 'REGION',
+      value: 'eu-west-1',
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/secrets/variable', {
+      json: {
+        workspace_id: workspaceId,
+        actor_id: actorId,
+        project_id: '33333333-3333-4333-8333-333333333333',
+        key: 'REGION',
+        value: 'eu-west-1',
+      },
+    });
+  });
+});

--- a/e2e/helpers/secrets/src/index.ts
+++ b/e2e/helpers/secrets/src/index.ts
@@ -1,0 +1,88 @@
+import type {
+  E2eCreateSecretBodyDto,
+  E2eCreateSecretResponseDto,
+  E2eCreateVariableBodyDto,
+  E2eCreateVariableResponseDto,
+} from '@shipfox/api-secrets-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+export type {
+  E2eCreateSecretBodyDto,
+  E2eCreateSecretResponseDto,
+  E2eCreateVariableBodyDto,
+  E2eCreateVariableResponseDto,
+} from '@shipfox/api-secrets-dto';
+
+export interface CreateSecretParams {
+  workspaceId: string;
+  actorId: string;
+  key: string;
+  value: string;
+  projectId?: string | undefined;
+}
+
+export interface CreateVariableParams {
+  workspaceId: string;
+  actorId: string;
+  key: string;
+  value: string;
+  projectId?: string | undefined;
+}
+
+function secretBody(params: CreateSecretParams): E2eCreateSecretBodyDto {
+  return {
+    workspace_id: params.workspaceId,
+    actor_id: params.actorId,
+    key: params.key,
+    value: params.value,
+    ...(params.projectId ? {project_id: params.projectId} : {}),
+  };
+}
+
+function variableBody(params: CreateVariableParams): E2eCreateVariableBodyDto {
+  return {
+    workspace_id: params.workspaceId,
+    actor_id: params.actorId,
+    key: params.key,
+    value: params.value,
+    ...(params.projectId ? {project_id: params.projectId} : {}),
+  };
+}
+
+export async function createSecret(
+  params: CreateSecretParams,
+): Promise<E2eCreateSecretResponseDto> {
+  return await requestJson<E2eCreateSecretResponseDto>('post', '/__e2e/secrets/secret', {
+    json: secretBody(params),
+  });
+}
+
+export async function createVariable(
+  params: CreateVariableParams,
+): Promise<E2eCreateVariableResponseDto> {
+  return await requestJson<E2eCreateVariableResponseDto>('post', '/__e2e/secrets/variable', {
+    json: variableBody(params),
+  });
+}
+
+export function createSecretsHelper() {
+  return {
+    createSecret,
+    createVariable,
+  };
+}
+
+export type SecretsHelper = ReturnType<typeof createSecretsHelper>;
+
+export interface SecretsFixtures {
+  secrets: SecretsHelper;
+}
+
+export const secretsHelper = {
+  secrets: async (
+    {request: _request}: {request: unknown},
+    use: (helper: SecretsHelper) => Promise<void>,
+  ) => {
+    await use(createSecretsHelper());
+  },
+};

--- a/e2e/helpers/secrets/tsconfig.build.json
+++ b/e2e/helpers/secrets/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/secrets/tsconfig.json
+++ b/e2e/helpers/secrets/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/e2e/helpers/secrets/tsconfig.test.json
+++ b/e2e/helpers/secrets/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/e2e/helpers/secrets/vitest.config.ts
+++ b/e2e/helpers/secrets/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/api/secrets-dto/src/schemas/e2e.ts
+++ b/libs/api/secrets-dto/src/schemas/e2e.ts
@@ -1,0 +1,23 @@
+import {z} from 'zod';
+import {secretKeySchema} from './identifiers.js';
+import {secretDtoSchema, variableDtoSchema} from './management.js';
+
+const optionalProjectIdSchema = z.string().uuid().optional();
+
+export const e2eCreateSecretBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  actor_id: z.string().uuid(),
+  project_id: optionalProjectIdSchema,
+  key: secretKeySchema,
+  value: z.string(),
+});
+export type E2eCreateSecretBodyDto = z.infer<typeof e2eCreateSecretBodySchema>;
+
+export const e2eCreateSecretResponseSchema = secretDtoSchema;
+export type E2eCreateSecretResponseDto = z.infer<typeof e2eCreateSecretResponseSchema>;
+
+export const e2eCreateVariableBodySchema = e2eCreateSecretBodySchema;
+export type E2eCreateVariableBodyDto = z.infer<typeof e2eCreateVariableBodySchema>;
+
+export const e2eCreateVariableResponseSchema = variableDtoSchema;
+export type E2eCreateVariableResponseDto = z.infer<typeof e2eCreateVariableResponseSchema>;

--- a/libs/api/secrets-dto/src/schemas/index.ts
+++ b/libs/api/secrets-dto/src/schemas/index.ts
@@ -1,3 +1,4 @@
+export * from './e2e.js';
 export * from './identifiers.js';
 export * from './management.js';
 export * from './secret-binding.js';

--- a/libs/api/secrets-dto/src/schemas/management.test.ts
+++ b/libs/api/secrets-dto/src/schemas/management.test.ts
@@ -1,3 +1,4 @@
+import {e2eCreateSecretBodySchema, e2eCreateVariableResponseSchema} from './e2e.js';
 import {
   batchSecretsBodySchema,
   batchVariablesBodySchema,
@@ -91,5 +92,25 @@ describe('management schemas', () => {
     });
 
     expect(result.warnings).toEqual([{code: 'short-secret-value', key: 'API_TOKEN'}]);
+  });
+
+  it('validates e2e setup payloads and responses', () => {
+    const body = e2eCreateSecretBodySchema.parse({
+      workspace_id: '11111111-1111-4111-8111-111111111111',
+      actor_id: '22222222-2222-4222-8222-222222222222',
+      key: 'API_TOKEN',
+      value: 'seeded-secret',
+    });
+    const variable = e2eCreateVariableResponseSchema.parse({
+      key: 'REGION',
+      project_id: null,
+      value: 'eu-west-1',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      last_edited_by: '22222222-2222-4222-8222-222222222222',
+    });
+
+    expect(body.key).toBe('API_TOKEN');
+    expect(variable.value).toBe('eu-west-1');
   });
 });

--- a/libs/api/secrets/src/index.ts
+++ b/libs/api/secrets/src/index.ts
@@ -1,6 +1,7 @@
 import {secretsEventSchemas} from '@shipfox/api-secrets-dto';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {db, migrationsPath, secretsOutbox} from '#db/index.js';
+import {secretsE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {secretsRoutes} from '#presentation/routes/index.js';
 
 export {
@@ -42,5 +43,6 @@ export const secretsModule: ShipfoxModule = {
   name: 'secrets',
   database: {db, migrationsPath},
   routes: secretsRoutes,
+  e2eRoutes: [secretsE2eRoutes],
   publishers: [{name: 'secrets', table: secretsOutbox, db, eventSchemas: secretsEventSchemas}],
 };

--- a/libs/api/secrets/src/presentation/e2eRoutes/create-secret.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/create-secret.ts
@@ -4,6 +4,8 @@ import {setManagedSecrets} from '#core/index.js';
 import {toSecretDto} from '#presentation/dto/index.js';
 import {translateManagementError} from '#presentation/routes/errors.js';
 
+type ManagedSecret = Awaited<ReturnType<typeof setManagedSecrets>>[number];
+
 export const createE2eSecretRoute = defineRoute({
   method: 'POST',
   path: '/secret',
@@ -14,13 +16,14 @@ export const createE2eSecretRoute = defineRoute({
   },
   errorHandler: translateManagementError,
   handler: async (request, reply) => {
-    const [secret] = await setManagedSecrets({
-      workspaceId: request.body.workspace_id,
-      actorId: request.body.actor_id,
-      projectId: request.body.project_id,
-      entries: [{key: request.body.key, value: request.body.value}],
-    });
-    if (!secret) throw new Error('E2E secret setup returned no row');
+    const secret = (
+      await setManagedSecrets({
+        workspaceId: request.body.workspace_id,
+        actorId: request.body.actor_id,
+        projectId: request.body.project_id,
+        entries: [{key: request.body.key, value: request.body.value}],
+      })
+    )[0] as ManagedSecret;
 
     reply.code(201);
     return toSecretDto(secret);

--- a/libs/api/secrets/src/presentation/e2eRoutes/create-secret.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/create-secret.ts
@@ -1,0 +1,28 @@
+import {e2eCreateSecretBodySchema, e2eCreateSecretResponseSchema} from '@shipfox/api-secrets-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+import {setManagedSecrets} from '#core/index.js';
+import {toSecretDto} from '#presentation/dto/index.js';
+import {translateManagementError} from '#presentation/routes/errors.js';
+
+export const createE2eSecretRoute = defineRoute({
+  method: 'POST',
+  path: '/secret',
+  description: 'Create a workspace secret for E2E tests.',
+  schema: {
+    body: e2eCreateSecretBodySchema,
+    response: {201: e2eCreateSecretResponseSchema},
+  },
+  errorHandler: translateManagementError,
+  handler: async (request, reply) => {
+    const [secret] = await setManagedSecrets({
+      workspaceId: request.body.workspace_id,
+      actorId: request.body.actor_id,
+      projectId: request.body.project_id,
+      entries: [{key: request.body.key, value: request.body.value}],
+    });
+    if (!secret) throw new Error('E2E secret setup returned no row');
+
+    reply.code(201);
+    return toSecretDto(secret);
+  },
+});

--- a/libs/api/secrets/src/presentation/e2eRoutes/create-variable.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/create-variable.ts
@@ -1,0 +1,31 @@
+import {
+  e2eCreateVariableBodySchema,
+  e2eCreateVariableResponseSchema,
+} from '@shipfox/api-secrets-dto';
+import {defineRoute} from '@shipfox/node-fastify';
+import {setManagedVariables} from '#core/index.js';
+import {toVariableDto} from '#presentation/dto/index.js';
+import {translateManagementError} from '#presentation/routes/errors.js';
+
+export const createE2eVariableRoute = defineRoute({
+  method: 'POST',
+  path: '/variable',
+  description: 'Create a workspace variable for E2E tests.',
+  schema: {
+    body: e2eCreateVariableBodySchema,
+    response: {201: e2eCreateVariableResponseSchema},
+  },
+  errorHandler: translateManagementError,
+  handler: async (request, reply) => {
+    const [variable] = await setManagedVariables({
+      workspaceId: request.body.workspace_id,
+      actorId: request.body.actor_id,
+      projectId: request.body.project_id,
+      entries: [{key: request.body.key, value: request.body.value}],
+    });
+    if (!variable) throw new Error('E2E variable setup returned no row');
+
+    reply.code(201);
+    return toVariableDto(variable);
+  },
+});

--- a/libs/api/secrets/src/presentation/e2eRoutes/create-variable.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/create-variable.ts
@@ -7,6 +7,8 @@ import {setManagedVariables} from '#core/index.js';
 import {toVariableDto} from '#presentation/dto/index.js';
 import {translateManagementError} from '#presentation/routes/errors.js';
 
+type ManagedVariable = Awaited<ReturnType<typeof setManagedVariables>>[number];
+
 export const createE2eVariableRoute = defineRoute({
   method: 'POST',
   path: '/variable',
@@ -17,13 +19,14 @@ export const createE2eVariableRoute = defineRoute({
   },
   errorHandler: translateManagementError,
   handler: async (request, reply) => {
-    const [variable] = await setManagedVariables({
-      workspaceId: request.body.workspace_id,
-      actorId: request.body.actor_id,
-      projectId: request.body.project_id,
-      entries: [{key: request.body.key, value: request.body.value}],
-    });
-    if (!variable) throw new Error('E2E variable setup returned no row');
+    const variable = (
+      await setManagedVariables({
+        workspaceId: request.body.workspace_id,
+        actorId: request.body.actor_id,
+        projectId: request.body.project_id,
+        entries: [{key: request.body.key, value: request.body.value}],
+      })
+    )[0] as ManagedVariable;
 
     reply.code(201);
     return toVariableDto(variable);

--- a/libs/api/secrets/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/index.test.ts
@@ -1,0 +1,94 @@
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {eq} from 'drizzle-orm';
+import {getSecret} from '#core/index.js';
+import {db, secretValues, secretVariables} from '#db/index.js';
+import {secretsE2eRoutes} from './index.js';
+
+const ACTOR_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('secrets e2e routes', () => {
+  let app: Awaited<ReturnType<typeof createApp>>;
+  let workspaceId: string;
+
+  beforeEach(async () => {
+    await closeApp();
+    workspaceId = crypto.randomUUID();
+    app = await createApp({routes: [secretsE2eRoutes], swagger: false});
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await db().delete(secretValues).where(eq(secretValues.workspaceId, workspaceId));
+    await db().delete(secretVariables).where(eq(secretVariables.workspaceId, workspaceId));
+    await closeApp();
+  });
+
+  it('creates a secret setup row without exposing plaintext', async () => {
+    const value = 'seeded-secret-value';
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/secrets/secret',
+      payload: {
+        workspace_id: workspaceId,
+        actor_id: ACTOR_ID,
+        key: 'API_TOKEN',
+        value,
+      },
+    });
+    const stored = await getSecret({workspaceId, key: 'API_TOKEN'});
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      key: 'API_TOKEN',
+      project_id: null,
+      last_edited_by: ACTOR_ID,
+    });
+    expect(stored).toBe(value);
+    expect(res.body).not.toContain(value);
+  });
+
+  it('creates a variable setup row with its readable value', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/secrets/variable',
+      payload: {
+        workspace_id: workspaceId,
+        actor_id: ACTOR_ID,
+        key: 'REGION',
+        value: 'eu-west-1',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      key: 'REGION',
+      project_id: null,
+      value: 'eu-west-1',
+      last_edited_by: ACTOR_ID,
+    });
+  });
+
+  it('rejects invalid setup keys through route validation', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/secrets/secret',
+      payload: {
+        workspace_id: workspaceId,
+        actor_id: ACTOR_ID,
+        key: 'bad-key',
+        value: 'seeded-secret-value',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({code: 'validation-error'});
+  });
+
+  it('registers e2e setup routes without user auth', () => {
+    const route = secretsE2eRoutes.routes[0];
+
+    expect(secretsE2eRoutes.prefix).toBe('/secrets');
+    expect(route?.auth).toBeUndefined();
+  });
+});

--- a/libs/api/secrets/src/presentation/e2eRoutes/index.test.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/index.test.ts
@@ -86,9 +86,9 @@ describe('secrets e2e routes', () => {
   });
 
   it('registers e2e setup routes without user auth', () => {
-    const route = secretsE2eRoutes.routes[0];
-
     expect(secretsE2eRoutes.prefix).toBe('/secrets');
-    expect(route?.auth).toBeUndefined();
+    for (const route of secretsE2eRoutes.routes) {
+      expect(route.auth).toBeUndefined();
+    }
   });
 });

--- a/libs/api/secrets/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/secrets/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,8 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createE2eSecretRoute} from './create-secret.js';
+import {createE2eVariableRoute} from './create-variable.js';
+
+export const secretsE2eRoutes: RouteGroup = {
+  prefix: '/secrets',
+  routes: [createE2eSecretRoute, createE2eVariableRoute],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,48 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/client/secrets:
+    devDependencies:
+      '@shipfox/api-secrets':
+        specifier: workspace:*
+        version: link:../../../libs/api/secrets
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/secrets-dto
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/client-router':
+        specifier: workspace:*
+        version: link:../../../libs/client/router
+      '@shipfox/client-secrets':
+        specifier: workspace:*
+        version: link:../../../libs/client/secrets
+      '@shipfox/client-workspace-settings':
+        specifier: workspace:*
+        version: link:../../../libs/client/workspace-settings
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../../helpers/auth
+      '@shipfox/e2e-helper-secrets':
+        specifier: workspace:*
+        version: link:../../helpers/secrets
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/client/workspaces:
     devDependencies:
       '@shipfox/api-workspaces':
@@ -435,6 +477,31 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/helpers/definitions:
+    dependencies:
+      '@shipfox/api-definitions-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/definitions-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
   e2e/helpers/integrations-gitea:
     dependencies:
       '@shipfox/api-integration-gitea-dto':
@@ -462,6 +529,31 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+
+  e2e/helpers/logs:
+    dependencies:
+      '@shipfox/api-logs-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/logs-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
 
   e2e/helpers/runners:
     dependencies:
@@ -491,36 +583,11 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
-  e2e/helpers/definitions:
+  e2e/helpers/secrets:
     dependencies:
-      '@shipfox/api-definitions-dto':
+      '@shipfox/api-secrets-dto':
         specifier: workspace:*
-        version: link:../../../libs/api/definitions-dto
-      '@shipfox/e2e-core':
-        specifier: workspace:*
-        version: link:../../core
-    devDependencies:
-      '@shipfox/biome':
-        specifier: workspace:*
-        version: link:../../../tools/biome
-      '@shipfox/swc':
-        specifier: workspace:*
-        version: link:../../../tools/swc
-      '@shipfox/ts-config':
-        specifier: workspace:*
-        version: link:../../../tools/ts-config
-      '@shipfox/typescript':
-        specifier: workspace:*
-        version: link:../../../tools/typescript
-      '@shipfox/vitest':
-        specifier: workspace:*
-        version: link:../../../tools/vitest
-
-  e2e/helpers/logs:
-    dependencies:
-      '@shipfox/api-logs-dto':
-        specifier: workspace:*
-        version: link:../../../libs/api/logs-dto
+        version: link:../../../libs/api/secrets-dto
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,9 +357,6 @@ importers:
       '@shipfox/api-secrets':
         specifier: workspace:*
         version: link:../../../libs/api/secrets
-      '@shipfox/api-secrets-dto':
-        specifier: workspace:*
-        version: link:../../../libs/api/secrets-dto
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../../tools/biome


### PR DESCRIPTION
Add E2E setup APIs and browser coverage for workspace secrets and variables in settings.

The settings UI now has green-path coverage for creating, editing, and deleting both secrets and variables. The new module-owned setup routes keep the E2E flow HTTP-first, and the helper package gives browser tests a stable way to seed secrets and variables without direct database access.

The PR also adds route/unit coverage for the setup endpoints and a changeset for the new API test surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add E2E setup APIs and Playwright coverage for workspace secrets and variables in settings. Enables HTTP-first seeding and green-path tests for create, edit, and delete.

- **New Features**
  - API/DTOs: module-registered E2E routes at `/__e2e/secrets` — `POST /secret` and `POST /variable` — validated by new `e2e` DTOs; no user auth; secret responses never include plaintext, variable responses include the value.
  - Helper: new `@shipfox/e2e-helper-secrets` with `createSecret` and `createVariable` (optional `projectId`) for tests; no direct DB access.
  - E2E: new `@shipfox/e2e-client-secrets` with Playwright tests for settings (create/edit/delete); uses Argos in CI; added route/unit tests and patch bumps for `@shipfox/api-secrets` and `@shipfox/api-secrets-dto`.

- **Dependencies**
  - Removed a redundant `@shipfox/api-secrets-dto` dependency from the E2E client.

<sup>Written for commit 491feef8de3f881a563403a2729d1d27ccb9d96f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

