### PR TITLE
Declare workflow field failure policies

### DIFF
--- a/.changeset/clear-fields-fail.md
+++ b/.changeset/clear-fields-fail.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds declared workflow field failure policies and a shared fail-closed predicate evaluator.

--- a/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.test.ts
@@ -9,9 +9,19 @@ const fireManualSubscriptionMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@shipfox/api-workflows', () => {
   class InterpolationUnresolvableError extends Error {
-    constructor(definitionId: string) {
+    readonly field: string;
+    readonly source: string;
+    readonly envKey?: string;
+
+    constructor(
+      definitionId: string,
+      params: {readonly field: string; readonly source: string; readonly envKey?: string},
+    ) {
       super(`Workflow interpolation cannot be resolved for definition ${definitionId}`);
       this.name = 'InterpolationUnresolvableError';
+      this.field = params.field;
+      this.source = params.source;
+      if (params.envKey !== undefined) this.envKey = params.envKey;
     }
   }
   return {InterpolationUnresolvableError};
@@ -70,7 +80,13 @@ describe('POST /:definitionId/fire-manual', () => {
   test('maps unresolvable workflow interpolation to 422', async () => {
     const definitionId = crypto.randomUUID();
     await triggerSubscriptionFactory.create({workspaceId, workflowDefinitionId: definitionId});
-    fireManualSubscriptionMock.mockRejectedValue(new InterpolationUnresolvableError(definitionId));
+    fireManualSubscriptionMock.mockRejectedValue(
+      new InterpolationUnresolvableError(definitionId, {
+        field: 'env',
+        source: 'event.ref',
+        envKey: 'REF',
+      }),
+    );
 
     const res = await app.inject({
       method: 'POST',
@@ -79,7 +95,14 @@ describe('POST /:definitionId/fire-manual', () => {
     });
 
     expect(res.statusCode).toBe(422);
-    expect(res.json().code).toBe('workflow-interpolation-unresolvable');
+    expect(res.json()).toMatchObject({
+      code: 'workflow-interpolation-unresolvable',
+      details: {
+        field: 'env',
+        source: 'event.ref',
+        env_key: 'REF',
+      },
+    });
   });
 
   test('returns 404 when the manual trigger is unavailable', async () => {

--- a/libs/api/triggers/src/presentation/routes/fire-manual.ts
+++ b/libs/api/triggers/src/presentation/routes/fire-manual.ts
@@ -21,6 +21,14 @@ export const fireManualTriggerRoute = defineRoute({
     body: fireManualTriggerBodySchema,
     response: {
       201: fireManualTriggerResponseSchema,
+      422: z.object({
+        code: z.string(),
+        details: z.object({
+          field: z.string(),
+          source: z.string(),
+          env_key: z.string().optional(),
+        }),
+      }),
     },
   },
   errorHandler: (error) => {
@@ -28,7 +36,14 @@ export const fireManualTriggerRoute = defineRoute({
       throw new ClientError(error.message, 'manual-trigger-not-found', {status: 404});
     }
     if (error instanceof InterpolationUnresolvableError) {
-      throw new ClientError(error.message, 'workflow-interpolation-unresolvable', {status: 422});
+      throw new ClientError(error.message, 'workflow-interpolation-unresolvable', {
+        status: 422,
+        details: {
+          field: error.field,
+          source: error.source,
+          ...(error.envKey === undefined ? {} : {env_key: error.envKey}),
+        },
+      });
     }
     throw error;
   },

--- a/libs/api/workflows/src/core/errors.ts
+++ b/libs/api/workflows/src/core/errors.ts
@@ -27,14 +27,46 @@ export class AgentConfigUnresolvableError extends Error {
   }
 }
 
+export type InterpolationUnresolvableField =
+  | 'run'
+  | 'env'
+  | 'agent.prompt'
+  | 'agent.model'
+  | 'agent.provider'
+  | 'step.name';
+
 export class InterpolationUnresolvableError extends Error {
+  readonly field: InterpolationUnresolvableField;
+  readonly source: string;
+  readonly envKey?: string;
+
   constructor(
     readonly definitionId: string,
-    options?: ErrorOptions | undefined,
+    params: {
+      readonly field: InterpolationUnresolvableField;
+      readonly source: string;
+      readonly envKey?: string;
+      readonly cause?: unknown;
+    },
   ) {
-    super(`Workflow interpolation cannot be resolved for definition ${definitionId}`, options);
+    super(interpolationUnresolvableMessage(definitionId, params), {cause: params.cause});
     this.name = 'InterpolationUnresolvableError';
+    this.field = params.field;
+    this.source = params.source;
+    if (params.envKey !== undefined) this.envKey = params.envKey;
   }
+}
+
+function interpolationUnresolvableMessage(
+  definitionId: string,
+  params: {
+    readonly field: InterpolationUnresolvableField;
+    readonly source: string;
+    readonly envKey?: string;
+  },
+): string {
+  const envSuffix = params.envKey === undefined ? '' : ` (${params.envKey})`;
+  return `Workflow interpolation cannot be resolved for definition ${definitionId}: ${params.field}${envSuffix} uses \`${params.source}\`. Use has(x) ? x : '' for optional references.`;
 }
 
 /**

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -1,8 +1,4 @@
-import {
-  evaluateWorkflowPredicate,
-  type WorkflowExpression,
-  WorkflowExpressionEvaluationError,
-} from '@shipfox/expression';
+import {evaluateWorkflowPredicateFailClosed, type WorkflowExpression} from '@shipfox/expression';
 import type {GateOutcome, StepResult} from './decide-step-transition.js';
 
 // The exact `uncheckable` reason recorded when the gate's CEL expression itself
@@ -64,20 +60,16 @@ export function evaluateGate(gate: StepGate | undefined, result: StepResult): Ga
     return {kind: 'uncheckable', reason: 'step produced no exit code'};
   }
 
-  try {
-    const passed = evaluateWorkflowPredicate(gate.successIf, {
-      step: {
-        exit_code: BigInt(result.exitCode),
-        status: result.status,
-      },
-    });
-    return passed ? {kind: 'passed', source} : {kind: 'failed', source};
-  } catch (error) {
-    if (error instanceof WorkflowExpressionEvaluationError) {
-      return {kind: 'uncheckable', reason: GATE_EVALUATION_ERROR_REASON};
-    }
-    throw error;
+  const outcome = evaluateWorkflowPredicateFailClosed(gate.successIf, {
+    step: {
+      exit_code: BigInt(result.exitCode),
+      status: result.status,
+    },
+  });
+  if (outcome.evaluationFailed) {
+    return {kind: 'uncheckable', reason: GATE_EVALUATION_ERROR_REASON};
   }
+  return outcome.value ? {kind: 'passed', source} : {kind: 'failed', source};
 }
 
 // Build the audit payload recorded on the step attempt for a gate evaluation.

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-job-execution-steps.test.ts
@@ -114,6 +114,38 @@ describe('materializeJobExecutionSteps', () => {
     ]);
   });
 
+  it('throws a permanent interpolation error for available missing value paths', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          steps: [{run: 'echo ok', env: {TICKET: template('inputs.ticket')}}],
+        },
+      },
+    });
+    const job = model.jobs[0];
+    if (!job) throw new Error('Expected workflow job');
+    const baseContext = jobExecutionContext();
+
+    let error: unknown;
+    try {
+      materializeJobExecutionSteps({
+        model,
+        job,
+        context: {...baseContext, values: {...baseContext.values, inputs: {}}},
+        definitionId: 'def-1',
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(InterpolationUnresolvableError);
+    expect(error).toMatchObject({
+      field: 'env',
+      source: 'inputs.ticket',
+      envKey: 'TICKET',
+    });
+  });
+
   it.each([
     new UnsupportedModelProviderError('unknown-provider'),
     new InvalidAgentModelError('anthropic', 'missing-model'),

--- a/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/materialize-workflow-model.test.ts
@@ -486,7 +486,7 @@ describe('materializeWorkflowModel', () => {
     expect(rows[0]?.steps[1]?.diagnostics).toBeUndefined();
   });
 
-  it('records missing untrusted env paths as diagnostics', () => {
+  it('throws a permanent interpolation error for available missing untrusted env paths', () => {
     const model = workflowModel({
       jobs: {
         build: {
@@ -495,24 +495,24 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const rows = materializeWorkflowModel({
-      model,
-      context: creationContext({...runContext(), event: {}}),
-    });
+    let error: unknown;
+    try {
+      materializeWorkflowModel({
+        model,
+        context: creationContext({...runContext(), event: {}}),
+        definitionId: 'def-1',
+      });
+    } catch (caught) {
+      error = caught;
+    }
 
-    expect(rows[0]?.steps[1]?.config).toEqual({
-      run: 'echo ok',
-      env: {REF: ''},
+    expect(error).toBeInstanceOf(InterpolationUnresolvableError);
+    expect(error).toMatchObject({
+      field: 'env',
+      source: 'event.ref',
+      envKey: 'REF',
     });
-    expect(rows[0]?.steps[1]?.diagnostics).toEqual([
-      {
-        reason: 'missing-path',
-        expression: 'event.ref',
-        contextRoots: ['event'],
-        field: 'env',
-        envKey: 'REF',
-      },
-    ]);
+    expect((error as Error).message).toContain("Use has(x) ? x : ''");
   });
 
   it('records unavailable execution paths in non-step-name fields as diagnostics at creation', () => {
@@ -636,7 +636,57 @@ describe('materializeWorkflowModel', () => {
     expect(materialize).toThrow(InterpolationUnresolvableError);
   });
 
-  it('throws a permanent interpolation error for a missing execution path in step names', () => {
+  it('throws a permanent interpolation error for missing available agent prompt paths', () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {steps: [{prompt: template('inputs.ticket')}]},
+      },
+    });
+
+    let error: unknown;
+    try {
+      materializeWorkflowModel({
+        model,
+        context: creationContext({...runContext(), inputs: {}}),
+        definitionId: 'def-1',
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(InterpolationUnresolvableError);
+    expect(error).toMatchObject({
+      field: 'agent.prompt',
+      source: 'inputs.ticket',
+    });
+  });
+
+  it('throws a permanent interpolation error for a missing trusted agent model path', () => {
+    const model = workflowModel({
+      jobs: {
+        fix: {steps: [{model: template('run.missing'), prompt: 'Fix it.'}]},
+      },
+    });
+
+    let error: unknown;
+    try {
+      materializeWorkflowModel({
+        model,
+        context: creationContext(),
+        definitionId: 'def-1',
+      });
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error).toBeInstanceOf(InterpolationUnresolvableError);
+    expect(error).toMatchObject({
+      field: 'agent.model',
+      source: 'run.missing',
+    });
+  });
+
+  it('degrades missing execution paths in step names', () => {
     const model = workflowModel({
       jobs: {
         review: {
@@ -650,10 +700,89 @@ describe('materializeWorkflowModel', () => {
       },
     });
 
-    const materialize = () =>
-      materializeWorkflowModel({model, context: creationContext(), definitionId: 'def-1'});
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext(),
+      definitionId: 'def-1',
+    });
 
-    expect(materialize).toThrow(InterpolationUnresolvableError);
+    expect(rows[0]?.steps[1]).toMatchObject({
+      name: 'Review ',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'execution.events[0].data.body',
+          contextRoots: ['execution'],
+          field: 'step.name',
+        },
+      ],
+    });
+  });
+
+  it('degrades missing available untrusted paths in step names', () => {
+    const model = workflowModel({
+      jobs: {
+        review: {
+          steps: [
+            {
+              name: `Review ${template('event.title')}`,
+              prompt: 'Summarize the review',
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext({...runContext(), event: {}}),
+      definitionId: 'def-1',
+    });
+
+    expect(rows[0]?.steps[1]).toMatchObject({
+      name: 'Review ',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'event.title',
+          contextRoots: ['event'],
+          field: 'step.name',
+        },
+      ],
+    });
+  });
+
+  it('uses the display-name fallback when a degraded step name resolves empty', () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {
+              name: template('event.title'),
+              run: 'npm test',
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext({...runContext(), event: {}}),
+      definitionId: 'def-1',
+    });
+
+    expect(rows[0]?.steps[1]).toMatchObject({
+      name: 'npm test',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'event.title',
+          contextRoots: ['event'],
+          field: 'step.name',
+        },
+      ],
+    });
   });
 
   it('skips listening job steps at workflow-run creation', () => {

--- a/libs/api/workflows/src/core/workflow-runtime/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/workflow-runtime/resolve-step-config.ts
@@ -7,18 +7,22 @@ import type {MaterializedAgentStepConfigDto} from '@shipfox/api-agent-dto';
 import type {WorkflowEnvTemplates, WorkflowModel} from '@shipfox/api-definitions';
 import {
   type AvailabilitySite,
-  getWorkflowContextDefinition,
+  getWorkflowInterpolationFieldFailurePolicy,
   resolveRunCommand,
   resolveWorkflowTemplate,
   rootsAvailableAt,
   UnsafeRunInterpolationError,
-  type WorkflowContextName,
   type WorkflowExpressionEvaluationContext,
+  type WorkflowInterpolationField,
   type WorkflowTemplateDiagnostic,
   WorkflowTemplateResolutionError,
-  workflowContextNames,
+  type WorkflowTemplateResolutionOptions,
 } from '@shipfox/expression';
-import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
+import {
+  AgentConfigUnresolvableError,
+  InterpolationUnresolvableError,
+  type InterpolationUnresolvableField,
+} from '#core/errors.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
 type WorkflowModelStep = WorkflowModelJob['steps'][number];
@@ -26,13 +30,7 @@ type WorkflowModelRunStep = Extract<WorkflowModelStep, {kind: 'run'}>;
 type WorkflowModelAgentStep = Extract<WorkflowModelStep, {kind: 'agent'}>;
 type WorkflowFieldTemplate = NonNullable<NonNullable<WorkflowModelRunStep['templates']>['command']>;
 
-export type StepConfigField =
-  | 'run'
-  | 'env'
-  | 'agent.prompt'
-  | 'agent.model'
-  | 'agent.provider'
-  | 'step.name';
+export type StepConfigField = InterpolationUnresolvableField;
 
 export interface WorkflowStepTemplateDiagnostic extends WorkflowTemplateDiagnostic {
   readonly field: StepConfigField;
@@ -64,28 +62,18 @@ interface WinningEnvValue {
 }
 
 export function resolveStepConfig(params: ResolveStepConfigParams): ResolvedStepConfig {
-  try {
-    const effective = buildStepConfig({...params, mode: 'effective'});
-    const authoredConfig = effective.hasTemplates
-      ? buildStepConfig({...params, mode: 'authored'}).config
-      : null;
-    const name = resolveStepName(params.step, params.context, params.site);
+  const effective = buildStepConfig({...params, mode: 'effective'});
+  const authoredConfig = effective.hasTemplates
+    ? buildStepConfig({...params, mode: 'authored'}).config
+    : null;
+  const name = resolveStepName(params.step, params.context, params.site, params.definitionId);
 
-    return {
-      config: effective.config,
-      authoredConfig,
-      ...(name.value === undefined ? {} : {name: name.value}),
-      diagnostics: [...effective.diagnostics, ...name.diagnostics],
-    };
-  } catch (error) {
-    if (
-      error instanceof UnsafeRunInterpolationError ||
-      error instanceof WorkflowTemplateResolutionError
-    ) {
-      throw new InterpolationUnresolvableError(params.definitionId, {cause: error});
-    }
-    throw error;
-  }
+  return {
+    config: effective.config,
+    authoredConfig,
+    ...(name.value === undefined || name.value === '' ? {} : {name: name.value}),
+    diagnostics: [...effective.diagnostics, ...name.diagnostics],
+  };
 }
 
 function buildStepConfig(
@@ -99,13 +87,20 @@ function buildStepConfig(
 
   if (params.step.kind === 'run') {
     const env = winningEnv(params);
-    const envResolution = resolveEnv(env, params.context, params.site, params.mode);
+    const envResolution = resolveEnv(
+      env,
+      params.context,
+      params.site,
+      params.mode,
+      params.definitionId,
+    );
     const commandResolution = resolveCommand({
       step: params.step,
       envKeys: Object.keys(envResolution.env),
       context: params.context,
       site: params.site,
       mode: params.mode,
+      definitionId: params.definitionId,
     });
     const mergedEnv = {...envResolution.env, ...commandResolution.env};
     const envConfig = Object.keys(mergedEnv).length === 0 ? {} : {env: mergedEnv};
@@ -131,6 +126,7 @@ function resolveCommand(params: {
   readonly context: WorkflowExpressionEvaluationContext;
   readonly site: AvailabilitySite;
   readonly mode: 'effective' | 'authored';
+  readonly definitionId: string;
 }): {
   readonly command: string;
   readonly env: Readonly<Record<string, string>>;
@@ -146,10 +142,21 @@ function resolveCommand(params: {
     return {command: params.step.command.value, env: {}, diagnostics: [], hasTemplate: true};
   }
 
-  const resolved = resolveRunCommand(template, params.context, {
-    reservedNames: params.envKeys,
-    requiredContextRoots: requiredTrustedRoots(template, params.site),
-  });
+  let resolved: ReturnType<typeof resolveRunCommand>;
+  try {
+    resolved = resolveRunCommand(template, params.context, {
+      reservedNames: params.envKeys,
+      ...resolutionOptions('run', params.site),
+    });
+  } catch (error) {
+    if (
+      error instanceof UnsafeRunInterpolationError ||
+      error instanceof WorkflowTemplateResolutionError
+    ) {
+      throw interpolationError(params.definitionId, 'run', error);
+    }
+    throw error;
+  }
 
   return {
     command: resolved.command,
@@ -164,6 +171,7 @@ function resolveEnv(
   context: WorkflowExpressionEvaluationContext,
   site: AvailabilitySite,
   mode: 'effective' | 'authored',
+  definitionId: string,
 ): {
   readonly env: Readonly<Record<string, string>>;
   readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
@@ -181,9 +189,19 @@ function resolveEnv(
     }
 
     hasTemplates = true;
-    const resolved = resolveWorkflowTemplate(entry.template, context, {
-      requiredContextRoots: requiredTrustedRoots(entry.template, site),
-    });
+    let resolved: ReturnType<typeof resolveWorkflowTemplate>;
+    try {
+      resolved = resolveWorkflowTemplate(
+        entry.template,
+        context,
+        resolutionOptions('env.value', site),
+      );
+    } catch (error) {
+      if (error instanceof WorkflowTemplateResolutionError) {
+        throw interpolationError(definitionId, 'env', error, key);
+      }
+      throw error;
+    }
     resolvedEnv[key] = resolved.value;
     diagnostics.push(
       ...resolved.diagnostics.map((diagnostic) => ({
@@ -215,6 +233,7 @@ function agentStepConfig(
     mode: params.mode,
     site: params.site,
     diagnostics,
+    definitionId: params.definitionId,
   });
   const model = resolveOptionalAgentField({
     field: 'agent.model',
@@ -224,6 +243,7 @@ function agentStepConfig(
     mode: params.mode,
     site: params.site,
     diagnostics,
+    definitionId: params.definitionId,
   });
   const provider = resolveOptionalAgentField({
     field: 'agent.provider',
@@ -233,6 +253,7 @@ function agentStepConfig(
     mode: params.mode,
     site: params.site,
     diagnostics,
+    definitionId: params.definitionId,
   });
   const hasTemplates =
     step.templates?.prompt !== undefined ||
@@ -284,12 +305,23 @@ function resolveAgentField(params: {
   readonly site: AvailabilitySite;
   readonly mode: 'effective' | 'authored';
   readonly diagnostics: WorkflowStepTemplateDiagnostic[];
+  readonly definitionId: string;
 }): string {
   if (params.template === undefined || params.mode === 'authored') return params.value;
 
-  const resolved = resolveWorkflowTemplate(params.template, params.context, {
-    requiredContextRoots: requiredTrustedRoots(params.template, params.site),
-  });
+  let resolved: ReturnType<typeof resolveWorkflowTemplate>;
+  try {
+    resolved = resolveWorkflowTemplate(
+      params.template,
+      params.context,
+      resolutionOptions(params.field, params.site),
+    );
+  } catch (error) {
+    if (error instanceof WorkflowTemplateResolutionError) {
+      throw interpolationError(params.definitionId, params.field, error);
+    }
+    throw error;
+  }
   params.diagnostics.push(
     ...resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: params.field})),
   );
@@ -304,6 +336,7 @@ function resolveOptionalAgentField(params: {
   readonly site: AvailabilitySite;
   readonly mode: 'effective' | 'authored';
   readonly diagnostics: WorkflowStepTemplateDiagnostic[];
+  readonly definitionId: string;
 }): string | undefined {
   if (params.value === undefined) return undefined;
   return resolveAgentField({...params, value: params.value});
@@ -313,6 +346,7 @@ function resolveStepName(
   step: WorkflowModelStep,
   context: WorkflowExpressionEvaluationContext,
   site: AvailabilitySite,
+  definitionId: string,
 ): {
   readonly value: string | undefined;
   readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
@@ -320,9 +354,19 @@ function resolveStepName(
   if (step.name === undefined) return {value: undefined, diagnostics: []};
   if (step.templates?.name === undefined) return {value: step.name, diagnostics: []};
 
-  const resolved = resolveWorkflowTemplate(step.templates.name, context, {
-    requiredContextRoots: requiredStepNameRoots(step.templates.name, site),
-  });
+  let resolved: ReturnType<typeof resolveWorkflowTemplate>;
+  try {
+    resolved = resolveWorkflowTemplate(
+      step.templates.name,
+      context,
+      resolutionOptions('step.name', site),
+    );
+  } catch (error) {
+    if (error instanceof WorkflowTemplateResolutionError) {
+      throw interpolationError(definitionId, 'step.name', error);
+    }
+    throw error;
+  }
   return {
     value: resolved.value,
     diagnostics: resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: 'step.name'})),
@@ -363,52 +407,29 @@ function mergeEnvLayers(
   return merged;
 }
 
-function requiredTrustedRoots(
-  segments: readonly unknown[],
+function resolutionOptions(
+  field: WorkflowInterpolationField,
   site: AvailabilitySite,
-): WorkflowContextName[] {
-  const roots = new Set<WorkflowContextName>();
-  const availableRoots = new Set(rootsAvailableAt(site));
-
-  for (const segment of segments) {
-    if (!hasContextRoots(segment)) continue;
-    for (const root of segment.contextRoots) {
-      if (!isWorkflowContextName(root)) continue;
-      if (!availableRoots.has(root)) continue;
-      if (getWorkflowContextDefinition(root).trustTier === 'trusted') roots.add(root);
-    }
-  }
-
-  return [...roots];
+): WorkflowTemplateResolutionOptions {
+  return {
+    failurePolicy: getWorkflowInterpolationFieldFailurePolicy(field),
+    availableRoots: rootsAvailableAt(site),
+  };
 }
 
-function requiredStepNameRoots(
-  segments: readonly unknown[],
-  site: AvailabilitySite,
-): WorkflowContextName[] {
-  const roots = new Set<WorkflowContextName>(requiredTrustedRoots(segments, site));
-  const availableRoots = new Set(rootsAvailableAt(site));
-
-  for (const segment of segments) {
-    if (!hasContextRoots(segment)) continue;
-    for (const root of segment.contextRoots) {
-      if (!isWorkflowContextName(root)) continue;
-      if (!availableRoots.has(root)) roots.add(root);
-    }
-  }
-
-  return [...roots];
+function interpolationError(
+  definitionId: string,
+  field: InterpolationUnresolvableField,
+  error: WorkflowTemplateResolutionError | UnsafeRunInterpolationError,
+  envKey?: string,
+): InterpolationUnresolvableError {
+  return new InterpolationUnresolvableError(definitionId, {
+    field,
+    source: error.source,
+    ...(envKey === undefined ? {} : {envKey}),
+    cause: error,
+  });
 }
-
-function hasContextRoots(value: unknown): value is {readonly contextRoots: readonly string[]} {
-  return typeof value === 'object' && value !== null && 'contextRoots' in value;
-}
-
-function isWorkflowContextName(value: string): value is WorkflowContextName {
-  return workflowContextNameSet.has(value);
-}
-
-const workflowContextNameSet: ReadonlySet<string> = new Set(workflowContextNames);
 
 function stepGateConfig(gate: NonNullable<WorkflowModelStep['gate']>): Record<string, unknown> {
   return {

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -8,9 +8,9 @@ import {
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
 } from '@shipfox/api-workflows-dto';
 import {createWorkflowExpression} from '@shipfox/expression';
-import * as opentelemetry from '@shipfox/node-opentelemetry';
 import {and, eq, inArray, sql} from 'drizzle-orm';
 import {
+  InterpolationUnresolvableError,
   JobNotFoundError,
   NoFailedJobsError,
   RunNotTerminalError,
@@ -526,9 +526,7 @@ describe('workflow run queries', () => {
       });
     });
 
-    test('logs enriched diagnostics for missing untrusted interpolation paths', async () => {
-      const warn = vi.fn();
-      vi.spyOn(opentelemetry, 'logger').mockReturnValue({warn} as never);
+    test('fails for missing available untrusted interpolation paths', async () => {
       const model = normalizeWorkflowDocument({
         name: 'Diagnostic workflow',
         runner: 'ubuntu-latest',
@@ -540,36 +538,40 @@ describe('workflow run queries', () => {
         },
       });
 
-      const run = await createWorkflowRun({
-        workspaceId,
-        projectId,
-        definitionId,
-        model,
-        triggerPayload: {
-          source: 'github',
-          event: 'push',
-          deliveryId: 'delivery-1',
-          data: {},
-        },
-      });
+      let error: unknown;
+      try {
+        await createWorkflowRun({
+          workspaceId,
+          projectId,
+          definitionId,
+          model,
+          triggerPayload: {
+            source: 'github',
+            event: 'push',
+            deliveryId: 'delivery-1',
+            data: {},
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
 
-      expect(warn).toHaveBeenCalledWith(
-        {
-          workflowRunId: run.id,
-          diagnostics: [
-            {
-              jobKey: 'build',
-              stepName: 'echo ok',
-              reason: 'missing-path',
-              expression: 'event.ref',
-              contextRoots: ['event'],
-              field: 'env',
-              envKey: 'REF',
-            },
-          ],
-        },
-        'Workflow interpolation resolved with diagnostics',
-      );
+      expect(error).toBeInstanceOf(InterpolationUnresolvableError);
+      expect(error).toMatchObject({
+        field: 'env',
+        source: 'event.ref',
+        envKey: 'REF',
+      });
+      const runs = await db()
+        .select()
+        .from(workflowRuns)
+        .where(
+          and(
+            eq(workflowRuns.workspaceId, workspaceId),
+            eq(workflowRuns.definitionId, definitionId),
+          ),
+        );
+      expect(runs).toEqual([]);
     });
 
     test('rolls back outbox event when transaction fails', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -15,11 +15,7 @@ import {
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
   type WorkflowsEventMapDto,
 } from '@shipfox/api-workflows-dto';
-import {
-  createWorkflowExpression,
-  evaluateWorkflowPredicate,
-  WorkflowExpressionEvaluationError,
-} from '@shipfox/expression';
+import {createWorkflowExpression, evaluateWorkflowPredicateFailClosed} from '@shipfox/expression';
 import {
   paginateTimestampIdRows,
   type TimestampIdCursor,
@@ -1746,21 +1742,12 @@ export async function resolveJobStatusFromJobExecutions(params: {
       check: {mode: 'syntax'},
     });
     const context = assembleExecutionsContext(jobExecutionRows.map(toJobExecution));
-    // Fail closed so a runtime-only predicate error cannot abort job resolution.
-    let passed: boolean;
-    let predicateEvaluationFailed = false;
-    try {
-      passed = evaluateWorkflowPredicate(expression, context);
-    } catch (error) {
-      if (!(error instanceof WorkflowExpressionEvaluationError)) throw error;
-      passed = false;
-      predicateEvaluationFailed = true;
-    }
-    const status: RuntimeCompletionStatus = passed ? 'succeeded' : 'failed';
+    const predicateOutcome = evaluateWorkflowPredicateFailClosed(expression, context);
+    const status: RuntimeCompletionStatus = predicateOutcome.value ? 'succeeded' : 'failed';
     // A thrown predicate is a job-level failure, not evidence that any execution failed.
     const statusReason =
       status === 'failed'
-        ? predicateEvaluationFailed
+        ? predicateOutcome.evaluationFailed
           ? 'unknown'
           : (jobExecutionRows.find((jobExecution) => jobExecution.statusReason)?.statusReason ??
             'step_failed')

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.test.ts
@@ -3,6 +3,7 @@ import {WorkflowExpressionEvaluationError} from './errors.js';
 import {
   evaluateWorkflowExpression,
   evaluateWorkflowPredicate,
+  evaluateWorkflowPredicateFailClosed,
 } from './evaluate-workflow-expression.js';
 
 describe('evaluateWorkflowExpression', () => {
@@ -58,6 +59,42 @@ describe('evaluateWorkflowExpression', () => {
     });
 
     expect(result).toBe(true);
+  });
+
+  it('returns fail-closed predicate outcomes for clean evaluations', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
+      },
+    });
+
+    const result = evaluateWorkflowPredicateFailClosed(expression, {
+      event: {conclusion: 'success'},
+    });
+
+    expect(result).toEqual({value: true, evaluationFailed: false});
+  });
+
+  it('returns condition-false when fail-closed predicate evaluation fails', () => {
+    const expression = createWorkflowExpression({
+      source: 'event.conclusion == "success"',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          event: {kind: 'object', fields: {conclusion: 'string'}},
+        },
+      },
+    });
+
+    const result = evaluateWorkflowPredicateFailClosed(expression, {
+      event: {},
+    });
+
+    expect(result).toEqual({value: false, evaluationFailed: true});
   });
 
   it('wraps evaluation errors when supplied values do not match the checked context', () => {

--- a/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
+++ b/libs/shared/expression/src/evaluator/evaluate-workflow-expression.ts
@@ -22,3 +22,22 @@ export function evaluateWorkflowPredicate(
 ): boolean {
   return evaluateWorkflowExpression(expression, context) === true;
 }
+
+export interface FailClosedPredicateOutcome {
+  readonly value: boolean;
+  readonly evaluationFailed: boolean;
+}
+
+export function evaluateWorkflowPredicateFailClosed(
+  expression: WorkflowExpression,
+  context: WorkflowExpressionEvaluationContext,
+): FailClosedPredicateOutcome {
+  try {
+    return {value: evaluateWorkflowPredicate(expression, context), evaluationFailed: false};
+  } catch (error) {
+    if (error instanceof WorkflowExpressionEvaluationError) {
+      return {value: false, evaluationFailed: true};
+    }
+    throw error;
+  }
+}

--- a/libs/shared/expression/src/evaluator/index.ts
+++ b/libs/shared/expression/src/evaluator/index.ts
@@ -6,6 +6,8 @@ export {
 export {
   evaluateWorkflowExpression,
   evaluateWorkflowPredicate,
+  evaluateWorkflowPredicateFailClosed,
+  type FailClosedPredicateOutcome,
   type WorkflowExpressionEvaluationContext,
   type WorkflowExpressionEvaluationValue,
 } from './evaluate-workflow-expression.js';

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -6,6 +6,8 @@ export {
 export {
   evaluateWorkflowExpression,
   evaluateWorkflowPredicate,
+  evaluateWorkflowPredicateFailClosed,
+  type FailClosedPredicateOutcome,
   type WorkflowExpressionEvaluationContext,
   type WorkflowExpressionEvaluationValue,
 } from './evaluator/evaluate-workflow-expression.js';
@@ -35,6 +37,7 @@ export {
   resolveWorkflowTemplate,
   resolveWorkflowTemplateSource,
   type WorkflowTemplateDiagnostic,
+  type WorkflowTemplateFailurePolicy,
   type WorkflowTemplateResolution,
   type WorkflowTemplateResolutionOptions,
 } from './resolver/resolve-workflow-template.js';
@@ -67,6 +70,7 @@ export {
   getWorkflowContextSensitivity,
   getWorkflowContextTypeEnvironment,
   getWorkflowContextUntrustedPaths,
+  getWorkflowInterpolationFieldFailurePolicy,
   type OpenWorkflowContextDefinition,
   type ReservedRootDefinition,
   rootsAvailableAt,
@@ -80,8 +84,11 @@ export {
   type WorkflowContextSensitivity,
   type WorkflowContextShape,
   type WorkflowContextTrustTier,
+  type WorkflowFieldFailurePolicy,
+  type WorkflowInterpolationFailurePolicy,
   type WorkflowInterpolationField,
   type WorkflowInterpolationFieldPolicy,
+  type WorkflowPredicateField,
   workflowContextAvailabilityReference,
   workflowContextDefinitions,
   workflowContextHosts,
@@ -89,8 +96,11 @@ export {
   workflowContextReservedRoots,
   workflowContextSensitivities,
   workflowContextTrustTiers,
+  workflowFieldFailurePolicies,
   workflowInterpolationFieldAcceptsContext,
   workflowInterpolationFieldAcceptsTrustTier,
   workflowInterpolationFieldPolicies,
   workflowInterpolationFields,
+  workflowPredicateFieldFailurePolicy,
+  workflowPredicateFields,
 } from './workflow-context/workflow-context.js';

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
@@ -132,12 +132,16 @@ describe('resolveWorkflowTemplate', () => {
     );
   });
 
-  it('wraps missing paths for required context roots in resolution errors', () => {
+  it('wraps missing paths for fail-policy available roots in resolution errors', () => {
     const segments = parseWorkflowTemplate(`run-${templateExpression(' run.id ')}`);
 
     let error: unknown;
     try {
-      resolveWorkflowTemplate(segments, {run: {}}, {requiredContextRoots: ['run']});
+      resolveWorkflowTemplate(
+        segments,
+        {run: {}},
+        {failurePolicy: 'fail', availableRoots: ['run']},
+      );
     } catch (caught) {
       error = caught;
     }
@@ -151,6 +155,32 @@ describe('resolveWorkflowTemplate', () => {
     expect((error as WorkflowTemplateResolutionError).cause).toBeInstanceOf(
       WorkflowExpressionEvaluationError,
     );
+  });
+
+  it('degrades fail-policy missing paths when a segment root is not available yet', () => {
+    const segments = parseWorkflowTemplate(
+      `deploy-${templateExpression(' event.ref + execution.index ')}`,
+    );
+
+    const result = resolveWorkflowTemplate(
+      segments,
+      {
+        event: {ref: 'refs/heads/main'},
+        execution: {},
+      },
+      {failurePolicy: 'fail', availableRoots: ['event']},
+    );
+
+    expect(result).toEqual({
+      value: 'deploy-',
+      diagnostics: [
+        {
+          reason: 'missing-path',
+          expression: 'event.ref + execution.index',
+          contextRoots: ['event', 'execution'],
+        },
+      ],
+    });
   });
 
   it('resolves caller-provided context sets without a hard-coded context list', () => {

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.test.ts
@@ -157,6 +157,29 @@ describe('resolveWorkflowTemplate', () => {
     );
   });
 
+  it('ignores over-included non-workflow roots when applying fail-policy availability', () => {
+    const segments = parseWorkflowTemplate(templateExpression(' {foo: event.ref}.foo '));
+
+    let error: unknown;
+    try {
+      resolveWorkflowTemplate(
+        segments,
+        {event: {}},
+        {failurePolicy: 'fail', availableRoots: ['event']},
+      );
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(segments[0]).toMatchObject({kind: 'expr', contextRoots: ['event', 'foo']});
+    expect(error).toBeInstanceOf(WorkflowTemplateResolutionError);
+    expect(error).toMatchObject({
+      code: 'workflow-template-resolution-failed',
+      name: 'WorkflowTemplateResolutionError',
+      source: '{foo: event.ref}.foo',
+    });
+  });
+
   it('degrades fail-policy missing paths when a segment root is not available yet', () => {
     const segments = parseWorkflowTemplate(
       `deploy-${templateExpression(' event.ref + execution.index ')}`,

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.ts
@@ -8,6 +8,8 @@ import type {WorkflowTemplateSegment} from '../template/template-segment.js';
 import {coerceWorkflowValueToString} from './coerce-workflow-value-to-string.js';
 import {WorkflowTemplateResolutionError} from './errors.js';
 
+export type WorkflowTemplateFailurePolicy = 'fail' | 'degrade';
+
 export interface WorkflowTemplateDiagnostic {
   readonly reason: 'missing-path';
   readonly expression: string;
@@ -20,7 +22,8 @@ export interface WorkflowTemplateResolution {
 }
 
 export interface WorkflowTemplateResolutionOptions {
-  readonly requiredContextRoots?: readonly string[];
+  readonly failurePolicy?: WorkflowTemplateFailurePolicy;
+  readonly availableRoots?: readonly string[];
 }
 
 export function resolveWorkflowTemplate(
@@ -47,7 +50,7 @@ export function resolveWorkflowTemplate(
           contextRoots: segment.contextRoots,
         } as const satisfies WorkflowTemplateDiagnostic;
 
-        if (missingPathRequiresFailure(diagnostic, options)) {
+        if (missingPathRequiresFailure(segment, options)) {
           throw new WorkflowTemplateResolutionError({
             source: segment.expression.source,
             cause: error,
@@ -77,9 +80,10 @@ export function resolveWorkflowTemplateSource(
 }
 
 function missingPathRequiresFailure(
-  diagnostic: WorkflowTemplateDiagnostic,
+  segment: WorkflowTemplateSegment & {readonly kind: 'expr'},
   options: WorkflowTemplateResolutionOptions,
 ): boolean {
-  const requiredContextRoots = options.requiredContextRoots ?? [];
-  return diagnostic.contextRoots.some((contextRoot) => requiredContextRoots.includes(contextRoot));
+  if (options.failurePolicy !== 'fail') return false;
+  const availableRoots = options.availableRoots ?? [];
+  return segment.contextRoots.every((contextRoot) => availableRoots.includes(contextRoot));
 }

--- a/libs/shared/expression/src/resolver/resolve-workflow-template.ts
+++ b/libs/shared/expression/src/resolver/resolve-workflow-template.ts
@@ -5,6 +5,7 @@ import {
 } from '../evaluator/index.js';
 import {parseWorkflowTemplate} from '../template/parse-workflow-template.js';
 import type {WorkflowTemplateSegment} from '../template/template-segment.js';
+import {workflowContextNames} from '../workflow-context/workflow-context.js';
 import {coerceWorkflowValueToString} from './coerce-workflow-value-to-string.js';
 import {WorkflowTemplateResolutionError} from './errors.js';
 
@@ -85,5 +86,15 @@ function missingPathRequiresFailure(
 ): boolean {
   if (options.failurePolicy !== 'fail') return false;
   const availableRoots = options.availableRoots ?? [];
-  return segment.contextRoots.every((contextRoot) => availableRoots.includes(contextRoot));
+  const workflowContextRoots = segment.contextRoots.filter(isWorkflowContextName);
+  return (
+    workflowContextRoots.length > 0 &&
+    workflowContextRoots.every((contextRoot) => availableRoots.includes(contextRoot))
+  );
 }
+
+function isWorkflowContextName(contextRoot: string): boolean {
+  return workflowContextNameSet.has(contextRoot);
+}
+
+const workflowContextNameSet: ReadonlySet<string> = new Set(workflowContextNames);

--- a/libs/shared/expression/src/run/hoist-run-command.test.ts
+++ b/libs/shared/expression/src/run/hoist-run-command.test.ts
@@ -198,10 +198,11 @@ describe('resolveRunCommand', () => {
     });
   });
 
-  it('passes required context roots through to the resolver', () => {
+  it('passes failure policy and available roots through to the resolver', () => {
     const segments = parseWorkflowTemplate(`echo ${templateExpression(' run.missing ')}`);
 
-    const act = () => resolveRunCommand(segments, {run: {}}, {requiredContextRoots: ['run']});
+    const act = () =>
+      resolveRunCommand(segments, {run: {}}, {failurePolicy: 'fail', availableRoots: ['run']});
 
     expect(act).toThrow(WorkflowTemplateResolutionError);
   });

--- a/libs/shared/expression/src/run/hoist-run-command.ts
+++ b/libs/shared/expression/src/run/hoist-run-command.ts
@@ -2,6 +2,8 @@ import type {WorkflowExpressionEvaluationContext} from '../evaluator/evaluate-wo
 import {
   resolveWorkflowTemplate,
   type WorkflowTemplateDiagnostic,
+  type WorkflowTemplateFailurePolicy,
+  type WorkflowTemplateResolutionOptions,
 } from '../resolver/resolve-workflow-template.js';
 import type {
   WorkflowTemplateExprSegment,
@@ -23,7 +25,8 @@ const shellIdentifierPattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 export interface RunCommandOptions {
   readonly reservedNames?: Iterable<string>;
-  readonly requiredContextRoots?: readonly string[];
+  readonly failurePolicy?: WorkflowTemplateFailurePolicy;
+  readonly availableRoots?: readonly string[];
 }
 
 export interface ResolvedRunCommand {
@@ -67,16 +70,23 @@ export function resolveRunCommand(
   const diagnostics: WorkflowTemplateDiagnostic[] = [];
 
   for (const binding of hoisted.bindings) {
-    const resolutionOptions =
-      options.requiredContextRoots === undefined
-        ? undefined
-        : {requiredContextRoots: options.requiredContextRoots};
+    const resolutionOptions = runCommandResolutionOptions(options);
     const resolution = resolveWorkflowTemplate([binding.segment], context, resolutionOptions);
     env[binding.name] = resolution.value;
     diagnostics.push(...resolution.diagnostics);
   }
 
   return {command: hoisted.command, env, diagnostics};
+}
+
+function runCommandResolutionOptions(
+  options: RunCommandOptions,
+): WorkflowTemplateResolutionOptions | undefined {
+  if (options.failurePolicy === undefined && options.availableRoots === undefined) return undefined;
+  return {
+    ...(options.failurePolicy === undefined ? {} : {failurePolicy: options.failurePolicy}),
+    ...(options.availableRoots === undefined ? {} : {availableRoots: options.availableRoots}),
+  };
 }
 
 export function hoistRunCommand(

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -5,6 +5,7 @@ import {
   availabilitySites,
   type FillTarget,
   getWorkflowContextTypeEnvironment,
+  getWorkflowInterpolationFieldFailurePolicy,
   rootsAvailableAt,
   runnerFillTarget,
   type WorkflowContextName,
@@ -17,10 +18,13 @@ import {
   workflowContextReservedRoots,
   workflowContextSensitivities,
   workflowContextTrustTiers,
+  workflowFieldFailurePolicies,
   workflowInterpolationFieldAcceptsContext,
   workflowInterpolationFieldAcceptsTrustTier,
   workflowInterpolationFieldPolicies,
   workflowInterpolationFields,
+  workflowPredicateFieldFailurePolicy,
+  workflowPredicateFields,
 } from './workflow-context.js';
 
 describe('workflow context registry', () => {
@@ -496,6 +500,33 @@ describe('workflow context registry', () => {
         },
       ]
     `);
+  });
+
+  describe('workflow field failure policies', () => {
+    it('declares the supported failure-policy classes', () => {
+      expect(workflowFieldFailurePolicies).toEqual(['fail', 'degrade', 'fail-closed']);
+    });
+
+    it('maps interpolation fields to fail or degrade policies', () => {
+      expect(getWorkflowInterpolationFieldFailurePolicy('run')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('env.value')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('agent.prompt')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('agent.model')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('agent.provider')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('agent.thinking')).toBe('fail');
+      expect(getWorkflowInterpolationFieldFailurePolicy('job.name')).toBe('degrade');
+      expect(getWorkflowInterpolationFieldFailurePolicy('step.name')).toBe('degrade');
+      expect(
+        workflowInterpolationFields.map(
+          (field) => workflowInterpolationFieldPolicies[field].failurePolicy,
+        ),
+      ).not.toContain('fail-closed');
+    });
+
+    it('declares predicate fields as fail-closed', () => {
+      expect(workflowPredicateFields).toEqual(['step.success_if', 'job.success']);
+      expect(workflowPredicateFieldFailurePolicy).toBe('fail-closed');
+    });
   });
 
   it('supports CEL type-checking against the known context fields', () => {

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -250,8 +250,13 @@ export type WorkflowInterpolationField =
   | 'job.name'
   | 'step.name';
 
+export const workflowFieldFailurePolicies = ['fail', 'degrade', 'fail-closed'] as const;
+export type WorkflowFieldFailurePolicy = (typeof workflowFieldFailurePolicies)[number];
+export type WorkflowInterpolationFailurePolicy = Exclude<WorkflowFieldFailurePolicy, 'fail-closed'>;
+
 export interface WorkflowInterpolationFieldPolicy {
   readonly acceptedTrustTiers: readonly WorkflowContextTrustTier[];
+  readonly failurePolicy: WorkflowInterpolationFailurePolicy;
   readonly renderSanitize: boolean;
 }
 
@@ -261,34 +266,42 @@ const anyTrustTier: readonly WorkflowContextTrustTier[] = ['trusted', 'untrusted
 export const workflowInterpolationFieldPolicies = {
   run: {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    failurePolicy: 'fail',
     renderSanitize: false,
   },
   'env.value': {
     acceptedTrustTiers: anyTrustTier,
+    failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.prompt': {
     acceptedTrustTiers: anyTrustTier,
+    failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.model': {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.provider': {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.thinking': {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    failurePolicy: 'fail',
     renderSanitize: false,
   },
   'job.name': {
     acceptedTrustTiers: anyTrustTier,
+    failurePolicy: 'degrade',
     renderSanitize: true,
   },
   'step.name': {
     acceptedTrustTiers: anyTrustTier,
+    failurePolicy: 'degrade',
     renderSanitize: true,
   },
 } as const satisfies Record<WorkflowInterpolationField, WorkflowInterpolationFieldPolicy>;
@@ -296,6 +309,12 @@ export const workflowInterpolationFieldPolicies = {
 export const workflowInterpolationFields = Object.keys(
   workflowInterpolationFieldPolicies,
 ) as readonly WorkflowInterpolationField[];
+
+export const workflowPredicateFields = ['step.success_if', 'job.success'] as const;
+export type WorkflowPredicateField = (typeof workflowPredicateFields)[number];
+
+export const workflowPredicateFieldFailurePolicy =
+  'fail-closed' as const satisfies WorkflowFieldFailurePolicy;
 
 export function getWorkflowContextDefinition(name: WorkflowContextName): WorkflowContextDefinition {
   return workflowContextDefinitions[name];
@@ -355,6 +374,12 @@ export function workflowInterpolationFieldAcceptsContext(
     field,
     workflowContextDefinitions[context].trustTier,
   );
+}
+
+export function getWorkflowInterpolationFieldFailurePolicy(
+  field: WorkflowInterpolationField,
+): WorkflowInterpolationFailurePolicy {
+  return workflowInterpolationFieldPolicies[field].failurePolicy;
 }
 
 export interface WorkflowContextAvailabilityReferenceEntry {


### PR DESCRIPTION
Declare workflow interpolation failure behavior per field instead of deriving it from context trust. Value-bearing fields now fail when an available reference is missing, display fields degrade with diagnostics, and predicates share a fail-closed evaluator.

This prevents unsafe silent empty values for fields such as env and agent prompts while preserving deferral for roots that are not available yet. Step names no longer kill runs when interpolation is unresolvable and fall back to the generated display name when they degrade fully empty.

The resolver now receives the field failure policy and availability set directly, which keeps mixed available/unavailable expressions precise at segment granularity. The manual trigger route also returns structured interpolation details for author-facing 422s.

Review the policy boundary in `resolve-step-config.ts` and the resolver's all-roots-available rule carefully; those are the behavior-defining pieces.

Closes ENG-749

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare explicit failure policies per workflow field and apply them across resolution and evaluation. Value fields now fail on available missing references, display fields degrade, and predicates are evaluated fail-closed to improve safety and clarity. Implements ENG-749.

- **New Features**
  - Declared failure policies: fail (`run`, `env`, `agent.model`/`provider`/`prompt`), degrade (`step.name`, `job.name`), fail-closed (predicate fields).
  - Resolver accepts field policy and available roots; filters non-workflow CEL locals/map keys when applying availability; handles mixed availability per segment. Step names degrade and fall back to the generated display name when empty.
  - Added `evaluateWorkflowPredicateFailClosed` in `@shipfox/expression`; used in gate checks and job success resolution.
  - Enriched `InterpolationUnresolvableError` with `field`, `source`, and optional `envKey`; manual trigger returns 422 with structured `details`. Error message suggests wrapping optional refs with `has(x) ? x : ''`.

- **Migration**
  - Missing but available refs in value fields now fail. For optional data, wrap with `has(x) ? x : ''`.
  - Step names no longer abort runs; they degrade with diagnostics and may fall back to the display name.

<sup>Written for commit 6fbf15cb5e2d15a5d30039a35527acc5369df72f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

