### PR TITLE
Add E2E project setup helper

### DIFF
--- a/.changeset/steady-projects-provision.md
+++ b/.changeset/steady-projects-provision.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-projects": minor
+"@shipfox/api-projects-dto": minor
+---
+
+Adds HTTP-first E2E project setup contracts and routes for creating synthetic projects without source-control setup.

--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -24,6 +24,7 @@
     "@shipfox/client-integrations": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",

--- a/e2e/client/integrations/tests/sentry-callback.e2e.ts
+++ b/e2e/client/integrations/tests/sentry-callback.e2e.ts
@@ -34,37 +34,6 @@ async function stubConnect(page: Page, response: {status: number; body: unknown}
   });
 }
 
-async function stubProjectExists(page: Page, workspaceId: string): Promise<void> {
-  await page.route('**/projects?*', async (route) => {
-    const url = new URL(route.request().url());
-    if (url.searchParams.get('workspace_id') !== workspaceId) {
-      await route.continue();
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        projects: [
-          {
-            id: '00000000-0000-4000-8000-000000000001',
-            workspace_id: workspaceId,
-            name: 'Platform',
-            source: {
-              connection_id: '00000000-0000-4000-8000-000000000002',
-              external_repository_id: 'debug:platform',
-            },
-            created_at: '2026-01-15T12:00:00.000Z',
-            updated_at: '2026-01-15T12:00:00.000Z',
-          },
-        ],
-        next_cursor: null,
-      }),
-    });
-  });
-}
-
 test('Sentry callback shows an error when required params are missing', async ({
   page,
   auth,
@@ -100,16 +69,21 @@ test('Sentry callback shows the workspace picker', async ({page, auth, workspace
   await argosScreenshot(page, 'integrations/sentry-callback-pick-workspace');
 });
 
-test('Sentry callback installs to a workspace on success', async ({page, auth, workspaces}) => {
+test('Sentry callback installs to a workspace on success', async ({
+  page,
+  auth,
+  projects,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   const workspace = await workspaces.create({
     userId: user.user.id,
     name: 'Sentry Install Workspace',
   });
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, user);
 
   await stubConnect(page, {status: 200, body: sentryConnectionFixture(workspace.id)});
-  await stubProjectExists(page, workspace.id);
 
   await page.goto(CALLBACK_URL);
   await expect(page.getByRole('heading', {name: 'Install Sentry'})).toBeVisible();

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -27,40 +27,10 @@ async function stubProviders(page: Page): Promise<void> {
   });
 }
 
-async function stubProjectExists(page: Page, workspaceId: string): Promise<void> {
-  await page.route('**/projects?*', async (route) => {
-    const url = new URL(route.request().url());
-    if (url.searchParams.get('workspace_id') !== workspaceId) {
-      await route.continue();
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        projects: [
-          {
-            id: '00000000-0000-4000-8000-000000000001',
-            workspace_id: workspaceId,
-            name: 'Platform',
-            source: {
-              connection_id: '00000000-0000-4000-8000-000000000002',
-              external_repository_id: 'debug:platform',
-            },
-            created_at: '2026-01-15T12:00:00.000Z',
-            updated_at: '2026-01-15T12:00:00.000Z',
-          },
-        ],
-        next_cursor: null,
-      }),
-    });
-  });
-}
-
 test('settings catalogue lists available providers with an empty installed state', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const user = await auth.createUser();
@@ -68,10 +38,10 @@ test('settings catalogue lists available providers with an empty installed state
     userId: user.user.id,
     name: 'Integrations Settings Workspace',
   });
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, user);
 
   await stubProviders(page);
-  await stubProjectExists(page, workspace.id);
 
   await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
 
@@ -87,6 +57,7 @@ test('settings catalogue lists available providers with an empty installed state
 test('settings catalogue shows an installed provider after Debug install', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const user = await auth.createUser();
@@ -94,8 +65,8 @@ test('settings catalogue shows an installed provider after Debug install', async
     userId: user.user.id,
     name: 'Integrations Installed Workspace',
   });
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, user);
-  await stubProjectExists(page, workspace.id);
 
   // Real Debug install (no external dependency): the install page creates the
   // connection on mount, fires the success toast, then forwards to

--- a/e2e/client/integrations/tests/test.ts
+++ b/e2e/client/integrations/tests/test.ts
@@ -1,9 +1,11 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
 import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
 
-export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
+export const test = base.extend<AuthFixtures & ProjectsFixtures & WorkspacesFixtures>({
   ...authHelper,
+  ...projectsHelper,
   ...workspacesHelper,
 });
 export {expect};

--- a/e2e/client/runners/package.json
+++ b/e2e/client/runners/package.json
@@ -25,6 +25,7 @@
     "@shipfox/client-workspace-settings": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/regex": "workspace:*",

--- a/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
@@ -1,4 +1,4 @@
-import {argosScreenshot, type Page} from '@shipfox/playwright';
+import {argosScreenshot} from '@shipfox/playwright';
 import {createShipfoxTokenPrefixRegexes} from '@shipfox/regex';
 import {expect, test} from './test.js';
 
@@ -9,40 +9,10 @@ const VISUAL_TEST_RUNNER_TOKEN = 'sf_mrt_visual_regression_token';
 const VISUAL_TEST_CREATED_AT = 'Jan 15, 2026, 12:00 PM';
 const VISUAL_TEST_EXPIRES_AT = 'Jan 16, 2026, 12:00 PM';
 
-async function stubProjectExists(page: Page, workspaceId: string): Promise<void> {
-  await page.route('**/projects?*', async (route) => {
-    const url = new URL(route.request().url());
-    if (url.searchParams.get('workspace_id') !== workspaceId) {
-      await route.continue();
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        projects: [
-          {
-            id: '00000000-0000-4000-8000-000000000001',
-            workspace_id: workspaceId,
-            name: 'Platform',
-            source: {
-              connection_id: '00000000-0000-4000-8000-000000000002',
-              external_repository_id: 'debug:platform',
-            },
-            created_at: '2026-01-15T12:00:00.000Z',
-            updated_at: '2026-01-15T12:00:00.000Z',
-          },
-        ],
-        next_cursor: null,
-      }),
-    });
-  });
-}
-
 test('manages workspace manual registration tokens from settings', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   await page.clock.setFixedTime(VISUAL_TEST_NOW);
@@ -52,8 +22,8 @@ test('manages workspace manual registration tokens from settings', async ({
     userId: user.user.id,
     name: 'Runner Settings Workspace',
   });
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, user);
-  await stubProjectExists(page, workspace.id);
 
   await page.goto(`/workspaces/${workspace.id}/settings/runners`);
   await expect(page).toHaveURL(new RegExp(`/workspaces/${workspace.id}/settings/runners/?$`, 'u'));

--- a/e2e/client/runners/tests/test.ts
+++ b/e2e/client/runners/tests/test.ts
@@ -1,9 +1,11 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
 import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
 
-export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
+export const test = base.extend<AuthFixtures & ProjectsFixtures & WorkspacesFixtures>({
   ...authHelper,
+  ...projectsHelper,
   ...workspacesHelper,
 });
 export {expect};

--- a/e2e/client/secrets/package.json
+++ b/e2e/client/secrets/package.json
@@ -25,6 +25,7 @@
     "@shipfox/client-workspace-settings": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-secrets": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",

--- a/e2e/client/secrets/tests/secrets-settings.e2e.ts
+++ b/e2e/client/secrets/tests/secrets-settings.e2e.ts
@@ -1,4 +1,5 @@
 import type {AuthHelper} from '@shipfox/e2e-helper-auth';
+import type {ProjectsHelper} from '@shipfox/e2e-helper-projects';
 import type {WorkspacesHelper} from '@shipfox/e2e-helper-workspaces';
 import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
@@ -15,40 +16,10 @@ interface ReadyWorkspace {
   workspaceId: string;
 }
 
-async function stubProjectExists(page: Page, workspaceId: string): Promise<void> {
-  await page.route('**/projects?*', async (route) => {
-    const url = new URL(route.request().url());
-    if (url.searchParams.get('workspace_id') !== workspaceId) {
-      await route.continue();
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        projects: [
-          {
-            id: '00000000-0000-4000-8000-000000000001',
-            workspace_id: workspaceId,
-            name: 'Platform',
-            source: {
-              connection_id: '00000000-0000-4000-8000-000000000002',
-              external_repository_id: 'debug:platform',
-            },
-            created_at: '2026-01-15T12:00:00.000Z',
-            updated_at: '2026-01-15T12:00:00.000Z',
-          },
-        ],
-        next_cursor: null,
-      }),
-    });
-  });
-}
-
 async function createReadyWorkspace(params: {
   auth: AuthHelper;
   page: Page;
+  projects: ProjectsHelper;
   workspaces: WorkspacesHelper;
   name: string;
 }): Promise<ReadyWorkspace> {
@@ -57,8 +28,8 @@ async function createReadyWorkspace(params: {
     userId: user.user.id,
     name: params.name,
   });
+  await params.projects.createProject({workspaceId: workspace.id});
   await params.auth.loginAs(params.page, user);
-  await stubProjectExists(params.page, workspace.id);
 
   return {userId: user.user.id, workspaceId: workspace.id};
 }
@@ -115,10 +86,11 @@ async function createVariableFromSettings(page: Page, key: string, value: string
   await expect(rowByKey(section, key)).toBeVisible();
 }
 
-test('creates a workspace secret from settings', async ({page, auth, workspaces}) => {
+test('creates a workspace secret from settings', async ({page, auth, projects, workspaces}) => {
   const {workspaceId} = await createReadyWorkspace({
     page,
     auth,
+    projects,
     workspaces,
     name: 'Secrets Create Workspace',
   });
@@ -133,10 +105,17 @@ test('creates a workspace secret from settings', async ({page, auth, workspaces}
   await expect(secretsSection(page)).not.toContainText(value);
 });
 
-test('edits a workspace secret from settings', async ({page, auth, workspaces, secrets}) => {
+test('edits a workspace secret from settings', async ({
+  page,
+  auth,
+  projects,
+  workspaces,
+  secrets,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     page,
     auth,
+    projects,
     workspaces,
     name: 'Secrets Edit Workspace',
   });
@@ -166,10 +145,17 @@ test('edits a workspace secret from settings', async ({page, auth, workspaces, s
   await expect(secretsSection(page)).not.toContainText(newValue);
 });
 
-test('deletes a workspace secret from settings', async ({page, auth, workspaces, secrets}) => {
+test('deletes a workspace secret from settings', async ({
+  page,
+  auth,
+  projects,
+  workspaces,
+  secrets,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     page,
     auth,
+    projects,
     workspaces,
     name: 'Secrets Delete Workspace',
   });
@@ -193,10 +179,11 @@ test('deletes a workspace secret from settings', async ({page, auth, workspaces,
   await expect(section.getByText('No secrets yet')).toBeVisible();
 });
 
-test('creates a workspace variable from settings', async ({page, auth, workspaces}) => {
+test('creates a workspace variable from settings', async ({page, auth, projects, workspaces}) => {
   const {workspaceId} = await createReadyWorkspace({
     page,
     auth,
+    projects,
     workspaces,
     name: 'Variables Create Workspace',
   });
@@ -210,10 +197,17 @@ test('creates a workspace variable from settings', async ({page, auth, workspace
   await expect(row.getByText(value, {exact: true})).toBeVisible();
 });
 
-test('edits a workspace variable from settings', async ({page, auth, workspaces, secrets}) => {
+test('edits a workspace variable from settings', async ({
+  page,
+  auth,
+  projects,
+  workspaces,
+  secrets,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     page,
     auth,
+    projects,
     workspaces,
     name: 'Variables Edit Workspace',
   });
@@ -244,10 +238,17 @@ test('edits a workspace variable from settings', async ({page, auth, workspaces,
   await expect(row).not.toContainText(oldValue);
 });
 
-test('deletes a workspace variable from settings', async ({page, auth, workspaces, secrets}) => {
+test('deletes a workspace variable from settings', async ({
+  page,
+  auth,
+  projects,
+  workspaces,
+  secrets,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     page,
     auth,
+    projects,
     workspaces,
     name: 'Variables Delete Workspace',
   });

--- a/e2e/client/secrets/tests/test.ts
+++ b/e2e/client/secrets/tests/test.ts
@@ -1,10 +1,14 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
 import {type SecretsFixtures, secretsHelper} from '@shipfox/e2e-helper-secrets';
 import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
 
-export const test = base.extend<AuthFixtures & WorkspacesFixtures & SecretsFixtures>({
+export const test = base.extend<
+  AuthFixtures & ProjectsFixtures & WorkspacesFixtures & SecretsFixtures
+>({
   ...authHelper,
+  ...projectsHelper,
   ...workspacesHelper,
   ...secretsHelper,
 });

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -23,6 +23,7 @@
     "@shipfox/client-router": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",

--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -1,6 +1,5 @@
 import {randomUUID} from 'node:crypto';
-import type {Page} from '@shipfox/playwright';
-import {argosScreenshot} from '@shipfox/playwright';
+import {argosScreenshot, type Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const PENDING_INVITATION_RE = /open invitation already exists/u;
@@ -16,37 +15,6 @@ function workspaceUrlRe(wid: string): RegExp {
 
 function textRe(text: string): RegExp {
   return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&'), 'u');
-}
-
-async function stubProjectExists(page: Page, workspaceId: string): Promise<void> {
-  await page.route('**/projects?*', async (route) => {
-    const url = new URL(route.request().url());
-    if (url.searchParams.get('workspace_id') !== workspaceId) {
-      await route.continue();
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        projects: [
-          {
-            id: '00000000-0000-4000-8000-000000000001',
-            workspace_id: workspaceId,
-            name: 'Platform',
-            source: {
-              connection_id: '00000000-0000-4000-8000-000000000002',
-              external_repository_id: 'debug:platform',
-            },
-            created_at: '2026-01-15T12:00:00.000Z',
-            updated_at: '2026-01-15T12:00:00.000Z',
-          },
-        ],
-        next_cursor: null,
-      }),
-    });
-  });
 }
 
 async function stableArgosScreenshot(
@@ -156,6 +124,7 @@ async function stableArgosScreenshot(
 test('accepts an invitation from the public landing page via login', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const owner = await auth.createUser({name: 'Owner User'});
@@ -199,7 +168,7 @@ test('accepts an invitation from the public landing page via login', async ({
   await expect(page.getByLabel('Email')).toHaveValue(invitee.email);
 
   await page.getByLabel('Password').fill(invitee.password);
-  await stubProjectExists(page, workspace.id);
+  await projects.createProject({workspaceId: workspace.id});
   await page.getByRole('button', {name: 'Log in'}).click();
 
   await expect(page).toHaveURL(workspaceUrlRe(workspace.id));
@@ -227,6 +196,7 @@ test('accepts an invitation from the public landing page via login', async ({
 test('creates an account from an invitation with the email locked', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const owner = await auth.createUser({name: 'Signup Owner'});
@@ -255,7 +225,7 @@ test('creates an account from an invitation with the email locked', async ({
 
   await page.getByLabel('Name').fill('Signup Invitee');
   await page.getByLabel('Password').fill('correct horse battery staple');
-  await stubProjectExists(page, workspace.id);
+  await projects.createProject({workspaceId: workspace.id});
   await page.getByRole('button', {name: 'Create account'}).click();
 
   await expect(page).toHaveURL(workspaceUrlRe(workspace.id));
@@ -269,6 +239,7 @@ test('creates an account from an invitation with the email locked', async ({
 test('creates, rejects duplicate, and revokes a pending invitation from members settings', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const owner = await auth.createUser({name: 'Settings Owner'});
@@ -279,8 +250,8 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
     name: 'Members Settings Workspace',
   });
   const pendingEmail = `pending-${randomUUID()}@example.test`;
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, owner);
-  await stubProjectExists(page, workspace.id);
 
   await page.goto(`/workspaces/${workspace.id}/settings/members`);
   await expect(page.getByRole('heading', {name: 'Pending invitations'})).toBeVisible();

--- a/e2e/client/workspaces/tests/test.ts
+++ b/e2e/client/workspaces/tests/test.ts
@@ -1,9 +1,11 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
 import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
 
-export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
+export const test = base.extend<AuthFixtures & ProjectsFixtures & WorkspacesFixtures>({
   ...authHelper,
+  ...projectsHelper,
   ...workspacesHelper,
 });
 export {expect};

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -38,39 +38,6 @@ async function expectSetupNavigationHidden(page: Page): Promise<void> {
   await expect(page.getByLabel('Switch workspace')).toBeVisible();
 }
 
-async function stubProjectsExist(page: Page, workspaceIds: ReadonlyArray<string>): Promise<void> {
-  const completedWorkspaceIds = new Set(workspaceIds);
-  await page.route('**/projects?*', async (route) => {
-    const url = new URL(route.request().url());
-    const workspaceId = url.searchParams.get('workspace_id');
-    if (!workspaceId || !completedWorkspaceIds.has(workspaceId)) {
-      await route.continue();
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        projects: [
-          {
-            id: '00000000-0000-4000-8000-000000000001',
-            workspace_id: workspaceId,
-            name: 'Platform',
-            source: {
-              connection_id: '00000000-0000-4000-8000-000000000002',
-              external_repository_id: 'debug:platform',
-            },
-            created_at: '2026-01-15T12:00:00.000Z',
-            updated_at: '2026-01-15T12:00:00.000Z',
-          },
-        ],
-        next_cursor: null,
-      }),
-    });
-  });
-}
-
 async function completeWorkspaceSetup(page: Page, workspaceId: string): Promise<void> {
   await page.goto(`/workspaces/${workspaceId}/integrations/debug`);
   await expect(page).toHaveURL(setupDestinationUrlRe(workspaceId), {
@@ -143,14 +110,15 @@ test('creates the first workspace via onboarding and persists lastWorkspaceId', 
   await argosScreenshot(page, 'workspaces/onboarding-complete');
 });
 
-test('switches between workspaces from the top nav', async ({page, auth, workspaces}) => {
+test('switches between workspaces from the top nav', async ({page, auth, projects, workspaces}) => {
   const user = await auth.createUser();
   const workspaceAName = 'Alpha Workspace';
   const workspaceBName = 'Beta Workspace';
   const wsA = await workspaces.create({userId: user.user.id, name: workspaceAName});
   const wsB = await workspaces.create({userId: user.user.id, name: workspaceBName});
+  await projects.createProject({workspaceId: wsA.id});
+  await projects.createProject({workspaceId: wsB.id});
   await auth.loginAs(page, user);
-  await stubProjectsExist(page, [wsA.id, wsB.id]);
 
   await page.goto(`/workspaces/${wsA.id}`);
   await expect(page).toHaveURL(workspaceUrlRe(wsA.id));
@@ -230,14 +198,15 @@ test('settings tab opens members settings', async ({page, auth, workspaces}) => 
 test('creates a second workspace from the switcher mid-session', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const user = await auth.createUser();
   const workspaceAName = 'Alpha Workspace';
   const workspaceBName = 'Beta Workspace';
   const wsA = await workspaces.create({userId: user.user.id, name: workspaceAName});
+  await projects.createProject({workspaceId: wsA.id});
   await auth.loginAs(page, user);
-  await stubProjectsExist(page, [wsA.id]);
 
   await page.goto(`/workspaces/${wsA.id}`);
   await page.getByLabel('Switch workspace').click();
@@ -265,12 +234,13 @@ test('creates a second workspace from the switcher mid-session', async ({
 test('switcher keeps Create workspace visible when search filters every workspace out', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const user = await auth.createUser();
   const wsA = await workspaces.create({userId: user.user.id, name: 'Alpha Workspace'});
+  await projects.createProject({workspaceId: wsA.id});
   await auth.loginAs(page, user);
-  await stubProjectsExist(page, [wsA.id]);
 
   await page.goto(`/workspaces/${wsA.id}`);
   await page.getByLabel('Switch workspace').click();
@@ -293,16 +263,17 @@ test('switcher keeps Create workspace visible when search filters every workspac
 test('switcher list scrolls while Create workspace stays pinned', async ({
   page,
   auth,
+  projects,
   workspaces,
 }) => {
   const user = await auth.createUser();
   const first = await workspaces.create({userId: user.user.id, name: 'Workspace 01'});
+  await projects.createProject({workspaceId: first.id});
   for (let i = 2; i <= 20; i++) {
     const name = `Workspace ${String(i).padStart(2, '0')}`;
     await workspaces.create({userId: user.user.id, name});
   }
   await auth.loginAs(page, user);
-  await stubProjectsExist(page, [first.id]);
 
   await page.goto(`/workspaces/${first.id}`);
   await expect(page).toHaveURL(workspaceUrlRe(first.id));

--- a/e2e/helpers/projects/package.json
+++ b/e2e/helpers/projects/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shipfox/e2e-helper-projects",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/helpers/projects"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-projects-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/e2e/helpers/projects/src/index.test.ts
+++ b/e2e/helpers/projects/src/index.test.ts
@@ -1,0 +1,90 @@
+import {E2eApiError} from '@shipfox/e2e-core';
+
+const workspaceId = '11111111-1111-4111-8111-111111111111';
+const projectId = '22222222-2222-4222-8222-222222222222';
+const sourceConnectionId = '33333333-3333-4333-8333-333333333333';
+
+describe('createProject', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  test('posts to the projects E2E setup route', async () => {
+    const requestJson = vi.fn().mockResolvedValue({
+      id: projectId,
+      workspace_id: workspaceId,
+      name: 'E2E Project',
+      source: {
+        connection_id: sourceConnectionId,
+        external_repository_id: 'e2e:project',
+      },
+      created_at: '2026-01-15T12:00:00.000Z',
+      updated_at: '2026-01-15T12:00:00.000Z',
+    });
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+    const {createProject: createProjectWithMock} = await import('./index.js');
+
+    const result = await createProjectWithMock({workspaceId});
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/projects', {
+      json: {
+        workspace_id: workspaceId,
+        name: 'E2E Project',
+        source_connection_id: undefined,
+        source_external_repository_id: undefined,
+      },
+    });
+    expect(result.id).toBe(projectId);
+  });
+
+  test('maps camelCase params to a snake_case body', async () => {
+    const requestJson = vi.fn().mockResolvedValue({});
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+    const {createProject: createProjectWithMock} = await import('./index.js');
+
+    await createProjectWithMock({
+      workspaceId,
+      name: 'Platform',
+      sourceConnectionId,
+      sourceExternalRepositoryId: 'e2e:platform',
+    });
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/projects', {
+      json: {
+        workspace_id: workspaceId,
+        name: 'Platform',
+        source_connection_id: sourceConnectionId,
+        source_external_repository_id: 'e2e:platform',
+      },
+    });
+  });
+
+  test('applies defaults', async () => {
+    const requestJson = vi.fn().mockResolvedValue({});
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+    const {createProject: createProjectWithMock} = await import('./index.js');
+
+    await createProjectWithMock({workspaceId});
+
+    expect(requestJson).toHaveBeenCalledWith('post', '/__e2e/projects', {
+      json: expect.objectContaining({
+        name: 'E2E Project',
+      }),
+    });
+  });
+
+  test('bubbles request errors', async () => {
+    const error = new E2eApiError({
+      message: 'E2E API request failed',
+      status: 409,
+      details: {code: 'project-already-exists'},
+    });
+    const requestJson = vi.fn().mockRejectedValue(error);
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+    const {createProject: createProjectWithMock} = await import('./index.js');
+
+    const result = createProjectWithMock({workspaceId});
+
+    await expect(result).rejects.toBe(error);
+  });
+});

--- a/e2e/helpers/projects/src/index.ts
+++ b/e2e/helpers/projects/src/index.ts
@@ -1,0 +1,48 @@
+import type {E2eCreateProjectBodyDto, E2eCreateProjectResponseDto} from '@shipfox/api-projects-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+export type {E2eCreateProjectBodyDto, E2eCreateProjectResponseDto} from '@shipfox/api-projects-dto';
+
+export interface CreateProjectParams {
+  workspaceId: string;
+  name?: string;
+  sourceConnectionId?: string | undefined;
+  sourceExternalRepositoryId?: string | undefined;
+}
+
+const DEFAULT_PROJECT_NAME = 'E2E Project';
+
+export async function createProject(
+  params: CreateProjectParams,
+): Promise<E2eCreateProjectResponseDto> {
+  const body: E2eCreateProjectBodyDto = {
+    workspace_id: params.workspaceId,
+    name: params.name ?? DEFAULT_PROJECT_NAME,
+    source_connection_id: params.sourceConnectionId,
+    source_external_repository_id: params.sourceExternalRepositoryId,
+  };
+  return await requestJson<E2eCreateProjectResponseDto>('post', '/__e2e/projects', {
+    json: body,
+  });
+}
+
+export function createProjectsHelper() {
+  return {
+    createProject,
+  };
+}
+
+export type ProjectsHelper = ReturnType<typeof createProjectsHelper>;
+
+export interface ProjectsFixtures {
+  projects: ProjectsHelper;
+}
+
+export const projectsHelper = {
+  projects: async (
+    {request: _request}: {request: unknown},
+    use: (helper: ProjectsHelper) => Promise<void>,
+  ) => {
+    await use(createProjectsHelper());
+  },
+};

--- a/e2e/helpers/projects/tsconfig.build.json
+++ b/e2e/helpers/projects/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/projects/tsconfig.json
+++ b/e2e/helpers/projects/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/helpers/projects/tsconfig.test.json
+++ b/e2e/helpers/projects/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/helpers/projects/vitest.config.ts
+++ b/e2e/helpers/projects/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/api/projects-dto/src/e2e/index.ts
+++ b/libs/api/projects-dto/src/e2e/index.ts
@@ -1,0 +1,6 @@
+export {
+  type E2eCreateProjectBodyDto,
+  type E2eCreateProjectResponseDto,
+  e2eCreateProjectBodySchema,
+  e2eCreateProjectResponseSchema,
+} from './project.js';

--- a/libs/api/projects-dto/src/e2e/project.ts
+++ b/libs/api/projects-dto/src/e2e/project.ts
@@ -1,0 +1,16 @@
+import {displayNameSchema} from '@shipfox/api-common-dto';
+import {z} from 'zod';
+import {projectResponseSchema} from '../schemas/project.js';
+
+export const e2eCreateProjectBodySchema = z.object({
+  workspace_id: z.string().uuid(),
+  name: displayNameSchema,
+  source_connection_id: z.string().uuid().optional(),
+  source_external_repository_id: z.string().min(1).max(255).optional(),
+});
+
+export type E2eCreateProjectBodyDto = z.infer<typeof e2eCreateProjectBodySchema>;
+
+export const e2eCreateProjectResponseSchema = projectResponseSchema;
+
+export type E2eCreateProjectResponseDto = z.infer<typeof e2eCreateProjectResponseSchema>;

--- a/libs/api/projects-dto/src/index.ts
+++ b/libs/api/projects-dto/src/index.ts
@@ -1,2 +1,3 @@
+export * from './e2e/index.js';
 export * from './events.js';
 export * from './schemas/index.js';

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -8,6 +8,7 @@ import {
 import {projectsEventSchemas} from '@shipfox/api-projects-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, projectsOutbox} from '#db/index.js';
+import {projectsE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
 import {onSourceCommitPushed} from '#presentation/subscribers/index.js';
 import {createProjectsMaintenanceActivities} from '#temporal/activities/index.js';
@@ -47,6 +48,7 @@ export function createProjectsModule({sourceControl}: CreateProjectsModuleOption
     name: 'projects',
     database: {db, migrationsPath},
     routes: createProjectRoutes(sourceControl),
+    e2eRoutes: [projectsE2eRoutes],
     publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
     subscribers: [subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed)],
     workers: [

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.test.ts
@@ -1,0 +1,119 @@
+import {closeApp, createApp} from '@shipfox/node-fastify';
+import {sql} from 'drizzle-orm';
+import {db} from '#db/index.js';
+import {projectsOutbox} from '#db/schema/outbox.js';
+import {projectsE2eRoutes} from './index.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/u;
+const E2E_SOURCE_RE = /^e2e:/u;
+
+describe('projects E2E routes', () => {
+  afterEach(async () => {
+    await closeApp();
+  });
+
+  test('creates a project with generated synthetic source values', async () => {
+    const workspaceId = crypto.randomUUID();
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: workspaceId,
+        name: '  E2E Project  ',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toMatchObject({
+      workspace_id: workspaceId,
+      name: 'E2E Project',
+    });
+    expect(res.json().source.connection_id).toMatch(UUID_RE);
+    expect(res.json().source.external_repository_id).toMatch(E2E_SOURCE_RE);
+  });
+
+  test('preserves explicit synthetic source values', async () => {
+    const workspaceId = crypto.randomUUID();
+    const sourceConnectionId = crypto.randomUUID();
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: workspaceId,
+        name: 'E2E Project',
+        source_connection_id: sourceConnectionId,
+        source_external_repository_id: 'e2e:explicit',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json().source).toEqual({
+      connection_id: sourceConnectionId,
+      external_repository_id: 'e2e:explicit',
+    });
+  });
+
+  test('returns conflict for duplicate explicit source values', async () => {
+    const workspaceId = crypto.randomUUID();
+    const sourceConnectionId = crypto.randomUUID();
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+    const payload = {
+      workspace_id: workspaceId,
+      name: 'E2E Project',
+      source_connection_id: sourceConnectionId,
+      source_external_repository_id: 'e2e:duplicate',
+    };
+    await app.inject({method: 'POST', url: '/projects', payload});
+
+    const res = await app.inject({method: 'POST', url: '/projects', payload});
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toMatchObject({
+      code: 'project-already-exists',
+      details: {
+        source_connection_id: sourceConnectionId,
+        source_external_repository_id: 'e2e:duplicate',
+      },
+    });
+  });
+
+  test('rejects invalid bodies', async () => {
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: 'not-a-uuid',
+        name: 'E2E Project',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('does not write project outbox events', async () => {
+    const workspaceId = crypto.randomUUID();
+    const app = await createApp({routes: [projectsE2eRoutes], swagger: false});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/projects',
+      payload: {
+        workspace_id: workspaceId,
+        name: 'E2E Project',
+      },
+    });
+
+    const events = await db()
+      .select()
+      .from(projectsOutbox)
+      .where(sql`${projectsOutbox.payload}->>'projectId' = ${res.json().id}`);
+    expect(res.statusCode).toBe(201);
+    expect(events).toEqual([]);
+  });
+});

--- a/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/create-project.ts
@@ -1,0 +1,50 @@
+import {randomUUID} from 'node:crypto';
+import {
+  e2eCreateProjectBodySchema,
+  e2eCreateProjectResponseSchema,
+} from '@shipfox/api-projects-dto';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {ProjectAlreadyExistsError} from '#core/index.js';
+import {createProject} from '#db/index.js';
+import {toProjectDto} from '#presentation/dto/index.js';
+
+function syntheticExternalRepositoryId(): string {
+  return `e2e:${randomUUID()}`;
+}
+
+export const createE2eProjectRoute = defineRoute({
+  method: 'POST',
+  path: '/',
+  description: 'Create a synthetic project for E2E tests.',
+  schema: {
+    body: e2eCreateProjectBodySchema,
+    response: {
+      201: e2eCreateProjectResponseSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof ProjectAlreadyExistsError) {
+      throw new ClientError(error.message, 'project-already-exists', {
+        details: {
+          existing_project_id: error.existingProjectId,
+          source_connection_id: error.sourceConnectionId,
+          source_external_repository_id: error.sourceExternalRepositoryId,
+        },
+        status: 409,
+      });
+    }
+    throw error;
+  },
+  handler: async (request, reply) => {
+    const project = await createProject({
+      workspaceId: request.body.workspace_id,
+      name: request.body.name,
+      sourceConnectionId: request.body.source_connection_id ?? randomUUID(),
+      sourceExternalRepositoryId:
+        request.body.source_external_repository_id ?? syntheticExternalRepositoryId(),
+    });
+
+    reply.code(201);
+    return toProjectDto(project);
+  },
+});

--- a/libs/api/projects/src/presentation/e2eRoutes/index.ts
+++ b/libs/api/projects/src/presentation/e2eRoutes/index.ts
@@ -1,0 +1,7 @@
+import type {RouteGroup} from '@shipfox/node-fastify';
+import {createE2eProjectRoute} from './create-project.js';
+
+export const projectsE2eRoutes: RouteGroup = {
+  prefix: '/projects',
+  routes: [createE2eProjectRoute],
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@shipfox/e2e-helper-auth':
         specifier: workspace:*
         version: link:../../helpers/auth
+      '@shipfox/e2e-helper-projects':
+        specifier: workspace:*
+        version: link:../../helpers/projects
       '@shipfox/e2e-helper-workspaces':
         specifier: workspace:*
         version: link:../../helpers/workspaces
@@ -336,6 +339,9 @@ importers:
       '@shipfox/e2e-helper-auth':
         specifier: workspace:*
         version: link:../../helpers/auth
+      '@shipfox/e2e-helper-projects':
+        specifier: workspace:*
+        version: link:../../helpers/projects
       '@shipfox/e2e-helper-workspaces':
         specifier: workspace:*
         version: link:../../helpers/workspaces
@@ -408,6 +414,9 @@ importers:
       '@shipfox/e2e-helper-auth':
         specifier: workspace:*
         version: link:../../helpers/auth
+      '@shipfox/e2e-helper-projects':
+        specifier: workspace:*
+        version: link:../../helpers/projects
       '@shipfox/e2e-helper-workspaces':
         specifier: workspace:*
         version: link:../../helpers/workspaces
@@ -532,6 +541,31 @@ importers:
       '@shipfox/api-logs-dto':
         specifier: workspace:*
         version: link:../../../libs/api/logs-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
+
+  e2e/helpers/projects:
+    dependencies:
+      '@shipfox/api-projects-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/projects-dto
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
       '@shipfox/e2e-helper-auth':
         specifier: workspace:*
         version: link:../../helpers/auth
+      '@shipfox/e2e-helper-projects':
+        specifier: workspace:*
+        version: link:../../helpers/projects
       '@shipfox/e2e-helper-secrets':
         specifier: workspace:*
         version: link:../../helpers/secrets


### PR DESCRIPTION
Add a projects-owned E2E setup API and helper for creating synthetic projects.

Workspace setup guards only need to know that a workspace has at least one project, but several E2E specs were satisfying that precondition by stubbing `GET /projects?...` responses in Playwright. This keeps setup HTTP-first by adding `POST /__e2e/projects` and `@shipfox/e2e-helper-projects`, then rewires the workspaces, runners, and integrations suites to create real setup data.

The E2E route inserts projects directly with synthetic source identifiers and deliberately skips source-control resolution and project outbox events, because these tests are setup-data-only and do not need production source binding.

Validation:
- `mise exec -- turbo build --filter '...[origin/main]'`
- `mise exec -- turbo test --filter '...[origin/main]'`
- `mise exec -- turbo check --filter '...[origin/main]'`
- `API_URL=http://localhost:55171 CLIENT_URL=http://localhost:55170 mise exec -- turbo test:e2e --filter=@shipfox/e2e-client-workspaces --filter=@shipfox/e2e-client-runners --filter=@shipfox/e2e-client-integrations`

Closes ENG-753

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an HTTP-first E2E project setup via `POST /__e2e/projects` and a `@shipfox/e2e-helper-projects` helper to create real projects for tests, replacing Playwright stubs. Addresses ENG-753 by keeping E2E setup decoupled from source control and avoiding direct DB access.

- **New Features**
  - Added `POST /__e2e/projects` in `@shipfox/api-projects` to create synthetic projects; generates source IDs by default, skips source-control and outbox, and returns 409 `project-already-exists` on duplicate explicit source.
  - Introduced `@shipfox/e2e-helper-projects` with `projects.createProject({workspaceId, ...})` and a Playwright fixture.
  - Added DTO schemas in `@shipfox/api-projects-dto` for the E2E create body/response; registered the E2E routes.
  - Updated E2E suites (`workspaces`, `runners`, `integrations`, `secrets`) to use the helper and removed `GET /projects` stubs.

<sup>Written for commit 614530e694ce0fd9ddc0985978f65ddf02d99801. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

