### PR TITLE
Add phase-aware workflow validation hints

### DIFF
--- a/.changeset/steady-contexts-validate.md
+++ b/.changeset/steady-contexts-validate.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/expression": minor
+"@shipfox/api-definitions": patch
+---
+
+Reject workflow definitions whose step run/env/agent/name interpolation references a context root not yet available at that field's fill site, with a message naming when the root becomes available.

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -1,6 +1,7 @@
 export const invalidWorkflowModelErrorCode = 'invalid-workflow-model';
 
 export type WorkflowModelValidationIssueCode =
+  | 'context-unavailable-at-fill-site'
   | 'duplicate-job-id'
   | 'duplicate-step-id'
   | 'duplicate-trigger-id'

--- a/libs/api/definitions/src/core/workflow-model/normalize-env.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-env.ts
@@ -1,3 +1,4 @@
+import type {AvailabilitySite} from '@shipfox/expression';
 import type {WorkflowEnvTemplates, WorkflowFieldTemplate} from '../entities/workflow-model.js';
 import type {
   WorkflowModelValidationIssue,
@@ -9,6 +10,7 @@ export function normalizeEnv(params: {
   env: Readonly<Record<string, string | number | boolean>> | undefined;
   path: readonly WorkflowModelValidationIssuePathSegment[];
   issues: WorkflowModelValidationIssue[];
+  fillSite?: AvailabilitySite;
 }): {env?: Readonly<Record<string, string>>; templates?: {env: WorkflowEnvTemplates}} {
   const env = params.env;
   if (env === undefined || Object.keys(env).length === 0) return {};
@@ -28,6 +30,7 @@ export function normalizeEnv(params: {
       source: value,
       path: [...params.path, key],
       issues: params.issues,
+      ...(params.fillSite === undefined ? {} : {fillSite: params.fillSite}),
     });
     if (template !== undefined) templates[key] = template;
   }

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -1,4 +1,5 @@
 import {getModelProviderEntry} from '@shipfox/api-agent-dto';
+import type {AvailabilitySite} from '@shipfox/expression';
 import {
   canonicalizeLabels,
   findInvalidLabels,
@@ -70,12 +71,17 @@ function normalizeJob(params: {
     job: params.job,
     jobIdBySourceName: params.jobIdBySourceName,
   });
+  // Keep this aligned with materialize-workflow-model.ts and ENG-673's listener loop:
+  // one-shot steps are filled at run creation; listening steps are filled per execution.
+  const stepFillSite: AvailabilitySite =
+    params.job.listening === undefined ? 'run-creation' : 'execution-creation';
   const steps = normalizeJobSteps({
     sourceName: params.sourceName,
     jobId: id,
     job: params.job,
     issues: params.issues,
     stepSourceLocations: params.stepSourceLocations,
+    fillSite: stepFillSite,
   });
   const runner = normalizeRunner({
     document: params.document,
@@ -149,6 +155,7 @@ function normalizeJobSteps(params: {
   job: WorkflowDocumentJob;
   issues: WorkflowModelValidationIssue[];
   stepSourceLocations: WorkflowStepSourceLocationMap | undefined;
+  fillSite: AvailabilitySite;
 }): readonly WorkflowModelStep[] {
   const usedStepIds = new Map<string, number>();
 
@@ -162,6 +169,7 @@ function normalizeJobSteps(params: {
       usedStepIds,
       issues: params.issues,
       stepSourceLocations: params.stepSourceLocations,
+      fillSite: params.fillSite,
     }),
   );
 }
@@ -175,6 +183,7 @@ function normalizeStep(params: {
   usedStepIds: Map<string, number>;
   issues: WorkflowModelValidationIssue[];
   stepSourceLocations: WorkflowStepSourceLocationMap | undefined;
+  fillSite: AvailabilitySite;
 }): WorkflowModelStep {
   const stepKey = params.step.key;
   const stepId =
@@ -217,6 +226,7 @@ function normalizeStep(params: {
           source: params.step.name,
           path: ['jobs', params.sourceName, 'steps', params.index, 'name'],
           issues: params.issues,
+          fillSite: params.fillSite,
         });
   const stepBase = {
     id: stepId,
@@ -234,6 +244,7 @@ function normalizeStep(params: {
       stepIndex: params.index,
       name,
       issues: params.issues,
+      fillSite: params.fillSite,
     });
   }
 
@@ -245,6 +256,7 @@ function normalizeStep(params: {
       stepIndex: params.index,
       name,
       issues: params.issues,
+      fillSite: params.fillSite,
     });
   }
 
@@ -260,6 +272,7 @@ function normalizeRunStep(params: {
   stepIndex: number;
   name: WorkflowFieldTemplate | undefined;
   issues: WorkflowModelValidationIssue[];
+  fillSite: AvailabilitySite;
 }): WorkflowModelRunStep {
   if (params.step.run === undefined) {
     throw new Error('Run step normalization requires a run command');
@@ -270,11 +283,13 @@ function normalizeRunStep(params: {
     source: params.step.run,
     path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'run'],
     issues: params.issues,
+    fillSite: params.fillSite,
   });
   const stepEnv = normalizeEnv({
     env: params.step.env,
     path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'env'],
     issues: params.issues,
+    fillSite: params.fillSite,
   });
   const templates = optionalRunStepTemplates({
     command: commandTemplate,
@@ -298,6 +313,7 @@ function normalizeAgentStep(params: {
   stepIndex: number;
   name: WorkflowFieldTemplate | undefined;
   issues: WorkflowModelValidationIssue[];
+  fillSite: AvailabilitySite;
 }): WorkflowModelAgentStep {
   if (params.step.prompt === undefined) {
     throw new Error('Agent step normalization requires a prompt');
@@ -308,6 +324,7 @@ function normalizeAgentStep(params: {
     source: params.step.prompt,
     path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'prompt'],
     issues: params.issues,
+    fillSite: params.fillSite,
   });
   const modelTemplate =
     params.step.model === undefined
@@ -317,6 +334,7 @@ function normalizeAgentStep(params: {
           source: params.step.model,
           path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'model'],
           issues: params.issues,
+          fillSite: params.fillSite,
         });
   const providerTemplate =
     params.step.provider === undefined
@@ -326,6 +344,7 @@ function normalizeAgentStep(params: {
           source: params.step.provider,
           path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'provider'],
           issues: params.issues,
+          fillSite: params.fillSite,
         });
   if (providerTemplate === undefined) {
     validateAgentStep({

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1456,6 +1456,10 @@ describe('normalizeWorkflowDocument', () => {
 
   describe('definition-time interpolation', () => {
     const interpolation = (source: string) => '$'.concat('{{ ', source, ' }}');
+    const listening = () => ({
+      on: [{source: 'github', event: 'pull_request_review'}],
+      max_executions: 1,
+    });
 
     it('stores parsed templates for run, env, prompt, and step name fields', () => {
       const document: WorkflowDocument = {
@@ -1710,11 +1714,252 @@ describe('normalizeWorkflowDocument', () => {
       ]);
     });
 
+    it.each([
+      ['run', {run: `echo ${interpolation('execution.index')}`}, ['run']],
+      [
+        'step-level env',
+        {run: 'echo ok', env: {EXECUTION_INDEX: interpolation('execution.index')}},
+        ['env', 'EXECUTION_INDEX'],
+      ],
+      ['step name', {name: interpolation('execution.index'), run: 'echo ok'}, ['name']],
+    ] as const)('rejects one-shot %s interpolation before its context is available', (_field, step, path) => {
+      const document: WorkflowDocument = {
+        name: 'early execution context',
+        jobs: {
+          build: {
+            steps: [step],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'context-unavailable-at-fill-site',
+          path: ['jobs', 'build', 'steps', 0, ...path],
+          message: expect.stringContaining(
+            '"execution" is not available at run creation; it becomes available at execution creation.',
+          ),
+          details: expect.objectContaining({
+            contextRoots: ['execution'],
+            unavailableRoots: ['execution'],
+            fillSite: 'run-creation',
+          }),
+        }),
+      ]);
+    });
+
+    it.each([
+      ['run', {run: `echo ${interpolation('execution.index')}`}],
+      [
+        'step-level env',
+        {run: 'echo ok', env: {EXECUTION_INDEX: interpolation('execution.index')}},
+      ],
+      ['step name', {name: interpolation('execution.index'), run: 'echo ok'}],
+    ] as const)('allows listening job %s interpolation when execution context is available', (_field, step) => {
+      const document: WorkflowDocument = {
+        name: 'execution context',
+        jobs: {
+          build: {
+            listening: listening(),
+            steps: [step],
+          },
+        },
+      };
+
+      const model = normalizeWorkflowDocument(document);
+
+      expect(model.jobs[0]?.mode).toBe('listening');
+    });
+
+    it.each([
+      ['prompt', {prompt: interpolation('execution.index')}, ['prompt']],
+      ['model', {model: interpolation('execution.name'), prompt: 'Fix it.'}, ['model']],
+      ['provider', {provider: interpolation('execution.name'), prompt: 'Fix it.'}, ['provider']],
+    ] as const)('rejects one-shot agent %s interpolation before its context is available', (_field, step, path) => {
+      const document: WorkflowDocument = {
+        name: 'early agent context',
+        jobs: {
+          fix: {
+            steps: [step],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'context-unavailable-at-fill-site',
+          path: ['jobs', 'fix', 'steps', 0, ...path],
+          details: expect.objectContaining({
+            contextRoots: ['execution'],
+            unavailableRoots: ['execution'],
+            fillSite: 'run-creation',
+          }),
+        }),
+      ]);
+    });
+
+    it.each([
+      ['prompt', {prompt: interpolation('execution.index')}],
+      ['model', {model: interpolation('execution.name'), prompt: 'Fix it.'}],
+      ['provider', {provider: interpolation('execution.name'), prompt: 'Fix it.'}],
+    ] as const)('allows listening job agent %s interpolation when execution context is available', (_field, step) => {
+      const document: WorkflowDocument = {
+        name: 'agent execution context',
+        jobs: {
+          fix: {
+            listening: listening(),
+            steps: [step],
+          },
+        },
+      };
+
+      const model = normalizeWorkflowDocument(document);
+
+      expect(model.jobs[0]?.mode).toBe('listening');
+    });
+
+    it('rejects step context before step reporting', () => {
+      const document: WorkflowDocument = {
+        name: 'early step context',
+        jobs: {
+          build: {
+            listening: listening(),
+            steps: [{run: `echo ${interpolation('step.status')}`}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'context-unavailable-at-fill-site',
+          path: ['jobs', 'build', 'steps', 0, 'run'],
+          message: expect.stringContaining(
+            '"step" is not available at execution creation; it becomes available at step reporting.',
+          ),
+          details: expect.objectContaining({
+            contextRoots: ['step'],
+            unavailableRoots: ['step'],
+            fillSite: 'execution-creation',
+          }),
+        }),
+      ]);
+    });
+
+    it('does not apply availability checks to job names', () => {
+      const document: WorkflowDocument = {
+        name: 'job display context',
+        jobs: {
+          build: {
+            name: interpolation('execution.index'),
+            steps: [{run: 'echo ok'}],
+          },
+          review: {
+            name: interpolation('execution.index'),
+            listening: listening(),
+            steps: [{run: 'echo ok'}],
+          },
+        },
+      };
+
+      const model = normalizeWorkflowDocument(document);
+
+      expect(model.jobs[0]?.name?.[0]).toMatchObject({
+        kind: 'expr',
+        contextRoots: ['execution'],
+      });
+      expect(model.jobs[1]?.name?.[0]).toMatchObject({
+        kind: 'expr',
+        contextRoots: ['execution'],
+      });
+    });
+
+    it('does not apply availability checks to workflow-level or job-level env', () => {
+      const document: WorkflowDocument = {
+        name: 'shared env context',
+        env: {WORKFLOW_EXECUTION: interpolation('execution.index')},
+        jobs: {
+          build: {
+            env: {JOB_EXECUTION: interpolation('execution.index')},
+            steps: [{run: 'echo ok'}],
+          },
+        },
+      };
+
+      const model = normalizeWorkflowDocument(document);
+
+      expect(model.templates?.env?.WORKFLOW_EXECUTION?.[0]).toMatchObject({
+        kind: 'expr',
+        contextRoots: ['execution'],
+      });
+      expect(model.jobs[0]?.templates?.env?.JOB_EXECUTION?.[0]).toMatchObject({
+        kind: 'expr',
+        contextRoots: ['execution'],
+      });
+    });
+
+    it('reports only unavailable roots from a multi-root segment', () => {
+      const document: WorkflowDocument = {
+        name: 'mixed availability',
+        jobs: {
+          build: {
+            steps: [{run: `echo ${interpolation('run.id + execution.index')}`}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'context-unavailable-at-fill-site',
+          details: expect.objectContaining({
+            contextRoots: expect.arrayContaining(['run', 'execution']),
+            unavailableRoots: ['execution'],
+          }),
+        }),
+      ]);
+    });
+
+    it('keeps one-shot fields valid when they reference run-scoped contexts', () => {
+      const document: WorkflowDocument = {
+        name: 'run context',
+        jobs: {
+          build: {
+            steps: [
+              {
+                name: interpolation('job.key'),
+                run: `echo ${interpolation('run.id + trigger.source')}`,
+                env: {INPUT: interpolation('inputs.value')},
+              },
+            ],
+          },
+        },
+      };
+
+      const model = normalizeWorkflowDocument(document);
+
+      expect(model.jobs[0]?.steps[0]).toMatchObject({
+        kind: 'run',
+        templates: {
+          command: [{kind: 'literal'}, {kind: 'expr', contextRoots: ['run', 'trigger']}],
+          name: [{kind: 'expr', contextRoots: ['job']}],
+          env: {INPUT: [{kind: 'expr', contextRoots: ['inputs']}]},
+        },
+      });
+    });
+
     it('allows trusted execution metadata in run commands', () => {
       const document: WorkflowDocument = {
         name: 'execution metadata',
         jobs: {
           build: {
+            listening: listening(),
             steps: [{run: `echo ${interpolation('executions[0].name')}`}],
           },
         },
@@ -1743,6 +1988,7 @@ describe('normalizeWorkflowDocument', () => {
         jobs: {
           build: {
             name: `batch ${interpolation('execution.events[0].data.title')}`,
+            listening: listening(),
             steps: [{provider: 'openai', prompt: interpolation('execution.events[0].data.body')}],
           },
         },

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1739,7 +1739,7 @@ describe('normalizeWorkflowDocument', () => {
           code: 'context-unavailable-at-fill-site',
           path: ['jobs', 'build', 'steps', 0, ...path],
           message: expect.stringContaining(
-            '"execution" is not available at run creation; it becomes available at execution creation.',
+            'context "execution" that is not available at run creation. "execution" becomes available at execution creation.',
           ),
           details: expect.objectContaining({
             contextRoots: ['execution'],
@@ -1840,7 +1840,7 @@ describe('normalizeWorkflowDocument', () => {
           code: 'context-unavailable-at-fill-site',
           path: ['jobs', 'build', 'steps', 0, 'run'],
           message: expect.stringContaining(
-            '"step" is not available at execution creation; it becomes available at step reporting.',
+            'context "step" that is not available at execution creation. "step" becomes available at step reporting.',
           ),
           details: expect.objectContaining({
             contextRoots: ['step'],
@@ -1921,6 +1921,34 @@ describe('normalizeWorkflowDocument', () => {
           details: expect.objectContaining({
             contextRoots: expect.arrayContaining(['run', 'execution']),
             unavailableRoots: ['execution'],
+          }),
+        }),
+      ]);
+    });
+
+    it('reports multiple unavailable roots in one message', () => {
+      const document: WorkflowDocument = {
+        name: 'multiple unavailable roots',
+        jobs: {
+          build: {
+            steps: [{run: `echo ${interpolation('execution.index + step.status')}`}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'context-unavailable-at-fill-site',
+          path: ['jobs', 'build', 'steps', 0, 'run'],
+          message: expect.stringContaining(
+            'contexts "execution", "step" that are not available at run creation.',
+          ),
+          details: expect.objectContaining({
+            contextRoots: expect.arrayContaining(['execution', 'step']),
+            unavailableRoots: ['execution', 'step'],
+            fillSite: 'run-creation',
           }),
         }),
       ]);

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -1,13 +1,16 @@
 import {
+  type AvailabilitySite,
   createWorkflowExpression,
   type ExpressionTypeEnvironment,
   extractCelUntrustedPathAccesses,
+  getWorkflowContextAvailability,
   getWorkflowContextDefinition,
   getWorkflowContextTypeEnvironment,
   getWorkflowContextUntrustedPaths,
   InvalidWorkflowExpressionError,
   InvalidWorkflowTemplateError,
   parseWorkflowTemplate,
+  unavailableRootsAt,
   type WorkflowContextName,
   type WorkflowInterpolationField,
   type WorkflowTemplateExprSegment,
@@ -37,6 +40,7 @@ export function parseInterpolationField(params: {
   source: string;
   path: readonly WorkflowModelValidationIssuePathSegment[];
   issues: WorkflowModelValidationIssue[];
+  fillSite?: AvailabilitySite;
 }): WorkflowFieldTemplate | undefined {
   const segments = parseTemplate(params);
   if (segments === undefined) return undefined;
@@ -88,6 +92,7 @@ function validateExpressionSegment(params: {
   path: readonly WorkflowModelValidationIssuePathSegment[];
   issues: WorkflowModelValidationIssue[];
   segment: WorkflowTemplateExprSegment;
+  fillSite?: AvailabilitySite;
 }): WorkflowTemplateExprSegment | undefined {
   const contextRoots = uniqueStrings(params.segment.contextRoots);
   const knownRoots = contextRoots.filter(isWorkflowContextName);
@@ -127,6 +132,17 @@ function validateExpressionSegment(params: {
       }),
     );
     return undefined;
+  }
+
+  const fillSite = params.fillSite;
+  if (fillSite !== undefined) {
+    const unavailableRoots = unavailableRootsAt(knownRoots, fillSite);
+    if (unavailableRoots.length > 0) {
+      params.issues.push(
+        unavailableContextIssue({...params, contextRoots, unavailableRoots, fillSite}),
+      );
+      return undefined;
+    }
   }
 
   if (knownRoots.length === 0 || knownRoots.some((root) => hasSyntaxOnlyCheckMode(root))) {
@@ -216,6 +232,53 @@ function untrustedContextIssue(params: {
       rejectedRoots: params.rejectedRoots,
     },
   });
+}
+
+const availabilitySiteLabels = {
+  ingest: 'ingest',
+  'run-creation': 'run creation',
+  'execution-creation': 'execution creation',
+  'job-activation': 'job activation',
+  'step-dispatch': 'step dispatch',
+  'step-report': 'step reporting',
+  'execution-resolution': 'execution resolution',
+  'job-resolution': 'job resolution',
+} as const satisfies Record<AvailabilitySite, string>;
+
+function unavailableContextIssue(params: {
+  field: WorkflowInterpolationField;
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  segment: WorkflowTemplateExprSegment;
+  contextRoots: readonly string[];
+  unavailableRoots: readonly WorkflowContextName[];
+  fillSite: AvailabilitySite;
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'context-unavailable-at-fill-site',
+    message: `${fieldLabel(params.field)} interpolation references context ${params.unavailableRoots
+      .map((root) => unavailableRootMessage(root, params.fillSite))
+      .join(' ')}`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      expression: params.segment.expression.source,
+      contextRoots: params.contextRoots,
+      unavailableRoots: params.unavailableRoots,
+      fillSite: params.fillSite,
+    },
+  });
+}
+
+function unavailableRootMessage(root: WorkflowContextName, fillSite: AvailabilitySite): string {
+  return `"${root}" is not available at ${describeAvailabilitySite(
+    fillSite,
+  )}; it becomes available at ${describeAvailabilitySite(getWorkflowContextAvailability(root))}.`;
+}
+
+function describeAvailabilitySite(site: AvailabilitySite): string {
+  return availabilitySiteLabels[site];
 }
 
 function hasSyntaxOnlyCheckMode(root: WorkflowContextName): boolean {

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -256,8 +256,12 @@ function unavailableContextIssue(params: {
 }): WorkflowModelValidationIssue {
   return issue({
     code: 'context-unavailable-at-fill-site',
-    message: `${fieldLabel(params.field)} interpolation references context ${params.unavailableRoots
-      .map((root) => unavailableRootMessage(root, params.fillSite))
+    message: `${fieldLabel(params.field)} interpolation references ${contextNoun(
+      params.unavailableRoots,
+    )} ${formatList(params.unavailableRoots)} that ${availabilityVerb(
+      params.unavailableRoots,
+    )} not available at ${describeAvailabilitySite(params.fillSite)}. ${params.unavailableRoots
+      .map(unavailableRootAvailabilityMessage)
       .join(' ')}`,
     path: params.path,
     details: {
@@ -271,10 +275,18 @@ function unavailableContextIssue(params: {
   });
 }
 
-function unavailableRootMessage(root: WorkflowContextName, fillSite: AvailabilitySite): string {
-  return `"${root}" is not available at ${describeAvailabilitySite(
-    fillSite,
-  )}; it becomes available at ${describeAvailabilitySite(getWorkflowContextAvailability(root))}.`;
+function contextNoun(roots: readonly WorkflowContextName[]): 'context' | 'contexts' {
+  return roots.length === 1 ? 'context' : 'contexts';
+}
+
+function availabilityVerb(roots: readonly WorkflowContextName[]): 'is' | 'are' {
+  return roots.length === 1 ? 'is' : 'are';
+}
+
+function unavailableRootAvailabilityMessage(root: WorkflowContextName): string {
+  return `"${root}" becomes available at ${describeAvailabilitySite(
+    getWorkflowContextAvailability(root),
+  )}.`;
 }
 
 function describeAvailabilitySite(site: AvailabilitySite): string {

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -72,6 +72,7 @@ export {
   rootsAvailableAt,
   runnerFillTarget,
   type TypedWorkflowContextDefinition,
+  unavailableRootsAt,
   type WorkflowContextAvailabilityReferenceEntry,
   type WorkflowContextDefinition,
   type WorkflowContextHost,

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -7,6 +7,7 @@ import {
   getWorkflowContextTypeEnvironment,
   rootsAvailableAt,
   runnerFillTarget,
+  unavailableRootsAt,
   type WorkflowContextName,
   type WorkflowContextTrustTier,
   type WorkflowInterpolationField,
@@ -237,6 +238,40 @@ describe('workflow context registry', () => {
       'execution',
       'step',
     ]);
+  });
+
+  it('returns unavailable known roots at an availability site', () => {
+    expect(unavailableRootsAt(['run', 'execution', 'executions', 'step'], 'run-creation')).toEqual([
+      'execution',
+      'executions',
+      'step',
+    ]);
+    expect(
+      unavailableRootsAt(['run', 'execution', 'executions', 'step'], 'execution-creation'),
+    ).toEqual(['step']);
+    expect(unavailableRootsAt(['run', 'execution', 'executions', 'step'], 'step-report')).toEqual(
+      [],
+    );
+  });
+
+  it.each(
+    availabilitySites,
+  )('returns no unavailable roots when all roots are available at %s', (site) => {
+    const roots = rootsAvailableAt(site);
+
+    const unavailableRoots = unavailableRootsAt(roots, site);
+
+    expect(unavailableRoots).toEqual([]);
+  });
+
+  it.each(
+    availabilitySites.filter(
+      (site) => availabilitySites.indexOf(site) < availabilitySites.indexOf('step-report'),
+    ),
+  )('reports step as unavailable before step-report at %s', (site) => {
+    const unavailableRoots = unavailableRootsAt(['step'], site);
+
+    expect(unavailableRoots).toEqual(['step']);
   });
 
   it('never returns runner-host roots at a server availability site', () => {

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -326,6 +326,14 @@ export function rootsAvailableAt(site: AvailabilitySite): readonly WorkflowConte
   });
 }
 
+export function unavailableRootsAt(
+  roots: readonly WorkflowContextName[],
+  site: AvailabilitySite,
+): readonly WorkflowContextName[] {
+  const availableRoots = new Set(rootsAvailableAt(site));
+  return roots.filter((root) => !availableRoots.has(root));
+}
+
 export function getWorkflowContextTypeEnvironment(
   name: WorkflowContextName,
 ): ExpressionTypeEnvironment | undefined {


### PR DESCRIPTION
Add author-facing validation for workflow interpolation that references context roots before they are available at a field's fill site.

Workflow authors could previously save definitions that referenced execution context from one-shot step fields, leading to runtime crashes for step names or silent empty-string resolution for value fields. This threads fill-site availability into definition-time interpolation validation for step run, step env, step name, and agent prompt/model/provider fields while preserving the existing exclusions for job names and shared env.

The availability decision comes from the shared expression context registry via a new `unavailableRootsAt` helper, and the validation message names when each unavailable root becomes available. Review should pay particular attention to the fill-site mapping in `normalize-jobs.ts` and the excluded-field tests, since those encode the intended false-positive boundaries.

Fixes ENG-726

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phase-aware validation for workflow interpolations, rejecting step fields that reference context roots before they’re available with clear lifecycle hints; messages now handle singular/plural and list multiple unavailable roots with when each becomes available. Prevents runtime crashes and addresses ENG-726.

- **New Features**
  - Validate interpolations in step `run`, step `env`, step `name`, and agent `prompt`/`model`/`provider`; emit `context-unavailable-at-fill-site` naming unavailable roots and when each becomes available, with correct singular/plural and multi-root messaging.
  - Fill-site mapping: one-shot steps at `run-creation`; listening steps at `execution-creation`; `step` context only at `step-report`.
  - Exclusions: job `name` and workflow/job-level `env` skip availability checks; uses the context registry via `unavailableRootsAt`, wired through interpolation parsing and job/step normalization.

- **Dependencies**
  - Export `unavailableRootsAt` from `@shipfox/expression`.
  - Version bumps: `@shipfox/expression` (minor), `@shipfox/api-definitions` (patch).

<sup>Written for commit 6b9141e484678462a44dcebb8e8bc8e8446907d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

