### PR TITLE
[api-runners] Harden reconcile lock-wait test

### DIFF
--- a/.changeset/brisk-locks-reconcile.md
+++ b/.changeset/brisk-locks-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Fixes provisioned-runner reconcile results when fresh lifecycle reports commit during stale-absent termination.

--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -1253,6 +1253,7 @@ async function waitForLockWait(params?: {minWaiters?: number; queryLike?: string
         FROM pg_stat_activity
         WHERE datname = current_database()
           AND pid <> pg_backend_pid()
+          AND state = 'active'
           AND wait_event_type = 'Lock'
           AND ($1::text IS NULL OR query ILIKE $1)
       `,


### PR DESCRIPTION
Harden the provisioned-runner reconcile concurrency test helper to count only active Postgres lock waiters.

The merged ENG-697 fix already covers the live reconcile/report race. This follow-up applies the review hardening so `pg_stat_activity` polling cannot count a backend with a stale wait event, and adds the patch changeset expected for the runners package.

Closes ENG-697

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the reconcile concurrency test to count only active Postgres lock waiters, preventing false positives from stale wait events. Adds a patch changeset for `@shipfox/api-runners` to release the ENG-697 reconcile fix for interleaved report/register cases.

<sup>Written for commit 801be5ac92e9e64d929db340acbd39eaafb1b3a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

