### PR TITLE
Restore default RTL test timeouts

### DIFF
--- a/libs/client/test-setup/README.md
+++ b/libs/client/test-setup/README.md
@@ -25,5 +25,5 @@ It:
 `matchMedia` reports `min-width` queries as matching (desktop) and everything
 else as not matching.
 
-A package that needs extra Testing Library configuration (for example a widened
-`asyncUtilTimeout`) adds it in its own `test/setup.ts` after the call.
+A package that needs extra DOM test configuration adds it in its own
+`test/setup.ts` after the call.

--- a/libs/client/triggers/test/setup.ts
+++ b/libs/client/triggers/test/setup.ts
@@ -1,5 +1,4 @@
 import {installClientDomTestEnv} from '@shipfox/client-test-setup';
-import {configure} from '@testing-library/react';
 import {type AnchorHTMLAttributes, createElement, type ReactNode} from 'react';
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
@@ -34,9 +33,3 @@ vi.mock('#hooks/api/trigger-events.js', () => ({
 }));
 
 installClientDomTestEnv();
-
-// The happy-dom `dom` project shares a `vitest run` with the CPU-heavy `storybook (chromium)`
-// browser project, so a `findBy*`/`waitFor` can starve well past Testing Library's 1s
-// default while the browser tests saturate the host. Widen the ceiling: a resolved query
-// still returns immediately, so this only buys headroom for a contended cold start.
-configure({asyncUtilTimeout: 5000});

--- a/libs/client/workflows/test/setup.ts
+++ b/libs/client/workflows/test/setup.ts
@@ -1,10 +1,3 @@
 import {installClientDomTestEnv} from '@shipfox/client-test-setup';
-import {configure} from '@testing-library/react';
 
 installClientDomTestEnv();
-
-// The jsdom `dom` project shares a `vitest run` with the CPU-heavy `storybook (chromium)`
-// browser project, so a `findBy*`/`waitFor` can starve well past Testing Library's 1s
-// default while the browser tests saturate the host. Widen the ceiling: a resolved query
-// still returns immediately, so this only buys headroom for a contended cold start.
-configure({asyncUtilTimeout: 5000});

--- a/libs/client/workflows/vitest.config.ts
+++ b/libs/client/workflows/vitest.config.ts
@@ -33,9 +33,6 @@ export default defineConfig(
             include: ['src/**/*.test.tsx'],
             setupFiles: ['test/setup.ts'],
             isolate: false,
-            // Keep the per-test budget above the widened `asyncUtilTimeout` (test/setup.ts) so a
-            // contended `findBy*` reports the real query failure instead of a Vitest timeout.
-            testTimeout: 15000,
           },
         },
         {


### PR DESCRIPTION
Restore the default React Testing Library and Vitest timeout budgets for client DOM tests.

The widened `asyncUtilTimeout` and `testTimeout` settings were compensating for CI host contention. With CI scheduling work landed, keeping those larger budgets makes genuine slow queries and component regressions take longer to fail, so this removes the overrides from the affected workflows and triggers test setup.

Also updates the shared client DOM test setup README so widened Testing Library timeouts are no longer documented as the example extension point. The touched client packages are private, so no changeset is included.

Closes ENG-739

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore default React Testing Library and Vitest timeouts for client DOM tests. Removes widened budgets added for CI contention so slow queries fail faster. Closes ENG-739.

- **Refactors**
  - Remove `configure({asyncUtilTimeout: 5000})` from `libs/client/triggers/test/setup.ts` and `libs/client/workflows/test/setup.ts` (`@testing-library/react`).
  - Drop `testTimeout: 15000` from `libs/client/workflows/vitest.config.ts` (`vitest`).
  - Update `libs/client/test-setup/README.md` to stop recommending widened Testing Library timeouts.

<sup>Written for commit 3413f110567452c2c7922ad39b16e526a482fe55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

