### PR TITLE
Cache CI dependency downloads

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,31 @@
+name: Set up Playwright
+description: Restore, install, and save Playwright browsers from main.
+
+runs:
+  using: composite
+  steps:
+    - name: Get Playwright version
+      id: playwright-version
+      shell: bash
+      run: |
+        version="$(pnpm --filter=@shipfox/playwright exec playwright --version | awk '{print $2}')"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Restore Playwright browser cache
+      id: playwright-cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+    - name: Install Playwright browsers
+      shell: bash
+      run: pnpm --filter=@shipfox/playwright exec playwright install --with-deps chromium
+
+    - name: Save Playwright browser cache
+      if: github.ref == 'refs/heads/main' && steps.playwright-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      continue-on-error: true
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,31 @@
+name: Set up pnpm
+description: Restore the pnpm store cache, install dependencies, and save the cache from main.
+
+runs:
+  using: composite
+  steps:
+    - name: Get pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore pnpm store cache
+      id: pnpm-store-cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm store cache
+      if: github.ref == 'refs/heads/main' && steps.pnpm-store-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      continue-on-error: true
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Run static verification
         run: turbo check type build depcruise --concurrency="$SHIPFOX_TURBO_CONCURRENCY"
@@ -54,16 +54,14 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Set up Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Start test services
         run: docker compose up --wait -d postgres temporal garage garage-init
-
-      # Client Vitest browser tests run under `turbo test`, so this non-E2E
-      # job still needs Chromium.
-      - name: Install Playwright browsers
-        run: pnpm --filter=@shipfox/playwright exec playwright install --with-deps chromium
 
       - name: Run tests
         env:
@@ -82,14 +80,14 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Set up Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Start test services
         run: docker compose up --wait -d postgres temporal garage garage-init
-
-      - name: Install Playwright browsers
-        run: pnpm --filter=@shipfox/playwright exec playwright install --with-deps chromium
 
       # E2E dev servers still depend on dist/ for Temporal workflow bundles and
       # the shared vite-dev bin.
@@ -149,8 +147,8 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
@@ -183,8 +181,8 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Set up pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4


### PR DESCRIPTION
Cache CI dependency downloads by extracting reusable setup actions for pnpm and Playwright.

Every CI job previously re-downloaded the pnpm store, and the browser-backed jobs also re-downloaded Playwright browsers. The new local actions restore those caches for all runs while saving cache entries only from `main`, so pull requests can consume trusted warm caches without writing new ones.

Playwright remains installed through `playwright install --with-deps chromium`; the action now wraps that install so the browser cache is saved after it is populated on `main`.

Closes ENG-756

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up CI by caching dependency downloads and reusing them across jobs. Adds reusable actions for `pnpm` and `Playwright` that restore caches on all runs and save them only on `main` (ENG-756).

- **Refactors**
  - Added `.github/actions/setup-pnpm`: restores `pnpm` store keyed by `pnpm-lock.yaml` with a prefix fallback; runs `pnpm install --frozen-lockfile`.
  - Added `.github/actions/setup-playwright`: restores `~/.cache/ms-playwright` keyed by detected `Playwright` version; wraps `@shipfox/playwright` install of `chromium` with deps.
  - Updated `.github/workflows/ci.yml` to use these actions and removed inline `pnpm install` and `playwright install` steps across jobs.

<sup>Written for commit a64a2dbe9831b0a06f79fd110c97715aba49dbab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

