### PR TITLE
[expression] Add residual evaluation planning APIs

### DIFF
--- a/.changeset/brisk-fields-plan.md
+++ b/.changeset/brisk-fields-plan.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds residual workflow expression planning APIs for deferred field segments, runner-fill validation, server-evaluability checks, and monotone site fills.

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -29,6 +29,26 @@ export type {
   WorkflowExpressionCheck,
   WorkflowExpressionCheckOptions,
 } from './expression/workflow-expression.js';
+export {isBareContextReference} from './plan/bare-reference.js';
+export {extractExactContextRoots} from './plan/extract-exact-context-roots.js';
+export {fillResolvedFieldAtSite} from './plan/fill.js';
+export {
+  type FieldPlan,
+  type FieldPlanResult,
+  type PlanViolation,
+  planInterpolationField,
+} from './plan/plan-field.js';
+export type {
+  ResolvedField,
+  ResolvedFieldDeferredSegment,
+  ResolvedFieldLiteralSegment,
+  ResolvedFieldSegment,
+} from './plan/resolved-field.js';
+export {
+  type ServerEvaluabilityResult,
+  type ServerEvaluabilityViolation,
+  validateServerEvaluable,
+} from './plan/validate-server-evaluable.js';
 export {
   WorkflowTemplateResolutionError,
   workflowTemplateResolutionErrorCode,
@@ -73,6 +93,8 @@ export {
   getWorkflowInterpolationFieldFailurePolicy,
   type OpenWorkflowContextDefinition,
   type ReservedRootDefinition,
+  resolveContextRootAvailability,
+  resolveContextRootHost,
   rootsAvailableAt,
   runnerFillTarget,
   type TypedWorkflowContextDefinition,

--- a/libs/shared/expression/src/plan/bare-reference.test.ts
+++ b/libs/shared/expression/src/plan/bare-reference.test.ts
@@ -1,0 +1,27 @@
+import {isBareContextReference} from './bare-reference.js';
+
+describe('isBareContextReference', () => {
+  it.each([
+    'runner.os',
+    'runner.labels.os',
+    'steps.build.outputs.sha',
+  ])('accepts dotted member access: %s', (source) => {
+    const result = isBareContextReference(source);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    'runner',
+    'runner.?os',
+    'runner.os + runner.arch',
+    'runner.labels["os"]',
+    'runner.os()',
+    'runner.os ? runner.arch : "x"',
+    '[runner.os]',
+  ])('rejects non-bare reference shape: %s', (source) => {
+    const result = isBareContextReference(source);
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/shared/expression/src/plan/bare-reference.ts
+++ b/libs/shared/expression/src/plan/bare-reference.ts
@@ -1,0 +1,22 @@
+import {type ASTNode, parse as parseCel} from '@marcbachmann/cel-js';
+
+export function isBareContextReference(source: string): boolean {
+  try {
+    return bareMemberAccessDepth(parseCel(source).ast) > 0;
+  } catch {
+    return false;
+  }
+}
+
+function bareMemberAccessDepth(node: ASTNode): number {
+  switch (node.op) {
+    case 'id':
+      return 0;
+    case '.': {
+      const targetDepth = bareMemberAccessDepth(node.args[0]);
+      return targetDepth >= 0 ? targetDepth + 1 : -1;
+    }
+    default:
+      return -1;
+  }
+}

--- a/libs/shared/expression/src/plan/extract-exact-context-roots.test.ts
+++ b/libs/shared/expression/src/plan/extract-exact-context-roots.test.ts
@@ -1,0 +1,48 @@
+import {extractExactContextRoots} from './extract-exact-context-roots.js';
+
+describe('extractExactContextRoots', () => {
+  it('extracts sorted unique free context roots', () => {
+    const roots = extractExactContextRoots(
+      'inputs.count > 1 && (event.ok || run.name == trigger["name"]) ? job.id : event.id',
+    );
+
+    expect(roots).toEqual(['event', 'inputs', 'job', 'run', 'trigger']);
+  });
+
+  it.each([
+    ['executions.all(e, e.status == "succeeded")', ['executions']],
+    ['executions.all(step, step.status == "x")', ['executions']],
+    ['executions.all(runner, runner.status)', ['executions']],
+    ['executions.map(e, e.status)', ['executions']],
+    ['executions.filter(e, e.status == "x")', ['executions']],
+    ['executions.exists(e, e.events.exists(event, event.data.ok))', ['executions']],
+  ])('excludes comprehension aliases in %s', (source, expectedRoots) => {
+    const roots = extractExactContextRoots(source);
+
+    expect(roots).toEqual(expectedRoots);
+  });
+
+  it('does not leak map-literal keys as roots', () => {
+    const roots = extractExactContextRoots('{runner: event.x, step: inputs.value}');
+
+    expect(roots).toEqual(['event', 'inputs']);
+  });
+
+  it('keeps receiver-call arguments when the method is not a comprehension macro', () => {
+    const roots = extractExactContextRoots('event.ref.matches(inputs.pattern)');
+
+    expect(roots).toEqual(['event', 'inputs']);
+  });
+
+  it('keeps unknown free identifiers so callers can decide how to route them', () => {
+    const roots = extractExactContextRoots('typo_root.value + run.id');
+
+    expect(roots).toEqual(['run', 'typo_root']);
+  });
+
+  it('throws when the CEL source cannot be parsed', () => {
+    const act = () => extractExactContextRoots('event.');
+
+    expect(act).toThrow();
+  });
+});

--- a/libs/shared/expression/src/plan/extract-exact-context-roots.test.ts
+++ b/libs/shared/expression/src/plan/extract-exact-context-roots.test.ts
@@ -28,6 +28,12 @@ describe('extractExactContextRoots', () => {
     expect(roots).toEqual(['event', 'inputs']);
   });
 
+  it('extracts roots from dynamic map keys', () => {
+    const roots = extractExactContextRoots('{run.id: event.x, trigger.event + inputs.suffix: "x"}');
+
+    expect(roots).toEqual(['event', 'inputs', 'run', 'trigger']);
+  });
+
   it('keeps receiver-call arguments when the method is not a comprehension macro', () => {
     const roots = extractExactContextRoots('event.ref.matches(inputs.pattern)');
 

--- a/libs/shared/expression/src/plan/extract-exact-context-roots.ts
+++ b/libs/shared/expression/src/plan/extract-exact-context-roots.ts
@@ -1,0 +1,111 @@
+import {type ASTNode, type BinaryOperator, parse as parseCel} from '@marcbachmann/cel-js';
+
+const binaryOperators = new Set<BinaryOperator>([
+  '!=',
+  '==',
+  'in',
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '<',
+  '<=',
+  '>',
+  '>=',
+]);
+
+const comprehensionMethods = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
+
+export function extractExactContextRoots(source: string): string[] {
+  const roots = new Set<string>();
+  collectExactContextRoots(parseCel(source).ast, roots, new Set());
+  return [...roots].sort();
+}
+
+function collectExactContextRoots(
+  node: ASTNode,
+  roots: Set<string>,
+  scopedIdentifiers: ReadonlySet<string>,
+): void {
+  if (binaryOperators.has(node.op as BinaryOperator) || node.op === '||' || node.op === '&&') {
+    collectBinaryExactContextRoots(node.args as [ASTNode, ASTNode], roots, scopedIdentifiers);
+    return;
+  }
+
+  switch (node.op) {
+    case 'id':
+      if (!scopedIdentifiers.has(node.args)) roots.add(node.args);
+      return;
+    case 'value':
+      return;
+    case '.':
+    case '.?':
+      collectExactContextRoots(node.args[0], roots, scopedIdentifiers);
+      return;
+    case '[]':
+    case '[?]':
+      collectBinaryExactContextRoots(node.args, roots, scopedIdentifiers);
+      return;
+    case 'call':
+      for (const argument of node.args[1]) {
+        collectExactContextRoots(argument, roots, scopedIdentifiers);
+      }
+      return;
+    case 'rcall': {
+      const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
+      collectExactContextRoots(receiver, roots, scopedIdentifiers);
+      const binding = bindComprehensionAlias(method, args, scopedIdentifiers);
+      for (const argument of args.slice(binding.skipArgs)) {
+        collectExactContextRoots(argument, roots, binding.scopedIdentifiers);
+      }
+      return;
+    }
+    case 'list':
+      for (const element of node.args) {
+        collectExactContextRoots(element, roots, scopedIdentifiers);
+      }
+      return;
+    case 'map':
+      for (const [, value] of node.args) {
+        collectExactContextRoots(value, roots, scopedIdentifiers);
+      }
+      return;
+    case '?:':
+      collectExactContextRoots(node.args[0], roots, scopedIdentifiers);
+      collectExactContextRoots(node.args[1], roots, scopedIdentifiers);
+      collectExactContextRoots(node.args[2], roots, scopedIdentifiers);
+      return;
+    case '!_':
+    case '-_':
+      collectExactContextRoots(node.args, roots, scopedIdentifiers);
+      return;
+  }
+
+  throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectBinaryExactContextRoots(
+  [left, right]: [ASTNode, ASTNode],
+  roots: Set<string>,
+  scopedIdentifiers: ReadonlySet<string>,
+): void {
+  collectExactContextRoots(left, roots, scopedIdentifiers);
+  collectExactContextRoots(right, roots, scopedIdentifiers);
+}
+
+function bindComprehensionAlias(
+  method: string,
+  args: readonly ASTNode[],
+  scopedIdentifiers: ReadonlySet<string>,
+): {readonly scopedIdentifiers: ReadonlySet<string>; readonly skipArgs: number} {
+  if (!comprehensionMethods.has(method)) return {scopedIdentifiers, skipArgs: 0};
+
+  const [alias] = args;
+  if (alias?.op !== 'id') return {scopedIdentifiers, skipArgs: 0};
+
+  return {
+    scopedIdentifiers: new Set([...scopedIdentifiers, alias.args]),
+    skipArgs: 1,
+  };
+}

--- a/libs/shared/expression/src/plan/extract-exact-context-roots.ts
+++ b/libs/shared/expression/src/plan/extract-exact-context-roots.ts
@@ -67,7 +67,8 @@ function collectExactContextRoots(
       }
       return;
     case 'map':
-      for (const [, value] of node.args) {
+      for (const [key, value] of node.args) {
+        collectMapKeyExactContextRoots(key, roots, scopedIdentifiers);
         collectExactContextRoots(value, roots, scopedIdentifiers);
       }
       return;
@@ -92,6 +93,15 @@ function collectBinaryExactContextRoots(
 ): void {
   collectExactContextRoots(left, roots, scopedIdentifiers);
   collectExactContextRoots(right, roots, scopedIdentifiers);
+}
+
+function collectMapKeyExactContextRoots(
+  key: ASTNode,
+  roots: Set<string>,
+  scopedIdentifiers: ReadonlySet<string>,
+): void {
+  if (key.op === 'id') return;
+  collectExactContextRoots(key, roots, scopedIdentifiers);
 }
 
 function bindComprehensionAlias(

--- a/libs/shared/expression/src/plan/fill.test.ts
+++ b/libs/shared/expression/src/plan/fill.test.ts
@@ -1,0 +1,138 @@
+import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
+import {fillResolvedFieldAtSite} from './fill.js';
+import type {ResolvedField} from './resolved-field.js';
+
+function expression(source: string) {
+  return createWorkflowExpression({source, check: {mode: 'syntax'}});
+}
+
+describe('fillResolvedFieldAtSite', () => {
+  it('leaves a fully literal field unchanged', () => {
+    const field: ResolvedField = {segments: [{kind: 'literal', value: 'deploy main'}]};
+
+    const result = fillResolvedFieldAtSite({field, site: 'run-creation', context: {}});
+
+    expect(result).toEqual(field);
+  });
+
+  it('fills deferred server segments whose targets are at or before the current site', () => {
+    const field: ResolvedField = {
+      segments: [
+        {kind: 'literal', value: 'run:'},
+        {
+          kind: 'deferred',
+          expression: expression('run.id'),
+          roots: ['run'],
+          fillTarget: 'run-creation',
+        },
+        {kind: 'literal', value: ':step:'},
+        {
+          kind: 'deferred',
+          expression: expression('step.status'),
+          roots: ['step'],
+          fillTarget: 'step-report',
+        },
+        {kind: 'literal', value: ':runner:'},
+        {
+          kind: 'deferred',
+          expression: expression('runner.os'),
+          roots: ['runner'],
+          fillTarget: 'runner-fill',
+        },
+      ],
+    };
+
+    const result = fillResolvedFieldAtSite({
+      field,
+      site: 'job-activation',
+      context: {run: {id: 'run-123'}, step: {status: 'succeeded'}, runner: {os: 'linux'}},
+    });
+
+    expect(result).toEqual({
+      segments: [
+        {kind: 'literal', value: 'run:'},
+        {kind: 'literal', value: 'run-123'},
+        {kind: 'literal', value: ':step:'},
+        {
+          kind: 'deferred',
+          expression: expression('step.status'),
+          roots: ['step'],
+          fillTarget: 'step-report',
+        },
+        {kind: 'literal', value: ':runner:'},
+        {
+          kind: 'deferred',
+          expression: expression('runner.os'),
+          roots: ['runner'],
+          fillTarget: 'runner-fill',
+        },
+      ],
+    });
+  });
+
+  it('fills an earlier target when the orchestration reaches a later site first', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('run.id'),
+          roots: ['run'],
+          fillTarget: 'run-creation',
+        },
+      ],
+    };
+
+    const result = fillResolvedFieldAtSite({
+      field,
+      site: 'job-activation',
+      context: {run: {id: 'run-123'}},
+    });
+
+    expect(result).toEqual({segments: [{kind: 'literal', value: 'run-123'}]});
+  });
+
+  it('narrows across multiple server sites to a frozen field', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('run.id'),
+          roots: ['run'],
+          fillTarget: 'run-creation',
+        },
+        {kind: 'literal', value: ':'},
+        {
+          kind: 'deferred',
+          expression: expression('step.status'),
+          roots: ['step'],
+          fillTarget: 'step-report',
+        },
+      ],
+    };
+
+    const atRunCreation = fillResolvedFieldAtSite({
+      field,
+      site: 'run-creation',
+      context: {run: {id: 'run-123'}},
+    });
+    const atStepReport = fillResolvedFieldAtSite({
+      field: atRunCreation,
+      site: 'step-report',
+      context: {run: {id: 'run-123'}, step: {status: 'succeeded'}},
+    });
+    const repeated = fillResolvedFieldAtSite({
+      field: atStepReport,
+      site: 'step-report',
+      context: {run: {id: 'changed'}, step: {status: 'failed'}},
+    });
+
+    expect(atStepReport).toEqual({
+      segments: [
+        {kind: 'literal', value: 'run-123'},
+        {kind: 'literal', value: ':'},
+        {kind: 'literal', value: 'succeeded'},
+      ],
+    });
+    expect(repeated).toEqual(atStepReport);
+  });
+});

--- a/libs/shared/expression/src/plan/fill.ts
+++ b/libs/shared/expression/src/plan/fill.ts
@@ -1,0 +1,34 @@
+import {
+  evaluateWorkflowExpression,
+  type WorkflowExpressionEvaluationContext,
+} from '../evaluator/evaluate-workflow-expression.js';
+import {coerceWorkflowValueToString} from '../resolver/coerce-workflow-value-to-string.js';
+import {type AvailabilitySite, availabilitySites} from '../workflow-context/workflow-context.js';
+import type {ResolvedField} from './resolved-field.js';
+
+export function fillResolvedFieldAtSite(params: {
+  readonly field: ResolvedField;
+  readonly site: AvailabilitySite;
+  readonly context: WorkflowExpressionEvaluationContext;
+}): ResolvedField {
+  return {
+    segments: params.field.segments.map((segment) => {
+      if (segment.kind === 'literal') return segment;
+      if (!shouldFillAtSite(segment.fillTarget, params.site)) return segment;
+
+      return {
+        kind: 'literal',
+        value: coerceWorkflowValueToString(
+          evaluateWorkflowExpression(segment.expression, params.context),
+        ),
+      };
+    }),
+  };
+}
+
+function shouldFillAtSite(fillTarget: string, site: AvailabilitySite): boolean {
+  const fillTargetIndex = availabilitySites.indexOf(fillTarget as AvailabilitySite);
+  if (fillTargetIndex < 0) return false;
+
+  return fillTargetIndex <= availabilitySites.indexOf(site);
+}

--- a/libs/shared/expression/src/plan/plan-field.test.ts
+++ b/libs/shared/expression/src/plan/plan-field.test.ts
@@ -9,8 +9,8 @@ function templateExpression(source: string): string {
 }
 
 describe('planInterpolationField', () => {
-  const runnerRootNotBareHint =
-    'split runner-host references into their own adjacent $' + '{{ }} segments';
+  const templateExpressionOpen = '$' + '{{';
+  const runnerRootNotBareHint = `split runner-host references into their own adjacent ${templateExpressionOpen} }} segments`;
 
   it('plans literal-only fields as frozen config with the field failure policy', () => {
     const segments = parseWorkflowTemplate('deploy main');

--- a/libs/shared/expression/src/plan/plan-field.test.ts
+++ b/libs/shared/expression/src/plan/plan-field.test.ts
@@ -1,0 +1,148 @@
+import {parseWorkflowTemplate} from '../template/parse-workflow-template.js';
+import {planInterpolationField} from './plan-field.js';
+
+const templateOpen = '$' + '{{';
+const templateClose = '}' + '}';
+
+function templateExpression(source: string): string {
+  return `${templateOpen}${source}${templateClose}`;
+}
+
+describe('planInterpolationField', () => {
+  const runnerRootNotBareHint =
+    'split runner-host references into their own adjacent $' + '{{ }} segments';
+
+  it('plans literal-only fields as frozen config with the field failure policy', () => {
+    const segments = parseWorkflowTemplate('deploy main');
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        failurePolicy: 'fail',
+        field: {segments: [{kind: 'literal', value: 'deploy main'}]},
+      },
+    });
+  });
+
+  it('routes same-site roots to one deferred segment targeting that site', () => {
+    const segments = parseWorkflowTemplate(templateExpression(' run.id + "-" + trigger.event '));
+
+    const result = planInterpolationField({field: 'job.name', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        failurePolicy: 'degrade',
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: ['run', 'trigger'],
+              fillTarget: 'run-creation',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('keeps template segment boundaries while assigning fill targets', () => {
+    const segments = parseWorkflowTemplate(
+      `${templateExpression(' run.id ')}-${templateExpression(' trigger.event ')}`,
+    );
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        field: {
+          segments: [
+            {kind: 'deferred', roots: ['run'], fillTarget: 'run-creation'},
+            {kind: 'literal', value: '-'},
+            {kind: 'deferred', roots: ['trigger'], fillTarget: 'run-creation'},
+          ],
+        },
+      },
+    });
+  });
+
+  it('allows a bare runner reference as a runner-fill deferred segment', () => {
+    const segments = parseWorkflowTemplate(templateExpression(' runner.os '));
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: ['runner'],
+              fillTarget: 'runner-fill',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it.each([
+    'runner.os + steps.build.outputs.sha',
+    'runner.os + runner.arch',
+    'runner',
+  ])('rejects runner-host expressions that are not bare references: %s', (source) => {
+    const segments = parseWorkflowTemplate(templateExpression(source));
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toEqual({
+      ok: false,
+      violations: [
+        {
+          reason: 'runner-root-not-bare',
+          source,
+          runnerRoots: ['runner'],
+          hint: runnerRootNotBareHint,
+        },
+      ],
+    });
+  });
+
+  it('routes alias-shadowed runner references on their free context root only', () => {
+    const segments = parseWorkflowTemplate(
+      templateExpression(' executions.all(runner, runner.status == "succeeded") '),
+    );
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: ['executions'],
+              fillTarget: 'execution-creation',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('round-trips a field plan through JSON', () => {
+    const segments = parseWorkflowTemplate(
+      `prefix-${templateExpression(' run.id ')}-${templateExpression(' runner.os ')}`,
+    );
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    const roundTripped = JSON.parse(JSON.stringify(result));
+
+    expect(roundTripped).toEqual(result);
+  });
+});

--- a/libs/shared/expression/src/plan/plan-field.ts
+++ b/libs/shared/expression/src/plan/plan-field.ts
@@ -8,8 +8,8 @@ import {isBareContextReference} from './bare-reference.js';
 import type {ResolvedField} from './resolved-field.js';
 import {routeExpression} from './route-expression.js';
 
-const runnerRootNotBareHint =
-  'split runner-host references into their own adjacent $' + '{{ }} segments';
+const templateExpressionOpen = '$' + '{{';
+const runnerRootNotBareHint = `split runner-host references into their own adjacent ${templateExpressionOpen} }} segments`;
 
 export type PlanViolation = {
   readonly reason: 'runner-root-not-bare';

--- a/libs/shared/expression/src/plan/plan-field.ts
+++ b/libs/shared/expression/src/plan/plan-field.ts
@@ -1,0 +1,65 @@
+import type {WorkflowTemplateSegment} from '../template/template-segment.js';
+import {
+  getWorkflowInterpolationFieldFailurePolicy,
+  type WorkflowInterpolationFailurePolicy,
+  type WorkflowInterpolationField,
+} from '../workflow-context/workflow-context.js';
+import {isBareContextReference} from './bare-reference.js';
+import type {ResolvedField} from './resolved-field.js';
+import {routeExpression} from './route-expression.js';
+
+const runnerRootNotBareHint =
+  'split runner-host references into their own adjacent $' + '{{ }} segments';
+
+export type PlanViolation = {
+  readonly reason: 'runner-root-not-bare';
+  readonly source: string;
+  readonly runnerRoots: readonly string[];
+  readonly hint: string;
+};
+
+export interface FieldPlan {
+  readonly field: ResolvedField;
+  readonly failurePolicy: WorkflowInterpolationFailurePolicy;
+}
+
+export type FieldPlanResult =
+  | {readonly ok: true; readonly plan: FieldPlan}
+  | {readonly ok: false; readonly violations: readonly PlanViolation[]};
+
+export function planInterpolationField(params: {
+  readonly field: WorkflowInterpolationField;
+  readonly segments: readonly WorkflowTemplateSegment[];
+}): FieldPlanResult {
+  const violations: PlanViolation[] = [];
+  const resolvedSegments: ResolvedField['segments'] = params.segments.map((segment) => {
+    if (segment.kind === 'literal') return {kind: 'literal', value: segment.text};
+
+    const route = routeExpression(segment.expression);
+    if (route.runnerRoots.length > 0 && !isBareContextReference(segment.expression.source)) {
+      violations.push({
+        reason: 'runner-root-not-bare',
+        source: segment.expression.source,
+        runnerRoots: route.runnerRoots,
+        hint: runnerRootNotBareHint,
+      });
+    }
+
+    return {
+      kind: 'deferred',
+      expression: segment.expression,
+      roots: route.roots,
+      fillTarget: route.fillTarget,
+    };
+  });
+
+  if (violations.length > 0) return {ok: false, violations};
+
+  return {
+    ok: true,
+    plan: {
+      field: {segments: resolvedSegments},
+      failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
+    },
+  };
+}

--- a/libs/shared/expression/src/plan/resolved-field.ts
+++ b/libs/shared/expression/src/plan/resolved-field.ts
@@ -1,0 +1,20 @@
+import type {WorkflowExpression} from '../expression/workflow-expression.js';
+import type {FillTarget} from '../workflow-context/workflow-context.js';
+
+export interface ResolvedFieldLiteralSegment {
+  readonly kind: 'literal';
+  readonly value: string;
+}
+
+export interface ResolvedFieldDeferredSegment {
+  readonly kind: 'deferred';
+  readonly expression: WorkflowExpression;
+  readonly roots: readonly string[];
+  readonly fillTarget: FillTarget;
+}
+
+export type ResolvedFieldSegment = ResolvedFieldLiteralSegment | ResolvedFieldDeferredSegment;
+
+export interface ResolvedField {
+  readonly segments: readonly ResolvedFieldSegment[];
+}

--- a/libs/shared/expression/src/plan/route-expression.test.ts
+++ b/libs/shared/expression/src/plan/route-expression.test.ts
@@ -1,0 +1,43 @@
+import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
+import {
+  type AvailabilitySite,
+  unavailableRootsAt,
+  type WorkflowContextName,
+} from '../workflow-context/workflow-context.js';
+import {routeExpression} from './route-expression.js';
+
+describe('routeExpression', () => {
+  it.each([
+    ['1 + 1', [], [], 'ingest'],
+    ['run.id', ['run'], [], 'run-creation'],
+    ['run.id + execution.name', ['execution', 'run'], [], 'execution-creation'],
+    ['steps.build.outputs.sha', ['steps'], [], 'step-report'],
+    ['step.status', ['step'], [], 'step-report'],
+    ['runner.os', ['runner'], ['runner'], 'runner-fill'],
+    ['runner.os + step.status', ['runner', 'step'], ['runner'], 'runner-fill'],
+    ['typo_root.value + run.id', ['run', 'typo_root'], [], 'run-creation'],
+  ])('routes %s from known roots to %s', (source, roots, runnerRoots, fillTarget) => {
+    const expression = createWorkflowExpression({source, check: {mode: 'syntax'}});
+
+    const route = routeExpression(expression);
+
+    expect(route).toEqual({roots, runnerRoots, fillTarget});
+  });
+
+  it.each([
+    'run.id',
+    'run.id + execution.name',
+    'step.status',
+  ])('does not target a server site before %s roots are available', (source) => {
+    const expression = createWorkflowExpression({source, check: {mode: 'syntax'}});
+
+    const route = routeExpression(expression);
+
+    expect(
+      unavailableRootsAt(
+        route.roots as WorkflowContextName[],
+        route.fillTarget as AvailabilitySite,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/libs/shared/expression/src/plan/route-expression.ts
+++ b/libs/shared/expression/src/plan/route-expression.ts
@@ -1,0 +1,42 @@
+import type {WorkflowExpression} from '../expression/workflow-expression.js';
+import {
+  availabilitySites,
+  type FillTarget,
+  resolveContextRootAvailability,
+  resolveContextRootHost,
+  runnerFillTarget,
+} from '../workflow-context/workflow-context.js';
+import {extractExactContextRoots} from './extract-exact-context-roots.js';
+
+export interface RoutedExpression {
+  readonly roots: readonly string[];
+  readonly runnerRoots: readonly string[];
+  readonly fillTarget: FillTarget;
+}
+
+export function routeExpression(expression: WorkflowExpression): RoutedExpression {
+  const roots = extractExactContextRoots(expression.source);
+  const knownRoots = roots.filter((root) => resolveContextRootHost(root) !== undefined);
+  const runnerRoots = knownRoots.filter((root) => resolveContextRootHost(root) === 'runner');
+
+  if (runnerRoots.length > 0) {
+    return {roots, runnerRoots, fillTarget: runnerFillTarget};
+  }
+
+  return {
+    roots,
+    runnerRoots,
+    fillTarget: maxAvailabilitySite(knownRoots),
+  };
+}
+
+function maxAvailabilitySite(roots: readonly string[]): FillTarget {
+  let maxIndex = 0;
+  for (const root of roots) {
+    const availability = resolveContextRootAvailability(root);
+    if (availability === undefined) continue;
+    maxIndex = Math.max(maxIndex, availabilitySites.indexOf(availability));
+  }
+
+  return availabilitySites[maxIndex] ?? availabilitySites[0];
+}

--- a/libs/shared/expression/src/plan/validate-server-evaluable.test.ts
+++ b/libs/shared/expression/src/plan/validate-server-evaluable.test.ts
@@ -1,0 +1,46 @@
+import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
+import {validateServerEvaluable} from './validate-server-evaluable.js';
+
+describe('validateServerEvaluable', () => {
+  it('rejects predicates that reference runner-host roots', () => {
+    const expression = createWorkflowExpression({
+      source: 'runner.os == "linux"',
+      check: {mode: 'syntax'},
+    });
+
+    const result = validateServerEvaluable(expression);
+
+    expect(result).toEqual({
+      ok: false,
+      violations: [
+        {
+          reason: 'runner-root-in-server-expression',
+          source: 'runner.os == "linux"',
+          runnerRoots: ['runner'],
+        },
+      ],
+    });
+  });
+
+  it.each([
+    'step.exit_code == 0',
+    'executions.all(e, e.status == "succeeded")',
+  ])('accepts server-evaluable expression: %s', (source) => {
+    const expression = createWorkflowExpression({source, check: {mode: 'syntax'}});
+
+    const result = validateServerEvaluable(expression);
+
+    expect(result).toEqual({ok: true});
+  });
+
+  it('does not confuse a macro alias named runner with the runner root', () => {
+    const expression = createWorkflowExpression({
+      source: 'executions.all(runner, runner.status == "succeeded")',
+      check: {mode: 'syntax'},
+    });
+
+    const result = validateServerEvaluable(expression);
+
+    expect(result).toEqual({ok: true});
+  });
+});

--- a/libs/shared/expression/src/plan/validate-server-evaluable.ts
+++ b/libs/shared/expression/src/plan/validate-server-evaluable.ts
@@ -1,0 +1,32 @@
+import type {WorkflowExpression} from '../expression/workflow-expression.js';
+import {resolveContextRootHost} from '../workflow-context/workflow-context.js';
+import {extractExactContextRoots} from './extract-exact-context-roots.js';
+
+export type ServerEvaluabilityViolation = {
+  readonly reason: 'runner-root-in-server-expression';
+  readonly source: string;
+  readonly runnerRoots: readonly string[];
+};
+
+export type ServerEvaluabilityResult =
+  | {readonly ok: true}
+  | {readonly ok: false; readonly violations: readonly ServerEvaluabilityViolation[]};
+
+export function validateServerEvaluable(expression: WorkflowExpression): ServerEvaluabilityResult {
+  const runnerRoots = extractExactContextRoots(expression.source).filter(
+    (root) => resolveContextRootHost(root) === 'runner',
+  );
+
+  if (runnerRoots.length === 0) return {ok: true};
+
+  return {
+    ok: false,
+    violations: [
+      {
+        reason: 'runner-root-in-server-expression',
+        source: expression.source,
+        runnerRoots,
+      },
+    ],
+  };
+}

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -6,6 +6,8 @@ import {
   type FillTarget,
   getWorkflowContextTypeEnvironment,
   getWorkflowInterpolationFieldFailurePolicy,
+  resolveContextRootAvailability,
+  resolveContextRootHost,
   rootsAvailableAt,
   runnerFillTarget,
   unavailableRootsAt,
@@ -535,6 +537,17 @@ describe('workflow context registry', () => {
         },
       ]
     `);
+  });
+
+  it('resolves root host and availability across implemented and reserved roots', () => {
+    expect(resolveContextRootHost('run')).toBe('server');
+    expect(resolveContextRootAvailability('run')).toBe('run-creation');
+    expect(resolveContextRootHost('steps')).toBe('server');
+    expect(resolveContextRootAvailability('steps')).toBe('step-report');
+    expect(resolveContextRootHost('runner')).toBe('runner');
+    expect(resolveContextRootAvailability('runner')).toBeUndefined();
+    expect(resolveContextRootHost('unknown')).toBeUndefined();
+    expect(resolveContextRootAvailability('unknown')).toBeUndefined();
   });
 
   describe('workflow field failure policies', () => {

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -328,6 +328,20 @@ export function getWorkflowContextHost(name: WorkflowContextName): WorkflowConte
   return workflowContextDefinitions[name].host;
 }
 
+export function resolveContextRootHost(root: string): WorkflowContextHost | undefined {
+  if (isWorkflowContextName(root)) return workflowContextDefinitions[root].host;
+  if (isWorkflowContextReservedRoot(root)) return workflowContextReservedRoots[root].host;
+  return undefined;
+}
+
+export function resolveContextRootAvailability(root: string): AvailabilitySite | undefined {
+  if (isWorkflowContextName(root)) return workflowContextDefinitions[root].availability;
+
+  if (!isWorkflowContextReservedRoot(root)) return undefined;
+  const reservedRoot = workflowContextReservedRoots[root];
+  return reservedRoot?.host === 'server' ? reservedRoot.availability : undefined;
+}
+
 export function getWorkflowContextSensitivity(
   name: WorkflowContextName,
 ): WorkflowContextSensitivity {
@@ -438,4 +452,12 @@ function noServerAvailabilityReferenceEntry(
   >;
 
   return {root, reserved, availableAt};
+}
+
+function isWorkflowContextName(root: string): root is WorkflowContextName {
+  return Object.hasOwn(workflowContextDefinitions, root);
+}
+
+function isWorkflowContextReservedRoot(root: string): root is WorkflowContextReservedRoot {
+  return Object.hasOwn(workflowContextReservedRoots, root);
 }

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -339,7 +339,7 @@ export function resolveContextRootAvailability(root: string): AvailabilitySite |
 
   if (!isWorkflowContextReservedRoot(root)) return undefined;
   const reservedRoot = workflowContextReservedRoots[root];
-  return reservedRoot?.host === 'server' ? reservedRoot.availability : undefined;
+  return reservedRoot.host === 'server' ? reservedRoot.availability : undefined;
 }
 
 export function getWorkflowContextSensitivity(


### PR DESCRIPTION
Adds a residual field representation and expression planning APIs for workflow interpolation fields.

This turns a partially evaluated field into explicit literal and deferred segments, including host-first routing, runner-fill shape validation, server-evaluability checks for predicates, and monotone server-side filling by availability site. The planner keeps exact context roots for diagnostics while ignoring macro aliases that shadow registered roots, preventing silent mis-routing when CEL comprehensions use names like `step` or `runner`.

This stays scoped to `@shipfox/expression`; downstream call-site wiring and persistence changes remain for the follow-up engine work.

Closes ENG-748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds residual workflow expression planning APIs in `@shipfox/expression` to split interpolation fields into literal and deferred segments and route them by host and availability. Implements the ENG-748 residual form and planner; now supports dynamic map keys in root extraction; library-only with no call-site changes yet.

- **New Features**
  - New `ResolvedField` JSON form with `literal` and `deferred` segments.
  - `planInterpolationField` routes segments host-first, then by max availability; attaches the field’s failure policy.
  - Runner-host rule: non-bare runner references are rejected with a hint (`isBareContextReference`).
  - Server-evaluability: `validateServerEvaluable` blocks predicates that reference runner roots.
  - Exact root extraction that ignores comprehension aliases and handles dynamic map keys (`extractExactContextRoots`); used by `routeExpression`.
  - Monotone filling across server sites via `fillResolvedFieldAtSite`; never fills `runner-fill` segments on server.
  - Exposes helpers `resolveContextRootHost` and `resolveContextRootAvailability` and new planner APIs from the package index.
  - Minor release via changeset; supports the ENG-748 planner scope and unblocks downstream engine wiring.

<sup>Written for commit 02163685dca14a1c50c69019b55d467d7ce4d98a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

