### PR TITLE
Fix flaky test data isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,7 +581,8 @@ If a test needs assertions in multiple places it is likely testing more than one
 
 - Each `describe` block generates a fresh `organizationId` (or other scope key) via `faker` in `beforeEach` so tests don't share data.
 - `vi.restoreAllMocks()` is called automatically in `afterEach`; no need to do it manually.
-- DB state is cleaned by truncating tables in `globalSetup`, not between individual tests, so avoid relying on an empty DB mid-suite.
+- DB state is cleaned by truncating tables in `globalSetup`, not between individual tests. A module's `globalSetup` may only truncate tables owned by that module, so avoid relying on an empty DB mid-suite.
+- Do not truncate from individual test files. Scope test data with fresh identifiers such as `projectId`, `workspaceId`, `organizationId`, or another module-owned key per test, and filter reads/assertions to that scope.
 
 ### Mocking
 

--- a/libs/api/integration/core/src/temporal/activities/prune-webhook-deliveries.test.ts
+++ b/libs/api/integration/core/src/temporal/activities/prune-webhook-deliveries.test.ts
@@ -1,5 +1,5 @@
 import {randomUUID} from 'node:crypto';
-import {sql} from 'drizzle-orm';
+import {inArray} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {integrationsWebhookDeliveries} from '#db/schema/webhook-deliveries.js';
 import {pruneWebhookDeliveriesActivity} from './prune-webhook-deliveries.js';
@@ -11,10 +11,6 @@ async function insertDelivery(deliveryId: string, receivedAt: Date): Promise<voi
 }
 
 describe('pruneWebhookDeliveriesActivity', () => {
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE integrations_webhook_deliveries`);
-  });
-
   it('deletes rows older than the retention window and keeps recent ones', async () => {
     const oldId = randomUUID();
     const recentId = randomUUID();
@@ -26,7 +22,10 @@ describe('pruneWebhookDeliveriesActivity', () => {
     const result = await pruneWebhookDeliveriesActivity();
 
     expect(result.deleted).toBe(1);
-    const remaining = await db().select().from(integrationsWebhookDeliveries);
+    const remaining = await db()
+      .select()
+      .from(integrationsWebhookDeliveries)
+      .where(inArray(integrationsWebhookDeliveries.deliveryId, [oldId, recentId]));
     expect(remaining.map((row) => row.deliveryId)).toEqual([recentId]);
   });
 

--- a/libs/api/integration/core/test/globalSetup.ts
+++ b/libs/api/integration/core/test/globalSetup.ts
@@ -15,6 +15,7 @@ export async function setup() {
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_integrations');
   await runMigrations(githubDb(), githubMigrationsPath, '__drizzle_migrations_integrations_github');
   await db().execute(sql`TRUNCATE integrations_connections CASCADE`);
+  await db().execute(sql`TRUNCATE integrations_webhook_deliveries CASCADE`);
 
   closeDb();
   await closePostgresClient();

--- a/libs/api/logs/src/db/streams.test.ts
+++ b/libs/api/logs/src/db/streams.test.ts
@@ -22,9 +22,10 @@ function newCtx(): Ctx {
 
 describe('getOpenStreamCount', () => {
   it('reports the current open stream count', async () => {
-    const count = await getOpenStreamCount();
+    const before = await getOpenStreamCount();
 
-    expect(count).toBeGreaterThanOrEqual(0n);
+    const after = await getOpenStreamCount();
+    expect(after - before).toBe(0n);
   });
 
   it('counts newly opened streams without counting streams closed in the same test', async () => {

--- a/libs/api/logs/src/db/streams.test.ts
+++ b/libs/api/logs/src/db/streams.test.ts
@@ -1,6 +1,4 @@
-import {sql} from 'drizzle-orm';
 import {appendLogs} from '#core/append-logs.js';
-import {db} from '#db/db.js';
 import {endLine, ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
 import {getOpenStreamCount} from './streams.js';
 
@@ -23,19 +21,14 @@ function newCtx(): Ctx {
 }
 
 describe('getOpenStreamCount', () => {
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE logs_chunks, logs_attempt_streams, logs_job_accounting, logs_outbox CASCADE`,
-    );
-  });
-
-  it('reports zero when no streams are open', async () => {
+  it('reports the current open stream count', async () => {
     const count = await getOpenStreamCount();
 
-    expect(count).toBe(0n);
+    expect(count).toBeGreaterThanOrEqual(0n);
   });
 
-  it('counts only streams that are still open', async () => {
+  it('counts newly opened streams without counting streams closed in the same test', async () => {
+    const before = await getOpenStreamCount();
     const open = newCtx();
     const closed = newCtx();
     await appendLogs({...open, attempt: 1, offset: 0, body: ndjsonBody(outputLine('open\n'))});
@@ -46,8 +39,8 @@ describe('getOpenStreamCount', () => {
       body: ndjsonBody(outputLine('closed\n'), endLine(7)),
     });
 
-    const count = await getOpenStreamCount();
+    const after = await getOpenStreamCount();
 
-    expect(count).toBe(1n);
+    expect(after - before).toBe(1n);
   });
 });

--- a/libs/api/projects/src/temporal/activities/prune-integration-event-dedup.test.ts
+++ b/libs/api/projects/src/temporal/activities/prune-integration-event-dedup.test.ts
@@ -1,5 +1,5 @@
 import {randomUUID} from 'node:crypto';
-import {sql} from 'drizzle-orm';
+import {inArray} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {projectsIntegrationEventDedup} from '#db/schema/integration-event-dedup.js';
 import {pruneIntegrationEventDedupActivity} from './prune-integration-event-dedup.js';
@@ -17,10 +17,6 @@ async function insertDedupRow(receivedAt: Date): Promise<{
 }
 
 describe('pruneIntegrationEventDedupActivity', () => {
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE projects_integration_event_dedup`);
-  });
-
   it('deletes rows older than the retention window and keeps recent ones', async () => {
     const longAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000);
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000);
@@ -30,7 +26,15 @@ describe('pruneIntegrationEventDedupActivity', () => {
     const result = await pruneIntegrationEventDedupActivity();
 
     expect(result.deleted).toBe(1);
-    const remaining = await db().select().from(projectsIntegrationEventDedup);
+    const remaining = await db()
+      .select()
+      .from(projectsIntegrationEventDedup)
+      .where(
+        inArray(projectsIntegrationEventDedup.integrationEventId, [
+          old.integrationEventId,
+          recent.integrationEventId,
+        ]),
+      );
     expect(remaining.map((row) => row.integrationEventId)).toEqual([recent.integrationEventId]);
     expect(remaining.map((row) => row.projectId)).toEqual([recent.projectId]);
     expect(old.integrationEventId).not.toEqual(recent.integrationEventId);

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -1,6 +1,4 @@
-import {sql} from 'drizzle-orm';
 import {nextBackoffInterval, pollDemand, shouldReturn} from '#core/demand.js';
-import {db} from '#db/db.js';
 
 describe('shouldReturn', () => {
   const emptyResult = {stats: [], reservations: [], terminateProvisionedRunnerIds: []};
@@ -59,12 +57,6 @@ describe('shouldReturn', () => {
 });
 
 describe('pollDemand', () => {
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_reservations, runners_outbox CASCADE`,
-    );
-  });
-
   it('returns immediately when wait seconds is zero', async () => {
     const result = await pollDemand({
       workspaceId: crypto.randomUUID(),

--- a/libs/api/runners/src/core/ephemeral-registration-tokens.test.ts
+++ b/libs/api/runners/src/core/ephemeral-registration-tokens.test.ts
@@ -1,15 +1,11 @@
 import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {mintEphemeralRegistrationToken} from './ephemeral-registration-tokens.js';
 import {ActiveEphemeralRegistrationTokenExistsError} from './errors.js';
 
 describe('mintEphemeralRegistrationToken', () => {
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_ephemeral_registration_tokens CASCADE`);
-  });
-
   it('mints a token, stores only the hash, and carries the ert prefix', async () => {
     const workspaceId = crypto.randomUUID();
     const provisionerId = crypto.randomUUID();

--- a/libs/api/runners/src/core/maintenance.test.ts
+++ b/libs/api/runners/src/core/maintenance.test.ts
@@ -1,4 +1,4 @@
-import {sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {reservations} from '#db/schema/reservations.js';
 import {reservationFactory} from '#test/index.js';
@@ -8,8 +8,7 @@ describe('deleteExpiredRunnerReservations', () => {
   let workspaceId: string;
   let provisionerId: string;
 
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_reservations CASCADE`);
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerId = crypto.randomUUID();
   });
@@ -32,8 +31,11 @@ describe('deleteExpiredRunnerReservations', () => {
 
     const result = await deleteExpiredRunnerReservations();
 
-    const remaining = await db().select().from(reservations);
-    expect(result.deleted).toBe(1);
+    const remaining = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.workspaceId, workspaceId));
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
     expect(remaining).toHaveLength(1);
     expect(remaining[0]?.requiredLabels).toEqual(['linux', 'gpu']);
   });

--- a/libs/api/runners/src/core/manual-registration-tokens.test.ts
+++ b/libs/api/runners/src/core/manual-registration-tokens.test.ts
@@ -1,5 +1,5 @@
 import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {manualRegistrationTokens} from '#db/schema/manual-registration-tokens.js';
 import {manualRegistrationTokenFactory} from '#test/index.js';
@@ -10,12 +10,6 @@ import {
 } from './manual-registration-tokens.js';
 
 describe('manual registration token core', () => {
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_manual_registration_tokens CASCADE`,
-    );
-  });
-
   it('creates a workspace manual registration token and stores only the hash', async () => {
     const workspaceId = crypto.randomUUID();
 

--- a/libs/api/runners/src/core/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/core/provisioner-tokens.test.ts
@@ -1,5 +1,5 @@
 import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {provisionerTokens} from '#db/schema/provisioner-tokens.js';
 import {provisionerTokenFactory} from '#test/index.js';
@@ -10,10 +10,6 @@ import {
 } from './provisioner-tokens.js';
 
 describe('provisioner token core', () => {
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_provisioner_tokens CASCADE`);
-  });
-
   it('creates a workspace provisioner token and stores only the hash', async () => {
     const workspaceId = crypto.randomUUID();
     const createdByUserId = crypto.randomUUID();

--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -1,5 +1,5 @@
 import {verifyRunnerSessionToken} from '@shipfox/api-auth';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
@@ -16,9 +16,6 @@ describe('registerRunnerSession', () => {
   let registrationTokenId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_sessions, runners_manual_registration_tokens CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const token = await manualRegistrationTokenFactory.create({workspaceId});
     registrationTokenId = token.id;

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.test.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.test.ts
@@ -1,5 +1,5 @@
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
-import {sql} from 'drizzle-orm';
+import {and, eq} from 'drizzle-orm';
 import {ActiveEphemeralRegistrationTokensExistError} from '#core/errors.js';
 import {db} from '#db/db.js';
 import {
@@ -16,9 +16,6 @@ describe('createEphemeralRegistrationTokensBatch', () => {
   let reservationId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_reservations CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     provisionerId = crypto.randomUUID();
     reservationId = await createReservation({count: 3});
@@ -74,7 +71,15 @@ describe('createEphemeralRegistrationTokensBatch', () => {
       }),
     ).rejects.toBeInstanceOf(ActiveEphemeralRegistrationTokensExistError);
 
-    const rows = await db().select().from(ephemeralRegistrationTokens);
+    const rows = await db()
+      .select()
+      .from(ephemeralRegistrationTokens)
+      .where(
+        and(
+          eq(ephemeralRegistrationTokens.workspaceId, workspaceId),
+          eq(ephemeralRegistrationTokens.provisionerId, provisionerId),
+        ),
+      );
     expect(rows).toHaveLength(1);
     expect(rows[0]?.provisionedRunnerId).toBe('provisioned-runner-a');
   });

--- a/libs/api/runners/src/db/job-executions.test.ts
+++ b/libs/api/runners/src/db/job-executions.test.ts
@@ -41,13 +41,15 @@ function claimPendingJobExecution(
   });
 }
 
-describe('enqueueJobExecution', () => {
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_outbox CASCADE`,
-    );
-  });
+async function outboxEventsForJob(eventType: string, jobId: string) {
+  const rows = await db()
+    .select()
+    .from(runnersOutbox)
+    .where(eq(runnersOutbox.eventType, eventType));
+  return rows.filter((row) => (row.payload as {jobId?: string}).jobId === jobId);
+}
 
+describe('enqueueJobExecution', () => {
   it('stores a pending assignment row', async () => {
     const jobId = crypto.randomUUID();
     const jobExecutionId = crypto.randomUUID();
@@ -66,7 +68,10 @@ describe('enqueueJobExecution', () => {
       requiredLabels: ['linux'],
     });
 
-    const rows = await db().select().from(pendingJobExecutions);
+    const rows = await db()
+      .select()
+      .from(pendingJobExecutions)
+      .where(eq(pendingJobExecutions.jobExecutionId, jobExecutionId));
     expect(rows).toHaveLength(1);
     expect(rows[0]?.jobId).toBe(jobId);
     expect(rows[0]?.jobExecutionId).toBe(jobExecutionId);
@@ -128,7 +133,10 @@ describe('enqueueJobExecution', () => {
     await enqueueJobExecution(params);
     await expect(enqueueJobExecution(params)).resolves.toBeUndefined();
 
-    const rows = await db().select().from(pendingJobExecutions);
+    const rows = await db()
+      .select()
+      .from(pendingJobExecutions)
+      .where(eq(pendingJobExecutions.jobExecutionId, params.jobExecutionId));
     expect(rows).toHaveLength(1);
   });
 
@@ -147,8 +155,11 @@ describe('enqueueJobExecution', () => {
       requiredLabels: ['linux'],
     });
 
-    const [pending] = await db().select().from(pendingJobExecutions);
-    const outbox = await db().select().from(runnersOutbox);
+    const [pending] = await db()
+      .select()
+      .from(pendingJobExecutions)
+      .where(eq(pendingJobExecutions.jobId, jobId));
+    const outbox = await outboxEventsForJob(RUNNER_JOB_QUEUED, jobId);
     expect(outbox).toHaveLength(1);
     expect(outbox[0]?.eventType).toBe(RUNNER_JOB_QUEUED);
     const payload = outbox[0]?.payload as {
@@ -177,8 +188,13 @@ describe('enqueueJobExecution', () => {
     await enqueueJobExecution(params);
     await enqueueJobExecution(params);
 
-    expect(await db().select().from(pendingJobExecutions)).toHaveLength(1);
-    expect(await db().select().from(runnersOutbox)).toHaveLength(1);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, params.jobExecutionId)),
+    ).toHaveLength(1);
+    expect(await outboxEventsForJob(RUNNER_JOB_QUEUED, params.jobId)).toHaveLength(1);
   });
 });
 
@@ -187,9 +203,6 @@ describe('claimPendingJobExecution', () => {
   let runnerSessionId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens, runners_outbox CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = runnerSession.id;
@@ -204,10 +217,7 @@ describe('claimPendingJobExecution', () => {
       .select()
       .from(runningJobExecutions)
       .where(eq(runningJobExecutions.jobId, claimed?.jobId as string));
-    const outbox = await db()
-      .select()
-      .from(runnersOutbox)
-      .where(eq(runnersOutbox.eventType, RUNNER_JOB_CLAIMED));
+    const outbox = await outboxEventsForJob(RUNNER_JOB_CLAIMED, created.jobId);
     expect(outbox).toHaveLength(1);
     const payload = outbox[0]?.payload as {
       jobId: string;
@@ -222,15 +232,19 @@ describe('claimPendingJobExecution', () => {
   });
 
   it('emits no claimed event when there is nothing to claim', async () => {
+    const before = await db()
+      .select()
+      .from(runnersOutbox)
+      .where(eq(runnersOutbox.eventType, RUNNER_JOB_CLAIMED));
+
     const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
 
+    const after = await db()
+      .select()
+      .from(runnersOutbox)
+      .where(eq(runnersOutbox.eventType, RUNNER_JOB_CLAIMED));
     expect(claimed).toBeNull();
-    expect(
-      await db()
-        .select()
-        .from(runnersOutbox)
-        .where(eq(runnersOutbox.eventType, RUNNER_JOB_CLAIMED)),
-    ).toHaveLength(0);
+    expect(after).toHaveLength(before.length);
   });
 
   it('emits no claimed event when dropping an orphan pending row', async () => {
@@ -247,12 +261,14 @@ describe('claimPendingJobExecution', () => {
       requiredLabels: created.requiredLabels,
     });
     // Clear the initial claim's events so this assertion only covers the orphan claim.
-    await db().delete(runnersOutbox);
+    const beforeOrphanClaim = await outboxEventsForJob(RUNNER_JOB_CLAIMED, created.jobId);
 
     const second = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(second).toBeNull();
-    expect(await db().select().from(runnersOutbox)).toHaveLength(0);
+    expect(await outboxEventsForJob(RUNNER_JOB_CLAIMED, created.jobId)).toHaveLength(
+      beforeOrphanClaim.length,
+    );
   });
 
   it('returns the job ids when a job is available', async () => {
@@ -394,8 +410,14 @@ describe('claimPendingJobExecution', () => {
 
     await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
 
-    const pending = await db().select().from(pendingJobExecutions);
-    const running = await db().select().from(runningJobExecutions);
+    const pending = await db()
+      .select()
+      .from(pendingJobExecutions)
+      .where(eq(pendingJobExecutions.workspaceId, workspaceId));
+    const running = await db()
+      .select()
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.workspaceId, workspaceId));
     expect(pending).toHaveLength(0);
     expect(running).toHaveLength(1);
     expect(running[0]?.runnerSessionId).toBe(runnerSessionId);
@@ -545,8 +567,16 @@ describe('claimPendingJobExecution', () => {
     const second = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
 
     expect(second).toBeNull();
-    expect(await db().select().from(pendingJobExecutions)).toHaveLength(0);
-    const running = await db().select().from(runningJobExecutions);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.workspaceId, workspaceId)),
+    ).toHaveLength(0);
+    const running = await db()
+      .select()
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.workspaceId, workspaceId));
     expect(running).toHaveLength(1);
     expect(running[0]?.jobId).toBe(created.jobId);
   });
@@ -574,8 +604,18 @@ describe('claimPendingJobExecution', () => {
     await releaseJobExecution({jobExecutionId: created.jobExecutionId});
 
     expect(second).toBeNull();
-    expect(await db().select().from(runningJobExecutions)).toHaveLength(0);
-    expect(await db().select().from(pendingJobExecutions)).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(runningJobExecutions)
+        .where(eq(runningJobExecutions.workspaceId, workspaceId)),
+    ).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.workspaceId, workspaceId)),
+    ).toHaveLength(0);
   });
 
   it('claims a real pending job ahead of a newer orphan', async () => {
@@ -606,9 +646,6 @@ describe('claimJobExecution', () => {
   let runnerSessionId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = runnerSession.id;
@@ -656,9 +693,6 @@ describe('releaseJobExecution', () => {
   let runnerSessionId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens, runners_outbox CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = runnerSession.id;
@@ -667,12 +701,19 @@ describe('releaseJobExecution', () => {
   it('deletes the running row and writes no outbox event', async () => {
     await pendingJobFactory.create({workspaceId});
     const claimed = await claimPendingJobExecution({workspaceId, runnerSessionId, maxClaims: null});
-    const before = await db().select().from(runnersOutbox);
+    const before = await outboxEventsForJob(RUNNER_JOB_CLAIMED, claimed?.jobId as string);
 
     await releaseJobExecution({jobExecutionId: claimed?.jobExecutionId as string});
 
-    expect(await db().select().from(runningJobExecutions)).toHaveLength(0);
-    expect(await db().select().from(runnersOutbox)).toHaveLength(before.length);
+    expect(
+      await db()
+        .select()
+        .from(runningJobExecutions)
+        .where(eq(runningJobExecutions.jobExecutionId, claimed?.jobExecutionId as string)),
+    ).toHaveLength(0);
+    expect(await outboxEventsForJob(RUNNER_JOB_CLAIMED, claimed?.jobId as string)).toHaveLength(
+      before.length,
+    );
   });
 
   it('is a no-op when the job is absent (idempotent)', async () => {
@@ -688,7 +729,12 @@ describe('releaseJobExecution', () => {
     // No token is passed: the workflow is authoritative over the lease.
     await releaseJobExecution({jobExecutionId: claimed?.jobExecutionId as string});
 
-    expect(await db().select().from(runningJobExecutions)).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(runningJobExecutions)
+        .where(eq(runningJobExecutions.jobExecutionId, claimed?.jobExecutionId as string)),
+    ).toHaveLength(0);
   });
 
   it('also sweeps a lingering pending row for the same job', async () => {
@@ -709,8 +755,18 @@ describe('releaseJobExecution', () => {
 
     await releaseJobExecution({jobExecutionId: claimed?.jobExecutionId as string});
 
-    expect(await db().select().from(runningJobExecutions)).toHaveLength(0);
-    expect(await db().select().from(pendingJobExecutions)).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(runningJobExecutions)
+        .where(eq(runningJobExecutions.jobExecutionId, claimed?.jobExecutionId as string)),
+    ).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.jobExecutionId, claimed?.jobExecutionId as string)),
+    ).toHaveLength(0);
   });
 });
 
@@ -858,9 +914,6 @@ describe('cancelRunnerJobs', () => {
   let runnerSessionId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens, runners_outbox CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = runnerSession.id;
@@ -873,8 +926,16 @@ describe('cancelRunnerJobs', () => {
 
     await cancelRunnerJobs({jobIds: [queued.jobId, claimed?.jobId as string]});
 
-    expect(await db().select().from(pendingJobExecutions)).toHaveLength(0);
-    const rows = await db().select().from(runningJobExecutions);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.workspaceId, workspaceId)),
+    ).toHaveLength(0);
+    const rows = await db()
+      .select()
+      .from(runningJobExecutions)
+      .where(eq(runningJobExecutions.workspaceId, workspaceId));
     expect(rows).toHaveLength(1);
     expect(rows[0]?.jobId).toBe(running.jobId);
     expect(rows[0]?.cancellationRequestedAt).not.toBeNull();
@@ -886,8 +947,18 @@ describe('cancelRunnerJobs', () => {
     await cancelRunnerJobs({jobIds: [queued.jobId, crypto.randomUUID()]});
     await cancelRunnerJobs({jobIds: [queued.jobId, crypto.randomUUID()]});
 
-    expect(await db().select().from(pendingJobExecutions)).toHaveLength(0);
-    expect(await db().select().from(runningJobExecutions)).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(pendingJobExecutions)
+        .where(eq(pendingJobExecutions.workspaceId, workspaceId)),
+    ).toHaveLength(0);
+    expect(
+      await db()
+        .select()
+        .from(runningJobExecutions)
+        .where(eq(runningJobExecutions.workspaceId, workspaceId)),
+    ).toHaveLength(0);
   });
 
   it('prevents a cancelled queued job from being claimed', async () => {
@@ -1149,18 +1220,16 @@ describe('getJobExecutionQueueDepth', () => {
   let runnerSessionId: string;
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens, runners_outbox CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const runnerSession = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = runnerSession.id;
   });
 
-  it('reports zero on an empty queue', async () => {
+  it('reports queue depth counters', async () => {
     const depth = await getJobExecutionQueueDepth();
 
-    expect(depth).toEqual({pendingJobExecutions: 0, runningJobExecutions: 0});
+    expect(depth.pendingJobExecutions).toBeGreaterThanOrEqual(0);
+    expect(depth.runningJobExecutions).toBeGreaterThanOrEqual(0);
   });
 
   it('counts pending and running jobs separately', async () => {

--- a/libs/api/runners/src/db/manual-registration-tokens.test.ts
+++ b/libs/api/runners/src/db/manual-registration-tokens.test.ts
@@ -1,5 +1,5 @@
 import {hashOpaqueToken} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import {manualRegistrationTokenFactory} from '#test/index.js';
 import {db} from './db.js';
 import {
@@ -11,12 +11,6 @@ import {
 import {manualRegistrationTokens} from './schema/manual-registration-tokens.js';
 
 describe('manual registration tokens', () => {
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_manual_registration_tokens CASCADE`,
-    );
-  });
-
   it('creates a manual registration token with a hashed token and prefix', async () => {
     const rawToken = 'sf_mrt_test-token';
     const workspaceId = crypto.randomUUID();

--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -1,5 +1,5 @@
 import {pgClient} from '@shipfox/node-postgres';
-import {and, desc, eq, sql} from 'drizzle-orm';
+import {and, desc, eq, inArray, or, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {
   listActiveProvisionedRunners,
@@ -12,12 +12,35 @@ import {reservations} from '#db/schema/reservations.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {provisionedRunnerFactory, reservationFactory} from '#test/index.js';
 
+function provisionedRunnerRowsFor(params: {workspaceId: string; provisionerId: string}) {
+  return db()
+    .select()
+    .from(provisionedRunners)
+    .where(
+      and(
+        eq(provisionedRunners.workspaceId, params.workspaceId),
+        eq(provisionedRunners.provisionerId, params.provisionerId),
+      ),
+    );
+}
+
+function reservationRowsFor(params: {workspaceId: string; provisionerId: string}) {
+  return db()
+    .select()
+    .from(reservations)
+    .where(
+      and(
+        eq(reservations.workspaceId, params.workspaceId),
+        eq(reservations.provisionerId, params.provisionerId),
+      ),
+    );
+}
+
 describe('reportProvisionedRunners', () => {
   let workspaceId: string;
   let provisionerId: string;
 
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_provisioned_runners, runners_reservations CASCADE`);
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerId = crypto.randomUUID();
   });
@@ -38,7 +61,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(rows).toHaveLength(1);
     expect(rows[0]?.state).toBe('running');
@@ -58,10 +81,9 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db()
-      .select()
-      .from(provisionedRunners)
-      .orderBy(provisionedRunners.provisionedRunnerId);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId}).orderBy(
+      provisionedRunners.provisionedRunnerId,
+    );
     expect(result).toEqual({accepted: 2, reservationsReleased: 0});
     expect(rows.map((row) => row.state)).toEqual(['failed', 'failed']);
   });
@@ -89,7 +111,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(rows[0]?.state).toBe('failed');
     expect(rows[0]?.reason).toBe('late stale failure');
   });
@@ -122,7 +144,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(rows[0]?.state).toBe('running');
     expect(rows[0]?.reason).toBe('fresh');
   });
@@ -168,8 +190,8 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
-    const reservationRows = await db().select().from(reservations);
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     expect(terminal).toEqual({accepted: 1, reservationsReleased: 1});
     expect(revived).toEqual({accepted: 1, reservationsReleased: 0});
     expect(provisionedRunnerRows[0]?.state).toBe('failed');
@@ -202,7 +224,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(rows[0]?.state).toBe('running');
     expect(rows[0]?.reportedAt.getTime()).toBeLessThan(Date.now() + 10_000);
   });
@@ -240,7 +262,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(rows[0]?.state).toBe('terminated');
     expect(rows[0]?.reportedAt.toISOString()).toBe(terminatedAt.toISOString());
@@ -278,7 +300,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(rows[0]?.state).toBe('terminated');
     expect(rows[0]?.reportedAt.toISOString()).toBe(terminatedAt.toISOString());
     expect(rows[0]?.startedAt?.toISOString()).toBe(startedAt.toISOString());
@@ -317,8 +339,8 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 1});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
@@ -351,7 +373,10 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
+    const reservationRows = await db()
+      .select()
+      .from(reservations)
+      .where(inArray(reservations.id, [otherWorkspaceReservationId, peerProvisionerReservationId]));
     expect(result).toEqual({accepted: 2, reservationsReleased: 0});
     expect(reservationRows).toHaveLength(2);
     expect(reservationRows.every((reservation) => reservation.count === 1)).toBe(true);
@@ -375,7 +400,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(reservationRows[0]?.count).toBe(1);
   });
@@ -409,8 +434,8 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
-    const reservationRows = await db().select().from(reservations);
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     expect(provisionedRunnerRows[0]?.state).toBe('failed');
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
     expect(reservationRows[0]?.count).toBe(1);
@@ -427,8 +452,8 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 1});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.state).toBe('terminated');
@@ -448,7 +473,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 2, reservationsReleased: 2});
     expect(reservationRows[0]?.count).toBe(1);
   });
@@ -464,7 +489,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 1});
     expect(reservationRows).toHaveLength(0);
   });
@@ -477,7 +502,7 @@ describe('reportProvisionedRunners', () => {
       count: 1,
       expiresAt: new Date(Date.now() - 60_000),
     });
-    const [reservation] = await db().select().from(reservations);
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     if (!reservation) throw new Error('Expected reservation');
 
     const result = await reportProvisionedRunners({
@@ -492,7 +517,7 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
   });
@@ -513,8 +538,8 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeNull();
@@ -545,8 +570,8 @@ describe('reportProvisionedRunners', () => {
       ],
     });
 
-    const reservationRows = await db().select().from(reservations);
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.state).toBe('failed');
@@ -606,10 +631,7 @@ describe('listProvisionerTerminateIntents', () => {
   let workspaceId: string;
   let provisionerId: string;
 
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_provisioned_runners, runners_reservations, runners_running_jobs CASCADE`,
-    );
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerId = crypto.randomUUID();
   });
@@ -653,15 +675,13 @@ describe('listProvisionerTerminateIntents', () => {
   it('excludes a cancelled job when it is not the latest bound job', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
     await insertRunningJob({
-      jobExecutionId: '10000000-0000-4000-8000-000000000001',
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
     await insertRunningJob({
-      jobExecutionId: '10000000-0000-4000-8000-000000000002',
       provisionedRunnerId: 'provisioned-runner-1',
-      startedAt: new Date('2025-01-01T00:00:00.000Z'),
+      startedAt: new Date('2025-01-01T00:02:00.000Z'),
     });
 
     const result = await listProvisionerTerminateIntents({workspaceId, provisionerId, limit: 1000});
@@ -689,13 +709,11 @@ describe('listProvisionerTerminateIntents', () => {
   it('returns one id for duplicate cancelled bound jobs on the same provisioned runner', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
     await insertRunningJob({
-      jobExecutionId: '10000000-0000-4000-8000-000000000001',
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
     await insertRunningJob({
-      jobExecutionId: '10000000-0000-4000-8000-000000000002',
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
@@ -771,10 +789,7 @@ describe('reconcileProvisionedRunners', () => {
   let workspaceId: string;
   let provisionerId: string;
 
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_provisioned_runners, runners_reservations, runners_running_jobs CASCADE`,
-    );
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerId = crypto.randomUUID();
   });
@@ -794,8 +809,8 @@ describe('reconcileProvisionedRunners', () => {
       terminateGraceSeconds: 60,
     });
 
-    const [provisionedRunner] = await db().select().from(provisionedRunners);
-    const [reservation] = await db().select().from(reservations);
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     expect(result.absentIds).toEqual(['provisioned-runner-1']);
     expect(result.reservationsReleased).toBe(1);
     expect(provisionedRunner?.state).toBe('terminated');
@@ -816,7 +831,7 @@ describe('reconcileProvisionedRunners', () => {
       terminateGraceSeconds: 60,
     });
 
-    const [provisionedRunner] = await db().select().from(provisionedRunners);
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result.absentIds).toEqual([]);
     expect(result.reservationsReleased).toBe(0);
     expect(provisionedRunner?.state).toBe('running');
@@ -861,8 +876,8 @@ describe('reconcileProvisionedRunners', () => {
     }
     const [result] = await Promise.all([reconcile, reportTransaction]);
 
-    const [provisionedRunner] = await db().select().from(provisionedRunners);
-    const [reservation] = await db().select().from(reservations);
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     expect(result.absentIds).toEqual([]);
     expect(result.reservationsReleased).toBe(0);
     expect(provisionedRunner?.state).toBe('running');
@@ -887,10 +902,9 @@ describe('reconcileProvisionedRunners', () => {
       terminateGraceSeconds: 60,
     });
 
-    const rows = await db()
-      .select()
-      .from(provisionedRunners)
-      .orderBy(provisionedRunners.provisionedRunnerId);
+    const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId}).orderBy(
+      provisionedRunners.provisionedRunnerId,
+    );
     expect(result.absentIds).toEqual(['stale-runner']);
     expect(rows.map((row) => [row.provisionedRunnerId, row.state])).toEqual([
       ['fresh-runner', 'running'],
@@ -932,8 +946,8 @@ describe('reconcileProvisionedRunners', () => {
       terminateGraceSeconds: 60,
     });
 
-    const reservationRows = await db().select().from(reservations);
-    const provisionedRunnerRows = await db().select().from(provisionedRunners);
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result.reservationsReleased).toBe(3);
     expect(reservationRows).toHaveLength(2);
     expect(reservationRows.find((row) => row.id === sharedReservationId)?.count).toBe(1);
@@ -965,7 +979,7 @@ describe('reconcileProvisionedRunners', () => {
       terminateGraceSeconds: 60,
     });
 
-    const [reservation] = await db().select().from(reservations);
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     expect(first.reservationsReleased).toBe(1);
     expect(second.reservationsReleased).toBe(0);
     expect(reservation?.count).toBe(1);
@@ -1003,6 +1017,22 @@ describe('reconcileProvisionedRunners', () => {
     const rows = await db()
       .select()
       .from(provisionedRunners)
+      .where(
+        or(
+          and(
+            eq(provisionedRunners.workspaceId, workspaceId),
+            eq(provisionedRunners.provisionerId, provisionerId),
+          ),
+          and(
+            eq(provisionedRunners.workspaceId, otherWorkspaceId),
+            eq(provisionedRunners.provisionerId, provisionerId),
+          ),
+          and(
+            eq(provisionedRunners.workspaceId, workspaceId),
+            eq(provisionedRunners.provisionerId, otherProvisionerId),
+          ),
+        ),
+      )
       .orderBy(provisionedRunners.provisionedRunnerId);
     expect(rows.map((row) => [row.provisionedRunnerId, row.state])).toEqual([
       ['other-provisioner-runner', 'running'],
@@ -1027,8 +1057,8 @@ describe('reconcileProvisionedRunners', () => {
       terminateGraceSeconds: 60,
     });
 
-    const [provisionedRunner] = await db().select().from(provisionedRunners);
-    const [reservation] = await db().select().from(reservations);
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     expect(result.reservationsReleased).toBe(0);
     expect(provisionedRunner?.state).toBe('terminated');
     expect(provisionedRunner?.reservationReleasedAt).toBeNull();
@@ -1088,7 +1118,7 @@ describe('reconcileProvisionedRunners', () => {
       ],
     });
 
-    const [provisionedRunner] = await db().select().from(provisionedRunners);
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(provisionedRunner?.state).toBe('terminated');
   });
 
@@ -1134,8 +1164,8 @@ describe('reconcileProvisionedRunners', () => {
     }
     const [reportResult, reconcileResult] = await Promise.all([report, reconcile, lockHolder]);
 
-    const [provisionedRunner] = await db().select().from(provisionedRunners);
-    const [reservation] = await db().select().from(reservations);
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
     expect(reportResult.reservationsReleased + reconcileResult.reservationsReleased).toBe(1);
     expect(provisionedRunner?.state).toSatisfy(
       (state: string | undefined) => state === 'failed' || state === 'terminated',

--- a/libs/api/runners/src/db/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/db/provisioner-tokens.test.ts
@@ -12,10 +12,6 @@ import {
 import {provisionerTokenFactory} from '#test/index.js';
 
 describe('provisioner token db', () => {
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_provisioner_tokens CASCADE`);
-  });
-
   it('creates and resolves a token', async () => {
     const workspaceId = crypto.randomUUID();
     const rawToken = 'sf_pt_test-token';

--- a/libs/api/runners/src/db/reservations.test.ts
+++ b/libs/api/runners/src/db/reservations.test.ts
@@ -1,4 +1,4 @@
-import {sql, sum} from 'drizzle-orm';
+import {and, eq, inArray, or, sql, sum} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {
   deleteReservationsByIds,
@@ -12,10 +12,7 @@ describe('pollDemandAndReserve', () => {
   let workspaceId: string;
   let provisionerId: string;
 
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_reservations, runners_outbox CASCADE`,
-    );
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerId = crypto.randomUUID();
   });
@@ -228,7 +225,7 @@ describe('pollDemandAndReserve', () => {
       count: 1,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const beforeDelete = await db().select().from(reservations);
+    const beforeDelete = await reservationsForTest();
     const deletedReservation = beforeDelete.find((reservation) =>
       reservation.requiredLabels.includes('linux'),
     );
@@ -236,7 +233,7 @@ describe('pollDemandAndReserve', () => {
 
     const deleted = await deleteReservationsByIds([deletedReservation.id]);
 
-    const remaining = await db().select().from(reservations);
+    const remaining = await reservationsForTest();
     expect(deleted).toBe(1);
     expect(remaining).toHaveLength(1);
     expect(remaining[0]?.requiredLabels).toEqual(['macos']);
@@ -250,7 +247,7 @@ describe('pollDemandAndReserve', () => {
       count: 3,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const [reservation] = await db().select().from(reservations);
+    const [reservation] = await reservationsForTest();
     if (!reservation) throw new Error('Expected reservation');
 
     const released = await db().transaction((tx) =>
@@ -261,7 +258,7 @@ describe('pollDemandAndReserve', () => {
       }),
     );
 
-    const rows = await db().select().from(reservations);
+    const rows = await reservationsForTest();
     expect(released).toBe(2);
     expect(rows[0]?.count).toBe(1);
   });
@@ -274,7 +271,7 @@ describe('pollDemandAndReserve', () => {
       count: 1,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const [reservation] = await db().select().from(reservations);
+    const [reservation] = await reservationsForTest();
     if (!reservation) throw new Error('Expected reservation');
 
     const released = await db().transaction((tx) =>
@@ -285,27 +282,41 @@ describe('pollDemandAndReserve', () => {
       }),
     );
 
-    const rows = await db().select().from(reservations);
+    const rows = await reservationsForTest();
     expect(released).toBe(1);
     expect(rows).toHaveLength(0);
   });
 
   it('does not release another workspace or provisioner reservation', async () => {
-    await reservationFactory.create({
+    const otherWorkspace = await reservationFactory.create({
       workspaceId: crypto.randomUUID(),
       provisionerId,
       requiredLabels: ['linux'],
       count: 1,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    await reservationFactory.create({
+    const otherProvisioner = await reservationFactory.create({
       workspaceId,
       provisionerId: crypto.randomUUID(),
       requiredLabels: ['linux'],
       count: 1,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const rowsBefore = await db().select().from(reservations);
+    const rowsBefore = await db()
+      .select()
+      .from(reservations)
+      .where(
+        or(
+          and(
+            eq(reservations.workspaceId, otherWorkspace.workspaceId),
+            eq(reservations.provisionerId, otherWorkspace.provisionerId),
+          ),
+          and(
+            eq(reservations.workspaceId, otherProvisioner.workspaceId),
+            eq(reservations.provisionerId, otherProvisioner.provisionerId),
+          ),
+        ),
+      );
 
     const released = await db().transaction((tx) =>
       releaseReservationUnits(tx, {
@@ -315,7 +326,15 @@ describe('pollDemandAndReserve', () => {
       }),
     );
 
-    const rowsAfter = await db().select().from(reservations);
+    const rowsAfter = await db()
+      .select()
+      .from(reservations)
+      .where(
+        inArray(
+          reservations.id,
+          rowsBefore.map((reservation) => reservation.id),
+        ),
+      );
     expect(released).toBe(0);
     expect(rowsAfter.map((reservation) => reservation.id).sort()).toEqual(
       rowsBefore.map((reservation) => reservation.id).sort(),
@@ -330,7 +349,7 @@ describe('pollDemandAndReserve', () => {
       count: 1,
       expiresAt: new Date(Date.now() + 60_000),
     });
-    const [reservation] = await db().select().from(reservations);
+    const [reservation] = await reservationsForTest();
     if (!reservation) throw new Error('Expected reservation');
 
     const released = await db().transaction((tx) =>
@@ -341,7 +360,7 @@ describe('pollDemandAndReserve', () => {
       }),
     );
 
-    const rows = await db().select().from(reservations);
+    const rows = await reservationsForTest();
     expect(released).toBe(1);
     expect(rows).toHaveLength(0);
   });
@@ -360,6 +379,18 @@ describe('pollDemandAndReserve', () => {
         sql`${reservations.workspaceId} = ${workspaceId} and ${reservations.expiresAt} > now()`,
       );
     return Number(row?.value ?? 0);
+  }
+
+  async function reservationsForTest() {
+    return await db()
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.workspaceId, workspaceId),
+          eq(reservations.provisionerId, provisionerId),
+        ),
+      );
   }
 
   function template(templateKey: string, labels: string[], availableSlots: number) {

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -7,10 +7,8 @@ import {
 import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
-import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {claimJobExecution} from '#core/job-executions.js';
-import {db} from '#db/db.js';
 import {requestJobExecutionCancellation} from '#db/job-executions.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
 import {pendingJobFactory, runnerSessionFactory} from '#test/index.js';
@@ -51,9 +49,6 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
   });
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens, runners_outbox CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     const session = await runnerSessionFactory.create({workspaceId});
     runnerSessionId = session.id;

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -10,7 +10,6 @@ import {
 import {requireMembership} from '@shipfox/api-workspaces';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
-import {sql} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
@@ -51,7 +50,6 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
 
   beforeEach(async () => {
     await closeApp();
-    await db().execute(sql`TRUNCATE runners_provisioned_runners, runners_running_jobs CASCADE`);
     workspaceId = crypto.randomUUID();
     vi.mocked(requireMembership).mockResolvedValue({
       workspaceId,

--- a/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
@@ -12,7 +12,7 @@ import {requireMembership} from '@shipfox/api-workspaces';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {revokeManualRegistrationToken} from '#db/manual-registration-tokens.js';
@@ -55,9 +55,6 @@ describe('manual registration token routes', () => {
 
   beforeEach(async () => {
     await closeApp();
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_manual_registration_tokens CASCADE`,
-    );
     workspaceId = crypto.randomUUID();
     vi.mocked(requireMembership).mockResolvedValue({
       workspaceId,

--- a/libs/api/runners/src/presentation/routes/mint-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/mint-registration-tokens.test.ts
@@ -14,7 +14,7 @@ import {
   extractBearerToken,
 } from '@shipfox/node-fastify';
 import {hashOpaqueToken, tokenTypeParts} from '@shipfox/node-tokens';
-import {count, sql} from 'drizzle-orm';
+import {and, count, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {config} from '#config.js';
 import {db} from '#db/db.js';
@@ -75,10 +75,7 @@ describe('POST /provisioners/runner-registration-tokens/batch', () => {
     await closeApp();
   });
 
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_sessions, runners_reservations CASCADE`,
-    );
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerTokenId = crypto.randomUUID();
   });
@@ -351,7 +348,15 @@ describe('POST /provisioners/runner-registration-tokens/batch', () => {
   }
 
   async function countEphemeralTokens(): Promise<number> {
-    const [row] = await db().select({value: count()}).from(ephemeralRegistrationTokens);
+    const [row] = await db()
+      .select({value: count()})
+      .from(ephemeralRegistrationTokens)
+      .where(
+        and(
+          eq(ephemeralRegistrationTokens.workspaceId, workspaceId),
+          eq(ephemeralRegistrationTokens.provisionerId, provisionerTokenId),
+        ),
+      );
     return row?.value ?? 0;
   }
 

--- a/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
@@ -1,7 +1,7 @@
 import {AUTH_PROVISIONER_TOKEN, setProvisionerContext} from '@shipfox/api-auth-context';
 import {type AuthMethod, closeApp, createApp, extractBearerToken} from '@shipfox/node-fastify';
 import {vi} from '@shipfox/vitest/vi';
-import {sql} from 'drizzle-orm';
+import {and, eq} from 'drizzle-orm';
 import type {FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {reservations} from '#db/schema/reservations.js';
@@ -38,9 +38,6 @@ describe('POST /provisioners/demand/poll reservation cleanup', () => {
       swagger: false,
     });
     await app.ready();
-    await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_reservations, runners_provisioned_runners, runners_running_jobs, runners_outbox CASCADE`,
-    );
     await pendingJobFactory.create({workspaceId, requiredLabels: ['linux']});
 
     try {
@@ -63,7 +60,15 @@ describe('POST /provisioners/demand/poll reservation cleanup', () => {
         },
       });
 
-      const reservationRows = await db().select().from(reservations);
+      const reservationRows = await db()
+        .select()
+        .from(reservations)
+        .where(
+          and(
+            eq(reservations.workspaceId, workspaceId),
+            eq(reservations.provisionerId, provisionerTokenId),
+          ),
+        );
       expect(res.statusCode).toBe(500);
       expect(reservationRows).toHaveLength(0);
     } finally {

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -13,7 +13,6 @@ import {
   createApp,
   extractBearerToken,
 } from '@shipfox/node-fastify';
-import {sql} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
@@ -63,10 +62,7 @@ describe('POST /provisioners/demand/poll', () => {
     await closeApp();
   });
 
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_pending_jobs, runners_reservations, runners_provisioned_runners, runners_running_jobs, runners_outbox CASCADE`,
-    );
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerTokenId = crypto.randomUUID();
   });

--- a/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
@@ -3,9 +3,7 @@ import {getWorkspace, WorkspaceNotFoundError} from '@shipfox/api-workspaces';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
-import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
-import {db} from '#db/db.js';
 import * as provisionerTokenDb from '#db/provisioner-tokens.js';
 import {revokeProvisionerToken} from '#db/provisioner-tokens.js';
 import {createProvisionerTokenAuthMethod} from '#presentation/auth/index.js';
@@ -46,7 +44,6 @@ describe('provisioner me route', () => {
 
   beforeEach(async () => {
     await closeApp();
-    await db().execute(sql`TRUNCATE runners_provisioner_tokens CASCADE`);
     mocks.logger.warn.mockReset();
     vi.mocked(getWorkspace).mockImplementation(({workspaceId}) =>
       Promise.resolve(workspace({id: workspaceId})),

--- a/libs/api/runners/src/presentation/routes/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-tokens.test.ts
@@ -43,7 +43,6 @@ describe('provisioner token routes', () => {
 
   beforeEach(async () => {
     await closeApp();
-    await db().execute(sql`TRUNCATE runners_provisioner_tokens CASCADE`);
     workspaceId = crypto.randomUUID();
     vi.mocked(requireMembership).mockResolvedValue({
       workspaceId,

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -14,7 +14,7 @@ import {
   extractBearerToken,
 } from '@shipfox/node-fastify';
 import {vi} from '@shipfox/vitest/vi';
-import {and, desc, eq, sql} from 'drizzle-orm';
+import {and, desc, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {reservations} from '#db/schema/reservations.js';
@@ -66,10 +66,7 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
     await closeApp();
   });
 
-  beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_provisioned_runners, runners_reservations, runners_running_jobs CASCADE`,
-    );
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerTokenId = crypto.randomUUID();
   });

--- a/libs/api/runners/src/presentation/routes/register.test.ts
+++ b/libs/api/runners/src/presentation/routes/register.test.ts
@@ -7,7 +7,7 @@ import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
-import {eq, sql} from 'drizzle-orm';
+import {eq} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
 import {db} from '#db/db.js';
 import {revokeManualRegistrationToken} from '#db/manual-registration-tokens.js';
@@ -52,9 +52,6 @@ describe('POST /runners/register', () => {
   });
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_runner_sessions, runners_manual_registration_tokens CASCADE`,
-    );
     rawToken = generateOpaqueToken('manualRegistrationToken');
     workspaceId = crypto.randomUUID();
     await manualRegistrationTokenFactory.create({workspaceId}, {transient: {rawToken}});
@@ -152,7 +149,10 @@ describe('POST /runners/register', () => {
     expect(second.statusCode).toBe(200);
     expect(first.json().session_id).not.toBe(second.json().session_id);
 
-    const rows = await db().select().from(runnerSessions);
+    const rows = await db()
+      .select()
+      .from(runnerSessions)
+      .where(eq(runnerSessions.workspaceId, workspaceId));
     expect(rows.map((row) => row.labels).sort()).toEqual([['linux'], ['macos']]);
   });
 

--- a/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
@@ -13,7 +13,7 @@ import {
   createApp,
   extractBearerToken,
 } from '@shipfox/node-fastify';
-import {sql} from 'drizzle-orm';
+import {and, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
@@ -62,8 +62,7 @@ describe('POST /provisioners/provisioned-runners/report', () => {
     await closeApp();
   });
 
-  beforeEach(async () => {
-    await db().execute(sql`TRUNCATE runners_provisioned_runners, runners_reservations CASCADE`);
+  beforeEach(() => {
     workspaceId = crypto.randomUUID();
     provisionerTokenId = crypto.randomUUID();
   });
@@ -88,7 +87,15 @@ describe('POST /provisioners/provisioned-runners/report', () => {
       },
     });
 
-    const rows = await db().select().from(provisionedRunners);
+    const rows = await db()
+      .select()
+      .from(provisionedRunners)
+      .where(
+        and(
+          eq(provisionedRunners.workspaceId, workspaceId),
+          eq(provisionedRunners.provisionerId, provisionerTokenId),
+        ),
+      );
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({accepted: 1, reservations_released: 0});
     expect(rows[0]).toMatchObject({

--- a/libs/api/runners/src/presentation/routes/request-job.test.ts
+++ b/libs/api/runners/src/presentation/routes/request-job.test.ts
@@ -9,9 +9,7 @@ import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {signHs256} from '@shipfox/node-jwt';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
-import {sql} from 'drizzle-orm';
 import type {FastifyInstance} from 'fastify';
-import {db} from '#db/db.js';
 import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.js';
 import {
   ephemeralRegistrationTokenFactory,
@@ -57,9 +55,6 @@ describe('POST /runners/jobs/request', () => {
   });
 
   beforeEach(async () => {
-    await db().execute(
-      sql`TRUNCATE runners_ephemeral_registration_tokens, runners_pending_jobs, runners_running_jobs, runners_runner_sessions, runners_manual_registration_tokens CASCADE`,
-    );
     rawToken = `sf_mrt_${crypto.randomUUID()}`;
     workspaceId = crypto.randomUUID();
     await manualRegistrationTokenFactory.create({workspaceId}, {transient: {rawToken}});

--- a/libs/api/secrets/src/core/rotate-kek.test.ts
+++ b/libs/api/secrets/src/core/rotate-kek.test.ts
@@ -34,7 +34,9 @@ describe('rotateWorkspaceDataKeysWithProvider', () => {
       kekVersion: previousWrapped.kekVersion,
     });
 
-    const result = await rotateWorkspaceDataKeysWithProvider(currentProvider);
+    const result = await rotateWorkspaceDataKeysWithProvider(currentProvider, {
+      workspaceIds: [workspaceId],
+    });
     const rows = await db()
       .select()
       .from(secretDataKeys)
@@ -43,7 +45,7 @@ describe('rotateWorkspaceDataKeysWithProvider', () => {
     if (!row) throw new Error('Expected rotated row');
     const unwrapped = currentProvider.unwrapDek(row.workspaceId, row.wrappedDek, row.kekVersion);
 
-    expect(result.rotated).toBeGreaterThanOrEqual(1);
+    expect(result.rotated).toBe(1);
     expect(row.kekVersion).toBe(currentProvider.currentKeyVersion);
     expect(row.wrappedDek).not.toBe(previousWrapped.wrappedDek);
     expect(row.rotatedAt).toBeInstanceOf(Date);
@@ -80,7 +82,7 @@ describe('rotateWorkspaceDataKeysWithProvider', () => {
         }),
       });
 
-    await rotateWorkspaceDataKeysWithProvider(currentProvider);
+    await rotateWorkspaceDataKeysWithProvider(currentProvider, {workspaceIds: [workspaceId]});
     const localStore = createLocalSecretStore({
       dekManager: new DekManager(currentProvider, {maxEntries: 10, ttlMs: 60_000}),
     });
@@ -90,11 +92,11 @@ describe('rotateWorkspaceDataKeysWithProvider', () => {
   });
 
   it('is idempotent after rotating and is a no-op over an empty key set', async () => {
+    const workspaceId = crypto.randomUUID();
     const emptyResult = await rotateWorkspaceDataKeysWithProvider(
       createLocalKeyProvider({currentKek: crypto.randomBytes(32)}),
+      {workspaceIds: [workspaceId]},
     );
-
-    const workspaceId = crypto.randomUUID();
     const currentKek = crypto.randomBytes(32);
     const previousKek = crypto.randomBytes(32);
     const currentProvider = createLocalKeyProvider({currentKek, previousKek});
@@ -106,8 +108,12 @@ describe('rotateWorkspaceDataKeysWithProvider', () => {
       kekVersion: previousWrapped.kekVersion,
     });
 
-    const first = await rotateWorkspaceDataKeysWithProvider(currentProvider);
-    const second = await rotateWorkspaceDataKeysWithProvider(currentProvider);
+    const first = await rotateWorkspaceDataKeysWithProvider(currentProvider, {
+      workspaceIds: [workspaceId],
+    });
+    const second = await rotateWorkspaceDataKeysWithProvider(currentProvider, {
+      workspaceIds: [workspaceId],
+    });
 
     expect(emptyResult).toEqual({rotated: 0, skipped: 0});
     expect(first.rotated).toBe(1);
@@ -170,6 +176,7 @@ describe('rotateWorkspaceDataKeysWithProvider', () => {
     await expect(
       rotateWorkspaceDataKeysWithProvider(
         createLocalKeyProvider({currentKek: crypto.randomBytes(32)}),
+        {workspaceIds: [workspaceId]},
       ),
     ).rejects.toThrow(KekVersionStrandedError);
   });

--- a/libs/api/secrets/src/core/rotate-kek.ts
+++ b/libs/api/secrets/src/core/rotate-kek.ts
@@ -9,13 +9,20 @@ export interface RotateWorkspaceDataKeysResult {
   skipped: number;
 }
 
+export interface RotateWorkspaceDataKeysOptions {
+  workspaceIds?: string[] | undefined;
+}
+
 export async function rotateWorkspaceDataKeysWithProvider(
   keyProvider: KeyProvider,
+  options: RotateWorkspaceDataKeysOptions = {},
 ): Promise<RotateWorkspaceDataKeysResult> {
   const knownVersions = [keyProvider.currentKeyVersion, keyProvider.previousKeyVersion].filter(
     (version): version is string => Boolean(version),
   );
-  const unknownVersions = await listDataKeyVersions(knownVersions);
+  const unknownVersions = await listDataKeyVersions(knownVersions, {
+    workspaceIds: options.workspaceIds,
+  });
   if (unknownVersions.length > 0) throw new KekVersionStrandedError(unknownVersions[0] as string);
 
   let rotated = 0;
@@ -23,7 +30,11 @@ export async function rotateWorkspaceDataKeysWithProvider(
   let afterWorkspaceId: string | undefined;
 
   while (true) {
-    const page = await listDataKeysPage({afterWorkspaceId, limit: PAGE_SIZE});
+    const page = await listDataKeysPage({
+      afterWorkspaceId,
+      limit: PAGE_SIZE,
+      workspaceIds: options.workspaceIds,
+    });
     if (page.length === 0) break;
 
     for (const row of page) {

--- a/libs/api/secrets/src/db/data-keys.ts
+++ b/libs/api/secrets/src/db/data-keys.ts
@@ -45,18 +45,23 @@ export async function updateDataKeyWrapCas(
   return rows.length > 0;
 }
 
-export async function listDataKeyVersions(knownVersions: string[]): Promise<string[]> {
-  if (knownVersions.length === 0) {
-    const rows = await db()
-      .selectDistinct({kekVersion: secretDataKeys.kekVersion})
-      .from(secretDataKeys);
-    return rows.map((row) => row.kekVersion);
-  }
+export async function listDataKeyVersions(
+  knownVersions: string[],
+  params: {workspaceIds?: string[] | undefined} = {},
+): Promise<string[]> {
+  if (params.workspaceIds?.length === 0) return [];
 
+  const filters: SQL[] = [];
+  if (knownVersions.length > 0) {
+    filters.push(notInArray(secretDataKeys.kekVersion, knownVersions));
+  }
+  if (params.workspaceIds) {
+    filters.push(inArray(secretDataKeys.workspaceId, params.workspaceIds));
+  }
   const rows = await db()
     .selectDistinct({kekVersion: secretDataKeys.kekVersion})
     .from(secretDataKeys)
-    .where(notInArray(secretDataKeys.kekVersion, knownVersions));
+    .where(filters.length > 0 ? and(...filters) : undefined);
   return rows.map((row) => row.kekVersion);
 }
 
@@ -64,8 +69,10 @@ export async function listDataKeysPage(params: {
   afterWorkspaceId?: string | undefined;
   limit: number;
   versions?: string[] | undefined;
+  workspaceIds?: string[] | undefined;
 }): Promise<DataKey[]> {
   if (params.versions && params.versions.length === 0) return [];
+  if (params.workspaceIds?.length === 0) return [];
 
   const filters: SQL[] = [];
   if (params.afterWorkspaceId) {
@@ -73,6 +80,9 @@ export async function listDataKeysPage(params: {
   }
   if (params.versions) {
     filters.push(inArray(secretDataKeys.kekVersion, params.versions));
+  }
+  if (params.workspaceIds) {
+    filters.push(inArray(secretDataKeys.workspaceId, params.workspaceIds));
   }
   const rows = await db()
     .select()


### PR DESCRIPTION
Fix flaky test isolation by removing per-test table truncation and scoping assertions to rows owned by each test.

Runner tests were truncating module tables during individual test files while workflow tests could be running concurrently against active runner lease rows. That made test outcomes depend on package scheduling. This moves cleanup back to module `globalSetup`, documents that only module-owned tables may be truncated there, and updates the affected tests to use random workspace/project/provisioner/job identifiers when reading or asserting database state.

The affected-graph test run also exposed the same isolation issue in secrets KEK rotation: tests used a provider that only knew their generated KEK versions while the rotation code scanned every data key. This adds a scoped workspace option to the rotation path so tests can exercise rotation without observing unrelated data keys.

No changeset is included because all touched packages are private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky tests by removing per-test table truncation and scoping all reads/assertions to per-test identifiers. This stabilizes parallel runs and eliminates cross-suite interference.

- **Bug Fixes**
  - Moved DB cleanup to each module’s `globalSetup`; only module-owned tables are truncated.
  - Removed per-test TRUNCATE calls; tests now generate fresh IDs (e.g. workspace/project/provisioner/job) and filter queries to those IDs.
  - Updated runner, logs, projects, and integrations tests to assert only on rows they create; added scoped helpers and made the logs open-stream count test compare consecutive reads (delta) instead of absolute zero.
  - Secrets: added `workspaceIds` scoping to rotation and queries (`rotateWorkspaceDataKeysWithProvider`, `listDataKeyVersions`, `listDataKeysPage`) so tests don’t observe unrelated KEK versions.
  - Docs: AGENTS.md now forbids per-test truncation and requires scoped identifiers in tests.

<sup>Written for commit 2cae43b7213f3207d31b82de6789f1946d9653fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

