### PR TITLE
[api-runners] Link registered runners to provisioned rows

### DIFF
--- a/libs/api/runners/src/core/runner-sessions.test.ts
+++ b/libs/api/runners/src/core/runner-sessions.test.ts
@@ -1,9 +1,14 @@
 import {verifyRunnerSessionToken} from '@shipfox/api-auth';
-import {eq} from 'drizzle-orm';
+import {and, eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
+import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
-import {ephemeralRegistrationTokenFactory, manualRegistrationTokenFactory} from '#test/index.js';
+import {
+  ephemeralRegistrationTokenFactory,
+  manualRegistrationTokenFactory,
+  provisionedRunnerFactory,
+} from '#test/index.js';
 import {
   EmptyRunnerLabelsError,
   RegistrationTokenConsumedError,
@@ -95,6 +100,41 @@ describe('registerRunnerSession', () => {
 
     const claims = await verifyRunnerSessionToken(result.sessionToken);
     expect(claims?.maxClaims).toBe(1);
+  });
+
+  it('links an existing provisioned runner row when consuming an ephemeral token', async () => {
+    const token = await ephemeralRegistrationTokenFactory.create({workspaceId});
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId: token.provisionerId,
+      provisionedRunnerId: token.provisionedRunnerId,
+      runnerSessionId: null,
+      state: 'starting',
+    });
+
+    const result = await registerRunnerSession({
+      credential: {
+        kind: 'ephemeral',
+        ephemeralTokenId: token.id,
+        workspaceId,
+        provisionerId: token.provisionerId,
+        reservationId: token.reservationId,
+        provisionedRunnerId: token.provisionedRunnerId,
+      },
+      labels: ['linux'],
+    });
+
+    const [provisionedRunner] = await db()
+      .select()
+      .from(provisionedRunners)
+      .where(
+        and(
+          eq(provisionedRunners.workspaceId, workspaceId),
+          eq(provisionedRunners.provisionerId, token.provisionerId),
+          eq(provisionedRunners.provisionedRunnerId, token.provisionedRunnerId),
+        ),
+      );
+    expect(provisionedRunner?.runnerSessionId).toBe(result.session.id);
   });
 
   it('rejects a second consume of the same ephemeral token', async () => {

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -15,6 +15,7 @@ import {
   ephemeralRegistrationTokens,
   toEphemeralRegistrationToken,
 } from './schema/ephemeral-registration-tokens.js';
+import {provisionedRunners} from './schema/provisioned-runners.js';
 import {reservations} from './schema/reservations.js';
 import {runnerSessions, toRunnerSession} from './schema/runner-sessions.js';
 
@@ -201,6 +202,8 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
   maxClaims: number;
 }) {
   return await db().transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId}))`);
+
     const consumed = await tx
       .update(ephemeralRegistrationTokens)
       .set({consumedAt: sql`now()`})
@@ -266,6 +269,18 @@ export async function createRunnerSessionConsumingEphemeralToken(params: {
       .update(ephemeralRegistrationTokens)
       .set({consumedSessionId: session.id})
       .where(eq(ephemeralRegistrationTokens.id, params.ephemeralTokenId));
+
+    await tx
+      .update(provisionedRunners)
+      .set({runnerSessionId: session.id, updatedAt: sql`now()`})
+      .where(
+        and(
+          eq(provisionedRunners.workspaceId, params.workspaceId),
+          eq(provisionedRunners.provisionerId, consumed[0].provisionerId),
+          eq(provisionedRunners.provisionedRunnerId, consumed[0].provisionedRunnerId),
+          isNull(provisionedRunners.reservationReleasedAt),
+        ),
+      );
 
     return toRunnerSession(session);
   });

--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -1,6 +1,7 @@
 import {pgClient} from '@shipfox/node-postgres';
 import {and, desc, eq, inArray, or, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
+import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
 import {
   listActiveProvisionedRunners,
   listProvisionerTerminateIntents,
@@ -10,7 +11,11 @@ import {
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {reservations} from '#db/schema/reservations.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
-import {provisionedRunnerFactory, reservationFactory} from '#test/index.js';
+import {
+  ephemeralRegistrationTokenFactory,
+  provisionedRunnerFactory,
+  reservationFactory,
+} from '#test/index.js';
 
 function provisionedRunnerRowsFor(params: {workspaceId: string; provisionerId: string}) {
   return db()
@@ -542,6 +547,42 @@ describe('reportProvisionedRunners', () => {
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     expect(result).toEqual({accepted: 1, reservationsReleased: 0});
     expect(reservationRows[0]?.count).toBe(1);
+    expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeNull();
+  });
+
+  it('uses the consumed ephemeral token session before releasing a terminal report', async () => {
+    const reservationId = await createReservation(1);
+    const token = await ephemeralRegistrationTokenFactory.create({
+      workspaceId,
+      provisionerId,
+      reservationId,
+      provisionedRunnerId: 'provisioned-runner-1',
+    });
+    const session = await createRunnerSessionConsumingEphemeralToken({
+      ephemeralTokenId: token.id,
+      workspaceId,
+      labels: ['linux'],
+      maxClaims: 1,
+    });
+
+    const result = await reportProvisionedRunners({
+      workspaceId,
+      provisionerId,
+      events: [
+        event({
+          provisionedRunnerId: 'provisioned-runner-1',
+          reservationId,
+          state: 'failed',
+          runnerSessionId: crypto.randomUUID(),
+        }),
+      ],
+    });
+
+    const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
+    const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(reservationRows[0]?.count).toBe(1);
+    expect(provisionedRunnerRows[0]?.runnerSessionId).toBe(session.id);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeNull();
   });
 

--- a/libs/api/runners/src/db/provisioned-runners.ts
+++ b/libs/api/runners/src/db/provisioned-runners.ts
@@ -25,6 +25,7 @@ import {
   type ProvisionedRunnerBoundJobExecution,
 } from './job-executions.js';
 import {releaseReservationUnits} from './reservations.js';
+import {ephemeralRegistrationTokens} from './schema/ephemeral-registration-tokens.js';
 import {provisionedRunners, toProvisionedRunner} from './schema/provisioned-runners.js';
 import {runningJobExecutions} from './schema/running-job-executions.js';
 
@@ -94,12 +95,14 @@ export async function reportProvisionedRunners(params: ReportProvisionedRunnersP
 
   return await db().transaction(async (tx) => {
     const receivedAt = new Date();
-    const events = aggregateEvents(params.events, receivedAt);
-    const hasTerminalEvent = events.some((event) => isTerminalState(event.state));
+    const aggregatedEvents = aggregateEvents(params.events, receivedAt);
+    const hasTerminalEvent = aggregatedEvents.some((event) => isTerminalState(event.state));
 
     if (hasTerminalEvent) {
       await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId}))`);
     }
+
+    const events = await hydrateRunnerSessionIdsFromConsumedTokens(tx, params, aggregatedEvents);
 
     const values = events.map((event) => ({
       workspaceId: params.workspaceId,
@@ -135,7 +138,7 @@ export async function reportProvisionedRunners(params: ReportProvisionedRunnersP
           labels: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN excluded.labels ELSE ${provisionedRunners.labels} END`,
           state: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN excluded.state ELSE ${provisionedRunners.state} END`,
           reason: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN excluded.reason ELSE ${provisionedRunners.reason} END`,
-          runnerSessionId: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN coalesce(excluded.runner_session_id, ${provisionedRunners.runnerSessionId}) ELSE ${provisionedRunners.runnerSessionId} END`,
+          runnerSessionId: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN coalesce(${provisionedRunners.runnerSessionId}, excluded.runner_session_id) ELSE ${provisionedRunners.runnerSessionId} END`,
           providerKind: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN coalesce(excluded.provider_kind, ${provisionedRunners.providerKind}) ELSE ${provisionedRunners.providerKind} END`,
           reportedAt: sql`CASE WHEN ${provisionedRunnerProjectionUpdateCondition()} THEN excluded.reported_at ELSE ${provisionedRunners.reportedAt} END`,
           startedAt: firstObservedAt(provisionedRunners.startedAt, sql`excluded.started_at`),
@@ -422,6 +425,7 @@ async function releaseTerminalProvisionedRunnerReservationsByIds(
           provisionedRunners.id,
           rows.map((row) => row.id),
         ),
+        isNull(provisionedRunners.runnerSessionId),
         isNull(provisionedRunners.reservationReleasedAt),
       ),
     )
@@ -445,6 +449,51 @@ async function releaseTerminalProvisionedRunnerReservationsByIds(
       reservationId,
       count,
     })),
+  });
+}
+
+async function hydrateRunnerSessionIdsFromConsumedTokens(
+  tx: Tx,
+  params: ReportProvisionedRunnersParams,
+  events: ProvisionedRunnerReportRow[],
+): Promise<ProvisionedRunnerReportRow[]> {
+  const provisionedRunnerIds = [...new Set(events.map((event) => event.provisionedRunnerId))];
+  if (provisionedRunnerIds.length === 0) return events;
+
+  const tokenRows = await tx
+    .select({
+      provisionedRunnerId: ephemeralRegistrationTokens.provisionedRunnerId,
+      consumedSessionId: ephemeralRegistrationTokens.consumedSessionId,
+    })
+    .from(ephemeralRegistrationTokens)
+    .where(
+      and(
+        eq(ephemeralRegistrationTokens.workspaceId, params.workspaceId),
+        eq(ephemeralRegistrationTokens.provisionerId, params.provisionerId),
+        inArray(ephemeralRegistrationTokens.provisionedRunnerId, provisionedRunnerIds),
+        isNotNull(ephemeralRegistrationTokens.consumedSessionId),
+      ),
+    )
+    .orderBy(
+      desc(ephemeralRegistrationTokens.consumedAt),
+      desc(ephemeralRegistrationTokens.createdAt),
+    );
+
+  const consumedSessionIdsByProvisionedRunnerId = new Map<string, string>();
+  for (const row of tokenRows) {
+    if (!row.consumedSessionId) continue;
+    if (consumedSessionIdsByProvisionedRunnerId.has(row.provisionedRunnerId)) continue;
+    consumedSessionIdsByProvisionedRunnerId.set(row.provisionedRunnerId, row.consumedSessionId);
+  }
+
+  if (consumedSessionIdsByProvisionedRunnerId.size === 0) return events;
+
+  return events.map((event) => {
+    const consumedSessionId = consumedSessionIdsByProvisionedRunnerId.get(
+      event.provisionedRunnerId,
+    );
+    if (!consumedSessionId || event.runnerSessionId === consumedSessionId) return event;
+    return {...event, runnerSessionId: consumedSessionId};
   });
 }
 


### PR DESCRIPTION
Link runner sessions created from ephemeral registration tokens back to their matching provisioned runner rows.

A terminal provisioner report could release a reservation for a provisioned runner even after that runner had registered a real session. This persists the consumed token's session id onto the provisioned runner row, hydrates terminal report events from consumed tokens before release decisions, and serializes registration/report races with the existing per-workspace advisory lock pattern.

The release guard now mirrors the session-null check used when selecting releasable rows, so the reservation release path remains defensive if the locking model changes later.

Closes ENG-661

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link runner sessions created with ephemeral registration tokens to their matching provisioned runner rows to prevent releasing reservations after a runner has registered. Closes ENG-661.

- **Bug Fixes**
  - Persist `runnerSessionId` onto the matching provisioned runner row when consuming an ephemeral token.
  - Prefer the consumed token’s session id in report processing and avoid overwriting an existing `runnerSessionId`.
  - Serialize registration/report handling with a per-workspace advisory lock to avoid races.
  - Only release terminal reservations when `runnerSessionId` is null, matching the selection guard.

<sup>Written for commit 6c5e3861f6671561b53c1734feae0c348ba4630e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

