### PR TITLE
[api/integration-core] Enable webhook integration by default

### DIFF
--- a/.changeset/fresh-webhooks-open.md
+++ b/.changeset/fresh-webhooks-open.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-integration-core": patch
+---
+
+Enables the generic webhook integration provider by default because it does not require provider setup.

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -18,7 +18,7 @@ export const config = createConfig({
     default: false,
   }),
   INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER: bool({
-    desc: 'Enables the generic webhook integration provider so users can create inbound webhook URLs.',
-    default: false,
+    desc: 'Enables the generic webhook integration provider so users can create inbound webhook URLs. It is enabled by default because it does not require provider setup.',
+    default: true,
   }),
 });


### PR DESCRIPTION
Enable the generic webhook integration provider by default.

The webhook provider does not require external provider credentials or setup, so installations should expose inbound webhook URLs without requiring self-hosters to discover and set an enable flag.

This also adds the release changeset for `@shipfox/api-integration-core`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the generic webhook integration provider by default so new installs expose inbound webhook URLs out of the box. No external credentials or setup needed.

- **Migration**
  - To opt out, set INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER=false.

<sup>Written for commit d05e4dc4ad348ac9584c5b8bdcadd48d11522a42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

