### PR TITLE
[api] Enable shared Vitest isolation for API test suites

### DIFF
--- a/.changeset/steady-tests-share.md
+++ b/.changeset/steady-tests-share.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-integration-core": patch
+"@shipfox/api-runners": patch
+---
+
+Runs the API runners and integration core test suites without per-file Vitest module isolation, removing runner auth-helper mocks and cleaning up module-reset handling for shared test modules.

--- a/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
+++ b/libs/api/agent/src/presentation/routes/model-provider-config.test.ts
@@ -3,8 +3,8 @@ import type {ModelProviderRef} from '@shipfox/api-agent-dto';
 import {
   AUTH_USER,
   buildUserContext,
-  requireWorkspaceAccess,
   setUserContext,
+  type UserContextMembership,
 } from '@shipfox/api-auth-context';
 import {getSecretsByNamespace, setSecrets} from '@shipfox/api-secrets';
 import type {AuthMethod, FastifyRequest} from '@shipfox/node-fastify';
@@ -21,17 +21,13 @@ import {
 import {modelProviderConfigs} from '#db/schema/model-provider-configs.js';
 import {agentRoutes} from './index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {...actual, requireWorkspaceAccess: vi.fn()};
-});
-
 vi.mock('@earendil-works/pi-ai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@earendil-works/pi-ai')>();
   return {...actual, complete: vi.fn()};
 });
 
 const AUTH_USER_ID = '11111111-1111-4111-8111-111111111111';
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -45,7 +41,7 @@ const fakeUserAuth: AuthMethod = {
       buildUserContext({
         userId: AUTH_USER_ID,
         email: 'user@example.com',
-        memberships: [{workspaceId: 'workspace-from-auth', role: 'admin'}],
+        memberships: authenticatedMemberships,
       }),
     );
     return Promise.resolve();
@@ -78,11 +74,7 @@ describe('model provider config routes', () => {
       stopReason: 'stop',
       timestamp: Date.now(),
     });
-    vi.mocked(requireWorkspaceAccess).mockReturnValue({
-      workspaceId,
-      userId: AUTH_USER_ID,
-      role: 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     app = await createApp({
       auth: [fakeUserAuth],
       routes: agentRoutes,
@@ -111,9 +103,7 @@ describe('model provider config routes', () => {
     });
 
     it('returns 403 when the user is not a workspace member', async () => {
-      vi.mocked(requireWorkspaceAccess).mockImplementationOnce(() => {
-        throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-      });
+      authenticatedMemberships = [];
 
       const res = await app.inject({
         method: 'GET',

--- a/libs/api/integration/core/src/presentation/routes/list-connections.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/list-connections.test.ts
@@ -1,11 +1,5 @@
-import {ClientError} from '@shipfox/node-fastify';
 import {upsertIntegrationConnection} from '#db/connections.js';
-import {
-  createTestApp,
-  requireWorkspaceAccessMock,
-  sourceProvider,
-  useIntegrationRouteTest,
-} from '#test/route-utils.js';
+import {createTestApp, sourceProvider, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('GET /integration-connections', () => {
   const context = useIntegrationRouteTest();
@@ -122,13 +116,11 @@ describe('GET /integration-connections', () => {
 
   it('returns membership errors', async () => {
     const app = await createTestApp([sourceProvider()]);
-    requireWorkspaceAccessMock.mockImplementationOnce(() => {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-    });
+    const inaccessibleWorkspaceId = crypto.randomUUID();
 
     const res = await app.inject({
       method: 'GET',
-      url: `/integration-connections?workspace_id=${context.workspaceId}`,
+      url: `/integration-connections?workspace_id=${inaccessibleWorkspaceId}`,
       headers: {authorization: 'Bearer user'},
     });
 

--- a/libs/api/integration/core/src/presentation/routes/list-repositories.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/list-repositories.test.ts
@@ -1,11 +1,6 @@
 import {IntegrationProviderError} from '#core/errors.js';
 import {upsertIntegrationConnection} from '#db/connections.js';
-import {
-  createTestApp,
-  requireWorkspaceAccessMock,
-  sourceProvider,
-  useIntegrationRouteTest,
-} from '#test/route-utils.js';
+import {createTestApp, sourceProvider, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('GET /integration-connections/:connectionId/repositories', () => {
   const context = useIntegrationRouteTest();
@@ -27,9 +22,6 @@ describe('GET /integration-connections/:connectionId/repositories', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(requireWorkspaceAccessMock).toHaveBeenCalledWith(
-      expect.objectContaining({workspaceId: connection.workspaceId}),
-    );
     expect(res.json().repositories[0].full_name).toBe('gitea-owner/platform');
   });
 

--- a/libs/api/integration/core/src/presentation/routes/manage-connections.test.ts
+++ b/libs/api/integration/core/src/presentation/routes/manage-connections.test.ts
@@ -1,11 +1,5 @@
-import {ClientError} from '@shipfox/node-fastify';
 import {getIntegrationConnectionById, upsertIntegrationConnection} from '#db/connections.js';
-import {
-  createTestApp,
-  requireWorkspaceAccessMock,
-  sourceProvider,
-  useIntegrationRouteTest,
-} from '#test/route-utils.js';
+import {createTestApp, sourceProvider, useIntegrationRouteTest} from '#test/route-utils.js';
 
 describe('PATCH /integration-connections/:connectionId', () => {
   const context = useIntegrationRouteTest();
@@ -73,14 +67,11 @@ describe('PATCH /integration-connections/:connectionId', () => {
   it('returns membership errors', async () => {
     const app = await createTestApp([sourceProvider()]);
     const connection = await upsertIntegrationConnection({
-      workspaceId: context.workspaceId,
+      workspaceId: crypto.randomUUID(),
       provider: 'gitea',
       externalAccountId: 'gitea-owner',
       slug: 'gitea_owner',
       displayName: 'Gitea',
-    });
-    requireWorkspaceAccessMock.mockImplementationOnce(() => {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
     });
 
     const res = await app.inject({

--- a/libs/api/integration/core/test/route-utils.ts
+++ b/libs/api/integration/core/test/route-utils.ts
@@ -1,23 +1,15 @@
-import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
 import {type AuthMethod, ClientError, closeApp, createApp} from '@shipfox/node-fastify';
 import {afterEach, beforeEach} from '@shipfox/vitest/vi';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {createIntegrationsModule, type IntegrationProvider} from '#index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {
-    ...actual,
-    requireWorkspaceAccess: vi.fn(() => ({
-      workspaceId: 'workspace',
-      userId: 'user-1',
-      role: 'admin',
-    })),
-  };
-});
-
-const {requireWorkspaceAccess} = await import('@shipfox/api-auth-context');
-export const requireWorkspaceAccessMock = vi.mocked(requireWorkspaceAccess);
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -28,7 +20,11 @@ const fakeUserAuth: AuthMethod = {
 
     setUserContext(
       request,
-      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
     );
     return Promise.resolve();
   },
@@ -93,11 +89,7 @@ export function useIntegrationRouteTest() {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    requireWorkspaceAccessMock.mockReturnValue({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
   });
 
   afterEach(async () => {

--- a/libs/api/integration/core/vitest.config.ts
+++ b/libs/api/integration/core/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig(
     test: {
       fileParallelism: false,
       globalSetup: ['test/globalSetup.ts'],
+      isolate: false,
       setupFiles: ['test/setup.ts'],
     },
   },

--- a/libs/api/integration/gitea/src/presentation/routes/connections.test.ts
+++ b/libs/api/integration/gitea/src/presentation/routes/connections.test.ts
@@ -1,4 +1,9 @@
-import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
 import {
   ConnectionSlugConflictError,
   type IntegrationConnection,
@@ -9,20 +14,7 @@ import type {GiteaApiClient} from '#api/client.js';
 import type {ConnectGiteaConnectionInput} from '#core/connect.js';
 import {createGiteaIntegrationProvider} from '#index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {
-    ...actual,
-    requireWorkspaceAccess: vi.fn(({workspaceId}) => ({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    })),
-  };
-});
-
-const {requireWorkspaceAccess} = await import('@shipfox/api-auth-context');
-const requireWorkspaceAccessMock = vi.mocked(requireWorkspaceAccess);
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -33,7 +25,11 @@ const fakeUserAuth: AuthMethod = {
 
     setUserContext(
       request,
-      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
     );
     return Promise.resolve();
   },
@@ -97,6 +93,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
 
 describe('Gitea connection routes', () => {
   beforeEach(async () => {
+    authenticatedMemberships = [];
     await closeApp();
   });
 
@@ -119,6 +116,7 @@ describe('Gitea connection routes', () => {
   it('connects an org and returns the connection DTO', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -132,19 +130,20 @@ describe('Gitea connection routes', () => {
     expect(res.json().external_account_id).toBe('shipfox');
     expect(res.json().lifecycle_status).toBe('active');
     expect(res.json().external_url).toBe('https://gitea.example.com/shipfox');
-    expect(requireWorkspaceAccessMock).toHaveBeenCalledWith(expect.objectContaining({workspaceId}));
   });
 
   it('returns 404 when the org does not exist', async () => {
     const app = await createTestApp({
       gitea: giteaClient({organizationExists: vi.fn(() => Promise.resolve(false))}),
     });
+    const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
 
     const res = await app.inject({
       method: 'POST',
       url: '/integrations/gitea/connections',
       headers: {authorization: 'Bearer user'},
-      payload: {workspace_id: crypto.randomUUID(), org: 'ghost'},
+      payload: {workspace_id: workspaceId, org: 'ghost'},
     });
 
     expect(res.statusCode).toBe(404);
@@ -152,6 +151,8 @@ describe('Gitea connection routes', () => {
   });
 
   it('returns 409 when the org is already linked to another workspace', async () => {
+    const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     const app = await createTestApp({
       existingConnection: {
         id: crypto.randomUUID(),
@@ -170,7 +171,7 @@ describe('Gitea connection routes', () => {
       method: 'POST',
       url: '/integrations/gitea/connections',
       headers: {authorization: 'Bearer user'},
-      payload: {workspace_id: crypto.randomUUID(), org: 'shipfox'},
+      payload: {workspace_id: workspaceId, org: 'shipfox'},
     });
 
     expect(res.statusCode).toBe(409);
@@ -178,6 +179,8 @@ describe('Gitea connection routes', () => {
   });
 
   it('returns 409 when connection slug allocation conflicts repeatedly', async () => {
+    const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     const app = await createTestApp({
       connectGiteaConnection: vi.fn(() =>
         Promise.reject(new ConnectionSlugConflictError(new Error('duplicate slug'))),
@@ -188,7 +191,7 @@ describe('Gitea connection routes', () => {
       method: 'POST',
       url: '/integrations/gitea/connections',
       headers: {authorization: 'Bearer user'},
-      payload: {workspace_id: crypto.randomUUID(), org: 'shipfox'},
+      payload: {workspace_id: workspaceId, org: 'shipfox'},
     });
 
     expect(res.statusCode).toBe(409);

--- a/libs/api/integration/github/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/github/src/presentation/routes/install.test.ts
@@ -1,4 +1,9 @@
-import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
 import {
   ConnectionSlugConflictError,
   type IntegrationConnection,
@@ -10,26 +15,13 @@ import type {ConnectGithubInstallationInput} from '#core/install.js';
 import {verifyGithubInstallState} from '#core/state.js';
 import {createGithubIntegrationProvider} from '#index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {
-    ...actual,
-    requireWorkspaceAccess: vi.fn(({workspaceId}) => ({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    })),
-  };
-});
-
 vi.mock('@shipfox/api-workspaces', () => ({
   requireWorkspaceMembership: vi.fn(() => Promise.resolve()),
 }));
 
-const {requireWorkspaceAccess} = await import('@shipfox/api-auth-context');
 const {requireWorkspaceMembership} = await import('@shipfox/api-workspaces');
-const requireWorkspaceAccessMock = vi.mocked(requireWorkspaceAccess);
 const requireWorkspaceMembershipMock = vi.mocked(requireWorkspaceMembership);
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -40,7 +32,11 @@ const fakeUserAuth: AuthMethod = {
 
     setUserContext(
       request,
-      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
     );
     return Promise.resolve();
   },
@@ -127,6 +123,7 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
 
 describe('GitHub integration routes', () => {
   beforeEach(async () => {
+    authenticatedMemberships = [];
     await closeApp();
   });
 
@@ -149,6 +146,7 @@ describe('GitHub integration routes', () => {
   it('returns an install URL with signed workspace state', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -166,7 +164,6 @@ describe('GitHub integration routes', () => {
     );
     expect(claims.workspaceId).toBe(workspaceId);
     expect(claims.userId).toBe('user-1');
-    expect(requireWorkspaceAccessMock).toHaveBeenCalledWith(expect.objectContaining({workspaceId}));
   });
 
   it('requires auth on the GitHub callback API', async () => {
@@ -198,7 +195,7 @@ describe('GitHub integration routes', () => {
     expect(requireWorkspaceMembershipMock).toHaveBeenCalledWith({
       workspaceId,
       userId: 'user-1',
-      memberships: [],
+      memberships: [{workspaceId, role: 'admin'}],
     });
   });
 
@@ -268,6 +265,7 @@ describe('GitHub integration routes', () => {
 });
 
 async function createInstallState(app: FastifyInstance, workspaceId: string): Promise<string> {
+  authenticatedMemberships = [{workspaceId, role: 'admin'}];
   const res = await app.inject({
     method: 'POST',
     url: '/integrations/github/install',

--- a/libs/api/integration/sentry/src/presentation/routes/install.test.ts
+++ b/libs/api/integration/sentry/src/presentation/routes/install.test.ts
@@ -1,4 +1,9 @@
-import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
 import {
   ConnectionSlugConflictError,
   type IntegrationConnection,
@@ -11,20 +16,7 @@ import type {ConnectSentryInstallationInput} from '#core/install.js';
 import type {SentryInstallation} from '#db/installations.js';
 import {createSentryIntegrationProvider} from '#index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {
-    ...actual,
-    requireWorkspaceAccess: vi.fn(({workspaceId}) => ({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    })),
-  };
-});
-
-const {requireWorkspaceAccess} = await import('@shipfox/api-auth-context');
-const requireWorkspaceAccessMock = vi.mocked(requireWorkspaceAccess);
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -34,7 +26,11 @@ const fakeUserAuth: AuthMethod = {
     }
     setUserContext(
       request,
-      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
     );
     return Promise.resolve();
   },
@@ -110,9 +106,13 @@ async function createTestApp(options: CreateTestAppOptions = {}): Promise<Fastif
   return app;
 }
 
-function connectPayload() {
+function connectPayload(options: {authorize?: boolean} = {}) {
+  const workspaceId = crypto.randomUUID();
+  if (options.authorize !== false) {
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
+  }
   return {
-    workspace_id: crypto.randomUUID(),
+    workspace_id: workspaceId,
     code: 'the-code',
     installation_id: 'install-uuid-1',
   };
@@ -120,7 +120,7 @@ function connectPayload() {
 
 describe('Sentry integration routes', () => {
   beforeEach(async () => {
-    requireWorkspaceAccessMock.mockClear();
+    authenticatedMemberships = [];
     await closeApp();
   });
 
@@ -143,6 +143,7 @@ describe('Sentry integration routes', () => {
   it('returns the external-install URL for a member', async () => {
     const app = await createTestApp();
     const workspaceId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
 
     const res = await app.inject({
       method: 'POST',
@@ -155,7 +156,6 @@ describe('Sentry integration routes', () => {
     expect(res.json().install_url).toBe(
       'https://sentry.io/sentry-apps/shipfox-test/external-install/',
     );
-    expect(requireWorkspaceAccessMock).toHaveBeenCalledWith(expect.objectContaining({workspaceId}));
   });
 
   it('requires auth for connect', async () => {
@@ -188,16 +188,13 @@ describe('Sentry integration routes', () => {
   });
 
   it('returns 403 when the caller is not a workspace member', async () => {
-    requireWorkspaceAccessMock.mockImplementationOnce(() => {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-    });
     const app = await createTestApp();
 
     const res = await app.inject({
       method: 'POST',
       url: '/integrations/sentry/connect',
       headers: {authorization: 'Bearer user'},
-      payload: connectPayload(),
+      payload: connectPayload({authorize: false}),
     });
 
     expect(res.statusCode).toBe(403);

--- a/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
+++ b/libs/api/integration/webhook/src/presentation/routes/connections.test.ts
@@ -1,4 +1,9 @@
-import {AUTH_USER, buildUserContext, setUserContext} from '@shipfox/api-auth-context';
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
 import {
   ConnectionSlugConflictError,
   type IntegrationConnection,
@@ -18,17 +23,11 @@ type DeleteConnectionFn = CreateWebhookIntegrationProviderOptions['deleteIntegra
 
 const INBOUND_URL_RE = /^https:\/\/api\.example\.com\/webhook\//;
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {
-    ...actual,
-    requireWorkspaceAccess: vi.fn(({workspaceId}) => ({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    })),
-  };
-});
+let authenticatedMemberships: UserContextMembership[] = [];
+
+function authorizeWorkspace(workspaceId: string): void {
+  authenticatedMemberships = [{workspaceId, role: 'admin'}];
+}
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -39,7 +38,11 @@ const fakeUserAuth: AuthMethod = {
 
     setUserContext(
       request,
-      buildUserContext({userId: 'user-1', email: 'user@example.com', memberships: []}),
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        memberships: authenticatedMemberships,
+      }),
     );
     return Promise.resolve();
   },
@@ -138,6 +141,7 @@ async function createTestApp(store = createStore()): Promise<{
 
 describe('webhook connection routes', () => {
   beforeEach(async () => {
+    authenticatedMemberships = [];
     await closeApp();
   });
 
@@ -147,6 +151,7 @@ describe('webhook connection routes', () => {
 
   it('creates a webhook connection with its inbound URL', async () => {
     const workspaceId = crypto.randomUUID();
+    authorizeWorkspace(workspaceId);
     const {app} = await createTestApp();
 
     const res = await app.inject({
@@ -168,6 +173,7 @@ describe('webhook connection routes', () => {
 
   it('returns 409 for a duplicate slug in the workspace', async () => {
     const workspaceId = crypto.randomUUID();
+    authorizeWorkspace(workspaceId);
     const {app} = await createTestApp();
     const payload = {workspace_id: workspaceId, name: 'Stripe', slug: 'stripe-prod'};
 
@@ -191,6 +197,7 @@ describe('webhook connection routes', () => {
 
   it('returns 409 when the core connection create reports a slug conflict', async () => {
     const workspaceId = crypto.randomUUID();
+    authorizeWorkspace(workspaceId);
     const store = createStore();
     store.createIntegrationConnection.mockRejectedValueOnce(connectionSlugConflictError());
     const {app} = await createTestApp(store);
@@ -208,6 +215,7 @@ describe('webhook connection routes', () => {
 
   it('lists only webhook connections for the workspace', async () => {
     const workspaceId = crypto.randomUUID();
+    authorizeWorkspace(workspaceId);
     const store = createStore();
     const webhook = store.seed(fakeConnection({workspaceId, externalAccountId: 'stripe'}));
     store.seed(fakeConnection({workspaceId, provider: 'github', externalAccountId: 'gh'}));
@@ -229,6 +237,7 @@ describe('webhook connection routes', () => {
   it('updates a webhook connection lifecycle status', async () => {
     const store = createStore();
     const connection = store.seed(fakeConnection());
+    authorizeWorkspace(connection.workspaceId);
     const {app} = await createTestApp(store);
 
     const res = await app.inject({
@@ -253,6 +262,10 @@ describe('webhook connection routes', () => {
   ])('returns 404 when patching a $description', async ({connectionId, seed}) => {
     const store = createStore();
     const id = seed ? seed(store) : connectionId;
+    if (seed && id) {
+      const connection = await store.getIntegrationConnectionById(id);
+      if (connection) authorizeWorkspace(connection.workspaceId);
+    }
     const {app} = await createTestApp(store);
 
     const res = await app.inject({
@@ -270,6 +283,7 @@ describe('webhook connection routes', () => {
   it('returns 404 when a webhook connection disappears during patch', async () => {
     const store = createStore();
     const connection = store.seed(fakeConnection());
+    authorizeWorkspace(connection.workspaceId);
     store.updateIntegrationConnectionLifecycleStatus.mockResolvedValueOnce(undefined);
     const {app} = await createTestApp(store);
 
@@ -287,6 +301,7 @@ describe('webhook connection routes', () => {
   it('deletes a webhook connection', async () => {
     const store = createStore();
     const connection = store.seed(fakeConnection());
+    authorizeWorkspace(connection.workspaceId);
     const {app} = await createTestApp(store);
 
     const res = await app.inject({
@@ -310,6 +325,10 @@ describe('webhook connection routes', () => {
   ])('returns 404 when deleting a $description', async ({connectionId, seed}) => {
     const store = createStore();
     const id = seed ? seed(store) : connectionId;
+    if (seed && id) {
+      const connection = await store.getIntegrationConnectionById(id);
+      if (connection) authorizeWorkspace(connection.workspaceId);
+    }
     const {app} = await createTestApp(store);
 
     const res = await app.inject({
@@ -324,26 +343,30 @@ describe('webhook connection routes', () => {
   });
 
   it.each(WEBHOOK_RESERVED_SLUGS)('rejects reserved slug %s', async (slug) => {
+    const workspaceId = crypto.randomUUID();
+    authorizeWorkspace(workspaceId);
     const {app} = await createTestApp();
 
     const res = await app.inject({
       method: 'POST',
       url: '/integrations/webhook/connections',
       headers: {authorization: 'Bearer user'},
-      payload: {workspace_id: crypto.randomUUID(), name: 'Reserved', slug},
+      payload: {workspace_id: workspaceId, name: 'Reserved', slug},
     });
 
     expect(res.statusCode).toBe(400);
   });
 
   it('rejects a malformed slug', async () => {
+    const workspaceId = crypto.randomUUID();
+    authorizeWorkspace(workspaceId);
     const {app} = await createTestApp();
 
     const res = await app.inject({
       method: 'POST',
       url: '/integrations/webhook/connections',
       headers: {authorization: 'Bearer user'},
-      payload: {workspace_id: crypto.randomUUID(), name: 'Malformed', slug: 'Stripe_Prod'},
+      payload: {workspace_id: workspaceId, name: 'Malformed', slug: 'Stripe_Prod'},
     });
 
     expect(res.statusCode).toBe(400);

--- a/libs/api/projects/src/presentation/routes/projects.test.ts
+++ b/libs/api/projects/src/presentation/routes/projects.test.ts
@@ -1,4 +1,9 @@
-import {AUTH_USER, setUserContext} from '@shipfox/api-auth-context';
+import {
+  AUTH_USER,
+  buildUserContext,
+  setUserContext,
+  type UserContextMembership,
+} from '@shipfox/api-auth-context';
 import type {IntegrationSourceControlService} from '@shipfox/api-integration-core';
 import {IntegrationConnectionNotFoundError} from '@shipfox/api-integration-core';
 import type {AuthMethod} from '@shipfox/node-fastify';
@@ -6,29 +11,20 @@ import {closeApp, createApp} from '@shipfox/node-fastify';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {createProjectRoutes} from './index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {
-    ...actual,
-    requireWorkspaceAccess: vi.fn(({workspaceId}) => ({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    })),
-  };
-});
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
   authenticate: (request: FastifyRequest) => {
-    setUserContext(request, {
-      userId: 'user-1',
-      email: 'user@example.com',
-      name: 'User One',
-      memberships: [],
-      canAccess: () => true,
-      hasRole: () => true,
-    });
+    setUserContext(
+      request,
+      buildUserContext({
+        userId: 'user-1',
+        email: 'user@example.com',
+        name: 'User One',
+        memberships: authenticatedMemberships,
+      }),
+    );
     return Promise.resolve();
   },
 };
@@ -43,6 +39,7 @@ describe('project routes', () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
     sourceConnectionId = crypto.randomUUID();
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     sourceControl = {
       getConnection: vi.fn(),
       listRepositories: vi.fn(),

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -5,8 +5,8 @@ import {
   AUTH_RUNNER_SESSION,
   AUTH_USER,
   buildUserContext,
-  requireWorkspaceAccess,
   setUserContext,
+  type UserContextMembership,
 } from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
@@ -17,10 +17,7 @@ import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {...actual, requireWorkspaceAccess: vi.fn()};
-});
+let authenticatedMemberships: ReadonlyArray<UserContextMembership> = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -34,7 +31,7 @@ const fakeUserAuth: AuthMethod = {
       buildUserContext({
         userId: 'user-1',
         email: 'user@example.com',
-        memberships: [{workspaceId: 'workspace-from-auth', role: 'admin'}],
+        memberships: authenticatedMemberships,
       }),
     );
     return Promise.resolve();
@@ -53,11 +50,7 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    vi.mocked(requireWorkspaceAccess).mockReturnValue({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     app = await createApp({
       auth: [
         fakeUserAuth,
@@ -360,9 +353,7 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
   });
 
   it('returns 403 when the user is not a workspace member', async () => {
-    vi.mocked(requireWorkspaceAccess).mockImplementationOnce(() => {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-    });
+    authenticatedMemberships = [{workspaceId: crypto.randomUUID(), role: 'admin'}];
 
     const res = await app.inject({
       method: 'GET',

--- a/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/manual-registration-tokens.test.ts
@@ -6,8 +6,8 @@ import {
   AUTH_RUNNER_SESSION,
   AUTH_USER,
   buildUserContext,
-  requireWorkspaceAccess,
   setUserContext,
+  type UserContextMembership,
 } from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
@@ -21,10 +21,7 @@ import {createRunnerRegistrationTokenAuthMethod} from '#presentation/auth/index.
 import {manualRegistrationTokenFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {...actual, requireWorkspaceAccess: vi.fn()};
-});
+let authenticatedMemberships: ReadonlyArray<UserContextMembership> = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -38,7 +35,7 @@ const fakeUserAuth: AuthMethod = {
       buildUserContext({
         userId: 'user-1',
         email: 'user@example.com',
-        memberships: [{workspaceId: 'workspace-from-auth', role: 'admin'}],
+        memberships: authenticatedMemberships,
       }),
     );
     return Promise.resolve();
@@ -57,11 +54,7 @@ describe('manual registration token routes', () => {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    vi.mocked(requireWorkspaceAccess).mockReturnValue({
-      workspaceId,
-      userId: 'user-1',
-      role: 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     app = await createApp({
       auth: [
         fakeUserAuth,
@@ -111,9 +104,7 @@ describe('manual registration token routes', () => {
     });
 
     it('returns 403 when the user is not a workspace member', async () => {
-      vi.mocked(requireWorkspaceAccess).mockImplementationOnce(() => {
-        throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-      });
+      authenticatedMemberships = [{workspaceId: crypto.randomUUID(), role: 'admin'}];
 
       const res = await app.inject({
         method: 'GET',

--- a/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
@@ -73,6 +73,7 @@ describe('POST /provisioners/demand/poll reservation cleanup', () => {
       expect(reservationRows).toHaveLength(0);
     } finally {
       vi.doUnmock('#db/provisioned-runners.js');
+      vi.resetModules();
       await closeApp();
     }
   });

--- a/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
@@ -9,25 +9,6 @@ import {createProvisionerTokenAuthMethod} from '#presentation/auth/index.js';
 import {provisionerTokenFactory} from '#test/index.js';
 import {provisionerRoutes} from './index.js';
 
-const mocks = vi.hoisted(() => ({
-  logger: {
-    child: vi.fn(),
-    debug: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
-    info: vi.fn(),
-    trace: vi.fn(),
-    warn: vi.fn(),
-  },
-}));
-
-mocks.logger.child.mockReturnValue(mocks.logger);
-
-vi.mock('@shipfox/node-opentelemetry', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@shipfox/node-opentelemetry')>()),
-  logger: () => mocks.logger,
-}));
-
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
   authenticate: () => Promise.resolve(),
@@ -38,7 +19,6 @@ describe('provisioner me route', () => {
 
   beforeEach(async () => {
     await closeApp();
-    mocks.logger.warn.mockReset();
     app = await createApp({
       auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],
       routes: provisionerRoutes,
@@ -95,10 +75,6 @@ describe('provisioner me route', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({id: token.id, workspace_id: workspaceId});
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {error: expect.any(Error), provisionerTokenId: token.id},
-      'last-seen touch failed',
-    );
   });
 
   it('returns 401 without an authorization header', async () => {
@@ -109,10 +85,6 @@ describe('provisioner me route', () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('unauthorized');
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {prefix: undefined, reason: 'missing'},
-      'provisioner token auth failed',
-    );
   });
 
   it('returns 401 for a non-provisioner token type before lookup', async () => {
@@ -126,10 +98,6 @@ describe('provisioner me route', () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('unauthorized');
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {prefix: rawToken.slice(0, 12), reason: 'type'},
-      'provisioner token auth failed',
-    );
   });
 
   it('returns 401 for an unknown provisioner token', async () => {
@@ -143,10 +111,6 @@ describe('provisioner me route', () => {
 
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('unauthorized');
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {prefix: rawToken.slice(0, 12), reason: 'not-found'},
-      'provisioner token auth failed',
-    );
   });
 
   it('returns 401 for a revoked provisioner token', async () => {

--- a/libs/api/runners/src/presentation/routes/provisioner-tokens.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-tokens.test.ts
@@ -1,8 +1,8 @@
 import {
   AUTH_USER,
   buildUserContext,
-  requireWorkspaceAccess,
   setUserContext,
+  type UserContextMembership,
 } from '@shipfox/api-auth-context';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {ClientError, closeApp, createApp} from '@shipfox/node-fastify';
@@ -16,12 +16,8 @@ import {createProvisionerTokenAuthMethod} from '#presentation/auth/index.js';
 import {provisionerTokenFactory} from '#test/index.js';
 import {provisionerRoutes} from './index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {...actual, requireWorkspaceAccess: vi.fn()};
-});
-
 const userId = crypto.randomUUID();
+let authenticatedMemberships: ReadonlyArray<UserContextMembership> = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -35,7 +31,7 @@ const fakeUserAuth: AuthMethod = {
       buildUserContext({
         userId,
         email: 'user@example.com',
-        memberships: [{workspaceId: 'workspace-from-auth', role: 'admin'}],
+        memberships: authenticatedMemberships,
       }),
     );
     return Promise.resolve();
@@ -49,11 +45,7 @@ describe('provisioner token routes', () => {
   beforeEach(async () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
-    vi.mocked(requireWorkspaceAccess).mockReturnValue({
-      workspaceId,
-      userId,
-      role: 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     app = await createApp({
       auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],
       routes: provisionerRoutes,
@@ -82,9 +74,7 @@ describe('provisioner token routes', () => {
     });
 
     it('returns 403 when the user is not a workspace member', async () => {
-      vi.mocked(requireWorkspaceAccess).mockImplementationOnce(() => {
-        throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-      });
+      authenticatedMemberships = [{workspaceId: crypto.randomUUID(), role: 'admin'}];
 
       const res = await app.inject({
         method: 'GET',

--- a/libs/api/runners/vitest.config.ts
+++ b/libs/api/runners/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig(
     test: {
       fileParallelism: false,
       globalSetup: ['test/globalSetup.ts'],
+      isolate: false,
+      maxWorkers: 1,
       setupFiles: ['test/setup.ts'],
     },
   },

--- a/libs/api/secrets/src/presentation/routes/management.test.ts
+++ b/libs/api/secrets/src/presentation/routes/management.test.ts
@@ -1,7 +1,6 @@
 import {
   AUTH_USER,
   buildUserContext,
-  requireWorkspaceAccess,
   setUserContext,
   type UserContextMembership,
 } from '@shipfox/api-auth-context';
@@ -20,17 +19,13 @@ import {setSecrets} from '#core/index.js';
 import {db, secretsOutbox, secretValues, secretVariables} from '#db/index.js';
 import {secretsRoutes} from './index.js';
 
-vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shipfox/api-auth-context')>();
-  return {...actual, requireWorkspaceAccess: vi.fn()};
-});
-
 vi.mock('@shipfox/api-projects', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@shipfox/api-projects')>();
   return {...actual, requireProjectForWorkspace: vi.fn()};
 });
 
 const USER_ID = '11111111-1111-4111-8111-111111111111';
+let authenticatedMemberships: UserContextMembership[] = [];
 
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
@@ -39,15 +34,12 @@ const fakeUserAuth: AuthMethod = {
       throw new ClientError('Invalid user token', 'unauthorized', {status: 401});
     }
 
-    const memberships: UserContextMembership[] = [
-      {workspaceId: (request.params as {workspaceId: string}).workspaceId, role: 'admin'},
-    ];
     setUserContext(
       request,
       buildUserContext({
         userId: USER_ID,
         email: 'user@example.com',
-        memberships,
+        memberships: authenticatedMemberships,
       }),
     );
     return Promise.resolve();
@@ -63,11 +55,7 @@ describe('secrets management routes', () => {
     await closeApp();
     workspaceId = crypto.randomUUID();
     projectId = crypto.randomUUID();
-    vi.mocked(requireWorkspaceAccess).mockReturnValue({
-      workspaceId,
-      userId: USER_ID,
-      role: 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'admin'}];
     vi.mocked(requireProjectForWorkspace).mockResolvedValue({
       id: projectId,
       workspaceId,
@@ -96,9 +84,7 @@ describe('secrets management routes', () => {
       method: 'GET',
       url: `/workspaces/${workspaceId}/secrets`,
     });
-    vi.mocked(requireWorkspaceAccess).mockImplementationOnce(() => {
-      throw new ClientError('Not a member of this workspace', 'forbidden', {status: 403});
-    });
+    authenticatedMemberships = [];
 
     const forbidden = await app.inject({
       method: 'GET',
@@ -111,11 +97,7 @@ describe('secrets management routes', () => {
   });
 
   it('requires admin membership for writes', async () => {
-    vi.mocked(requireWorkspaceAccess).mockReturnValueOnce({
-      workspaceId,
-      userId: USER_ID,
-      role: 'viewer' as 'admin',
-    });
+    authenticatedMemberships = [{workspaceId, role: 'viewer' as UserContextMembership['role']}];
 
     const res = await app.inject({
       method: 'PUT',


### PR DESCRIPTION
Enable `isolate:false` for `@shipfox/api-runners` and `@shipfox/api-integration-core` so these DB-backed API test suites can reuse a shared Vitest module graph instead of rebuilding package setup and imports per file.

The runners route tests no longer mock the stateless workspace-access helper. They seed memberships into the fake user context and let the real helper run. The remaining targeted `vi.doMock` test resets modules after cleanup so it does not leak mocked imports into the shared module graph. `api-runners` is pinned to one worker to keep its DB-backed shared-module run deterministic while still removing per-file module isolation cost.

`@shipfox/api-logs` was probed but left out of this PR: its terminal fallback read-log tests still need broader shared `@shipfox/api-workflows` mock cleanup before that package can safely switch to `isolate:false`.

Refs ENG-757