### PR TITLE
[runner] Log setup identifiers

### DIFF
--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -1,3 +1,4 @@
+import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError} from 'ky';
 
 const requestCheckoutTokenMock = vi.fn();
@@ -34,6 +35,7 @@ const jobContext = {
   workflowRunId: '00000000-0000-0000-0000-0000000000ac',
   workflowRunAttemptId: '00000000-0000-0000-0000-0000000000ab',
   jobId: '00000000-0000-0000-0000-0000000000aa',
+  jobExecutionId: '00000000-0000-0000-0000-0000000000ad',
 };
 
 function checkoutResponse(auth?: unknown) {
@@ -45,7 +47,7 @@ function checkoutResponse(auth?: unknown) {
 }
 
 function run(log?: ReturnType<typeof fakeLog>) {
-  return executeSetupStep({cwd: CWD, leaseClient, signal, ...(log ? {log, jobContext} : {})});
+  return executeSetupStep({cwd: CWD, leaseClient, signal, ...(log ? {log} : {}), jobContext});
 }
 
 function fakeLog() {
@@ -118,6 +120,7 @@ describe('executeSetupStep', () => {
         `Workflow run: ${jobContext.workflowRunId}`,
         `Workflow run attempt: ${jobContext.workflowRunAttemptId}`,
         `Job: ${jobContext.jobId}`,
+        `Job execution: ${jobContext.jobExecutionId}`,
       ],
     });
     expect(log.writeGroupStart).toHaveBeenCalledWith('Checkout');
@@ -145,6 +148,16 @@ describe('executeSetupStep', () => {
     );
   });
 
+  it('writes structured setup lifecycle logs', async () => {
+    const info = vi.spyOn(logger(), 'info').mockImplementation(() => undefined);
+
+    const result = await run();
+
+    expect(result.success).toBe(true);
+    expect(info).toHaveBeenCalledWith(jobContext, 'Setup step started');
+    expect(info).toHaveBeenCalledWith(jobContext, 'Setup step completed');
+  });
+
   it('routes checkout callbacks to the setup log sink', async () => {
     const log = fakeLog();
 
@@ -170,6 +183,7 @@ describe('executeSetupStep', () => {
 
   it('checks git before minting a credential', async () => {
     const log = fakeLog();
+    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
     assertGitAvailableMock.mockRejectedValue(new Error('git is not available on the runner host'));
 
     const result = await run(log);
@@ -185,6 +199,10 @@ describe('executeSetupStep', () => {
     expect(log.writeOutputLine).toHaveBeenCalledWith(
       'Next step: Install Git in the runner image or use a runner image that includes Git.',
       'stderr',
+    );
+    expect(warn).toHaveBeenCalledWith(
+      {...jobContext, reason: 'git_unavailable'},
+      'Setup step failed',
     );
   });
 

--- a/libs/runner/execution/src/core/setup-step.test.ts
+++ b/libs/runner/execution/src/core/setup-step.test.ts
@@ -61,6 +61,17 @@ function fakeLog() {
   };
 }
 
+function spySetupWarnings() {
+  return vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+}
+
+function expectSetupFailureWarning(
+  warn: ReturnType<typeof spySetupWarnings>,
+  reason: string,
+): void {
+  expect(warn).toHaveBeenCalledWith({...jobContext, reason}, 'Setup step failed');
+}
+
 // ky populates `error.data` with the pre-parsed body and consumes `error.response`, so
 // the production classifier reads `error.data` — mirror that here rather than faking a
 // re-readable `response.clone().json()`, which production can never do.
@@ -81,6 +92,10 @@ beforeEach(() => {
   createJobDirMock.mockResolvedValue(undefined);
   requestCheckoutTokenMock.mockResolvedValue(checkoutResponse());
   checkoutRepositoryMock.mockResolvedValue('abc123');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe('executeSetupStep', () => {
@@ -183,7 +198,7 @@ describe('executeSetupStep', () => {
 
   it('checks git before minting a credential', async () => {
     const log = fakeLog();
-    const warn = vi.spyOn(logger(), 'warn').mockImplementation(() => undefined);
+    const warn = spySetupWarnings();
     assertGitAvailableMock.mockRejectedValue(new Error('git is not available on the runner host'));
 
     const result = await run(log);
@@ -200,14 +215,12 @@ describe('executeSetupStep', () => {
       'Next step: Install Git in the runner image or use a runner image that includes Git.',
       'stderr',
     );
-    expect(warn).toHaveBeenCalledWith(
-      {...jobContext, reason: 'git_unavailable'},
-      'Setup step failed',
-    );
+    expectSetupFailureWarning(warn, 'git_unavailable');
   });
 
   it('reports workspace_prep_failed when creating the directory fails', async () => {
     const log = fakeLog();
+    const warn = spySetupWarnings();
     createJobDirMock.mockRejectedValue(new Error('mkdir denied'));
 
     const result = await run(log);
@@ -222,6 +235,7 @@ describe('executeSetupStep', () => {
       'Next step: Check the runner workspace permissions and available disk space.',
       'stderr',
     );
+    expectSetupFailureWarning(warn, 'workspace_prep_failed');
   });
 
   it.each([
@@ -233,6 +247,7 @@ describe('executeSetupStep', () => {
     {status: 409, reason: 'checkout_failed'},
     {status: 422, reason: 'checkout_failed'},
   ])('maps a $status checkout-token error to $reason', async ({status, reason}) => {
+    const warn = spySetupWarnings();
     requestCheckoutTokenMock.mockRejectedValue(httpError(status));
 
     const result = await run();
@@ -240,6 +255,7 @@ describe('executeSetupStep', () => {
     expect(checkoutRepositoryMock).not.toHaveBeenCalled();
     expect(result.success).toBe(false);
     expect(result.error?.reason).toBe(reason);
+    expectSetupFailureWarning(warn, reason);
   });
 
   it.each([
@@ -247,19 +263,23 @@ describe('executeSetupStep', () => {
     {code: 'rate-limited', reason: 'checkout_unavailable'},
     {code: 'provider-unavailable', reason: 'checkout_unavailable'},
   ])('maps a 422 with code $code to $reason', async ({code, reason}) => {
+    const warn = spySetupWarnings();
     requestCheckoutTokenMock.mockRejectedValue(httpError(422, {code}));
 
     const result = await run();
 
     expect(result.error?.reason).toBe(reason);
+    expectSetupFailureWarning(warn, reason);
   });
 
   it('maps a non-HTTP checkout-token error to checkout_failed', async () => {
+    const warn = spySetupWarnings();
     requestCheckoutTokenMock.mockRejectedValue(new Error('socket hang up'));
 
     const result = await run();
 
     expect(result.error).toEqual({message: 'socket hang up', reason: 'checkout_failed'});
+    expectSetupFailureWarning(warn, 'checkout_failed');
   });
 
   it.each([
@@ -268,16 +288,19 @@ describe('executeSetupStep', () => {
     {kind: 'failed' as const, reason: 'checkout_failed'},
     {kind: 'aborted' as const, reason: 'setup_aborted'},
   ])('maps a $kind checkout failure to $reason', async ({kind, reason}) => {
+    const warn = spySetupWarnings();
     checkoutRepositoryMock.mockRejectedValue(new CheckoutError(kind, 'boom'));
 
     const result = await run();
 
     expect(result.success).toBe(false);
     expect(result.error?.reason).toBe(reason);
+    expectSetupFailureWarning(warn, reason);
   });
 
   it('logs the checkout phase that failed', async () => {
     const log = fakeLog();
+    const warn = spySetupWarnings();
     checkoutRepositoryMock.mockRejectedValue(
       new CheckoutError('failed', 'remote rejected', {phase: 'fetch'}),
     );
@@ -295,13 +318,16 @@ describe('executeSetupStep', () => {
       'Next step: Check that the repository URL and requested ref are valid. The git output above may include provider details.',
       'stderr',
     );
+    expectSetupFailureWarning(warn, 'checkout_failed');
   });
 
   it('maps an unexpected checkout error to checkout_failed', async () => {
+    const warn = spySetupWarnings();
     checkoutRepositoryMock.mockRejectedValue(new Error('weird'));
 
     const result = await run();
 
     expect(result.error).toEqual({message: 'weird', reason: 'checkout_failed'});
+    expectSetupFailureWarning(warn, 'checkout_failed');
   });
 });

--- a/libs/runner/execution/src/core/setup-step.ts
+++ b/libs/runner/execution/src/core/setup-step.ts
@@ -1,5 +1,6 @@
 import {arch, platform, release} from 'node:os';
 import type {CheckoutTokenResponseDto, StepErrorReasonDto} from '@shipfox/api-workflows-dto';
+import {logger} from '@shipfox/node-opentelemetry';
 import {HTTPError, requestCheckoutToken} from '@shipfox/runner-protocol';
 import {
   assertGitAvailable,
@@ -29,6 +30,7 @@ export interface SetupJobContext {
   workflowRunId: string;
   workflowRunAttemptId: string;
   jobId: string;
+  jobExecutionId: string;
 }
 
 // The synthetic "Set up job" step body. It owns per-job workspace preparation and the
@@ -47,18 +49,20 @@ export async function executeSetupStep(params: {
 }): Promise<StepResult> {
   const {cwd, leaseClient, signal, log, jobContext} = params;
 
+  logger().info(setupLogFields(jobContext), 'Setup step started');
   writeJobContext(log, jobContext);
 
   const gitFailure = await checkGit(log);
-  if (gitFailure) return gitFailure;
+  if (gitFailure) return logSetupFailure(gitFailure, jobContext);
 
   const workspaceFailure = await prepareWorkspace({cwd, log});
-  if (workspaceFailure) return workspaceFailure;
+  if (workspaceFailure) return logSetupFailure(workspaceFailure, jobContext);
 
   const checkoutFailure = await runCheckoutSetup({cwd, leaseClient, signal, log});
-  if (checkoutFailure) return checkoutFailure;
+  if (checkoutFailure) return logSetupFailure(checkoutFailure, jobContext);
 
   log?.writeOutputLine('Setup completed successfully. The job is ready to run.');
+  logger().info(setupLogFields(jobContext), 'Setup step completed');
   return {success: true, error: null, exit_code: 0};
 }
 
@@ -263,8 +267,32 @@ function writeJobContext(
       `Workflow run: ${jobContext.workflowRunId}`,
       `Workflow run attempt: ${jobContext.workflowRunAttemptId}`,
       `Job: ${jobContext.jobId}`,
+      `Job execution: ${jobContext.jobExecutionId}`,
     ],
   });
+}
+
+function setupLogFields(
+  jobContext: SetupJobContext | undefined,
+): Partial<Record<keyof SetupJobContext, string>> {
+  if (!jobContext) return {};
+  return {
+    workflowRunId: jobContext.workflowRunId,
+    workflowRunAttemptId: jobContext.workflowRunAttemptId,
+    jobId: jobContext.jobId,
+    jobExecutionId: jobContext.jobExecutionId,
+  };
+}
+
+function logSetupFailure(result: StepResult, jobContext: SetupJobContext | undefined): StepResult {
+  logger().warn(
+    {
+      ...setupLogFields(jobContext),
+      ...(result.error?.reason ? {reason: result.error.reason} : {}),
+    },
+    'Setup step failed',
+  );
+  return result;
 }
 
 function writeRunnerEnvironment(log: SetupLogSink | undefined, gitVersion: string): void {

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -147,6 +147,7 @@ describe('runJob', () => {
           workflowRunId: JOB.workflow_run_id,
           workflowRunAttemptId: JOB.workflow_run_attempt_id,
           jobId: JOB.job_id,
+          jobExecutionId: JOB.job_execution_id,
         },
       }),
     );

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -191,6 +191,7 @@ export async function runJob(
         workflowRunId: job.workflow_run_id,
         workflowRunAttemptId: job.workflow_run_attempt_id,
         jobId: job.job_id,
+        jobExecutionId: job.job_execution_id,
       },
     });
     logger().info({jobId: job.job_id}, 'Job step loop finished');

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -65,6 +65,7 @@ const JOB_CONTEXT = {
   workflowRunId: '00000000-0000-0000-0000-000000000004',
   workflowRunAttemptId: RUN_ID,
   jobId: JOB_ID,
+  jobExecutionId: '00000000-0000-0000-0000-0000000000ad',
 };
 const leaseClient = {} as never;
 const STREAM_LENGTH = 128;


### PR DESCRIPTION
Adds structured lifecycle logs around the synthetic runner setup step with workflow run, workflow run attempt, job, and job execution identifiers.

Runner setup failures were difficult to correlate across API events, runner logs, and durable step logs because setup-step logging did not consistently carry the job execution identity. This threads the already-claimed job execution ID into setup context, includes it in the user-facing setup log group, and emits start, completion, and failure records without logging lease tokens or credentials.

The workflow run attempt number is intentionally not added here because it is not currently available on the runner claim path without expanding the runner queue contract.

Closes ENG-700

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured lifecycle logs to the runner setup step and include the job execution ID so setup events can be correlated across API, runner, and durable step logs. Also logs a structured warning with a failure reason when setup fails. Addresses ENG-700.

- **New Features**
  - Emit “Setup step started/completed” as info and failures as warn via `@shipfox/node-opentelemetry` with `workflowRunId`, `workflowRunAttemptId`, `jobId`, `jobExecutionId`.
  - Add “Job execution: <id>” to the user-facing “Set up job” log group.
  - Thread `jobExecutionId` from orchestration into the setup context; no lease tokens or credentials are logged.

<sup>Written for commit c7090d4c109d9bf6922669ddba0b3871fb401ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

