### PR TITLE
Fix E2E diagnostics upload scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,13 +115,11 @@ jobs:
 
       - name: Upload E2E diagnostics
         if: failure() && steps.e2e.outcome == 'failure'
-        timeout-minutes: 10
+        timeout-minutes: 3
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-diagnostics
-          path: |
-            ${{ runner.temp }}/shipfox-e2e-logs/
-            e2e/**/test-results/
+          path: ${{ runner.temp }}/shipfox-e2e-logs/
           if-no-files-found: error
 
   # PR image validation stays separate so it can run without package write

--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import {spawn, spawnSync} from 'node:child_process';
-import {cp, mkdir} from 'node:fs/promises';
 import {closeSync, openSync} from 'node:fs';
+import {cp, mkdir, readdir, stat} from 'node:fs/promises';
 import {dirname, join, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -11,6 +11,7 @@ const defaultClientUrl = 'http://localhost:5173';
 const defaultReadinessTimeoutMs = 60_000;
 const defaultShutdownTimeoutMs = 15_000;
 const defaultTurboTask = 'test:e2e';
+const trailingSlashPattern = /\/$/;
 
 if (isCliEntryPoint()) {
   main(process.argv.slice(2)).catch((error) => {
@@ -68,7 +69,7 @@ export async function main(argv) {
       }),
     );
 
-    await waitForUrl(`${env.API_URL.replace(/\/$/, '')}/readyz`, {
+    await waitForUrl(`${env.API_URL.replace(trailingSlashPattern, '')}/readyz`, {
       timeoutMs: options.readinessTimeoutMs,
     });
     await waitForUrl(env.CLIENT_URL, {timeoutMs: options.readinessTimeoutMs});
@@ -128,7 +129,8 @@ export function parseArgs(argv) {
       continue;
     }
     if (arg === '--log-dir') {
-      options.logDir = requireValue(args, (index += 1), arg);
+      index += 1;
+      options.logDir = requireValue(args, index, arg);
       continue;
     }
     if (arg.startsWith('--log-dir=')) {
@@ -136,7 +138,8 @@ export function parseArgs(argv) {
       continue;
     }
     if (arg === '--timeout-ms') {
-      options.readinessTimeoutMs = parsePositiveInteger(requireValue(args, (index += 1), arg), arg);
+      index += 1;
+      options.readinessTimeoutMs = parsePositiveInteger(requireValue(args, index, arg), arg);
       continue;
     }
     if (arg.startsWith('--timeout-ms=')) {
@@ -147,7 +150,8 @@ export function parseArgs(argv) {
       continue;
     }
     if (arg === '--task') {
-      options.turboTask = requireValue(args, (index += 1), arg);
+      index += 1;
+      options.turboTask = requireValue(args, index, arg);
       continue;
     }
     if (arg.startsWith('--task=')) {
@@ -285,6 +289,43 @@ export async function collectE2eDiagnostics(logDir) {
     });
   } catch (error) {
     if (error?.code !== 'ENOENT') throw error;
+  }
+
+  await copyPlaywrightTestResults(logDir);
+}
+
+export async function copyPlaywrightTestResults(logDir) {
+  const packageGroupDirs = ['e2e/api', 'e2e/client', 'e2e/platform'];
+
+  for (const packageGroupDir of packageGroupDirs) {
+    let entries;
+    try {
+      entries = await readdir(packageGroupDir, {withFileTypes: true});
+    } catch (error) {
+      if (error?.code === 'ENOENT') continue;
+      throw error;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const source = join(packageGroupDir, entry.name, 'test-results');
+      if (!(await isDirectory(source))) continue;
+
+      await cp(source, join(logDir, 'playwright-test-results', source), {
+        recursive: true,
+        force: true,
+      });
+    }
+  }
+}
+
+async function isDirectory(path) {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
   }
 }
 

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -110,6 +110,13 @@ describe('copyPlaywrightTestResults', () => {
 
       assert.equal(
         await readFile(
+          join(logDir, 'playwright-test-results/e2e/api/auth/test-results/auth-flow/trace.zip'),
+          'utf8',
+        ),
+        'api trace',
+      );
+      assert.equal(
+        await readFile(
           join(
             logDir,
             'playwright-test-results/e2e/client/workspaces/test-results/workspace-flow/trace.zip',
@@ -117,6 +124,16 @@ describe('copyPlaywrightTestResults', () => {
           'utf8',
         ),
         'client trace',
+      );
+      assert.equal(
+        await readFile(
+          join(
+            logDir,
+            'playwright-test-results/e2e/platform/workflows/test-results/scenario/trace.zip',
+          ),
+          'utf8',
+        ),
+        'platform trace',
       );
       await assert.rejects(
         readFile(

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
+import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
 import {describe, test} from 'node:test';
-import {defaultLogDir, e2eEnv, parseArgs} from './e2e.mjs';
+import {copyPlaywrightTestResults, defaultLogDir, e2eEnv, parseArgs} from './e2e.mjs';
+
+const unknownCommandPattern = /Unknown command/;
 
 describe('parseArgs', () => {
   test('defaults to running all E2E tests', () => {
@@ -35,7 +40,7 @@ describe('parseArgs', () => {
   });
 
   test('rejects unknown commands', () => {
-    assert.throws(() => parseArgs(['down']), /Unknown command/);
+    assert.throws(() => parseArgs(['down']), unknownCommandPattern);
   });
 });
 
@@ -79,5 +84,53 @@ describe('defaultLogDir', () => {
 
   test('falls back to .context locally', () => {
     assert.equal(defaultLogDir({}), '.context/shipfox-e2e-logs');
+  });
+});
+
+describe('copyPlaywrightTestResults', () => {
+  test('stages only Playwright package test results', async () => {
+    const originalCwd = process.cwd();
+    const workspaceDir = await mkdtemp(join(tmpdir(), 'shipfox-e2e-workspace-'));
+    const logDir = join(workspaceDir, 'logs');
+    try {
+      process.chdir(workspaceDir);
+      await mkdir('e2e/api/auth/test-results/auth-flow', {recursive: true});
+      await mkdir('e2e/client/workspaces/test-results/workspace-flow', {recursive: true});
+      await mkdir('e2e/platform/workflows/test-results/scenario', {recursive: true});
+      await mkdir('e2e/helpers/auth/test-results/helper-flow', {recursive: true});
+      await writeFile('e2e/api/auth/test-results/auth-flow/trace.zip', 'api trace');
+      await writeFile(
+        'e2e/client/workspaces/test-results/workspace-flow/trace.zip',
+        'client trace',
+      );
+      await writeFile('e2e/platform/workflows/test-results/scenario/trace.zip', 'platform trace');
+      await writeFile('e2e/helpers/auth/test-results/helper-flow/trace.zip', 'helper trace');
+
+      await copyPlaywrightTestResults(logDir);
+
+      assert.equal(
+        await readFile(
+          join(
+            logDir,
+            'playwright-test-results/e2e/client/workspaces/test-results/workspace-flow/trace.zip',
+          ),
+          'utf8',
+        ),
+        'client trace',
+      );
+      await assert.rejects(
+        readFile(
+          join(
+            logDir,
+            'playwright-test-results/e2e/helpers/auth/test-results/helper-flow/trace.zip',
+          ),
+          'utf8',
+        ),
+        {code: 'ENOENT'},
+      );
+    } finally {
+      process.chdir(originalCwd);
+      await rm(workspaceDir, {recursive: true, force: true});
+    }
   });
 });


### PR DESCRIPTION
Fix E2E failure diagnostics so GitHub Actions uploads a single staged diagnostics directory instead of recursively globbing `e2e/**/test-results/`.

The previous glob can walk every E2E package's pnpm `node_modules` tree while the artifact action searches for Playwright results, which makes failure handling spend up to the full 10 minute upload timeout. The E2E harness now stages Playwright result directories from the known E2E package groups into the existing log bundle, and CI uploads only that bundle with a shorter timeout.

This keeps API/client logs, Docker diagnostics, platform runner logs, and Playwright traces available on failures while avoiding broad artifact path traversal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix E2E failure diagnostics to upload a single staged bundle instead of globbing Playwright results. This avoids walking node_modules, speeds up failure handling, and keeps logs and traces intact.

- **Bug Fixes**
  - Stage Playwright `test-results` from `e2e/api`, `e2e/client`, and `e2e/platform` into `${{ runner.temp }}/shipfox-e2e-logs/playwright-test-results` via `copyPlaywrightTestResults`, covering all packages in those groups.
  - CI uploads only that bundle with `actions/upload-artifact` and a 3-minute timeout; removed `e2e/**/test-results/` glob.
  - Added tests to ensure only Playwright package results are copied (helper packages are excluded).

- **Refactors**
  - Introduced `trailingSlashPattern` and fixed `parseArgs` index handling for option values.

<sup>Written for commit 3280d1ee4ba6e3277e730dfeb2dca287ad6aa6f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

