### PR TITLE
[api-projects] Instrument project metrics

### DIFF
--- a/.changeset/steady-metrics-observe.md
+++ b/.changeset/steady-metrics-observe.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-projects": patch
+---
+
+Adds OpenTelemetry project creation, source-commit handling, and current project-count metrics.

--- a/libs/api/projects/src/core/projects.ts
+++ b/libs/api/projects/src/core/projects.ts
@@ -9,6 +9,7 @@ import {and, eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
 import {projects, toProject} from '#db/schema/projects.js';
+import {recordProjectCreated} from '#metrics/instance.js';
 import type {Project} from './entities/project.js';
 import {ProjectAlreadyExistsError} from './errors.js';
 
@@ -30,7 +31,7 @@ export async function createProjectFromSource(
     externalRepositoryId: params.sourceExternalRepositoryId,
   });
 
-  return await db().transaction(async (tx) => {
+  const project = await db().transaction(async (tx) => {
     const [projectRow] = await tx
       .insert(projects)
       .values({
@@ -91,4 +92,6 @@ export async function createProjectFromSource(
 
     return project;
   });
+  recordProjectCreated();
+  return project;
 }

--- a/libs/api/projects/src/db/index.ts
+++ b/libs/api/projects/src/db/index.ts
@@ -16,6 +16,7 @@ export {
   createProject,
   getProjectById,
   getProjectBySource,
+  getProjectCount,
   listProjects,
   requireProjectForWorkspace,
 } from './projects.js';

--- a/libs/api/projects/src/db/projects.test.ts
+++ b/libs/api/projects/src/db/projects.test.ts
@@ -1,0 +1,22 @@
+import {projectFactory} from '#test/index.js';
+import {getProjectCount} from './projects.js';
+
+describe('getProjectCount', () => {
+  it('reports the current project count', async () => {
+    const before = await getProjectCount();
+
+    const after = await getProjectCount();
+
+    expect(after - before).toBe(0);
+  });
+
+  it('counts newly created projects', async () => {
+    const before = await getProjectCount();
+    await projectFactory.create();
+    await projectFactory.create();
+
+    const after = await getProjectCount();
+
+    expect(after - before).toBe(2);
+  });
+});

--- a/libs/api/projects/src/db/projects.ts
+++ b/libs/api/projects/src/db/projects.ts
@@ -1,6 +1,7 @@
-import {and, desc, eq, ilike, lt, or, type SQL} from 'drizzle-orm';
+import {and, count, desc, eq, ilike, lt, or, type SQL} from 'drizzle-orm';
 import type {Project} from '#core/entities/project.js';
 import {ProjectAlreadyExistsError, ProjectNotFoundError} from '#core/errors.js';
+import {recordProjectCreated} from '#metrics/instance.js';
 import {db} from './db.js';
 import {projects, toProject} from './schema/projects.js';
 
@@ -41,7 +42,7 @@ function cursorWhere(params: ListProjectsParams): SQL | undefined {
 }
 
 export async function createProject(params: CreateProjectParams): Promise<Project> {
-  return await db().transaction(async (tx) => {
+  const project = await db().transaction(async (tx) => {
     const [projectRow] = await tx
       .insert(projects)
       .values({
@@ -78,6 +79,8 @@ export async function createProject(params: CreateProjectParams): Promise<Projec
 
     return toProject(projectRow);
   });
+  recordProjectCreated();
+  return project;
 }
 
 export async function getProjectById(id: string): Promise<Project | undefined> {
@@ -147,4 +150,9 @@ export async function listProjects(params: ListProjectsParams): Promise<ListProj
     projects: pageRows.map(toProject),
     nextCursor: hasMore && last ? {createdAt: last.createdAt, id: last.id} : null,
   };
+}
+
+export async function getProjectCount(): Promise<number> {
+  const [row] = await db().select({value: count()}).from(projects);
+  return row?.value ?? 0;
 }

--- a/libs/api/projects/src/index.ts
+++ b/libs/api/projects/src/index.ts
@@ -8,6 +8,7 @@ import {
 import {projectsEventSchemas} from '@shipfox/api-projects-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, projectsOutbox} from '#db/index.js';
+import {registerProjectsServiceMetrics} from '#metrics/index.js';
 import {projectsE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {createProjectRoutes} from '#presentation/index.js';
 import {onSourceCommitPushed} from '#presentation/subscribers/index.js';
@@ -49,6 +50,7 @@ export function createProjectsModule({sourceControl}: CreateProjectsModuleOption
     database: {db, migrationsPath},
     routes: createProjectRoutes(sourceControl),
     e2eRoutes: [projectsE2eRoutes],
+    metrics: registerProjectsServiceMetrics,
     publishers: [{name: 'projects', table: projectsOutbox, db, eventSchemas: projectsEventSchemas}],
     subscribers: [subscriber(INTEGRATION_SOURCE_COMMIT_PUSHED, onSourceCommitPushed)],
     workers: [

--- a/libs/api/projects/src/metrics/index.ts
+++ b/libs/api/projects/src/metrics/index.ts
@@ -1,0 +1,2 @@
+export {recordProjectCreated, recordSourceCommitPushed} from './instance.js';
+export {registerProjectsServiceMetrics} from './service.js';

--- a/libs/api/projects/src/metrics/instance.ts
+++ b/libs/api/projects/src/metrics/instance.ts
@@ -1,0 +1,34 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+const meter = instanceMetrics.getMeter('projects');
+
+const projectsCreatedCount = meter.createCounter<Record<string, never>>('projects_created', {
+  description: 'Projects created',
+});
+
+export type SourceCommitPushedOutcome =
+  | 'duplicate'
+  | 'non_default_branch'
+  | 'observed'
+  | 'unbound_source';
+
+const sourceCommitPushedCount = meter.createCounter<{outcome: SourceCommitPushedOutcome}>(
+  'projects_source_commit_pushed',
+  {description: 'Source commit pushed events handled by outcome'},
+);
+
+function recordMetric(record: () => void): void {
+  try {
+    record();
+  } catch {
+    // Metrics must not affect project writes or subscriber acknowledgements.
+  }
+}
+
+export function recordProjectCreated(): void {
+  recordMetric(() => projectsCreatedCount.add(1));
+}
+
+export function recordSourceCommitPushed(outcome: SourceCommitPushedOutcome): void {
+  recordMetric(() => sourceCommitPushedCount.add(1, {outcome}));
+}

--- a/libs/api/projects/src/metrics/service.ts
+++ b/libs/api/projects/src/metrics/service.ts
@@ -1,0 +1,17 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getProjectCount} from '#db/projects.js';
+
+export function registerProjectsServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('projects');
+
+  const projectCount = meter.createObservableGauge('projects_project_count', {
+    description: 'Projects currently stored',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      observer.observe(projectCount, await getProjectCount());
+    },
+    [projectCount],
+  );
+}

--- a/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.ts
+++ b/libs/api/projects/src/presentation/subscribers/on-source-commit-pushed.ts
@@ -6,6 +6,7 @@ import {db} from '#db/db.js';
 import {recordIntegrationEventForProject} from '#db/integration-event-dedup.js';
 import {getProjectBySource} from '#db/projects.js';
 import {projectsOutbox} from '#db/schema/outbox.js';
+import {recordSourceCommitPushed, type SourceCommitPushedOutcome} from '#metrics/instance.js';
 
 export async function onSourceCommitPushed(
   payload: IntegrationSourceCommitPushedEvent,
@@ -15,6 +16,7 @@ export async function onSourceCommitPushed(
 
   // Projects only track the default branch; other branches are someone else's policy.
   if (!push.isDefaultBranch) {
+    recordSourceCommitPushed('non_default_branch');
     return;
   }
 
@@ -32,16 +34,17 @@ export async function onSourceCommitPushed(
       },
       'source commit pushed: no project bound to source, dropping',
     );
+    recordSourceCommitPushed('unbound_source');
     return;
   }
 
-  await db().transaction(async (tx) => {
+  const outcome = await db().transaction<SourceCommitPushedOutcome>(async (tx) => {
     const {firstSeen} = await recordIntegrationEventForProject({
       tx,
       integrationEventId: event.id,
       projectId: project.id,
     });
-    if (!firstSeen) return;
+    if (!firstSeen) return 'duplicate';
 
     await writeOutboxEvent(tx, projectsOutbox, {
       type: PROJECT_SOURCE_COMMIT_OBSERVED,
@@ -55,5 +58,7 @@ export async function onSourceCommitPushed(
         headCommitSha: push.headCommitSha,
       },
     });
+    return 'observed';
   });
+  recordSourceCommitPushed(outcome);
 }


### PR DESCRIPTION
Adds OpenTelemetry metrics for `@shipfox/api-projects`: project creation, source commit push handling outcomes, and a service gauge for the current project count.

Projects had no module-owned metrics, so operators could not observe project creation volume or whether source commit events were observed, skipped, duplicated, or unbound. This follows the existing runners/logs metrics shape with instance counters recorded at the decision points and a service gauge registered through the module metrics hook.

The source commit counter uses only bounded outcome labels. The project-count gauge reads through a package-owned DB query with Vitest coverage.

Closes ENG-574

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenTelemetry metrics to `@shipfox/api-projects` for project creation, source commit push outcomes, and a service gauge for current project count. Improves operator visibility and fulfills ENG-574.

- **New Features**
  - Instance counters: `projects_created` (incremented after successful commit) and `projects_source_commit_pushed{outcome}` with outcomes: observed, duplicate, non_default_branch, unbound_source.
  - Service gauge: `projects_project_count` reads from `getProjectCount()` and is registered via the module metrics hook using `@shipfox/node-opentelemetry`.
  - Metrics recording is wrapped to avoid impacting writes or subscriber acks; tests added for `getProjectCount()`.

<sup>Written for commit 4c2dc3ca358e341b98b5505be1fab621dec878f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

