### PR TITLE
[api-runners] Add reconciliation observability

### DIFF
--- a/.changeset/observant-runners-reconcile.md
+++ b/.changeset/observant-runners-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Adds reconciliation observability metrics for provisioned-runner divergence and terminate-intent reconciliation.

--- a/libs/api/runners/drizzle/0004_sudden_tomorrow_man.sql
+++ b/libs/api/runners/drizzle/0004_sudden_tomorrow_man.sql
@@ -24,6 +24,7 @@ CREATE TABLE "runners_provisioned_runners" (
 --> statement-breakpoint
 CREATE UNIQUE INDEX "runners_provisioned_runners_workspace_provisioner_runner_unique" ON "runners_provisioned_runners" USING btree ("workspace_id","provisioner_id","provisioned_runner_id");--> statement-breakpoint
 CREATE INDEX "runners_provisioned_runners_workspace_state_updated_idx" ON "runners_provisioned_runners" USING btree ("workspace_id","state","updated_at");--> statement-breakpoint
+CREATE INDEX "runners_provisioned_runners_active_template_counts_idx" ON "runners_provisioned_runners" USING btree ("workspace_id","provisioner_id","state","template_key") WHERE "state" in ('starting', 'running') and "template_key" is not null;--> statement-breakpoint
 CREATE INDEX "runners_provisioned_runners_reservation_id_idx" ON "runners_provisioned_runners" USING btree ("reservation_id");
 --> statement-breakpoint
 CREATE TABLE "runners_provisioner_tokens" (

--- a/libs/api/runners/drizzle/meta/0004_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0004_snapshot.json
@@ -603,6 +603,40 @@
           "method": "btree",
           "with": {}
         },
+        "runners_provisioned_runners_active_template_counts_idx": {
+          "name": "runners_provisioned_runners_active_template_counts_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" in ('starting', 'running') and \"template_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
         "runners_provisioned_runners_reservation_id_idx": {
           "name": "runners_provisioned_runners_reservation_id_idx",
           "columns": [

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -173,3 +173,27 @@ describe('stale provisioned runner threshold validation', () => {
     );
   });
 });
+
+describe('PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('defaults to disabling template_key on the divergence metric', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED).toBe(false);
+  });
+
+  it('can enable template_key on the divergence metric', async () => {
+    vi.stubEnv('PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED', 'true');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED).toBe(true);
+  });
+});

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -1,5 +1,5 @@
 import {REGISTRATION_TOKEN_BATCH_HARD_MAX} from '@shipfox/api-runners-dto';
-import {createConfig, num} from '@shipfox/config';
+import {bool, createConfig, num} from '@shipfox/config';
 
 const EPHEMERAL_REGISTRATION_TOKEN_TTL_HARD_MAX_SECONDS = 3600;
 
@@ -55,6 +55,10 @@ export const config = createConfig({
   PROVISIONER_LAST_SEEN_THROTTLE_SECONDS: num({
     desc: 'Minimum time, in seconds, between last-seen writes for one provisioner token.',
     default: 10,
+  }),
+  PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED: bool({
+    desc: 'Whether runners_provisioned_runner_count_divergence includes template_key as a metric label. Use true or false. Defaults to false because template keys can create high-cardinality metric series. Set true only when template keys are bounded and stable.',
+    default: false,
   }),
 });
 

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -175,6 +175,63 @@ describe('pollDemand', () => {
       vi.resetModules();
     }
   });
+
+  it('includes template_key on divergence metrics when the env flag is enabled', async () => {
+    vi.resetModules();
+    vi.stubEnv('PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED', 'true');
+    const divergenceAdd = vi.fn();
+    const pollDemandAndReserveTx = vi.fn().mockResolvedValue({stats: [], reservations: []});
+    const listProvisionerTerminateIntentRowsTx = vi.fn().mockResolvedValue([]);
+    const listActiveProvisionedRunnerCountsByTemplateTx = vi
+      .fn()
+      .mockResolvedValue([{templateKey: 'linux', state: 'running', count: 2}]);
+    vi.doMock('#db/db.js', () => ({
+      db: () => ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}),
+    }));
+    vi.doMock('#db/reservations.js', () => ({
+      deleteReservationsByIds: vi.fn(),
+      pollDemandAndReserveTx,
+    }));
+    vi.doMock('#db/provisioned-runners.js', () => ({
+      listActiveProvisionedRunnerCountsByTemplateTx,
+      listProvisionerTerminateIntentRowsTx,
+    }));
+    vi.doMock('#metrics/instance.js', () => ({
+      provisionedRunnerCountDivergenceCount: {add: divergenceAdd},
+      provisionedRunnerTerminateIntentIssuedCount: {add: vi.fn()},
+    }));
+
+    try {
+      const {pollDemand: mockedPollDemand} = await import('#core/demand.js');
+
+      const result = await mockedPollDemand({
+        workspaceId: crypto.randomUUID(),
+        provisionerId: crypto.randomUUID(),
+        maxReservations: 0,
+        waitSeconds: 0,
+        ttlSeconds: 60,
+        terminateIntentLimit: 1000,
+        templates: [
+          {templateKey: 'linux', labels: ['linux'], availableSlots: 1, starting: 0, running: 1},
+        ],
+        signal: new AbortController().signal,
+      });
+
+      expect(result).toEqual({stats: [], reservations: [], terminateProvisionedRunnerIds: []});
+      expect(divergenceAdd).toHaveBeenCalledWith(1, {
+        template_key: 'linux',
+        state: 'running',
+        direction: 'backend-higher',
+      });
+    } finally {
+      vi.unstubAllEnvs();
+      vi.doUnmock('#db/db.js');
+      vi.doUnmock('#db/reservations.js');
+      vi.doUnmock('#db/provisioned-runners.js');
+      vi.doUnmock('#metrics/instance.js');
+      vi.resetModules();
+    }
+  });
 });
 
 describe('calculateProvisionedRunnerCountDivergences', () => {

--- a/libs/api/runners/src/core/demand.test.ts
+++ b/libs/api/runners/src/core/demand.test.ts
@@ -1,4 +1,9 @@
-import {nextBackoffInterval, pollDemand, shouldReturn} from '#core/demand.js';
+import {
+  calculateProvisionedRunnerCountDivergences,
+  nextBackoffInterval,
+  pollDemand,
+  shouldReturn,
+} from '#core/demand.js';
 
 describe('shouldReturn', () => {
   const emptyResult = {stats: [], reservations: [], terminateProvisionedRunnerIds: []};
@@ -77,7 +82,10 @@ describe('pollDemand', () => {
   it('returns immediately when terminate intents exist without reservation demand', async () => {
     vi.resetModules();
     const pollDemandAndReserveTx = vi.fn().mockResolvedValue({stats: [], reservations: []});
-    const listProvisionerTerminateIntentsTx = vi.fn().mockResolvedValue(['provisioned-runner-1']);
+    const listProvisionerTerminateIntentRowsTx = vi
+      .fn()
+      .mockResolvedValue([{provisionedRunnerId: 'provisioned-runner-1', reason: 'job-cancelled'}]);
+    const listActiveProvisionedRunnerCountsByTemplateTx = vi.fn().mockResolvedValue([]);
     vi.doMock('#db/db.js', () => ({
       db: () => ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}),
     }));
@@ -86,7 +94,8 @@ describe('pollDemand', () => {
       pollDemandAndReserveTx,
     }));
     vi.doMock('#db/provisioned-runners.js', () => ({
-      listProvisionerTerminateIntentsTx,
+      listActiveProvisionedRunnerCountsByTemplateTx,
+      listProvisionerTerminateIntentRowsTx,
     }));
 
     try {
@@ -111,7 +120,7 @@ describe('pollDemand', () => {
         terminateProvisionedRunnerIds: ['provisioned-runner-1'],
       });
       expect(pollDemandAndReserveTx).toHaveBeenCalledOnce();
-      expect(listProvisionerTerminateIntentsTx).toHaveBeenCalledOnce();
+      expect(listProvisionerTerminateIntentRowsTx).toHaveBeenCalledOnce();
     } finally {
       vi.doUnmock('#db/db.js');
       vi.doUnmock('#db/reservations.js');
@@ -119,6 +128,109 @@ describe('pollDemand', () => {
       vi.resetModules();
     }
   });
+
+  it('does not calculate divergence for a non-returned long-poll retry', async () => {
+    vi.resetModules();
+    const abortController = new AbortController();
+    const pollDemandAndReserveTx = vi.fn().mockResolvedValue({stats: [], reservations: []});
+    const listProvisionerTerminateIntentRowsTx = vi.fn().mockImplementation(() => {
+      abortController.abort();
+      return [];
+    });
+    const listActiveProvisionedRunnerCountsByTemplateTx = vi.fn().mockResolvedValue([]);
+    vi.doMock('#db/db.js', () => ({
+      db: () => ({transaction: (callback: (tx: unknown) => Promise<unknown>) => callback({})}),
+    }));
+    vi.doMock('#db/reservations.js', () => ({
+      deleteReservationsByIds: vi.fn(),
+      pollDemandAndReserveTx,
+    }));
+    vi.doMock('#db/provisioned-runners.js', () => ({
+      listActiveProvisionedRunnerCountsByTemplateTx,
+      listProvisionerTerminateIntentRowsTx,
+    }));
+
+    try {
+      const {pollDemand: mockedPollDemand} = await import('#core/demand.js');
+
+      const result = await mockedPollDemand({
+        workspaceId: crypto.randomUUID(),
+        provisionerId: crypto.randomUUID(),
+        maxReservations: 1,
+        waitSeconds: 60,
+        ttlSeconds: 60,
+        terminateIntentLimit: 1000,
+        templates: [
+          {templateKey: 'linux', labels: ['linux'], availableSlots: 1, starting: 0, running: 0},
+        ],
+        signal: abortController.signal,
+      });
+
+      expect(result).toEqual({stats: [], reservations: [], terminateProvisionedRunnerIds: []});
+      expect(listActiveProvisionedRunnerCountsByTemplateTx).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock('#db/db.js');
+      vi.doUnmock('#db/reservations.js');
+      vi.doUnmock('#db/provisioned-runners.js');
+      vi.resetModules();
+    }
+  });
+});
+
+describe('calculateProvisionedRunnerCountDivergences', () => {
+  it('returns no divergences when advertised and backend counts match', () => {
+    const result = calculateProvisionedRunnerCountDivergences({
+      advertisedTemplates: [template('linux', 1, 2)],
+      backendCounts: [
+        {templateKey: 'linux', state: 'starting', count: 1},
+        {templateKey: 'linux', state: 'running', count: 2},
+      ],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('detects backend-higher and advertised-higher counts', () => {
+    const result = calculateProvisionedRunnerCountDivergences({
+      advertisedTemplates: [template('linux', 1, 5)],
+      backendCounts: [
+        {templateKey: 'linux', state: 'starting', count: 3},
+        {templateKey: 'linux', state: 'running', count: 2},
+      ],
+    });
+
+    expect(result).toEqual([
+      {templateKey: 'linux', state: 'running', direction: 'advertised-higher', delta: 3},
+      {templateKey: 'linux', state: 'starting', direction: 'backend-higher', delta: 2},
+    ]);
+  });
+
+  it('aggregates duplicate advertised template keys before comparing', () => {
+    const result = calculateProvisionedRunnerCountDivergences({
+      advertisedTemplates: [template('linux', 1, 1), template('linux', 2, 3)],
+      backendCounts: [
+        {templateKey: 'linux', state: 'starting', count: 3},
+        {templateKey: 'linux', state: 'running', count: 4},
+      ],
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('detects backend-only template keys as backend-higher', () => {
+    const result = calculateProvisionedRunnerCountDivergences({
+      advertisedTemplates: [template('linux', 0, 0)],
+      backendCounts: [{templateKey: 'gpu', state: 'running', count: 2}],
+    });
+
+    expect(result).toEqual([
+      {templateKey: 'gpu', state: 'running', direction: 'backend-higher', delta: 2},
+    ]);
+  });
+
+  function template(templateKey: string, starting: number, running: number) {
+    return {templateKey, labels: ['linux'], availableSlots: 1, starting, running};
+  }
 });
 
 describe('nextBackoffInterval', () => {

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -1,7 +1,12 @@
 import {setTimeout as sleep} from 'node:timers/promises';
 import {config} from '#config.js';
 import {db} from '#db/db.js';
-import {listProvisionerTerminateIntentsTx} from '#db/provisioned-runners.js';
+import {
+  type ActiveProvisionedRunnerTemplateCount,
+  listActiveProvisionedRunnerCountsByTemplateTx,
+  listProvisionerTerminateIntentRowsTx,
+  type ProvisionedRunnerTerminateIntent,
+} from '#db/provisioned-runners.js';
 import {
   type DemandStat,
   deleteReservationsByIds,
@@ -9,6 +14,10 @@ import {
   type ReservationGrant,
   type ReservationTemplate,
 } from '#db/reservations.js';
+import {
+  provisionedRunnerCountDivergenceCount,
+  provisionedRunnerTerminateIntentIssuedCount,
+} from '#metrics/instance.js';
 
 export interface PollDemandParams {
   workspaceId: string;
@@ -27,6 +36,19 @@ export interface PollDemandResult {
   terminateProvisionedRunnerIds: string[];
 }
 
+export interface ProvisionedRunnerCountDivergence {
+  templateKey: string;
+  state: 'starting' | 'running';
+  direction: 'backend-higher' | 'advertised-higher';
+  delta: number;
+}
+
+interface PollDemandSnapshot {
+  result: PollDemandResult;
+  divergences: ProvisionedRunnerCountDivergence[];
+  terminateIntents: ProvisionedRunnerTerminateIntent[];
+}
+
 export async function pollDemand(params: PollDemandParams): Promise<PollDemandResult> {
   const waitSeconds = Math.min(
     params.waitSeconds ?? config.RESERVATION_LONG_POLL_MAX_WAIT_SECONDS,
@@ -38,18 +60,18 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
     0,
   );
   let interval = config.RESERVATION_POLL_INTERVAL_MS;
-  let lastResult: PollDemandResult = {
-    stats: [],
-    reservations: [],
-    terminateProvisionedRunnerIds: [],
+  let lastSnapshot: PollDemandSnapshot = {
+    result: {stats: [], reservations: [], terminateProvisionedRunnerIds: []},
+    divergences: [],
+    terminateIntents: [],
   };
 
   while (true) {
-    if (params.signal.aborted) return lastResult;
+    if (params.signal.aborted) return lastSnapshot.result;
 
-    const previousResult = lastResult;
+    const previousSnapshot = lastSnapshot;
     const deadlinePassed = Date.now() >= deadlineMs;
-    const result = await db().transaction(async (tx) => {
+    const snapshot = await db().transaction(async (tx) => {
       const demand = await pollDemandAndReserveTx(tx, {
         workspaceId: params.workspaceId,
         provisionerId: params.provisionerId,
@@ -57,30 +79,42 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
         ttlSeconds: params.ttlSeconds,
         templates: params.templates,
       });
+      const terminateIntents = await listProvisionerTerminateIntentRowsTx(tx, {
+        workspaceId: params.workspaceId,
+        provisionerId: params.provisionerId,
+        limit: params.terminateIntentLimit,
+      });
       const result: PollDemandResult = {
         ...demand,
-        terminateProvisionedRunnerIds: await listProvisionerTerminateIntentsTx(tx, {
-          workspaceId: params.workspaceId,
-          provisionerId: params.provisionerId,
-          limit: params.terminateIntentLimit,
-        }),
+        terminateProvisionedRunnerIds: terminateIntents.map((intent) => intent.provisionedRunnerId),
       };
 
       if (!shouldReturn(result, params.maxReservations, totalCapacity, deadlinePassed)) {
-        return result;
+        return {result, terminateIntents, divergences: []};
       }
 
-      return result;
+      return {
+        result,
+        terminateIntents,
+        divergences: calculateProvisionedRunnerCountDivergences({
+          advertisedTemplates: params.templates,
+          backendCounts: await listActiveProvisionedRunnerCountsByTemplateTx(tx, {
+            workspaceId: params.workspaceId,
+            provisionerId: params.provisionerId,
+          }),
+        }),
+      };
     });
     if (params.signal.aborted) {
-      await releaseReservationGrants(result.reservations);
-      return previousResult;
+      await releaseReservationGrants(snapshot.result.reservations);
+      return previousSnapshot.result;
     }
 
-    lastResult = result;
+    lastSnapshot = snapshot;
 
-    if (shouldReturn(lastResult, params.maxReservations, totalCapacity, deadlinePassed)) {
-      return lastResult;
+    if (shouldReturn(lastSnapshot.result, params.maxReservations, totalCapacity, deadlinePassed)) {
+      recordPollDemandMetrics(lastSnapshot);
+      return lastSnapshot.result;
     }
 
     const remainingWaitMs = Math.max(0, deadlineMs - Date.now());
@@ -89,7 +123,7 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
         signal: params.signal,
       });
     } catch (error) {
-      if (params.signal.aborted) return lastResult;
+      if (params.signal.aborted) return lastSnapshot.result;
       throw error;
     }
     interval = nextBackoffInterval(interval);
@@ -121,4 +155,69 @@ export function nextBackoffInterval(ms: number): number {
 
 export function withJitter(ms: number): number {
   return Math.random() * ms;
+}
+
+export function calculateProvisionedRunnerCountDivergences(params: {
+  advertisedTemplates: ReservationTemplate[];
+  backendCounts: ActiveProvisionedRunnerTemplateCount[];
+}): ProvisionedRunnerCountDivergence[] {
+  const advertisedCounts = new Map<string, number>();
+  const backendCounts = new Map<string, number>();
+
+  for (const template of params.advertisedTemplates) {
+    addCount(advertisedCounts, countKey(template.templateKey, 'starting'), template.starting);
+    addCount(advertisedCounts, countKey(template.templateKey, 'running'), template.running);
+  }
+  for (const count of params.backendCounts) {
+    addCount(backendCounts, countKey(count.templateKey, count.state), count.count);
+  }
+
+  const keys = [...new Set([...advertisedCounts.keys(), ...backendCounts.keys()])].sort();
+  return keys.flatMap((key) => {
+    const advertised = advertisedCounts.get(key) ?? 0;
+    const backend = backendCounts.get(key) ?? 0;
+    if (advertised === backend) return [];
+
+    const [templateKey, state] = splitCountKey(key);
+    return [
+      {
+        templateKey,
+        state,
+        direction: backend > advertised ? 'backend-higher' : 'advertised-higher',
+        delta: Math.abs(backend - advertised),
+      },
+    ];
+  });
+}
+
+function recordPollDemandMetrics(snapshot: PollDemandSnapshot): void {
+  for (const divergence of snapshot.divergences) {
+    provisionedRunnerCountDivergenceCount.add(divergence.delta, {
+      template_key: divergence.templateKey,
+      state: divergence.state,
+      direction: divergence.direction,
+    });
+  }
+  for (const intent of snapshot.terminateIntents) {
+    provisionedRunnerTerminateIntentIssuedCount.add(1, {
+      surface: 'poll-demand',
+      reason: intent.reason,
+    });
+  }
+}
+
+function addCount(counts: Map<string, number>, key: string, count: number): void {
+  counts.set(key, (counts.get(key) ?? 0) + count);
+}
+
+function countKey(templateKey: string, state: 'starting' | 'running'): string {
+  return `${templateKey}\0${state}`;
+}
+
+function splitCountKey(key: string): [string, 'starting' | 'running'] {
+  const [templateKey, state] = key.split('\0');
+  if (!templateKey || (state !== 'starting' && state !== 'running')) {
+    throw new Error(`Invalid provisioned runner count key: ${key}`);
+  }
+  return [templateKey, state];
 }

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -193,7 +193,7 @@ export function calculateProvisionedRunnerCountDivergences(params: {
 
 function recordPollDemandMetrics(params: PollDemandParams, snapshot: PollDemandSnapshot): void {
   for (const divergence of snapshot.divergences) {
-    logger().info(
+    logger().debug(
       {
         workspaceId: params.workspaceId,
         provisionerId: params.provisionerId,

--- a/libs/api/runners/src/core/demand.ts
+++ b/libs/api/runners/src/core/demand.ts
@@ -1,4 +1,5 @@
 import {setTimeout as sleep} from 'node:timers/promises';
+import {logger} from '@shipfox/node-opentelemetry';
 import {config} from '#config.js';
 import {db} from '#db/db.js';
 import {
@@ -113,7 +114,7 @@ export async function pollDemand(params: PollDemandParams): Promise<PollDemandRe
     lastSnapshot = snapshot;
 
     if (shouldReturn(lastSnapshot.result, params.maxReservations, totalCapacity, deadlinePassed)) {
-      recordPollDemandMetrics(lastSnapshot);
+      recordPollDemandMetrics(params, lastSnapshot);
       return lastSnapshot.result;
     }
 
@@ -190,13 +191,28 @@ export function calculateProvisionedRunnerCountDivergences(params: {
   });
 }
 
-function recordPollDemandMetrics(snapshot: PollDemandSnapshot): void {
+function recordPollDemandMetrics(params: PollDemandParams, snapshot: PollDemandSnapshot): void {
   for (const divergence of snapshot.divergences) {
-    provisionedRunnerCountDivergenceCount.add(divergence.delta, {
-      template_key: divergence.templateKey,
+    logger().info(
+      {
+        workspaceId: params.workspaceId,
+        provisionerId: params.provisionerId,
+        templateKey: divergence.templateKey,
+        state: divergence.state,
+        direction: divergence.direction,
+        delta: divergence.delta,
+      },
+      'provisioned runner count divergence observed',
+    );
+
+    const attributes = {
       state: divergence.state,
       direction: divergence.direction,
-    });
+      ...(config.PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED
+        ? {template_key: divergence.templateKey}
+        : {}),
+    };
+    provisionedRunnerCountDivergenceCount.add(divergence.delta, attributes);
   }
   for (const intent of snapshot.terminateIntents) {
     provisionedRunnerTerminateIntentIssuedCount.add(1, {

--- a/libs/api/runners/src/core/provisioned-runners.ts
+++ b/libs/api/runners/src/core/provisioned-runners.ts
@@ -11,7 +11,14 @@ import type {
   ActiveRunningJobExecution,
   ProvisionedRunnerBoundJobExecution,
 } from '#db/job-executions.js';
-import {provisionedRunnerReportCount, reservationReleasedCount} from '#metrics/instance.js';
+import {
+  provisionedRunnerAbsentTerminatedCount,
+  provisionedRunnerReconcileCallCount,
+  provisionedRunnerReportCount,
+  provisionedRunnerTerminateIntentHonoredCount,
+  provisionedRunnerTerminateIntentIssuedCount,
+  reservationReleasedCount,
+} from '#metrics/instance.js';
 import {config} from '../config.js';
 
 export interface ReportProvisionedRunnersParams {
@@ -32,6 +39,7 @@ export interface ReconcileProvisionedRunnersParams {
 }
 
 export type ReconcileDesiredIntent = 'keep' | 'terminate';
+type ReconcileDesiredIntentReason = 'job-cancelled' | 'terminal-state';
 
 export interface ReconciledBoundJobExecution {
   jobId: string;
@@ -48,6 +56,7 @@ export interface ReconciledProvisionedRunner {
   runnerSessionId: string | null;
   boundJobExecution: ReconciledBoundJobExecution | null;
   desiredIntent: ReconcileDesiredIntent;
+  desiredIntentReason: ReconcileDesiredIntentReason | null;
 }
 
 export interface ReconcileProvisionedRunnersResult {
@@ -80,6 +89,9 @@ export async function reportProvisionedRunners(
   for (const event of params.events) {
     provisionedRunnerReportCount.add(1, {state: event.state});
   }
+  for (const intent of result.terminateIntentsHonored) {
+    provisionedRunnerTerminateIntentHonoredCount.add(1, {reason: intent.reason});
+  }
   if (result.reservationsReleased > 0) reservationReleasedCount.add(result.reservationsReleased);
 
   return result;
@@ -94,13 +106,26 @@ export async function reconcileProvisionedRunners(
   });
 
   if (result.reservationsReleased > 0) reservationReleasedCount.add(result.reservationsReleased);
+  provisionedRunnerReconcileCallCount.add(1);
+  if (result.absentIds.length > 0)
+    provisionedRunnerAbsentTerminatedCount.add(result.absentIds.length);
+
+  const runners = reconcileProvisionedRunnersFromDbResult({
+    observedProvisionedRunnerIds: params.observedProvisionedRunnerIds,
+    observedRows: result.observedRows,
+    boundJobExecutionsByProvisionedRunnerId: result.boundJobExecutionsByProvisionedRunnerId,
+  });
+  for (const runner of runners) {
+    if (runner.desiredIntentReason) {
+      provisionedRunnerTerminateIntentIssuedCount.add(1, {
+        surface: 'reconcile',
+        reason: runner.desiredIntentReason,
+      });
+    }
+  }
 
   return {
-    runners: reconcileProvisionedRunnersFromDbResult({
-      observedProvisionedRunnerIds: params.observedProvisionedRunnerIds,
-      observedRows: result.observedRows,
-      boundJobExecutionsByProvisionedRunnerId: result.boundJobExecutionsByProvisionedRunnerId,
-    }),
+    runners,
     terminatedAbsentProvisionedRunnerIds: result.absentIds,
   };
 }
@@ -119,6 +144,8 @@ export function reconcileProvisionedRunnersFromDbResult(params: {
     const boundJobExecution =
       params.boundJobExecutionsByProvisionedRunnerId.get(provisionedRunnerId);
 
+    const desiredIntentReason = getDesiredIntentReason(row, boundJobExecution);
+
     return {
       provisionedRunnerId,
       state: row?.state ?? null,
@@ -127,7 +154,8 @@ export function reconcileProvisionedRunnersFromDbResult(params: {
       boundJobExecution: boundJobExecution
         ? toReconciledBoundJobExecution(boundJobExecution)
         : null,
-      desiredIntent: desiredIntent(row, boundJobExecution),
+      desiredIntent: desiredIntentReason ? 'terminate' : 'keep',
+      desiredIntentReason,
     };
   });
 }
@@ -163,10 +191,17 @@ export function desiredIntent(
   row: ProvisionedRunner | undefined,
   boundJobExecution: ProvisionedRunnerBoundJobExecution | undefined,
 ): ReconcileDesiredIntent {
-  if (!row) return 'keep';
-  if (isTerminalState(row.state)) return 'terminate';
-  if (boundJobExecution?.cancellationRequestedAt) return 'terminate';
-  return 'keep';
+  return getDesiredIntentReason(row, boundJobExecution) ? 'terminate' : 'keep';
+}
+
+function getDesiredIntentReason(
+  row: ProvisionedRunner | undefined,
+  boundJobExecution: ProvisionedRunnerBoundJobExecution | undefined,
+): ReconcileDesiredIntentReason | null {
+  if (!row) return null;
+  if (isTerminalState(row.state)) return 'terminal-state';
+  if (boundJobExecution?.cancellationRequestedAt) return 'job-cancelled';
+  return null;
 }
 
 function mergeActiveRunners(

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -34,9 +34,9 @@ export {
 export type {
   ActiveProvisionedRunnerTemplateCount,
   ProvisionedRunnerReportEvent,
-  ReapStaleProvisionedRunnersResult,
   ProvisionedRunnerTerminateIntent,
   ProvisionedRunnerTerminateIntentReason,
+  ReapStaleProvisionedRunnersResult,
   ReconcileProvisionedRunnersDbResult,
   ReconcileProvisionedRunnersParams,
   ReportProvisionedRunnersParams,

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -32,15 +32,20 @@ export {
   revokeManualRegistrationToken,
 } from './manual-registration-tokens.js';
 export type {
+  ActiveProvisionedRunnerTemplateCount,
   ProvisionedRunnerReportEvent,
   ReapStaleProvisionedRunnersResult,
+  ProvisionedRunnerTerminateIntent,
+  ProvisionedRunnerTerminateIntentReason,
   ReconcileProvisionedRunnersDbResult,
   ReconcileProvisionedRunnersParams,
   ReportProvisionedRunnersParams,
 } from './provisioned-runners.js';
 export {
   isTerminalState,
+  listActiveProvisionedRunnerCountsByTemplateTx,
   listActiveProvisionedRunners,
+  listProvisionerTerminateIntentRowsTx,
   listProvisionerTerminateIntents,
   reapStaleProvisionedRunners,
   reconcileProvisionedRunners,

--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -3,7 +3,9 @@ import {and, desc, eq, inArray, or, sql} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {createRunnerSessionConsumingEphemeralToken} from '#db/ephemeral-registration-tokens.js';
 import {
+  listActiveProvisionedRunnerCountsByTemplateTx,
   listActiveProvisionedRunners,
+  listProvisionerTerminateIntentRowsTx,
   listProvisionerTerminateIntents,
   reapStaleProvisionedRunners,
   reconcileProvisionedRunners,
@@ -72,7 +74,7 @@ describe('reportProvisionedRunners', () => {
     });
 
     const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(rows).toHaveLength(1);
     expect(rows[0]?.state).toBe('running');
   });
@@ -94,7 +96,7 @@ describe('reportProvisionedRunners', () => {
     const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId}).orderBy(
       provisionedRunners.provisionedRunnerId,
     );
-    expect(result).toEqual({accepted: 2, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 2, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(rows.map((row) => row.state)).toEqual(['failed', 'failed']);
   });
 
@@ -202,8 +204,8 @@ describe('reportProvisionedRunners', () => {
 
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
-    expect(terminal).toEqual({accepted: 1, reservationsReleased: 1});
-    expect(revived).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(terminal).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
+    expect(revived).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(provisionedRunnerRows[0]?.state).toBe('failed');
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
     expect(reservationRows).toHaveLength(0);
@@ -273,7 +275,7 @@ describe('reportProvisionedRunners', () => {
     });
 
     const rows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(rows[0]?.state).toBe('terminated');
     expect(rows[0]?.reportedAt.toISOString()).toBe(terminatedAt.toISOString());
     expect(rows[0]?.startedAt?.toISOString()).toBe(startedAt.toISOString());
@@ -351,7 +353,7 @@ describe('reportProvisionedRunners', () => {
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 1});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
   });
@@ -387,7 +389,7 @@ describe('reportProvisionedRunners', () => {
       .select()
       .from(reservations)
       .where(inArray(reservations.id, [otherWorkspaceReservationId, peerProvisionerReservationId]));
-    expect(result).toEqual({accepted: 2, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 2, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(reservationRows).toHaveLength(2);
     expect(reservationRows.every((reservation) => reservation.count === 1)).toBe(true);
   });
@@ -411,7 +413,7 @@ describe('reportProvisionedRunners', () => {
     });
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
   });
 
@@ -464,7 +466,7 @@ describe('reportProvisionedRunners', () => {
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 1});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.state).toBe('terminated');
     expect(provisionedRunnerRows[0]?.terminatedAt).toBeInstanceOf(Date);
@@ -484,7 +486,7 @@ describe('reportProvisionedRunners', () => {
     });
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 2, reservationsReleased: 2});
+    expect(result).toEqual({accepted: 2, reservationsReleased: 2, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
   });
 
@@ -500,7 +502,7 @@ describe('reportProvisionedRunners', () => {
     });
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 1});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 1, terminateIntentsHonored: []});
     expect(reservationRows).toHaveLength(0);
   });
 
@@ -528,7 +530,7 @@ describe('reportProvisionedRunners', () => {
     });
 
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeInstanceOf(Date);
   });
 
@@ -550,7 +552,7 @@ describe('reportProvisionedRunners', () => {
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeNull();
   });
@@ -585,7 +587,7 @@ describe('reportProvisionedRunners', () => {
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.runnerSessionId).toBe(session.id);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeNull();
@@ -618,11 +620,40 @@ describe('reportProvisionedRunners', () => {
 
     const reservationRows = await reservationRowsFor({workspaceId, provisionerId});
     const provisionedRunnerRows = await provisionedRunnerRowsFor({workspaceId, provisionerId});
-    expect(result).toEqual({accepted: 1, reservationsReleased: 0});
+    expect(result).toEqual({accepted: 1, reservationsReleased: 0, terminateIntentsHonored: []});
     expect(reservationRows[0]?.count).toBe(1);
     expect(provisionedRunnerRows[0]?.state).toBe('failed');
     expect(provisionedRunnerRows[0]?.runnerSessionId).toBe(runnerSessionId);
     expect(provisionedRunnerRows[0]?.reservationReleasedAt).toBeNull();
+  });
+
+  it('returns honored terminate intents only for the first active-to-terminated transition', async () => {
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'provisioned-runner-1',
+      state: 'running',
+    });
+    await insertRunningJob({
+      provisionedRunnerId: 'provisioned-runner-1',
+      cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
+    });
+
+    const first = await reportProvisionedRunners({
+      workspaceId,
+      provisionerId,
+      events: [event({provisionedRunnerId: 'provisioned-runner-1', state: 'terminated'})],
+    });
+    const second = await reportProvisionedRunners({
+      workspaceId,
+      provisionerId,
+      events: [event({provisionedRunnerId: 'provisioned-runner-1', state: 'terminated'})],
+    });
+
+    expect(first.terminateIntentsHonored).toEqual([
+      {provisionedRunnerId: 'provisioned-runner-1', reason: 'job-cancelled'},
+    ]);
+    expect(second.terminateIntentsHonored).toEqual([]);
   });
 
   async function createReservation(
@@ -671,6 +702,90 @@ describe('reportProvisionedRunners', () => {
       reportedAt: params.reportedAt ?? new Date(),
     };
   }
+
+  async function insertRunningJob(params: {
+    provisionedRunnerId: string;
+    cancellationRequestedAt?: Date | null;
+  }) {
+    await db()
+      .insert(runningJobExecutions)
+      .values({
+        workspaceId,
+        workflowRunId: crypto.randomUUID(),
+        workflowRunAttemptId: crypto.randomUUID(),
+        jobId: crypto.randomUUID(),
+        jobExecutionId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        runnerSessionId: crypto.randomUUID(),
+        provisionerId,
+        provisionedRunnerId: params.provisionedRunnerId,
+        requiredLabels: ['linux'],
+        runnerLabels: ['linux'],
+        startedAt: new Date('2025-01-01T00:00:00.000Z'),
+        lastHeartbeatAt: new Date('2025-01-01T00:00:00.000Z'),
+        cancellationRequestedAt: params.cancellationRequestedAt ?? null,
+      });
+  }
+});
+
+describe('listActiveProvisionedRunnerCountsByTemplateTx', () => {
+  let workspaceId: string;
+  let provisionerId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+    provisionerId = crypto.randomUUID();
+  });
+
+  it('groups starting and running provisioned runners by template and ignores non-divergence states', async () => {
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'starting-1',
+      templateKey: 'linux',
+      state: 'starting',
+    });
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'running-1',
+      templateKey: 'linux',
+      state: 'running',
+    });
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'running-2',
+      templateKey: 'linux',
+      state: 'running',
+    });
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'stopping-1',
+      templateKey: 'linux',
+      state: 'stopping',
+    });
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'null-template',
+      templateKey: null,
+      state: 'running',
+    });
+
+    const result = await db().transaction((tx) =>
+      listActiveProvisionedRunnerCountsByTemplateTx(tx, {workspaceId, provisionerId}),
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {templateKey: 'linux', state: 'starting', count: 1},
+        {templateKey: 'linux', state: 'running', count: 2},
+      ]),
+    );
+    expect(result).toHaveLength(2);
+  });
 });
 
 describe('listProvisionerTerminateIntents', () => {
@@ -692,6 +807,22 @@ describe('listProvisionerTerminateIntents', () => {
     const result = await listProvisionerTerminateIntents({workspaceId, provisionerId, limit: 1000});
 
     expect(result).toEqual(['provisioned-runner-1']);
+  });
+
+  it('returns structured rows with bounded reasons from the shared query', async () => {
+    await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
+    await insertRunningJob({
+      provisionedRunnerId: 'provisioned-runner-1',
+      cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
+    });
+
+    const result = await db().transaction((tx) =>
+      listProvisionerTerminateIntentRowsTx(tx, {workspaceId, provisionerId, limit: 1000}),
+    );
+
+    expect(result).toEqual([
+      {provisionedRunnerId: 'provisioned-runner-1', reason: 'job-cancelled'},
+    ]);
   });
 
   it('excludes active provisioned runners whose latest bound job is healthy', async () => {

--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -48,6 +48,36 @@ function reservationRowsFor(params: {workspaceId: string; provisionerId: string}
     );
 }
 
+async function insertRunningJobRow(params: {
+  workspaceId: string;
+  provisionerId: string;
+  provisionedRunnerId: string;
+  jobExecutionId?: string;
+  startedAt?: Date;
+  cancellationRequestedAt?: Date | null;
+}) {
+  const startedAt = params.startedAt ?? new Date('2025-01-01T00:00:00.000Z');
+
+  await db()
+    .insert(runningJobExecutions)
+    .values({
+      workspaceId: params.workspaceId,
+      workflowRunId: crypto.randomUUID(),
+      workflowRunAttemptId: crypto.randomUUID(),
+      jobId: crypto.randomUUID(),
+      jobExecutionId: params.jobExecutionId ?? crypto.randomUUID(),
+      projectId: crypto.randomUUID(),
+      runnerSessionId: crypto.randomUUID(),
+      provisionerId: params.provisionerId,
+      provisionedRunnerId: params.provisionedRunnerId,
+      requiredLabels: ['linux'],
+      runnerLabels: ['linux'],
+      startedAt,
+      lastHeartbeatAt: startedAt,
+      cancellationRequestedAt: params.cancellationRequestedAt ?? null,
+    });
+}
+
 describe('reportProvisionedRunners', () => {
   let workspaceId: string;
   let provisionerId: string;
@@ -634,7 +664,9 @@ describe('reportProvisionedRunners', () => {
       provisionedRunnerId: 'provisioned-runner-1',
       state: 'running',
     });
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
@@ -701,30 +733,6 @@ describe('reportProvisionedRunners', () => {
       providerKind: 'docker',
       reportedAt: params.reportedAt ?? new Date(),
     };
-  }
-
-  async function insertRunningJob(params: {
-    provisionedRunnerId: string;
-    cancellationRequestedAt?: Date | null;
-  }) {
-    await db()
-      .insert(runningJobExecutions)
-      .values({
-        workspaceId,
-        workflowRunId: crypto.randomUUID(),
-        workflowRunAttemptId: crypto.randomUUID(),
-        jobId: crypto.randomUUID(),
-        jobExecutionId: crypto.randomUUID(),
-        projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
-        provisionerId,
-        provisionedRunnerId: params.provisionedRunnerId,
-        requiredLabels: ['linux'],
-        runnerLabels: ['linux'],
-        startedAt: new Date('2025-01-01T00:00:00.000Z'),
-        lastHeartbeatAt: new Date('2025-01-01T00:00:00.000Z'),
-        cancellationRequestedAt: params.cancellationRequestedAt ?? null,
-      });
   }
 });
 
@@ -799,7 +807,9 @@ describe('listProvisionerTerminateIntents', () => {
 
   it('includes active provisioned runners whose latest bound job is cancelled', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
@@ -811,7 +821,9 @@ describe('listProvisionerTerminateIntents', () => {
 
   it('returns structured rows with bounded reasons from the shared query', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
@@ -827,7 +839,11 @@ describe('listProvisionerTerminateIntents', () => {
 
   it('excludes active provisioned runners whose latest bound job is healthy', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
-    await insertRunningJob({provisionedRunnerId: 'provisioned-runner-1'});
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
+      provisionedRunnerId: 'provisioned-runner-1',
+    });
 
     const result = await listProvisionerTerminateIntents({workspaceId, provisionerId, limit: 1000});
 
@@ -839,7 +855,9 @@ describe('listProvisionerTerminateIntents', () => {
       provisionedRunnerId: 'provisioned-runner-1',
       state: 'terminated',
     });
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
@@ -851,12 +869,16 @@ describe('listProvisionerTerminateIntents', () => {
 
   it('excludes a cancelled job when it is not the latest bound job', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:02:00.000Z'),
     });
@@ -872,7 +894,8 @@ describe('listProvisionerTerminateIntents', () => {
       provisionedRunnerId: 'provisioned-runner-1',
       provisionerId: otherProvisionerId,
     });
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
       provisionedRunnerId: 'provisioned-runner-1',
       provisionerId: otherProvisionerId,
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
@@ -885,12 +908,16 @@ describe('listProvisionerTerminateIntents', () => {
 
   it('returns one id for duplicate cancelled bound jobs on the same provisioned runner', async () => {
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
-    await insertRunningJob({
+    await insertRunningJobRow({
+      workspaceId,
+      provisionerId,
       provisionedRunnerId: 'provisioned-runner-1',
       startedAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
@@ -908,7 +935,9 @@ describe('listProvisionerTerminateIntents', () => {
       'provisioned-runner-b',
     ]) {
       await createProvisionedRunner({provisionedRunnerId});
-      await insertRunningJob({
+      await insertRunningJobRow({
+        workspaceId,
+        provisionerId,
         provisionedRunnerId,
         cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
       });
@@ -930,35 +959,6 @@ describe('listProvisionerTerminateIntents', () => {
       provisionedRunnerId: params.provisionedRunnerId,
       state: params.state ?? 'running',
     });
-  }
-
-  async function insertRunningJob(params: {
-    provisionedRunnerId: string;
-    provisionerId?: string;
-    jobExecutionId?: string;
-    startedAt?: Date;
-    cancellationRequestedAt?: Date | null;
-  }) {
-    const startedAt = params.startedAt ?? new Date('2025-01-01T00:00:00.000Z');
-
-    await db()
-      .insert(runningJobExecutions)
-      .values({
-        workspaceId,
-        workflowRunId: crypto.randomUUID(),
-        workflowRunAttemptId: crypto.randomUUID(),
-        jobId: crypto.randomUUID(),
-        jobExecutionId: params.jobExecutionId ?? crypto.randomUUID(),
-        projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
-        provisionerId: params.provisionerId ?? provisionerId,
-        provisionedRunnerId: params.provisionedRunnerId,
-        requiredLabels: ['linux'],
-        runnerLabels: ['linux'],
-        startedAt,
-        lastHeartbeatAt: startedAt,
-        cancellationRequestedAt: params.cancellationRequestedAt ?? null,
-      });
   }
 });
 

--- a/libs/api/runners/src/db/provisioned-runners.ts
+++ b/libs/api/runners/src/db/provisioned-runners.ts
@@ -42,6 +42,23 @@ export const activeStates = [
   'running',
   'stopping',
 ] as const satisfies readonly ProvisionedRunnerState[];
+export const divergenceCountStates = ['starting', 'running'] as const satisfies readonly Extract<
+  ProvisionedRunnerState,
+  'starting' | 'running'
+>[];
+
+export type ProvisionedRunnerTerminateIntentReason = 'job-cancelled';
+
+export interface ProvisionedRunnerTerminateIntent {
+  provisionedRunnerId: string;
+  reason: ProvisionedRunnerTerminateIntentReason;
+}
+
+export interface ActiveProvisionedRunnerTemplateCount {
+  templateKey: string;
+  state: (typeof divergenceCountStates)[number];
+  count: number;
+}
 
 export interface ProvisionedRunnerReportEvent {
   provisionedRunnerId: string;
@@ -98,8 +115,10 @@ type ProvisionedRunnerMilestoneColumn =
 export async function reportProvisionedRunners(params: ReportProvisionedRunnersParams): Promise<{
   accepted: number;
   reservationsReleased: number;
+  terminateIntentsHonored: ProvisionedRunnerTerminateIntent[];
 }> {
-  if (params.events.length === 0) return {accepted: 0, reservationsReleased: 0};
+  if (params.events.length === 0)
+    return {accepted: 0, reservationsReleased: 0, terminateIntentsHonored: []};
 
   return await db().transaction(async (tx) => {
     const receivedAt = new Date();
@@ -111,6 +130,11 @@ export async function reportProvisionedRunners(params: ReportProvisionedRunnersP
     }
 
     const events = await hydrateRunnerSessionIdsFromConsumedTokens(tx, params, aggregatedEvents);
+    const terminateIntentsHonored = await listTerminateIntentsHonoredByTerminatedReportsTx(
+      tx,
+      params,
+      events,
+    );
 
     const values = events.map((event) => ({
       workspaceId: params.workspaceId,
@@ -169,8 +193,36 @@ export async function reportProvisionedRunners(params: ReportProvisionedRunnersP
       ? await releaseTerminalProvisionedRunnerReservations(tx, params, events)
       : 0;
 
-    return {accepted: events.length, reservationsReleased};
+    return {accepted: events.length, reservationsReleased, terminateIntentsHonored};
   });
+}
+
+export async function listActiveProvisionedRunnerCountsByTemplateTx(
+  tx: Tx,
+  params: {workspaceId: string; provisionerId: string},
+): Promise<ActiveProvisionedRunnerTemplateCount[]> {
+  const rows = await tx
+    .select({
+      templateKey: provisionedRunners.templateKey,
+      state: provisionedRunners.state,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(provisionedRunners)
+    .where(
+      and(
+        eq(provisionedRunners.workspaceId, params.workspaceId),
+        eq(provisionedRunners.provisionerId, params.provisionerId),
+        inArray(provisionedRunners.state, divergenceCountStates),
+        isNotNull(provisionedRunners.templateKey),
+      ),
+    )
+    .groupBy(provisionedRunners.templateKey, provisionedRunners.state);
+
+  return rows.flatMap((row) =>
+    row.templateKey && isDivergenceCountState(row.state)
+      ? [{templateKey: row.templateKey, state: row.state, count: row.count}]
+      : [],
+  );
 }
 
 export async function listActiveProvisionedRunners(params: {
@@ -199,7 +251,10 @@ export async function listProvisionerTerminateIntents(params: {
   provisionerId: string;
   limit: number;
 }): Promise<string[]> {
-  return await db().transaction(async (tx) => listProvisionerTerminateIntentsTx(tx, params));
+  return await db().transaction(async (tx) => {
+    const rows = await listProvisionerTerminateIntentRowsTx(tx, params);
+    return rows.map((row) => row.provisionedRunnerId);
+  });
 }
 
 export async function listProvisionerTerminateIntentsTx(
@@ -210,6 +265,18 @@ export async function listProvisionerTerminateIntentsTx(
     limit: number;
   },
 ): Promise<string[]> {
+  const rows = await listProvisionerTerminateIntentRowsTx(tx, params);
+  return rows.map((row) => row.provisionedRunnerId);
+}
+
+export async function listProvisionerTerminateIntentRowsTx(
+  tx: Tx,
+  params: {
+    workspaceId: string;
+    provisionerId: string;
+    limit: number;
+  },
+): Promise<ProvisionedRunnerTerminateIntent[]> {
   const rows = await provisionerTerminateIntentsQuery(tx, params)
     .orderBy(asc(provisionedRunners.provisionedRunnerId))
     .limit(params.limit + 1);
@@ -228,17 +295,20 @@ export async function listProvisionerTerminateIntentsTx(
     );
   }
 
-  return returnedRows.map((row) => row.provisionedRunnerId);
+  return returnedRows;
 }
 
 function provisionerTerminateIntentsQuery(
   tx: Tx,
-  params: {workspaceId: string; provisionerId: string},
+  params: {workspaceId: string; provisionerId: string; provisionedRunnerIds?: string[]},
 ) {
   const newerRunningJobExecutions = alias(runningJobExecutions, 'newer_running_jobs');
 
   return tx
-    .select({provisionedRunnerId: provisionedRunners.provisionedRunnerId})
+    .select({
+      provisionedRunnerId: provisionedRunners.provisionedRunnerId,
+      reason: sql<ProvisionedRunnerTerminateIntentReason>`'job-cancelled'`,
+    })
     .from(runningJobExecutions)
     .innerJoin(
       provisionedRunners,
@@ -254,6 +324,9 @@ function provisionerTerminateIntentsQuery(
         eq(runningJobExecutions.provisionerId, params.provisionerId),
         isNotNull(runningJobExecutions.cancellationRequestedAt),
         inArray(provisionedRunners.state, activeStates),
+        params.provisionedRunnerIds && params.provisionedRunnerIds.length > 0
+          ? inArray(provisionedRunners.provisionedRunnerId, params.provisionedRunnerIds)
+          : undefined,
         notExists(
           tx
             .select({id: newerRunningJobExecutions.id})
@@ -282,6 +355,27 @@ function provisionerTerminateIntentsQuery(
       ),
     )
     .groupBy(provisionedRunners.provisionedRunnerId);
+}
+
+async function listTerminateIntentsHonoredByTerminatedReportsTx(
+  tx: Tx,
+  params: ReportProvisionedRunnersParams,
+  events: ProvisionedRunnerReportEvent[],
+): Promise<ProvisionedRunnerTerminateIntent[]> {
+  const terminatedProvisionedRunnerIds = [
+    ...new Set(
+      events
+        .filter((event) => event.state === 'terminated')
+        .map((event) => event.provisionedRunnerId),
+    ),
+  ];
+  if (terminatedProvisionedRunnerIds.length === 0) return [];
+
+  return await provisionerTerminateIntentsQuery(tx, {
+    workspaceId: params.workspaceId,
+    provisionerId: params.provisionerId,
+    provisionedRunnerIds: terminatedProvisionedRunnerIds,
+  }).orderBy(asc(provisionedRunners.provisionedRunnerId));
 }
 
 export async function reconcileProvisionedRunners(
@@ -795,4 +889,10 @@ function firstObservedAt(current: SQL | ProvisionedRunnerMilestoneColumn, incomi
 
 export function isTerminalState(state: ProvisionedRunnerState): boolean {
   return terminalStates.includes(state as (typeof terminalStates)[number]);
+}
+
+function isDivergenceCountState(
+  state: ProvisionedRunnerState,
+): state is (typeof divergenceCountStates)[number] {
+  return divergenceCountStates.includes(state as (typeof divergenceCountStates)[number]);
 }

--- a/libs/api/runners/src/db/provisioned-runners.ts
+++ b/libs/api/runners/src/db/provisioned-runners.ts
@@ -257,18 +257,6 @@ export async function listProvisionerTerminateIntents(params: {
   });
 }
 
-export async function listProvisionerTerminateIntentsTx(
-  tx: Tx,
-  params: {
-    workspaceId: string;
-    provisionerId: string;
-    limit: number;
-  },
-): Promise<string[]> {
-  const rows = await listProvisionerTerminateIntentRowsTx(tx, params);
-  return rows.map((row) => row.provisionedRunnerId);
-}
-
 export async function listProvisionerTerminateIntentRowsTx(
   tx: Tx,
   params: {

--- a/libs/api/runners/src/db/schema/provisioned-runners.ts
+++ b/libs/api/runners/src/db/schema/provisioned-runners.ts
@@ -1,4 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {sql} from 'drizzle-orm';
 import {index, pgEnum, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {ProvisionedRunner} from '#core/entities/provisioned-runner.js';
 import {pgTable} from './common.js';
@@ -53,6 +54,9 @@ export const provisionedRunners = pgTable(
       table.reportedAt,
       table.workspaceId,
     ),
+    index('runners_provisioned_runners_active_template_counts_idx')
+      .on(table.workspaceId, table.provisionerId, table.state, table.templateKey)
+      .where(sql`"state" in ('starting', 'running') and "template_key" is not null`),
     index('runners_provisioned_runners_reservation_id_idx').on(table.reservationId),
   ],
 );

--- a/libs/api/runners/src/metrics/index.ts
+++ b/libs/api/runners/src/metrics/index.ts
@@ -2,5 +2,10 @@ export {
   jobExecutionClaimedCount,
   jobExecutionEnqueuedCount,
   jobExecutionLeaseExpiredCount,
+  provisionedRunnerAbsentTerminatedCount,
+  provisionedRunnerCountDivergenceCount,
+  provisionedRunnerReconcileCallCount,
+  provisionedRunnerTerminateIntentHonoredCount,
+  provisionedRunnerTerminateIntentIssuedCount,
 } from './instance.js';
 export {registerRunnersServiceMetrics} from './service.js';

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -32,6 +32,41 @@ export const provisionedRunnerReapedCount = meter.createCounter<Record<string, n
   },
 );
 
+export const provisionedRunnerCountDivergenceCount = meter.createCounter<{
+  template_key: string;
+  state: 'starting' | 'running';
+  direction: 'backend-higher' | 'advertised-higher';
+}>('runners_provisioned_runner_count_divergence', {
+  description:
+    'Absolute difference between provisioner-advertised and backend-observed provisioned runner counts',
+});
+
+export const provisionedRunnerReconcileCallCount = meter.createCounter<Record<string, never>>(
+  'runners_provisioned_runner_reconcile_called',
+  {description: 'Provisioned runner reconcile calls completed successfully'},
+);
+
+export const provisionedRunnerAbsentTerminatedCount = meter.createCounter<Record<string, never>>(
+  'runners_provisioned_runner_absent_terminated',
+  {
+    description:
+      'Owned provisioned runners marked terminated because they were absent from reconcile',
+  },
+);
+
+export const provisionedRunnerTerminateIntentIssuedCount = meter.createCounter<{
+  surface: 'poll-demand' | 'reconcile';
+  reason: 'job-cancelled' | 'terminal-state';
+}>('runners_provisioned_runner_terminate_intent_issued', {
+  description: 'Provisioned runner terminate intents returned to provisioners',
+});
+
+export const provisionedRunnerTerminateIntentHonoredCount = meter.createCounter<{
+  reason: 'job-cancelled';
+}>('runners_provisioned_runner_terminate_intent_honored', {
+  description: 'Provisioned runner terminate intents honored by first transition to terminated',
+});
+
 export const reservationReleasedCount = meter.createCounter<Record<string, never>>(
   'runners_reservation_released',
   {description: 'Reservation units released from terminal provisioned runner reports'},

--- a/libs/api/runners/src/metrics/instance.ts
+++ b/libs/api/runners/src/metrics/instance.ts
@@ -33,7 +33,7 @@ export const provisionedRunnerReapedCount = meter.createCounter<Record<string, n
 );
 
 export const provisionedRunnerCountDivergenceCount = meter.createCounter<{
-  template_key: string;
+  template_key?: string;
   state: 'starting' | 'running';
   direction: 'backend-higher' | 'advertised-higher';
 }>('runners_provisioned_runner_count_divergence', {

--- a/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand-release.test.ts
@@ -12,12 +12,12 @@ const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
 describe('POST /provisioners/demand/poll reservation cleanup', () => {
   it('rolls back granted reservations if loading terminate intents throws', async () => {
     vi.resetModules();
-    const listProvisionerTerminateIntentsTx = vi
+    const listProvisionerTerminateIntentRowsTx = vi
       .fn()
       .mockRejectedValueOnce(new Error('db unavailable'));
     vi.doMock('#db/provisioned-runners.js', async (importOriginal) => ({
       ...(await importOriginal<typeof import('#db/provisioned-runners.js')>()),
-      listProvisionerTerminateIntentsTx,
+      listProvisionerTerminateIntentRowsTx,
     }));
     const {pollDemandRoute} = await import('./poll-demand.js');
     const workspaceId = crypto.randomUUID();

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -13,9 +13,14 @@ import {
   createApp,
   extractBearerToken,
 } from '@shipfox/node-fastify';
+import {vi} from '@shipfox/vitest/vi';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
+import {
+  provisionedRunnerCountDivergenceCount,
+  provisionedRunnerTerminateIntentIssuedCount,
+} from '#metrics/instance.js';
 import {pendingJobFactory, provisionedRunnerFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
@@ -94,7 +99,19 @@ describe('POST /provisioners/demand/poll', () => {
       method: 'POST',
       url: '/provisioners/demand/poll',
       headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
-      payload: body({max_reservations: 0}),
+      payload: {
+        wait_seconds: 0,
+        max_reservations: 0,
+        templates: [
+          {
+            template_key: 'linux',
+            labels: ['linux'],
+            available_slots: 1,
+            starting: 0,
+            running: 1,
+          },
+        ],
+      },
     });
 
     expect(res.statusCode).toBe(200);
@@ -121,13 +138,82 @@ describe('POST /provisioners/demand/poll', () => {
       method: 'POST',
       url: '/provisioners/demand/poll',
       headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
-      payload: body({max_reservations: 0}),
+      payload: {
+        wait_seconds: 0,
+        max_reservations: 0,
+        templates: [
+          {
+            template_key: 'linux',
+            labels: ['linux'],
+            available_slots: 1,
+            starting: 0,
+            running: 1,
+          },
+        ],
+      },
     });
 
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({
       reservations: [],
       terminate_provisioned_runner_ids: ['provisioned-runner-1'],
+    });
+  });
+
+  it('records count divergence and terminate-intent metrics for the returned poll result', async () => {
+    const divergenceSpy = vi.spyOn(provisionedRunnerCountDivergenceCount, 'add');
+    const intentSpy = vi.spyOn(provisionedRunnerTerminateIntentIssuedCount, 'add');
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisionerTokenId,
+      provisionedRunnerId: 'provisioned-runner-1',
+      templateKey: 'linux',
+      state: 'running',
+    });
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisionerTokenId,
+      provisionedRunnerId: 'provisioned-runner-2',
+      templateKey: 'linux',
+      state: 'running',
+    });
+    await insertRunningJob({
+      provisionedRunnerId: 'provisioned-runner-1',
+      cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/demand/poll',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        wait_seconds: 0,
+        max_reservations: 0,
+        templates: [
+          {
+            template_key: 'linux',
+            labels: ['linux'],
+            available_slots: 1,
+            starting: 0,
+            running: 1,
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      reservations: [],
+      terminate_provisioned_runner_ids: ['provisioned-runner-1'],
+    });
+    expect(divergenceSpy).toHaveBeenCalledWith(1, {
+      template_key: 'linux',
+      state: 'running',
+      direction: 'backend-higher',
+    });
+    expect(intentSpy).toHaveBeenCalledWith(1, {
+      surface: 'poll-demand',
+      reason: 'job-cancelled',
     });
   });
 

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -181,6 +181,8 @@ describe('POST /provisioners/demand/poll', () => {
       provisionedRunnerId: 'provisioned-runner-1',
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
+    const divergenceCallsBefore = divergenceSpy.mock.calls.length;
+    const intentCallsBefore = intentSpy.mock.calls.length;
 
     const res = await app.inject({
       method: 'POST',
@@ -206,14 +208,24 @@ describe('POST /provisioners/demand/poll', () => {
       reservations: [],
       terminate_provisioned_runner_ids: ['provisioned-runner-1'],
     });
-    expect(divergenceSpy).toHaveBeenCalledWith(1, {
-      state: 'running',
-      direction: 'backend-higher',
-    });
-    expect(intentSpy).toHaveBeenCalledWith(1, {
-      surface: 'poll-demand',
-      reason: 'job-cancelled',
-    });
+    const divergenceCalls = divergenceSpy.mock.calls
+      .slice(divergenceCallsBefore)
+      .filter(
+        ([value, attributes]) =>
+          value === 1 &&
+          JSON.stringify(attributes) ===
+            JSON.stringify({state: 'running', direction: 'backend-higher'}),
+      );
+    const intentCalls = intentSpy.mock.calls
+      .slice(intentCallsBefore)
+      .filter(
+        ([value, attributes]) =>
+          value === 1 &&
+          JSON.stringify(attributes) ===
+            JSON.stringify({surface: 'poll-demand', reason: 'job-cancelled'}),
+      );
+    expect(divergenceCalls).toHaveLength(1);
+    expect(intentCalls).toHaveLength(1);
   });
 
   it('returns 400 for max reservations above the request bound', async () => {

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -207,7 +207,6 @@ describe('POST /provisioners/demand/poll', () => {
       terminate_provisioned_runner_ids: ['provisioned-runner-1'],
     });
     expect(divergenceSpy).toHaveBeenCalledWith(1, {
-      template_key: 'linux',
       state: 'running',
       direction: 'backend-higher',
     });

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -165,6 +165,7 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
       lastHeartbeatAt: new Date('2025-01-01T00:00:00.000Z'),
       cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
     });
+    const intentCallsBefore = intentSpy.mock.calls.length;
 
     const res = await app.inject({
       method: 'POST',
@@ -180,7 +181,15 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
         cancellation_requested_at: '2025-01-01T00:01:00.000Z',
       },
     });
-    expect(intentSpy).toHaveBeenCalledWith(1, {surface: 'reconcile', reason: 'job-cancelled'});
+    const intentCalls = intentSpy.mock.calls
+      .slice(intentCallsBefore)
+      .filter(
+        ([value, attributes]) =>
+          value === 1 &&
+          JSON.stringify(attributes) ===
+            JSON.stringify({surface: 'reconcile', reason: 'job-cancelled'}),
+      );
+    expect(intentCalls).toHaveLength(1);
   });
 
   it('increments the reservation release metric when reconcile reaps an absent runner', async () => {
@@ -193,6 +202,9 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
       reservationId,
       reportedAt: new Date(Date.now() - 300_000),
     });
+    const reconcileCallsBefore = reconcileSpy.mock.calls.length;
+    const absentCallsBefore = absentSpy.mock.calls.length;
+    const addCallsBefore = addSpy.mock.calls.length;
 
     const res = await app.inject({
       method: 'POST',
@@ -203,9 +215,21 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().terminated_absent_provisioned_runner_ids).toEqual(['provisioned-runner-1']);
-    expect(reconcileSpy).toHaveBeenCalledWith(1);
-    expect(absentSpy).toHaveBeenCalledWith(1);
-    expect(addSpy).toHaveBeenCalledWith(1);
+    expect(
+      reconcileSpy.mock.calls
+        .slice(reconcileCallsBefore)
+        .filter(([value, attributes]) => value === 1 && attributes === undefined),
+    ).toHaveLength(3);
+    expect(
+      absentSpy.mock.calls
+        .slice(absentCallsBefore)
+        .filter(([value, attributes]) => value === 1 && attributes === undefined),
+    ).toHaveLength(3);
+    expect(
+      addSpy.mock.calls
+        .slice(addCallsBefore)
+        .filter(([value, attributes]) => value === 1 && attributes === undefined),
+    ).toHaveLength(3);
   });
 
   it('returns 401 without valid provisioner auth', async () => {

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -19,7 +19,12 @@ import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {reservations} from '#db/schema/reservations.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
-import {reservationReleasedCount} from '#metrics/instance.js';
+import {
+  provisionedRunnerAbsentTerminatedCount,
+  provisionedRunnerReconcileCallCount,
+  provisionedRunnerTerminateIntentIssuedCount,
+  reservationReleasedCount,
+} from '#metrics/instance.js';
 import {provisionedRunnerFactory, reservationFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
@@ -150,6 +155,7 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
   });
 
   it('returns terminate for an active runner with a cancelled bound job', async () => {
+    const intentSpy = vi.spyOn(provisionedRunnerTerminateIntentIssuedCount, 'add');
     await createProvisionedRunner({provisionedRunnerId: 'provisioned-runner-1'});
     await insertRunningJob({
       jobId: crypto.randomUUID(),
@@ -174,9 +180,12 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
         cancellation_requested_at: '2025-01-01T00:01:00.000Z',
       },
     });
+    expect(intentSpy).toHaveBeenCalledWith(1, {surface: 'reconcile', reason: 'job-cancelled'});
   });
 
   it('increments the reservation release metric when reconcile reaps an absent runner', async () => {
+    const reconcileSpy = vi.spyOn(provisionedRunnerReconcileCallCount, 'add');
+    const absentSpy = vi.spyOn(provisionedRunnerAbsentTerminatedCount, 'add');
     const addSpy = vi.spyOn(reservationReleasedCount, 'add');
     const reservationId = await createReservation(2);
     await createProvisionedRunner({
@@ -194,6 +203,8 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().terminated_absent_provisioned_runner_ids).toEqual(['provisioned-runner-1']);
+    expect(reconcileSpy).toHaveBeenCalledWith(1);
+    expect(absentSpy).toHaveBeenCalledWith(1);
     expect(addSpy).toHaveBeenCalledWith(1);
   });
 

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -196,10 +196,19 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
     const reconcileSpy = vi.spyOn(provisionedRunnerReconcileCallCount, 'add');
     const absentSpy = vi.spyOn(provisionedRunnerAbsentTerminatedCount, 'add');
     const addSpy = vi.spyOn(reservationReleasedCount, 'add');
-    const reservationId = await createReservation(2);
+    const reservationId = await createReservation(3);
     await createProvisionedRunner({
       provisionedRunnerId: 'provisioned-runner-1',
       reservationId,
+      reportedAt: new Date(Date.now() - 300_000),
+    });
+    await createProvisionedRunner({
+      provisionedRunnerId: 'provisioned-runner-2',
+      reservationId,
+      reportedAt: new Date(Date.now() - 300_000),
+    });
+    await createProvisionedRunner({
+      provisionedRunnerId: 'provisioned-runner-3',
       reportedAt: new Date(Date.now() - 300_000),
     });
     const reconcileCallsBefore = reconcileSpy.mock.calls.length;
@@ -214,22 +223,26 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().terminated_absent_provisioned_runner_ids).toEqual(['provisioned-runner-1']);
+    expect(res.json().terminated_absent_provisioned_runner_ids).toEqual([
+      'provisioned-runner-1',
+      'provisioned-runner-2',
+      'provisioned-runner-3',
+    ]);
     expect(
       reconcileSpy.mock.calls
         .slice(reconcileCallsBefore)
         .filter(([value, attributes]) => value === 1 && attributes === undefined),
-    ).toHaveLength(3);
+    ).toHaveLength(1);
     expect(
       absentSpy.mock.calls
         .slice(absentCallsBefore)
-        .filter(([value, attributes]) => value === 1 && attributes === undefined),
-    ).toHaveLength(3);
+        .filter(([value, attributes]) => value === 3 && attributes === undefined),
+    ).toHaveLength(1);
     expect(
       addSpy.mock.calls
         .slice(addCallsBefore)
-        .filter(([value, attributes]) => value === 1 && attributes === undefined),
-    ).toHaveLength(3);
+        .filter(([value, attributes]) => value === 2 && attributes === undefined),
+    ).toHaveLength(1);
   });
 
   it('returns 401 without valid provisioner auth', async () => {

--- a/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
@@ -13,10 +13,14 @@ import {
   createApp,
   extractBearerToken,
 } from '@shipfox/node-fastify';
+import {vi} from '@shipfox/vitest/vi';
 import {and, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
+import {runningJobExecutions} from '#db/schema/running-job-executions.js';
+import {provisionedRunnerTerminateIntentHonoredCount} from '#metrics/instance.js';
+import {provisionedRunnerFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
@@ -130,6 +134,69 @@ describe('POST /provisioners/provisioned-runners/report', () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  it('increments the honored terminate-intent metric once for a terminated report', async () => {
+    const honoredSpy = vi.spyOn(provisionedRunnerTerminateIntentHonoredCount, 'add');
+    await provisionedRunnerFactory.create({
+      workspaceId,
+      provisionerId: provisionerTokenId,
+      provisionedRunnerId: 'provisioned-runner-1',
+      state: 'running',
+    });
+    await db()
+      .insert(runningJobExecutions)
+      .values({
+        workspaceId,
+        workflowRunId: crypto.randomUUID(),
+        workflowRunAttemptId: crypto.randomUUID(),
+        jobId: crypto.randomUUID(),
+        jobExecutionId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        runnerSessionId: crypto.randomUUID(),
+        provisionerId: provisionerTokenId,
+        provisionedRunnerId: 'provisioned-runner-1',
+        requiredLabels: ['linux'],
+        runnerLabels: ['linux'],
+        startedAt: new Date('2025-01-01T00:00:00.000Z'),
+        lastHeartbeatAt: new Date('2025-01-01T00:00:00.000Z'),
+        cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
+      });
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/provisioners/provisioned-runners/report',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        events: [
+          {
+            provisioned_runner_id: 'provisioned-runner-1',
+            labels: ['linux'],
+            state: 'terminated',
+            reported_at: new Date().toISOString(),
+          },
+        ],
+      },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/provisioners/provisioned-runners/report',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {
+        events: [
+          {
+            provisioned_runner_id: 'provisioned-runner-1',
+            labels: ['linux'],
+            state: 'terminated',
+            reported_at: new Date().toISOString(),
+          },
+        ],
+      },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(honoredSpy).toHaveBeenCalledWith(1, {reason: 'job-cancelled'});
   });
 
   it('returns 400 for provider-sensitive extra fields', async () => {

--- a/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
@@ -162,6 +162,7 @@ describe('POST /provisioners/provisioned-runners/report', () => {
         lastHeartbeatAt: new Date('2025-01-01T00:00:00.000Z'),
         cancellationRequestedAt: new Date('2025-01-01T00:01:00.000Z'),
       });
+    const honoredCallsBefore = honoredSpy.mock.calls.length;
 
     const first = await app.inject({
       method: 'POST',
@@ -196,7 +197,13 @@ describe('POST /provisioners/provisioned-runners/report', () => {
 
     expect(first.statusCode).toBe(200);
     expect(second.statusCode).toBe(200);
-    expect(honoredSpy).toHaveBeenCalledWith(1, {reason: 'job-cancelled'});
+    const honoredCalls = honoredSpy.mock.calls
+      .slice(honoredCallsBefore)
+      .filter(
+        ([value, attributes]) =>
+          value === 1 && JSON.stringify(attributes) === JSON.stringify({reason: 'job-cancelled'}),
+      );
+    expect(honoredCalls).toHaveLength(1);
   });
 
   it('returns 400 for provider-sensitive extra fields', async () => {


### PR DESCRIPTION
Adds backend observability for provisioner reconciliation without changing runner HTTP DTOs or adding endpoints.

Provisioners can now surface aggregate demand divergence through bounded template/state/direction metrics, and reconcile/report/poll-demand paths record terminate-intent issuance, honoring, absent-runner termination, and reconcile calls. This makes reconciliation drift and intent follow-through visible while keeping the provisioner contract stable.

The divergence query is backed by a partial active provisioned-runner index scoped to workspace/provisioner/state/template lookup, and the folded Drizzle migration metadata is updated to match the repo's pre-deploy migration convention.

Reviewers should look closely at the poll-demand long-poll behavior: divergence is calculated and emitted only for the final returned poll result, after abort handling, so retries do not inflate metrics.

Closes ENG-658

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reconciliation observability to surface drift between provisioner‑advertised and backend counts, and to track terminate‑intent issuance/honoring, reconcile calls, and absent‑runner terminations without changing runner HTTP DTOs. Fulfills ENG-658 by making drift and intent follow‑through visible.

- New Features
  - Metrics: added `runners_provisioned_runner_count_divergence`, `runners_provisioned_runner_terminate_intent_issued`, `runners_provisioned_runner_terminate_intent_honored`, `runners_provisioned_runner_reconcile_called`, `runners_provisioned_runner_absent_terminated`. Divergence uses {state, direction} and optional {template_key} gated by `PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED` (default false).
  - Demand polling: computes divergence only for the final returned long‑poll result; collects terminate‑intent rows with bounded reasons while the response still returns IDs only.
  - DB/query: adds `listActiveProvisionedRunnerCountsByTemplateTx`, `listProvisionerTerminateIntentRowsTx`, and partial index `runners_provisioned_runners_active_template_counts_idx` for active template counts.

- Refactors
  - Lowered per‑divergence logs to debug; tightened observability tests (deduped metric assertions, shared running‑job helper, explicit no‑attribute reconcile counter checks); removed unused `listProvisionerTerminateIntentsTx` wrapper.

<sup>Written for commit efb9afa0c9656f22037c72692b4bf8b2399d3d70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

