### PR TITLE
[api/workspaces] Instrument workspace metrics

### DIFF
--- a/libs/api/workspaces/package.json
+++ b/libs/api/workspaces/package.json
@@ -45,6 +45,7 @@
     "@shipfox/node-email": "workspace:*",
     "@shipfox/node-mailer": "workspace:*",
     "@shipfox/node-module": "workspace:*",
+    "@shipfox/node-opentelemetry": "workspace:*",
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-tokens": "workspace:*",

--- a/libs/api/workspaces/src/db/index.ts
+++ b/libs/api/workspaces/src/db/index.ts
@@ -28,7 +28,16 @@ export {
   removeMembership,
 } from './memberships.js';
 export {workspacesOutbox} from './schema/outbox.js';
-export type {CreateWorkspaceParams, UpdateWorkspaceParams} from './workspaces.js';
-export {createWorkspace, getWorkspaceById, updateWorkspace} from './workspaces.js';
+export type {
+  CreateWorkspaceParams,
+  UpdateWorkspaceParams,
+  WorkspaceServiceMetrics,
+} from './workspaces.js';
+export {
+  createWorkspace,
+  getWorkspaceById,
+  getWorkspaceServiceMetrics,
+  updateWorkspace,
+} from './workspaces.js';
 
 export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/workspaces/src/db/invitations.ts
+++ b/libs/api/workspaces/src/db/invitations.ts
@@ -7,6 +7,11 @@ import {and, eq, gt, isNull, lt, sql} from 'drizzle-orm';
 import type {Invitation} from '#core/entities/invitation.js';
 import type {Membership} from '#core/entities/membership.js';
 import {OpenInvitationExistsError} from '#core/errors.js';
+import {
+  recordWorkspaceInvitationAccepted,
+  recordWorkspaceInvitationCreated,
+  recordWorkspaceMembershipChanged,
+} from '#metrics/instance.js';
 import {db} from './db.js';
 import {invitations, toInvitation} from './schema/invitations.js';
 import {memberships, toMembership} from './schema/memberships.js';
@@ -35,7 +40,7 @@ export type CreateInvitationParams = CreateInvitationBaseParams &
   );
 
 export async function createInvitation(params: CreateInvitationParams): Promise<Invitation> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     await tx
       .delete(invitations)
       .where(
@@ -86,8 +91,14 @@ export async function createInvitation(params: CreateInvitationParams): Promise<
         },
       });
     }
-    return toInvitation(row);
+    return {
+      invitation: toInvitation(row),
+      emailRequested: params.sendEmail ? ('requested' as const) : ('skipped' as const),
+    };
   });
+
+  recordWorkspaceInvitationCreated(result.emailRequested);
+  return result.invitation;
 }
 
 export async function findInvitationByToken(params: {
@@ -148,7 +159,7 @@ export interface AcceptInvitationResult {
 export async function acceptInvitation(
   params: AcceptInvitationParams,
 ): Promise<AcceptInvitationResult | undefined> {
-  return await db().transaction(async (tx) => {
+  const result = await db().transaction(async (tx) => {
     const inv = await tx
       .select()
       .from(invitations)
@@ -212,4 +223,10 @@ export async function acceptInvitation(
 
     return {invitation: toInvitation(updatedRow), membership, alreadyMember};
   });
+
+  if (result && !result.alreadyMember) recordWorkspaceMembershipChanged('added');
+  if (result) {
+    recordWorkspaceInvitationAccepted(result.alreadyMember ? 'already_member' : 'added');
+  }
+  return result;
 }

--- a/libs/api/workspaces/src/db/memberships.ts
+++ b/libs/api/workspaces/src/db/memberships.ts
@@ -1,6 +1,7 @@
 import {and, eq, sql} from 'drizzle-orm';
 import type {Membership} from '#core/entities/membership.js';
 import {LastMemberError} from '#core/errors.js';
+import {recordWorkspaceMembershipChanged} from '#metrics/instance.js';
 import {db} from './db.js';
 import {memberships, toMembership} from './schema/memberships.js';
 import {workspaces} from './schema/workspaces.js';
@@ -25,6 +26,7 @@ export async function createMembership(params: CreateMembershipParams): Promise<
 
   const row = rows[0];
   if (!row) throw new Error('Insert returned no rows');
+  recordWorkspaceMembershipChanged('added');
   return toMembership(row);
 }
 
@@ -87,7 +89,7 @@ export interface RemoveMembershipParams {
 }
 
 export async function removeMembership(params: RemoveMembershipParams): Promise<void> {
-  await db().transaction(async (tx) => {
+  const removed = await db().transaction(async (tx) => {
     const countResult = await tx
       .select({count: sql<number>`count(*)::int`})
       .from(memberships)
@@ -97,10 +99,15 @@ export async function removeMembership(params: RemoveMembershipParams): Promise<
       throw new LastMemberError(params.workspaceId);
     }
 
-    await tx
+    const deleted = await tx
       .delete(memberships)
       .where(
         and(eq(memberships.userId, params.userId), eq(memberships.workspaceId, params.workspaceId)),
-      );
+      )
+      .returning({id: memberships.id});
+
+    return deleted.length > 0;
   });
+
+  if (removed) recordWorkspaceMembershipChanged('removed');
 }

--- a/libs/api/workspaces/src/db/workspaces.test.ts
+++ b/libs/api/workspaces/src/db/workspaces.test.ts
@@ -71,10 +71,6 @@ describe('workspace queries', () => {
       const activeWorkspace = await createWorkspace({
         name: `Metrics Active ${crypto.randomUUID()}`,
       });
-      const suspendedWorkspace = await createWorkspace({
-        name: `Metrics Suspended ${crypto.randomUUID()}`,
-      });
-      await updateWorkspace({id: suspendedWorkspace.id, status: 'suspended'});
       await createMembership({
         userId: crypto.randomUUID(),
         workspaceId: activeWorkspace.id,

--- a/libs/api/workspaces/src/db/workspaces.test.ts
+++ b/libs/api/workspaces/src/db/workspaces.test.ts
@@ -1,4 +1,11 @@
-import {createWorkspace, getWorkspaceById, updateWorkspace} from './workspaces.js';
+import {acceptInvitation, createInvitation} from './invitations.js';
+import {createMembership} from './memberships.js';
+import {
+  createWorkspace,
+  getWorkspaceById,
+  getWorkspaceServiceMetrics,
+  updateWorkspace,
+} from './workspaces.js';
 
 describe('workspace queries', () => {
   describe('createWorkspace', () => {
@@ -55,6 +62,58 @@ describe('workspace queries', () => {
       const result = await updateWorkspace({id: crypto.randomUUID(), name: 'Ghost'});
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getWorkspaceServiceMetrics', () => {
+    test('counts current workspace service state', async () => {
+      const baseline = await getWorkspaceServiceMetrics();
+      const activeWorkspace = await createWorkspace({
+        name: `Metrics Active ${crypto.randomUUID()}`,
+      });
+      const suspendedWorkspace = await createWorkspace({
+        name: `Metrics Suspended ${crypto.randomUUID()}`,
+      });
+      await updateWorkspace({id: suspendedWorkspace.id, status: 'suspended'});
+      await createMembership({
+        userId: crypto.randomUUID(),
+        workspaceId: activeWorkspace.id,
+      });
+      const openInvitation = await createInvitation({
+        workspaceId: activeWorkspace.id,
+        email: `open-${crypto.randomUUID()}@example.com`,
+        hashedToken: `open-${crypto.randomUUID()}`,
+        expiresAt: new Date(Date.now() + 60_000),
+        invitedByUserId: crypto.randomUUID(),
+        skipEmail: true,
+      });
+      const acceptedInvitation = await createInvitation({
+        workspaceId: activeWorkspace.id,
+        email: `accepted-${crypto.randomUUID()}@example.com`,
+        hashedToken: `accepted-${crypto.randomUUID()}`,
+        expiresAt: new Date(Date.now() + 60_000),
+        invitedByUserId: crypto.randomUUID(),
+        skipEmail: true,
+      });
+      await createInvitation({
+        workspaceId: activeWorkspace.id,
+        email: `expired-${crypto.randomUUID()}@example.com`,
+        hashedToken: `expired-${crypto.randomUUID()}`,
+        expiresAt: new Date(Date.now() - 60_000),
+        invitedByUserId: crypto.randomUUID(),
+        skipEmail: true,
+      });
+      await acceptInvitation({
+        invitationId: acceptedInvitation.id,
+        acceptedByUserId: crypto.randomUUID(),
+      });
+
+      const metrics = await getWorkspaceServiceMetrics();
+
+      expect(openInvitation.acceptedAt).toBeNull();
+      expect(metrics.activeWorkspaces).toBeGreaterThanOrEqual(baseline.activeWorkspaces + 1);
+      expect(metrics.memberships).toBeGreaterThanOrEqual(baseline.memberships + 2);
+      expect(metrics.openInvitations).toBeGreaterThanOrEqual(baseline.openInvitations + 1);
     });
   });
 });

--- a/libs/api/workspaces/src/db/workspaces.ts
+++ b/libs/api/workspaces/src/db/workspaces.ts
@@ -1,6 +1,9 @@
-import {eq, sql} from 'drizzle-orm';
+import {and, count, eq, gt, isNull, sql} from 'drizzle-orm';
 import type {Workspace, WorkspaceStatus} from '#core/entities/workspace.js';
+import {recordWorkspaceCreated} from '#metrics/instance.js';
 import {db} from './db.js';
+import {invitations} from './schema/invitations.js';
+import {memberships} from './schema/memberships.js';
 import {toWorkspace, workspaces} from './schema/workspaces.js';
 
 export interface CreateWorkspaceParams {
@@ -17,6 +20,7 @@ export async function createWorkspace(params: CreateWorkspaceParams): Promise<Wo
 
   const row = rows[0];
   if (!row) throw new Error('Insert returned no rows');
+  recordWorkspaceCreated();
   return toWorkspace(row);
 }
 
@@ -51,4 +55,27 @@ export async function getWorkspaceById(id: string): Promise<Workspace | undefine
   const row = rows[0];
   if (!row) return undefined;
   return toWorkspace(row);
+}
+
+export interface WorkspaceServiceMetrics {
+  activeWorkspaces: number;
+  memberships: number;
+  openInvitations: number;
+}
+
+export async function getWorkspaceServiceMetrics(): Promise<WorkspaceServiceMetrics> {
+  const [workspaceRows, membershipRows, invitationRows] = await Promise.all([
+    db().select({value: count()}).from(workspaces).where(eq(workspaces.status, 'active')),
+    db().select({value: count()}).from(memberships),
+    db()
+      .select({value: count()})
+      .from(invitations)
+      .where(and(isNull(invitations.acceptedAt), gt(invitations.expiresAt, sql`now()`))),
+  ]);
+
+  return {
+    activeWorkspaces: workspaceRows[0]?.value ?? 0,
+    memberships: membershipRows[0]?.value ?? 0,
+    openInvitations: invitationRows[0]?.value ?? 0,
+  };
 }

--- a/libs/api/workspaces/src/index.ts
+++ b/libs/api/workspaces/src/index.ts
@@ -6,6 +6,7 @@ import {
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, workspacesOutbox} from '#db/index.js';
+import {registerWorkspacesServiceMetrics} from '#metrics/index.js';
 import {workspacesE2eRoutes} from '#presentation/e2eRoutes/index.js';
 import {workspacesRoutes} from '#presentation/routes/index.js';
 import {onInvitationSendRequested} from '#presentation/subscribers/index.js';
@@ -38,4 +39,5 @@ export const workspacesModule: ShipfoxModule = {
     {name: 'workspaces', table: workspacesOutbox, db, eventSchemas: workspacesEventSchemas},
   ],
   subscribers: [subscriber(WORKSPACES_INVITATION_SEND_REQUESTED, onInvitationSendRequested)],
+  metrics: registerWorkspacesServiceMetrics,
 };

--- a/libs/api/workspaces/src/metrics/index.ts
+++ b/libs/api/workspaces/src/metrics/index.ts
@@ -1,0 +1,1 @@
+export {registerWorkspacesServiceMetrics} from './service.js';

--- a/libs/api/workspaces/src/metrics/instance.test.ts
+++ b/libs/api/workspaces/src/metrics/instance.test.ts
@@ -1,0 +1,74 @@
+const metricMocks = vi.hoisted(() => {
+  const counters = new Map<string, {add: ReturnType<typeof vi.fn>}>();
+  const createCounter = vi.fn((name: string) => {
+    const counter = {add: vi.fn()};
+    counters.set(name, counter);
+    return counter;
+  });
+
+  return {counters, createCounter};
+});
+
+vi.mock('@shipfox/node-opentelemetry', () => ({
+  instanceMetrics: {
+    getMeter: () => ({
+      createCounter: metricMocks.createCounter,
+    }),
+  },
+}));
+
+function counterAdd(name: string): ReturnType<typeof vi.fn> {
+  const counter = metricMocks.counters.get(name);
+  if (!counter) throw new Error(`Missing counter: ${name}`);
+  return counter.add;
+}
+
+let metrics: typeof import('./instance.js');
+
+describe('workspace metrics', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    metricMocks.counters.clear();
+    metrics = await import('./instance.js');
+  });
+
+  it('records workspace creation', () => {
+    metrics.recordWorkspaceCreated();
+
+    expect(counterAdd('workspaces_created')).toHaveBeenCalledWith(1);
+  });
+
+  it('records membership changes with bounded action labels', () => {
+    metrics.recordWorkspaceMembershipChanged('removed');
+
+    expect(counterAdd('workspaces_membership_changed')).toHaveBeenCalledWith(1, {
+      action: 'removed',
+    });
+  });
+
+  it('records invitation creation with email request labels', () => {
+    metrics.recordWorkspaceInvitationCreated('requested');
+
+    expect(counterAdd('workspaces_invitation_created')).toHaveBeenCalledWith(1, {
+      email_requested: 'requested',
+    });
+  });
+
+  it('records invitation acceptance outcomes', () => {
+    metrics.recordWorkspaceInvitationAccepted('already_member');
+
+    expect(counterAdd('workspaces_invitation_accepted')).toHaveBeenCalledWith(1, {
+      outcome: 'already_member',
+    });
+  });
+
+  it('does not let metric failures affect callers', () => {
+    counterAdd('workspaces_membership_changed').mockImplementationOnce(() => {
+      throw new Error('metrics unavailable');
+    });
+
+    const act = () => metrics.recordWorkspaceMembershipChanged('added');
+
+    expect(act).not.toThrow();
+  });
+});

--- a/libs/api/workspaces/src/metrics/instance.ts
+++ b/libs/api/workspaces/src/metrics/instance.ts
@@ -1,0 +1,57 @@
+import {instanceMetrics} from '@shipfox/node-opentelemetry';
+
+export type WorkspacesInvitationEmailRequested = 'requested' | 'skipped';
+export type WorkspacesMembershipChangeAction = 'added' | 'removed';
+export type WorkspacesInvitationAcceptOutcome = 'added' | 'already_member';
+
+const meter = instanceMetrics.getMeter('workspaces');
+
+const workspaceCreatedCount = meter.createCounter<Record<string, never>>('workspaces_created', {
+  description: 'Workspaces created',
+});
+
+const membershipChangedCount = meter.createCounter<{
+  action: WorkspacesMembershipChangeAction;
+}>('workspaces_membership_changed', {
+  description: 'Workspace membership changes by action',
+});
+
+const invitationCreatedCount = meter.createCounter<{
+  email_requested: WorkspacesInvitationEmailRequested;
+}>('workspaces_invitation_created', {
+  description: 'Workspace invitations created by whether an invitation email was requested',
+});
+
+const invitationAcceptedCount = meter.createCounter<{
+  outcome: WorkspacesInvitationAcceptOutcome;
+}>('workspaces_invitation_accepted', {
+  description: 'Workspace invitations accepted by membership outcome',
+});
+
+function recordMetric(record: () => void): void {
+  try {
+    record();
+  } catch {
+    // Metrics must not affect workspace mutations.
+  }
+}
+
+export function recordWorkspaceCreated(): void {
+  recordMetric(() => workspaceCreatedCount.add(1));
+}
+
+export function recordWorkspaceMembershipChanged(action: WorkspacesMembershipChangeAction): void {
+  recordMetric(() => membershipChangedCount.add(1, {action}));
+}
+
+export function recordWorkspaceInvitationCreated(
+  emailRequested: WorkspacesInvitationEmailRequested,
+): void {
+  recordMetric(() => invitationCreatedCount.add(1, {email_requested: emailRequested}));
+}
+
+export function recordWorkspaceInvitationAccepted(
+  outcome: WorkspacesInvitationAcceptOutcome,
+): void {
+  recordMetric(() => invitationAcceptedCount.add(1, {outcome}));
+}

--- a/libs/api/workspaces/src/metrics/service.ts
+++ b/libs/api/workspaces/src/metrics/service.ts
@@ -1,0 +1,26 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {getWorkspaceServiceMetrics} from '#db/workspaces.js';
+
+export function registerWorkspacesServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('workspaces');
+
+  const activeWorkspaces = meter.createObservableGauge('workspaces_active', {
+    description: 'Workspaces currently marked active',
+  });
+  const memberships = meter.createObservableGauge('workspaces_memberships', {
+    description: 'Workspace memberships currently present',
+  });
+  const openInvitations = meter.createObservableGauge('workspaces_open_invitations', {
+    description: 'Workspace invitations currently unaccepted and unexpired',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      const metrics = await getWorkspaceServiceMetrics();
+      observer.observe(activeWorkspaces, metrics.activeWorkspaces);
+      observer.observe(memberships, metrics.memberships);
+      observer.observe(openInvitations, metrics.openInvitations);
+    },
+    [activeWorkspaces, memberships, openInvitations],
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2623,6 +2623,9 @@ importers:
       '@shipfox/node-module':
         specifier: workspace:*
         version: link:../../shared/node/module
+      '@shipfox/node-opentelemetry':
+        specifier: workspace:*
+        version: link:../../shared/node/opentelemetry
       '@shipfox/node-outbox':
         specifier: workspace:*
         version: link:../../shared/node/outbox


### PR DESCRIPTION
Adds OpenTelemetry metrics to `@shipfox/api-workspaces` for workspace creation, membership changes, invitation creation, invitation acceptance, and current workspace service state.

The workspaces module previously had no Prometheus-visible signals for lifecycle activity or shared-state totals. This follows the existing runners metrics pattern with instance counters recorded at mutation points and service gauges registered through the module metrics hook.

The metric labels are bounded and low-cardinality, and metric recording is isolated so observability failures do not affect workspace mutations. `@shipfox/api-workspaces` is private, so no changeset is included.

Closes ENG-576

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry metrics to `@shipfox/api-workspaces` to report workspace lifecycle and current totals to Prometheus. Implements the low-cardinality counters and gauges required by ENG-576.

- **New Features**
  - Counters: workspace created; membership change (`action`); invitation created (`email_requested`); invitation accepted (`outcome`).
  - Gauges: active workspaces, memberships, open invitations; wired via the module `metrics` hook.
  - Metrics are non-blocking with bounded labels; added `getWorkspaceServiceMetrics()` and tests; updated the service metrics test setup to remove a misleading suspended workspace case.

- **Dependencies**
  - Add `@shipfox/node-opentelemetry`.

<sup>Written for commit eef4f99810d117c0b36d6c814393bff284b92119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

