### PR TITLE
[api/runners] Add runner session retention GC

### DIFF
--- a/libs/api/runners/drizzle/0001_manual_registration_tokens.sql
+++ b/libs/api/runners/drizzle/0001_manual_registration_tokens.sql
@@ -48,11 +48,14 @@ CREATE TABLE "runners_runner_sessions" (
 ALTER TABLE "runners_running_jobs" ADD COLUMN "runner_session_id" uuid DEFAULT uuidv7() NOT NULL;--> statement-breakpoint
 ALTER TABLE "runners_running_jobs" DROP COLUMN "runner_token";--> statement-breakpoint
 ALTER TABLE "runners_running_jobs" ALTER COLUMN "runner_session_id" DROP DEFAULT;--> statement-breakpoint
+ALTER TABLE "runners_running_jobs" ADD CONSTRAINT "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk" FOREIGN KEY ("runner_session_id") REFERENCES "public"."runners_runner_sessions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "runners_pending_jobs_workspace_created_idx" ON "runners_pending_jobs" USING btree ("workspace_id","created_at");--> statement-breakpoint
+CREATE INDEX "runners_running_jobs_runner_session_id_idx" ON "runners_running_jobs" USING btree ("runner_session_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_ephemeral_registration_tokens_hashed_token_unique" ON "runners_ephemeral_registration_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_ephemeral_registration_tokens_workspace_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("workspace_id");--> statement-breakpoint
 CREATE INDEX "runners_ephemeral_registration_tokens_provisioner_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("provisioner_id");--> statement-breakpoint
 CREATE INDEX "runners_ephemeral_registration_tokens_active_provisioned_runner_idx" ON "runners_ephemeral_registration_tokens" USING btree ("workspace_id","provisioner_id","provisioned_runner_id","consumed_at","expires_at");--> statement-breakpoint
+CREATE INDEX "runners_runner_sessions_kind_created_id_idx" ON "runners_runner_sessions" USING btree ("registration_token_kind","created_at","id");--> statement-breakpoint
 CREATE UNIQUE INDEX "runners_manual_registration_tokens_hashed_token_unique" ON "runners_manual_registration_tokens" USING btree ("hashed_token");--> statement-breakpoint
 CREATE INDEX "runners_manual_registration_tokens_workspace_id_idx" ON "runners_manual_registration_tokens" USING btree ("workspace_id");--> statement-breakpoint
 CREATE INDEX "runners_manual_registration_tokens_active_lookup_idx" ON "runners_manual_registration_tokens" USING btree ("hashed_token","revoked_at","expires_at");

--- a/libs/api/runners/drizzle/meta/0001_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0001_snapshot.json
@@ -497,7 +497,35 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
@@ -792,9 +820,34 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "runners_running_jobs_job_execution_id_unique": {

--- a/libs/api/runners/drizzle/meta/0002_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0002_snapshot.json
@@ -305,7 +305,35 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
@@ -603,9 +631,34 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "runners_running_jobs_job_execution_id_unique": {

--- a/libs/api/runners/drizzle/meta/0003_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0003_snapshot.json
@@ -602,7 +602,35 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
@@ -909,9 +937,34 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "runners_running_jobs_job_execution_id_unique": {

--- a/libs/api/runners/drizzle/meta/0004_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0004_snapshot.json
@@ -989,7 +989,35 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
@@ -1324,9 +1352,34 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "runners_running_jobs_job_execution_id_unique": {

--- a/libs/api/runners/drizzle/meta/0005_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0005_snapshot.json
@@ -1360,7 +1360,17 @@
           "with": {}
         }
       },
-      "foreignKeys": {},
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "runners_running_jobs_job_execution_id_unique": {

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -225,3 +225,37 @@ describe('PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED', () =>
     expect(config.PROVISIONED_RUNNER_COUNT_DIVERGENCE_TEMPLATE_KEY_LABEL_ENABLED).toBe(true);
   });
 });
+
+describe('runner session retention config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses the default retention windows and batch size', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.RUNNER_SESSION_MANUAL_RETENTION_DAYS).toBe(30);
+    expect(config.RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS).toBe(7);
+    expect(config.RUNNER_SESSION_GC_BATCH_SIZE).toBe(1000);
+  });
+
+  it.each([
+    ['RUNNER_SESSION_MANUAL_RETENTION_DAYS', '0'],
+    ['RUNNER_SESSION_MANUAL_RETENTION_DAYS', '-5'],
+    ['RUNNER_SESSION_MANUAL_RETENTION_DAYS', '1.5'],
+    ['RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS', '0'],
+    ['RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS', '-5'],
+    ['RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS', '1.5'],
+    ['RUNNER_SESSION_GC_BATCH_SIZE', '0'],
+    ['RUNNER_SESSION_GC_BATCH_SIZE', '-5'],
+    ['RUNNER_SESSION_GC_BATCH_SIZE', '1.5'],
+  ])('fails startup when %s is %s', async (name, value) => {
+    vi.stubEnv(name, value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(name);
+  });
+});

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -53,6 +53,18 @@ export const config = createConfig({
     desc: 'Minimum time, in seconds, between runner session liveness writes from job request polls. Set this lower than RUNNER_STALE_PROVISIONED_RUNNER_THRESHOLD_SECONDS so active idle runners stay fresh.',
     default: 10,
   }),
+  RUNNER_SESSION_MANUAL_RETENTION_DAYS: num({
+    desc: 'How long manual runner sessions are retained before maintenance deletes them, in days. Set this longer than AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN so a valid session token never outlives its row.',
+    default: 30,
+  }),
+  RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS: num({
+    desc: 'How long ephemeral runner sessions are retained before maintenance deletes them, in days. Set this longer than AUTH_RUNNER_SESSION_TOKEN_EXPIRES_IN so a valid session token never outlives its row.',
+    default: 7,
+  }),
+  RUNNER_SESSION_GC_BATCH_SIZE: num({
+    desc: 'Maximum number of expired runner sessions maintenance deletes in one pass.',
+    default: 1000,
+  }),
   PROVISIONER_ACTIVE_WINDOW_SECONDS: num({
     desc: 'Time window, in seconds, used to list active provisioners from recent authenticated requests.',
     default: 120,
@@ -173,6 +185,33 @@ if (
 ) {
   throw new Error(
     `RUNNER_SESSION_LIVENESS_THROTTLE_SECONDS (${config.RUNNER_SESSION_LIVENESS_THROTTLE_SECONDS}) must be a whole number of seconds >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_SESSION_MANUAL_RETENTION_DAYS) ||
+  config.RUNNER_SESSION_MANUAL_RETENTION_DAYS < 1
+) {
+  throw new Error(
+    `RUNNER_SESSION_MANUAL_RETENTION_DAYS (${config.RUNNER_SESSION_MANUAL_RETENTION_DAYS}) must be a whole number of days >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS) ||
+  config.RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS < 1
+) {
+  throw new Error(
+    `RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS (${config.RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS}) must be a whole number of days >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_SESSION_GC_BATCH_SIZE) ||
+  config.RUNNER_SESSION_GC_BATCH_SIZE < 1
+) {
+  throw new Error(
+    `RUNNER_SESSION_GC_BATCH_SIZE (${config.RUNNER_SESSION_GC_BATCH_SIZE}) must be a whole number >= 1.`,
   );
 }
 

--- a/libs/api/runners/src/core/maintenance.test.ts
+++ b/libs/api/runners/src/core/maintenance.test.ts
@@ -3,13 +3,18 @@ import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {reservations} from '#db/schema/reservations.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
 import {provisionedRunnerReapedCount, reservationReleasedCount} from '#metrics/instance.js';
 import {
   provisionedRunnerFactory,
   provisionerTokenFactory,
   reservationFactory,
 } from '#test/index.js';
-import {deleteExpiredRunnerReservations, reapStaleProvisionedRunners} from './maintenance.js';
+import {
+  deleteExpiredRunnerReservations,
+  deleteExpiredRunnerSessions,
+  reapStaleProvisionedRunners,
+} from './maintenance.js';
 
 describe('deleteExpiredRunnerReservations', () => {
   let workspaceId: string;
@@ -84,4 +89,94 @@ describe('reapStaleProvisionedRunners', () => {
     expect(reapedSpy).toHaveBeenCalledWith(1);
     expect(releasedSpy).toHaveBeenCalledWith(1);
   });
+});
+
+describe('deleteExpiredRunnerSessions', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('deletes expired runner sessions using default retention policy', async () => {
+    const manualId = crypto.randomUUID();
+    const ephemeralId = crypto.randomUUID();
+    await db()
+      .insert(runnerSessions)
+      .values([
+        buildRunnerSession({
+          id: manualId,
+          kind: 'manual',
+          createdAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000),
+        }),
+        buildRunnerSession({
+          id: ephemeralId,
+          kind: 'ephemeral',
+          createdAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000),
+        }),
+      ]);
+
+    const result = await deleteExpiredRunnerSessions();
+
+    const remaining = await db()
+      .select({id: runnerSessions.id})
+      .from(runnerSessions)
+      .where(eq(runnerSessions.workspaceId, workspaceId));
+    expect(result.deleted).toBeGreaterThanOrEqual(2);
+    expect(remaining).toEqual([]);
+  });
+
+  it('passes explicit retention and limit values to the DB cleanup', async () => {
+    const deleteableId = crypto.randomUUID();
+    const keptId = crypto.randomUUID();
+    await db()
+      .insert(runnerSessions)
+      .values([
+        buildRunnerSession({
+          id: deleteableId,
+          kind: 'manual',
+          createdAt: new Date(Date.now() - 3650 * 24 * 60 * 60 * 1000),
+        }),
+        buildRunnerSession({
+          id: keptId,
+          kind: 'manual',
+          createdAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000),
+        }),
+      ]);
+
+    const result = await deleteExpiredRunnerSessions({
+      manualRetentionDays: 5,
+      ephemeralRetentionDays: 7,
+      limit: 1,
+    });
+
+    const remaining = await db()
+      .select({id: runnerSessions.id})
+      .from(runnerSessions)
+      .where(eq(runnerSessions.workspaceId, workspaceId));
+    expect(result.deleted).toBe(1);
+    expect(remaining.map((row) => row.id)).toEqual([keptId]);
+  });
+
+  function buildRunnerSession(params: {
+    id: string;
+    kind: 'manual' | 'ephemeral';
+    createdAt: Date;
+  }): typeof runnerSessions.$inferInsert {
+    const provisionerId = params.kind === 'ephemeral' ? crypto.randomUUID() : null;
+    return {
+      id: params.id,
+      workspaceId,
+      scope: 'workspace',
+      registrationTokenId: crypto.randomUUID(),
+      registrationTokenKind: params.kind,
+      provisionerId,
+      provisionedRunnerId: params.kind === 'ephemeral' ? `provisioned-${params.id}` : null,
+      labels: ['linux'],
+      maxClaims: params.kind === 'ephemeral' ? 1 : null,
+      claimsUsed: 0,
+      createdAt: params.createdAt,
+      updatedAt: params.createdAt,
+    };
+  }
 });

--- a/libs/api/runners/src/core/maintenance.ts
+++ b/libs/api/runners/src/core/maintenance.ts
@@ -1,8 +1,9 @@
+import {config} from '#config.js';
 import {expireStuckJobExecutions} from '#db/job-executions.js';
 import {reapStaleProvisionedRunners as reapStaleProvisionedRunnersDb} from '#db/provisioned-runners.js';
 import {deleteExpiredReservations} from '#db/reservations.js';
+import {deleteExpiredRunnerSessions as deleteExpiredRunnerSessionsDb} from '#db/runner-sessions.js';
 import {provisionedRunnerReapedCount, reservationReleasedCount} from '#metrics/instance.js';
-import {config} from '../config.js';
 import {STUCK_JOB_THRESHOLD_SECONDS} from './maintenance-policy.js';
 
 export interface DetectAndExpireStuckJobsParams {
@@ -44,4 +45,18 @@ export async function reapStaleProvisionedRunners(params?: {
   }
 
   return result;
+}
+
+export async function deleteExpiredRunnerSessions(params?: {
+  manualRetentionDays?: number;
+  ephemeralRetentionDays?: number;
+  limit?: number;
+}): Promise<{deleted: number}> {
+  const deleted = await deleteExpiredRunnerSessionsDb({
+    manualRetentionDays: params?.manualRetentionDays ?? config.RUNNER_SESSION_MANUAL_RETENTION_DAYS,
+    ephemeralRetentionDays:
+      params?.ephemeralRetentionDays ?? config.RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS,
+    limit: params?.limit ?? config.RUNNER_SESSION_GC_BATCH_SIZE,
+  });
+  return {deleted};
 }

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -72,8 +72,11 @@ export {
   pollDemandAndReserve,
   releaseReservationUnits,
 } from './reservations.js';
-export type {CreateRunnerSessionParams} from './runner-sessions.js';
-export {createRunnerSession} from './runner-sessions.js';
+export type {
+  CreateRunnerSessionParams,
+  DeleteExpiredRunnerSessionsParams,
+} from './runner-sessions.js';
+export {createRunnerSession, deleteExpiredRunnerSessions} from './runner-sessions.js';
 export {runnersOutbox} from './schema/outbox.js';
 
 export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -57,6 +57,7 @@ async function insertRunningJobRow(params: {
   cancellationRequestedAt?: Date | null;
 }) {
   const startedAt = params.startedAt ?? new Date('2025-01-01T00:00:00.000Z');
+  const runnerSession = await runnerSessionFactory.create({workspaceId: params.workspaceId});
 
   await db()
     .insert(runningJobExecutions)
@@ -67,7 +68,7 @@ async function insertRunningJobRow(params: {
       jobId: crypto.randomUUID(),
       jobExecutionId: params.jobExecutionId ?? crypto.randomUUID(),
       projectId: crypto.randomUUID(),
-      runnerSessionId: crypto.randomUUID(),
+      runnerSessionId: runnerSession.id,
       provisionerId: params.provisionerId,
       provisionedRunnerId: params.provisionedRunnerId,
       requiredLabels: ['linux'],
@@ -1224,6 +1225,8 @@ describe('reapStaleProvisionedRunners', () => {
   }
 
   async function insertRunningJob(params: {provisionedRunnerId: string}) {
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+
     await db()
       .insert(runningJobExecutions)
       .values({
@@ -1233,7 +1236,7 @@ describe('reapStaleProvisionedRunners', () => {
         jobId: crypto.randomUUID(),
         jobExecutionId: crypto.randomUUID(),
         projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
+        runnerSessionId: runnerSession.id,
         provisionerId,
         provisionedRunnerId: params.provisionedRunnerId,
         requiredLabels: ['linux'],
@@ -1702,6 +1705,8 @@ describe('reconcileProvisionedRunners', () => {
     provisionedRunnerId: string;
     startedAt: Date;
   }) {
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+
     await db()
       .insert(runningJobExecutions)
       .values({
@@ -1711,7 +1716,7 @@ describe('reconcileProvisionedRunners', () => {
         workflowRunId: crypto.randomUUID(),
         workflowRunAttemptId: crypto.randomUUID(),
         projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
+        runnerSessionId: runnerSession.id,
         provisionerId,
         provisionedRunnerId: params.provisionedRunnerId,
         requiredLabels: ['linux'],

--- a/libs/api/runners/src/db/runner-sessions.test.ts
+++ b/libs/api/runners/src/db/runner-sessions.test.ts
@@ -1,0 +1,153 @@
+import {and, eq, inArray} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {deleteExpiredRunnerSessions} from '#db/runner-sessions.js';
+import {runnerSessions} from '#db/schema/runner-sessions.js';
+import {runningJobExecutions} from '#db/schema/running-job-executions.js';
+
+describe('deleteExpiredRunnerSessions', () => {
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('deletes manual sessions older than the manual retention window', async () => {
+    const expired = await insertRunnerSession({kind: 'manual', createdDaysAgo: 31});
+    const active = await insertRunnerSession({kind: 'manual', createdDaysAgo: 29});
+
+    const deleted = await deleteExpiredRunnerSessions({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 100,
+    });
+
+    const remaining = await listRunnerSessionIds([expired, active]);
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    expect(remaining).toEqual([active]);
+  });
+
+  it('deletes ephemeral sessions older than the ephemeral retention window', async () => {
+    const expired = await insertRunnerSession({kind: 'ephemeral', createdDaysAgo: 8});
+    const active = await insertRunnerSession({kind: 'ephemeral', createdDaysAgo: 6});
+
+    const deleted = await deleteExpiredRunnerSessions({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 100,
+    });
+
+    const remaining = await listRunnerSessionIds([expired, active]);
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    expect(remaining).toEqual([active]);
+  });
+
+  it('applies the retention window for each registration token kind independently', async () => {
+    const manualExpired = await insertRunnerSession({kind: 'manual', createdDaysAgo: 31});
+    const manualActive = await insertRunnerSession({kind: 'manual', createdDaysAgo: 8});
+    const ephemeralExpired = await insertRunnerSession({kind: 'ephemeral', createdDaysAgo: 8});
+    const ephemeralActive = await insertRunnerSession({kind: 'ephemeral', createdDaysAgo: 6});
+
+    await deleteExpiredRunnerSessions({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 100,
+    });
+
+    const remaining = await listRunnerSessionIds([
+      manualExpired,
+      manualActive,
+      ephemeralExpired,
+      ephemeralActive,
+    ]);
+    expect(remaining).toEqual([manualActive, ephemeralActive]);
+  });
+
+  it('keeps expired sessions referenced by running jobs', async () => {
+    const expired = await insertRunnerSession({kind: 'manual', createdDaysAgo: 31});
+    await insertRunningJob(expired);
+
+    const deleted = await deleteExpiredRunnerSessions({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 100,
+    });
+
+    const remaining = await listRunnerSessionIds([expired]);
+    expect(deleted).toBe(0);
+    expect(remaining).toEqual([expired]);
+  });
+
+  it('honors the deletion limit', async () => {
+    const first = await insertRunnerSession({kind: 'manual', createdDaysAgo: 3652});
+    const second = await insertRunnerSession({kind: 'manual', createdDaysAgo: 3651});
+    const third = await insertRunnerSession({kind: 'manual', createdDaysAgo: 3650});
+
+    const deleted = await deleteExpiredRunnerSessions({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 2,
+    });
+
+    const remaining = await listRunnerSessionIds([first, second, third]);
+    expect(deleted).toBe(2);
+    expect(remaining).toHaveLength(1);
+  });
+
+  async function insertRunnerSession(params: {
+    kind: 'manual' | 'ephemeral';
+    createdDaysAgo: number;
+  }): Promise<string> {
+    const id = crypto.randomUUID();
+    const registrationTokenId = crypto.randomUUID();
+    const createdAt = new Date(Date.now() - params.createdDaysAgo * 24 * 60 * 60 * 1000);
+    const provisionerId = params.kind === 'ephemeral' ? crypto.randomUUID() : null;
+    const provisionedRunnerId =
+      params.kind === 'ephemeral' ? `provisioned-${crypto.randomUUID()}` : null;
+
+    await db()
+      .insert(runnerSessions)
+      .values({
+        id,
+        workspaceId,
+        scope: 'workspace',
+        registrationTokenId,
+        registrationTokenKind: params.kind,
+        provisionerId,
+        provisionedRunnerId,
+        labels: ['linux'],
+        maxClaims: params.kind === 'ephemeral' ? 1 : null,
+        claimsUsed: 0,
+        createdAt,
+        updatedAt: createdAt,
+      });
+
+    return id;
+  }
+
+  async function insertRunningJob(runnerSessionId: string): Promise<void> {
+    await db()
+      .insert(runningJobExecutions)
+      .values({
+        workspaceId,
+        workflowRunId: crypto.randomUUID(),
+        workflowRunAttemptId: crypto.randomUUID(),
+        jobId: crypto.randomUUID(),
+        jobExecutionId: crypto.randomUUID(),
+        projectId: crypto.randomUUID(),
+        runnerSessionId,
+        requiredLabels: ['linux'],
+        runnerLabels: ['linux'],
+      });
+  }
+
+  async function listRunnerSessionIds(ids: string[]): Promise<string[]> {
+    if (ids.length === 0) return [];
+
+    const rows = await db()
+      .select({id: runnerSessions.id})
+      .from(runnerSessions)
+      .where(and(eq(runnerSessions.workspaceId, workspaceId), inArray(runnerSessions.id, ids)));
+
+    return ids.filter((id) => rows.some((row) => row.id === id));
+  }
+});

--- a/libs/api/runners/src/db/runner-sessions.ts
+++ b/libs/api/runners/src/db/runner-sessions.ts
@@ -1,6 +1,8 @@
+import {and, asc, eq, inArray, lt, notExists, or, sql} from 'drizzle-orm';
 import type {RunnerSession} from '#core/entities/runner-session.js';
 import {db} from './db.js';
 import {runnerSessions, toRunnerSession} from './schema/runner-sessions.js';
+import {runningJobExecutions} from './schema/running-job-executions.js';
 
 export interface CreateRunnerSessionParams {
   workspaceId: string;
@@ -28,4 +30,53 @@ export async function createRunnerSession(
   const row = rows[0];
   if (!row) throw new Error('Insert returned no rows');
   return toRunnerSession(row);
+}
+
+export interface DeleteExpiredRunnerSessionsParams {
+  manualRetentionDays: number;
+  ephemeralRetentionDays: number;
+  limit?: number;
+}
+
+export async function deleteExpiredRunnerSessions(
+  params: DeleteExpiredRunnerSessionsParams,
+): Promise<number> {
+  const expiredIds = db()
+    .select({id: runnerSessions.id})
+    .from(runnerSessions)
+    .where(
+      and(
+        or(
+          and(
+            eq(runnerSessions.registrationTokenKind, 'manual'),
+            lt(
+              runnerSessions.createdAt,
+              sql`now() - (${params.manualRetentionDays} || ' days')::interval`,
+            ),
+          ),
+          and(
+            eq(runnerSessions.registrationTokenKind, 'ephemeral'),
+            lt(
+              runnerSessions.createdAt,
+              sql`now() - (${params.ephemeralRetentionDays} || ' days')::interval`,
+            ),
+          ),
+        ),
+        notExists(
+          db()
+            .select({id: runningJobExecutions.id})
+            .from(runningJobExecutions)
+            .where(eq(runningJobExecutions.runnerSessionId, runnerSessions.id)),
+        ),
+      ),
+    )
+    .orderBy(asc(runnerSessions.createdAt), asc(runnerSessions.id))
+    .limit(params.limit ?? 1000);
+
+  const deleted = await db()
+    .delete(runnerSessions)
+    .where(inArray(runnerSessions.id, expiredIds))
+    .returning({id: runnerSessions.id});
+
+  return deleted.length;
 }

--- a/libs/api/runners/src/db/schema/runner-sessions.ts
+++ b/libs/api/runners/src/db/schema/runner-sessions.ts
@@ -28,6 +28,11 @@ export const runnerSessions = pgTable(
     updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
   },
   (table) => [
+    index('runners_runner_sessions_kind_created_id_idx').on(
+      table.registrationTokenKind,
+      table.createdAt,
+      table.id,
+    ),
     check(
       'runners_runner_sessions_claims_ck',
       sql`${table.claimsUsed} >= 0 AND ((${table.registrationTokenKind} = 'manual' AND ${table.maxClaims} IS NULL) OR (${table.registrationTokenKind} = 'ephemeral' AND ${table.maxClaims} IS NOT NULL AND ${table.maxClaims} > 0 AND ${table.claimsUsed} <= ${table.maxClaims}))`,

--- a/libs/api/runners/src/db/schema/running-job-executions.ts
+++ b/libs/api/runners/src/db/schema/running-job-executions.ts
@@ -2,6 +2,7 @@ import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
 import {check, index, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {pgTable} from './common.js';
+import {runnerSessions} from './runner-sessions.js';
 
 export const runningJobExecutions = pgTable(
   'running_jobs',
@@ -13,7 +14,9 @@ export const runningJobExecutions = pgTable(
     jobId: uuid('job_id').notNull(),
     jobExecutionId: uuid('job_execution_id').notNull().unique(),
     projectId: uuid('project_id').notNull(),
-    runnerSessionId: uuid('runner_session_id').notNull(),
+    runnerSessionId: uuid('runner_session_id')
+      .notNull()
+      .references(() => runnerSessions.id),
     provisionerId: uuid('provisioner_id'),
     provisionedRunnerId: text('provisioned_runner_id'),
     requiredLabels: text('required_labels').array().notNull(),
@@ -35,6 +38,7 @@ export const runningJobExecutions = pgTable(
       .on(table.workspaceId, table.provisionerId, table.provisionedRunnerId)
       .where(sql`"cancellation_requested_at" IS NOT NULL`),
     index('runners_running_jobs_job_id_idx').on(table.jobId),
+    index('runners_running_jobs_runner_session_id_idx').on(table.runnerSessionId),
     check(
       'runners_running_jobs_link_ck',
       sql`(${table.provisionerId} IS NULL) = (${table.provisionedRunnerId} IS NULL)`,

--- a/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/list-active-runners.test.ts
@@ -14,6 +14,7 @@ import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
+import {runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 vi.mock('@shipfox/api-auth-context', async (importOriginal) => {
@@ -76,7 +77,8 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
   });
 
   it('returns active provisioned runners merged with running jobs by runner session', async () => {
-    const runnerSessionId = crypto.randomUUID();
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    const runnerSessionId = runnerSession.id;
     await db()
       .insert(provisionedRunners)
       .values({
@@ -121,7 +123,8 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
   });
 
   it('returns every active job for the same runner session', async () => {
-    const runnerSessionId = crypto.randomUUID();
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    const runnerSessionId = runnerSession.id;
     const firstJobId = crypto.randomUUID();
     const secondJobId = crypto.randomUUID();
     await db()
@@ -192,7 +195,8 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
 
   it('merges active jobs by provisioned-runner link when the session id is not reported', async () => {
     const provisionerId = crypto.randomUUID();
-    const runnerSessionId = crypto.randomUUID();
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    const runnerSessionId = runnerSession.id;
     const jobId = crypto.randomUUID();
     await db()
       .insert(provisionedRunners)
@@ -242,7 +246,8 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
 
   it('surfaces the job link for a busy runner without an active provisioned-runner row', async () => {
     const provisionerId = crypto.randomUUID();
-    const runnerSessionId = crypto.randomUUID();
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    const runnerSessionId = runnerSession.id;
     const jobId = crypto.randomUUID();
     await db()
       .insert(runningJobExecutions)
@@ -280,7 +285,8 @@ describe('GET /workspaces/:workspaceId/runners/active', () => {
 
   it('keeps a provisioned runner visible when its session fallback job was already merged', async () => {
     const provisionerId = crypto.randomUUID();
-    const runnerSessionId = crypto.randomUUID();
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+    const runnerSessionId = runnerSession.id;
     const jobId = crypto.randomUUID();
     const older = new Date(Date.now() - 1000);
     const newer = new Date();

--- a/libs/api/runners/src/presentation/routes/poll-demand.test.ts
+++ b/libs/api/runners/src/presentation/routes/poll-demand.test.ts
@@ -21,7 +21,7 @@ import {
   provisionedRunnerCountDivergenceCount,
   provisionedRunnerTerminateIntentIssuedCount,
 } from '#metrics/instance.js';
-import {pendingJobFactory, provisionedRunnerFactory} from '#test/index.js';
+import {pendingJobFactory, provisionedRunnerFactory, runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
@@ -299,6 +299,8 @@ describe('POST /provisioners/demand/poll', () => {
     provisionedRunnerId: string;
     cancellationRequestedAt?: Date | null;
   }) {
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+
     await db()
       .insert(runningJobExecutions)
       .values({
@@ -308,7 +310,7 @@ describe('POST /provisioners/demand/poll', () => {
         jobId: crypto.randomUUID(),
         jobExecutionId: crypto.randomUUID(),
         projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
+        runnerSessionId: runnerSession.id,
         provisionerId: provisionerTokenId,
         provisionedRunnerId: params.provisionedRunnerId,
         requiredLabels: ['linux'],

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -25,7 +25,7 @@ import {
   provisionedRunnerTerminateIntentIssuedCount,
   reservationReleasedCount,
 } from '#metrics/instance.js';
-import {provisionedRunnerFactory, reservationFactory} from '#test/index.js';
+import {provisionedRunnerFactory, reservationFactory, runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
@@ -309,6 +309,8 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
     lastHeartbeatAt: Date;
     cancellationRequestedAt?: Date | null;
   }) {
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
+
     await db()
       .insert(runningJobExecutions)
       .values({
@@ -318,7 +320,7 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
         jobExecutionId: crypto.randomUUID(),
         workflowRunAttemptId: params.workflowRunAttemptId,
         projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
+        runnerSessionId: runnerSession.id,
         provisionerId: provisionerTokenId,
         provisionedRunnerId: params.provisionedRunnerId,
         requiredLabels: ['linux'],

--- a/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/report-provisioned-runners.test.ts
@@ -20,7 +20,7 @@ import {db} from '#db/db.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {provisionedRunnerTerminateIntentHonoredCount} from '#metrics/instance.js';
-import {provisionedRunnerFactory} from '#test/index.js';
+import {provisionedRunnerFactory, runnerSessionFactory} from '#test/index.js';
 import {runnerRoutes} from './index.js';
 
 const VALID_PROVISIONER_TOKEN = 'valid-provisioner-token';
@@ -138,6 +138,7 @@ describe('POST /provisioners/provisioned-runners/report', () => {
 
   it('increments the honored terminate-intent metric once for a terminated report', async () => {
     const honoredSpy = vi.spyOn(provisionedRunnerTerminateIntentHonoredCount, 'add');
+    const runnerSession = await runnerSessionFactory.create({workspaceId});
     await provisionedRunnerFactory.create({
       workspaceId,
       provisionerId: provisionerTokenId,
@@ -153,7 +154,7 @@ describe('POST /provisioners/provisioned-runners/report', () => {
         jobId: crypto.randomUUID(),
         jobExecutionId: crypto.randomUUID(),
         projectId: crypto.randomUUID(),
-        runnerSessionId: crypto.randomUUID(),
+        runnerSessionId: runnerSession.id,
         provisionerId: provisionerTokenId,
         provisionedRunnerId: 'provisioned-runner-1',
         requiredLabels: ['linux'],

--- a/libs/api/runners/src/temporal/activities/index.ts
+++ b/libs/api/runners/src/temporal/activities/index.ts
@@ -1,5 +1,6 @@
 import {
   deleteExpiredReservationsActivity,
+  deleteExpiredRunnerSessionsActivity,
   detectAndExpireStuckJobsActivity,
   reapStaleProvisionedRunnersActivity,
 } from './maintenance-activities.js';
@@ -7,6 +8,7 @@ import {
 export function createRunnersMaintenanceActivities() {
   return {
     deleteExpiredReservationsActivity,
+    deleteExpiredRunnerSessionsActivity,
     detectAndExpireStuckJobsActivity,
     reapStaleProvisionedRunnersActivity,
   };

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -1,16 +1,19 @@
 import {
   deleteExpiredRunnerReservations,
+  deleteExpiredRunnerSessions,
   detectAndExpireStuckJobs,
   reapStaleProvisionedRunners,
 } from '#core/maintenance.js';
 import {
   deleteExpiredReservationsActivity,
+  deleteExpiredRunnerSessionsActivity,
   detectAndExpireStuckJobsActivity,
   reapStaleProvisionedRunnersActivity,
 } from './maintenance-activities.js';
 
 vi.mock('#core/maintenance.js', () => ({
   deleteExpiredRunnerReservations: vi.fn(),
+  deleteExpiredRunnerSessions: vi.fn(),
   detectAndExpireStuckJobs: vi.fn(),
   reapStaleProvisionedRunners: vi.fn(),
 }));
@@ -57,6 +60,25 @@ describe('reapStaleProvisionedRunnersActivity', () => {
     expect(reapStaleProvisionedRunners).toHaveBeenCalledWith({
       thresholdSeconds: 300,
       limit: 100,
+    });
+  });
+});
+
+describe('deleteExpiredRunnerSessionsActivity', () => {
+  it('delegates to core maintenance', async () => {
+    vi.mocked(deleteExpiredRunnerSessions).mockResolvedValueOnce({deleted: 4});
+
+    const result = await deleteExpiredRunnerSessionsActivity({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 25,
+    });
+
+    expect(result).toEqual({deleted: 4});
+    expect(deleteExpiredRunnerSessions).toHaveBeenCalledWith({
+      manualRetentionDays: 30,
+      ephemeralRetentionDays: 7,
+      limit: 25,
     });
   });
 });

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.ts
@@ -1,5 +1,6 @@
 import {
   deleteExpiredRunnerReservations,
+  deleteExpiredRunnerSessions,
   detectAndExpireStuckJobs,
   reapStaleProvisionedRunners,
 } from '#core/maintenance.js';
@@ -21,4 +22,12 @@ export function reapStaleProvisionedRunnersActivity(params?: {
   limit: number;
 }): Promise<{reaped: number; reservationsReleased: number}> {
   return reapStaleProvisionedRunners(params);
+}
+
+export function deleteExpiredRunnerSessionsActivity(params?: {
+  manualRetentionDays?: number;
+  ephemeralRetentionDays?: number;
+  limit?: number;
+}): Promise<{deleted: number}> {
+  return deleteExpiredRunnerSessions(params);
 }

--- a/libs/api/runners/src/temporal/workflows/stuck-job-detector.test.ts
+++ b/libs/api/runners/src/temporal/workflows/stuck-job-detector.test.ts
@@ -1,0 +1,60 @@
+const mocks = vi.hoisted(() => ({
+  deleteExpiredReservationsActivity: vi.fn(),
+  deleteExpiredRunnerSessionsActivity: vi.fn(),
+  detectAndExpireStuckJobsActivity: vi.fn(),
+  reapStaleProvisionedRunnersActivity: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('@temporalio/workflow', () => ({
+  log: {
+    info: mocks.info,
+    warn: mocks.warn,
+  },
+  proxyActivities: vi.fn(() => ({
+    deleteExpiredReservationsActivity: mocks.deleteExpiredReservationsActivity,
+    deleteExpiredRunnerSessionsActivity: mocks.deleteExpiredRunnerSessionsActivity,
+    detectAndExpireStuckJobsActivity: mocks.detectAndExpireStuckJobsActivity,
+    reapStaleProvisionedRunnersActivity: mocks.reapStaleProvisionedRunnersActivity,
+  })),
+}));
+
+describe('stuckJobDetector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteExpiredReservationsActivity.mockResolvedValue({deleted: 0});
+    mocks.deleteExpiredRunnerSessionsActivity.mockResolvedValue({deleted: 0});
+    mocks.detectAndExpireStuckJobsActivity.mockResolvedValue({expired: 0});
+    mocks.reapStaleProvisionedRunnersActivity.mockResolvedValue({
+      reaped: 0,
+      reservationsReleased: 0,
+    });
+  });
+
+  it('runs expired session GC before stuck job expiry and logs deletions', async () => {
+    const {stuckJobDetector} = await import('./stuck-job-detector.js');
+    mocks.deleteExpiredRunnerSessionsActivity.mockResolvedValueOnce({deleted: 2});
+
+    await stuckJobDetector();
+
+    expect(mocks.deleteExpiredRunnerSessionsActivity).toHaveBeenCalledWith();
+    expect(mocks.detectAndExpireStuckJobsActivity).toHaveBeenCalledWith({thresholdSeconds: 180});
+    expect(mocks.info).toHaveBeenCalledWith('Stuck-job detector deleted expired runner sessions', {
+      deleted: 2,
+    });
+  });
+
+  it('continues stuck job expiry when expired session GC fails', async () => {
+    const {stuckJobDetector} = await import('./stuck-job-detector.js');
+    mocks.deleteExpiredRunnerSessionsActivity.mockRejectedValueOnce(new Error('database down'));
+
+    await stuckJobDetector();
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'Stuck-job detector failed to delete expired runner sessions',
+      {error: 'database down'},
+    );
+    expect(mocks.detectAndExpireStuckJobsActivity).toHaveBeenCalledWith({thresholdSeconds: 180});
+  });
+});

--- a/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
+++ b/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
@@ -5,6 +5,7 @@ import type {createRunnersMaintenanceActivities} from '../activities/index.js';
 
 const {
   deleteExpiredReservationsActivity,
+  deleteExpiredRunnerSessionsActivity,
   detectAndExpireStuckJobsActivity,
   reapStaleProvisionedRunnersActivity,
 } = proxyActivities<ReturnType<typeof createRunnersMaintenanceActivities>>({
@@ -19,6 +20,17 @@ export async function stuckJobDetector(): Promise<void> {
     }
   } catch (error) {
     log.warn('Stuck-job detector failed to delete expired runner reservations', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const {deleted} = await deleteExpiredRunnerSessionsActivity();
+    if (deleted > 0) {
+      log.info('Stuck-job detector deleted expired runner sessions', {deleted});
+    }
+  } catch (error) {
+    log.warn('Stuck-job detector failed to delete expired runner sessions', {
       error: error instanceof Error ? error.message : String(error),
     });
   }

--- a/libs/api/workflows/src/db/runner-lease-table.ts
+++ b/libs/api/workflows/src/db/runner-lease-table.ts
@@ -1,7 +1,29 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
-import {pgTableCreator, text, uuid} from 'drizzle-orm/pg-core';
+import {integer, pgEnum, pgTableCreator, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 
 const pgTable = pgTableCreator((name) => `runners_${name}`);
+
+export const runnerSessionScopeEnum = pgEnum('runners_runner_session_scope', ['workspace']);
+export const runnerSessionRegistrationTokenKindEnum = pgEnum(
+  'runners_runner_session_registration_token_kind',
+  ['manual', 'ephemeral'],
+);
+
+export const runnerSessions = pgTable('runner_sessions', {
+  id: uuidv7PrimaryKey(),
+  workspaceId: uuid('workspace_id').notNull(),
+  scope: runnerSessionScopeEnum('scope').notNull().default('workspace'),
+  registrationTokenId: uuid('registration_token_id').notNull(),
+  registrationTokenKind:
+    runnerSessionRegistrationTokenKindEnum('registration_token_kind').notNull(),
+  provisionerId: uuid('provisioner_id'),
+  provisionedRunnerId: text('provisioned_runner_id'),
+  labels: text('labels').array().notNull(),
+  maxClaims: integer('max_claims'),
+  claimsUsed: integer('claims_used').notNull().default(0),
+  createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+});
 
 export const runningJobExecutions = pgTable('running_jobs', {
   id: uuidv7PrimaryKey(),

--- a/libs/api/workflows/test/fixtures/active-lease-token.ts
+++ b/libs/api/workflows/test/fixtures/active-lease-token.ts
@@ -1,5 +1,5 @@
 import {db} from '#db/db.js';
-import {runningJobExecutions} from '#db/runner-lease-table.js';
+import {runnerSessions, runningJobExecutions} from '#db/runner-lease-table.js';
 import {
   getFirstJobExecutionByJobId,
   getJobById,
@@ -58,6 +58,17 @@ export interface InsertRunningJobLeaseParams {
 }
 
 export async function insertRunningJobLease(params: InsertRunningJobLeaseParams): Promise<void> {
+  await db()
+    .insert(runnerSessions)
+    .values({
+      id: params.runnerSessionId,
+      workspaceId: params.workspaceId,
+      scope: 'workspace',
+      registrationTokenId: crypto.randomUUID(),
+      registrationTokenKind: 'manual',
+      labels: ['linux'],
+    });
+
   await db()
     .insert(runningJobExecutions)
     .values({


### PR DESCRIPTION
Add bounded runner-session retention to the runners maintenance path.

Runner sessions were durable write-only rows. Ephemeral one-job runners make that table high churn, so this adds configurable retention windows for manual and ephemeral sessions and deletes expired rows through the existing stuck-job detector maintenance workflow. The delete path skips any session referenced by an active running job.

The schema indexes are folded into the pre-deploy runners baseline, matching the existing migration convention. Ephemeral registration-token retention has separate audit/reuse semantics, so I split that follow-up into ENG-759 instead of bundling it here.

Closes ENG-622
Refs ENG-759

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retention-based GC for runner sessions to reduce churn from ephemeral runners and keep the table small. Closes ENG-622; ephemeral registration-token retention will be handled in ENG-759.

- New Features
  - Maintenance deletes expired sessions per kind (manual, ephemeral), skipping sessions referenced by active jobs.
  - Config: RUNNER_SESSION_MANUAL_RETENTION_DAYS (30), RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS (7), RUNNER_SESSION_GC_BATCH_SIZE (1000) with strict integer validation.
  - DB: index on runners_runner_sessions (registration_token_kind, created_at, id); index on runners_running_jobs (runner_session_id); FK from running_job_executions.runner_session_id to runner_sessions.id.
  - Workflow: runs before stuck-job expiry via a new activity; logs deletions and continues on failure.
  - Tests for config validation, DB cleanup logic, activities, and workflow integration.

<sup>Written for commit 3c7d6d1736933e0ee556547ee7786d12eb241902. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

