### PR TITLE
[e2e] Fix workflow definition sync race

### DIFF
--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -207,15 +207,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
 
   try {
     await createRepo({org: suite.org, name: repo});
-    const project = await createProject({
-      workspaceId: suite.workspaceId,
-      sessionToken: token,
-      name: repo,
-      connectionId: suite.connectionId,
-      externalRepositoryId: giteaExternalRepositoryId(suite.org, repo),
-    });
-
-    // The seed push can race subscription creation; assertions use the explicit trigger below.
+    // Project binding starts a definition sync, so the repo must already contain the workflow.
     await commitFiles({
       org: suite.org,
       repo,
@@ -224,6 +216,14 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
         {path: scenario.configPath, content: workflowYaml},
         ...scenario.extraFiles.map((file) => ({path: file.path, content: file.content})),
       ],
+    });
+
+    const project = await createProject({
+      workspaceId: suite.workspaceId,
+      sessionToken: token,
+      name: repo,
+      connectionId: suite.connectionId,
+      externalRepositoryId: giteaExternalRepositoryId(suite.org, repo),
     });
 
     const definition = await waitForDefinition({


### PR DESCRIPTION
Fix the platform workflow E2E setup so the scenario workflow file is committed before the project is created and bound to the Gitea repo.

Project binding starts definition sync immediately. The previous order created the project first, so the initial sync could run against an empty repo and permanently record `no-workflow-files` before the seed commit arrived. Seeding first keeps the initial sync aligned with the scenario state while preserving the later explicit trigger push for run assertions.

Validated with the scoped package checks and the full `@shipfox/e2e-platform-workflows` Playwright suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commit the scenario workflow to the repo before creating/binding the project to stop the definition-sync race. This makes the initial sync see the workflow instead of “no-workflow-files” and removes E2E flakes while keeping the later explicit trigger push for run assertions.

<sup>Written for commit cddd4179a7179a6bffb038267ecc207f78dd1281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

