### PR TITLE
[e2e] Stabilize integrations installed screenshot

### DIFF
--- a/e2e/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/client/integrations/tests/integration-flows.e2e.ts
@@ -72,7 +72,7 @@ test('connecting Gitea from onboarding flows into project creation', async ({
   await expect(page.getByRole('tab', {name: 'Runs'})).toBeVisible();
   await expect(page.getByLabel('Switch project')).toBeVisible();
 
-  await page.goto(`/workspaces/${wid}/integrations`);
+  await page.goto(`/workspaces/${wid}/settings/integrations`);
 
   await expect(page).toHaveURL(new RegExp(`/workspaces/${wid}/settings/integrations/?$`, 'u'));
   await expect(page.getByRole('heading', {name: 'Installed integrations'})).toBeVisible();

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -3,6 +3,8 @@ import {argosScreenshot, type Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const ADDED_DATE_RE = /^Added /u;
+const VISUAL_GITEA_CONNECTION_NAME = 'Gitea visual-test-org';
+const VISUAL_ADDED_DATE = 'Added Jan 15, 2026';
 
 // The e2e API may enable a different provider set, so stub the list to keep the
 // multi-tile grid deterministic. Typed against the real response DTO so a
@@ -79,16 +81,23 @@ test('settings catalogue shows an installed provider after Gitea install', async
   await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
 
   const installed = page.locator('section[aria-label="Installed integrations"]');
-  await expect(installed.getByText(`Gitea ${org.org}`, {exact: true})).toBeVisible();
+  const installedName = installed.getByText(`Gitea ${org.org}`, {exact: true});
+  await expect(installedName).toBeVisible();
   await expect(installed.getByText('Connected')).toHaveCount(0);
   await expect(installed.getByText(ADDED_DATE_RE)).toBeVisible();
 
-  // `Added <date>` is server-generated, so it would drift the Argos baseline.
-  // Pin only that text and keep the rest of the row anchored to the real Gitea
-  // connection.
-  await installed.getByText(ADDED_DATE_RE).evaluate((element) => {
-    element.textContent = 'Added Jan 15, 2026';
-  });
+  await installedName.evaluate((element, text) => {
+    element.textContent = text;
+  }, VISUAL_GITEA_CONNECTION_NAME);
+  await installed.getByText(ADDED_DATE_RE).evaluate((element, text) => {
+    element.textContent = text;
+  }, VISUAL_ADDED_DATE);
+
+  await installed
+    .getByLabel(`Open Gitea ${org.org} integration actions`)
+    .evaluate((element, text) => {
+      element.setAttribute('aria-label', `Open ${text} integration actions`);
+    }, VISUAL_GITEA_CONNECTION_NAME);
 
   await argosScreenshot(page, 'integrations/settings-installed');
 });


### PR DESCRIPTION
Stabilize the integrations installed Argos screenshot by replacing the run-generated Gitea organization label with a fixed visual placeholder immediately before capture.

The test still asserts the real generated Gitea connection name after install, so the end-to-end install path remains covered. Only the screenshot DOM is normalized, matching the existing date normalization and preventing per-run Gitea IDs from changing the baseline.

No changeset is needed because this only changes an E2E test. The focused integrations E2E package passes locally; the broad affected unit-test run hit unrelated DB-backed workflow/runner suite timeouts in this worktree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the integrations installed screenshot by replacing the dynamic Gitea org name and “Added <date>” with fixed placeholders before capture, and uses the canonical settings route in E2E. Prevents Argos baseline drift while keeping the real install path assertions.

- **Bug Fixes**
  - Replace visible “Gitea <org>” with `VISUAL_GITEA_CONNECTION_NAME` only for the screenshot; still assert the real name.
  - Pin “Added <date>` to `Added Jan 15, 2026`, and normalize the actions button aria-label to reference the placeholder.
  - Use the canonical route `/workspaces/:id/settings/integrations` in tests.

<sup>Written for commit 43c1ed0ed39918b1337cb10da8e778d6cdab1376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

