### PR TITLE
Focus workspace and integrations E2E setup flows

### DIFF
--- a/e2e/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/client/integrations/tests/integration-flows.e2e.ts
@@ -1,14 +1,9 @@
-import {argosScreenshot, type Page} from '@shipfox/playwright';
+import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const WORKSPACE_INTEGRATIONS_URL_RE = /\/workspaces\/[^/]+\/integrations\/?$/u;
 const GITEA_INSTALL_URL_RE = /\/workspaces\/[^/]+\/integrations\/gitea\/?$/u;
 const SETUP_NAVIGATION_TIMEOUT_MS = 15_000;
-const PLATFORM_REPOSITORY = 'platform';
-
-function projectsNewUrlRe(wid: string): RegExp {
-  return new RegExp(`/workspaces/${wid}/projects/new/?$`, 'u');
-}
 
 function modelProviderUrlRe(wid: string): RegExp {
   return new RegExp(`/workspaces/${wid}/model-provider/?$`, 'u');
@@ -21,59 +16,38 @@ async function expectSetupNavigationHidden(page: Page): Promise<void> {
   await expect(page.getByLabel('Switch workspace')).toBeVisible();
 }
 
-async function captureAndSkipModelProviderSetup(page: Page, wid: string): Promise<void> {
+async function expectModelProviderSetup(page: Page, wid: string): Promise<void> {
   await expect(page).toHaveURL(modelProviderUrlRe(wid));
   await expect(page.getByRole('heading', {name: 'Configure model provider'})).toBeVisible();
   await expectSetupNavigationHidden(page);
-  await argosScreenshot(page, 'integrations/model-provider-onboarding');
-  await page.getByRole('button', {name: 'Skip for now'}).click();
 }
 
-test('connecting Gitea from onboarding flows into project creation', async ({
+test('connecting Gitea from source-control setup opens model-provider setup', async ({
   page,
   auth,
   gitea,
+  workspaces,
 }) => {
   const user = await auth.createUser();
+  const workspace = await workspaces.create({userId: user.user.id, name: 'E2E Workspace'});
   await auth.loginAs(page, user);
 
   const org = await gitea.createOrg();
-  await gitea.createRepo({org: org.org, name: PLATFORM_REPOSITORY});
 
   await page.goto('/');
-  await page.getByLabel('Workspace name').fill('E2E Workspace');
-  await page.getByRole('button', {name: 'Create workspace'}).click();
   await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
+  await expect(page).toHaveURL(new RegExp(`/workspaces/${workspace.id}/integrations/?$`, 'u'));
   await expect(page.getByRole('heading', {name: 'Install source control'})).toBeVisible();
   await expectSetupNavigationHidden(page);
 
-  const wid = new URL(page.url()).pathname.split('/')[2];
-  expect(wid).toBeTruthy();
-
-  await page.locator(`a[href$="/workspaces/${wid}/integrations/gitea"]`).click();
+  await page.locator(`a[href$="/workspaces/${workspace.id}/integrations/gitea"]`).click();
   await page.getByLabel('Organization').fill(org.org);
   await page.getByRole('button', {name: 'Install'}).click();
 
-  await expect(page).toHaveURL(modelProviderUrlRe(wid as string), {
+  await expect(page).toHaveURL(modelProviderUrlRe(workspace.id), {
     timeout: SETUP_NAVIGATION_TIMEOUT_MS,
   });
   await expect(page).not.toHaveURL(GITEA_INSTALL_URL_RE);
   await expect(page).not.toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
-  await captureAndSkipModelProviderSetup(page, wid as string);
-
-  await expect(page).toHaveURL(projectsNewUrlRe(wid as string));
-  await expectSetupNavigationHidden(page);
-
-  await expect(page.getByRole('radio', {name: `${org.org}/${PLATFORM_REPOSITORY}`})).toBeVisible();
-  await expect(page.getByRole('button', {name: 'Create project'})).toBeEnabled();
-  await page.getByRole('button', {name: 'Create project'}).click();
-
-  await expect(page.getByText('Project created.')).toBeVisible();
-  await expect(page.getByRole('tab', {name: 'Runs'})).toBeVisible();
-  await expect(page.getByLabel('Switch project')).toBeVisible();
-
-  await page.goto(`/workspaces/${wid}/settings/integrations`);
-
-  await expect(page).toHaveURL(new RegExp(`/workspaces/${wid}/settings/integrations/?$`, 'u'));
-  await expect(page.getByRole('heading', {name: 'Installed integrations'})).toBeVisible();
+  await expectModelProviderSetup(page, workspace.id);
 });

--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -1,5 +1,4 @@
 import {randomUUID} from 'node:crypto';
-import type {GiteaHelper} from '@shipfox/e2e-helper-integrations-gitea';
 import {argosScreenshot, type Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
@@ -8,22 +7,9 @@ const WORKSPACE_INTEGRATIONS_URL_RE = /\/workspaces\/[^/]+\/integrations\/?$/u;
 const CREATE_WORKSPACE_LABEL_RE = /Create workspace/u;
 const LAST_WORKSPACE_KEY = 'shipfox.lastWorkspaceId';
 const SETUP_NAVIGATION_TIMEOUT_MS = 15_000;
-const PLATFORM_REPOSITORY = 'platform';
 
 function workspaceUrlRe(wid: string): RegExp {
   return new RegExp(`/workspaces/${wid}(/|$)`, 'u');
-}
-
-function projectsNewUrlRe(wid: string): RegExp {
-  return new RegExp(`/workspaces/${wid}/projects/new/?$`, 'u');
-}
-
-function modelProviderUrlRe(wid: string): RegExp {
-  return new RegExp(`/workspaces/${wid}/model-provider/?$`, 'u');
-}
-
-function setupDestinationUrlRe(wid: string): RegExp {
-  return new RegExp(`/workspaces/${wid}/(model-provider|projects/new)/?$`, 'u');
 }
 
 async function readLastWorkspaceId(page: Page): Promise<string> {
@@ -37,37 +23,6 @@ async function expectSetupNavigationHidden(page: Page): Promise<void> {
   await expect(page.getByRole('tab', {name: 'Settings'})).toHaveCount(0);
   await expect(page.getByLabel('Switch project')).toHaveCount(0);
   await expect(page.getByLabel('Switch workspace')).toBeVisible();
-}
-
-async function completeWorkspaceSetup(
-  page: Page,
-  workspaceId: string,
-  gitea: GiteaHelper,
-): Promise<void> {
-  const org = await gitea.createOrg();
-  await gitea.createRepo({org: org.org, name: PLATFORM_REPOSITORY});
-
-  await page.goto(`/workspaces/${workspaceId}/integrations/gitea`);
-  await page.getByLabel('Organization').fill(org.org);
-  await page.getByRole('button', {name: 'Install'}).click();
-  await expect(page).toHaveURL(setupDestinationUrlRe(workspaceId), {
-    timeout: SETUP_NAVIGATION_TIMEOUT_MS,
-  });
-  if (modelProviderUrlRe(workspaceId).test(page.url())) {
-    await expect(page.getByRole('heading', {name: 'Configure model provider'})).toBeVisible();
-    await expectSetupNavigationHidden(page);
-    await page.getByRole('button', {name: 'Skip for now'}).click();
-  }
-
-  await expect(page).toHaveURL(projectsNewUrlRe(workspaceId));
-  await expect(page.getByRole('radio', {name: `${org.org}/${PLATFORM_REPOSITORY}`})).toBeVisible();
-  await expect(page.getByRole('button', {name: 'Create project'})).toBeEnabled();
-  await page.getByRole('button', {name: 'Create project'}).click();
-
-  await expect(page.getByText('Project created.')).toBeVisible();
-  await expect(page).toHaveURL(
-    new RegExp(`/workspaces/${workspaceId}/projects/[^/]+/runs/?$`, 'u'),
-  );
 }
 
 test('redirects a no-workspace user from / to onboarding', async ({page, auth}) => {
@@ -159,11 +114,16 @@ test('persists the active workspace across reload and via /', async ({page, auth
   expect(page.url()).not.toMatch(workspaceUrlRe(wsA.id));
 });
 
-test('routes workspace settings to members by default', async ({page, auth, gitea, workspaces}) => {
+test('routes workspace settings to members by default', async ({
+  page,
+  auth,
+  projects,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   const workspace = await workspaces.create({userId: user.user.id, name: 'Settings Workspace'});
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, user);
-  await completeWorkspaceSetup(page, workspace.id, gitea);
 
   await page.goto(`/workspaces/${workspace.id}/settings`);
 
@@ -192,11 +152,11 @@ test('routes setup workspace settings back to source-control onboarding', async 
   await expectSetupNavigationHidden(page);
 });
 
-test('settings tab opens members settings', async ({page, auth, gitea, workspaces}) => {
+test('settings tab opens members settings', async ({page, auth, projects, workspaces}) => {
   const user = await auth.createUser();
   const workspace = await workspaces.create({userId: user.user.id, name: 'Settings Tab Workspace'});
+  await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, user);
-  await completeWorkspaceSetup(page, workspace.id, gitea);
 
   await page.goto(`/workspaces/${workspace.id}`);
   await page.getByRole('tab', {name: 'Settings'}).click();


### PR DESCRIPTION
Focus the workspace and integrations E2E specs on their own setup responsibilities.

The integrations flow now starts from a new workspace with no integration setup, loads `/`, asserts the app redirects to `/workspaces/:id/integrations`, installs Gitea, and verifies the next setup step is model provider onboarding. It no longer continues through repository-backed project creation or captures the model-provider onboarding screenshot.

The workspace flow now stops once onboarding reaches the integrations setup page. Settings-oriented workspace tests use project fixtures for their prerequisites instead of replaying the full Gitea setup path, which removes overlapping coverage and keeps these tests more atomic.

The removed model-provider visual screenshot remains covered by the client-agent Storybook stories and Argos build, so the Playwright flow only asserts navigation and behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor E2E onboarding tests to isolate responsibilities and cut overlap. Integrations now verifies Gitea install redirects to model-provider; workspace stops at integrations and uses fixtures for settings tests to reduce flakiness.

- **Refactors**
  - Integrations flow: start at `/`, assert redirect to `/workspaces/:id/integrations`, install Gitea, expect `/model-provider`. Removed project creation and model-provider screenshot.
  - Workspace flow: stop onboarding at integrations setup. Settings tests use project fixtures instead of full Gitea setup path.
  - Dropped `argosScreenshot` usage and imports from `@shipfox/playwright`; visual coverage remains via Storybook/Argos.
  - Seed workspaces via helpers (no URL parsing), reducing cross-test coupling and runtime.

<sup>Written for commit 82d9cfded468dde4aff31f1b82f328855fc07616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

