### PR TITLE
Fix CI init service startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
         uses: ./.github/actions/setup-playwright
 
       - name: Start test services
-        run: docker compose up --wait -d postgres temporal garage garage-init
+        run: |
+          docker compose up --wait -d postgres temporal garage
+          docker compose run --rm garage-init
 
       - name: Run tests
         env:
@@ -89,7 +91,10 @@ jobs:
       - name: Start test services
         env:
           SHIPFOX_GITEA_HTTP_HOST: 0.0.0.0
-        run: docker compose up --wait -d postgres temporal garage garage-init gitea gitea-init
+        run: |
+          docker compose up --wait -d postgres temporal garage gitea
+          docker compose run --rm garage-init
+          docker compose run --rm gitea-init
 
       - name: Install Playwright browsers
         run: pnpm --filter=@shipfox/playwright exec playwright install --with-deps chromium


### PR DESCRIPTION
Fix CI service startup when Docker Compose waits on init containers.

The CI jobs were passing `garage-init` and `gitea-init` to `docker compose up --wait`. Those services are one-shot bootstrap containers, so Compose can observe them as exited after successful completion and return 1 even though the backing services are healthy.

The workflow now waits only on long-running services and invokes init containers separately with `docker compose run --rm`, matching the Conductor worktree helper behavior.

Validated locally with an isolated Compose project that brought up postgres, temporal, garage, and gitea, then ran both init containers successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI service startup by removing init containers from `docker compose up --wait`. This avoids false failures when `garage-init` or `gitea-init` exit successfully after completing.

- **Bug Fixes**
  - Wait only for long‑running services: `postgres`, `temporal`, `garage`, `gitea`.
  - Run init containers separately: `docker compose run --rm garage-init` and `docker compose run --rm gitea-init`.

<sup>Written for commit 194cbf523c34bf000e6357f9351ce69a9deae09a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

