### PR TITLE
Add Conductor dev app script

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -20,3 +20,8 @@ if [ "${CONDUCTOR_IS_LOCAL:-1}" = "1" ]; then
   mise exec -- node dev/worktree-services.mjs destroy
 fi
 """
+
+[scripts.run.dev]
+command = "SHIPFOX_CLIENT_OPEN=1 mise exec -- turbo dev --filter=@shipfox/api --filter=@shipfox/client"
+default = true
+icon = "play"

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     port,
+    open: process.env.SHIPFOX_CLIENT_OPEN === '1',
     // Worktree ports must fail fast instead of silently shifting to another port.
     strictPort: true,
   },

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -18,6 +18,26 @@
       "outputs": ["dist/**/*", "!dist/**/*.d.ts", "!dist/**/*.d.ts.map", ".vercel/**/*"],
       "dependsOn": ["^build"]
     },
+    "dev": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["^build"],
+      "passThroughEnv": [
+        "API_PORT",
+        "BROWSER",
+        "BROWSER_ARGS",
+        "CLIENT_BASE_URL",
+        "GITEA_BASE_URL",
+        "HOST",
+        "LOG_STORAGE_S3_ENDPOINT",
+        "OTEL_INSTANCE_METRICS_PORT",
+        "OTEL_SERVICE_METRICS_PORT",
+        "POSTGRES_*",
+        "SHIPFOX_*",
+        "TEMPORAL_ADDRESS",
+        "VITE_*"
+      ]
+    },
     "check": {
       "cache": true,
       "dependsOn": ["@shipfox/biome#build"]


### PR DESCRIPTION
Add a shared Conductor run script that starts the API and client dev servers together.

Conductor workspaces already provision per-worktree ports and app environment during setup, but there was no run-menu entry for the normal app development loop. This adds a default `dev` script that runs Turbo over `@shipfox/api` and `@shipfox/client`, and configures Turbo's `dev` task to build upstream dependencies first while preserving the generated service env.

The client Vite server now opens only when `SHIPFOX_CLIENT_OPEN=1`, so Conductor can auto-open the app without changing normal `pnpm dev` behavior. Browser choice remains user-local through the standard `BROWSER` environment variable rather than being hard-coded for the team.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Conductor run script to start the API and client dev servers together via `turbo dev`. The client now auto-opens only when `SHIPFOX_CLIENT_OPEN=1`, keeping normal `pnpm dev` behavior unchanged.

- New Features
  - Default Conductor `dev` run entry launches `@shipfox/api` and `@shipfox/client` with `turbo dev`.
  - `turbo` dev task is persistent, no-cache, depends on `^build`, and passes through env vars (e.g., `BROWSER`, `SHIPFOX_*`, `VITE_*`).
  - Vite server opens the browser only when `SHIPFOX_CLIENT_OPEN=1`; browser choice remains user-local via `BROWSER`.

<sup>Written for commit 920d4af88c2417b1ed5352ba7b08e5332b86036b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

