### PR TITLE
[api-runners] Drop the workspace lookup from provisioner token auth

### DIFF
--- a/.changeset/lean-provisioners-authenticate.md
+++ b/.changeset/lean-provisioners-authenticate.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-runners": patch
+---
+
+Removes the per-request workspace existence and status check from provisioner token auth, severing the last `@shipfox/api-workspaces` dependency in `@shipfox/api-runners`; workspace-status enforcement on the provisioner path moves to the upcoming workspace removal/disable work.

--- a/libs/api/runners/package.json
+++ b/libs/api/runners/package.json
@@ -41,7 +41,6 @@
     "@shipfox/api-auth-context": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
-    "@shipfox/api-workspaces": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",
     "@shipfox/node-fastify": "workspace:*",

--- a/libs/api/runners/src/presentation/auth/provisioner-token-auth.ts
+++ b/libs/api/runners/src/presentation/auth/provisioner-token-auth.ts
@@ -3,21 +3,13 @@ import {
   type ProvisionerContext,
   setProvisionerContext,
 } from '@shipfox/api-auth-context';
-import {getWorkspace, WorkspaceNotFoundError} from '@shipfox/api-workspaces';
 import {type AuthMethod, ClientError, extractBearerToken} from '@shipfox/node-fastify';
 import {logger} from '@shipfox/node-opentelemetry';
 import {extractDisplayPrefix, getTokenType, hashOpaqueToken} from '@shipfox/node-tokens';
 import {config} from '#config.js';
 import {resolveProvisionerTokenByHash, touchProvisionerLastSeen} from '#db/provisioner-tokens.js';
 
-type AuthFailureReason =
-  | 'missing'
-  | 'type'
-  | 'not-found'
-  | 'revoked'
-  | 'expired'
-  | 'workspace-not-found'
-  | 'workspace-inactive';
+type AuthFailureReason = 'missing' | 'type' | 'not-found' | 'revoked' | 'expired';
 
 export function createProvisionerTokenAuthMethod(): AuthMethod {
   return {
@@ -56,24 +48,9 @@ export function createProvisionerTokenAuthMethod(): AuthMethod {
         });
       }
 
-      const workspace = await getWorkspace({workspaceId: provisionerToken.workspaceId}).catch(
-        (error: unknown) => {
-          if (error instanceof WorkspaceNotFoundError) {
-            logAuthFailure({rawToken, reason: 'workspace-not-found'});
-            throw new ClientError('Invalid provisioner token', 'unauthorized', {status: 401});
-          }
-          throw error;
-        },
-      );
-
-      if (workspace.status !== 'active') {
-        logAuthFailure({rawToken, reason: 'workspace-inactive'});
-        throw new ClientError('Workspace is not active', 'workspace-inactive', {status: 403});
-      }
-
       const context: ProvisionerContext = {
         provisionerTokenId: provisionerToken.id,
-        workspaceId: workspace.id,
+        workspaceId: provisionerToken.workspaceId,
       };
 
       await touchProvisionerLastSeen({

--- a/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
+++ b/libs/api/runners/src/presentation/routes/provisioner-me.test.ts
@@ -1,5 +1,4 @@
 import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
-import {getWorkspace, WorkspaceNotFoundError} from '@shipfox/api-workspaces';
 import type {AuthMethod} from '@shipfox/node-fastify';
 import {closeApp, createApp} from '@shipfox/node-fastify';
 import {generateOpaqueToken} from '@shipfox/node-tokens';
@@ -29,11 +28,6 @@ vi.mock('@shipfox/node-opentelemetry', async (importOriginal) => ({
   logger: () => mocks.logger,
 }));
 
-vi.mock('@shipfox/api-workspaces', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@shipfox/api-workspaces')>()),
-  getWorkspace: vi.fn(),
-}));
-
 const fakeUserAuth: AuthMethod = {
   name: AUTH_USER,
   authenticate: () => Promise.resolve(),
@@ -45,9 +39,6 @@ describe('provisioner me route', () => {
   beforeEach(async () => {
     await closeApp();
     mocks.logger.warn.mockReset();
-    vi.mocked(getWorkspace).mockImplementation(({workspaceId}) =>
-      Promise.resolve(workspace({id: workspaceId})),
-    );
     app = await createApp({
       auth: [fakeUserAuth, createProvisionerTokenAuthMethod()],
       routes: provisionerRoutes,
@@ -214,53 +205,4 @@ describe('provisioner me route', () => {
     expect(res.statusCode).toBe(401);
     expect(res.json().code).toBe('provisioner-token-expired');
   });
-
-  it('returns 401 for a provisioner token whose workspace does not exist', async () => {
-    const workspaceId = crypto.randomUUID();
-    const rawToken = generateOpaqueToken('provisionerToken');
-    await provisionerTokenFactory.create({workspaceId}, {transient: {rawToken}});
-    vi.mocked(getWorkspace).mockRejectedValueOnce(new WorkspaceNotFoundError(workspaceId));
-
-    const res = await app.inject({
-      method: 'GET',
-      url: '/provisioners/me',
-      headers: {authorization: `Bearer ${rawToken}`},
-    });
-
-    expect(res.statusCode).toBe(401);
-    expect(res.json().code).toBe('unauthorized');
-    expect(mocks.logger.warn).toHaveBeenCalledWith(
-      {prefix: rawToken.slice(0, 12), reason: 'workspace-not-found'},
-      'provisioner token auth failed',
-    );
-  });
-
-  it('returns 403 for a provisioner token in a suspended workspace', async () => {
-    const workspaceId = crypto.randomUUID();
-    const rawToken = generateOpaqueToken('provisionerToken');
-    await provisionerTokenFactory.create({workspaceId}, {transient: {rawToken}});
-    vi.mocked(getWorkspace).mockResolvedValueOnce(
-      workspace({id: workspaceId, status: 'suspended'}),
-    );
-
-    const res = await app.inject({
-      method: 'GET',
-      url: '/provisioners/me',
-      headers: {authorization: `Bearer ${rawToken}`},
-    });
-
-    expect(res.statusCode).toBe(403);
-    expect(res.json().code).toBe('workspace-inactive');
-  });
 });
-
-function workspace(params: {id: string; status?: 'active' | 'suspended' | 'deleted'}) {
-  return {
-    id: params.id,
-    name: 'Test Workspace',
-    status: params.status ?? 'active',
-    settings: {},
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2013,9 +2013,6 @@ importers:
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../workflows-dto
-      '@shipfox/api-workspaces':
-        specifier: workspace:*
-        version: link:../workspaces
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config


### PR DESCRIPTION
Provisioner token auth fetched the workspace row on every request only to reject suspended or deleted workspaces, coupling `api-runners` to `api-workspaces` and adding a second database read to every provisioner call.

Blocking work matters more than blocking sessions: a provisioner connected to an inactive workspace should simply never receive jobs. Auth now resolves the provisioner token row alone and takes the workspace id from it, and the `@shipfox/api-workspaces` dependency is removed from `@shipfox/api-runners` (this auth adapter was its only consumer).

This continues #548, which removed the equivalent per-request workspace read from user-token authorization and deferred workspace-status enforcement to token issuance. Known trade-off until workspace removal/disable lands: nothing else on the machine path checks workspace status today (demand poll, registration tokens, runner sessions, and job claim are all unfiltered), so a suspended workspace's provisioner could still mint registration tokens and execute queued work. Enforcement will be reintroduced with that work, either by filtering suspended workspaces at demand/claim or by revoking provisioner tokens on suspension.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the per-request workspace lookup in provisioner token auth to cut one DB read per call and decouple `@shipfox/api-runners` from `@shipfox/api-workspaces`.

- **Refactors**
  - Auth now resolves only the provisioner token row and uses its `workspaceId`.
  - Removes workspace existence/status checks and related failure reasons; updates tests.
  - Note: workspace-status enforcement for provisioners moves to the upcoming workspace disable/removal work.

- **Dependencies**
  - Removes `@shipfox/api-workspaces` from `@shipfox/api-runners`.

<sup>Written for commit cebf4edd031c07525345e70e5b561ef5c6981558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

