### PR TITLE
Fix freeze policy for reserved roots

### DIFF
--- a/.changeset/steady-roots-freeze.md
+++ b/.changeset/steady-roots-freeze.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Fixes fail-policy freezing for reserved server roots such as steps, jobs, and matrix.

--- a/libs/shared/expression/src/plan/freeze.test.ts
+++ b/libs/shared/expression/src/plan/freeze.test.ts
@@ -150,6 +150,29 @@ describe('freezeResolvedFieldAtSite', () => {
     expect(act).toThrow(WorkflowTemplateResolutionError);
   });
 
+  it('throws for fail-policy missing paths on reserved server roots available at the site', () => {
+    const field: ResolvedField = {
+      segments: [
+        {
+          kind: 'deferred',
+          expression: expression('steps.build.output'),
+          roots: ['steps'],
+          fillTarget: 'step-report',
+        },
+      ],
+    };
+
+    const act = () =>
+      freezeResolvedFieldAtSite({
+        field,
+        failurePolicy: 'fail',
+        site: 'step-report',
+        context: {steps: {}},
+      });
+
+    expect(act).toThrow(WorkflowTemplateResolutionError);
+  });
+
   it('skips deferred-past-site segments without evaluating their expression', () => {
     const field: ResolvedField = {
       segments: [

--- a/libs/shared/expression/src/plan/freeze.ts
+++ b/libs/shared/expression/src/plan/freeze.ts
@@ -8,9 +8,7 @@ import {WorkflowTemplateResolutionError} from '../resolver/errors.js';
 import {
   type AvailabilitySite,
   resolveContextRootAvailability,
-  type WorkflowContextName,
   type WorkflowInterpolationFailurePolicy,
-  workflowContextNames,
 } from '../workflow-context/workflow-context.js';
 import {shouldFillAtSite} from './fill.js';
 import type {ResolvedField, ResolvedFieldDeferredSegment} from './resolved-field.js';
@@ -98,16 +96,12 @@ function missingPathRequiresFailure(
   site: AvailabilitySite,
 ): boolean {
   if (failurePolicy !== 'fail') return false;
-  const workflowContextRoots = segment.roots.filter(isWorkflowContextName);
+  const rootAvailabilities = segment.roots.flatMap((root) => {
+    const availability = resolveContextRootAvailability(root);
+    return availability === undefined ? [] : [availability];
+  });
   return (
-    workflowContextRoots.length > 0 &&
-    workflowContextRoots.every((contextRoot) => {
-      const availability = resolveContextRootAvailability(contextRoot);
-      return availability !== undefined && shouldFillAtSite(availability, site);
-    })
+    rootAvailabilities.length > 0 &&
+    rootAvailabilities.every((availability) => shouldFillAtSite(availability, site))
   );
-}
-
-function isWorkflowContextName(root: string): root is WorkflowContextName {
-  return (workflowContextNames as readonly string[]).includes(root);
 }


### PR DESCRIPTION
Fix fail-policy freezing for planned fields that reference reserved server roots such as `steps`, `jobs`, and `matrix`.

The planner can route reserved roots because they have server availability, but the freeze missing-path guard only counted named workflow contexts. That made fail-policy missing paths on reserved roots degrade instead of throwing once the reserved root was available at the freeze site. This switches the guard to use `resolveContextRootAvailability` as the source of known server roots and adds regression coverage for `steps`.

Refs ENG-750

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix fail-policy freezing for fields that reference reserved server roots (`steps`, `jobs`, `matrix`). Roots with server availability are now recognized, so missing paths correctly throw at the freeze site, aligning with ENG-750 planner routing.

- **Bug Fixes**
  - Use `resolveContextRootAvailability` to detect available roots; remove the `workflowContextNames` filter.
  - Add regression test for `steps.build.output` failing at `step-report`.
  - Patch release for `@shipfox/expression`.

<sup>Written for commit a5d4c48ca854267631d7762a317db4036f2ef2e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

