### PR TITLE
Reduce Argos screenshot spend from feature-package stories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded PR/branch runs before they finish, so rapid pushes stop paying
+# for CI work they already invalidated. main is never cancelled: every merged commit
+# must run to completion to publish its per-commit release artifacts.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: shipfox

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -696,9 +696,9 @@ display name so they are easy to distinguish from visual coverage.
 Argos catches UI drift on every PR via one named build per source package. The
 `buildName` is the package name without the `@shipfox/` scope:
 
-- `react-ui`: `@shipfox/react-ui` stories captured in **light + dark** by `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin`. Capture is part of `turbo test` for `@shipfox/react-ui`. Adding a new story snapshots automatically in both themes.
-- `client-workflows`: `@shipfox/client-workflows` stories, captured the same way under `turbo test` for that package. Story-based capture isn't limited to `react-ui`: any client package with stories can register its own `argosVitestPlugin` build named after the package.
-- `client-auth`: `@shipfox/client-auth` Storybook stories, captured the same way under `turbo test` for that package. Today this covers workspace switcher states in light and dark without full workspace E2E setup.
+- `react-ui`: `@shipfox/react-ui` stories captured in **light + dark** by `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin`. Capture is part of `turbo test` for `@shipfox/react-ui`. It is the theming source of truth, so it is the only build that snapshots every story in both themes.
+- `client-workflows`: `@shipfox/client-workflows` stories, captured the same way under `turbo test` for that package. Story-based capture isn't limited to `react-ui`: any client package with stories can register its own `argosVitestPlugin` build named after the package. Feature (`client-*`) builds capture the primary **dark** theme only; keep their `parameters.argos.modes` to `dark` since `react-ui` already proves theme correctness.
+- `client-auth`: `@shipfox/client-auth` Storybook stories, captured the same way under `turbo test` for that package. Today this covers workspace switcher states in dark without full workspace E2E setup.
 - `e2e-client-<module>` (today: `e2e-client-auth`): explicit `argosScreenshot(page, '<surface>/<state>')` calls in the matching `e2e/client/<module>/*` Playwright specs. Each E2E package sets its own `buildName` matching the package name without the `@shipfox/` scope so PR checks stay scoped per surface. Place the call **after** the assertions that prove the page reached the expected state; the helper waits for fonts and layout, not for content you have not asserted on.
 
 A surface with both Storybook and E2E visual coverage gets two standalone builds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,9 +318,17 @@ through parallel or sharded Argos builds.
 | Build name | Source | Captured |
 | --- | --- | --- |
 | `react-ui` | `@shipfox/react-ui` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | every story in **light + dark** (declared in `libs/shared/react/ui/.storybook/preview.tsx` as `parameters.argos.modes`) |
-| `client-workflows` | `@shipfox/client-workflows` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | every story in **light + dark** (declared in `libs/client/workflows/.storybook/preview.tsx` as `parameters.argos.modes`) |
-| `client-auth` | `@shipfox/client-auth` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | workspace switcher states in **light + dark** (declared in `libs/client/auth/.storybook/preview.tsx` as `parameters.argos.modes`) |
+| `client-workflows` | `@shipfox/client-workflows` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | every story in **dark** (declared in `libs/client/workflows/.storybook/preview.tsx` as `parameters.argos.modes`) |
+| `client-auth` | `@shipfox/client-auth` stories via `@storybook/addon-vitest` + `@argos-ci/storybook/vitest-plugin` | workspace switcher states in **dark** (declared in `libs/client/auth/.storybook/preview.tsx` as `parameters.argos.modes`) |
 | `e2e-client-auth` | `@shipfox/e2e-client-auth` Playwright specs via `@argos-ci/playwright` reporter | explicit `argosScreenshot()` calls at user-visible checkpoints |
+
+`react-ui` is the theming source of truth, so it captures every story in **light
+and dark**. Feature packages (`client-*`) compose those primitives, so they
+capture only the product's primary **dark** theme: theme correctness is already
+proven upstream in `react-ui`, and one theme per feature story roughly halves the
+Argos screenshots those builds cost. Keep new `client-*` `parameters.argos.modes`
+to `dark` only; reach for a second theme in a feature package only when it renders
+theme-specific markup that `react-ui` does not already cover.
 
 The goal is review-grade signal on UI drift, not 100% state coverage. Capture the
 states a reviewer would want to eyeball on a PR; skip anything that re-renders
@@ -347,10 +355,11 @@ the Argos reporter is not active, so no screenshots are uploaded.
 ### Add a new component snapshot
 
 Just add a story. `@storybook/addon-vitest` discovers `.stories.@(js|jsx|ts|tsx|mdx)`
-under `src/**` automatically and the Argos vitest plugin captures each one in
-both themes. To cover a state that a single render can't reach (e.g. error
-states, populated lists), add it as a new story rather than driving
-interactions in `play`.
+under `src/**` automatically and the Argos vitest plugin captures each one in the
+themes that package's `parameters.argos.modes` declares (light + dark in
+`react-ui`, dark only in feature packages). To cover a state that a single render
+can't reach (e.g. error states, populated lists), add it as a new story rather
+than driving interactions in `play`.
 
 ### Add a new client-page snapshot
 

--- a/libs/client/agent/.storybook/preview.tsx
+++ b/libs/client/agent/.storybook/preview.tsx
@@ -24,8 +24,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/auth/.storybook/preview.tsx
+++ b/libs/client/auth/.storybook/preview.tsx
@@ -24,8 +24,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/integrations/.storybook/preview.tsx
+++ b/libs/client/integrations/.storybook/preview.tsx
@@ -24,8 +24,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/logs/.storybook/preview.tsx
+++ b/libs/client/logs/.storybook/preview.tsx
@@ -24,8 +24,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/projects/.storybook/preview.tsx
+++ b/libs/client/projects/.storybook/preview.tsx
@@ -24,8 +24,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/runners/.storybook/preview.tsx
+++ b/libs/client/runners/.storybook/preview.tsx
@@ -32,8 +32,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/secrets/.storybook/preview.tsx
+++ b/libs/client/secrets/.storybook/preview.tsx
@@ -24,8 +24,9 @@ const preview: Preview = {
   decorators: [withTheme],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/triggers/.storybook/preview.tsx
+++ b/libs/client/triggers/.storybook/preview.tsx
@@ -57,8 +57,9 @@ const preview: Preview = {
   decorators: [withTheme, withRelativeTime, withRouter],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,

--- a/libs/client/workflows/.storybook/preview.tsx
+++ b/libs/client/workflows/.storybook/preview.tsx
@@ -65,8 +65,9 @@ const preview: Preview = {
   decorators: [withTheme, withRelativeTime, withRouter],
   parameters: {
     argos: {
+      // Dual-theme coverage lives in @shipfox/react-ui (the theming source of truth);
+      // feature packages capture only the primary dark theme to limit Argos spend.
       modes: {
-        light: {theme: 'light'},
         dark: {theme: 'dark'},
       },
       fitToContent: false,


### PR DESCRIPTION
Cuts Argos visual-testing spend on two axes at once, with no loss of design-system coverage.

## Why

Argos bills per uploaded screenshot, and our count was inflated by two structural things:

- **Every client story was captured in both light and dark.** That is a literal x2 on the ~640 story screenshots. Theme correctness only genuinely needs verifying in one place: `react-ui`, the theming source of truth.
- **Rapid pushes to a PR each ran to completion and uploaded** before the next superseded them, so iterating on a branch re-paid for the full screenshot set on every push.

## What changed

**Single-theme capture for feature packages.** The 9 `client-*` Storybook builds now capture the product's primary **dark** theme only (`parameters.argos.modes` in each `.storybook/preview.tsx`). `react-ui` stays **light + dark** as the source of truth. Feature packages compose react-ui primitives, so their dark-mode correctness is already proven upstream; the second theme added cost without new signal. This roughly halves the screenshots those builds produce and keeps every future feature story at one capture instead of two.

**CI `concurrency` cancel-in-progress.** Superseded PR and branch runs are now cancelled before they reach the Argos upload. `main` is explicitly excluded (`github.ref != 'refs/heads/main'`), so every merged commit still finishes to publish its Argos baseline and its images.

**Docs.** `CONTRIBUTING.md` and `AGENTS.md` now record the react-ui-only dual-theme policy, so new `client-*` packages default to dark-only.

## Review notes

- `client-auth` was previously documented as capturing light + dark for the workspace switcher; it is now dark-only like the other feature packages. If that surface specifically needs light verification, we can re-add just its `light` mode.
- No changeset: all `client-*` packages are `private: true` (never published) and the changes are Storybook/CI config only, so there is no npm-consumer impact.

Not yet included, but the natural follow-ups if spend is still high: a per-PR Turbo cache-write scope so unchanged builds skip re-upload across pushes, and folding enum-per-story stories into matrix stories.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Argos screenshot costs by capturing dark-only stories in `client-*` packages and cancelling superseded CI runs. `react-ui` stays light + dark as the theming source of truth, so coverage is preserved.

- **Refactors**
  - Set `parameters.argos.modes` to `dark` in `libs/client/*/.storybook/preview.tsx`.
  - Add GitHub Actions `concurrency` to cancel in-progress PR/branch runs before the Argos upload; excludes `main`.
  - Update `CONTRIBUTING.md` and `AGENTS.md` to document the `react-ui`-only dual-theme policy.

<sup>Written for commit 1b410d397be218cb6a64557c695c93801a2a95ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

