### PR TITLE
Add Docker provisioner image publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
             image: api
           - package: "@shipfox/client"
             image: client
+          - package: "@shipfox/provisioner-docker"
+            image: provisioner-docker
           - package: "@shipfox/runner"
             image: runner
 

--- a/apps/provisioner-docker/Dockerfile
+++ b/apps/provisioner-docker/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+# "Build outside Docker, ingest dist": `shipfox-docker --setup-context` prunes
+# the workspace and overlays the turbo-cached dist/. The build stage installs
+# the pruned workspace and runs `pnpm deploy` to extract the provisioner's
+# production dependency closure into a self-contained tree; the runtime stage
+# ships only that, so Docker never compiles TypeScript.
+
+ARG NODE_VERSION=24.16.0
+ARG PNPM_VERSION=11.6.0
+
+FROM node:${NODE_VERSION}-slim AS base
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+WORKDIR /app
+
+FROM base AS build
+# Manifests + lockfile first (out/full carries the source but not the lockfile).
+COPY out/json/ ./
+COPY out/full/ ./
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir=/pnpm/store
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm --filter=@shipfox/provisioner-docker deploy --prod --legacy \
+      --store-dir=/pnpm/store --config.strict-peer-dependencies=false /prod
+
+FROM base AS runtime
+ENV NODE_ENV=production
+
+COPY --from=build /prod ./
+
+# The Docker provisioner usually talks to a mounted Docker socket. Running as root
+# avoids requiring deployments to align the container user with the host socket's
+# group id; remote Docker hosts can still be selected with SHIPFOX_PROVISIONER_DOCKER_HOST.
+
+# The build/promotion workflows pass revision/created as build args.
+ARG IMAGE_SOURCE="https://github.com/ShipfoxHQ/shipfox"
+ARG IMAGE_REVISION
+ARG IMAGE_CREATED
+LABEL org.opencontainers.image.title="@shipfox/provisioner-docker" \
+      org.opencontainers.image.description="Shipfox Docker provisioner" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source=$IMAGE_SOURCE \
+      org.opencontainers.image.revision=$IMAGE_REVISION \
+      org.opencontainers.image.created=$IMAGE_CREATED
+
+# --enable-source-maps maps stack traces back to TypeScript.
+CMD ["node", "--enable-source-maps", "./dist/index.js"]

--- a/apps/provisioner-docker/package.json
+++ b/apps/provisioner-docker/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "build": "shipfox-swc",
     "dev": "tsx watch --conditions=development --env-file-if-exists=../../.env --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts",
+    "image": "shipfox-docker --setup-context --image provisioner-docker",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
     "type": "shipfox-tsc-check",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",
+    "@shipfox/docker": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@shipfox/biome':
         specifier: workspace:*
         version: link:../../tools/biome
+      '@shipfox/docker':
+        specifier: workspace:*
+        version: link:../../tools/docker
       '@shipfox/swc':
         specifier: workspace:*
         version: link:../../tools/swc


### PR DESCRIPTION
Add a published Docker image for the Docker provisioner app.

The provisioner is currently an app package but was not part of the shared image build and publish matrix, so self-hosted deployments had no first-class image to pull. This adds an app Dockerfile using the existing pruned workspace and production deploy flow, wires the package into `shipfox-docker`, and includes it in CI image validation and main-branch GHCR publishing alongside the API, client, and runner images.

The runtime intentionally keeps the default root user because the Docker provisioner commonly talks to a mounted Docker socket; deployments using a remote daemon can still point it at `SHIPFOX_PROVISIONER_DOCKER_HOST`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a Docker image for the Docker provisioner to support self‑hosted deployments. `@shipfox/provisioner-docker` now builds, validates, and publishes to GHCR alongside our other images.

- **New Features**
  - Add app Dockerfile using pruned workspace and `pnpm deploy` prod tree (Node 24).
  - Add `image` script and `@shipfox/docker` dev dep in `@shipfox/provisioner-docker`.
  - Wire into CI `shipfox-docker` matrix for image validation and GHCR publish.
  - Runtime stays root for Docker socket access; remote hosts via `SHIPFOX_PROVISIONER_DOCKER_HOST`.

<sup>Written for commit 3573a933a1a34274cd2376c523e3f609d2dfc543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

