### PR TITLE
[api/runners] Add ephemeral registration token retention GC

### DIFF
--- a/libs/api/runners/drizzle/0007_ephemeral_token_gc_index.sql
+++ b/libs/api/runners/drizzle/0007_ephemeral_token_gc_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "runners_ephemeral_registration_tokens_created_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("created_at","id");

--- a/libs/api/runners/drizzle/0007_ephemeral_token_gc_index.sql
+++ b/libs/api/runners/drizzle/0007_ephemeral_token_gc_index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX "runners_ephemeral_registration_tokens_created_id_idx" ON "runners_ephemeral_registration_tokens" USING btree ("created_at","id");
+CREATE INDEX "runners_ephemeral_registration_tokens_terminal_idx" ON "runners_ephemeral_registration_tokens" USING btree (coalesce("consumed_at", "expires_at"),"id");

--- a/libs/api/runners/drizzle/meta/0007_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0007_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "77159114-5118-4a11-adae-0513721c7522",
+  "id": "1fc45aa6-7700-46a3-98a5-4f9be355734a",
   "prevId": "c0278e57-95b7-4c5e-a0ce-8122a20b75d0",
   "version": "7",
   "dialect": "postgresql",
@@ -177,13 +177,13 @@
           "method": "btree",
           "with": {}
         },
-        "runners_ephemeral_registration_tokens_created_id_idx": {
-          "name": "runners_ephemeral_registration_tokens_created_id_idx",
+        "runners_ephemeral_registration_tokens_terminal_idx": {
+          "name": "runners_ephemeral_registration_tokens_terminal_idx",
           "columns": [
             {
-              "expression": "created_at",
-              "isExpression": false,
+              "expression": "coalesce(\"consumed_at\", \"expires_at\")",
               "asc": true,
+              "isExpression": true,
               "nulls": "last"
             },
             {

--- a/libs/api/runners/drizzle/meta/0007_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1666 @@
+{
+  "id": "77159114-5118-4a11-adae-0513721c7522",
+  "prevId": "c0278e57-95b7-4c5e-a0ce-8122a20b75d0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.runners_ephemeral_registration_tokens": {
+      "name": "runners_ephemeral_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_session_id": {
+          "name": "consumed_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_ephemeral_registration_tokens_hashed_token_unique": {
+          "name": "runners_ephemeral_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_workspace_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_provisioner_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_provisioner_id_idx",
+          "columns": [
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_reservation_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_active_provisioned_runner_idx": {
+          "name": "runners_ephemeral_registration_tokens_active_provisioned_runner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioned_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_ephemeral_registration_tokens_created_id_idx": {
+          "name": "runners_ephemeral_registration_tokens_created_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_manual_registration_tokens": {
+      "name": "runners_manual_registration_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_manual_registration_tokens_hashed_token_unique": {
+          "name": "runners_manual_registration_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_manual_registration_tokens_workspace_id_idx": {
+          "name": "runners_manual_registration_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_manual_registration_tokens_active_lookup_idx": {
+          "name": "runners_manual_registration_tokens_active_lookup_idx",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_outbox": {
+      "name": "runners_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_dispatch_at": {
+          "name": "next_dispatch_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_dispatch_error": {
+          "name": "last_dispatch_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_dispatch_failed_at": {
+          "name": "last_dispatch_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_outbox_pending_idx": {
+          "name": "runners_outbox_pending_idx",
+          "columns": [
+            {
+              "expression": "next_dispatch_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NULL AND \"dead_lettered_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_outbox_dispatched_retention_idx": {
+          "name": "runners_outbox_dispatched_retention_idx",
+          "columns": [
+            {
+              "expression": "dispatched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"dispatched_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_pending_jobs": {
+      "name": "runners_pending_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_pending_jobs_created_idx": {
+          "name": "runners_pending_jobs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_pending_jobs_workspace_created_idx": {
+          "name": "runners_pending_jobs_workspace_created_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_pending_jobs_job_id_idx": {
+          "name": "runners_pending_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_pending_jobs_job_execution_id_unique": {
+          "name": "runners_pending_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioned_runners": {
+      "name": "runners_provisioned_runners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reservation_id": {
+          "name": "reservation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_key": {
+          "name": "template_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "runners_provisioned_runner_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_kind": {
+          "name": "provider_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reported_at": {
+          "name": "reported_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopping_at": {
+          "name": "stopping_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stopped_at": {
+          "name": "stopped_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reservation_released_at": {
+          "name": "reservation_released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioned_runners_workspace_provisioner_runner_unique": {
+          "name": "runners_provisioned_runners_workspace_provisioner_runner_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioned_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioned_runners_workspace_state_updated_idx": {
+          "name": "runners_provisioned_runners_workspace_state_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioned_runners_stale_reaper_idx": {
+          "name": "runners_provisioned_runners_stale_reaper_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reported_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioned_runners_active_template_counts_idx": {
+          "name": "runners_provisioned_runners_active_template_counts_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"state\" in ('starting', 'running') and \"template_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioned_runners_reservation_id_idx": {
+          "name": "runners_provisioned_runners_reservation_id_idx",
+          "columns": [
+            {
+              "expression": "reservation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_provisioner_tokens": {
+      "name": "runners_provisioner_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_token": {
+          "name": "hashed_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_provisioner_tokens_hashed_token_unique": {
+          "name": "runners_provisioner_tokens_hashed_token_unique",
+          "columns": [
+            {
+              "expression": "hashed_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_tokens_workspace_id_idx": {
+          "name": "runners_provisioner_tokens_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_provisioner_tokens_workspace_last_seen_idx": {
+          "name": "runners_provisioner_tokens_workspace_last_seen_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_rate_limits": {
+      "name": "runners_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_rate_limits_window_unique": {
+          "name": "runners_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_rate_limits_expires_at_idx": {
+          "name": "runners_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runners_reservations": {
+      "name": "runners_reservations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "runners_reservations_workspace_expires_idx": {
+          "name": "runners_reservations_workspace_expires_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_reservations_expires_idx": {
+          "name": "runners_reservations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_reservations_count_positive_ck": {
+          "name": "runners_reservations_count_positive_ck",
+          "value": "\"runners_reservations\".\"count\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_runner_sessions": {
+      "name": "runners_runner_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "runners_runner_session_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "registration_token_id": {
+          "name": "registration_token_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_token_kind": {
+          "name": "registration_token_kind",
+          "type": "runners_runner_session_registration_token_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_claims": {
+          "name": "max_claims",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claims_used": {
+          "name": "claims_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "runners_runner_sessions_kind_created_id_idx": {
+          "name": "runners_runner_sessions_kind_created_id_idx",
+          "columns": [
+            {
+              "expression": "registration_token_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_runner_sessions_provisioned_runner_updated_idx": {
+          "name": "runners_runner_sessions_provisioned_runner_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioned_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runners_runner_sessions_claims_ck": {
+          "name": "runners_runner_sessions_claims_ck",
+          "value": "\"runners_runner_sessions\".\"claims_used\" >= 0 AND ((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"max_claims\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"max_claims\" IS NOT NULL AND \"runners_runner_sessions\".\"max_claims\" > 0 AND \"runners_runner_sessions\".\"claims_used\" <= \"runners_runner_sessions\".\"max_claims\"))"
+        },
+        "runners_runner_sessions_link_ck": {
+          "name": "runners_runner_sessions_link_ck",
+          "value": "((\"runners_runner_sessions\".\"registration_token_kind\" = 'manual' AND \"runners_runner_sessions\".\"provisioner_id\" IS NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NULL) OR (\"runners_runner_sessions\".\"registration_token_kind\" = 'ephemeral' AND \"runners_runner_sessions\".\"provisioner_id\" IS NOT NULL AND \"runners_runner_sessions\".\"provisioned_runner_id\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runners_running_jobs": {
+      "name": "runners_running_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuidv7()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_run_attempt_id": {
+          "name": "workflow_run_attempt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_execution_id": {
+          "name": "job_execution_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_session_id": {
+          "name": "runner_session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisioner_id": {
+          "name": "provisioner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provisioned_runner_id": {
+          "name": "provisioned_runner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_labels": {
+          "name": "required_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runner_labels": {
+          "name": "runner_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_heartbeat_at": {
+          "name": "first_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "cancellation_requested_at": {
+          "name": "cancellation_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runners_running_jobs_no_first_heartbeat_started_idx": {
+          "name": "runners_running_jobs_no_first_heartbeat_started_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"first_heartbeat_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_last_heartbeat_at_idx": {
+          "name": "runners_running_jobs_last_heartbeat_at_idx",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_provisioned_runner_started_idx": {
+          "name": "runners_running_jobs_provisioned_runner_started_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioned_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"provisioner_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_cancellation_requested_idx": {
+          "name": "runners_running_jobs_cancellation_requested_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provisioned_runner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"cancellation_requested_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_job_id_idx": {
+          "name": "runners_running_jobs_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runners_running_jobs_runner_session_id_idx": {
+          "name": "runners_running_jobs_runner_session_id_idx",
+          "columns": [
+            {
+              "expression": "runner_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk": {
+          "name": "runners_running_jobs_runner_session_id_runners_runner_sessions_id_fk",
+          "tableFrom": "runners_running_jobs",
+          "tableTo": "runners_runner_sessions",
+          "columnsFrom": ["runner_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "runners_running_jobs_job_execution_id_unique": {
+          "name": "runners_running_jobs_job_execution_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["job_execution_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "runners_running_jobs_link_ck": {
+          "name": "runners_running_jobs_link_ck",
+          "value": "(\"runners_running_jobs\".\"provisioner_id\" IS NULL) = (\"runners_running_jobs\".\"provisioned_runner_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.runners_provisioned_runner_state": {
+      "name": "runners_provisioned_runner_state",
+      "schema": "public",
+      "values": ["starting", "running", "stopping", "stopped", "failed", "terminated"]
+    },
+    "public.runners_runner_session_registration_token_kind": {
+      "name": "runners_runner_session_registration_token_kind",
+      "schema": "public",
+      "values": ["manual", "ephemeral"]
+    },
+    "public.runners_runner_session_scope": {
+      "name": "runners_runner_session_scope",
+      "schema": "public",
+      "values": ["workspace"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/libs/api/runners/drizzle/meta/_journal.json
+++ b/libs/api/runners/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1783140420801,
       "tag": "0006_petite_zzzax",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1783153838011,
+      "tag": "0007_ephemeral_token_gc_index",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/api/runners/drizzle/meta/_journal.json
+++ b/libs/api/runners/drizzle/meta/_journal.json
@@ -54,7 +54,7 @@
     {
       "idx": 7,
       "version": "7",
-      "when": 1783153838011,
+      "when": 1783156499381,
       "tag": "0007_ephemeral_token_gc_index",
       "breakpoints": true
     }

--- a/libs/api/runners/src/config.test.ts
+++ b/libs/api/runners/src/config.test.ts
@@ -313,3 +313,33 @@ describe('runner session retention config', () => {
     await expect(import('#config.js')).rejects.toThrow(name);
   });
 });
+
+describe('ephemeral registration token retention config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses the default retention window and batch size', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS).toBe(7);
+    expect(config.RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE).toBe(1000);
+  });
+
+  it.each([
+    ['RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS', '0'],
+    ['RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS', '-5'],
+    ['RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS', '1.5'],
+    ['RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE', '0'],
+    ['RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE', '-5'],
+    ['RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE', '1.5'],
+  ])('fails startup when %s is %s', async (name, value) => {
+    vi.stubEnv(name, value);
+    vi.resetModules();
+
+    await expect(import('#config.js')).rejects.toThrow(name);
+  });
+});

--- a/libs/api/runners/src/config.ts
+++ b/libs/api/runners/src/config.ts
@@ -89,6 +89,14 @@ export const config = createConfig({
     desc: 'Maximum number of expired runner sessions maintenance deletes in one pass.',
     default: 1000,
   }),
+  RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS: num({
+    desc: 'How long consumed or expired ephemeral registration tokens are retained for audit and debugging before maintenance deletes them, in days. Active tokens that are neither consumed nor expired are never deleted. This window is independent of the runner-session retention windows.',
+    default: 7,
+  }),
+  RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE: num({
+    desc: 'Maximum number of consumed or expired ephemeral registration tokens maintenance deletes in one pass.',
+    default: 1000,
+  }),
   PROVISIONER_ACTIVE_WINDOW_SECONDS: num({
     desc: 'Time window, in seconds, used to list active provisioners from recent authenticated requests.',
     default: 120,
@@ -251,6 +259,24 @@ if (
 ) {
   throw new Error(
     `RUNNER_SESSION_GC_BATCH_SIZE (${config.RUNNER_SESSION_GC_BATCH_SIZE}) must be a whole number >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS) ||
+  config.RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS < 1
+) {
+  throw new Error(
+    `RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS (${config.RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS}) must be a whole number of days >= 1.`,
+  );
+}
+
+if (
+  !Number.isInteger(config.RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE) ||
+  config.RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE < 1
+) {
+  throw new Error(
+    `RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE (${config.RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE}) must be a whole number >= 1.`,
   );
 }
 

--- a/libs/api/runners/src/core/maintenance.test.ts
+++ b/libs/api/runners/src/core/maintenance.test.ts
@@ -1,6 +1,7 @@
 import {vi} from '@shipfox/vitest/vi';
 import {eq} from 'drizzle-orm';
 import {db} from '#db/db.js';
+import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
 import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {reservations} from '#db/schema/reservations.js';
 import {runnerSessions} from '#db/schema/runner-sessions.js';
@@ -11,6 +12,7 @@ import {
   reservationFactory,
 } from '#test/index.js';
 import {
+  deleteExpiredEphemeralRegistrationTokens,
   deleteExpiredRunnerReservations,
   deleteExpiredRunnerSessions,
   reapStaleProvisionedRunners,
@@ -177,6 +179,73 @@ describe('deleteExpiredRunnerSessions', () => {
       claimsUsed: 0,
       createdAt: params.createdAt,
       updatedAt: params.createdAt,
+    };
+  }
+});
+
+describe('deleteExpiredEphemeralRegistrationTokens', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  let workspaceId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+  });
+
+  it('deletes expired ephemeral tokens using the default retention policy', async () => {
+    const staleId = crypto.randomUUID();
+    await db()
+      .insert(ephemeralRegistrationTokens)
+      .values(
+        buildEphemeralToken({
+          id: staleId,
+          expiresAt: new Date(Date.now() - 8 * DAY_MS),
+        }),
+      );
+
+    const result = await deleteExpiredEphemeralRegistrationTokens();
+
+    const remaining = await db()
+      .select({id: ephemeralRegistrationTokens.id})
+      .from(ephemeralRegistrationTokens)
+      .where(eq(ephemeralRegistrationTokens.workspaceId, workspaceId));
+    expect(result.deleted).toBeGreaterThanOrEqual(1);
+    expect(remaining).toEqual([]);
+  });
+
+  it('passes explicit retention and limit values to the DB cleanup', async () => {
+    const deletableId = crypto.randomUUID();
+    const keptId = crypto.randomUUID();
+    await db()
+      .insert(ephemeralRegistrationTokens)
+      .values([
+        buildEphemeralToken({id: deletableId, expiresAt: new Date(Date.now() - 3650 * DAY_MS)}),
+        buildEphemeralToken({id: keptId, expiresAt: new Date(Date.now() - 4 * DAY_MS)}),
+      ]);
+
+    const result = await deleteExpiredEphemeralRegistrationTokens({retentionDays: 5, limit: 1});
+
+    const remaining = await db()
+      .select({id: ephemeralRegistrationTokens.id})
+      .from(ephemeralRegistrationTokens)
+      .where(eq(ephemeralRegistrationTokens.workspaceId, workspaceId));
+    expect(result.deleted).toBe(1);
+    expect(remaining.map((row) => row.id)).toEqual([keptId]);
+  });
+
+  function buildEphemeralToken(params: {
+    id: string;
+    expiresAt: Date;
+  }): typeof ephemeralRegistrationTokens.$inferInsert {
+    return {
+      id: params.id,
+      workspaceId,
+      provisionerId: crypto.randomUUID(),
+      provisionedRunnerId: `provisioned-${params.id}`,
+      hashedToken: crypto.randomUUID(),
+      prefix: 'sfxr_test',
+      expiresAt: params.expiresAt,
+      consumedAt: null,
+      createdAt: params.expiresAt,
     };
   }
 });

--- a/libs/api/runners/src/core/maintenance.ts
+++ b/libs/api/runners/src/core/maintenance.ts
@@ -1,4 +1,5 @@
 import {config} from '#config.js';
+import {deleteExpiredEphemeralRegistrationTokens as deleteExpiredEphemeralRegistrationTokensDb} from '#db/ephemeral-registration-tokens.js';
 import {expireStuckJobExecutions} from '#db/job-executions.js';
 import {reapStaleProvisionedRunners as reapStaleProvisionedRunnersDb} from '#db/provisioned-runners.js';
 import {deleteExpiredReservations} from '#db/reservations.js';
@@ -57,6 +58,17 @@ export async function deleteExpiredRunnerSessions(params?: {
     ephemeralRetentionDays:
       params?.ephemeralRetentionDays ?? config.RUNNER_SESSION_EPHEMERAL_RETENTION_DAYS,
     limit: params?.limit ?? config.RUNNER_SESSION_GC_BATCH_SIZE,
+  });
+  return {deleted};
+}
+
+export async function deleteExpiredEphemeralRegistrationTokens(params?: {
+  retentionDays?: number;
+  limit?: number;
+}): Promise<{deleted: number}> {
+  const deleted = await deleteExpiredEphemeralRegistrationTokensDb({
+    retentionDays: params?.retentionDays ?? config.RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS,
+    limit: params?.limit ?? config.RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE,
   });
   return {deleted};
 }

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.test.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.test.ts
@@ -1,5 +1,5 @@
 import {extractDisplayPrefix, generateOpaqueToken, hashOpaqueToken} from '@shipfox/node-tokens';
-import {and, eq} from 'drizzle-orm';
+import {and, eq, inArray} from 'drizzle-orm';
 import {
   ActiveEphemeralRegistrationTokensExistError,
   type RegistrationTokenBatchExceedsReservationError,
@@ -7,6 +7,7 @@ import {
 import {db} from '#db/db.js';
 import {
   createEphemeralRegistrationTokensBatch,
+  deleteExpiredEphemeralRegistrationTokens,
   resolveEphemeralRegistrationTokenByHash,
 } from '#db/ephemeral-registration-tokens.js';
 import {ephemeralRegistrationTokens} from '#db/schema/ephemeral-registration-tokens.js';
@@ -214,5 +215,118 @@ describe('createEphemeralRegistrationTokensBatch', () => {
       hashedToken: hashOpaqueToken(rawToken),
       prefix: extractDisplayPrefix(rawToken),
     };
+  }
+});
+
+describe('deleteExpiredEphemeralRegistrationTokens', () => {
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  let workspaceId: string;
+  let provisionerId: string;
+
+  beforeEach(() => {
+    workspaceId = crypto.randomUUID();
+    provisionerId = crypto.randomUUID();
+  });
+
+  it('deletes consumed tokens whose consumption is older than the retention window', async () => {
+    const stale = await insertToken({consumedAt: daysAgo(8), expiresAt: daysAgo(8)});
+    const fresh = await insertToken({consumedAt: daysAgo(6), expiresAt: daysAgo(6)});
+
+    const deleted = await deleteExpiredEphemeralRegistrationTokens({retentionDays: 7, limit: 100});
+
+    const remaining = await listTokenIds([stale, fresh]);
+    expect(deleted).toBe(1);
+    expect(remaining).toEqual([fresh]);
+  });
+
+  it('deletes expired unconsumed tokens older than the retention window', async () => {
+    const stale = await insertToken({consumedAt: null, expiresAt: daysAgo(8)});
+    const fresh = await insertToken({consumedAt: null, expiresAt: daysAgo(6)});
+
+    const deleted = await deleteExpiredEphemeralRegistrationTokens({retentionDays: 7, limit: 100});
+
+    const remaining = await listTokenIds([stale, fresh]);
+    expect(deleted).toBe(1);
+    expect(remaining).toEqual([fresh]);
+  });
+
+  it('keeps active tokens that are neither consumed nor expired', async () => {
+    const active = await insertToken({consumedAt: null, expiresAt: daysFromNow(1)});
+
+    const deleted = await deleteExpiredEphemeralRegistrationTokens({retentionDays: 7, limit: 100});
+
+    const remaining = await listTokenIds([active]);
+    expect(deleted).toBe(0);
+    expect(remaining).toEqual([active]);
+  });
+
+  it('keeps recently consumed tokens even when their expiry has already passed', async () => {
+    const recentlyConsumed = await insertToken({consumedAt: daysAgo(1), expiresAt: daysAgo(6)});
+
+    const deleted = await deleteExpiredEphemeralRegistrationTokens({retentionDays: 7, limit: 100});
+
+    const remaining = await listTokenIds([recentlyConsumed]);
+    expect(deleted).toBe(0);
+    expect(remaining).toEqual([recentlyConsumed]);
+  });
+
+  it('honors the deletion limit', async () => {
+    const first = await insertToken({consumedAt: daysAgo(30), expiresAt: daysAgo(30)});
+    const second = await insertToken({consumedAt: daysAgo(20), expiresAt: daysAgo(20)});
+    const third = await insertToken({consumedAt: daysAgo(10), expiresAt: daysAgo(10)});
+
+    const deleted = await deleteExpiredEphemeralRegistrationTokens({retentionDays: 7, limit: 2});
+
+    const remaining = await listTokenIds([first, second, third]);
+    expect(deleted).toBe(2);
+    expect(remaining).toEqual([third]);
+  });
+
+  function daysAgo(days: number): Date {
+    return new Date(Date.now() - days * DAY_MS);
+  }
+
+  function daysFromNow(days: number): Date {
+    return new Date(Date.now() + days * DAY_MS);
+  }
+
+  async function insertToken(params: {
+    consumedAt: Date | null;
+    expiresAt: Date;
+    createdAt?: Date;
+  }): Promise<string> {
+    const id = crypto.randomUUID();
+
+    await db()
+      .insert(ephemeralRegistrationTokens)
+      .values({
+        id,
+        workspaceId,
+        provisionerId,
+        provisionedRunnerId: `provisioned-${id}`,
+        hashedToken: crypto.randomUUID(),
+        prefix: 'sfxr_test',
+        expiresAt: params.expiresAt,
+        consumedAt: params.consumedAt,
+        createdAt: params.createdAt ?? params.expiresAt,
+      });
+
+    return id;
+  }
+
+  async function listTokenIds(ids: string[]): Promise<string[]> {
+    if (ids.length === 0) return [];
+
+    const rows = await db()
+      .select({id: ephemeralRegistrationTokens.id})
+      .from(ephemeralRegistrationTokens)
+      .where(
+        and(
+          eq(ephemeralRegistrationTokens.workspaceId, workspaceId),
+          inArray(ephemeralRegistrationTokens.id, ids),
+        ),
+      );
+
+    return ids.filter((id) => rows.some((row) => row.id === id));
   }
 });

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -1,4 +1,4 @@
-import {and, eq, gt, inArray, isNull, sql} from 'drizzle-orm';
+import {and, asc, eq, gt, inArray, isNotNull, isNull, lt, or, sql} from 'drizzle-orm';
 import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
 import {
   ActiveEphemeralRegistrationTokenExistsError,
@@ -212,6 +212,50 @@ export async function resolveEphemeralRegistrationTokenByHash(
   const row = rows[0];
   if (!row) return undefined;
   return toEphemeralRegistrationToken(row);
+}
+
+export interface DeleteExpiredEphemeralRegistrationTokensParams {
+  retentionDays: number;
+  limit?: number;
+}
+
+/**
+ * Deletes ephemeral registration tokens that have reached a terminal state and
+ * outlived the retention window. A token is terminal once it is consumed
+ * (single use spent) or expired without consumption; the retention window is
+ * measured from that terminal event so the audit record survives a bounded
+ * debugging window. Active tokens that are neither consumed nor expired are
+ * never deleted, so a live single-use credential is never removed early.
+ */
+export async function deleteExpiredEphemeralRegistrationTokens(
+  params: DeleteExpiredEphemeralRegistrationTokensParams,
+): Promise<number> {
+  const retentionCutoff = sql`now() - (${params.retentionDays} || ' days')::interval`;
+
+  const deletableIds = db()
+    .select({id: ephemeralRegistrationTokens.id})
+    .from(ephemeralRegistrationTokens)
+    .where(
+      or(
+        and(
+          isNotNull(ephemeralRegistrationTokens.consumedAt),
+          lt(ephemeralRegistrationTokens.consumedAt, retentionCutoff),
+        ),
+        and(
+          isNull(ephemeralRegistrationTokens.consumedAt),
+          lt(ephemeralRegistrationTokens.expiresAt, retentionCutoff),
+        ),
+      ),
+    )
+    .orderBy(asc(ephemeralRegistrationTokens.createdAt), asc(ephemeralRegistrationTokens.id))
+    .limit(params.limit ?? 1000);
+
+  const deleted = await db()
+    .delete(ephemeralRegistrationTokens)
+    .where(inArray(ephemeralRegistrationTokens.id, deletableIds))
+    .returning({id: ephemeralRegistrationTokens.id});
+
+  return deleted.length;
 }
 
 export async function createRunnerSessionConsumingEphemeralToken(params: {

--- a/libs/api/runners/src/db/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/ephemeral-registration-tokens.ts
@@ -1,4 +1,4 @@
-import {and, asc, eq, gt, inArray, isNotNull, isNull, lt, or, sql} from 'drizzle-orm';
+import {and, asc, eq, gt, inArray, isNull, lt, sql} from 'drizzle-orm';
 import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
 import {
   ActiveEphemeralRegistrationTokenExistsError,
@@ -230,24 +230,18 @@ export interface DeleteExpiredEphemeralRegistrationTokensParams {
 export async function deleteExpiredEphemeralRegistrationTokens(
   params: DeleteExpiredEphemeralRegistrationTokensParams,
 ): Promise<number> {
+  // coalesce(consumed_at, expires_at) is the terminal timestamp: consumed_at
+  // when the token was spent, otherwise its expiry. Comparing it to the cutoff
+  // both selects deletable rows and orders the batch, and it matches the
+  // terminal index so idle GC ticks never scan live rows.
+  const terminalAt = sql`coalesce(${ephemeralRegistrationTokens.consumedAt}, ${ephemeralRegistrationTokens.expiresAt})`;
   const retentionCutoff = sql`now() - (${params.retentionDays} || ' days')::interval`;
 
   const deletableIds = db()
     .select({id: ephemeralRegistrationTokens.id})
     .from(ephemeralRegistrationTokens)
-    .where(
-      or(
-        and(
-          isNotNull(ephemeralRegistrationTokens.consumedAt),
-          lt(ephemeralRegistrationTokens.consumedAt, retentionCutoff),
-        ),
-        and(
-          isNull(ephemeralRegistrationTokens.consumedAt),
-          lt(ephemeralRegistrationTokens.expiresAt, retentionCutoff),
-        ),
-      ),
-    )
-    .orderBy(asc(ephemeralRegistrationTokens.createdAt), asc(ephemeralRegistrationTokens.id))
+    .where(lt(terminalAt, retentionCutoff))
+    .orderBy(asc(terminalAt), asc(ephemeralRegistrationTokens.id))
     .limit(params.limit ?? 1000);
 
   const deleted = await db()

--- a/libs/api/runners/src/db/index.ts
+++ b/libs/api/runners/src/db/index.ts
@@ -2,10 +2,14 @@ import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 export {closeDb, db, schema} from './db.js';
-export type {CreateEphemeralRegistrationTokenParams} from './ephemeral-registration-tokens.js';
+export type {
+  CreateEphemeralRegistrationTokenParams,
+  DeleteExpiredEphemeralRegistrationTokensParams,
+} from './ephemeral-registration-tokens.js';
 export {
   createEphemeralRegistrationToken,
   createRunnerSessionConsumingEphemeralToken,
+  deleteExpiredEphemeralRegistrationTokens,
   resolveEphemeralRegistrationTokenByHash,
 } from './ephemeral-registration-tokens.js';
 export type {

--- a/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
@@ -1,4 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {sql} from 'drizzle-orm';
 import {index, text, timestamp, uniqueIndex, uuid} from 'drizzle-orm/pg-core';
 import type {EphemeralRegistrationToken} from '#core/entities/ephemeral-registration-token.js';
 import {pgTable} from './common.js';
@@ -30,7 +31,10 @@ export const ephemeralRegistrationTokens = pgTable(
       table.consumedAt,
       table.expiresAt,
     ),
-    index('runners_ephemeral_registration_tokens_created_id_idx').on(table.createdAt, table.id),
+    index('runners_ephemeral_registration_tokens_terminal_idx').on(
+      sql`coalesce(${table.consumedAt}, ${table.expiresAt})`,
+      table.id,
+    ),
   ],
 );
 

--- a/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
+++ b/libs/api/runners/src/db/schema/ephemeral-registration-tokens.ts
@@ -30,6 +30,7 @@ export const ephemeralRegistrationTokens = pgTable(
       table.consumedAt,
       table.expiresAt,
     ),
+    index('runners_ephemeral_registration_tokens_created_id_idx').on(table.createdAt, table.id),
   ],
 );
 

--- a/libs/api/runners/src/temporal/activities/index.ts
+++ b/libs/api/runners/src/temporal/activities/index.ts
@@ -1,4 +1,5 @@
 import {
+  deleteExpiredEphemeralRegistrationTokensActivity,
   deleteExpiredReservationsActivity,
   deleteExpiredRunnerSessionsActivity,
   detectAndExpireStuckJobsActivity,
@@ -7,6 +8,7 @@ import {
 
 export function createRunnersMaintenanceActivities() {
   return {
+    deleteExpiredEphemeralRegistrationTokensActivity,
     deleteExpiredReservationsActivity,
     deleteExpiredRunnerSessionsActivity,
     detectAndExpireStuckJobsActivity,

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.test.ts
@@ -1,10 +1,12 @@
 import {
+  deleteExpiredEphemeralRegistrationTokens,
   deleteExpiredRunnerReservations,
   deleteExpiredRunnerSessions,
   detectAndExpireStuckJobs,
   reapStaleProvisionedRunners,
 } from '#core/maintenance.js';
 import {
+  deleteExpiredEphemeralRegistrationTokensActivity,
   deleteExpiredReservationsActivity,
   deleteExpiredRunnerSessionsActivity,
   detectAndExpireStuckJobsActivity,
@@ -12,6 +14,7 @@ import {
 } from './maintenance-activities.js';
 
 vi.mock('#core/maintenance.js', () => ({
+  deleteExpiredEphemeralRegistrationTokens: vi.fn(),
   deleteExpiredRunnerReservations: vi.fn(),
   deleteExpiredRunnerSessions: vi.fn(),
   detectAndExpireStuckJobs: vi.fn(),
@@ -78,6 +81,23 @@ describe('deleteExpiredRunnerSessionsActivity', () => {
     expect(deleteExpiredRunnerSessions).toHaveBeenCalledWith({
       manualRetentionDays: 30,
       ephemeralRetentionDays: 7,
+      limit: 25,
+    });
+  });
+});
+
+describe('deleteExpiredEphemeralRegistrationTokensActivity', () => {
+  it('delegates to core maintenance', async () => {
+    vi.mocked(deleteExpiredEphemeralRegistrationTokens).mockResolvedValueOnce({deleted: 6});
+
+    const result = await deleteExpiredEphemeralRegistrationTokensActivity({
+      retentionDays: 7,
+      limit: 25,
+    });
+
+    expect(result).toEqual({deleted: 6});
+    expect(deleteExpiredEphemeralRegistrationTokens).toHaveBeenCalledWith({
+      retentionDays: 7,
       limit: 25,
     });
   });

--- a/libs/api/runners/src/temporal/activities/maintenance-activities.ts
+++ b/libs/api/runners/src/temporal/activities/maintenance-activities.ts
@@ -1,4 +1,5 @@
 import {
+  deleteExpiredEphemeralRegistrationTokens,
   deleteExpiredRunnerReservations,
   deleteExpiredRunnerSessions,
   detectAndExpireStuckJobs,
@@ -30,4 +31,11 @@ export function deleteExpiredRunnerSessionsActivity(params?: {
   limit?: number;
 }): Promise<{deleted: number}> {
   return deleteExpiredRunnerSessions(params);
+}
+
+export function deleteExpiredEphemeralRegistrationTokensActivity(params?: {
+  retentionDays?: number;
+  limit?: number;
+}): Promise<{deleted: number}> {
+  return deleteExpiredEphemeralRegistrationTokens(params);
 }

--- a/libs/api/runners/src/temporal/workflows/stuck-job-detector.test.ts
+++ b/libs/api/runners/src/temporal/workflows/stuck-job-detector.test.ts
@@ -1,4 +1,5 @@
 const mocks = vi.hoisted(() => ({
+  deleteExpiredEphemeralRegistrationTokensActivity: vi.fn(),
   deleteExpiredReservationsActivity: vi.fn(),
   deleteExpiredRunnerSessionsActivity: vi.fn(),
   detectAndExpireStuckJobsActivity: vi.fn(),
@@ -13,6 +14,8 @@ vi.mock('@temporalio/workflow', () => ({
     warn: mocks.warn,
   },
   proxyActivities: vi.fn(() => ({
+    deleteExpiredEphemeralRegistrationTokensActivity:
+      mocks.deleteExpiredEphemeralRegistrationTokensActivity,
     deleteExpiredReservationsActivity: mocks.deleteExpiredReservationsActivity,
     deleteExpiredRunnerSessionsActivity: mocks.deleteExpiredRunnerSessionsActivity,
     detectAndExpireStuckJobsActivity: mocks.detectAndExpireStuckJobsActivity,
@@ -23,6 +26,7 @@ vi.mock('@temporalio/workflow', () => ({
 describe('stuckJobDetector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.deleteExpiredEphemeralRegistrationTokensActivity.mockResolvedValue({deleted: 0});
     mocks.deleteExpiredReservationsActivity.mockResolvedValue({deleted: 0});
     mocks.deleteExpiredRunnerSessionsActivity.mockResolvedValue({deleted: 0});
     mocks.detectAndExpireStuckJobsActivity.mockResolvedValue({expired: 0});
@@ -53,6 +57,35 @@ describe('stuckJobDetector', () => {
 
     expect(mocks.warn).toHaveBeenCalledWith(
       'Stuck-job detector failed to delete expired runner sessions',
+      {error: 'database down'},
+    );
+    expect(mocks.detectAndExpireStuckJobsActivity).toHaveBeenCalledWith({thresholdSeconds: 180});
+  });
+
+  it('runs expired ephemeral token GC before stuck job expiry and logs deletions', async () => {
+    const {stuckJobDetector} = await import('./stuck-job-detector.js');
+    mocks.deleteExpiredEphemeralRegistrationTokensActivity.mockResolvedValueOnce({deleted: 3});
+
+    await stuckJobDetector();
+
+    expect(mocks.deleteExpiredEphemeralRegistrationTokensActivity).toHaveBeenCalledWith();
+    expect(mocks.detectAndExpireStuckJobsActivity).toHaveBeenCalledWith({thresholdSeconds: 180});
+    expect(mocks.info).toHaveBeenCalledWith(
+      'Stuck-job detector deleted expired ephemeral registration tokens',
+      {deleted: 3},
+    );
+  });
+
+  it('continues stuck job expiry when expired ephemeral token GC fails', async () => {
+    const {stuckJobDetector} = await import('./stuck-job-detector.js');
+    mocks.deleteExpiredEphemeralRegistrationTokensActivity.mockRejectedValueOnce(
+      new Error('database down'),
+    );
+
+    await stuckJobDetector();
+
+    expect(mocks.warn).toHaveBeenCalledWith(
+      'Stuck-job detector failed to delete expired ephemeral registration tokens',
       {error: 'database down'},
     );
     expect(mocks.detectAndExpireStuckJobsActivity).toHaveBeenCalledWith({thresholdSeconds: 180});

--- a/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
+++ b/libs/api/runners/src/temporal/workflows/stuck-job-detector.ts
@@ -4,6 +4,7 @@ import {STUCK_JOB_THRESHOLD_SECONDS} from '#core/maintenance-policy.js';
 import type {createRunnersMaintenanceActivities} from '../activities/index.js';
 
 const {
+  deleteExpiredEphemeralRegistrationTokensActivity,
   deleteExpiredReservationsActivity,
   deleteExpiredRunnerSessionsActivity,
   detectAndExpireStuckJobsActivity,
@@ -31,6 +32,17 @@ export async function stuckJobDetector(): Promise<void> {
     }
   } catch (error) {
     log.warn('Stuck-job detector failed to delete expired runner sessions', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const {deleted} = await deleteExpiredEphemeralRegistrationTokensActivity();
+    if (deleted > 0) {
+      log.info('Stuck-job detector deleted expired ephemeral registration tokens', {deleted});
+    }
+  } catch (error) {
+    log.warn('Stuck-job detector failed to delete expired ephemeral registration tokens', {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
Deletes consumed or expired ephemeral registration tokens from the existing runners maintenance path once they outlive a dedicated retention window, while never removing an active token that is still exchangeable.

Follow-up from ENG-622 (runner-session retention). `runners_ephemeral_registration_tokens` becomes high-churn once provisioned one-job runners are active, but rows were kept forever. ENG-622 intentionally scoped GC to `runner_sessions` because tokens have different audit, reuse, and security semantics, so their retention is defined separately here.

## Retention semantics

A token is terminal once it is **consumed** (`consumed_at` set) or **expired without consumption** (`expires_at <= now`). GC deletes a terminal token only after it has outlived the retention window, anchored on the terminal event:

- consumed tokens are measured from `consumed_at`
- expired-unconsumed tokens are measured from `expires_at`

Because the two branches are mutually exclusive on `consumed_at IS NULL`, a token that was consumed recently but whose short TTL already lapsed stays retained for the audit window instead of being swept by expiry. That is the deliberate audit distinction from runner-session GC. Active tokens (neither consumed nor expired) are never deleted. Deleting a consumed token is safe: post-consumption it is never read again, and an unknown-hash replay is rejected identically to a consumed one.

The window and batch size are independent, dedicated config (`RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS` default 7, `RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE` default 1000), not shared with the session knobs.

## Notes for review

- The cleanup is a bounded two-phase select-then-delete mirroring `deleteExpiredRunnerSessions`, backed by a new `(created_at, id)` index and run from the `stuckJobDetector` maintenance tick inside its own try/catch so a GC failure never blocks stuck-job expiry.
- Migration `0007` adds only the new index. `drizzle-kit generate` re-emitted already-applied DDL from an earlier stale snapshot; the SQL was reduced to the single new index while keeping the full 0007 snapshot, which realigns that drift going forward.

Covered by DB-backed GC tests (consumed/expired/active/recently-consumed/limit), config validation tests, and maintenance/activity/workflow wiring tests.

Fixes ENG-759

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GC for ephemeral runner registration tokens, deleting consumed or expired tokens after a configurable retention window while never touching active tokens. Reduces churn/table growth for one-job runners and fixes ENG-759 (follow-up to ENG-622).

- New Features
  - Retention is anchored on the terminal event: consumed tokens use consumed_at; expired-unconsumed use expires_at.
  - Independent config: RUNNER_EPHEMERAL_TOKEN_RETENTION_DAYS (default 7) and RUNNER_EPHEMERAL_TOKEN_GC_BATCH_SIZE (default 1000).
  - Bounded select-then-delete GC with batch limits; integrated into the maintenance tick; failures are logged and do not block stuck-job expiry.

- Migration
  - Adds `runners_ephemeral_registration_tokens_terminal_idx` on `coalesce(consumed_at, expires_at)`, `id` to make GC scans predicate-covered. Run DB migrations.

<sup>Written for commit b8de145d7a499f0543a9fec2862665a6c4521b0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

