### PR TITLE
Extract shared resilient loop helpers

### DIFF
--- a/.changeset/steady-loops-share.md
+++ b/.changeset/steady-loops-share.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/node-resilient-loop": patch
+"@shipfox/runner-orchestration": patch
+"@shipfox/provisioner-core": patch
+---
+
+Extracts shared resilient-loop helpers for runner and provisioner backoff, jitter, interruptible sleep, and graceful shutdown handling.

--- a/libs/provisioner/core/package.json
+++ b/libs/provisioner/core/package.json
@@ -40,6 +40,7 @@
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/node-resilient-loop": "workspace:*",
     "ky": "^2.0.0"
   },
   "devDependencies": {

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -1,5 +1,10 @@
-import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
 import {logger} from '@shipfox/node-opentelemetry';
+import {
+  withJitter as applyJitter,
+  nextBackoffInterval as calculateNextBackoffInterval,
+  createGracefulShutdownController,
+  interruptibleSleep,
+} from '@shipfox/node-resilient-loop';
 import {
   createProvisionerClient,
   ProvisionerAuthenticationError,
@@ -14,11 +19,20 @@ import type {ProvisionerAdapter, ProvisionerTemplate} from '#types.js';
 const MAX_TEMPLATES_PER_POLL = 100;
 
 let running = true;
-let shuttingDown = false;
-let signalHandlersRegistered = false;
 // Module-level so the long-lived signal handler can cancel the in-flight long-poll;
 // a locally-scoped capture isn't reachable from a process-global handler.
 let pollAbortController: AbortController | undefined;
+const shutdownController = createGracefulShutdownController({
+  onFirstSignal: (signal) => {
+    running = false;
+    logger().info({signal}, 'Shutting down gracefully');
+    pollAbortController?.abort('shutdown');
+  },
+  onSecondSignal: (signal) => {
+    logger().info({signal}, 'Second signal received, exiting now');
+    process.exit(1);
+  },
+});
 
 export interface StartProvisionerOptions<Spec> {
   readonly adapter: ProvisionerAdapter<Spec>;
@@ -49,8 +63,8 @@ export async function startProvisioner<Spec>(
   options: StartProvisionerOptions<Spec>,
 ): Promise<void> {
   running = true;
-  shuttingDown = false;
-  setupSignalHandlers();
+  shutdownController.reset();
+  shutdownController.start();
 
   const templates = await options.adapter.loadTemplates();
   if (templates.length === 0) {
@@ -208,59 +222,16 @@ export const buildRunnerEnv: RunnerEnvFactory<unknown> = ({template, registratio
 });
 
 export function nextBackoffInterval(ms: number): number {
-  return Math.min(ms * 1.5, config.SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS);
+  return calculateNextBackoffInterval(ms, {
+    maxMs: config.SHIPFOX_PROVISIONER_POLL_MAX_INTERVAL_MS,
+  });
 }
 
 export function withJitter(ms: number): number {
-  // Keep a floor of half the interval so a fast-returning poll (for example with
-  // wait_seconds=0) cannot collapse the delay toward zero and busy-loop the API.
-  return ms * (0.5 + Math.random() * 0.5);
-}
-
-function setupSignalHandlers(): void {
-  if (signalHandlersRegistered) return;
-
-  process.on('SIGINT', handleSigint);
-  process.on('SIGTERM', handleSigterm);
-  signalHandlersRegistered = true;
-}
-
-function handleSigint(): void {
-  handleSignal('SIGINT');
-}
-
-function handleSigterm(): void {
-  handleSignal('SIGTERM');
-}
-
-function handleSignal(signal: string): void {
-  if (shuttingDown) {
-    logger().info({signal}, 'Second signal received, exiting now');
-    process.exit(1);
-  }
-
-  shuttingDown = true;
-  running = false;
-  logger().info({signal}, 'Shutting down gracefully');
-  // Cancel the in-flight long-poll so the loop wakes without waiting out wait_seconds.
-  pollAbortController?.abort('shutdown');
+  return applyJitter(ms, {minFactor: 0.5});
 }
 
 async function interruptableSleep(ms: number): Promise<void> {
-  const ac = new AbortController();
-  const onStop = () => ac.abort();
-
   if (!running) return;
-
-  process.once('SIGINT', onStop);
-  process.once('SIGTERM', onStop);
-
-  try {
-    await setTimeoutPromise(ms, undefined, {signal: ac.signal});
-  } catch {
-    // AbortError from signal interruption — expected
-  } finally {
-    process.removeListener('SIGINT', onStop);
-    process.removeListener('SIGTERM', onStop);
-  }
+  await interruptibleSleep(ms, shutdownController.signal);
 }

--- a/libs/provisioner/core/src/provisioner.ts
+++ b/libs/provisioner/core/src/provisioner.ts
@@ -228,6 +228,8 @@ export function nextBackoffInterval(ms: number): number {
 }
 
 export function withJitter(ms: number): number {
+  // Floor the jitter at half the interval so a fast-returning poll (for example with
+  // wait_seconds=0) cannot collapse the delay toward zero and busy-loop the API.
   return applyJitter(ms, {minFactor: 0.5});
 }
 

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -63,13 +63,7 @@ import {
 } from '@shipfox/runner-workspace';
 import {config as runnerConfig} from '#config.js';
 import {startHeartbeatLoop} from '#core/heartbeat-loop.js';
-import {
-  nextBackoffInterval,
-  nextPollDeadline,
-  runJob,
-  startRunner,
-  withJitter,
-} from '#core/runner.js';
+import {nextPollDeadline, runJob, startRunner} from '#core/runner.js';
 import {runJobSteps} from '#core/step-loop.js';
 
 const mockJobWorkspacePath = vi.mocked(jobWorkspacePath);
@@ -321,38 +315,6 @@ describe('startRunner', () => {
 });
 
 describe('poll helpers', () => {
-  it('grows backoff intervals before reaching the configured cap', () => {
-    const next = nextBackoffInterval(2);
-
-    expect(next).toBe(3);
-  });
-
-  it('grows backoff intervals up to the configured cap', () => {
-    const next = nextBackoffInterval(4);
-
-    expect(next).toBe(5);
-  });
-
-  it.each([
-    {random: 0, expected: 0},
-    {random: 0.25, expected: 2},
-    {random: 0.999, expected: 7.992},
-  ])('applies full jitter at random=$random', ({random, expected}) => {
-    vi.spyOn(Math, 'random').mockReturnValue(random);
-
-    const sleep = withJitter(8);
-
-    expect(sleep).toBe(expected);
-  });
-
-  it('keeps zero sleeps at zero when jittered', () => {
-    vi.spyOn(Math, 'random').mockReturnValue(0.999);
-
-    const sleep = withJitter(0);
-
-    expect(sleep).toBe(0);
-  });
-
   it('computes a poll deadline from the configured max duration', () => {
     vi.spyOn(Date, 'now').mockReturnValue(41);
 

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -231,8 +231,10 @@ describe('startRunner', () => {
   });
 
   it('resolves cleanly when no jobs arrive before the poll deadline', async () => {
-    vi.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValue(2);
     mockRequestJob.mockResolvedValue(null);
+    vi.spyOn(Date, 'now').mockImplementation(() =>
+      mockRequestJob.mock.calls.length === 0 ? 0 : 2,
+    );
 
     await startRunner();
 
@@ -243,8 +245,10 @@ describe('startRunner', () => {
 
   it('rejects when poll errors continue past the poll deadline', async () => {
     const pollError = new Error('api unavailable');
-    vi.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValue(2);
     mockRequestJob.mockRejectedValue(pollError);
+    vi.spyOn(Date, 'now').mockImplementation(() =>
+      mockRequestJob.mock.calls.length === 0 ? 0 : 2,
+    );
 
     await expect(startRunner()).rejects.toBe(pollError);
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(1);
@@ -275,8 +279,8 @@ describe('startRunner', () => {
 
   it('rejects when unauthorized responses continue past the poll deadline', async () => {
     const unauthorized = httpError(401);
-    vi.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(0).mockReturnValue(2);
     mockRequestJob.mockRejectedValue(unauthorized);
+    vi.spyOn(Date, 'now').mockImplementation(() => (mockRequestJob.mock.calls.length < 2 ? 0 : 2));
 
     await expect(startRunner()).rejects.toBe(unauthorized);
     expect(mockRegisterRunnerSession).toHaveBeenCalledTimes(2);

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -1,5 +1,10 @@
-import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
 import {logger} from '@shipfox/node-opentelemetry';
+import {
+  withJitter as applyJitter,
+  nextBackoffInterval as calculateNextBackoffInterval,
+  createGracefulShutdownController,
+  interruptibleSleep,
+} from '@shipfox/node-resilient-loop';
 import {
   createLeaseClient,
   HTTPError,
@@ -21,17 +26,26 @@ import {startHeartbeatLoop} from '#core/heartbeat-loop.js';
 import {runJobSteps} from '#core/step-loop.js';
 
 let running = true;
-let shuttingDown = false;
-let signalHandlersRegistered = false;
 // Module-level so the long-lived SIGINT handler can reach the in-flight job's
 // controller; locally-scoped capture isn't possible from a process-global handler.
 let currentJobAbortController: AbortController | undefined;
 type RunnerSession = Awaited<ReturnType<typeof registerRunnerSession>>;
+const shutdownController = createGracefulShutdownController({
+  onFirstSignal: (signal) => {
+    running = false;
+    logger().info({signal}, 'Shutting down gracefully, waiting for current job to finish...');
+  },
+  onSecondSignal: (signal) => {
+    logger().info({signal}, 'Second signal received, aborting current job');
+    currentJobAbortController?.abort('shutdown');
+    process.exit(1);
+  },
+});
 
 export async function startRunner(): Promise<void> {
   running = true;
-  shuttingDown = false;
-  setupSignalHandlers();
+  shutdownController.reset();
+  shutdownController.start();
 
   // Fail fast at startup: a dangerous root should crash the process at deploy,
   // not silently fail every job.
@@ -116,11 +130,11 @@ export async function startRunner(): Promise<void> {
 }
 
 export function nextBackoffInterval(ms: number): number {
-  return Math.min(ms * 1.5, config.SHIPFOX_POLL_MAX_INTERVAL_MS);
+  return calculateNextBackoffInterval(ms, {maxMs: config.SHIPFOX_POLL_MAX_INTERVAL_MS});
 }
 
 export function withJitter(ms: number): number {
-  return Math.random() * ms;
+  return applyJitter(ms);
 }
 
 export function nextPollDeadline(): number | undefined {
@@ -217,50 +231,7 @@ function hasPollDeadlinePassed(deadline: number | undefined): boolean {
   return deadline !== undefined && Date.now() >= deadline;
 }
 
-function setupSignalHandlers(): void {
-  if (signalHandlersRegistered) return;
-
-  process.on('SIGINT', handleSigint);
-  process.on('SIGTERM', handleSigterm);
-  signalHandlersRegistered = true;
-}
-
-function handleSigint(): void {
-  handleSignal('SIGINT');
-}
-
-function handleSigterm(): void {
-  handleSignal('SIGTERM');
-}
-
-function handleSignal(signal: string): void {
-  if (shuttingDown) {
-    logger().info({signal}, 'Second signal received, aborting current job');
-    currentJobAbortController?.abort('shutdown');
-    // Also exit promptly — the runner loop's interruptableSleep wakes on signals.
-    process.exit(1);
-  }
-
-  shuttingDown = true;
-  running = false;
-  logger().info({signal}, 'Shutting down gracefully, waiting for current job to finish...');
-}
-
 async function interruptableSleep(ms: number): Promise<void> {
-  const ac = new AbortController();
-  const onStop = () => ac.abort();
-
   if (!running) return;
-
-  process.once('SIGINT', onStop);
-  process.once('SIGTERM', onStop);
-
-  try {
-    await setTimeoutPromise(ms, undefined, {signal: ac.signal});
-  } catch {
-    // AbortError from signal interruption — expected
-  } finally {
-    process.removeListener('SIGINT', onStop);
-    process.removeListener('SIGTERM', onStop);
-  }
+  await interruptibleSleep(ms, shutdownController.signal);
 }

--- a/libs/shared/node/resilient-loop/README.md
+++ b/libs/shared/node/resilient-loop/README.md
@@ -1,0 +1,82 @@
+# Shipfox Resilient Loop
+
+Node helpers for Shipfox loops that need retry waits and a clean stop path.
+
+## What it does
+
+- **`nextBackoffInterval(currentMs, options)`**: Grows a retry wait and caps it at `maxMs`.
+- **`withJitter(ms, options)`**: Returns a random wait inside a factor range for the current wait.
+- **`interruptibleSleep(ms, signal)`**: Sleeps until the timer ends or the abort signal fires.
+- **`createGracefulShutdownController(options)`**: Adds process signal handlers and exposes one abort signal for loop sleeps.
+
+## Installation / Setup
+
+This is private workspace code. Add it where it is used with `workspace:*`:
+
+```json
+{
+  "dependencies": {
+    "@shipfox/node-resilient-loop": "workspace:*"
+  }
+}
+```
+
+## Usage
+
+Use it when a Node process runs in a loop and must wait between tries.
+The same signal can wake the sleep and tell the loop to stop.
+Keep one controller for the life of the loop.
+
+```ts
+import {
+  createGracefulShutdownController,
+  interruptibleSleep,
+  nextBackoffInterval,
+  withJitter,
+} from '@shipfox/node-resilient-loop';
+
+let running = true;
+const shutdown = createGracefulShutdownController({
+  onFirstSignal: () => {
+    running = false;
+  },
+  onSecondSignal: () => {
+    process.exit(1);
+  },
+});
+
+shutdown.start();
+shutdown.reset();
+
+let intervalMs = 1000;
+
+while (running) {
+  try {
+    await runOneIteration({signal: shutdown.signal});
+    intervalMs = 1000;
+  } catch {
+    intervalMs = nextBackoffInterval(intervalMs, {maxMs: 5000});
+  }
+
+  await interruptibleSleep(withJitter(intervalMs, {minFactor: 0.5}), shutdown.signal);
+}
+```
+
+## Behavior Notes
+
+- `createGracefulShutdownController()` listens for `SIGINT` and `SIGTERM` by default.
+- `start()` is safe to call more than once, so repeated loop starts do not add duplicate signal handlers.
+- `reset()` clears shutdown state and creates a fresh abort signal after a previous stop.
+- `interruptibleSleep()` resolves when its signal aborts. It rethrows timer errors that are not caused by that signal.
+
+## Development
+
+```sh
+turbo check --filter=@shipfox/node-resilient-loop
+turbo type --filter=@shipfox/node-resilient-loop
+turbo test --filter=@shipfox/node-resilient-loop
+```
+
+## License
+
+MIT

--- a/libs/shared/node/resilient-loop/package.json
+++ b/libs/shared/node/resilient-loop/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@shipfox/runner-orchestration",
+  "name": "@shipfox/node-resilient-loop",
   "license": "MIT",
+  "private": true,
   "version": "0.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
-    "directory": "libs/runner/orchestration"
+    "directory": "libs/shared/node/resilient-loop"
   },
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,19 +35,6 @@
     "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
-  },
-  "dependencies": {
-    "@shipfox/api-workflows-dto": "workspace:*",
-    "@shipfox/config": "workspace:*",
-    "@shipfox/node-opentelemetry": "workspace:*",
-    "@shipfox/node-resilient-loop": "workspace:*",
-    "@shipfox/redact": "workspace:*",
-    "@shipfox/runner-agent": "workspace:*",
-    "@shipfox/runner-execution": "workspace:*",
-    "@shipfox/runner-logs": "workspace:*",
-    "@shipfox/runner-protocol": "workspace:*",
-    "@shipfox/runner-workspace": "workspace:*",
-    "ky": "^2.0.0"
   },
   "devDependencies": {
     "@shipfox/biome": "workspace:*",

--- a/libs/shared/node/resilient-loop/src/index.test.ts
+++ b/libs/shared/node/resilient-loop/src/index.test.ts
@@ -110,6 +110,30 @@ describe('createGracefulShutdownController', () => {
     expect(controller.signal.aborted).toBe(true);
   });
 
+  it('deduplicates configured signal handlers', () => {
+    const firstSignals: NodeJS.Signals[] = [];
+    const secondSignals: NodeJS.Signals[] = [];
+    const initialListeners = process.listenerCount(signal);
+    const controller = createGracefulShutdownController({
+      signals: [signal, signal],
+      onFirstSignal: (receivedSignal) => firstSignals.push(receivedSignal),
+      onSecondSignal: (receivedSignal) => secondSignals.push(receivedSignal),
+    });
+    controllers.push(controller);
+    controller.start();
+
+    process.emit(signal, signal);
+
+    expect(process.listenerCount(signal)).toBe(initialListeners + 1);
+    expect(firstSignals).toEqual([signal]);
+    expect(secondSignals).toEqual([]);
+
+    process.emit(signal, signal);
+
+    expect(firstSignals).toEqual([signal]);
+    expect(secondSignals).toEqual([signal]);
+  });
+
   it('resets shutdown state and creates a fresh abort signal', () => {
     const controller = createGracefulShutdownController({signals: [signal]});
     controllers.push(controller);

--- a/libs/shared/node/resilient-loop/src/index.test.ts
+++ b/libs/shared/node/resilient-loop/src/index.test.ts
@@ -1,0 +1,126 @@
+import {
+  createGracefulShutdownController,
+  interruptibleSleep,
+  nextBackoffInterval,
+  withJitter,
+} from './index.js';
+
+describe('nextBackoffInterval', () => {
+  it('grows by the default factor before the cap', () => {
+    const next = nextBackoffInterval(1000, {maxMs: 5000});
+
+    expect(next).toBe(1500);
+  });
+
+  it('caps at the configured maximum', () => {
+    const next = nextBackoffInterval(4000, {maxMs: 5000});
+
+    expect(next).toBe(5000);
+  });
+
+  it('uses a custom factor', () => {
+    const next = nextBackoffInterval(1000, {maxMs: 5000, factor: 2});
+
+    expect(next).toBe(2000);
+  });
+});
+
+describe('withJitter', () => {
+  it.each([
+    {random: 0, expected: 0},
+    {random: 0.25, expected: 2},
+    {random: 0.999, expected: 7.992},
+  ])('applies full jitter at random=$random', ({random, expected}) => {
+    const sleep = withJitter(8, {random: () => random});
+
+    expect(sleep).toBe(expected);
+  });
+
+  it('applies bounded jitter', () => {
+    const sleep = withJitter(8, {minFactor: 0.5, maxFactor: 1, random: () => 0.25});
+
+    expect(sleep).toBe(5);
+  });
+
+  it('keeps zero sleeps at zero when jittered', () => {
+    const sleep = withJitter(0, {random: () => 0.999});
+
+    expect(sleep).toBe(0);
+  });
+});
+
+describe('interruptibleSleep', () => {
+  it('resolves when the signal aborts', async () => {
+    const controller = new AbortController();
+    const sleep = interruptibleSleep(10_000, controller.signal);
+
+    controller.abort('test');
+
+    await expect(sleep).resolves.toBeUndefined();
+  });
+
+  it('resolves immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort('test');
+
+    await expect(interruptibleSleep(10_000, controller.signal)).resolves.toBeUndefined();
+  });
+});
+
+describe('createGracefulShutdownController', () => {
+  const signal = 'SIGHUP';
+  const controllers: {stop: () => void}[] = [];
+
+  afterEach(() => {
+    for (const controller of controllers.splice(0)) controller.stop();
+  });
+
+  it('registers signal handlers once and removes them on stop', () => {
+    const initialListeners = process.listenerCount(signal);
+    const controller = createGracefulShutdownController({signals: [signal]});
+    controllers.push(controller);
+
+    controller.start();
+    controller.start();
+
+    expect(process.listenerCount(signal)).toBe(initialListeners + 1);
+    controller.stop();
+    controllers.splice(controllers.indexOf(controller), 1);
+
+    expect(process.listenerCount(signal)).toBe(initialListeners);
+  });
+
+  it('runs first and second signal callbacks separately', () => {
+    const firstSignals: NodeJS.Signals[] = [];
+    const secondSignals: NodeJS.Signals[] = [];
+    const controller = createGracefulShutdownController({
+      signals: [signal],
+      onFirstSignal: (receivedSignal) => firstSignals.push(receivedSignal),
+      onSecondSignal: (receivedSignal) => secondSignals.push(receivedSignal),
+    });
+    controllers.push(controller);
+    controller.start();
+
+    process.emit(signal, signal);
+    process.emit(signal, signal);
+
+    expect(firstSignals).toEqual([signal]);
+    expect(secondSignals).toEqual([signal]);
+    expect(controller.isShuttingDown()).toBe(true);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('resets shutdown state and creates a fresh abort signal', () => {
+    const controller = createGracefulShutdownController({signals: [signal]});
+    controllers.push(controller);
+    controller.start();
+
+    process.emit(signal, signal);
+    const abortedSignal = controller.signal;
+    controller.reset();
+
+    expect(controller.isShuttingDown()).toBe(false);
+    expect(controller.signal).not.toBe(abortedSignal);
+    expect(controller.signal.aborted).toBe(false);
+  });
+});

--- a/libs/shared/node/resilient-loop/src/index.ts
+++ b/libs/shared/node/resilient-loop/src/index.ts
@@ -51,7 +51,9 @@ export async function interruptibleSleep(ms: number, signal: AbortSignal): Promi
 export function createGracefulShutdownController(
   options: GracefulShutdownControllerOptions = {},
 ): GracefulShutdownController {
-  const signals = options.signals ?? (['SIGINT', 'SIGTERM'] satisfies NodeJS.Signals[]);
+  const signals = [
+    ...new Set(options.signals ?? (['SIGINT', 'SIGTERM'] satisfies NodeJS.Signals[])),
+  ];
   let started = false;
   let shuttingDown = false;
   let abortController = new AbortController();

--- a/libs/shared/node/resilient-loop/src/index.ts
+++ b/libs/shared/node/resilient-loop/src/index.ts
@@ -1,0 +1,96 @@
+import {setTimeout as setTimeoutPromise} from 'node:timers/promises';
+
+export interface BackoffOptions {
+  readonly maxMs: number;
+  readonly factor?: number;
+}
+
+export interface JitterOptions {
+  readonly minFactor?: number;
+  readonly maxFactor?: number;
+  readonly random?: () => number;
+}
+
+export interface GracefulShutdownControllerOptions {
+  readonly signals?: readonly NodeJS.Signals[];
+  readonly onFirstSignal?: (signal: NodeJS.Signals) => void;
+  readonly onSecondSignal?: (signal: NodeJS.Signals) => void;
+}
+
+export interface GracefulShutdownController {
+  readonly signal: AbortSignal;
+  start: () => void;
+  stop: () => void;
+  reset: () => void;
+  isShuttingDown: () => boolean;
+}
+
+export function nextBackoffInterval(currentMs: number, options: BackoffOptions): number {
+  return Math.min(currentMs * (options.factor ?? 1.5), options.maxMs);
+}
+
+export function withJitter(ms: number, options: JitterOptions = {}): number {
+  const minFactor = options.minFactor ?? 0;
+  const maxFactor = options.maxFactor ?? 1;
+  const random = options.random ?? Math.random;
+
+  return ms * (minFactor + random() * (maxFactor - minFactor));
+}
+
+export async function interruptibleSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+
+  try {
+    await setTimeoutPromise(ms, undefined, {signal});
+  } catch (error) {
+    if (signal.aborted) return;
+    throw error;
+  }
+}
+
+export function createGracefulShutdownController(
+  options: GracefulShutdownControllerOptions = {},
+): GracefulShutdownController {
+  const signals = options.signals ?? (['SIGINT', 'SIGTERM'] satisfies NodeJS.Signals[]);
+  let started = false;
+  let shuttingDown = false;
+  let abortController = new AbortController();
+
+  const handleSignal = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      options.onSecondSignal?.(signal);
+      return;
+    }
+
+    shuttingDown = true;
+    abortController.abort(signal);
+    options.onFirstSignal?.(signal);
+  };
+
+  return {
+    get signal() {
+      return abortController.signal;
+    },
+    start: () => {
+      if (started) return;
+
+      for (const signal of signals) {
+        process.on(signal, handleSignal);
+      }
+      started = true;
+    },
+    stop: () => {
+      if (!started) return;
+
+      for (const signal of signals) {
+        process.removeListener(signal, handleSignal);
+      }
+      started = false;
+    },
+    reset: () => {
+      shuttingDown = false;
+      if (abortController.signal.aborted) abortController = new AbortController();
+    },
+    isShuttingDown: () => shuttingDown,
+  };
+}

--- a/libs/shared/node/resilient-loop/tsconfig.build.json
+++ b/libs/shared/node/resilient-loop/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.tsx", "**/*.test.ts"]
+}

--- a/libs/shared/node/resilient-loop/tsconfig.json
+++ b/libs/shared/node/resilient-loop/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/libs/shared/node/resilient-loop/tsconfig.test.json
+++ b/libs/shared/node/resilient-loop/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/libs/shared/node/resilient-loop/vitest.config.ts
+++ b/libs/shared/node/resilient-loop/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4158,6 +4158,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/node-resilient-loop':
+        specifier: workspace:*
+        version: link:../../shared/node/resilient-loop
       ky:
         specifier: ^2.0.0
         version: 2.0.2
@@ -4349,6 +4352,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/node-resilient-loop':
+        specifier: workspace:*
+        version: link:../../shared/node/resilient-loop
       '@shipfox/redact':
         specifier: workspace:*
         version: link:../../shared/common/redact
@@ -4965,6 +4971,24 @@ importers:
         version: 8.20.0
 
   libs/shared/node/rate-limit:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../../tools/vitest
+
+  libs/shared/node/resilient-loop:
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Extract shared resilient-loop helpers for runner and provisioner retry/backoff, jitter, interruptible sleep, and graceful shutdown handling.

The runner and Docker provisioner duplicated the same process-signal and sleep/backoff machinery after the provisioner control loop shipped. This adds a small Node-only helper package and keeps each caller's loop body local so runner poll deadlines and provisioner degraded-mode behavior remain explicit.

Considered extracting a full resilient-loop primitive, but the current loops differ enough that a smaller helper extraction avoids forcing runner/provisioner-specific behavior into a broad callback API.

Closes ENG-662

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted resilient-loop helpers into `@shipfox/node-resilient-loop` and switched runner and provisioner to use them. This unifies retry/backoff, jitter, interruptible sleep, and graceful shutdown, and prevents duplicate signal handlers with custom signals. Fulfills ENG-662.

- **Refactors**
  - Added `@shipfox/node-resilient-loop` with `nextBackoffInterval`, `withJitter`, `interruptibleSleep`, and `createGracefulShutdownController`.
  - Replaced duplicated signal and sleep logic in runner and provisioner; kept poll deadlines and degraded-mode logic local.
  - Centralized shutdown flow: first signal = graceful stop, second = force exit/abort.
  - Deduplicated shutdown signal handlers when configured signals repeat.
  - Added unit tests and README in the new package; removed duplicate tests from runner.
  - Made runner poll deadline tests isolation-safe under Vitest.

- **Dependencies**
  - New workspace package `@shipfox/node-resilient-loop`.
  - Added as a dependency in `@shipfox/runner-orchestration` and `@shipfox/provisioner-core`.

<sup>Written for commit 31031e2885f4119f12d0ee7ab5f0e54360213d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

