### PR TITLE
Add custom model provider E2E coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Build dev server dependencies
         run: turbo build --filter @shipfox/api --filter @shipfox/vite
 
+      - name: Start Ollama
+        run: mise run ollama:up
+
       - name: Run E2E tests
         id: e2e
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
         id: e2e
         env:
           API_URL: http://localhost:16101
+          AGENT_PROVIDER_VALIDATION_TIMEOUT_MS: "60000"
           CLIENT_URL: http://localhost:5173
           E2E_ADMIN_API_KEY: e2e-admin-api-key
           E2E_ENABLED: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,6 @@ jobs:
         id: e2e
         env:
           API_URL: http://localhost:16101
-          AGENT_PROVIDER_VALIDATION_TIMEOUT_MS: "60000"
           CLIENT_URL: http://localhost:5173
           E2E_ADMIN_API_KEY: e2e-admin-api-key
           E2E_ENABLED: "true"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,14 @@ docker compose up -d
 mise run e2e -- --filter=@shipfox/e2e-client-auth
 ```
 
+Agent E2E tests that validate custom model providers against local Ollama also
+require the shared Ollama service and default model:
+
+```sh
+mise run ollama:up
+mise run e2e -- --filter=@shipfox/e2e-client-agent
+```
+
 The harness writes API/client logs and failure diagnostics to
 `.context/shipfox-e2e-logs/` locally. It also reads Conductor worktree ports from
 `.context/local-services/env` through mise, so the same command works in worktrees.

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -82,7 +82,7 @@ async function up(context) {
   }
 
   runRootMise(context, ['exec', '--', 'ollama', 'pull', context.model]);
-  startWarmup(context);
+  await preloadModel(context);
 
   printLine(`Shared Ollama is ready at ${context.baseUrl}.`);
   printLine(`Model: ${context.model}`);
@@ -138,23 +138,6 @@ function startServer(context) {
     listenHost: context.listenHost,
     startedAt: new Date().toISOString(),
   });
-}
-
-function startWarmup(context) {
-  const log = openSync(context.logFile, 'a');
-  const child = spawn(process.execPath, [fileURLToPath(import.meta.url), 'warm'], {
-    cwd: context.rootPath,
-    detached: true,
-    env: {
-      ...process.env,
-      CONDUCTOR_ROOT_PATH: context.rootPath,
-      SHIPFOX_OLLAMA_BASE_URL: context.baseUrl,
-      SHIPFOX_OLLAMA_KEEP_ALIVE: context.keepAlive,
-      SHIPFOX_OLLAMA_MODEL: context.model,
-    },
-    stdio: ['ignore', log, log],
-  });
-  child.unref();
 }
 
 function runRootMise(context, args) {

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -9,6 +9,7 @@ const defaultKeepAlive = '24h';
 const defaultBaseUrl = 'http://127.0.0.1:11434';
 const startupTimeoutMs = 30_000;
 const pollIntervalMs = 500;
+const preloadTimeoutMs = 120_000;
 
 if (isCliEntryPoint()) {
   await main(process.argv[2]);
@@ -154,19 +155,22 @@ function runRootMise(context, args) {
 }
 
 async function preloadModel(context) {
-  const response = await fetch(`${context.baseUrl}/api/generate`, {
+  const response = await fetch(`${context.baseUrl}/v1/chat/completions`, {
     method: 'POST',
     headers: {'content-type': 'application/json'},
     body: JSON.stringify({
       model: context.model,
-      prompt: '',
+      messages: [{role: 'user', content: 'Reply with OK.'}],
+      max_tokens: 16,
       stream: false,
       keep_alive: context.keepAlive,
     }),
+    signal: AbortSignal.timeout(preloadTimeoutMs),
   });
   if (!response.ok) {
     fail(`Failed to preload ${context.model}: ${response.status} ${response.statusText}`);
   }
+  await response.body?.cancel();
 }
 
 async function waitForHealthy(baseUrl) {
@@ -329,6 +333,7 @@ function printError(message) {
 
 export {
   ollamaListenHost,
+  preloadModel,
   processIdentityMatches,
   processStartTime,
   processStateMatchesContext,

--- a/dev/shared-ollama.test.mjs
+++ b/dev/shared-ollama.test.mjs
@@ -3,6 +3,7 @@ import {describe, test} from 'node:test';
 
 import {
   ollamaListenHost,
+  preloadModel,
   processIdentityMatches,
   processStartTime,
   processStateMatchesContext,
@@ -51,6 +52,37 @@ describe('serviceContext', () => {
 describe('ollamaListenHost', () => {
   test('converts the API base URL into the OLLAMA_HOST bind value', () => {
     assert.equal(ollamaListenHost('http://127.0.0.1:11434'), '127.0.0.1:11434');
+  });
+});
+
+describe('preloadModel', () => {
+  test('uses the OpenAI-compatible chat endpoint', async () => {
+    const originalFetch = globalThis.fetch;
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push({url, init});
+      return new Response('{}', {status: 200});
+    };
+
+    try {
+      await preloadModel({
+        baseUrl: 'http://127.0.0.1:11434',
+        model: 'custom:model',
+        keepAlive: '2h',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, 'http://127.0.0.1:11434/v1/chat/completions');
+    assert.deepEqual(JSON.parse(calls[0].init.body), {
+      model: 'custom:model',
+      messages: [{role: 'user', content: 'Reply with OK.'}],
+      max_tokens: 16,
+      stream: false,
+      keep_alive: '2h',
+    });
   });
 });
 

--- a/e2e/client/agent/package.json
+++ b/e2e/client/agent/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@shipfox/e2e-client-agent",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/client/agent"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./tests/*"
+  },
+  "scripts": {
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test:e2e": "shipfox-playwright-test",
+    "type": "shipfox-tsc-check"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/client-agent": "workspace:*",
+    "@shipfox/client-router": "workspace:*",
+    "@shipfox/client-workspace-settings": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-agent": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-projects": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/client/agent/playwright.config.ts
+++ b/e2e/client/agent/playwright.config.ts
@@ -1,0 +1,32 @@
+import {config} from '@shipfox/e2e-core';
+import {defineConfig, devices} from '@shipfox/playwright';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/*.e2e.ts',
+  globalSetup: './tests/global-setup.ts',
+  reporter: process.env.CI
+    ? [
+        ['github'],
+        [
+          '@argos-ci/playwright/reporter',
+          {
+            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
+            buildName: 'e2e-client-agent',
+            ignoreUploadFailures: true,
+          },
+        ],
+      ]
+    : 'list',
+  use: {
+    baseURL: config.CLIENT_URL,
+    trace: 'retain-on-failure',
+    contextOptions: {reducedMotion: 'reduce'},
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome'],
+    },
+  ],
+});

--- a/e2e/client/agent/playwright.config.ts
+++ b/e2e/client/agent/playwright.config.ts
@@ -4,6 +4,7 @@ import {defineConfig, devices} from '@shipfox/playwright';
 export default defineConfig({
   testDir: './tests',
   testMatch: '**/*.e2e.ts',
+  timeout: 180_000,
   globalSetup: './tests/global-setup.ts',
   reporter: process.env.CI
     ? [

--- a/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
+++ b/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
@@ -1,0 +1,214 @@
+import {type AgentHelper, ollamaConfig} from '@shipfox/e2e-helper-agent';
+import type {AuthHelper} from '@shipfox/e2e-helper-auth';
+import type {ProjectsHelper} from '@shipfox/e2e-helper-projects';
+import type {WorkspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import type {Page} from '@shipfox/playwright';
+import {expect, test} from './test.js';
+
+const OLLAMA = ollamaConfig();
+const OLLAMA_MODEL_ID = OLLAMA.model;
+const CREATE_PROVIDER_ID = 'local-ollama-create';
+const CREATE_PROVIDER_NAME = 'Local Ollama Create';
+const EDIT_PROVIDER_ID = 'local-ollama-edit';
+const EDIT_PROVIDER_NAME = 'Local Ollama Edit';
+const EDITED_PROVIDER_NAME = 'Local Ollama Edited';
+const DELETE_PROVIDER_ID = 'local-ollama-delete';
+const DELETE_PROVIDER_NAME = 'Local Ollama Delete';
+
+interface ReadyWorkspace {
+  sessionToken: string;
+  workspaceId: string;
+}
+
+async function createReadyWorkspace(params: {
+  auth: AuthHelper;
+  page: Page;
+  projects: ProjectsHelper;
+  workspaces: WorkspacesHelper;
+  name: string;
+}): Promise<ReadyWorkspace> {
+  const user = await params.auth.createUser();
+  const workspace = await params.workspaces.create({
+    userId: user.user.id,
+    name: params.name,
+  });
+  await params.projects.createProject({workspaceId: workspace.id});
+  const session = await params.auth.createSession({user_id: user.user.id});
+  await params.auth.loginAs(params.page, user);
+
+  return {sessionToken: session.token, workspaceId: workspace.id};
+}
+
+async function gotoModelProviders(page: Page, workspaceId: string) {
+  await page.goto(`/workspaces/${workspaceId}/settings/model-providers`);
+  await expect(page).toHaveURL(
+    new RegExp(`/workspaces/${workspaceId}/settings/model-providers/?$`, 'u'),
+  );
+  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
+  await expect(page.getByRole('heading', {name: 'Configured providers'})).toBeVisible();
+}
+
+function configuredProvidersSection(page: Page): ReturnType<Page['locator']> {
+  return page.locator('section[aria-label="Configured providers"]');
+}
+
+function configuredProviderRow(page: Page, label: string): ReturnType<Page['locator']> {
+  return configuredProvidersSection(page)
+    .locator('li')
+    .filter({has: page.getByText(label, {exact: true})});
+}
+
+async function expectProviderInApi(params: {
+  agent: AgentHelper;
+  displayName: string;
+  providerId: string;
+  sessionToken: string;
+  workspaceId: string;
+}) {
+  const configs = await params.agent.listModelProviderConfigs({
+    workspaceId: params.workspaceId,
+    sessionToken: params.sessionToken,
+  });
+  expect(configs.configs).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        provider_id: params.providerId,
+        display_name: params.displayName,
+      }),
+    ]),
+  );
+}
+
+test('creates a custom model provider backed by local Ollama', async ({
+  page,
+  auth,
+  agent,
+  projects,
+  workspaces,
+}) => {
+  const {workspaceId, sessionToken} = await createReadyWorkspace({
+    page,
+    auth,
+    projects,
+    workspaces,
+    name: 'Agent Provider Create Workspace',
+  });
+
+  await gotoModelProviders(page, workspaceId);
+  await page.getByRole('button', {name: 'Configure custom provider'}).click();
+  const dialog = page.getByRole('dialog', {name: 'Add custom provider'});
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByLabel('Display name').fill(CREATE_PROVIDER_NAME);
+  await dialog.getByLabel('Provider ID').fill(CREATE_PROVIDER_ID);
+  await dialog.getByLabel('Base URL').fill(OLLAMA.openAiBaseUrl);
+  const discoveryResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/agent/custom-model-providers/discover-models') &&
+      response.request().method() === 'POST',
+  );
+  await dialog.getByRole('button', {name: 'Fetch models'}).click();
+  expect((await discoveryResponse).ok()).toBe(true);
+
+  const defaultModelField = dialog.getByLabel('Default model');
+  const discoveredModelOption = defaultModelField.locator('option').filter({
+    hasText: OLLAMA_MODEL_ID,
+  });
+  if ((await discoveredModelOption.count()) === 0) {
+    await dialog.getByLabel('Model id').first().fill(OLLAMA_MODEL_ID);
+    await dialog.getByLabel('Label').first().fill(OLLAMA_MODEL_ID);
+  }
+  await expect(defaultModelField).toContainText(OLLAMA_MODEL_ID);
+
+  await defaultModelField.selectOption(OLLAMA_MODEL_ID);
+  await dialog.getByRole('button', {name: 'Test & save'}).click();
+
+  await expect(page.getByText('Custom provider saved')).toBeVisible();
+  await expect(configuredProviderRow(page, CREATE_PROVIDER_NAME)).toBeVisible();
+  await expectProviderInApi({
+    agent,
+    workspaceId,
+    sessionToken,
+    providerId: CREATE_PROVIDER_ID,
+    displayName: CREATE_PROVIDER_NAME,
+  });
+});
+
+test('edits an existing custom model provider and validates with local Ollama', async ({
+  page,
+  auth,
+  agent,
+  projects,
+  workspaces,
+}) => {
+  const {workspaceId, sessionToken} = await createReadyWorkspace({
+    page,
+    auth,
+    projects,
+    workspaces,
+    name: 'Agent Provider Edit Workspace',
+  });
+  await agent.createOllamaCustomProvider({
+    workspaceId,
+    sessionToken,
+    providerId: EDIT_PROVIDER_ID,
+    displayName: EDIT_PROVIDER_NAME,
+  });
+
+  await gotoModelProviders(page, workspaceId);
+  const row = configuredProviderRow(page, EDIT_PROVIDER_NAME);
+  await expect(row).toBeVisible();
+  await row.getByRole('button', {name: `Open ${EDIT_PROVIDER_NAME} provider actions`}).click();
+  await page.getByRole('menuitem', {name: 'Edit'}).click();
+  const dialog = page.getByRole('dialog', {name: `Edit ${EDIT_PROVIDER_NAME}`});
+  await expect(dialog.getByLabel('Provider ID')).toBeDisabled();
+
+  await dialog.getByLabel('Display name').fill(EDITED_PROVIDER_NAME);
+  await dialog.getByRole('button', {name: 'Test & save'}).click();
+
+  await expect(page.getByText(`${EDIT_PROVIDER_NAME} saved`)).toBeVisible();
+  await expect(configuredProviderRow(page, EDITED_PROVIDER_NAME)).toBeVisible();
+  await expect(configuredProviderRow(page, EDIT_PROVIDER_NAME)).toHaveCount(0);
+  await expectProviderInApi({
+    agent,
+    workspaceId,
+    sessionToken,
+    providerId: EDIT_PROVIDER_ID,
+    displayName: EDITED_PROVIDER_NAME,
+  });
+});
+
+test('deletes an existing custom model provider', async ({
+  page,
+  auth,
+  agent,
+  projects,
+  workspaces,
+}) => {
+  const {workspaceId, sessionToken} = await createReadyWorkspace({
+    page,
+    auth,
+    projects,
+    workspaces,
+    name: 'Agent Provider Delete Workspace',
+  });
+  await agent.createOllamaCustomProvider({
+    workspaceId,
+    sessionToken,
+    providerId: DELETE_PROVIDER_ID,
+    displayName: DELETE_PROVIDER_NAME,
+  });
+
+  await gotoModelProviders(page, workspaceId);
+  const row = configuredProviderRow(page, DELETE_PROVIDER_NAME);
+  await expect(row).toBeVisible();
+  await row.getByRole('button', {name: `Open ${DELETE_PROVIDER_NAME} provider actions`}).click();
+  await page.getByRole('menuitem', {name: 'Delete'}).click();
+  const dialog = page.getByRole('dialog', {name: 'Delete model provider'});
+  await dialog.getByRole('button', {name: 'Delete'}).click();
+
+  await expect(page.getByText(`${DELETE_PROVIDER_NAME} deleted`)).toBeVisible();
+  await expect(row).toHaveCount(0);
+  const configs = await agent.listModelProviderConfigs({workspaceId, sessionToken});
+  expect(configs.configs.map((config) => config.provider_id)).not.toContain(DELETE_PROVIDER_ID);
+});

--- a/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
+++ b/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
@@ -14,6 +14,7 @@ const EDIT_PROVIDER_NAME = 'Local Ollama Edit';
 const EDITED_PROVIDER_NAME = 'Local Ollama Edited';
 const DELETE_PROVIDER_ID = 'local-ollama-delete';
 const DELETE_PROVIDER_NAME = 'Local Ollama Delete';
+const PROVIDER_SAVE_TIMEOUT_MS = 75_000;
 
 interface ReadyWorkspace {
   sessionToken: string;
@@ -126,7 +127,7 @@ test('creates a custom model provider backed by local Ollama', async ({
       response.url().includes('/agent/custom-model-providers') &&
       response.request().method() === 'POST' &&
       !response.url().includes('/discover-models'),
-    {timeout: 30_000},
+    {timeout: PROVIDER_SAVE_TIMEOUT_MS},
   );
   await dialog.getByRole('button', {name: 'Test & save'}).click();
   expect((await saveResponse).ok()).toBe(true);
@@ -176,7 +177,7 @@ test('edits an existing custom model provider and validates with local Ollama', 
     (response) =>
       response.url().includes(`/agent/custom-model-providers/${EDIT_PROVIDER_ID}`) &&
       response.request().method() === 'PUT',
-    {timeout: 30_000},
+    {timeout: PROVIDER_SAVE_TIMEOUT_MS},
   );
   await dialog.getByRole('button', {name: 'Test & save'}).click();
   expect((await saveResponse).ok()).toBe(true);

--- a/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
+++ b/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
@@ -121,7 +121,15 @@ test('creates a custom model provider backed by local Ollama', async ({
   await expect(defaultModelField).toContainText(OLLAMA_MODEL_ID);
 
   await defaultModelField.selectOption(OLLAMA_MODEL_ID);
+  const saveResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/agent/custom-model-providers') &&
+      response.request().method() === 'POST' &&
+      !response.url().includes('/discover-models'),
+    {timeout: 30_000},
+  );
   await dialog.getByRole('button', {name: 'Test & save'}).click();
+  expect((await saveResponse).ok()).toBe(true);
 
   await expect(page.getByText('Custom provider saved')).toBeVisible();
   await expect(configuredProviderRow(page, CREATE_PROVIDER_NAME)).toBeVisible();
@@ -164,7 +172,14 @@ test('edits an existing custom model provider and validates with local Ollama', 
   await expect(dialog.getByLabel('Provider ID')).toBeDisabled();
 
   await dialog.getByLabel('Display name').fill(EDITED_PROVIDER_NAME);
+  const saveResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/agent/custom-model-providers/${EDIT_PROVIDER_ID}`) &&
+      response.request().method() === 'PUT',
+    {timeout: 30_000},
+  );
   await dialog.getByRole('button', {name: 'Test & save'}).click();
+  expect((await saveResponse).ok()).toBe(true);
 
   await expect(page.getByText(`${EDIT_PROVIDER_NAME} saved`)).toBeVisible();
   await expect(configuredProviderRow(page, EDITED_PROVIDER_NAME)).toBeVisible();

--- a/e2e/client/agent/tests/global-setup.ts
+++ b/e2e/client/agent/tests/global-setup.ts
@@ -1,0 +1,7 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+import {requireOllamaModel} from '@shipfox/e2e-helper-agent';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck();
+  await requireOllamaModel();
+}

--- a/e2e/client/agent/tests/test.ts
+++ b/e2e/client/agent/tests/test.ts
@@ -1,0 +1,15 @@
+import {test as base, expect} from '@shipfox/e2e-core/playwright';
+import {type AgentFixtures, agentHelper} from '@shipfox/e2e-helper-agent';
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+export const test = base.extend<
+  AuthFixtures & AgentFixtures & ProjectsFixtures & WorkspacesFixtures
+>({
+  ...authHelper,
+  ...agentHelper,
+  ...projectsHelper,
+  ...workspacesHelper,
+});
+export {expect};

--- a/e2e/client/agent/tsconfig.json
+++ b/e2e/client/agent/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"]
+  },
+  "include": ["playwright.config.ts", "tests"]
+}

--- a/e2e/helpers/agent/package.json
+++ b/e2e/helpers/agent/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shipfox/e2e-helper-agent",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/helpers/agent"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/api-agent-dto": "workspace:*",
+    "@shipfox/e2e-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
+  }
+}

--- a/e2e/helpers/agent/src/index.test.ts
+++ b/e2e/helpers/agent/src/index.test.ts
@@ -44,17 +44,32 @@ describe('agent e2e helper', () => {
   });
 
   it('passes when Ollama exposes the configured model', async () => {
-    const fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
-        status: 200,
-        headers: {'content-type': 'application/json'},
-      }),
-    );
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+      )
+      .mockResolvedValueOnce(new Response('{}'));
     const {requireOllamaModel} = await import('./index.js');
 
     const result = await requireOllamaModel({fetch});
 
     expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434/api/generate',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'qwen3.5:0.8b',
+          prompt: '',
+          stream: false,
+          keep_alive: '24h',
+        }),
+      }),
+    );
     expect(result.model).toBe('qwen3.5:0.8b');
   });
 
@@ -85,12 +100,15 @@ describe('agent e2e helper', () => {
     requestJson.mockResolvedValueOnce({provider_id: 'local-ollama-e2e'});
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
-          status: 200,
-          headers: {'content-type': 'application/json'},
-        }),
-      ),
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+            status: 200,
+            headers: {'content-type': 'application/json'},
+          }),
+        )
+        .mockResolvedValueOnce(new Response('{}')),
     );
     const {createOllamaCustomProvider} = await import('./index.js');
 

--- a/e2e/helpers/agent/src/index.test.ts
+++ b/e2e/helpers/agent/src/index.test.ts
@@ -1,0 +1,135 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+
+const requestJson = vi.fn();
+const workspaceId = '11111111-1111-4111-8111-111111111111';
+const sessionToken = 'user-session-token';
+
+describe('agent e2e helper', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    requestJson.mockReset();
+    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves Ollama defaults and appends the OpenAI-compatible path', async () => {
+    const {ollamaConfig} = await import('./index.js');
+
+    const config = ollamaConfig({});
+
+    expect(config).toEqual({
+      baseUrl: 'http://127.0.0.1:11434',
+      model: 'qwen3.5:0.8b',
+      openAiBaseUrl: 'http://127.0.0.1:11434/v1',
+    });
+  });
+
+  it('prefers OLLAMA_BASE_URL over SHIPFOX_OLLAMA_BASE_URL and trims trailing slashes', async () => {
+    const {ollamaConfig} = await import('./index.js');
+
+    const config = ollamaConfig({
+      OLLAMA_BASE_URL: 'http://127.0.0.1:11500///',
+      SHIPFOX_OLLAMA_BASE_URL: 'http://127.0.0.1:11434',
+      SHIPFOX_OLLAMA_MODEL: 'custom:model',
+    });
+
+    expect(config).toEqual({
+      baseUrl: 'http://127.0.0.1:11500',
+      model: 'custom:model',
+      openAiBaseUrl: 'http://127.0.0.1:11500/v1',
+    });
+  });
+
+  it('passes when Ollama exposes the configured model', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      }),
+    );
+    const {requireOllamaModel} = await import('./index.js');
+
+    const result = await requireOllamaModel({fetch});
+
+    expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags');
+    expect(result.model).toBe('qwen3.5:0.8b');
+  });
+
+  it('fails clearly when Ollama is unavailable', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const {requireOllamaModel} = await import('./index.js');
+
+    await expect(requireOllamaModel({fetch})).rejects.toThrow(
+      'Run `mise run ollama:up` before running agent E2E tests.',
+    );
+  });
+
+  it('fails clearly when the configured model is missing', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({models: [{name: 'llama3.2:1b'}]}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      }),
+    );
+    const {requireOllamaModel} = await import('./index.js');
+
+    await expect(requireOllamaModel({fetch, model: 'qwen3.5:0.8b'})).rejects.toThrow(
+      'Available models: llama3.2:1b.',
+    );
+  });
+
+  it('creates a local Ollama custom provider through the product route', async () => {
+    requestJson.mockResolvedValueOnce({provider_id: 'local-ollama-e2e'});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+      ),
+    );
+    const {createOllamaCustomProvider} = await import('./index.js');
+
+    await createOllamaCustomProvider({
+      workspaceId,
+      sessionToken,
+      providerId: 'local-ollama-e2e',
+      displayName: 'Local Ollama E2E',
+    });
+
+    expect(requestJson).toHaveBeenCalledWith(
+      'post',
+      `/workspaces/${workspaceId}/agent/custom-model-providers`,
+      {
+        headers: {authorization: `Bearer ${sessionToken}`},
+        json: {
+          slug: 'local-ollama-e2e',
+          display_name: 'Local Ollama E2E',
+          api: 'openai-completions',
+          base_url: 'http://127.0.0.1:11434/v1',
+          models: [{id: 'qwen3.5:0.8b', label: 'qwen3.5:0.8b'}],
+          default_model: 'qwen3.5:0.8b',
+        },
+      },
+    );
+  });
+
+  it('lists model provider configs through the product route', async () => {
+    requestJson.mockResolvedValueOnce({configs: [], default_provider_id: null});
+    const {listModelProviderConfigs} = await import('./index.js');
+
+    await listModelProviderConfigs({workspaceId, sessionToken});
+
+    expect(requestJson).toHaveBeenCalledWith(
+      'get',
+      `/workspaces/${workspaceId}/agent/model-providers`,
+      {
+        headers: {authorization: `Bearer ${sessionToken}`},
+      },
+    );
+  });
+});

--- a/e2e/helpers/agent/src/index.test.ts
+++ b/e2e/helpers/agent/src/index.test.ts
@@ -44,32 +44,17 @@ describe('agent e2e helper', () => {
   });
 
   it('passes when Ollama exposes the configured model', async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
-          status: 200,
-          headers: {'content-type': 'application/json'},
-        }),
-      )
-      .mockResolvedValueOnce(new Response('{}'));
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+        status: 200,
+        headers: {'content-type': 'application/json'},
+      }),
+    );
     const {requireOllamaModel} = await import('./index.js');
 
     const result = await requireOllamaModel({fetch});
 
     expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags');
-    expect(fetch).toHaveBeenCalledWith(
-      'http://127.0.0.1:11434/api/generate',
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({
-          model: 'qwen3.5:0.8b',
-          prompt: '',
-          stream: false,
-          keep_alive: '24h',
-        }),
-      }),
-    );
     expect(result.model).toBe('qwen3.5:0.8b');
   });
 
@@ -100,15 +85,12 @@ describe('agent e2e helper', () => {
     requestJson.mockResolvedValueOnce({provider_id: 'local-ollama-e2e'});
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
-            status: 200,
-            headers: {'content-type': 'application/json'},
-          }),
-        )
-        .mockResolvedValueOnce(new Response('{}')),
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+          status: 200,
+          headers: {'content-type': 'application/json'},
+        }),
+      ),
     );
     const {createOllamaCustomProvider} = await import('./index.js');
 

--- a/e2e/helpers/agent/src/index.ts
+++ b/e2e/helpers/agent/src/index.ts
@@ -10,7 +10,6 @@ import {requestJson} from '@shipfox/e2e-core';
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_OLLAMA_MODEL = 'qwen3.5:0.8b';
 const DEFAULT_OLLAMA_PROVIDER_API: ModelProviderApi = 'openai-completions';
-const OLLAMA_WARMUP_TIMEOUT_MS = 120_000;
 const TRAILING_SLASHES_RE = /\/+$/u;
 
 export interface OllamaConfig {
@@ -81,8 +80,6 @@ export async function requireOllamaModel(
       ].join(' '),
     );
   }
-
-  await warmOllamaModel({baseUrl, fetch: fetchImpl, model});
 
   return {baseUrl, model, openAiBaseUrl: `${baseUrl}/v1`};
 }
@@ -189,43 +186,7 @@ function ollamaModelNames(payload: unknown): string[] {
 
 const ollamaFix = 'Run `mise run ollama:up` before running agent E2E tests.';
 
-async function warmOllamaModel(params: {
-  baseUrl: string;
-  fetch: typeof fetch;
-  model: string;
-}): Promise<void> {
-  let response: Response;
-  try {
-    response = await params.fetch(`${params.baseUrl}/api/generate`, {
-      method: 'POST',
-      headers: {'content-type': 'application/json'},
-      body: JSON.stringify({
-        model: params.model,
-        prompt: '',
-        stream: false,
-        keep_alive: '24h',
-      }),
-      signal: AbortSignal.timeout(OLLAMA_WARMUP_TIMEOUT_MS),
-    });
-  } catch (error) {
-    throw new Error(ollamaWarmupMessage(params.baseUrl, params.model, error));
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `Ollama at ${params.baseUrl} returned ${response.status} while warming ${params.model}. ${ollamaFix}`,
-    );
-  }
-
-  await response.body?.cancel();
-}
-
 function ollamaUnavailableMessage(baseUrl: string, error: unknown): string {
   const reason = error instanceof Error ? ` ${error.message}` : '';
   return `Could not reach Ollama at ${baseUrl}.${reason} ${ollamaFix}`;
-}
-
-function ollamaWarmupMessage(baseUrl: string, model: string, error: unknown): string {
-  const reason = error instanceof Error ? ` ${error.message}` : '';
-  return `Could not warm Ollama model ${model} at ${baseUrl}.${reason} ${ollamaFix}`;
 }

--- a/e2e/helpers/agent/src/index.ts
+++ b/e2e/helpers/agent/src/index.ts
@@ -1,0 +1,192 @@
+import type {
+  CreateCustomModelProviderBodyDto,
+  CustomModelProviderConfigDto,
+  ListModelProviderConfigsResponseDto,
+  ModelProviderApi,
+  ModelProviderRef,
+} from '@shipfox/api-agent-dto';
+import {requestJson} from '@shipfox/e2e-core';
+
+const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
+const DEFAULT_OLLAMA_MODEL = 'qwen3.5:0.8b';
+const DEFAULT_OLLAMA_PROVIDER_API: ModelProviderApi = 'openai-completions';
+const TRAILING_SLASHES_RE = /\/+$/u;
+
+export interface OllamaConfig {
+  baseUrl: string;
+  model: string;
+  openAiBaseUrl: string;
+}
+
+export interface RequireOllamaModelParams {
+  baseUrl?: string | undefined;
+  fetch?: typeof fetch | undefined;
+  model?: string | undefined;
+}
+
+export interface CreateOllamaCustomProviderParams {
+  workspaceId: string;
+  sessionToken: string;
+  api?: ModelProviderApi | undefined;
+  baseUrl?: string | undefined;
+  displayName?: string | undefined;
+  model?: string | undefined;
+  providerId?: ModelProviderRef | undefined;
+}
+
+export interface ListModelProviderConfigsParams {
+  workspaceId: string;
+  sessionToken: string;
+}
+
+export function ollamaConfig(env: NodeJS.ProcessEnv = process.env): OllamaConfig {
+  const baseUrl = normalizeBaseUrl(
+    env.OLLAMA_BASE_URL || env.SHIPFOX_OLLAMA_BASE_URL || DEFAULT_OLLAMA_BASE_URL,
+  );
+  return {
+    baseUrl,
+    model: env.SHIPFOX_OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL,
+    openAiBaseUrl: `${baseUrl}/v1`,
+  };
+}
+
+export async function requireOllamaModel(
+  params: RequireOllamaModelParams = {},
+): Promise<OllamaConfig> {
+  const resolved = ollamaConfig();
+  const baseUrl = normalizeBaseUrl(params.baseUrl ?? resolved.baseUrl);
+  const model = params.model ?? resolved.model;
+  const fetchImpl = params.fetch ?? fetch;
+  const tagsUrl = `${baseUrl}/api/tags`;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(tagsUrl);
+  } catch (error) {
+    throw new Error(ollamaUnavailableMessage(baseUrl, error));
+  }
+
+  if (!response.ok) {
+    throw new Error(`Ollama at ${baseUrl} returned ${response.status} for /api/tags. ${ollamaFix}`);
+  }
+
+  const modelNames = ollamaModelNames(await response.json());
+  if (!modelNames.includes(model)) {
+    throw new Error(
+      [
+        `Ollama model ${model} is not available at ${baseUrl}.`,
+        modelNames.length > 0 ? `Available models: ${modelNames.join(', ')}.` : 'No models found.',
+        ollamaFix,
+      ].join(' '),
+    );
+  }
+
+  return {baseUrl, model, openAiBaseUrl: `${baseUrl}/v1`};
+}
+
+export async function createOllamaCustomProvider(
+  params: CreateOllamaCustomProviderParams,
+): Promise<CustomModelProviderConfigDto> {
+  const ollama = await requireOllamaModel({
+    baseUrl: params.baseUrl,
+    model: params.model,
+  });
+  const providerId = params.providerId ?? createOllamaProviderId();
+  const body = createOllamaCustomProviderBody({
+    api: params.api ?? DEFAULT_OLLAMA_PROVIDER_API,
+    baseUrl: ollama.openAiBaseUrl,
+    displayName: params.displayName ?? 'Local Ollama',
+    model: ollama.model,
+    providerId,
+  });
+
+  return await requestJson<CustomModelProviderConfigDto>(
+    'post',
+    `/workspaces/${params.workspaceId}/agent/custom-model-providers`,
+    {
+      headers: {authorization: `Bearer ${params.sessionToken}`},
+      json: body,
+    },
+  );
+}
+
+export async function listModelProviderConfigs(
+  params: ListModelProviderConfigsParams,
+): Promise<ListModelProviderConfigsResponseDto> {
+  return await requestJson<ListModelProviderConfigsResponseDto>(
+    'get',
+    `/workspaces/${params.workspaceId}/agent/model-providers`,
+    {
+      headers: {authorization: `Bearer ${params.sessionToken}`},
+    },
+  );
+}
+
+export function createAgentHelper() {
+  return {
+    createOllamaCustomProvider,
+    listModelProviderConfigs,
+    requireOllamaModel,
+  };
+}
+
+export type AgentHelper = ReturnType<typeof createAgentHelper>;
+
+export interface AgentFixtures {
+  agent: AgentHelper;
+}
+
+export const agentHelper = {
+  agent: async (
+    {request: _request}: {request: unknown},
+    use: (helper: AgentHelper) => Promise<void>,
+  ) => {
+    await use(createAgentHelper());
+  },
+};
+
+function createOllamaCustomProviderBody(params: {
+  api: ModelProviderApi;
+  baseUrl: string;
+  displayName: string;
+  model: string;
+  providerId: ModelProviderRef;
+}): CreateCustomModelProviderBodyDto {
+  return {
+    slug: params.providerId,
+    display_name: params.displayName,
+    api: params.api,
+    base_url: params.baseUrl,
+    models: [{id: params.model, label: params.model}],
+    default_model: params.model,
+  };
+}
+
+function createOllamaProviderId(): ModelProviderRef {
+  return `local-ollama-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(TRAILING_SLASHES_RE, '');
+}
+
+function ollamaModelNames(payload: unknown): string[] {
+  if (!payload || typeof payload !== 'object') return [];
+  const models = (payload as {models?: unknown}).models;
+  if (!Array.isArray(models)) return [];
+
+  return models.flatMap((model) => {
+    if (!model || typeof model !== 'object') return [];
+    const record = model as {model?: unknown; name?: unknown};
+    const name = typeof record.name === 'string' ? record.name : undefined;
+    const modelName = typeof record.model === 'string' ? record.model : undefined;
+    return [...new Set([name, modelName].filter((value): value is string => Boolean(value)))];
+  });
+}
+
+const ollamaFix = 'Run `mise run ollama:up` before running agent E2E tests.';
+
+function ollamaUnavailableMessage(baseUrl: string, error: unknown): string {
+  const reason = error instanceof Error ? ` ${error.message}` : '';
+  return `Could not reach Ollama at ${baseUrl}.${reason} ${ollamaFix}`;
+}

--- a/e2e/helpers/agent/src/index.ts
+++ b/e2e/helpers/agent/src/index.ts
@@ -10,6 +10,7 @@ import {requestJson} from '@shipfox/e2e-core';
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_OLLAMA_MODEL = 'qwen3.5:0.8b';
 const DEFAULT_OLLAMA_PROVIDER_API: ModelProviderApi = 'openai-completions';
+const OLLAMA_WARMUP_TIMEOUT_MS = 120_000;
 const TRAILING_SLASHES_RE = /\/+$/u;
 
 export interface OllamaConfig {
@@ -80,6 +81,8 @@ export async function requireOllamaModel(
       ].join(' '),
     );
   }
+
+  await warmOllamaModel({baseUrl, fetch: fetchImpl, model});
 
   return {baseUrl, model, openAiBaseUrl: `${baseUrl}/v1`};
 }
@@ -186,7 +189,43 @@ function ollamaModelNames(payload: unknown): string[] {
 
 const ollamaFix = 'Run `mise run ollama:up` before running agent E2E tests.';
 
+async function warmOllamaModel(params: {
+  baseUrl: string;
+  fetch: typeof fetch;
+  model: string;
+}): Promise<void> {
+  let response: Response;
+  try {
+    response = await params.fetch(`${params.baseUrl}/api/generate`, {
+      method: 'POST',
+      headers: {'content-type': 'application/json'},
+      body: JSON.stringify({
+        model: params.model,
+        prompt: '',
+        stream: false,
+        keep_alive: '24h',
+      }),
+      signal: AbortSignal.timeout(OLLAMA_WARMUP_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(ollamaWarmupMessage(params.baseUrl, params.model, error));
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Ollama at ${params.baseUrl} returned ${response.status} while warming ${params.model}. ${ollamaFix}`,
+    );
+  }
+
+  await response.body?.cancel();
+}
+
 function ollamaUnavailableMessage(baseUrl: string, error: unknown): string {
   const reason = error instanceof Error ? ` ${error.message}` : '';
   return `Could not reach Ollama at ${baseUrl}.${reason} ${ollamaFix}`;
+}
+
+function ollamaWarmupMessage(baseUrl: string, model: string, error: unknown): string {
+  const reason = error instanceof Error ? ` ${error.message}` : '';
+  return `Could not warm Ollama model ${model} at ${baseUrl}.${reason} ${ollamaFix}`;
 }

--- a/e2e/helpers/agent/tsconfig.build.json
+++ b/e2e/helpers/agent/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/helpers/agent/tsconfig.json
+++ b/e2e/helpers/agent/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }, { "path": "tsconfig.test.json" }]
+}

--- a/e2e/helpers/agent/tsconfig.test.json
+++ b/e2e/helpers/agent/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "vitest.config.ts"]
+}

--- a/e2e/helpers/agent/vitest.config.ts
+++ b/e2e/helpers/agent/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/libs/shared/node/egress-guard/src/index.ts
+++ b/libs/shared/node/egress-guard/src/index.ts
@@ -1,5 +1,5 @@
 import {lookup} from 'node:dns/promises';
-import * as ipaddr from 'ipaddr.js';
+import ipaddr from 'ipaddr.js';
 
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
 const METADATA_ADDRESS = '169.254.169.254';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,45 @@ importers:
         specifier: workspace:*
         version: link:../../../tools/typescript
 
+  e2e/client/agent:
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/client-agent':
+        specifier: workspace:*
+        version: link:../../../libs/client/agent
+      '@shipfox/client-router':
+        specifier: workspace:*
+        version: link:../../../libs/client/router
+      '@shipfox/client-workspace-settings':
+        specifier: workspace:*
+        version: link:../../../libs/client/workspace-settings
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@shipfox/e2e-helper-agent':
+        specifier: workspace:*
+        version: link:../../helpers/agent
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../../helpers/auth
+      '@shipfox/e2e-helper-projects':
+        specifier: workspace:*
+        version: link:../../helpers/projects
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
   e2e/client/auth:
     devDependencies:
       '@shipfox/biome':
@@ -466,6 +505,31 @@ importers:
       '@shipfox/vitest':
         specifier: workspace:*
         version: link:../../tools/vitest
+
+  e2e/helpers/agent:
+    dependencies:
+      '@shipfox/api-agent-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/agent-dto
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../../tools/vitest
 
   e2e/helpers/auth:
     dependencies:


### PR DESCRIPTION
Add reusable E2E support for configuring custom model providers against local Ollama and cover the workspace settings create, edit, and delete flows in a new client agent Playwright package.

Custom provider E2E setup will be useful to other suites that need a real model-provider config, so the helper creates providers through the same user-authenticated product route instead of seeding state through a test-only API. The client suite keeps Ollama startup explicit and fails in global setup when the service or expected model is unavailable.

While running the suite, local provider validation exposed a runtime import mismatch in `@shipfox/node-egress-guard`: `ipaddr.js` functions are on the default export under the dev server runtime. This fixes that import so loopback Ollama URLs can pass the configured local-development egress policy.

CI now starts the shared Ollama service before the E2E job, and the contributor docs call out the same local prerequisite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reusable agent E2E helpers and Playwright coverage for custom model providers against local Ollama (create, edit, delete). CI is stabilized by preloading the model via the OpenAI chat path and increasing the live validation timeout; tests wait for save responses, and loopback URL egress checks are fixed.

- New Features
  - Added `@shipfox/e2e-helper-agent` to create/list providers via product routes and to require a local Ollama model before tests.
  - Added `@shipfox/e2e-client-agent` with provider create/edit/delete tests; global setup requires Ollama and tests wait for the save response.
  - CI starts Ollama with `mise run ollama:up`, which now preloads the model through `/v1/chat/completions`, and sets AGENT_PROVIDER_VALIDATION_TIMEOUT_MS=60000; CONTRIBUTING updated with the Ollama prerequisite and command.

- Bug Fixes
  - Fixed `ipaddr.js` default import in `@shipfox/node-egress-guard` so loopback Ollama URLs pass the egress policy.

<sup>Written for commit 0262e38198273b8ccdb3aaf62cc7bc2062179b06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

