### PR TITLE
Scope log append authorization to step leases

### DIFF
--- a/.changeset/scoped-leases-authorize.md
+++ b/.changeset/scoped-leases-authorize.md
@@ -1,0 +1,12 @@
+---
+"@shipfox/api-auth-dto": patch
+"@shipfox/api-auth": patch
+"@shipfox/api-logs": patch
+"@shipfox/api-runners": patch
+"@shipfox/api-workflows-dto": patch
+"@shipfox/api-workflows": patch
+"@shipfox/runner-orchestration": patch
+"@shipfox/runner-protocol": patch
+---
+
+Scope runner log append authorization to the dispatched step attempt carried by the job lease token.

--- a/libs/api/auth-dto/src/schemas/job-lease-token.ts
+++ b/libs/api/auth-dto/src/schemas/job-lease-token.ts
@@ -15,6 +15,9 @@ export const jobLeaseTokenClaimsSchema = z.object({
   projectId: z.string().uuid(),
   workspaceId: z.string().uuid(),
   runnerSessionId: z.string().uuid(),
+  // Narrows append-log authorization to the step attempt currently dispatched to the runner.
+  currentStepId: z.string().uuid().optional(),
+  currentStepAttempt: z.number().int().positive().optional(),
   aud: z.literal(JOB_LEASE_TOKEN_AUDIENCE),
   iat: z.number().int(),
   exp: z.number().int(),

--- a/libs/api/auth/README.md
+++ b/libs/api/auth/README.md
@@ -129,10 +129,14 @@ progress and drives that job to completion.
   identity, it is **not** workspace-wide, and it is **not** a substitute for the
   long-lived runner credential used to claim work in the first place. The
   surrounding identifiers it carries (job, run, workspace, the claiming runner)
-  are context for consumers; they do not widen what the bearer may touch.
+  are context for consumers; they do not widen what the bearer may touch. When a
+  step is dispatched, the token may also carry the current step id and attempt so
+  log append can verify signed membership in that one step attempt without
+  querying workflow state.
 - **Trust boundary.** There is exactly one issuer: the scheduling side mints a
-  lease when a runner claims a job execution, and heartbeat re-mints the same
-  narrow capability after server state accepts the heartbeat. Everything
+  lease when a runner claims a job execution, next-step re-scopes it to the
+  dispatched step attempt, and heartbeat re-mints the same narrow capability
+  after server state accepts the heartbeat. Everything
   downstream only *verifies* — an in-process signature check, with no callback to
   the issuer. The runner, and the untrusted agent workload it hosts, never mints
   or modifies a token; it only presents the one it was handed.
@@ -152,6 +156,12 @@ progress and drives that job to completion.
   finalization is enforced outside the lease path. Cancellation flows the other way
   as well — the server can ask the runner to stop at any point, and that request
   rides on the response to each heartbeat rather than depending on the token.
+- **Log append scope.** A step-scoped lease is a signed membership and attempt
+  check for append-log authorization. It is not an active-step proof: until the
+  runner adopts a later step-scoped token or the lease expires, the bearer can
+  append to that step attempt's log stream. This is no broader than the job-scoped
+  append authority it replaces, and step completion remains governed by
+  server-side report/progression state.
 - **Threat model.** A leaked or replayed token has a deliberately small blast
   radius: it grants action on one already-claimed job execution while that
   execution remains live. It cannot claim new work, impersonate a runner, or reach

--- a/libs/api/auth/src/core/job-lease-token.test.ts
+++ b/libs/api/auth/src/core/job-lease-token.test.ts
@@ -36,6 +36,30 @@ describe('job-lease-token', () => {
     expect(verified?.exp).toBeGreaterThan(verified?.iat ?? 0);
   });
 
+  test('omits step scope when issuing a job-scoped token', async () => {
+    const input = claims();
+
+    const token = await issueJobLeaseToken(input);
+    const verified = await verifyJobLeaseToken(token);
+
+    expect(verified?.currentStepId).toBeUndefined();
+    expect(verified?.currentStepAttempt).toBeUndefined();
+  });
+
+  test('round-trips the current step scope when present', async () => {
+    const input = {
+      ...claims(),
+      currentStepId: crypto.randomUUID(),
+      currentStepAttempt: 2,
+    };
+
+    const token = await issueJobLeaseToken(input);
+    const verified = await verifyJobLeaseToken(token);
+
+    expect(verified?.currentStepId).toBe(input.currentStepId);
+    expect(verified?.currentStepAttempt).toBe(input.currentStepAttempt);
+  });
+
   test('returns claims when metric recording fails after successful verification', async () => {
     vi.resetModules();
     vi.doMock('@shipfox/node-opentelemetry', () => ({

--- a/libs/api/auth/src/core/job-lease-token.ts
+++ b/libs/api/auth/src/core/job-lease-token.ts
@@ -10,6 +10,33 @@ import {recordTokenIssued, recordTokenVerified} from '#metrics/index.js';
 // `aud`, `iat` and `exp` are set by the codec (jose); callers supply the business ids only.
 export type IssueJobLeaseTokenParams = Omit<JobLeaseTokenClaims, 'aud' | 'iat' | 'exp'>;
 
+type JobLeaseParamSource = Pick<
+  JobLeaseTokenClaims,
+  | 'workflowRunId'
+  | 'workflowRunAttemptId'
+  | 'jobId'
+  | 'jobExecutionId'
+  | 'projectId'
+  | 'workspaceId'
+  | 'runnerSessionId'
+>;
+
+export function jobLeaseParamsFrom(
+  source: JobLeaseParamSource,
+  stepScope?: {currentStepId: string; currentStepAttempt: number},
+): IssueJobLeaseTokenParams {
+  return {
+    workflowRunId: source.workflowRunId,
+    workflowRunAttemptId: source.workflowRunAttemptId,
+    jobId: source.jobId,
+    jobExecutionId: source.jobExecutionId,
+    projectId: source.projectId,
+    workspaceId: source.workspaceId,
+    runnerSessionId: source.runnerSessionId,
+    ...(stepScope ? stepScope : {}),
+  };
+}
+
 export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Promise<string> {
   const token = await signHs256({
     payload: {
@@ -20,6 +47,12 @@ export async function issueJobLeaseToken(claims: IssueJobLeaseTokenParams): Prom
       projectId: claims.projectId,
       workspaceId: claims.workspaceId,
       runnerSessionId: claims.runnerSessionId,
+      ...(claims.currentStepId && claims.currentStepAttempt !== undefined
+        ? {
+            currentStepId: claims.currentStepId,
+            currentStepAttempt: claims.currentStepAttempt,
+          }
+        : {}),
     },
     secret: config.AUTH_JOB_LEASE_TOKEN_SECRET,
     expiresIn: config.AUTH_JOB_LEASE_TOKEN_EXPIRES_IN,

--- a/libs/api/auth/src/index.ts
+++ b/libs/api/auth/src/index.ts
@@ -21,7 +21,11 @@ import {
 
 export type {JobLeaseTokenClaims, RunnerSessionTokenClaims} from '@shipfox/api-auth-dto';
 export type {User, UserStatus} from '#core/entities/user.js';
-export {issueJobLeaseToken, verifyJobLeaseToken} from '#core/job-lease-token.js';
+export {
+  issueJobLeaseToken,
+  jobLeaseParamsFrom,
+  verifyJobLeaseToken,
+} from '#core/job-lease-token.js';
 export {
   issueRunnerSessionToken,
   verifyRunnerSessionToken,

--- a/libs/api/logs/src/presentation/routes/append-logs.test.ts
+++ b/libs/api/logs/src/presentation/routes/append-logs.test.ts
@@ -1,18 +1,11 @@
 import {Buffer} from 'node:buffer';
 import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
 import {AUTH_USER} from '@shipfox/api-auth-context';
-import {getStepByIdForJobExecution} from '@shipfox/api-workflows';
 import {type AuthMethod, closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {mintLeaseToken} from '#test/fixtures/lease-token.js';
 import {endLine, ndjsonBody, outputLine, recordLine} from '#test/fixtures/ndjson.js';
 import {logsRoutes} from './index.js';
 
-vi.mock('@shipfox/api-workflows', () => ({
-  getStepByIdForJobExecution: vi.fn(),
-  getTerminalStepAttemptLogState: vi.fn(),
-}));
-
-const mockedGetStepByIdForJobExecution = vi.mocked(getStepByIdForJobExecution);
 const NDJSON = 'application/x-ndjson';
 const JOB_EXECUTION_ID = '00000000-0000-4000-8000-0000000000ee';
 
@@ -24,8 +17,17 @@ function logsUrl(stepId: string, attempt: number, offset: number): string {
   return `/runs/jobs/current/steps/${stepId}/logs?attempt=${attempt}&offset=${offset}`;
 }
 
-function mintTestLeaseToken(jobId = crypto.randomUUID()): Promise<string> {
-  return mintLeaseToken({jobId, jobExecutionId: JOB_EXECUTION_ID});
+function mintTestLeaseToken(params: {
+  jobId?: string;
+  stepId: string;
+  attempt?: number;
+}): Promise<string> {
+  return mintLeaseToken({
+    jobId: params.jobId ?? crypto.randomUUID(),
+    jobExecutionId: JOB_EXECUTION_ID,
+    currentStepId: params.stepId,
+    currentStepAttempt: params.attempt ?? 1,
+  });
 }
 
 describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
@@ -38,10 +40,6 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
       swagger: false,
     });
     await app.ready();
-  });
-
-  beforeEach(() => {
-    mockedGetStepByIdForJobExecution.mockResolvedValue({id: crypto.randomUUID()} as never);
   });
 
   afterAll(async () => {
@@ -63,13 +61,8 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   it('accepts an in-order append and returns the committed length', async () => {
     const jobId = crypto.randomUUID();
     const stepId = crypto.randomUUID();
-    const token = await mintTestLeaseToken(jobId);
+    const token = await mintTestLeaseToken({jobId, stepId});
     const body = ndjsonBody(outputLine('installing\n'));
-    mockedGetStepByIdForJobExecution.mockImplementation((params) =>
-      params.stepId === stepId && params.jobExecutionId === JOB_EXECUTION_ID
-        ? Promise.resolve({id: stepId} as never)
-        : Promise.resolve(undefined),
-    );
 
     const res = await app.inject({
       method: 'POST',
@@ -83,15 +76,48 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('rejects appends for a step outside the leased execution', async () => {
+    const leasedStepId = crypto.randomUUID();
+    const requestedStepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId: leasedStepId});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: logsUrl(requestedStepId, 1, 0),
+      headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
+      payload: ndjsonBody(outputLine('wrong execution\n')),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('step-not-found');
+  });
+
+  it('rejects appends for a different attempt than the leased step scope', async () => {
     const stepId = crypto.randomUUID();
-    const token = await mintTestLeaseToken();
-    mockedGetStepByIdForJobExecution.mockResolvedValue(undefined);
+    const token = await mintTestLeaseToken({stepId, attempt: 1});
+
+    const res = await app.inject({
+      method: 'POST',
+      url: logsUrl(stepId, 2, 0),
+      headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
+      payload: ndjsonBody(outputLine('wrong attempt\n')),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().code).toBe('step-not-found');
+  });
+
+  it('rejects appends with a job-scoped lease token', async () => {
+    const stepId = crypto.randomUUID();
+    const token = await mintLeaseToken({
+      jobId: crypto.randomUUID(),
+      jobExecutionId: JOB_EXECUTION_ID,
+    });
 
     const res = await app.inject({
       method: 'POST',
       url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
-      payload: ndjsonBody(outputLine('wrong execution\n')),
+      payload: ndjsonBody(outputLine('job scoped\n')),
     });
 
     expect(res.statusCode).toBe(404);
@@ -101,7 +127,7 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   it('acks a re-sent append at an earlier offset', async () => {
     const jobId = crypto.randomUUID();
     const stepId = crypto.randomUUID();
-    const token = await mintTestLeaseToken(jobId);
+    const token = await mintTestLeaseToken({jobId, stepId});
     const body = ndjsonBody(outputLine('once\n'));
     await app.inject({
       method: 'POST',
@@ -124,7 +150,7 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   it('rejects an offset gap with 409 and the committed length', async () => {
     const jobId = crypto.randomUUID();
     const stepId = crypto.randomUUID();
-    const token = await mintTestLeaseToken(jobId);
+    const token = await mintTestLeaseToken({jobId, stepId});
     const body = ndjsonBody(outputLine('first\n'));
     await app.inject({
       method: 'POST',
@@ -146,11 +172,12 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('rejects a forged server-only tombstone with 400', async () => {
-    const token = await mintTestLeaseToken();
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
       payload: ndjsonBody(recordLine({type: 'capped'})),
     });
@@ -160,11 +187,12 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('rejects a body that is not newline-terminated with 400', async () => {
-    const token = await mintTestLeaseToken();
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
       payload: '{"v":1,"ts":1,"type":"output","stream":"stdout","data":"no newline"}',
     });
@@ -174,11 +202,12 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('rejects a record whose data exceeds the per-record byte cap with 400', async () => {
-    const token = await mintTestLeaseToken();
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
       payload: ndjsonBody(outputLine('x'.repeat(16 * 1024 + 1))),
     });
@@ -188,11 +217,12 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('treats an empty body as a no-op', async () => {
-    const token = await mintTestLeaseToken();
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
       payload: '',
     });
@@ -202,11 +232,12 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('rejects a non-ndjson content type with 415', async () => {
-    const token = await mintTestLeaseToken();
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': 'application/json'},
       payload: '{"hello":"world"}',
     });
@@ -215,13 +246,14 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
   });
 
   it('rejects a body over the configured size limit with 413', async () => {
-    const token = await mintTestLeaseToken();
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({stepId});
     // Test body limit is 64 KiB (LOG_APPEND_BODY_LIMIT_BYTES in test/env.ts).
     const oversize = Buffer.alloc(65536 + 1024, 0x61).toString('utf8');
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
       payload: oversize,
     });
@@ -231,11 +263,12 @@ describe('POST /runs/jobs/current/steps/:stepId/logs', () => {
 
   it('reports capped once the budget is crossed', async () => {
     const jobId = crypto.randomUUID();
-    const token = await mintTestLeaseToken(jobId);
+    const stepId = crypto.randomUUID();
+    const token = await mintTestLeaseToken({jobId, stepId});
 
     const res = await app.inject({
       method: 'POST',
-      url: logsUrl(crypto.randomUUID(), 1, 0),
+      url: logsUrl(stepId, 1, 0),
       headers: {authorization: `Bearer ${token}`, 'content-type': NDJSON},
       payload: ndjsonBody(outputLine('x'.repeat(150)), endLine(150)),
     });

--- a/libs/api/logs/src/presentation/routes/append-logs.ts
+++ b/libs/api/logs/src/presentation/routes/append-logs.ts
@@ -5,7 +5,6 @@ import {
   appendLogsResponseSchema,
   offsetGapResponseSchema,
 } from '@shipfox/api-logs-dto';
-import {getStepByIdForJobExecution} from '@shipfox/api-workflows';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {z} from 'zod';
 import {appendLogs} from '#core/append-logs.js';
@@ -43,11 +42,9 @@ export const appendLogsRoute = defineRoute({
     const {stepId} = request.params;
     const {attempt, offset} = request.query;
 
-    const step = await getStepByIdForJobExecution({
-      stepId,
-      jobExecutionId: leasedJob.jobExecutionId,
-    });
-    if (!step) {
+    // The scoped lease proves membership in the dispatched step attempt; active-step
+    // completion remains governed by workflow/report state, not the log append route.
+    if (leasedJob.currentStepId !== stepId || leasedJob.currentStepAttempt !== attempt) {
       throw new ClientError('Step not found for leased job execution', 'step-not-found', {
         status: 404,
       });

--- a/libs/api/logs/test/fixtures/lease-token.ts
+++ b/libs/api/logs/test/fixtures/lease-token.ts
@@ -11,6 +11,8 @@ export interface MintLeaseTokenParams {
   projectId?: string;
   workflowRunId?: string;
   workflowRunAttemptId?: string;
+  currentStepId?: string;
+  currentStepAttempt?: number;
   secret?: string;
   expiresIn?: string;
   audience?: string;
@@ -26,6 +28,12 @@ export function mintLeaseToken(params: MintLeaseTokenParams): Promise<string> {
       projectId: params.projectId ?? crypto.randomUUID(),
       workspaceId: params.workspaceId ?? crypto.randomUUID(),
       runnerSessionId: crypto.randomUUID(),
+      ...(params.currentStepId && params.currentStepAttempt !== undefined
+        ? {
+            currentStepId: params.currentStepId,
+            currentStepAttempt: params.currentStepAttempt,
+          }
+        : {}),
     },
     secret: params.secret ?? SECRET,
     expiresIn: params.expiresIn ?? '90m',

--- a/libs/api/runners/src/presentation/routes/heartbeat.test.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.test.ts
@@ -2,6 +2,7 @@ import {
   createLeaseTokenAuthMethod,
   createRunnerSessionAuthMethod,
   issueJobLeaseToken,
+  jobLeaseParamsFrom,
   verifyJobLeaseToken,
 } from '@shipfox/api-auth';
 import {AUTH_PROVISIONER_TOKEN, AUTH_USER} from '@shipfox/api-auth-context';
@@ -111,6 +112,8 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
       workflowRunAttemptId,
       runnerSessionId,
     });
+    expect(refreshedLease?.currentStepId).toBeUndefined();
+    expect(refreshedLease?.currentStepAttempt).toBeUndefined();
     const [running] = await db()
       .select()
       .from(runningJobExecutions)
@@ -140,6 +143,25 @@ describe('POST /runners/jobs/:jobId/heartbeat', () => {
       workflowRunAttemptId,
       runnerSessionId,
     });
+  });
+
+  it('preserves current step scope when renewing a step-scoped lease', async () => {
+    const {jobId, leaseToken} = await claimAvailableJob();
+    const lease = await verifyJobLeaseToken(leaseToken);
+    if (!lease) throw new Error('Expected valid lease token');
+    const stepScope = {currentStepId: crypto.randomUUID(), currentStepAttempt: 3};
+    const stepScopedLeaseToken = await issueJobLeaseToken(jobLeaseParamsFrom(lease, stepScope));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/runners/jobs/${jobId}/heartbeat`,
+      headers: {authorization: `Bearer ${stepScopedLeaseToken}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{cancel: boolean; lease_token: string}>();
+    const refreshedLease = await verifyJobLeaseToken(body.lease_token);
+    expect(refreshedLease).toMatchObject(stepScope);
   });
 
   it('returns 404 when the jobId is unknown', async () => {

--- a/libs/api/runners/src/presentation/routes/heartbeat.ts
+++ b/libs/api/runners/src/presentation/routes/heartbeat.ts
@@ -1,4 +1,4 @@
-import {issueJobLeaseToken} from '@shipfox/api-auth';
+import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {heartbeatResponseSchema} from '@shipfox/api-runners-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
@@ -37,15 +37,17 @@ export const heartbeatRoute = defineRoute({
       runnerSessionId: lease.runnerSessionId,
     });
 
-    const leaseToken = await issueJobLeaseToken({
-      workflowRunId: runningJobExecution.workflowRunId,
-      workflowRunAttemptId: runningJobExecution.workflowRunAttemptId,
-      jobId: runningJobExecution.jobId,
-      jobExecutionId: runningJobExecution.jobExecutionId,
-      projectId: runningJobExecution.projectId,
-      workspaceId: runningJobExecution.workspaceId,
-      runnerSessionId: runningJobExecution.runnerSessionId,
-    });
+    const leaseToken = await issueJobLeaseToken(
+      jobLeaseParamsFrom(
+        runningJobExecution,
+        lease.currentStepId && lease.currentStepAttempt !== undefined
+          ? {
+              currentStepId: lease.currentStepId,
+              currentStepAttempt: lease.currentStepAttempt,
+            }
+          : undefined,
+      ),
+    );
 
     return {cancel: cancellationRequested, lease_token: leaseToken};
   },

--- a/libs/api/workflows-dto/src/schemas/job-execution.ts
+++ b/libs/api/workflows-dto/src/schemas/job-execution.ts
@@ -17,6 +17,12 @@ export const nextStepResponseSchema = z.discriminatedUnion('kind', [
       .describe(
         'Attempt number for this step dispatch. Echo it back when reporting the step result so stale reports from older attempts can be ignored.',
       ),
+    lease_token: z
+      .string()
+      .min(1)
+      .describe(
+        'Job-lease token re-scoped to this dispatched step attempt. The runner presents it as its lease for log-append authorization and carries it on later step requests.',
+      ),
   }),
   z.object({
     kind: z.literal('done'),

--- a/libs/api/workflows/src/presentation/routes/next-step.test.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.test.ts
@@ -1,4 +1,4 @@
-import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
+import {createLeaseTokenAuthMethod, verifyJobLeaseToken} from '@shipfox/api-auth';
 import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
 import {eq} from 'drizzle-orm';
 import {JobNotFoundError} from '#core/errors.js';
@@ -143,6 +143,14 @@ describe('POST /runs/jobs/current/steps/next', () => {
     expect(body.kind).toBe('step');
     expect(body.step.id).toBe(steps[0]?.id);
     expect(body.step.status).toBe('running');
+    expect(body.lease_token).toEqual(expect.any(String));
+    const scopedLease = await verifyJobLeaseToken(body.lease_token);
+    expect(scopedLease).toMatchObject({
+      jobId,
+      jobExecutionId: steps[0]?.jobExecutionId,
+      currentStepId: steps[0]?.id,
+      currentStepAttempt: 1,
+    });
     const after = await getStepsByJobId(jobId);
     expect(after[0]?.status).toBe('running');
     expect(after[1]?.status).toBe('pending');
@@ -291,6 +299,10 @@ describe('POST /runs/jobs/current/steps/next', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().attempt).toBe(2);
+    const body = res.json();
+    expect(body.attempt).toBe(2);
+    const scopedLease = await verifyJobLeaseToken(body.lease_token);
+    expect(scopedLease?.currentStepId).toBe(steps[0]?.id);
+    expect(scopedLease?.currentStepAttempt).toBe(body.attempt);
   });
 });

--- a/libs/api/workflows/src/presentation/routes/next-step.ts
+++ b/libs/api/workflows/src/presentation/routes/next-step.ts
@@ -1,3 +1,4 @@
+import {issueJobLeaseToken, jobLeaseParamsFrom} from '@shipfox/api-auth';
 import {requireLeasedJobContext} from '@shipfox/api-auth-context';
 import {nextStepResponseSchema} from '@shipfox/api-workflows-dto';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
@@ -34,9 +35,20 @@ export const nextStepRoute = defineRoute({
     });
 
     if (next.kind === 'step') {
+      const leaseToken = await issueJobLeaseToken(
+        jobLeaseParamsFrom(leasedJob, {
+          currentStepId: next.step.id,
+          currentStepAttempt: next.step.currentAttempt,
+        }),
+      );
       // The runner echoes this back on report so a stale report from a superseded
       // attempt is ignored.
-      return {kind: 'step' as const, step: toStepDto(next.step), attempt: next.step.currentAttempt};
+      return {
+        kind: 'step' as const,
+        step: toStepDto(next.step),
+        attempt: next.step.currentAttempt,
+        lease_token: leaseToken,
+      };
     }
     return {kind: 'done' as const, status: next.status};
   },

--- a/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.test.ts
@@ -28,7 +28,7 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockResolvedValue({cancel: false, lease_token: 'lease-1'});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 1000,
     });
@@ -43,6 +43,7 @@ describe('startHeartbeatLoop', () => {
     expect(heartbeatMock.mock.calls[0]?.[0]).toBe('job-1');
     expect(heartbeatMock.mock.calls[0]?.[1]).toBe('lease-1');
     expect(ac.signal.aborted).toBe(false);
+    expect(handle.bumpGeneration).toEqual(expect.any(Function));
 
     handle.stop();
   });
@@ -54,7 +55,7 @@ describe('startHeartbeatLoop', () => {
     );
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 10_000,
     });
@@ -74,15 +75,19 @@ describe('startHeartbeatLoop', () => {
 
   test('uses the renewed lease token on the next heartbeat tick', async () => {
     const renewedTokens: string[] = [];
+    let leaseToken = 'lease-1';
     heartbeatMock
       .mockResolvedValueOnce({cancel: false, lease_token: 'lease-2'})
       .mockResolvedValueOnce({cancel: false, lease_token: 'lease-3'});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => leaseToken, ac, {
       intervalMs: 100,
       maxStaleMs: 1000,
-      onLeaseTokenRenewed: (leaseToken) => renewedTokens.push(leaseToken),
+      onLeaseTokenRenewed: (renewedLeaseToken) => {
+        renewedTokens.push(renewedLeaseToken);
+        leaseToken = renewedLeaseToken;
+      },
     });
 
     await vi.advanceTimersByTimeAsync(100);
@@ -90,6 +95,30 @@ describe('startHeartbeatLoop', () => {
 
     expect(heartbeatMock.mock.calls.map((call) => call[1])).toEqual(['lease-1', 'lease-2']);
     expect(renewedTokens).toEqual(['lease-2', 'lease-3']);
+
+    handle.stop();
+  });
+
+  test('discards a stale renewal when the generation changes while heartbeat is in flight', async () => {
+    let resolve: ((v: {cancel: boolean; lease_token: string}) => void) | undefined;
+    const renewedTokens: string[] = [];
+    heartbeatMock.mockImplementation(
+      () => new Promise<{cancel: boolean; lease_token: string}>((r) => (resolve = r)),
+    );
+    const ac = new AbortController();
+
+    const handle = startHeartbeatLoop('job-1', () => 'lease-step-b', ac, {
+      intervalMs: 100,
+      maxStaleMs: 10_000,
+      onLeaseTokenRenewed: (leaseToken) => renewedTokens.push(leaseToken),
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    handle.bumpGeneration();
+    resolve?.({cancel: false, lease_token: 'lease-step-a-renewed'});
+    await Promise.resolve();
+
+    expect(renewedTokens).toEqual([]);
 
     handle.stop();
   });
@@ -109,7 +138,7 @@ describe('startHeartbeatLoop', () => {
     );
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 200,
     });
@@ -134,7 +163,7 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockResolvedValueOnce({cancel: true, lease_token: 'lease-2'});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 1000,
     });
@@ -153,7 +182,7 @@ describe('startHeartbeatLoop', () => {
     heartbeatMock.mockRejectedValueOnce(buildHTTPError(404));
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 1000,
     });
@@ -174,7 +203,7 @@ describe('startHeartbeatLoop', () => {
       .mockResolvedValueOnce({cancel: false, lease_token: 'lease-1'});
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 1000,
     });
@@ -204,7 +233,7 @@ describe('startHeartbeatLoop', () => {
     );
     const ac = new AbortController();
 
-    const handle = startHeartbeatLoop('job-1', 'lease-1', ac, {
+    const handle = startHeartbeatLoop('job-1', () => 'lease-1', ac, {
       intervalMs: 100,
       maxStaleMs: 10_000,
     });

--- a/libs/runner/orchestration/src/core/heartbeat-loop.ts
+++ b/libs/runner/orchestration/src/core/heartbeat-loop.ts
@@ -15,6 +15,8 @@ export interface HeartbeatLoopOptions {
 export interface HeartbeatLoopHandle {
   /** Aborts any in-flight heartbeat and clears the pending timer. Idempotent. */
   stop: () => void;
+  /** Marks externally adopted lease tokens so stale heartbeat renewals are ignored. */
+  bumpGeneration: () => void;
 }
 
 /**
@@ -30,12 +32,12 @@ export interface HeartbeatLoopHandle {
  */
 export function startHeartbeatLoop(
   jobId: string,
-  leaseToken: string,
+  getLeaseToken: () => string,
   jobAbortController: AbortController,
   options: HeartbeatLoopOptions,
 ): HeartbeatLoopHandle {
   let stopped = false;
-  let currentLeaseToken = leaseToken;
+  let generation = 0;
   let pendingTimer: NodeJS.Timeout | undefined;
   let currentHttpAc: AbortController | undefined;
 
@@ -49,6 +51,8 @@ export function startHeartbeatLoop(
 
     const httpAc = new AbortController();
     currentHttpAc = httpAc;
+    const sentGeneration = generation;
+    const sentLeaseToken = getLeaseToken();
 
     const staleTimer = setTimeout(() => {
       logger().warn(
@@ -59,12 +63,11 @@ export function startHeartbeatLoop(
     }, options.maxStaleMs);
 
     try {
-      const {cancel, lease_token: renewedLeaseToken} = await heartbeat(jobId, currentLeaseToken, {
+      const {cancel, lease_token: renewedLeaseToken} = await heartbeat(jobId, sentLeaseToken, {
         signal: httpAc.signal,
       });
       if (stopped) return;
-      if (renewedLeaseToken !== currentLeaseToken) {
-        currentLeaseToken = renewedLeaseToken;
+      if (generation === sentGeneration && renewedLeaseToken !== getLeaseToken()) {
         options.onLeaseTokenRenewed?.(renewedLeaseToken);
       }
       if (cancel) {
@@ -104,6 +107,9 @@ export function startHeartbeatLoop(
       stopped = true;
       if (pendingTimer) clearTimeout(pendingTimer);
       if (currentHttpAc) currentHttpAc.abort();
+    },
+    bumpGeneration: () => {
+      generation += 1;
     },
   };
 }

--- a/libs/runner/orchestration/src/core/runner.test.ts
+++ b/libs/runner/orchestration/src/core/runner.test.ts
@@ -9,7 +9,7 @@ vi.mock('#config.js', () => ({
 }));
 
 vi.mock('#core/heartbeat-loop.js', () => ({
-  startHeartbeatLoop: vi.fn(() => ({stop: vi.fn()})),
+  startHeartbeatLoop: vi.fn(() => ({stop: vi.fn(), bumpGeneration: vi.fn()})),
 }));
 
 vi.mock('@shipfox/runner-workspace', async (importActual) => ({
@@ -129,7 +129,7 @@ describe('runJob', () => {
 
     expect(mockStartHeartbeatLoop).toHaveBeenCalledWith(
       JOB.job_id,
-      JOB.lease_token,
+      expect.any(Function),
       expect.any(AbortController),
       expect.objectContaining({
         intervalMs: 10_000,
@@ -189,6 +189,29 @@ describe('runJob', () => {
       'lease-third',
       'lease-fourth',
     ]);
+  });
+
+  it('adopts next-step lease tokens for requests, redaction, and heartbeat generation', async () => {
+    const heartbeatHandle = {stop: vi.fn(), bumpGeneration: vi.fn()};
+    mockStartHeartbeatLoop.mockReturnValueOnce(heartbeatHandle);
+    mockJobWorkspacePath.mockReturnValue(JOB_CWD);
+    mockJobLogsPath.mockReturnValue(JOB_LOGS_DIR);
+
+    await runJob(JOB, WORKSPACE_ROOT);
+
+    const leaseTokenSource = mockCreateLeaseClient.mock.calls[0]?.[0];
+    const stepParams = mockRunJobSteps.mock.calls[0]?.[0];
+    expect(typeof leaseTokenSource).toBe('function');
+
+    stepParams?.onLeaseTokenAdopted?.('lease-step-scoped');
+
+    expect((leaseTokenSource as () => string)()).toBe('lease-step-scoped');
+    expect(stepParams?.secrets).toEqual([
+      'sf_mrt_runner-registration-token',
+      JOB.lease_token,
+      'lease-step-scoped',
+    ]);
+    expect(heartbeatHandle.bumpGeneration).toHaveBeenCalledTimes(1);
   });
 
   it('cleans up the per-job cwd when the step loop throws', async () => {

--- a/libs/runner/orchestration/src/core/runner.ts
+++ b/libs/runner/orchestration/src/core/runner.ts
@@ -168,7 +168,7 @@ export async function runJob(
     for (const subscriber of leaseTokenSecretSubscribers) subscriber(rotatingLeaseSecrets());
   };
 
-  const heartbeatLoop = startHeartbeatLoop(job.job_id, job.lease_token, ac, {
+  const heartbeatLoop = startHeartbeatLoop(job.job_id, () => currentLeaseToken, ac, {
     intervalMs: config.SHIPFOX_HEARTBEAT_INTERVAL_MS,
     maxStaleMs: config.SHIPFOX_HEARTBEAT_MAX_STALE_MS,
     onLeaseTokenRenewed: rememberLeaseToken,
@@ -192,6 +192,10 @@ export async function runJob(
         workflowRunAttemptId: job.workflow_run_attempt_id,
         jobId: job.job_id,
         jobExecutionId: job.job_execution_id,
+      },
+      onLeaseTokenAdopted: (leaseToken) => {
+        rememberLeaseToken(leaseToken);
+        heartbeatLoop.bumpGeneration();
       },
     });
     logger().info({jobId: job.job_id}, 'Job step loop finished');

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -56,7 +56,7 @@ vi.mock('@shipfox/runner-agent', () => ({
   executeAgentStep: (...args: unknown[]) => executeAgentStepMock(...args),
 }));
 
-const {executeStep, runJobSteps} = await import('#core/step-loop.js');
+const {executeStep, pullNextStep, runJobSteps} = await import('#core/step-loop.js');
 
 const JOB_ID = '00000000-0000-0000-0000-0000000000aa';
 const RUN_ID = '00000000-0000-0000-0000-0000000000ab';
@@ -145,6 +145,7 @@ function runLoop(params: {
   secrets?: string[];
   cwd?: string;
   subscribeSecrets?: (subscriber: (secrets: string[]) => void) => () => void;
+  onLeaseTokenAdopted?: (leaseToken: string) => void;
 }): Promise<void> {
   return runJobSteps({
     jobId: JOB_ID,
@@ -155,6 +156,7 @@ function runLoop(params: {
     cwd: params.cwd ?? '/work',
     logsDir: LOGS_DIR,
     jobContext: JOB_CONTEXT,
+    ...(params.onLeaseTokenAdopted ? {onLeaseTokenAdopted: params.onLeaseTokenAdopted} : {}),
   });
 }
 
@@ -225,6 +227,41 @@ describe('runJobSteps', () => {
       signal: ac.signal,
     });
     expect(requestNextStepMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('pullNextStep returns the step-scoped lease token', async () => {
+    const setup = buildSetupStep();
+    requestNextStepMock.mockResolvedValueOnce(stepResponse(setup, 4, 'lease-pulled'));
+    const ac = new AbortController();
+
+    const pulled = await pullNextStep({leaseClient, jobId: JOB_ID, signal: ac.signal});
+
+    expect(pulled).toEqual({step: setup, attempt: 4, leaseToken: 'lease-pulled'});
+  });
+
+  it('adopts the pulled step lease token before opening the step log stream', async () => {
+    const setup = buildSetupStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1, 'lease-step'))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    const ac = new AbortController();
+
+    await runLoop({
+      signal: ac.signal,
+      onLeaseTokenAdopted: (leaseToken) => events.push(`adopt:${leaseToken}`),
+    });
+
+    expect(events.indexOf('adopt:lease-step')).toBeLessThan(events.indexOf(`create:${setup.id}`));
+  });
+
+  it('does not adopt a token for a done response', async () => {
+    requestNextStepMock.mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    const onLeaseTokenAdopted = vi.fn();
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal, onLeaseTokenAdopted});
+
+    expect(onLeaseTokenAdopted).not.toHaveBeenCalled();
   });
 
   it('opens a per-attempt log stream for the run step and disposes it at the end', async () => {
@@ -993,8 +1030,12 @@ function buildStep(overrides: Partial<StepDto> = {}): StepDto {
   };
 }
 
-function stepResponse(step: StepDto, attempt: number): NextStepResponseDto {
-  return {kind: 'step', step, attempt};
+function stepResponse(
+  step: StepDto,
+  attempt: number,
+  leaseToken = `lease-${step.id}-${attempt}`,
+): NextStepResponseDto {
+  return {kind: 'step', step, attempt, lease_token: leaseToken};
 }
 
 function buildHTTPError(status: number): HTTPError {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -49,6 +49,7 @@ export async function runJobSteps(params: {
   cwd: string;
   logsDir: string;
   jobContext: SetupJobContext;
+  onLeaseTokenAdopted?: (leaseToken: string) => void;
 }): Promise<void> {
   const {jobId, leaseClient, secrets, signal, cwd, logsDir, jobContext} = params;
 
@@ -73,6 +74,7 @@ export async function runJobSteps(params: {
       if (!pulled) return;
       if (signal.aborted) return;
 
+      params.onLeaseTokenAdopted?.(pulled.leaseToken);
       const {step, attempt} = pulled;
       const stepLabel = step.name ?? `step #${step.position}`;
       logger().info(
@@ -131,6 +133,7 @@ export async function runJobSteps(params: {
 export interface PulledStep {
   step: StepDto;
   attempt: number;
+  leaseToken: string;
 }
 
 // Pulls the next step, translating the loop's two quiet stop conditions into `undefined`:
@@ -159,7 +162,7 @@ export async function pullNextStep(params: {
     return undefined;
   }
 
-  return {step: next.step, attempt: next.attempt};
+  return {step: next.step, attempt: next.attempt, leaseToken: next.lease_token};
 }
 
 export interface StepExecution {

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -149,6 +149,32 @@ describe('api-client auth contexts', () => {
     expect(calls[0]?.authorization).toBe('Bearer lease-abc');
   });
 
+  it('requestNextStep parses the step-scoped lease token on step responses', async () => {
+    const step = {
+      id: STEP_ID,
+      job_execution_id: JOB_EXECUTION_ID,
+      key: 'test-step',
+      name: 'Test step',
+      source_location: null,
+      status: 'running',
+      type: 'run',
+      config: {run: 'echo ok'},
+      error: null,
+      position: 1,
+      current_attempt: 2,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+    stubFetch(() =>
+      jsonResponse({kind: 'step', step, attempt: 2, lease_token: 'lease-step-scoped'}),
+    );
+    const leaseClient = createLeaseClient('lease-abc');
+
+    const next = await requestNextStep(leaseClient);
+
+    expect(next).toEqual({kind: 'step', step, attempt: 2, lease_token: 'lease-step-scoped'});
+  });
+
   it('lease clients read rotated lease tokens before each request', async () => {
     stubFetch(() => jsonResponse({kind: 'done', status: 'succeeded'}));
     let leaseToken = 'lease-initial';


### PR DESCRIPTION
Scope log append authorization to the step attempt named by the runner's job lease token.

Log append previously imported workflow state to prove that a step belonged to the leased job execution. This moves that membership fact into the lease capability: next-step re-scopes the lease to the dispatched step attempt, heartbeat preserves that scope, and append validates the signed step and attempt claims directly.

The runner now adopts next-step lease tokens before executing a step and shares that token source with the heartbeat loop. A generation guard prevents stale heartbeat renewals from overwriting a freshly adopted step-scoped lease.

This intentionally requires coordinated runner/API rollout: the next-step response now requires `lease_token`, and job-scoped appends are rejected. That is acceptable while the platform is still pre-deployment; add a compatibility shim before shipping self-hosted or independently upgraded runners.

Includes a patch changeset for the touched API and runner packages.

Closes ENG-760