### PR TITLE
[expression] Remove unused resolved-field fill primitive

### DIFF
--- a/.changeset/clear-fields-prune.md
+++ b/.changeset/clear-fields-prune.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Removes the unused resolved-field fill primitive from the expression package surface.

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -32,7 +32,6 @@ export type {
 export {isBareContextReference} from './plan/bare-reference.js';
 export {evaluatePlannedPredicateAtSite} from './plan/evaluate-planned-predicate.js';
 export {extractExactContextRoots} from './plan/extract-exact-context-roots.js';
-export {fillResolvedFieldAtSite} from './plan/fill.js';
 export {
   type FrozenResolvedField,
   freezeResolvedFieldAtSite,

--- a/libs/shared/expression/src/plan/fill.test.ts
+++ b/libs/shared/expression/src/plan/fill.test.ts
@@ -1,138 +1,27 @@
-import {createWorkflowExpression} from '../expression/create-workflow-expression.js';
-import {fillResolvedFieldAtSite} from './fill.js';
-import type {ResolvedField} from './resolved-field.js';
+import {shouldFillAtSite} from './fill.js';
 
-function expression(source: string) {
-  return createWorkflowExpression({source, check: {mode: 'syntax'}});
-}
+describe('shouldFillAtSite', () => {
+  it('fills server targets at the matching site', () => {
+    const result = shouldFillAtSite('run-creation', 'run-creation');
 
-describe('fillResolvedFieldAtSite', () => {
-  it('leaves a fully literal field unchanged', () => {
-    const field: ResolvedField = {segments: [{kind: 'literal', value: 'deploy main'}]};
-
-    const result = fillResolvedFieldAtSite({field, site: 'run-creation', context: {}});
-
-    expect(result).toEqual(field);
+    expect(result).toBe(true);
   });
 
-  it('fills deferred server segments whose targets are at or before the current site', () => {
-    const field: ResolvedField = {
-      segments: [
-        {kind: 'literal', value: 'run:'},
-        {
-          kind: 'deferred',
-          expression: expression('run.id'),
-          roots: ['run'],
-          fillTarget: 'run-creation',
-        },
-        {kind: 'literal', value: ':step:'},
-        {
-          kind: 'deferred',
-          expression: expression('step.status'),
-          roots: ['step'],
-          fillTarget: 'step-report',
-        },
-        {kind: 'literal', value: ':runner:'},
-        {
-          kind: 'deferred',
-          expression: expression('runner.os'),
-          roots: ['runner'],
-          fillTarget: 'runner-fill',
-        },
-      ],
-    };
+  it('fills earlier server targets at later sites', () => {
+    const result = shouldFillAtSite('run-creation', 'job-activation');
 
-    const result = fillResolvedFieldAtSite({
-      field,
-      site: 'job-activation',
-      context: {run: {id: 'run-123'}, step: {status: 'succeeded'}, runner: {os: 'linux'}},
-    });
-
-    expect(result).toEqual({
-      segments: [
-        {kind: 'literal', value: 'run:'},
-        {kind: 'literal', value: 'run-123'},
-        {kind: 'literal', value: ':step:'},
-        {
-          kind: 'deferred',
-          expression: expression('step.status'),
-          roots: ['step'],
-          fillTarget: 'step-report',
-        },
-        {kind: 'literal', value: ':runner:'},
-        {
-          kind: 'deferred',
-          expression: expression('runner.os'),
-          roots: ['runner'],
-          fillTarget: 'runner-fill',
-        },
-      ],
-    });
+    expect(result).toBe(true);
   });
 
-  it('fills an earlier target when the orchestration reaches a later site first', () => {
-    const field: ResolvedField = {
-      segments: [
-        {
-          kind: 'deferred',
-          expression: expression('run.id'),
-          roots: ['run'],
-          fillTarget: 'run-creation',
-        },
-      ],
-    };
+  it('does not fill later server targets at earlier sites', () => {
+    const result = shouldFillAtSite('step-report', 'job-activation');
 
-    const result = fillResolvedFieldAtSite({
-      field,
-      site: 'job-activation',
-      context: {run: {id: 'run-123'}},
-    });
-
-    expect(result).toEqual({segments: [{kind: 'literal', value: 'run-123'}]});
+    expect(result).toBe(false);
   });
 
-  it('narrows across multiple server sites to a frozen field', () => {
-    const field: ResolvedField = {
-      segments: [
-        {
-          kind: 'deferred',
-          expression: expression('run.id'),
-          roots: ['run'],
-          fillTarget: 'run-creation',
-        },
-        {kind: 'literal', value: ':'},
-        {
-          kind: 'deferred',
-          expression: expression('step.status'),
-          roots: ['step'],
-          fillTarget: 'step-report',
-        },
-      ],
-    };
+  it('does not fill runner targets at server sites', () => {
+    const result = shouldFillAtSite('runner-fill', 'job-resolution');
 
-    const atRunCreation = fillResolvedFieldAtSite({
-      field,
-      site: 'run-creation',
-      context: {run: {id: 'run-123'}},
-    });
-    const atStepReport = fillResolvedFieldAtSite({
-      field: atRunCreation,
-      site: 'step-report',
-      context: {run: {id: 'run-123'}, step: {status: 'succeeded'}},
-    });
-    const repeated = fillResolvedFieldAtSite({
-      field: atStepReport,
-      site: 'step-report',
-      context: {run: {id: 'changed'}, step: {status: 'failed'}},
-    });
-
-    expect(atStepReport).toEqual({
-      segments: [
-        {kind: 'literal', value: 'run-123'},
-        {kind: 'literal', value: ':'},
-        {kind: 'literal', value: 'succeeded'},
-      ],
-    });
-    expect(repeated).toEqual(atStepReport);
+    expect(result).toBe(false);
   });
 });

--- a/libs/shared/expression/src/plan/fill.ts
+++ b/libs/shared/expression/src/plan/fill.ts
@@ -1,30 +1,4 @@
-import {
-  evaluateWorkflowExpression,
-  type WorkflowExpressionEvaluationContext,
-} from '../evaluator/evaluate-workflow-expression.js';
-import {coerceWorkflowValueToString} from '../resolver/coerce-workflow-value-to-string.js';
 import {type AvailabilitySite, availabilitySites} from '../workflow-context/workflow-context.js';
-import type {ResolvedField} from './resolved-field.js';
-
-export function fillResolvedFieldAtSite(params: {
-  readonly field: ResolvedField;
-  readonly site: AvailabilitySite;
-  readonly context: WorkflowExpressionEvaluationContext;
-}): ResolvedField {
-  return {
-    segments: params.field.segments.map((segment) => {
-      if (segment.kind === 'literal') return segment;
-      if (!shouldFillAtSite(segment.fillTarget, params.site)) return segment;
-
-      return {
-        kind: 'literal',
-        value: coerceWorkflowValueToString(
-          evaluateWorkflowExpression(segment.expression, params.context),
-        ),
-      };
-    }),
-  };
-}
 
 export function shouldFillAtSite(fillTarget: string, site: AvailabilitySite): boolean {
   const fillTargetIndex = availabilitySites.indexOf(fillTarget as AvailabilitySite);


### PR DESCRIPTION
Remove the unused `fillResolvedFieldAtSite` primitive from the expression package surface.

The context evaluation engine now routes production fill sites through the richer `resolveFieldAtSite` and `freezeResolvedFieldAtSite` paths, so keeping the old pure narrowing helper exposed makes the engine surface larger than what is actually supported. `shouldFillAtSite` remains live and covered because freeze and predicate evaluation still depend on it.

Includes a patch changeset for `@shipfox/expression`.

Closes ENG-763

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the unused `fillResolvedFieldAtSite` from `@shipfox/expression` to match the engine’s current resolve/freeze flow and trim unsupported API surface. Keep `shouldFillAtSite` and update tests accordingly. Addresses ENG-763.

- **Refactors**
  - Remove `fillResolvedFieldAtSite` export and implementation; use `resolveFieldAtSite` and `freezeResolvedFieldAtSite` instead
  - Rewrite fill tests to focus on `shouldFillAtSite`
  - Add a patch changeset for `@shipfox/expression`

<sup>Written for commit 9fafd2aecd0beafdeeb4b4fd381004f289f57a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

