### PR TITLE
[api-definitions] Validate server-evaluable predicates

### DIFF
--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -8,10 +8,9 @@ Code that turns a checked workflow document into the model used by definitions.
   parsing.
 - **`normalizeWorkflowDocument(document)`**: Expands shorthand fields, assigns
   stable ids, validates explicit providers, and builds graph edges.
-- **Step gates**: Parse run-step `gate.success_if` as CEL against the `step`
-  self-root (`step.exit_code`, `step.status`) from the shared context registry,
-  and check `gate.on_failure.restart_from` against earlier named steps in the
-  same job.
+- **Step gates**: Parse run-step `gate.success_if` as a server-evaluated CEL
+  predicate against context roots available at step reporting, and check
+  `gate.on_failure.restart_from` against earlier named steps in the same job.
 - **`InvalidWorkflowModelError`**: Reports semantic workflow errors found during
   normalization.
 
@@ -81,10 +80,11 @@ The persisted `workflow_document` keeps author-provided runner labels exactly as
 written. Canonical and defaulted labels live on `workflow_model.jobs[].runner`;
 downstream consumers should read the model, not `document.runner`.
 
-Run-step gate expressions are different. They have a small local result context,
-so this module can parse and type-check `success_if` now. The accepted model
-stores a typed `WorkflowExpression` with `language: 'cel'`, the original source
-string, and `check: 'typed'`.
+Run-step gate expressions are different. They are server-evaluated predicates,
+so this module parses them against the shared context registry, rejects
+runner-host roots, and checks that each root is available at step reporting. The
+accepted model stores a `WorkflowExpression` with `language: 'cel'`, the
+original source string, and the strongest check mode the referenced roots allow.
 
 Agent steps keep omitted `provider`, `model`, and `thinking` fields omitted in
 the definition model. Run materialization resolves runner-ready catalog defaults
@@ -92,9 +92,10 @@ before execution. Explicit providers are checked against the shared provider
 catalog; explicit model ids are preserved because the shared seed catalog does
 not yet carry each provider's full model list.
 
-For now, run-step gates can use `step.exit_code` and `step.status`. Fields such
-as `step.output.pass` need a declared output schema, so they belong to later
-agent-step work.
+For now, run-step gates can use typed roots such as `step.exit_code`,
+`step.status`, and other server roots that are available by step reporting.
+Fields such as `step.output.pass` need a declared output schema, so they belong
+to later agent-step work.
 
 `on_failure.restart_from` must name an earlier step in the same job. The runtime
 host does not execute restart semantics yet. This module only records the

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -2,6 +2,7 @@ export const invalidWorkflowModelErrorCode = 'invalid-workflow-model';
 
 export type WorkflowModelValidationIssueCode =
   | 'context-unavailable-at-fill-site'
+  | 'context-unavailable-at-predicate-site'
   | 'duplicate-job-id'
   | 'duplicate-step-id'
   | 'duplicate-trigger-id'
@@ -19,6 +20,7 @@ export type WorkflowModelValidationIssueCode =
   | 'missing-runner-label'
   | 'multiple-manual-triggers'
   | 'runner-context-not-bare'
+  | 'runner-context-in-server-predicate'
   | 'self-job-dependency'
   | 'too-many-runner-labels'
   | 'unknown-interpolation-context'

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-success.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-success.ts
@@ -1,10 +1,5 @@
-import {
-  createWorkflowExpression,
-  getWorkflowContextTypeEnvironment,
-  InvalidWorkflowExpressionError,
-} from '@shipfox/expression';
 import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
-import {issue} from './validation-issue.js';
+import {validatePredicateExpression} from './validate-predicate-expression.js';
 
 export const DEFAULT_JOB_SUCCESS = 'executions.all(e, e.status == "succeeded")';
 
@@ -15,31 +10,14 @@ export function normalizeJobSuccess(params: {
 }): string | undefined {
   if (params.source === undefined) return undefined;
 
-  try {
-    createWorkflowExpression({
-      source: params.source,
-      check: {
-        mode: 'typed',
-        typeEnvironment: getWorkflowContextTypeEnvironment('executions') ?? {},
-        expectedResultType: 'bool',
-      },
-    });
-    return params.source;
-  } catch (error) {
-    params.issues.push(
-      issue({
-        code: 'invalid-job-success',
-        message: 'Job success must be a valid CEL boolean expression.',
-        path: ['jobs', params.sourceName, 'success'],
-        details: {
-          source: params.source,
-          reason:
-            error instanceof InvalidWorkflowExpressionError
-              ? error.reason
-              : 'Expression source did not parse or type-check.',
-        },
-      }),
-    );
-    return undefined;
-  }
+  const expression = validatePredicateExpression({
+    field: 'job.success',
+    source: params.source,
+    site: 'job-resolution',
+    path: ['jobs', params.sourceName, 'success'],
+    invalidCode: 'invalid-job-success',
+    invalidMessage: 'Job success must be a valid CEL boolean expression.',
+    issues: params.issues,
+  });
+  return expression?.source;
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-step-gate.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-step-gate.ts
@@ -1,12 +1,8 @@
-import {
-  createWorkflowExpression,
-  getWorkflowContextTypeEnvironment,
-  InvalidWorkflowExpressionError,
-  type WorkflowExpression,
-} from '@shipfox/expression';
+import type {WorkflowExpression} from '@shipfox/expression';
 import type {WorkflowDocumentStep} from '@shipfox/workflow-document';
 import type {WorkflowModelStepGate} from '../entities/workflow-model.js';
 import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
+import {validatePredicateExpression} from './validate-predicate-expression.js';
 import {issue} from './validation-issue.js';
 
 export function normalizeStepGate(params: {
@@ -61,30 +57,13 @@ function normalizeGateSuccessIf(params: {
 }): WorkflowExpression | undefined {
   if (params.source === undefined) return undefined;
 
-  try {
-    return createWorkflowExpression({
-      source: params.source,
-      check: {
-        mode: 'typed',
-        typeEnvironment: getWorkflowContextTypeEnvironment('step') ?? {},
-        expectedResultType: 'bool',
-      },
-    });
-  } catch (error) {
-    params.issues.push(
-      issue({
-        code: 'invalid-step-gate-success-if',
-        message: 'Step gate success_if must be a valid CEL boolean expression.',
-        path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'gate', 'success_if'],
-        details: {
-          source: params.source,
-          reason:
-            error instanceof InvalidWorkflowExpressionError
-              ? error.reason
-              : 'Expression source did not parse or type-check.',
-        },
-      }),
-    );
-    return undefined;
-  }
+  return validatePredicateExpression({
+    field: 'step.success_if',
+    source: params.source,
+    site: 'step-report',
+    path: ['jobs', params.sourceName, 'steps', params.stepIndex, 'gate', 'success_if'],
+    invalidCode: 'invalid-step-gate-success-if',
+    invalidMessage: 'Step gate success_if must be a valid CEL boolean expression.',
+    issues: params.issues,
+  });
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -769,12 +769,29 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
-  it('rejects a gate success_if referencing a root outside the step self-context', () => {
+  it('accepts server roots available at step reporting in gate success_if', () => {
     const document: WorkflowDocument = {
-      name: 'out-of-scope gate',
+      name: 'server-context gate',
+      jobs: {
+        build: {steps: [{run: 'npm run build', gate: {success_if: 'run.id != ""'}}]},
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[0]?.steps[0]?.gate?.successIf).toEqual({
+      language: 'cel',
+      source: 'run.id != ""',
+      check: 'typed',
+    });
+  });
+
+  it('rejects runner-host roots in gate success_if with a server-predicate issue', () => {
+    const document: WorkflowDocument = {
+      name: 'runner-context gate',
       jobs: {
         build: {
-          steps: [{run: 'npm run build', gate: {success_if: 'run.id == "x"'}}],
+          steps: [{run: 'npm run build', gate: {success_if: 'runner.os == "linux"'}}],
         },
       },
     };
@@ -783,9 +800,42 @@ describe('normalizeWorkflowDocument', () => {
 
     expect(error.issues).toEqual([
       expect.objectContaining({
-        code: 'invalid-step-gate-success-if',
+        code: 'runner-context-in-server-predicate',
+        message: expect.stringContaining('cannot reference runner context "runner"'),
         path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
-        details: expect.objectContaining({source: 'run.id == "x"'}),
+        details: expect.objectContaining({
+          field: 'step.success_if',
+          source: 'runner.os == "linux"',
+          runnerRoots: ['runner'],
+          site: 'step-report',
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects contexts unavailable at the gate predicate site', () => {
+    const document: WorkflowDocument = {
+      name: 'future-context gate',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build', gate: {success_if: 'jobs.deploy.status == "succeeded"'}}],
+        },
+        deploy: {needs: ['build'], steps: [{run: 'npm run deploy'}]},
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'context-unavailable-at-predicate-site',
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
+        details: expect.objectContaining({
+          field: 'step.success_if',
+          source: 'jobs.deploy.status == "succeeded"',
+          unavailableRoots: ['jobs'],
+          site: 'step-report',
+        }),
       }),
     ]);
   });
@@ -876,6 +926,34 @@ describe('normalizeWorkflowDocument', () => {
         details: expect.objectContaining({
           source: 'executions.all(e, e.statsu == "succeeded")',
           reason: expect.stringContaining('statsu'),
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects runner-host roots in job success with a server-predicate issue', () => {
+    const document: WorkflowDocument = {
+      name: 'runner-context job success',
+      jobs: {
+        build: {
+          success: 'runner.os == "linux"',
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'runner-context-in-server-predicate',
+        message: expect.stringContaining('cannot reference runner context "runner"'),
+        path: ['jobs', 'build', 'success'],
+        details: expect.objectContaining({
+          field: 'job.success',
+          source: 'runner.os == "linux"',
+          runnerRoots: ['runner'],
+          site: 'job-resolution',
         }),
       }),
     ]);

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -906,6 +906,31 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
+  it('reports rootless non-boolean job success expressions', () => {
+    const document: WorkflowDocument = {
+      name: 'rootless non-boolean job success',
+      jobs: {
+        build: {
+          success: '1 + 2',
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid-job-success',
+        path: ['jobs', 'build', 'success'],
+        details: expect.objectContaining({
+          source: '1 + 2',
+          reason: expect.stringContaining('must return bool'),
+        }),
+      }),
+    ]);
+  });
+
   it('reports misspelled execution fields in job success expressions', () => {
     const document: WorkflowDocument = {
       name: 'misspelled job success',

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -65,7 +65,7 @@ export function validatePredicateExpression(params: {
     return undefined;
   }
 
-  if (knownRoots.length === 0 || knownRoots.some((root) => hasSyntaxOnlyCheckMode(root))) {
+  if (knownRoots.some((root) => hasSyntaxOnlyCheckMode(root))) {
     return syntaxExpression;
   }
 

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -1,0 +1,260 @@
+import {
+  type AvailabilitySite,
+  availabilitySites,
+  createWorkflowExpression,
+  type ExpressionTypeEnvironment,
+  extractExactContextRoots,
+  getWorkflowContextDefinition,
+  getWorkflowContextTypeEnvironment,
+  InvalidWorkflowExpressionError,
+  resolveContextRootAvailability,
+  resolveContextRootHost,
+  validateServerEvaluable,
+  type WorkflowContextName,
+  type WorkflowExpression,
+  type WorkflowPredicateField,
+  workflowContextNames,
+} from '@shipfox/expression';
+import type {
+  WorkflowModelValidationIssue,
+  WorkflowModelValidationIssueCode,
+  WorkflowModelValidationIssuePathSegment,
+} from './invalid-workflow-model-error.js';
+import {issue} from './validation-issue.js';
+
+export function validatePredicateExpression(params: {
+  field: WorkflowPredicateField;
+  source: string;
+  site: AvailabilitySite;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  invalidCode: WorkflowModelValidationIssueCode;
+  invalidMessage: string;
+  issues: WorkflowModelValidationIssue[];
+}): WorkflowExpression | undefined {
+  const syntaxExpression = createSyntaxExpression(params);
+  if (syntaxExpression === undefined) return undefined;
+
+  const contextRoots = extractExactContextRoots(syntaxExpression.source);
+  const knownRoots = contextRoots.filter((root) => resolveContextRootHost(root) !== undefined);
+  const unknownRoots = contextRoots.filter((root) => resolveContextRootHost(root) === undefined);
+
+  if (unknownRoots.length > 0) {
+    params.issues.push(invalidPredicateIssue({...params, contextRoots}));
+    return undefined;
+  }
+
+  const serverEvaluability = validateServerEvaluable(syntaxExpression);
+  if (!serverEvaluability.ok) {
+    params.issues.push(
+      ...serverEvaluability.violations.map((violation) =>
+        runnerContextInServerPredicateIssue({
+          ...params,
+          contextRoots,
+          runnerRoots: violation.runnerRoots,
+        }),
+      ),
+    );
+    return undefined;
+  }
+
+  const unavailableRoots = knownRoots.filter((root) => !isRootAvailableAt(root, params.site));
+  if (unavailableRoots.length > 0) {
+    params.issues.push(
+      unavailablePredicateContextIssue({...params, contextRoots, unavailableRoots}),
+    );
+    return undefined;
+  }
+
+  if (knownRoots.length === 0 || knownRoots.some((root) => hasSyntaxOnlyCheckMode(root))) {
+    return syntaxExpression;
+  }
+
+  try {
+    return createWorkflowExpression({
+      source: params.source,
+      check: {
+        mode: 'typed',
+        typeEnvironment: mergeTypeEnvironments(knownRoots),
+        expectedResultType: 'bool',
+      },
+    });
+  } catch (error) {
+    params.issues.push(
+      invalidPredicateIssue({
+        ...params,
+        contextRoots,
+        reason:
+          error instanceof InvalidWorkflowExpressionError
+            ? error.reason
+            : 'Expression source did not parse or type-check.',
+      }),
+    );
+    return undefined;
+  }
+}
+
+function createSyntaxExpression(params: {
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  invalidCode: WorkflowModelValidationIssueCode;
+  invalidMessage: string;
+  issues: WorkflowModelValidationIssue[];
+}): WorkflowExpression | undefined {
+  try {
+    return createWorkflowExpression({
+      source: params.source,
+      check: {mode: 'syntax'},
+    });
+  } catch (error) {
+    params.issues.push(
+      invalidPredicateIssue({
+        ...params,
+        contextRoots: [],
+        reason:
+          error instanceof InvalidWorkflowExpressionError
+            ? error.reason
+            : 'Expression source did not parse or type-check.',
+      }),
+    );
+    return undefined;
+  }
+}
+
+function invalidPredicateIssue(params: {
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  invalidCode: WorkflowModelValidationIssueCode;
+  invalidMessage: string;
+  contextRoots: readonly string[];
+  reason?: string;
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: params.invalidCode,
+    message: params.invalidMessage,
+    path: params.path,
+    details: {
+      source: params.source,
+      contextRoots: params.contextRoots,
+      reason: params.reason ?? 'Expression source did not parse or type-check.',
+    },
+  });
+}
+
+const availabilitySiteLabels = {
+  ingest: 'ingest',
+  'run-creation': 'run creation',
+  'execution-creation': 'execution creation',
+  'job-activation': 'job activation',
+  'step-dispatch': 'step dispatch',
+  'step-report': 'step reporting',
+  'execution-resolution': 'execution resolution',
+  'job-resolution': 'job resolution',
+} as const satisfies Record<AvailabilitySite, string>;
+
+function runnerContextInServerPredicateIssue(params: {
+  field: WorkflowPredicateField;
+  source: string;
+  site: AvailabilitySite;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+  runnerRoots: readonly string[];
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'runner-context-in-server-predicate',
+    message: `${fieldLabel(params.field)} cannot reference runner context ${formatList(
+      params.runnerRoots,
+    )} because it is evaluated on the server at ${describeAvailabilitySite(params.site)}.`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      contextRoots: params.contextRoots,
+      runnerRoots: params.runnerRoots,
+      site: params.site,
+    },
+  });
+}
+
+function unavailablePredicateContextIssue(params: {
+  field: WorkflowPredicateField;
+  source: string;
+  site: AvailabilitySite;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+  unavailableRoots: readonly string[];
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'context-unavailable-at-predicate-site',
+    message: `${fieldLabel(params.field)} references ${contextNoun(
+      params.unavailableRoots,
+    )} ${formatList(params.unavailableRoots)} that ${availabilityVerb(
+      params.unavailableRoots,
+    )} not available at ${describeAvailabilitySite(params.site)}. ${params.unavailableRoots
+      .map(unavailableRootAvailabilityMessage)
+      .join(' ')}`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      contextRoots: params.contextRoots,
+      unavailableRoots: params.unavailableRoots,
+      site: params.site,
+    },
+  });
+}
+
+function isRootAvailableAt(root: string, site: AvailabilitySite): boolean {
+  const availability = resolveContextRootAvailability(root);
+  if (availability === undefined) return false;
+
+  return availabilitySites.indexOf(availability) <= availabilitySites.indexOf(site);
+}
+
+function unavailableRootAvailabilityMessage(root: string): string {
+  const availability = resolveContextRootAvailability(root);
+  if (availability === undefined) return `"${root}" is not available at any server site.`;
+  return `"${root}" becomes available at ${describeAvailabilitySite(availability)}.`;
+}
+
+function hasSyntaxOnlyCheckMode(root: string): boolean {
+  return isWorkflowContextName(root) && getWorkflowContextDefinition(root).checkMode === 'syntax';
+}
+
+function mergeTypeEnvironments(roots: readonly string[]): ExpressionTypeEnvironment {
+  const typeEnvironment: Record<string, ExpressionTypeEnvironment[string]> = {};
+
+  for (const root of roots) {
+    if (!isWorkflowContextName(root)) continue;
+
+    const contextTypeEnvironment = getWorkflowContextTypeEnvironment(root);
+    if (contextTypeEnvironment === undefined) continue;
+
+    Object.assign(typeEnvironment, contextTypeEnvironment);
+  }
+
+  return typeEnvironment;
+}
+
+function isWorkflowContextName(root: string): root is WorkflowContextName {
+  return (workflowContextNames as readonly string[]).includes(root);
+}
+
+function fieldLabel(field: WorkflowPredicateField): string {
+  return field === 'step.success_if' ? 'Step gate success_if' : 'Job success';
+}
+
+function contextNoun(roots: readonly string[]): 'context' | 'contexts' {
+  return roots.length === 1 ? 'context' : 'contexts';
+}
+
+function availabilityVerb(roots: readonly string[]): 'is' | 'are' {
+  return roots.length === 1 ? 'is' : 'are';
+}
+
+function describeAvailabilitySite(site: AvailabilitySite): string {
+  return availabilitySiteLabels[site];
+}
+
+function formatList(values: readonly string[]): string {
+  return values.map((value) => `"${value}"`).join(', ');
+}


### PR DESCRIPTION
Wire workflow predicate authoring validation through the shared context registry for gate `success_if` and job `success` expressions.

Server-evaluated predicates previously relied on narrow type environments to reject out-of-scope roots, which made runner-host roots fail only incidentally with generic type-check errors. This adds an explicit predicate validation path that rejects runner-host roots with a dedicated issue code and checks root availability at the predicate's server site before preserving existing CEL syntax/type validation.

The touched package is private, so no changeset is included.

Closes ENG-764

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side validation for `step.gate.success_if` and `job.success` predicates to reject runner-host roots, block contexts unavailable at evaluation time, and require rootless predicates to return boolean. Implements ENG-764.

- New Features
  - Introduced `validatePredicateExpression` to parse CEL, enforce server-evaluability, verify root availability by site, type-check when possible, and require boolean for rootless expressions.
  - Wired into `normalizeStepGate` and `normalizeJobSuccess`, added issue codes `runner-context-in-server-predicate` and `context-unavailable-at-predicate-site`, and updated README and tests.

<sup>Written for commit 8b778fffa64424284939a8adc56d2ecb87412023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

