### PR TITLE
[api-workflows] Avoid duplicated run detail attempt hydration

### DIFF
--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -40,6 +40,7 @@ import {
   getWorkflowJobExecutionDepth,
   getWorkflowRunAttemptById,
   getWorkflowRunById,
+  getWorkflowRunDetail,
   listRunAttempts,
   listWorkflowRunsByProject,
   resolveJobStatusFromJobExecutions,
@@ -279,6 +280,35 @@ describe('workflow run queries', () => {
       const [attemptSummary] = await listRunAttempts({workflowRunId: run.id, projectId});
       const attempt = await getWorkflowRunAttemptById(attemptSummary?.id as string);
       expect(attempt?.model).toEqual(model);
+    });
+
+    test('returns the persisted model in run detail', async () => {
+      const model = buildModel({
+        env: {RUN_ID: template('run.id')},
+        jobs: {
+          build: {
+            steps: [{run: 'echo first'}, {run: 'echo second'}],
+          },
+        },
+      });
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const detail = await getWorkflowRunDetail(run.id);
+
+      expect(detail?.runAttempt.model).toEqual(model);
+      expect(detail?.jobs).toHaveLength(1);
+      expect(detail?.jobs[0]?.jobExecutions[0]?.steps).toHaveLength(3);
     });
 
     test('persists listening job config without initial execution or steps', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -904,7 +904,7 @@ export async function getWorkflowRunDetail(
   const rows = await db()
     .select({
       run: workflowRuns,
-      attempt: workflowRunAttempts,
+      attemptId: workflowRunAttempts.id,
       job: jobs,
       jobExecution: jobExecutions,
       step: steps,
@@ -928,7 +928,7 @@ export async function getWorkflowRunDetail(
       asc(stepAttempts.id),
     );
 
-  return hydrateWorkflowRunDetail(rows, latestAttempt);
+  return hydrateWorkflowRunDetail(rows, target.attempt, latestAttempt);
 }
 
 export async function getJobExecutionDetail(
@@ -974,12 +974,13 @@ export async function getJobExecutionDetail(
 function hydrateWorkflowRunDetail(
   rows: {
     run: typeof workflowRuns.$inferSelect;
-    attempt: typeof workflowRunAttempts.$inferSelect;
+    attemptId: string;
     job: typeof jobs.$inferSelect | null;
     jobExecution: typeof jobExecutions.$inferSelect | null;
     step: typeof steps.$inferSelect | null;
     stepAttempt: typeof stepAttempts.$inferSelect | null;
   }[],
+  attempt: typeof workflowRunAttempts.$inferSelect,
   latestAttempt: number,
 ): WorkflowRunDetail | undefined {
   const first = rows[0];
@@ -987,7 +988,7 @@ function hydrateWorkflowRunDetail(
 
   const detail: WorkflowRunDetail = {
     ...toWorkflowRun(first.run),
-    runAttempt: toWorkflowRunAttempt(first.attempt),
+    runAttempt: toWorkflowRunAttempt(attempt),
     latestAttempt,
     jobs: [],
   };


### PR DESCRIPTION
Avoid duplicated workflow run attempt hydration in run detail reads.

`getWorkflowRunDetail` already fetches the target run attempt before assembling jobs, executions, steps, and step attempts. The fan-out query was selecting the full attempt row again, which now includes the persisted workflow model and can duplicate that JSON once per step-attempt row. This keeps the response shape unchanged while selecting only the attempt id through the join and reusing the target attempt for hydration.

Reviewers should focus on the read-model assembly path and the regression coverage that confirms run detail still exposes the persisted attempt model.

Closes ENG-725

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid duplicated attempt hydration in workflow run detail. Reuses the pre-fetched run attempt so the persisted model isn’t duplicated per step attempt, while keeping the response shape unchanged.

- Bug Fixes
  - Select only the attempt id in the step fan-out join and hydrate from the already-fetched attempt (ENG-725).
  - Preserve response shape; run detail still returns the persisted attempt model, with a regression test covering it.

<sup>Written for commit 4d74658ddfa687bee82867ff369ff864d1ff4f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

