### PR TITLE
[api/workflows] Refold migration baseline and tune indexes

### DIFF
--- a/.changeset/workflows-depth-gauge-indexes.md
+++ b/.changeset/workflows-depth-gauge-indexes.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Refold the workflows migration baseline and tune its indexes. Drops the redundant `step_attempts(job_execution_id)` index, which was fully covered by the `(job_execution_id, execution_order)` unique index. Adds partial `WHERE status = 'running'` indexes on `workflow_runs` and `job_executions` so the running-depth service gauge counts only active rows instead of sequentially scanning the full history on every scrape. No behavior or API change.

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -176,12 +176,12 @@ ALTER TABLE "workflows_step_attempts" ADD CONSTRAINT "workflows_step_attempts_st
 ALTER TABLE "workflows_steps" ADD CONSTRAINT "workflows_steps_job_execution_id_workflows_job_executions_id_fk" FOREIGN KEY ("job_execution_id") REFERENCES "public"."workflows_job_executions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "workflows_workflow_run_attempts" ADD CONSTRAINT "workflows_workflow_run_attempts_workflow_run_id_workflows_workflow_runs_id_fk" FOREIGN KEY ("workflow_run_id") REFERENCES "public"."workflows_workflow_runs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "workflows_job_executions_job_id_idx" ON "workflows_job_executions" USING btree ("job_id");--> statement-breakpoint
+CREATE INDEX "workflows_job_executions_running_idx" ON "workflows_job_executions" USING btree ("status") WHERE "workflows_job_executions"."status" = 'running';--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_job_listener_events_job_event_ref_unique" ON "workflows_job_listener_events" USING btree ("job_id","event_ref");--> statement-breakpoint
 CREATE INDEX "workflows_job_listener_events_job_received_idx" ON "workflows_job_listener_events" USING btree ("job_id","received_at");--> statement-breakpoint
 CREATE INDEX "workflows_jobs_workflow_run_attempt_id_idx" ON "workflows_jobs" USING btree ("workflow_run_attempt_id");--> statement-breakpoint
 CREATE INDEX "workflows_outbox_pending_idx" ON "workflows_outbox" USING btree ("next_dispatch_at","created_at") WHERE "dispatched_at" IS NULL AND "dead_lettered_at" IS NULL;--> statement-breakpoint
 CREATE INDEX "workflows_outbox_dispatched_retention_idx" ON "workflows_outbox" USING btree ("dispatched_at","id") WHERE "dispatched_at" IS NOT NULL;--> statement-breakpoint
-CREATE INDEX "workflows_step_attempts_job_execution_id_idx" ON "workflows_step_attempts" USING btree ("job_execution_id");--> statement-breakpoint
 CREATE INDEX "workflows_steps_job_execution_id_idx" ON "workflows_steps" USING btree ("job_execution_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wra_workflow_run_attempt_unique" ON "workflows_workflow_run_attempts" USING btree ("workflow_run_id","attempt");--> statement-breakpoint
 CREATE UNIQUE INDEX "workflows_wra_one_active_attempt_unique" ON "workflows_workflow_run_attempts" USING btree ("workflow_run_id") WHERE "workflows_workflow_run_attempts"."status" in ('pending', 'running');--> statement-breakpoint
@@ -189,4 +189,5 @@ CREATE UNIQUE INDEX "workflows_wr_trigger_idempotency_key_unique" ON "workflows_
 CREATE INDEX "workflows_wr_project_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","created_at","id");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_status_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","status","created_at","id");--> statement-breakpoint
 CREATE INDEX "workflows_wr_project_definition_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","definition_id","created_at","id");--> statement-breakpoint
-CREATE INDEX "workflows_wr_project_trigger_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","trigger_source","created_at","id");
+CREATE INDEX "workflows_wr_project_trigger_created_id_idx" ON "workflows_workflow_runs" USING btree ("project_id","trigger_source","created_at","id");--> statement-breakpoint
+CREATE INDEX "workflows_wr_running_idx" ON "workflows_workflow_runs" USING btree ("status") WHERE "workflows_workflow_runs"."status" = 'running';

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "3026afb5-6878-4a36-9288-ecff5f15b2ae",
+  "id": "d499edbd-b3b6-4d33-9934-22471a9a2e6a",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -113,6 +113,22 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_job_executions_running_idx": {
+          "name": "workflows_job_executions_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_job_executions\".\"status\" = 'running'",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -709,23 +725,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "workflows_step_attempts_job_execution_id_idx": {
-          "name": "workflows_step_attempts_job_execution_id_idx",
-          "columns": [
-            {
-              "expression": "job_execution_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "workflows_step_attempts_step_id_workflows_steps_id_fk": {
           "name": "workflows_step_attempts_step_id_workflows_steps_id_fk",
@@ -1363,6 +1363,22 @@
             }
           ],
           "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_wr_running_idx": {
+          "name": "workflows_wr_running_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"workflows_workflow_runs\".\"status\" = 'running'",
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/libs/api/workflows/drizzle/meta/_journal.json
+++ b/libs/api/workflows/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1782927309755,
+      "when": 1783159827882,
       "tag": "0000_initial",
       "breakpoints": true
     }

--- a/libs/api/workflows/src/db/schema/job-executions.ts
+++ b/libs/api/workflows/src/db/schema/job-executions.ts
@@ -1,4 +1,5 @@
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
+import {sql} from 'drizzle-orm';
 import {index, integer, jsonb, pgEnum, text, timestamp, uuid} from 'drizzle-orm/pg-core';
 import {toJobStatusReason} from '#core/entities/job.js';
 import type {JobExecution, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
@@ -33,7 +34,15 @@ export const jobExecutions = pgTable(
     finishedAt: timestamp('finished_at', {withTimezone: true}),
     timedOutAt: timestamp('timed_out_at', {withTimezone: true}),
   },
-  (table) => [index('workflows_job_executions_job_id_idx').on(table.jobId)],
+  (table) => [
+    index('workflows_job_executions_job_id_idx').on(table.jobId),
+    // Partial index backing the running-executions depth gauge, which counts on
+    // every Prometheus scrape. Indexes only active rows so the count stays cheap
+    // as the historical table grows.
+    index('workflows_job_executions_running_idx')
+      .on(table.status)
+      .where(sql`${table.status} = 'running'`),
+  ],
 );
 
 export type JobExecutionDb = typeof jobExecutions.$inferSelect;

--- a/libs/api/workflows/src/db/schema/step-attempts.ts
+++ b/libs/api/workflows/src/db/schema/step-attempts.ts
@@ -3,7 +3,6 @@ import {sql} from 'drizzle-orm';
 import {
   check,
   foreignKey,
-  index,
   integer,
   jsonb,
   text,
@@ -48,7 +47,6 @@ export const stepAttempts = pgTable(
       table.jobExecutionId,
       table.executionOrder,
     ),
-    index('workflows_step_attempts_job_execution_id_idx').on(table.jobExecutionId),
     foreignKey({
       name: 'workflows_step_attempts_step_id_job_execution_id_workflows_steps_fk',
       columns: [table.stepId, table.jobExecutionId],

--- a/libs/api/workflows/src/db/schema/workflow-runs.ts
+++ b/libs/api/workflows/src/db/schema/workflow-runs.ts
@@ -72,6 +72,10 @@ export const workflowRuns = pgTable(
       table.createdAt,
       table.id,
     ),
+    // Partial index backing the running-runs depth gauge, which counts on every
+    // Prometheus scrape. Indexes only active rows so the count stays cheap as the
+    // historical table grows.
+    index('workflows_wr_running_idx').on(table.status).where(sql`${table.status} = 'running'`),
     check('workflows_wr_current_attempt_positive_ck', sql`${table.currentAttempt} > 0`),
   ],
 );


### PR DESCRIPTION
Consolidates the workflows schema back into the single folded `0000_initial` baseline and audits every index against the query layer. We have landed many workflows DB changes recently, so this is a pre-release cleanup pass.

**Index changes**

- **Drop** the redundant `workflows_step_attempts_job_execution_id_idx`. The unique `(job_execution_id, execution_order)` index already covers every query that filters step attempts by `job_execution_id` (the ordered read and the `max(execution_order)` on insert), and it is not needed for FK-cascade maintenance either.
- **Add** partial indexes `workflows_wr_running_idx` and `workflows_job_executions_running_idx`, each on `(status) WHERE status = 'running'`. These back the running-depth service gauge (`metrics/service.ts`), which runs two `count(*) WHERE status='running'` queries on every Prometheus scrape. Without them the cost grows with the full historical table; the partials index only the handful of active rows, turning the scrape into an index-only count.

The rest of the index set was checked and left as is: the four `project_id`-prefixed `workflow_runs` indexes each back a real list filter and matching aggregate, the FK-lookup indexes are all justified, and the listening-event `(job_id, received_at)` index is kept for the in-flight drain path.

**Migration re-fold**

The baseline is regenerated as a single migration. Note that `drizzle-kit generate` on this schema reorders the FK-target unique index (`workflows_steps_id_job_execution_id_uq`) to after the composite `step_attempts` FK that references it, which fails on a fresh apply (`there is no unique constraint matching given keys`). The generated SQL restores the correct ordering (index before FK), matching the prior baseline.

Verified end to end: the migration applies cleanly on a fresh database, the full `@shipfox/api-workflows` suite passes (427 tests, via the real app migrator during setup), and `check` / `type` / `type:emit` are green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refolds the workflows migration baseline into a single `0000_initial` and tunes indexes to make running-depth metrics fast and remove redundancy. This turns Prometheus scrape counts into index-only reads and keeps fresh installs smooth.

- **Refactors**
  - Added partial indexes on `workflow_runs(status)` and `job_executions(status)` where `status = 'running'` for cheap counts.
  - Dropped redundant `workflows_step_attempts(job_execution_id)` index; covered by the unique `(job_execution_id, execution_order)`.
  - Regenerated folded baseline and restored FK/index order so fresh apply works with `drizzle-kit`.

<sup>Written for commit 36fd263f8ffe84e7c026e5fcf21976db2b4fa9f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

