### PR TITLE
[e2e-platform-workflows] Add step gate scenarios

### DIFF
--- a/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
@@ -15,6 +15,8 @@ test('manages workspace manual registration tokens from settings', async ({
   projects,
   workspaces,
 }) => {
+  test.setTimeout(60_000);
+
   await page.clock.setFixedTime(VISUAL_TEST_NOW);
 
   const user = await auth.createUser();
@@ -72,7 +74,18 @@ test('manages workspace manual registration tokens from settings', async ({
     .getByRole('button', {name: 'Open E2E runner token actions'})
     .click();
   await page.getByRole('menuitem', {name: 'Revoke token'}).click();
-  await page.getByRole('button', {name: 'Revoke', exact: true}).last().click();
+  const revokeDialog = page.getByRole('dialog', {name: 'Revoke token'});
+  await expect(revokeDialog).toBeVisible();
+  await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        response.url().includes('/runners/manual-registration-tokens/') &&
+        response.url().endsWith('/revoke') &&
+        response.status() === 200,
+    ),
+    revokeDialog.getByRole('button', {name: 'Revoke', exact: true}).click(),
+  ]);
+  await expect(revokeDialog).toBeHidden();
 
   await expect(manualRegistrationTokenRow).toHaveCount(0);
   await expect(page.getByText('No usable manual registration tokens')).toBeVisible();

--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -127,6 +127,8 @@ test('accepts an invitation from the public landing page via login', async ({
   projects,
   workspaces,
 }) => {
+  test.setTimeout(60_000);
+
   const owner = await auth.createUser({name: 'Owner User'});
   const invitee = await auth.createUser({name: 'Invitee User'});
   const workspace = await workspaces.create({

--- a/e2e/platform/workflows/scenarios/gate-on-failure-restart/expect.yaml
+++ b/e2e/platform/workflows/scenarios/gate-on-failure-restart/expect.yaml
@@ -1,0 +1,17 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      prepare:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["prepare rerun after restart"]
+      review:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["review passes after restart"]

--- a/e2e/platform/workflows/scenarios/gate-on-failure-restart/workflow.yml
+++ b/e2e/platform/workflows/scenarios/gate-on-failure-restart/workflow.yml
@@ -1,0 +1,32 @@
+name: Gate on failure restart
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: prepare
+        run: |
+          if [ -f .review-failed-once ]; then
+            echo "prepare rerun after restart"
+          else
+            echo "prepare first pass"
+          fi
+      - key: review
+        run: |
+          if [ -f .review-failed-once ]; then
+            echo "review passes after restart"
+            exit 0
+          fi
+
+          echo "review fails once"
+          touch .review-failed-once
+          exit 1
+        gate:
+          success_if: step.exit_code == 0
+          on_failure:
+            restart_from: prepare
+            output: retrying from prepare

--- a/e2e/platform/workflows/scenarios/gate-success-if/expect.yaml
+++ b/e2e/platform/workflows/scenarios/gate-success-if/expect.yaml
@@ -1,0 +1,12 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      nonzero-ok:
+        status: succeeded
+        exit_code: 1
+        logs:
+          include: ["gate accepts exit 1"]

--- a/e2e/platform/workflows/scenarios/gate-success-if/workflow.yml
+++ b/e2e/platform/workflows/scenarios/gate-success-if/workflow.yml
@@ -1,0 +1,16 @@
+name: Gate success if
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: nonzero-ok
+        run: |
+          echo "gate accepts exit 1"
+          exit 1
+        gate:
+          success_if: step.exit_code == 1


### PR DESCRIPTION
Add platform workflow E2E coverage for step gate behavior.

The gate evaluation and restart paths were already covered at lower levels, but not through the full runner-report to server-gate to terminal-outcome loop. This adds one scenario proving a nonzero step exit can still succeed when `success_if` passes, and one scenario proving `on_failure.restart_from` durably rewinds to an earlier keyed step before the run succeeds.

Closes ENG-769

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end workflow tests for step gates, covering non‑zero exit success via success_if and durable restart via on_failure.restart_from. Stabilizes E2E UI flows by increasing timeouts to 60s (login invitation, runner token revoke) and waiting for the revoke request before assertions to reduce CI flakiness; satisfies ENG-769.

<sup>Written for commit 947499f86ea947e4e34d595f65d5f0c6a1665788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

