### PR TITLE
Add expect.yaml runtime error assertions

### DIFF
--- a/e2e/platform/workflows/README.md
+++ b/e2e/platform/workflows/README.md
@@ -13,7 +13,7 @@ A scenario is a directory under `scenarios/`:
 ```
 scenarios/hello-world/
   workflow.yml    pushed verbatim to .shipfox/workflows/hello-world.yml
-  expect.yaml     declarative expectations (run/job/step status, exit code, logs)
+  expect.yaml     declarative expectations (run/job/step status, job status reason, step error, exit code, logs)
   files/          optional extra repo files, committed alongside the workflow
 ```
 
@@ -47,10 +47,15 @@ run:
 jobs:                    # optional, keyed by job key
   build:
     status: succeeded
+    status_reason: step_failed   # optional: why the job ended (step_failed, condition_false, ...)
     steps:               # optional, keyed by step key or name
       greet:
         status: succeeded
         exit_code: 0     # optional
+        error:           # optional: assert the step failed for a specific reason
+          reason: config_unresolvable  # step error reason enum
+          field: env.VERSION           # exact match on the failing field
+          source: steps.build.outputs  # substring match on the unresolved source
         logs:
           include: ["hello world"]   # substring, or /regex/
           exclude: ["SECRET_VALUE"]

--- a/e2e/platform/workflows/src/expect.test.ts
+++ b/e2e/platform/workflows/src/expect.test.ts
@@ -232,6 +232,180 @@ describe('evaluateExpectations', () => {
     ]);
   });
 
+  test('matches job status reasons and step error details', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          status: 'failed',
+          status_reason: 'step_failed',
+          job_executions: [
+            makeJobExecution({
+              status: 'failed',
+              status_reason: 'step_failed',
+              steps: [
+                makeStep({
+                  status: 'failed',
+                  error: {
+                    message: 'Could not resolve env.VERSION from steps.build.outputs.version',
+                    reason: 'config_unresolvable',
+                    field: 'env.VERSION',
+                    source: 'steps.build.outputs.version',
+                    category: 'user',
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {
+          build: {
+            status_reason: 'step_failed',
+            steps: {
+              greet: {
+                error: {
+                  reason: 'config_unresolvable',
+                  field: 'env.VERSION',
+                  source: 'build.outputs',
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.mismatches).toEqual([]);
+  });
+
+  test('reports absent job status reasons and step errors', () => {
+    const result = evaluateExpectations(
+      makeDetail(),
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {
+          build: {
+            status_reason: 'step_failed',
+            steps: {greet: {error: {reason: 'config_unresolvable'}}},
+          },
+        },
+      }),
+    );
+
+    expect(result.mismatches).toEqual([
+      {path: 'jobs.build.status_reason', expected: 'step_failed', actual: 'null'},
+      {path: 'jobs.build.steps.greet.error', expected: 'present', actual: 'null'},
+    ]);
+  });
+
+  test('reports job status reason and step error detail mismatches', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          status_reason: 'condition_false',
+          job_executions: [
+            makeJobExecution({
+              status_reason: 'condition_false',
+              steps: [
+                makeStep({
+                  error: {
+                    message: 'Agent config could not be resolved',
+                    reason: 'agent_config_invalid',
+                    category: 'user',
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {
+          build: {
+            status_reason: 'step_failed',
+            steps: {
+              greet: {
+                error: {
+                  reason: 'config_unresolvable',
+                  field: 'env.VERSION',
+                  source: 'steps.build.outputs.version',
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.mismatches).toEqual([
+      {path: 'jobs.build.status_reason', expected: 'step_failed', actual: 'condition_false'},
+      {
+        path: 'jobs.build.steps.greet.error.reason',
+        expected: 'config_unresolvable',
+        actual: 'agent_config_invalid',
+      },
+      {path: 'jobs.build.steps.greet.error.field', expected: 'env.VERSION', actual: 'null'},
+      {
+        path: 'jobs.build.steps.greet.error.source',
+        expected: 'include steps.build.outputs.version',
+        actual: 'null',
+      },
+    ]);
+  });
+
+  test('reports a step error source mismatch when the source is present', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          job_executions: [
+            makeJobExecution({
+              steps: [
+                makeStep({
+                  error: {
+                    message: 'Could not resolve env.VERSION from steps.build.outputs.version',
+                    reason: 'config_unresolvable',
+                    field: 'env.VERSION',
+                    source: 'steps.build.outputs.version',
+                    category: 'user',
+                  },
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {
+          build: {steps: {greet: {error: {source: 'steps.package.outputs.version'}}}},
+        },
+      }),
+    );
+
+    expect(result.mismatches).toEqual([
+      {
+        path: 'jobs.build.steps.greet.error.source',
+        expected: 'include steps.package.outputs.version',
+        actual: 'steps.build.outputs.version',
+      },
+    ]);
+  });
+
   test('reports a missing job and a missing step', () => {
     const missingJob = evaluateExpectations(
       makeDetail(),
@@ -406,5 +580,14 @@ describe('parseExpectation', () => {
 
   test('rejects unknown keys', () => {
     expect(() => parseExpectation({run: {status: 'succeeded'}, unexpected: true})).toThrow();
+  });
+
+  test('rejects unknown nested step error keys', () => {
+    expect(() =>
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {error: {code: 'config_unresolvable'}}}}},
+      }),
+    ).toThrow();
   });
 });

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -1,5 +1,8 @@
 import type {LogRecord} from '@shipfox/api-logs-dto';
 import type {
+  JobStatusReasonDto,
+  StepErrorDto,
+  StepErrorReasonDto,
   WorkflowRunDetailResponseDto,
   WorkflowRunJobDetailDto,
   WorkflowRunStepDetailDto,
@@ -20,6 +23,16 @@ const jobStatusSchema = z.enum([
   'cancelled',
   'skipped',
 ]);
+const jobStatusReasonSchema = z.enum([
+  'dependency_not_completed',
+  'condition_false',
+  'user_cancelled',
+  'run_cancelled',
+  'timed_out',
+  'runner_lost',
+  'step_failed',
+  'unknown',
+]);
 const stepStatusSchema = z.enum([
   'pending',
   'running',
@@ -28,6 +41,31 @@ const stepStatusSchema = z.enum([
   'skipped',
   'cancelled',
 ]);
+const stepErrorReasonSchema = z.enum([
+  'checkout_failed',
+  'checkout_auth_failed',
+  'checkout_unavailable',
+  'git_unavailable',
+  'workspace_prep_failed',
+  'setup_aborted',
+  'config_unresolvable',
+  'agent_config_invalid',
+  'agent_invocation_failed',
+]);
+
+type AssertExact<Actual, Expected> = [Actual] extends [Expected]
+  ? [Expected] extends [Actual]
+    ? true
+    : never
+  : never;
+export type _ExpectJobStatusReasonSchemaMatchesDto = AssertExact<
+  z.infer<typeof jobStatusReasonSchema>,
+  JobStatusReasonDto
+>;
+export type _ExpectStepErrorReasonSchemaMatchesDto = AssertExact<
+  z.infer<typeof stepErrorReasonSchema>,
+  StepErrorReasonDto
+>;
 
 const logsExpectationSchema = z
   .object({
@@ -42,10 +80,19 @@ const pushExpectationSchema = z
   })
   .strict();
 
+const stepErrorExpectationSchema = z
+  .object({
+    reason: stepErrorReasonSchema.optional(),
+    field: z.string().optional(),
+    source: z.string().optional(),
+  })
+  .strict();
+
 const stepExpectationSchema = z
   .object({
     status: stepStatusSchema.optional(),
     exit_code: z.number().int().optional(),
+    error: stepErrorExpectationSchema.optional(),
     logs: logsExpectationSchema.optional(),
   })
   .strict();
@@ -53,6 +100,7 @@ const stepExpectationSchema = z
 const jobExpectationSchema = z
   .object({
     status: jobStatusSchema.optional(),
+    status_reason: jobStatusReasonSchema.optional(),
     steps: z.record(z.string(), stepExpectationSchema).optional(),
   })
   .strict();
@@ -130,6 +178,11 @@ function latestExitCode(step: WorkflowRunStepDetailDto): number | null {
   return attempt?.exit_code ?? null;
 }
 
+function stringField(value: NonNullable<StepErrorDto>, field: string): string | null {
+  const fieldValue = (value as Record<string, unknown>)[field];
+  return typeof fieldValue === 'string' ? fieldValue : null;
+}
+
 /**
  * Compares a run detail against an expectation, returning every structural mismatch
  * (run/job/step status and step exit code) plus the log requirements the harness still
@@ -165,6 +218,17 @@ export function evaluateExpectations(
       });
     }
 
+    if (
+      jobExpectation.status_reason !== undefined &&
+      job.status_reason !== jobExpectation.status_reason
+    ) {
+      mismatches.push({
+        path: `jobs.${jobKey}.status_reason`,
+        expected: jobExpectation.status_reason,
+        actual: job.status_reason ?? 'null',
+      });
+    }
+
     const steps = jobExpectation.steps;
     if (!steps) continue;
     for (const [stepKey, stepExpectation] of Object.entries(steps)) {
@@ -191,6 +255,49 @@ export function evaluateExpectations(
             expected: String(stepExpectation.exit_code),
             actual: exitCode === null ? 'null' : String(exitCode),
           });
+        }
+      }
+
+      if (stepExpectation.error) {
+        if (step.error === null) {
+          mismatches.push({
+            path: `${stepPath}.error`,
+            expected: 'present',
+            actual: 'null',
+          });
+        } else {
+          if (
+            stepExpectation.error.reason !== undefined &&
+            step.error.reason !== stepExpectation.error.reason
+          ) {
+            mismatches.push({
+              path: `${stepPath}.error.reason`,
+              expected: stepExpectation.error.reason,
+              actual: step.error.reason ?? 'null',
+            });
+          }
+
+          if (stepExpectation.error.field !== undefined) {
+            const field = stringField(step.error, 'field');
+            if (field !== stepExpectation.error.field) {
+              mismatches.push({
+                path: `${stepPath}.error.field`,
+                expected: stepExpectation.error.field,
+                actual: field ?? 'null',
+              });
+            }
+          }
+
+          if (stepExpectation.error.source !== undefined) {
+            const source = stringField(step.error, 'source');
+            if (source === null || !source.includes(stepExpectation.error.source)) {
+              mismatches.push({
+                path: `${stepPath}.error.source`,
+                expected: `include ${stepExpectation.error.source}`,
+                actual: source ?? 'null',
+              });
+            }
+          }
         }
       }
 

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -52,7 +52,6 @@ const stepErrorReasonSchema = z.enum([
   'agent_config_invalid',
   'agent_invocation_failed',
 ]);
-
 type AssertExact<Actual, Expected> = [Actual] extends [Expected]
   ? [Expected] extends [Actual]
     ? true

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -44,6 +44,8 @@ export const stepErrorDtoSchema = z
     exit_code: z.number().int().nullable().optional(),
     signal: z.string().optional(),
     reason: stepErrorReasonSchema.optional(),
+    field: z.string().optional(),
+    source: z.string().optional(),
     agent_config_issue: agentConfigIssueSchema.optional(),
     category: stepErrorCategorySchema.optional(),
   })

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -108,6 +108,28 @@ describe('toStepDto error category', () => {
     });
   });
 
+  it('surfaces config error field and source diagnostics', () => {
+    const dto = toStepDto(
+      step({
+        type: 'run',
+        error: {
+          message: 'Could not resolve env.VERSION',
+          reason: 'config_unresolvable',
+          field: 'env.VERSION',
+          source: 'steps.build.outputs.version',
+        },
+      }),
+    );
+
+    expect(dto.error).toEqual({
+      message: 'Could not resolve env.VERSION',
+      reason: 'config_unresolvable',
+      field: 'env.VERSION',
+      source: 'steps.build.outputs.version',
+      category: 'user',
+    });
+  });
+
   it('renders no error (and no category) for a successful step', () => {
     const dto = toStepDto(step({type: 'run', status: 'succeeded', error: null}));
 

--- a/libs/api/workflows/src/presentation/dto/step.test.ts
+++ b/libs/api/workflows/src/presentation/dto/step.test.ts
@@ -47,6 +47,22 @@ describe('fromStepErrorDto', () => {
     });
   });
 
+  it('persists config error field and source diagnostics', () => {
+    const persisted = fromStepErrorDto({
+      message: 'Could not resolve env.VERSION',
+      reason: 'config_unresolvable',
+      field: 'env.VERSION',
+      source: 'steps.build.outputs.version',
+    });
+
+    expect(persisted).toEqual({
+      message: 'Could not resolve env.VERSION',
+      reason: 'config_unresolvable',
+      field: 'env.VERSION',
+      source: 'steps.build.outputs.version',
+    });
+  });
+
   it('ignores a runner-supplied category (the server derives it on read)', () => {
     const persisted = fromStepErrorDto({
       message: 'mkdir denied',

--- a/libs/api/workflows/src/presentation/dto/step.ts
+++ b/libs/api/workflows/src/presentation/dto/step.ts
@@ -23,6 +23,8 @@ function toStepErrorDto(
   const message = typeof error.message === 'string' ? error.message : '';
   const exitCode = error.exitCode;
   const signal = typeof error.signal === 'string' ? error.signal : undefined;
+  const field = typeof error.field === 'string' ? error.field : undefined;
+  const source = typeof error.source === 'string' ? error.source : undefined;
   const reason = stepErrorReasonSchema.safeParse(error.reason);
   const agentConfigIssue = agentConfigIssueSchema.safeParse(error.agentConfigIssue);
   return {
@@ -30,6 +32,8 @@ function toStepErrorDto(
     ...(exitCode === null || typeof exitCode === 'number' ? {exit_code: exitCode} : {}),
     ...(signal === undefined ? {} : {signal}),
     ...(reason.success ? {reason: reason.data} : {}),
+    ...(field === undefined ? {} : {field}),
+    ...(source === undefined ? {} : {source}),
     ...(agentConfigIssue.success ? {agent_config_issue: agentConfigIssue.data} : {}),
     category,
   };
@@ -48,6 +52,8 @@ export function fromStepErrorDto(error: StepErrorDto | undefined): Record<string
       : {}),
     ...(typeof error.signal === 'string' ? {signal: error.signal} : {}),
     ...(error.reason === undefined ? {} : {reason: error.reason}),
+    ...(error.field === undefined ? {} : {field: error.field}),
+    ...(error.source === undefined ? {} : {source: error.source}),
     ...(error.agent_config_issue === undefined ? {} : {agentConfigIssue: error.agent_config_issue}),
   };
 }


### PR DESCRIPTION
Add runtime error assertions to the platform workflow E2E harness.

The workflow error-case scenarios need to assert why a step or job failed, not just that it failed. This extends `expect.yaml` with job `status_reason` and step `error` expectations for reason, field, and source so upcoming fail-loud and gate/error scenarios can stay declarative instead of becoming bespoke specs.

The API step error DTO now preserves config diagnostic `field` and `source` values on run details, which makes those harness assertions possible for dispatch-time config failures.

No changeset is included because the touched library packages are private.

Closes ENG-771

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add runtime error assertions to workflow E2E expectations so tests can check why a job or step failed, not just that it failed. Surfaces field and source in step error DTOs to enable these checks. Closes ENG-771.

- New Features
  - `expect.yaml`: support job `status_reason` and step `error` assertions (`reason`, `field`, `source`) with strict schema validation.
  - E2E harness: mismatch reporting for absent/mismatched reasons and error details; `source` uses a contains check.
  - `@shipfox/api-workflows-dto`: add optional `field` and `source` to `StepErrorDto` and pass them through presentation DTOs.

- Refactors
  - Keep expectation schemas local to the E2E harness to avoid runtime imports from `@shipfox/api-workflows-dto` and prevent Playwright from loading the package entrypoint.
  - Add type-only parity checks to keep local enums aligned with DTO unions, add unit tests for `field`/`source` persistence and presentation, and update README to document the new `expect.yaml` error assertions.

<sup>Written for commit fc40ce0f7b172775323b1bf9442c5ad089cc1cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

