### PR TITLE
[api-workflows] Colocate workflow context assembly

### DIFF
--- a/.changeset/sharp-contexts-assemble.md
+++ b/.changeset/sharp-contexts-assemble.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Colocates workflow phase context assembly and threads phase-tagged evaluation contexts through runtime fill sites.

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -27,10 +27,8 @@ import {
   StepNotFoundError,
   StepNotRunningError,
 } from './errors.js';
-import {
-  assembleStepDispatchContext,
-  completeStepDispatchConfig,
-} from './step-config/complete-step-dispatch-config.js';
+import {assembleStepDispatchContext} from './step-config/assemble-run-context.js';
+import {completeStepDispatchConfig} from './step-config/complete-step-dispatch-config.js';
 import {
   applyStepTransition,
   type StepProgressionMetrics,

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -1,4 +1,14 @@
-import {assembleCreationContext, assembleWorkflowRunContext} from './assemble-run-context.js';
+import type {JobExecution} from '#core/entities/job-execution.js';
+import type {Step, StepAttempt} from '#core/entities/step.js';
+import {
+  assembleCreationContext,
+  assembleGateContext,
+  assembleJobResolutionContext,
+  assembleStepDispatchContext,
+  assembleWorkflowRunContext,
+} from './assemble-run-context.js';
+
+const date = new Date('2026-06-30T12:00:00.000Z');
 
 describe('assembleWorkflowRunContext', () => {
   const run = {
@@ -94,3 +104,190 @@ describe('assembleCreationContext', () => {
     });
   });
 });
+
+describe('assembleStepDispatchContext', () => {
+  it('wraps upstream step outputs and the current execution with the dispatch site', () => {
+    const targetStep = step({id: 'step-2', key: 'test'});
+    const steps = [
+      step({id: 'step-1', key: 'build'}),
+      targetStep,
+      step({id: 'step-3', key: null}),
+      step({id: 'step-4', key: 'running'}),
+    ];
+    const attempts = [
+      attempt({stepId: 'step-1', output: {image: 'app:123'}}),
+      attempt({stepId: 'step-4', status: 'running', output: {ignored: true}}),
+    ];
+    const execution = jobExecution();
+
+    const context = assembleStepDispatchContext({
+      steps,
+      attempts,
+      targetStepId: targetStep.id,
+      jobExecution: execution,
+    });
+
+    expect(context).toEqual({
+      site: 'step-dispatch',
+      values: {
+        execution: {
+          index: 2,
+          name: 'Deploy',
+          status: 'running',
+          started_at: date,
+          finished_at: null,
+          events: [
+            {
+              source: 'github',
+              event: 'push',
+              delivery_id: 'delivery-1',
+              received_at: '2026-06-30T12:00:00.000Z',
+              data: {ref: 'refs/heads/main'},
+            },
+          ],
+        },
+        steps: {
+          build: {outputs: {image: 'app:123'}},
+        },
+      },
+    });
+  });
+});
+
+describe('assembleGateContext', () => {
+  it('wraps the reported step result with the step-report site', () => {
+    const context = assembleGateContext({status: 'failed', exitCode: 1});
+
+    expect(context).toEqual({
+      site: 'step-report',
+      values: {
+        step: {
+          exit_code: 1n,
+          status: 'failed',
+        },
+      },
+    });
+  });
+});
+
+describe('assembleJobResolutionContext', () => {
+  it('wraps executions with the job-resolution site', () => {
+    const executions = [
+      jobExecution({sequence: 0, name: 'First', status: 'failed', finishedAt: date}),
+      jobExecution({sequence: 1, name: 'Second', status: 'succeeded', finishedAt: date}),
+    ];
+
+    const context = assembleJobResolutionContext(executions);
+
+    expect(context).toEqual({
+      site: 'job-resolution',
+      values: {
+        executions: [
+          {
+            index: 0,
+            name: 'First',
+            status: 'failed',
+            started_at: date,
+            finished_at: date,
+            events: [
+              {
+                source: 'github',
+                event: 'push',
+                delivery_id: 'delivery-1',
+                received_at: '2026-06-30T12:00:00.000Z',
+                data: {ref: 'refs/heads/main'},
+              },
+            ],
+          },
+          {
+            index: 1,
+            name: 'Second',
+            status: 'succeeded',
+            started_at: date,
+            finished_at: date,
+            events: [
+              {
+                source: 'github',
+                event: 'push',
+                delivery_id: 'delivery-1',
+                received_at: '2026-06-30T12:00:00.000Z',
+                data: {ref: 'refs/heads/main'},
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+});
+
+function step(overrides: Partial<Step> = {}): Step {
+  return {
+    id: 'step-1',
+    jobExecutionId: 'exec-1',
+    key: 'build',
+    name: 'Build',
+    sourceLocation: null,
+    status: 'pending',
+    type: 'run',
+    config: {},
+    configPlan: null,
+    authoredConfig: null,
+    output: null,
+    error: null,
+    position: 0,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: date,
+    updatedAt: date,
+    ...overrides,
+  };
+}
+
+function attempt(overrides: Partial<StepAttempt> = {}): StepAttempt {
+  return {
+    id: 'attempt-1',
+    stepId: 'step-1',
+    attempt: 1,
+    executionOrder: 1,
+    status: 'succeeded',
+    output: null,
+    error: null,
+    exitCode: 0,
+    gateResult: null,
+    restartReason: null,
+    logOutcome: null,
+    startedAt: date,
+    finishedAt: date,
+    createdAt: date,
+    ...overrides,
+  };
+}
+
+function jobExecution(overrides: Partial<JobExecution> = {}): JobExecution {
+  return {
+    id: 'exec-1',
+    jobId: 'job-1',
+    sequence: 2,
+    name: 'Deploy',
+    status: 'running',
+    statusReason: null,
+    triggerEvents: [
+      {
+        source: 'github',
+        event: 'push',
+        delivery_id: 'delivery-1',
+        received_at: '2026-06-30T12:00:00.000Z',
+        data: {ref: 'refs/heads/main'},
+      },
+    ],
+    version: 1,
+    createdAt: date,
+    updatedAt: date,
+    queuedAt: date,
+    startedAt: date,
+    finishedAt: null,
+    timedOutAt: null,
+    ...overrides,
+  };
+}

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -1,5 +1,6 @@
 import type {WorkflowExpressionEvaluationContext} from '@shipfox/expression';
 import type {JobExecution} from '#core/entities/job-execution.js';
+import type {Step, StepAttempt, StepStatus} from '#core/entities/step.js';
 import type {TriggerPayload, WorkflowRun} from '#core/entities/workflow-run.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
@@ -46,7 +47,7 @@ export function assembleCreationContext(
  * Keeps job-success predicate values aligned with the registry's `executions`
  * type environment.
  */
-export function assembleExecutionsContext(
+function assembleExecutionsContextValues(
   executions: readonly JobExecution[],
 ): WorkflowExpressionEvaluationContext {
   return {
@@ -58,5 +59,69 @@ export function assembleExecutionsContext(
       finished_at: execution.finishedAt,
       events: execution.triggerEvents,
     })),
+  };
+}
+
+export function assembleStepDispatchContext(params: {
+  readonly steps: readonly Step[];
+  readonly attempts: readonly StepAttempt[];
+  readonly targetStepId: string;
+  readonly jobExecution?: JobExecution;
+}): WorkflowEvaluationContext {
+  const attemptsByStepId = new Map(
+    params.attempts
+      .filter((attempt) => attempt.status !== 'running')
+      .map((attempt) => [attempt.stepId, attempt]),
+  );
+  const stepsContext: Record<string, {outputs: Record<string, unknown>}> = {};
+
+  for (const step of params.steps) {
+    if (step.id === params.targetStepId || step.key === null) continue;
+    const attempt = attemptsByStepId.get(step.id);
+    if (attempt === undefined) continue;
+    stepsContext[step.key] = {outputs: attempt.output ?? {}};
+  }
+
+  return {
+    site: 'step-dispatch',
+    values: {
+      ...(params.jobExecution === undefined
+        ? {}
+        : {
+            execution: {
+              index: params.jobExecution.sequence,
+              name: params.jobExecution.name,
+              status: params.jobExecution.status,
+              started_at: params.jobExecution.startedAt,
+              finished_at: params.jobExecution.finishedAt,
+              events: params.jobExecution.triggerEvents,
+            },
+          }),
+      steps: stepsContext,
+    },
+  };
+}
+
+export function assembleGateContext(params: {
+  readonly status: StepStatus;
+  readonly exitCode: number;
+}): WorkflowEvaluationContext {
+  return {
+    site: 'step-report',
+    values: {
+      step: {
+        exit_code: BigInt(params.exitCode),
+        status: params.status,
+      },
+    },
+  };
+}
+
+export function assembleJobResolutionContext(
+  executions: readonly JobExecution[],
+): WorkflowEvaluationContext {
+  return {
+    site: 'job-resolution',
+    values: assembleExecutionsContextValues(executions),
   };
 }

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -8,58 +8,20 @@ import {
   freezePlannedRunCommandAtSite,
   getWorkflowInterpolationFieldFailurePolicy,
   resolveFieldAtSite,
-  type WorkflowExpressionEvaluationContext,
   type WorkflowInterpolationField,
   WorkflowTemplateResolutionError,
 } from '@shipfox/expression';
-import type {JobExecution} from '#core/entities/job-execution.js';
-import type {Step, StepAttempt, StepConfigDispatchPlan} from '#core/entities/step.js';
+import type {Step, StepConfigDispatchPlan} from '#core/entities/step.js';
 import {
   AgentConfigUnresolvableError,
   InterpolationUnresolvableError,
   type InterpolationUnresolvableField,
 } from '#core/errors.js';
-
-export function assembleStepDispatchContext(params: {
-  readonly steps: readonly Step[];
-  readonly attempts: readonly StepAttempt[];
-  readonly targetStepId: string;
-  readonly jobExecution?: JobExecution;
-}): WorkflowExpressionEvaluationContext {
-  const attemptsByStepId = new Map(
-    params.attempts
-      .filter((attempt) => attempt.status !== 'running')
-      .map((attempt) => [attempt.stepId, attempt]),
-  );
-  const stepsContext: Record<string, {outputs: Record<string, unknown>}> = {};
-
-  for (const step of params.steps) {
-    if (step.id === params.targetStepId || step.key === null) continue;
-    const attempt = attemptsByStepId.get(step.id);
-    if (attempt === undefined) continue;
-    stepsContext[step.key] = {outputs: attempt.output ?? {}};
-  }
-
-  return {
-    ...(params.jobExecution === undefined
-      ? {}
-      : {
-          execution: {
-            index: params.jobExecution.sequence,
-            name: params.jobExecution.name,
-            status: params.jobExecution.status,
-            started_at: params.jobExecution.startedAt,
-            finished_at: params.jobExecution.finishedAt,
-            events: params.jobExecution.triggerEvents,
-          },
-        }),
-    steps: stepsContext,
-  };
-}
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 export function completeStepDispatchConfig(params: {
   readonly step: Step;
-  readonly context: WorkflowExpressionEvaluationContext;
+  readonly context: WorkflowEvaluationContext;
   readonly resolveAgentDefaults: AgentDefaultsResolver;
   readonly definitionId: string;
 }): Record<string, unknown> {
@@ -72,8 +34,8 @@ export function completeStepDispatchConfig(params: {
   if (plan.run !== undefined) {
     const resolved = freezePlannedRunCommandAtSite({
       field: plan.run,
-      site: 'step-dispatch',
-      context: params.context,
+      site: params.context.site,
+      context: params.context.values,
       failurePolicy: getWorkflowInterpolationFieldFailurePolicy('run'),
       reservedNames: Object.keys(env),
     });
@@ -109,7 +71,7 @@ export function completeStepDispatchConfig(params: {
 function completeAgentConfig(params: {
   readonly config: Record<string, unknown>;
   readonly plan: StepConfigDispatchPlan;
-  readonly context: WorkflowExpressionEvaluationContext;
+  readonly context: WorkflowEvaluationContext;
   readonly resolveAgentDefaults: AgentDefaultsResolver;
   readonly definitionId: string;
 }): void {
@@ -169,7 +131,7 @@ function completeField(params: {
   readonly field: WorkflowInterpolationField;
   readonly errorField: InterpolationUnresolvableField;
   readonly template: StepConfigDispatchPlan['run'];
-  readonly context: WorkflowExpressionEvaluationContext;
+  readonly context: WorkflowEvaluationContext;
   readonly definitionId: string;
   readonly envKey?: string;
 }): string {
@@ -177,8 +139,8 @@ function completeField(params: {
   try {
     const resolved = resolveFieldAtSite({
       field: params.template,
-      site: 'step-dispatch',
-      context: params.context,
+      site: params.context.site,
+      context: params.context.values,
       failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
     });
     if (resolved.kind === 'frozen') return resolved.value;

--- a/libs/api/workflows/src/core/step-config/index.ts
+++ b/libs/api/workflows/src/core/step-config/index.ts
@@ -1,13 +1,12 @@
 export {
   type AssembleWorkflowRunContextParams,
   assembleCreationContext,
-  assembleExecutionsContext,
+  assembleGateContext,
+  assembleJobResolutionContext,
+  assembleStepDispatchContext,
   assembleWorkflowRunContext,
 } from './assemble-run-context.js';
-export {
-  assembleStepDispatchContext,
-  completeStepDispatchConfig,
-} from './complete-step-dispatch-config.js';
+export {completeStepDispatchConfig} from './complete-step-dispatch-config.js';
 export {
   type MaterializedWorkflowStep,
   type MaterializeJobExecutionStepsParams,

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -1,4 +1,5 @@
 import {evaluatePlannedPredicateAtSite, type WorkflowExpression} from '@shipfox/expression';
+import {assembleGateContext} from '../step-config/assemble-run-context.js';
 import type {GateOutcome, StepResult} from './decide-step-transition.js';
 
 // The exact `uncheckable` reason recorded when the gate's CEL expression itself
@@ -60,16 +61,12 @@ export function evaluateGate(gate: StepGate | undefined, result: StepResult): Ga
     return {kind: 'uncheckable', reason: 'step produced no exit code'};
   }
 
+  const context = assembleGateContext({status: result.status, exitCode: result.exitCode});
   const outcome = evaluatePlannedPredicateAtSite({
     expression: gate.successIf,
     field: 'step.success_if',
-    site: 'step-report',
-    context: {
-      step: {
-        exit_code: BigInt(result.exitCode),
-        status: result.status,
-      },
-    },
+    site: context.site,
+    context: context.values,
   });
   if (outcome.evaluationFailed) {
     return {kind: 'uncheckable', reason: GATE_EVALUATION_ERROR_REASON};

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -67,7 +67,7 @@ import {
 } from '#core/errors.js';
 import {
   assembleCreationContext,
-  assembleExecutionsContext,
+  assembleJobResolutionContext,
 } from '#core/step-config/assemble-run-context.js';
 import type {MaterializedWorkflowJob} from '#core/step-config/materialize-workflow-model.js';
 import {materializeWorkflowModel} from '#core/step-config/materialize-workflow-model.js';
@@ -1744,12 +1744,12 @@ export async function resolveJobStatusFromJobExecutions(params: {
       source: jobRow.success ?? DEFAULT_JOB_SUCCESS,
       check: {mode: 'syntax'},
     });
-    const context = assembleExecutionsContext(jobExecutionRows.map(toJobExecution));
+    const context = assembleJobResolutionContext(jobExecutionRows.map(toJobExecution));
     const predicateOutcome = evaluatePlannedPredicateAtSite({
       expression,
       field: 'job.success',
-      site: 'job-resolution',
-      context,
+      site: context.site,
+      context: context.values,
     });
     const status: RuntimeCompletionStatus = predicateOutcome.value ? 'succeeded' : 'failed';
     // A thrown predicate is a job-level failure, not evidence that any execution failed.


### PR DESCRIPTION
Colocate workflow phase context assembly in the step-config assembly layer and thread the phase-tagged `WorkflowEvaluationContext` wrapper through runtime fill sites.

The context evaluation engine expects each fill site to consume one `{site, values}` context, but dispatch, gate, and job-success evaluation still passed bare value bags with separate site literals. This keeps behavior unchanged while making run creation, step dispatch, step-report gate evaluation, and job-resolution evaluation use the same context shape.

The dispatch assembler now lives next to creation and job-resolution assembly, with focused tests covering dispatch, gate, and job-resolution context shapes. The change also adds a patch changeset for `@shipfox/api-workflows`.

Validated locally with `mise exec -- turbo build --filter '...[origin/main]'`, `mise exec -- turbo test --filter '...[origin/main]'`, `mise exec -- turbo check --filter '...[origin/main]'`, and `mise exec -- turbo type test check --filter=@shipfox/api-workflows...`.

Closes ENG-765

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Colocated workflow phase context assembly in the step-config layer and unified evaluation to use a phase-tagged `WorkflowEvaluationContext {site, values}` across dispatch, gate, and job-resolution. Addresses ENG-765 by making all runtime fill sites use the same context shape without changing behavior.

- **Refactors**
  - Moved dispatch context assembly into step-config; added `assembleStepDispatchContext`, `assembleGateContext`, and `assembleJobResolutionContext`.
  - Updated runtime callers to pass the `{site, values}` wrapper for dispatch, gate evaluation, and job-resolution.
  - Simplified `completeStepDispatchConfig` to use `context.site` and `context.values`; removed `assembleExecutionsContext` from exports.
  - Added focused tests for context shapes; patch bump for `@shipfox/api-workflows`.

<sup>Written for commit abf418cbcb9ca9f68ba49187f3a668f9d96b9980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

