### PR TITLE
Add shell injection E2E coverage

### DIFF
--- a/e2e/platform/workflows/scenarios/interpolation-untrusted-hoist/expect.yaml
+++ b/e2e/platform/workflows/scenarios/interpolation-untrusted-hoist/expect.yaml
@@ -1,0 +1,17 @@
+trigger: push
+push:
+  message: "literal $(printf I''NJECTED) and `printf I''NJECTED`"
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      echo-message:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - "msg=literal $(printf I''NJECTED) and `printf I''NJECTED`"
+          exclude:
+            - "INJECTED"

--- a/e2e/platform/workflows/scenarios/interpolation-untrusted-hoist/workflow.yml
+++ b/e2e/platform/workflows/scenarios/interpolation-untrusted-hoist/workflow.yml
@@ -1,0 +1,15 @@
+name: Interpolation untrusted hoist
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: echo-message
+        env:
+          MSG: '${{ event.head_commit.message }}'
+        run: |
+          printf 'msg=%s\n' "$MSG"

--- a/e2e/platform/workflows/src/expect.test.ts
+++ b/e2e/platform/workflows/src/expect.test.ts
@@ -395,6 +395,15 @@ describe('parseExpectation', () => {
     expect(expectation.timeout_seconds).toBe(180);
   });
 
+  test('accepts a push commit message override', () => {
+    const expectation = parseExpectation({
+      push: {message: "literal $(printf I''NJECTED)"},
+      run: {status: 'succeeded'},
+    });
+
+    expect(expectation.push?.message).toBe("literal $(printf I''NJECTED)");
+  });
+
   test('rejects unknown keys', () => {
     expect(() => parseExpectation({run: {status: 'succeeded'}, unexpected: true})).toThrow();
   });

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -36,6 +36,12 @@ const logsExpectationSchema = z
   })
   .strict();
 
+const pushExpectationSchema = z
+  .object({
+    message: z.string().min(1).optional(),
+  })
+  .strict();
+
 const stepExpectationSchema = z
   .object({
     status: stepStatusSchema.optional(),
@@ -54,6 +60,7 @@ const jobExpectationSchema = z
 export const expectationSchema = z
   .object({
     trigger: z.enum(['push', 'manual']).default('push'),
+    push: pushExpectationSchema.optional(),
     inputs: z.record(z.string(), z.unknown()).optional(),
     timeout_seconds: z.number().int().positive().default(180),
     run: z.object({status: runStatusSchema}).strict(),

--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -149,6 +149,7 @@ async function triggerPushAndAwaitRun(params: {
   repo: string;
   scenario: string;
   uniqueId: string;
+  message?: string | undefined;
   projectId: string;
   token: string;
 }): Promise<string> {
@@ -158,7 +159,7 @@ async function triggerPushAndAwaitRun(params: {
     const triggerSha = await commitFiles({
       org: params.org,
       repo: params.repo,
-      message: `trigger ${params.scenario} ${params.uniqueId} #${attempt}`,
+      message: params.message ?? `trigger ${params.scenario} ${params.uniqueId} #${attempt}`,
       files: [
         {
           path: `.shipfox-e2e-trigger-${attempt}`,
@@ -264,6 +265,7 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
         repo,
         scenario: scenario.name,
         uniqueId,
+        message: scenario.expectation.push?.message,
         projectId: project.id,
         token,
       });


### PR DESCRIPTION
Add a platform workflow E2E scenario proving an untrusted push commit message can flow through `env` into a run step without shell evaluation.

The scenario pushes shell metacharacters in the commit message, binds `event.head_commit.message` to `MSG`, and asserts the logs contain the literal message while excluding the marker that would appear if command substitution executed. The generic scenario harness now accepts an optional push commit message so this stays declarative instead of requiring a bespoke Playwright spec.

Validated with affected build, test, and check commands, plus the focused `interpolation-untrusted-hoist` E2E scenario after building the local dev-server dependency graph.

Closes ENG-768

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds E2E coverage to ensure untrusted push commit messages are treated as literals when passed from the event payload through `env` into a run step. Satisfies ENG-768 by verifying no shell evaluation occurs and the exact message is logged.

- **New Features**
  - Added `interpolation-untrusted-hoist` scenario that pushes a commit message with shell metacharacters; asserts literal `msg=...` in logs and excludes command-substitution output.
  - Updated the workflow harness to accept an optional push commit message override for declarative tests.

<sup>Written for commit 6965196508e9d6d0e4bc9b37452b70e4a7ea52ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

