### PR TITLE
[e2e-platform-workflows] Add manual input scenario

### DIFF
--- a/e2e/platform/workflows/scenarios/manual-inputs/expect.yaml
+++ b/e2e/platform/workflows/scenarios/manual-inputs/expect.yaml
@@ -1,0 +1,14 @@
+trigger: manual
+inputs:
+  version: "1.2.3"
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      show-version:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["v=1.2.3"]

--- a/e2e/platform/workflows/scenarios/manual-inputs/workflow.yml
+++ b/e2e/platform/workflows/scenarios/manual-inputs/workflow.yml
@@ -1,0 +1,13 @@
+name: Manual inputs
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  build:
+    steps:
+      - key: show-version
+        env:
+          V: '${{ inputs.version }}'
+        run: echo "v=$V"

--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -1,7 +1,7 @@
 import {mkdir, readFile} from 'node:fs/promises';
 import {join} from 'node:path';
 import type {FireManualTriggerResponseDto} from '@shipfox/api-triggers-dto';
-import {createApiClient} from '@shipfox/e2e-core';
+import {createApiClient, E2eApiError} from '@shipfox/e2e-core';
 import {waitForDefinition} from '@shipfox/e2e-helper-definitions';
 import {commitFiles, createRepo} from '@shipfox/e2e-helper-integrations-gitea';
 import {fetchStepLogs} from '@shipfox/e2e-helper-logs';
@@ -183,6 +183,39 @@ async function triggerPushAndAwaitRun(params: {
     : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} trigger pushes`);
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fireManualAndAwaitRun(params: {
+  client: ReturnType<typeof createApiClient>;
+  definitionId: string;
+  inputs: Record<string, unknown>;
+  scenario: string;
+}): Promise<string> {
+  const maxAttempts = 8;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await params.client.requestJson<FireManualTriggerResponseDto>(
+        'post',
+        `/workflow-definitions/${params.definitionId}/fire-manual`,
+        {json: {inputs: params.inputs}},
+      );
+      return response.workflow_run_id;
+    } catch (error) {
+      if (!(error instanceof E2eApiError) || error.status !== 404) throw error;
+      lastError = error;
+      await sleep(500);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(
+        `Manual trigger for ${params.scenario} was not ready after ${maxAttempts} attempts`,
+      );
+}
+
 /**
  * Drives one declarative scenario end to end: fresh repo and project, seed commit,
  * definition-resolved poll, trigger (push commit or fire-manual), terminal-run poll,
@@ -252,12 +285,12 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
 
     let runId: string;
     if (scenario.expectation.trigger === 'manual') {
-      const response = await client.requestJson<FireManualTriggerResponseDto>(
-        'post',
-        `/workflow-definitions/${definition.id}/fire-manual`,
-        {json: {inputs: scenario.expectation.inputs ?? {}}},
-      );
-      runId = response.workflow_run_id;
+      runId = await fireManualAndAwaitRun({
+        client,
+        definitionId: definition.id,
+        inputs: scenario.expectation.inputs ?? {},
+        scenario: scenario.name,
+      });
     } else {
       runId = await triggerPushAndAwaitRun({
         org: suite.org,


### PR DESCRIPTION
Add a `manual-inputs` scenario to the platform workflow E2E suite. The scenario fires a manual trigger with `version: \"1.2.3\"`, routes `${{ inputs.version }}` through a step env var, and asserts the resolved value appears in step logs.

Manual trigger input resolution had no full-loop coverage, so regressions in the `fire-manual` path or P1 `inputs` context could slip through. While validating this, the manual fire path exposed the same asynchronous trigger-subscription projection race that push-trigger scenarios already handle; the harness now retries transient 404s while subscriptions catch up, while non-404 API errors still fail immediately.

Closes ENG-770

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add end-to-end coverage for manual workflow triggers with inputs and harden the manual fire path with retry-on-404. Addresses ENG-770 by verifying input resolution end to end.

- **New Features**
  - Add manual-inputs scenario: fires a manual trigger with version 1.2.3, passes ${{ inputs.version }} via a step env var, and asserts logs contain "v=1.2.3".

- **Bug Fixes**
  - Mitigate trigger-subscription race by retrying manual fire on transient 404s; non-404 API errors still fail immediately.

<sup>Written for commit f2ad32606563f32be3e6b6eeadaf118424b502b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

