### PR TITLE
Add workflow interpolation E2E coverage

### DIFF
--- a/e2e/platform/workflows/scenarios/interpolation-run-context/expect.yaml
+++ b/e2e/platform/workflows/scenarios/interpolation-run-context/expect.yaml
@@ -1,0 +1,17 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      show-context:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - "run.name=Interpolation run context"
+            - "/trigger.source=gitea_.+/"
+            - "trigger.event=push"
+            - "job.key=build"
+            - "event.ref=refs/heads/main"

--- a/e2e/platform/workflows/scenarios/interpolation-run-context/workflow.yml
+++ b/e2e/platform/workflows/scenarios/interpolation-run-context/workflow.yml
@@ -1,0 +1,19 @@
+name: Interpolation run context
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    env:
+      REF: '${{ event.ref }}'
+    steps:
+      - key: show-context
+        run: |
+          echo "run.name=${{ run.name }}"
+          echo "trigger.source=${{ trigger.source }}"
+          echo "trigger.event=${{ trigger.event }}"
+          echo "job.key=${{ job.key }}"
+          echo "event.ref=$REF"


### PR DESCRIPTION
Add a platform workflow E2E scenario that proves authored run/env interpolation reaches the runner through the real loop.

The existing workflow scenarios covered static commands only. This scenario pushes a workflow that interpolates trusted run context directly in a run command and routes the untrusted event ref through job env, then asserts the resolved values in step logs after dispatch and runner execution.

The standard `mise run e2e -- --filter=@shipfox/e2e-platform-workflows` path was blocked in this worktree by another Conductor workspace already occupying the generated client port, so the same harness was run with the client port overridden to a free port.

Closes ENG-767

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an end-to-end workflow scenario that verifies authored run/env interpolation reaches the runner through the real loop. The test asserts the resolved `run.name`, `trigger.source`, `trigger.event`, `job.key`, and `event.ref` (passed via job env) in step logs, fulfilling ENG-767.

<sup>Written for commit db78028c57184a073e320587a42165f4031299be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

