### PR TITLE
Clarify runner registration token actions

### DIFF
--- a/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
@@ -2,10 +2,10 @@ import {argosScreenshot} from '@shipfox/playwright';
 import {createShipfoxTokenPrefixRegexes} from '@shipfox/regex';
 import {expect, test} from './test.js';
 
-const RUNNER_TOKEN_PREFIX_RE = createShipfoxTokenPrefixRegexes(['mrt']).unqualified;
+const REGISTRATION_TOKEN_PREFIX_RE = createShipfoxTokenPrefixRegexes(['mrt']).unqualified;
 const VISUAL_TEST_NOW = new Date('2026-01-15T12:00:00Z');
-const VISUAL_TEST_RUNNER_TOKEN_PREFIX = 'sf_mrt_visual';
-const VISUAL_TEST_RUNNER_TOKEN = 'sf_mrt_visual_regression_token';
+const VISUAL_TEST_REGISTRATION_TOKEN_PREFIX = 'sf_mrt_visual';
+const VISUAL_TEST_REGISTRATION_TOKEN = 'sf_mrt_visual_regression_token';
 const VISUAL_TEST_CREATED_AT = 'Jan 15, 2026, 12:00 PM';
 const VISUAL_TEST_EXPIRES_AT = 'Jan 16, 2026, 12:00 PM';
 
@@ -46,19 +46,19 @@ test('manages workspace manual registration tokens from settings', async ({
   await expect(page.getByText('Token created')).toBeVisible();
   const rawToken = createTokenDialog
     .locator('p.font-code')
-    .filter({hasText: RUNNER_TOKEN_PREFIX_RE});
+    .filter({hasText: REGISTRATION_TOKEN_PREFIX_RE});
   await expect(rawToken).toBeVisible();
   await rawToken.evaluate((element: Element, token) => {
     element.textContent = token;
-  }, VISUAL_TEST_RUNNER_TOKEN);
-  await expect(createTokenDialog.getByText(VISUAL_TEST_RUNNER_TOKEN)).toBeVisible();
+  }, VISUAL_TEST_REGISTRATION_TOKEN);
+  await expect(createTokenDialog.getByText(VISUAL_TEST_REGISTRATION_TOKEN)).toBeVisible();
 
   const manualRegistrationTokenRow = page.locator('tr', {hasText: 'E2E runner'});
   await expect(manualRegistrationTokenRow).toBeVisible();
   const manualRegistrationTokenCells = manualRegistrationTokenRow.locator('td');
   await manualRegistrationTokenCells.nth(1).evaluate((element: Element, prefix) => {
     element.textContent = prefix;
-  }, VISUAL_TEST_RUNNER_TOKEN_PREFIX);
+  }, VISUAL_TEST_REGISTRATION_TOKEN_PREFIX);
   await manualRegistrationTokenCells.nth(2).evaluate((element: Element, expiresAt) => {
     element.textContent = expiresAt;
   }, VISUAL_TEST_EXPIRES_AT);
@@ -71,7 +71,7 @@ test('manages workspace manual registration tokens from settings', async ({
   await expect(manualRegistrationTokenRow).toBeVisible();
 
   await manualRegistrationTokenRow
-    .getByRole('button', {name: 'Open E2E runner token actions'})
+    .getByRole('button', {name: 'Open E2E runner registration token actions'})
     .click();
   await page.getByRole('menuitem', {name: 'Revoke token'}).click();
   const revokeDialog = page.getByRole('dialog', {name: 'Revoke token'});

--- a/libs/client/runners/src/components/manual-registration-token-list.tsx
+++ b/libs/client/runners/src/components/manual-registration-token-list.tsx
@@ -180,7 +180,7 @@ function RevokeManualRegistrationTokenButton({
             size="sm"
             variant="transparent"
             icon="more2Line"
-            aria-label={`Open ${tokenName} token actions`}
+            aria-label={`Open ${tokenName} registration token actions`}
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" size="sm">

--- a/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
+++ b/libs/client/runners/src/components/manual-registration-tokens-settings-section.test.tsx
@@ -55,7 +55,7 @@ function lastButton(name: string): HTMLElement {
 }
 
 async function chooseTokenAction(user: ReturnType<typeof userEvent.setup>, tokenName: string) {
-  await user.click(firstButton(`Open ${tokenName} token actions`));
+  await user.click(firstButton(`Open ${tokenName} registration token actions`));
   const menuItem = await screen.findByRole('menuitem', {name: 'Revoke token'});
   expect(menuItem.querySelector('svg')).not.toBeInTheDocument();
 


### PR DESCRIPTION
Clarify the runner settings action label for manual credentials so it refers to registration token actions rather than generic token actions.

ENG-624 separates manual runner registration tokens, runner session tokens, and job lease tokens. The UI copy already used registration-token terminology, but the actions button and its tests still carried the older generic wording. This aligns the accessible label and E2E naming without changing auth or protocol behavior.

No changeset is included because the touched client package is private.

Closes ENG-624

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the action button aria-label to 'registration token actions' and rename related E2E/unit test strings to match manual runner registration tokens (closes ENG-624). No functional changes.

<sup>Written for commit 08215fc466b8bbc8163e06f18cbe4242afb30fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

