### PR TITLE
[api/logs] Enable shared Vitest isolation

### DIFF
--- a/.changeset/steady-logs-share.md
+++ b/.changeset/steady-logs-share.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": patch
+---
+
+Runs the API logs test suite without per-file Vitest module isolation by replacing cached module mocks with explicit test dependencies.

--- a/libs/api/logs/src/core/finalize-attempt-stream.test.ts
+++ b/libs/api/logs/src/core/finalize-attempt-stream.test.ts
@@ -3,21 +3,19 @@ import {db} from '#db/db.js';
 import {getOrCreateAttemptStream} from '#db/streams.js';
 import {listChunks, listStreamClosedEvents} from '#test/queries.js';
 import {
+  createFinalizeAttemptLogStream,
   type FinalizeAttemptLogStreamParams,
-  finalizeAttemptLogStream,
 } from './finalize-attempt-stream.js';
 
-const metrics = vi.hoisted(() => ({
+const metrics = {
   recordAppendedAdd: vi.fn(),
   streamClosedAdd: vi.fn(),
-  streamOpenedAdd: vi.fn(),
-}));
+};
 
-vi.mock('#metrics/instance.js', () => ({
+const finalizeAttemptLogStream = createFinalizeAttemptLogStream({
   recordAppendedCount: {add: metrics.recordAppendedAdd},
   streamClosedCount: {add: metrics.streamClosedAdd},
-  streamOpenedCount: {add: metrics.streamOpenedAdd},
-}));
+});
 
 function newIdentity(
   overrides: Partial<FinalizeAttemptLogStreamParams> = {},
@@ -49,7 +47,6 @@ describe('finalizeAttemptLogStream', () => {
     expect(stream.truncated).toBe(false);
     expect(await listChunks(stream.id)).toHaveLength(0);
     expect(await listStreamClosedEvents(stream.id)).toHaveLength(1);
-    expect(metrics.streamOpenedAdd).not.toHaveBeenCalled();
     expect(metrics.streamClosedAdd).toHaveBeenCalledWith(1, {reason: 'declared'});
     expect(metrics.recordAppendedAdd).not.toHaveBeenCalled();
   });
@@ -73,7 +70,6 @@ describe('finalizeAttemptLogStream', () => {
       .map(parseLogRecordLine);
     expect(records).toMatchObject([{type: 'runner_lost'}]);
     expect(await listStreamClosedEvents(stream.id)).toHaveLength(1);
-    expect(metrics.streamOpenedAdd).not.toHaveBeenCalled();
     expect(metrics.streamClosedAdd).toHaveBeenCalledWith(1, {reason: 'timeout'});
     expect(metrics.recordAppendedAdd).toHaveBeenCalledWith(1, {kind: 'runner_lost'});
   });
@@ -88,7 +84,6 @@ describe('finalizeAttemptLogStream', () => {
     expect(second.state).toBe('closed');
     expect(await listChunks(first.id)).toHaveLength(1);
     expect(await listStreamClosedEvents(first.id)).toHaveLength(1);
-    expect(metrics.streamOpenedAdd).not.toHaveBeenCalled();
     expect(metrics.streamClosedAdd).toHaveBeenCalledTimes(1);
     expect(metrics.recordAppendedAdd).toHaveBeenCalledTimes(1);
   });

--- a/libs/api/logs/src/core/finalize-attempt-stream.ts
+++ b/libs/api/logs/src/core/finalize-attempt-stream.ts
@@ -18,26 +18,42 @@ interface FinalizeAttemptLogStreamResult {
   closedReason: 'declared' | 'timeout' | null;
 }
 
-export async function finalizeAttemptLogStream(
-  params: FinalizeAttemptLogStreamParams,
-): Promise<AttemptStream> {
-  const result: FinalizeAttemptLogStreamResult = await db().transaction(async (tx) => {
-    const {stream} = await getOrCreateAttemptStreamWithStatus(tx, params);
-    if (stream.state === 'closed') return {stream, closedReason: null};
-
-    const reason = params.logOutcome === 'abandoned' ? 'timeout' : 'declared';
-    const closed = await closeStream(tx, {streamId: stream.id, reason});
-    if (closed) return {stream: closed, closedReason: reason};
-
-    const current = await getAttemptStreamByIdInTransaction(tx, stream.id);
-    if (!current) throw new Error(`Log stream disappeared during finalization: ${stream.id}`);
-    return {stream: current, closedReason: null};
-  });
-
-  if (result.closedReason) {
-    if (result.closedReason === 'timeout') recordAppendedCount.add(1, {kind: 'runner_lost'});
-    streamClosedCount.add(1, {reason: result.closedReason});
-  }
-
-  return result.stream;
+interface FinalizeMetrics {
+  recordAppendedCount: {add: (value: number, attributes: {kind: 'runner_lost'}) => void};
+  streamClosedCount: {
+    add: (value: number, attributes: {reason: 'declared' | 'timeout'}) => void;
+  };
 }
+
+const defaultMetrics: FinalizeMetrics = {
+  recordAppendedCount,
+  streamClosedCount,
+};
+
+export function createFinalizeAttemptLogStream(metrics: FinalizeMetrics = defaultMetrics) {
+  return async (params: FinalizeAttemptLogStreamParams): Promise<AttemptStream> => {
+    const result: FinalizeAttemptLogStreamResult = await db().transaction(async (tx) => {
+      const {stream} = await getOrCreateAttemptStreamWithStatus(tx, params);
+      if (stream.state === 'closed') return {stream, closedReason: null};
+
+      const reason = params.logOutcome === 'abandoned' ? 'timeout' : 'declared';
+      const closed = await closeStream(tx, {streamId: stream.id, reason});
+      if (closed) return {stream: closed, closedReason: reason};
+
+      const current = await getAttemptStreamByIdInTransaction(tx, stream.id);
+      if (!current) throw new Error(`Log stream disappeared during finalization: ${stream.id}`);
+      return {stream: current, closedReason: null};
+    });
+
+    if (result.closedReason) {
+      if (result.closedReason === 'timeout') {
+        metrics.recordAppendedCount.add(1, {kind: 'runner_lost'});
+      }
+      metrics.streamClosedCount.add(1, {reason: result.closedReason});
+    }
+
+    return result.stream;
+  };
+}
+
+export const finalizeAttemptLogStream = createFinalizeAttemptLogStream();

--- a/libs/api/logs/src/temporal/activities/compact-stream.test.ts
+++ b/libs/api/logs/src/temporal/activities/compact-stream.test.ts
@@ -6,28 +6,26 @@ import {MockActivityEnvironment} from '@temporalio/testing';
 import {eq} from 'drizzle-orm';
 import {deleteObject, s3Client} from '#api/object-storage.js';
 import {config} from '#config.js';
+import {compactedGzipStream} from '#core/compaction.js';
 import {logObjectKey} from '#core/entities/log-object.js';
 import {db} from '#db/db.js';
 import {attemptStreams} from '#db/schema/attempt-streams.js';
-import {getAttemptStreamById} from '#db/streams.js';
+import {getAttemptStreamById, setObjectKeyAndDeleteChunks} from '#db/streams.js';
 import {arrangeClosedStream, type ClosedStreamIdentity} from '#test/fixtures/closed-stream.js';
 import {ndjsonBody, outputLine} from '#test/fixtures/ndjson.js';
 import {listChunks} from '#test/queries.js';
-import {type CompactStreamResult, compactStreamActivity} from './compact-stream.js';
+import {
+  type CompactStreamResult,
+  compactStreamActivity,
+  createCompactStreamActivity,
+} from './compact-stream.js';
 
-// Mocks default to the real implementation (via importActual); individual tests override
-// once to exercise the integrity-check and publish-race branches deterministically.
-vi.mock('#core/compaction.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('#core/compaction.js')>();
-  return {...actual, compactedGzipStream: vi.fn(actual.compactedGzipStream)};
+const compactedGzipStreamMock = vi.fn<typeof compactedGzipStream>();
+const setObjectKeyAndDeleteChunksMock = vi.fn<typeof setObjectKeyAndDeleteChunks>();
+const compactStreamActivityWithMocks = createCompactStreamActivity({
+  compactedGzipStream: compactedGzipStreamMock,
+  setObjectKeyAndDeleteChunks: setObjectKeyAndDeleteChunksMock,
 });
-vi.mock('#db/streams.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('#db/streams.js')>();
-  return {...actual, setObjectKeyAndDeleteChunks: vi.fn(actual.setObjectKeyAndDeleteChunks)};
-});
-
-import {compactedGzipStream} from '#core/compaction.js';
-import {setObjectKeyAndDeleteChunks} from '#db/streams.js';
 
 function newIdentity(): ClosedStreamIdentity {
   return {
@@ -40,8 +38,11 @@ function newIdentity(): ClosedStreamIdentity {
   };
 }
 
-function runCompaction(streamId: string): Promise<CompactStreamResult> {
-  return new MockActivityEnvironment().run(compactStreamActivity, {streamId});
+function runCompaction(
+  streamId: string,
+  activity = compactStreamActivity,
+): Promise<CompactStreamResult> {
+  return new MockActivityEnvironment().run(activity, {streamId});
 }
 
 async function getObjectBytes(key: string): Promise<Buffer> {
@@ -74,6 +75,11 @@ function compactedKey(result: CompactStreamResult): string {
 }
 
 describe('compactStreamActivity', () => {
+  beforeEach(() => {
+    compactedGzipStreamMock.mockImplementation(compactedGzipStream);
+    setObjectKeyAndDeleteChunksMock.mockImplementation(setObjectKeyAndDeleteChunks);
+  });
+
   it('compacts many chunks into one gzip object and deletes the chunk rows', async () => {
     const chunks = [outputLine('one\n'), outputLine('two\n'), outputLine('three\n')].map((l) =>
       ndjsonBody(l),
@@ -168,12 +174,14 @@ describe('compactStreamActivity', () => {
       chunks: [ndjsonBody(outputLine('a\n')), ndjsonBody(outputLine('b\n'))],
     });
     // Upload a (wrong) empty body whose stats claim zero chunks; the table has two.
-    vi.mocked(compactedGzipStream).mockReturnValueOnce({
+    compactedGzipStreamMock.mockReturnValueOnce({
       body: Readable.from([]).pipe(createGzip()),
       stats: {chunkCount: 0, lastSeq: 0, uncompressedBytes: 0},
     });
 
-    await expect(runCompaction(stream.id)).rejects.toThrow('integrity check');
+    await expect(runCompaction(stream.id, compactStreamActivityWithMocks)).rejects.toThrow(
+      'integrity check',
+    );
 
     const after = await getAttemptStreamById(stream.id);
     expect(after?.objectKey).toBeNull();
@@ -186,9 +194,9 @@ describe('compactStreamActivity', () => {
     const stream = await arrangeClosedStream(identity, {chunks: [ndjsonBody(outputLine('x\n'))]});
     // Simulate a concurrent attempt publishing first: the guarded update matches 0 rows while
     // the row still exists.
-    vi.mocked(setObjectKeyAndDeleteChunks).mockResolvedValueOnce({updated: false});
+    setObjectKeyAndDeleteChunksMock.mockResolvedValueOnce({updated: false});
 
-    const result = await runCompaction(stream.id);
+    const result = await runCompaction(stream.id, compactStreamActivityWithMocks);
 
     expect(result.outcome).toBe('superseded');
     expect(await listKeysUnderStream(identity)).toEqual([]);
@@ -198,12 +206,12 @@ describe('compactStreamActivity', () => {
     const identity = newIdentity();
     const stream = await arrangeClosedStream(identity, {chunks: [ndjsonBody(outputLine('x\n'))]});
     // Simulate retention hard-deleting the row mid-upload: the guarded update finds 0 rows.
-    vi.mocked(setObjectKeyAndDeleteChunks).mockImplementationOnce(async (_tx, params) => {
+    setObjectKeyAndDeleteChunksMock.mockImplementationOnce(async (_tx, params) => {
       await db().delete(attemptStreams).where(eq(attemptStreams.id, params.streamId));
       return {updated: false};
     });
 
-    const result = await runCompaction(stream.id);
+    const result = await runCompaction(stream.id, compactStreamActivityWithMocks);
 
     expect(result.outcome).toBe('retention-raced');
     expect(await listKeysUnderStream(identity)).toEqual([]);

--- a/libs/api/logs/src/temporal/activities/compact-stream.test.ts
+++ b/libs/api/logs/src/temporal/activities/compact-stream.test.ts
@@ -76,6 +76,8 @@ function compactedKey(result: CompactStreamResult): string {
 
 describe('compactStreamActivity', () => {
   beforeEach(() => {
+    compactedGzipStreamMock.mockReset();
+    setObjectKeyAndDeleteChunksMock.mockReset();
     compactedGzipStreamMock.mockImplementation(compactedGzipStream);
     setObjectKeyAndDeleteChunksMock.mockImplementation(setObjectKeyAndDeleteChunks);
   });

--- a/libs/api/logs/src/temporal/activities/compact-stream.ts
+++ b/libs/api/logs/src/temporal/activities/compact-stream.ts
@@ -2,7 +2,7 @@ import {Context} from '@temporalio/activity';
 import {compactedObjectKey, deleteObject, putCompactedObject} from '#api/object-storage.js';
 import {compactedGzipStream} from '#core/compaction.js';
 import {chunkStats} from '#db/chunks.js';
-import {db} from '#db/db.js';
+import {db, type Transaction} from '#db/db.js';
 import {getAttemptStreamById, setObjectKeyAndDeleteChunks} from '#db/streams.js';
 import {type CompactionMetricOutcome, compactionCount} from '#metrics/instance.js';
 
@@ -12,6 +12,19 @@ export type CompactStreamResult =
   | {outcome: 'superseded'}
   | {outcome: 'retention-raced'}
   | {outcome: 'compacted'; objectKey: string; chunkCount: number; uncompressedBytes: number};
+
+interface CompactStreamDependencies {
+  compactedGzipStream: typeof compactedGzipStream;
+  setObjectKeyAndDeleteChunks: (
+    tx: Transaction,
+    params: {streamId: string; objectKey: string},
+  ) => Promise<{updated: boolean}>;
+}
+
+const defaultDependencies: CompactStreamDependencies = {
+  compactedGzipStream,
+  setObjectKeyAndDeleteChunks,
+};
 
 /**
  * Compacts one closed stream into a single gzip NDJSON object, then deletes its chunk rows.
@@ -32,7 +45,10 @@ export type CompactStreamResult =
  * check (count, maxSeq, and byte total) guards a read bug from publishing a truncated object
  * before the only copy of the source is gone (S3 part checksums cover byte transfer).
  */
-async function compactStream(params: {streamId: string}): Promise<CompactStreamResult> {
+async function compactStream(
+  params: {streamId: string},
+  dependencies: CompactStreamDependencies,
+): Promise<CompactStreamResult> {
   const stream = await getAttemptStreamById(params.streamId);
   if (!stream) return {outcome: 'gone'};
   if (stream.objectKey) return {outcome: 'already-compacted'};
@@ -40,7 +56,10 @@ async function compactStream(params: {streamId: string}): Promise<CompactStreamR
   const ctx = Context.current();
   const uploadKey = compactedObjectKey(stream, crypto.randomUUID());
   const expected = await chunkStats(stream.id);
-  const {body, stats} = compactedGzipStream({streamId: stream.id, onPage: () => ctx.heartbeat()});
+  const {body, stats} = dependencies.compactedGzipStream({
+    streamId: stream.id,
+    onPage: () => ctx.heartbeat(),
+  });
 
   await putCompactedObject({
     key: uploadKey,
@@ -67,7 +86,10 @@ async function compactStream(params: {streamId: string}): Promise<CompactStreamR
   }
 
   const {updated} = await db().transaction((tx) =>
-    setObjectKeyAndDeleteChunks(tx, {streamId: stream.id, objectKey: uploadKey}),
+    dependencies.setObjectKeyAndDeleteChunks(tx, {
+      streamId: stream.id,
+      objectKey: uploadKey,
+    }),
   );
   if (!updated) {
     await deleteObject(uploadKey);
@@ -83,15 +105,19 @@ async function compactStream(params: {streamId: string}): Promise<CompactStreamR
   };
 }
 
-export async function compactStreamActivity(params: {
-  streamId: string;
-}): Promise<CompactStreamResult> {
-  let outcome: CompactionMetricOutcome = 'failed';
-  try {
-    const result = await compactStream(params);
-    outcome = result.outcome;
-    return result;
-  } finally {
-    compactionCount.add(1, {outcome});
-  }
+export function createCompactStreamActivity(
+  dependencies: CompactStreamDependencies = defaultDependencies,
+): (params: {streamId: string}) => Promise<CompactStreamResult> {
+  return async (params) => {
+    let outcome: CompactionMetricOutcome = 'failed';
+    try {
+      const result = await compactStream(params, dependencies);
+      outcome = result.outcome;
+      return result;
+    } finally {
+      compactionCount.add(1, {outcome});
+    }
+  };
 }
+
+export const compactStreamActivity = createCompactStreamActivity();

--- a/libs/api/logs/vitest.config.ts
+++ b/libs/api/logs/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig(
     test: {
       fileParallelism: false,
       globalSetup: ['test/globalSetup.ts'],
+      isolate: false,
       setupFiles: ['test/setup.ts'],
     },
   },


### PR DESCRIPTION
Enable `isolate:false` for the `@shipfox/api-logs` Vitest suite.

The earlier node/API rollout left logs out because route tests still depended on mocked workflow queries. That coupling has since been removed, so this finishes the remaining package by making the remaining shared-module hazards explicit: compaction and finalization tests now inject their test collaborators instead of relying on per-file module mocks that break once Vitest reuses the worker module graph.

The production activity and finalizer exports remain unchanged; the new factory helpers exist so tests can exercise race and metric branches without mutating cached imports. The package now runs 18 files and 120 tests in 3.96s locally with import down to 895ms and setup to 234ms.

Closes ENG-757

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables shared Vitest isolation (isolate:false) for `@shipfox/api-logs` by replacing cached module mocks with dependency-injected test helpers. Aligns with ENG-757 and keeps production exports stable; the suite runs 18 files and 120 tests in ~3.96s locally.

- **Refactors**
  - Enabled `test.isolate = false` in `libs/api/logs/vitest.config.ts`.
  - Added factories `createCompactStreamActivity()` and `createFinalizeAttemptLogStream()` to inject dependencies/metrics in tests; kept `compactStreamActivity` and `finalizeAttemptLogStream` as stable default exports.
  - Updated compaction/finalization tests to use injected dependencies and reset injected mocks before each test to prevent stale behavior under shared workers, covering race and metrics branches without mutating cached imports.
  - Added changeset for `@shipfox/api-logs` patch release.

<sup>Written for commit 46cc5e855935d8915fea800bd8ddbd3c3590c4d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

