### PR TITLE
[workflow-document] Bound workflow env size

### DIFF
--- a/.changeset/steady-envs-bound.md
+++ b/.changeset/steady-envs-bound.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": minor
+---
+
+Adds workflow env size limits with exported constants and author-facing validation errors.

--- a/libs/shared/workflow/document/README.md
+++ b/libs/shared/workflow/document/README.md
@@ -129,6 +129,9 @@ parseWorkflowDocument({
   strings, numbers, or booleans; the model layer stringifies numbers and
   booleans before a run is saved. Values are literal. Expression interpolation
   such as `${{ ... }}` is not evaluated.
+- Each `env` map can define up to 128 entries and must serialize to 32768 bytes
+  or less as JSON. The limit is checked separately at workflow, job, and run-step
+  scope before the model layer copies merged env into saved run-step config.
 - `env` applies only to run steps. Declaring `env` directly on an agent step is
   rejected. Workflow-level and job-level `env` is not applied to agent steps.
 - Run-step env is plaintext, non-secret configuration. Values are stored in the

--- a/libs/shared/workflow/document/src/document/index.ts
+++ b/libs/shared/workflow/document/src/document/index.ts
@@ -5,6 +5,8 @@ export {
   DEFAULT_MODEL_PROVIDER,
 } from './step-enums.js';
 export {
+  WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES,
+  WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES,
   type WorkflowDocument,
   type WorkflowDocumentEnv,
   type WorkflowDocumentJob,

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -1,4 +1,8 @@
-import {workflowDocumentSchema} from './workflow-document.js';
+import {
+  WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES,
+  WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES,
+  workflowDocumentSchema,
+} from './workflow-document.js';
 
 describe('workflowDocumentSchema', () => {
   it('accepts a valid minimal workflow document', () => {
@@ -188,6 +192,75 @@ describe('workflowDocumentSchema', () => {
     const result = workflowDocumentSchema.safeParse(workflowDocument);
 
     expect(result.success).toBe(true);
+  });
+
+  it.each([
+    [
+      'workflow',
+      (env: Record<string, string>) => ({
+        name: 'env build',
+        env,
+        jobs: {build: {steps: [{run: 'npm test'}]}},
+      }),
+      'env',
+    ],
+    [
+      'job',
+      (env: Record<string, string>) => ({
+        name: 'env build',
+        jobs: {build: {env, steps: [{run: 'npm test'}]}},
+      }),
+      'jobs.build.env',
+    ],
+    [
+      'run step',
+      (env: Record<string, string>) => ({
+        name: 'env build',
+        jobs: {build: {steps: [{run: 'npm test', env}]}},
+      }),
+      'jobs.build.steps.0.env',
+    ],
+  ])('rejects %s env with too many entries', (_scope, buildDocument, issuePath) => {
+    const env = Object.fromEntries(
+      Array.from({length: WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES + 1}, (_, index) => [
+        `KEY_${index}`,
+        'value',
+      ]),
+    );
+
+    const result = workflowDocumentSchema.safeParse(buildDocument(env));
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find((candidate) => candidate.path.join('.') === issuePath);
+    expect(issue?.message).toBe(
+      `Env cannot define more than ${WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES} entries.`,
+    );
+  });
+
+  it('rejects env maps that exceed the serialized byte limit', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'env build',
+      jobs: {
+        build: {
+          steps: [
+            {
+              run: 'npm test',
+              env: {LARGE_VALUE: 'x'.repeat(WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES)},
+            },
+          ],
+        },
+      },
+    });
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find(
+          (candidate) => candidate.path.join('.') === 'jobs.build.steps.0.env',
+        );
+    expect(issue?.message).toBe(
+      `Env cannot serialize to more than ${WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES} bytes.`,
+    );
   });
 
   it.each([

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -13,10 +13,30 @@ const envNameSchema = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
 const envStringValueSchema = z.string().refine((value) => !value.includes('\u0000'), {
   message: 'Env string values cannot contain null bytes',
 });
-export const workflowDocumentEnvSchema = z.record(
-  envNameSchema,
-  z.union([envStringValueSchema, z.number(), z.boolean()]),
-);
+export const WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES = 128;
+export const WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES = 32 * 1024;
+
+const utf8Encoder = new TextEncoder();
+
+export const workflowDocumentEnvSchema = z
+  .record(envNameSchema, z.union([envStringValueSchema, z.number(), z.boolean()]))
+  .superRefine((env, ctx) => {
+    const entries = Object.keys(env).length;
+    if (entries > WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Env cannot define more than ${WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES} entries.`,
+      });
+    }
+
+    const serializedBytes = utf8Encoder.encode(JSON.stringify(env)).byteLength;
+    if (serializedBytes > WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `Env cannot serialize to more than ${WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES} bytes.`,
+      });
+    }
+  });
 
 const workflowDocumentTriggerBaseSchema = {
   source: z.string().min(1),

--- a/libs/shared/workflow/document/src/index.ts
+++ b/libs/shared/workflow/document/src/index.ts
@@ -6,6 +6,8 @@ export {
   InvalidWorkflowDocumentError,
   invalidWorkflowDocumentErrorCode,
   parseWorkflowDocument,
+  WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES,
+  WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES,
   type WorkflowDocument,
   type WorkflowDocumentEnv,
   type WorkflowDocumentJob,


### PR DESCRIPTION
Bound workflow env maps at the document boundary before model normalization and run-step materialization.

Large workflow-level or job-level env maps are copied into each materialized run step, so an otherwise valid workflow could amplify JSONB storage and run-detail payload size. This adds explicit per-env entry and serialized-byte limits with author-facing validation errors, exports the constants for callers, and documents the limits next to the env contract.

The limits are checked independently for workflow, job, and run-step env maps so empty maps still normalize away and materialized run-step config continues to omit env when there is nothing to persist.

Closes ENG-627

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces size limits on workflow env maps to prevent run-step payload bloat and excessive JSONB storage. Adds clear validation and exports limit constants to satisfy ENG-627.

- **New Features**
  - Validate each env map (workflow, job, run-step) against 128 entries and 32 KB serialized JSON before normalization/materialization.
  - Export `WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES` and `WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES` from `@shipfox/workflow-document`.
  - Updated docs and tests; empty env maps still normalize away and run-step config omits env when empty.

<sup>Written for commit cc7ccb6b9de14ff663f31d99af797c0b497a3197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

