### PR TITLE
[api-workflows] Unify step config resolution

### DIFF
--- a/.changeset/brisk-fields-unify.md
+++ b/.changeset/brisk-fields-unify.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-workflows": patch
+---
+
+Unifies workflow step config field resolution and agent default completion across creation and dispatch fill sites.

--- a/libs/api/workflows/src/core/step-config/agent.ts
+++ b/libs/api/workflows/src/core/step-config/agent.ts
@@ -1,0 +1,330 @@
+import {
+  InvalidAgentModelError,
+  UnsupportedModelProviderError,
+} from '@shipfox/api-agent/core/errors';
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import type {AgentThinking} from '@shipfox/api-agent-dto';
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import type {ResolvedField, SiteResolvedField} from '@shipfox/expression';
+import type {StepConfigDispatchPlan} from '#core/entities/step.js';
+import {AgentConfigUnresolvableError} from '#core/errors.js';
+import {
+  completeStepField,
+  literalField,
+  resolveStepField,
+  type WorkflowStepTemplateDiagnostic,
+} from './fields.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+type WorkflowModelJob = WorkflowModel['jobs'][number];
+type WorkflowModelStep = WorkflowModelJob['steps'][number];
+type WorkflowModelAgentStep = Extract<WorkflowModelStep, {kind: 'agent'}>;
+type StepConfigMode = 'effective' | 'authored';
+type FieldResolution =
+  | {readonly kind: 'frozen'; readonly value: string}
+  | {readonly kind: 'residual'; readonly field: ResolvedField};
+
+interface AgentFieldResolutions {
+  readonly diagnostics: WorkflowStepTemplateDiagnostic[];
+  readonly prompt: FieldResolution;
+  readonly model: FieldResolution | undefined;
+  readonly provider: FieldResolution | undefined;
+  readonly hasTemplates: boolean;
+}
+
+export interface ResolveAgentStepConfigParams {
+  readonly step: WorkflowModelAgentStep;
+  readonly context: WorkflowEvaluationContext;
+  readonly mode: StepConfigMode;
+  readonly definitionId: string;
+  readonly resolveAgentDefaults: AgentDefaultsResolver;
+}
+
+export interface AgentStepConfig {
+  readonly config: Record<string, unknown>;
+  readonly configPlan: StepConfigDispatchPlan | null;
+  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
+  readonly hasTemplates: boolean;
+}
+
+export function resolveAgentStepConfig(params: ResolveAgentStepConfigParams): AgentStepConfig {
+  const fields = resolveAgentFields(params);
+  const usesAuthoredMode = params.mode === 'authored';
+
+  if (usesAuthoredMode) return authoredAgentStepConfig(params.step, fields);
+
+  const hasDeferredModelOrProvider =
+    fields.model?.kind === 'residual' || fields.provider?.kind === 'residual';
+  if (hasDeferredModelOrProvider) return deferredAgentStepConfig(params.step, fields);
+
+  return agentStepConfigWithDefaults(params.step, params, fields);
+}
+
+export function completeAgentConfig(params: {
+  readonly config: Record<string, unknown>;
+  readonly plan: StepConfigDispatchPlan;
+  readonly context: WorkflowEvaluationContext;
+  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly definitionId: string;
+}): void {
+  const agent = params.plan.agent;
+  if (agent === undefined) return;
+
+  const prompt =
+    agent.prompt === undefined
+      ? readConfigString(params.config, 'prompt')
+      : completeStepField({
+          field: 'agent.prompt',
+          errorField: 'agent.prompt',
+          template: agent.prompt,
+          context: params.context,
+          definitionId: params.definitionId,
+        });
+  const model =
+    agent.model === undefined
+      ? readConfigString(params.config, 'model')
+      : completeStepField({
+          field: 'agent.model',
+          errorField: 'agent.model',
+          template: agent.model,
+          context: params.context,
+          definitionId: params.definitionId,
+        });
+  const provider =
+    agent.provider === undefined
+      ? readConfigString(params.config, 'provider')
+      : completeStepField({
+          field: 'agent.provider',
+          errorField: 'agent.provider',
+          template: agent.provider,
+          context: params.context,
+          definitionId: params.definitionId,
+        });
+
+  const defaults = completeAgentDefaults({
+    provider,
+    model,
+    thinking: agent.thinking ?? readConfigThinking(params.config),
+    resolveAgentDefaults: params.resolveAgentDefaults,
+    definitionId: params.definitionId,
+  });
+  params.config.provider = defaults.provider;
+  params.config.model = defaults.model;
+  params.config.thinking = defaults.thinking;
+  params.config.prompt = prompt;
+}
+
+export function completeAgentDefaults(params: {
+  readonly provider: string | undefined;
+  readonly model: string | undefined;
+  readonly thinking: AgentThinking | undefined;
+  readonly resolveAgentDefaults: AgentDefaultsResolver;
+  readonly definitionId: string;
+}): ReturnType<AgentDefaultsResolver> {
+  try {
+    return params.resolveAgentDefaults({
+      provider: params.provider,
+      model: params.model,
+      thinking: params.thinking,
+    });
+  } catch (error) {
+    if (error instanceof UnsupportedModelProviderError || error instanceof InvalidAgentModelError) {
+      throw new AgentConfigUnresolvableError(params.definitionId, {cause: error});
+    }
+    throw error;
+  }
+}
+
+function resolveAgentFields(params: ResolveAgentStepConfigParams): AgentFieldResolutions {
+  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
+  const prompt = resolveAgentField({
+    field: 'agent.prompt',
+    value: params.step.prompt,
+    template: params.step.templates?.prompt,
+    context: params.context,
+    mode: params.mode,
+    diagnostics,
+    definitionId: params.definitionId,
+  });
+  const model = resolveOptionalAgentField({
+    field: 'agent.model',
+    value: params.step.model,
+    template: params.step.templates?.model,
+    context: params.context,
+    mode: params.mode,
+    diagnostics,
+    definitionId: params.definitionId,
+  });
+  const provider = resolveOptionalAgentField({
+    field: 'agent.provider',
+    value: params.step.provider,
+    template: params.step.templates?.provider,
+    context: params.context,
+    mode: params.mode,
+    diagnostics,
+    definitionId: params.definitionId,
+  });
+  const hasTemplates =
+    params.step.templates?.prompt !== undefined ||
+    params.step.templates?.model !== undefined ||
+    params.step.templates?.provider !== undefined;
+
+  return {diagnostics, prompt, model, provider, hasTemplates};
+}
+
+function authoredAgentStepConfig(
+  step: WorkflowModelAgentStep,
+  fields: AgentFieldResolutions,
+): AgentStepConfig {
+  return {
+    config: {
+      ...(step.provider === undefined ? {} : {provider: step.provider}),
+      ...(step.model === undefined ? {} : {model: step.model}),
+      ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+      prompt: step.prompt,
+    },
+    configPlan: null,
+    diagnostics: fields.diagnostics,
+    hasTemplates: fields.hasTemplates,
+  };
+}
+
+function deferredAgentStepConfig(
+  step: WorkflowModelAgentStep,
+  fields: AgentFieldResolutions,
+): AgentStepConfig {
+  return {
+    config: {},
+    configPlan: {
+      agent: {
+        prompt: dispatchPlanField(fields.prompt),
+        ...(fields.model === undefined ? {} : {model: dispatchPlanField(fields.model)}),
+        ...(fields.provider === undefined ? {} : {provider: dispatchPlanField(fields.provider)}),
+        ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
+      },
+    },
+    diagnostics: fields.diagnostics,
+    hasTemplates: fields.hasTemplates,
+  };
+}
+
+function agentStepConfigWithDefaults(
+  step: WorkflowModelAgentStep,
+  params: ResolveAgentStepConfigParams,
+  fields: AgentFieldResolutions,
+): AgentStepConfig {
+  const providerValue = frozenFieldValue(fields.provider);
+  const modelValue = frozenFieldValue(fields.model);
+  const promptIsDeferred = fields.prompt.kind === 'residual';
+
+  const resolved = completeAgentDefaults({
+    provider: providerValue,
+    model: modelValue,
+    thinking: step.thinking,
+    resolveAgentDefaults: params.resolveAgentDefaults,
+    definitionId: params.definitionId,
+  });
+  if (promptIsDeferred) {
+    return {
+      config: {
+        provider: resolved.provider,
+        model: resolved.model,
+        thinking: resolved.thinking,
+      },
+      configPlan: {
+        agent: {
+          prompt: dispatchPlanField(fields.prompt),
+        },
+      },
+      diagnostics: fields.diagnostics,
+      hasTemplates: fields.hasTemplates,
+    };
+  }
+
+  const promptValue = frozenFieldValue(fields.prompt) ?? step.prompt;
+  return {
+    config: {
+      provider: resolved.provider,
+      model: resolved.model,
+      thinking: resolved.thinking,
+      prompt: promptValue,
+    },
+    configPlan: null,
+    diagnostics: fields.diagnostics,
+    hasTemplates: fields.hasTemplates,
+  };
+}
+
+function dispatchPlanField(field: FieldResolution): ResolvedField {
+  const isResidual = field.kind === 'residual';
+  return isResidual ? field.field : literalField(field.value);
+}
+
+function frozenFieldValue(field: FieldResolution | undefined): string | undefined {
+  const isFrozen = field?.kind === 'frozen';
+  return isFrozen ? field.value : undefined;
+}
+
+function resolveAgentField(params: {
+  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider';
+  readonly value: string;
+  readonly template: ResolvedField['segments'] | undefined;
+  readonly context: WorkflowEvaluationContext;
+  readonly mode: StepConfigMode;
+  readonly diagnostics: WorkflowStepTemplateDiagnostic[];
+  readonly definitionId: string;
+}): FieldResolution {
+  const hasTemplate = params.template !== undefined;
+  const usesAuthoredMode = params.mode === 'authored';
+  if (!hasTemplate || usesAuthoredMode) {
+    return {kind: 'frozen', value: params.value};
+  }
+
+  const resolved = resolveStepField({
+    field: params.field,
+    template: {segments: params.template},
+    context: params.context,
+    definitionId: params.definitionId,
+    errorField: params.field,
+  });
+  params.diagnostics.push(
+    ...resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: params.field})),
+  );
+  return fieldResolution(resolved);
+}
+
+function resolveOptionalAgentField(params: {
+  readonly field: 'agent.prompt' | 'agent.model' | 'agent.provider';
+  readonly value: string | undefined;
+  readonly template: ResolvedField['segments'] | undefined;
+  readonly context: WorkflowEvaluationContext;
+  readonly mode: StepConfigMode;
+  readonly diagnostics: WorkflowStepTemplateDiagnostic[];
+  readonly definitionId: string;
+}): FieldResolution | undefined {
+  const hasValue = params.value !== undefined;
+  if (!hasValue) return undefined;
+  return resolveAgentField({...params, value: params.value});
+}
+
+function fieldResolution(resolved: SiteResolvedField): FieldResolution {
+  if (resolved.kind === 'residual') return {kind: 'residual', field: resolved.field};
+  return {kind: 'frozen', value: resolved.value};
+}
+
+function readConfigString(config: Record<string, unknown>, key: string): string | undefined {
+  const value = config[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readConfigThinking(config: Record<string, unknown>): AgentThinking | undefined {
+  const value = config.thinking;
+  return value === 'off' ||
+    value === 'minimal' ||
+    value === 'low' ||
+    value === 'medium' ||
+    value === 'high' ||
+    value === 'xhigh'
+    ? value
+    : undefined;
+}

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.ts
@@ -1,22 +1,7 @@
-import {
-  InvalidAgentModelError,
-  UnsupportedModelProviderError,
-} from '@shipfox/api-agent/core/errors';
 import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
-import type {AgentThinking} from '@shipfox/api-agent-dto';
-import {
-  freezePlannedRunCommandAtSite,
-  getWorkflowInterpolationFieldFailurePolicy,
-  resolveFieldAtSite,
-  type WorkflowInterpolationField,
-  WorkflowTemplateResolutionError,
-} from '@shipfox/expression';
-import type {Step, StepConfigDispatchPlan} from '#core/entities/step.js';
-import {
-  AgentConfigUnresolvableError,
-  InterpolationUnresolvableError,
-  type InterpolationUnresolvableField,
-} from '#core/errors.js';
+import type {Step} from '#core/entities/step.js';
+import {completeAgentConfig} from './agent.js';
+import {completeRunDispatchConfig} from './run.js';
 import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 export function completeStepDispatchConfig(params: {
@@ -29,34 +14,12 @@ export function completeStepDispatchConfig(params: {
   if (plan === null) return params.step.config;
 
   const config = {...params.step.config};
-  const env = {...readConfigEnv(config)};
-
-  if (plan.run !== undefined) {
-    const resolved = freezePlannedRunCommandAtSite({
-      field: plan.run,
-      site: params.context.site,
-      context: params.context.values,
-      failurePolicy: getWorkflowInterpolationFieldFailurePolicy('run'),
-      reservedNames: Object.keys(env),
-    });
-    config.run = resolved.command;
-    Object.assign(env, resolved.env);
-  }
-
-  if (plan.env !== undefined) {
-    for (const [key, field] of Object.entries(plan.env)) {
-      env[key] = completeField({
-        field: 'env.value',
-        errorField: 'env',
-        template: field,
-        context: params.context,
-        definitionId: params.definitionId,
-        envKey: key,
-      });
-    }
-  }
-
-  if (Object.keys(env).length > 0) config.env = env;
+  completeRunDispatchConfig({
+    config,
+    plan,
+    context: params.context,
+    definitionId: params.definitionId,
+  });
   completeAgentConfig({
     config,
     plan,
@@ -66,127 +29,4 @@ export function completeStepDispatchConfig(params: {
   });
 
   return config;
-}
-
-function completeAgentConfig(params: {
-  readonly config: Record<string, unknown>;
-  readonly plan: StepConfigDispatchPlan;
-  readonly context: WorkflowEvaluationContext;
-  readonly resolveAgentDefaults: AgentDefaultsResolver;
-  readonly definitionId: string;
-}): void {
-  const agent = params.plan.agent;
-  if (agent === undefined) return;
-
-  const prompt =
-    agent.prompt === undefined
-      ? readConfigString(params.config, 'prompt')
-      : completeField({
-          field: 'agent.prompt',
-          errorField: 'agent.prompt',
-          template: agent.prompt,
-          context: params.context,
-          definitionId: params.definitionId,
-        });
-  const model =
-    agent.model === undefined
-      ? readConfigString(params.config, 'model')
-      : completeField({
-          field: 'agent.model',
-          errorField: 'agent.model',
-          template: agent.model,
-          context: params.context,
-          definitionId: params.definitionId,
-        });
-  const provider =
-    agent.provider === undefined
-      ? readConfigString(params.config, 'provider')
-      : completeField({
-          field: 'agent.provider',
-          errorField: 'agent.provider',
-          template: agent.provider,
-          context: params.context,
-          definitionId: params.definitionId,
-        });
-
-  try {
-    const defaults = params.resolveAgentDefaults({
-      provider,
-      model,
-      thinking: agent.thinking ?? readConfigThinking(params.config),
-    });
-    params.config.provider = defaults.provider;
-    params.config.model = defaults.model;
-    params.config.thinking = defaults.thinking;
-    params.config.prompt = prompt;
-  } catch (error) {
-    if (error instanceof UnsupportedModelProviderError || error instanceof InvalidAgentModelError) {
-      throw new AgentConfigUnresolvableError(params.definitionId, {cause: error});
-    }
-    throw error;
-  }
-}
-
-function completeField(params: {
-  readonly field: WorkflowInterpolationField;
-  readonly errorField: InterpolationUnresolvableField;
-  readonly template: StepConfigDispatchPlan['run'];
-  readonly context: WorkflowEvaluationContext;
-  readonly definitionId: string;
-  readonly envKey?: string;
-}): string {
-  if (params.template === undefined) return '';
-  try {
-    const resolved = resolveFieldAtSite({
-      field: params.template,
-      site: params.context.site,
-      context: params.context.values,
-      failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
-    });
-    if (resolved.kind === 'frozen') return resolved.value;
-    const source = resolved.field.segments.find((segment) => segment.kind === 'deferred')
-      ?.expression.source;
-    throw new InterpolationUnresolvableError(params.definitionId, {
-      field: params.errorField,
-      source: source ?? params.field,
-      ...(params.envKey === undefined ? {} : {envKey: params.envKey}),
-    });
-  } catch (error) {
-    if (error instanceof WorkflowTemplateResolutionError) {
-      throw new InterpolationUnresolvableError(params.definitionId, {
-        field: params.errorField,
-        source: error.source,
-        ...(params.envKey === undefined ? {} : {envKey: params.envKey}),
-        cause: error,
-      });
-    }
-    throw error;
-  }
-}
-
-function readConfigEnv(config: Record<string, unknown>): Record<string, string> {
-  const env = config.env;
-  if (env === null || typeof env !== 'object' || Array.isArray(env)) return {};
-  return Object.fromEntries(
-    Object.entries(env).flatMap(([key, value]) =>
-      typeof value === 'string' ? [[key, value]] : [],
-    ),
-  );
-}
-
-function readConfigString(config: Record<string, unknown>, key: string): string | undefined {
-  const value = config[key];
-  return typeof value === 'string' ? value : undefined;
-}
-
-function readConfigThinking(config: Record<string, unknown>): AgentThinking | undefined {
-  const value = config.thinking;
-  return value === 'off' ||
-    value === 'minimal' ||
-    value === 'low' ||
-    value === 'medium' ||
-    value === 'high' ||
-    value === 'xhigh'
-    ? value
-    : undefined;
 }

--- a/libs/api/workflows/src/core/step-config/fields.ts
+++ b/libs/api/workflows/src/core/step-config/fields.ts
@@ -1,0 +1,97 @@
+import {
+  freezeResolvedFieldAtSite,
+  getWorkflowInterpolationFieldFailurePolicy,
+  type ResolvedField,
+  resolveFieldAtSite,
+  type SiteResolvedField,
+  type UnsafeRunInterpolationError,
+  type WorkflowInterpolationField,
+  type WorkflowTemplateDiagnostic,
+  WorkflowTemplateResolutionError,
+} from '@shipfox/expression';
+import {InterpolationUnresolvableError, type InterpolationUnresolvableField} from '#core/errors.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+export type StepConfigField = InterpolationUnresolvableField;
+
+export interface WorkflowStepTemplateDiagnostic extends WorkflowTemplateDiagnostic {
+  readonly field: StepConfigField;
+  readonly envKey?: string;
+}
+
+export interface ResolveStepFieldParams {
+  readonly field: WorkflowInterpolationField;
+  readonly template: ResolvedField;
+  readonly context: WorkflowEvaluationContext;
+  readonly definitionId: string;
+  readonly errorField: InterpolationUnresolvableField;
+  readonly envKey?: string;
+}
+
+export function resolveStepField(params: ResolveStepFieldParams): SiteResolvedField {
+  try {
+    return resolveFieldAtSite({
+      field: params.template,
+      context: params.context.values,
+      site: params.context.site,
+      failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
+    });
+  } catch (error) {
+    if (error instanceof WorkflowTemplateResolutionError) {
+      throw stepConfigInterpolationError(params, error);
+    }
+    throw error;
+  }
+}
+
+export function freezeStepField(params: ResolveStepFieldParams): {
+  readonly value: string;
+  readonly diagnostics: SiteResolvedField['diagnostics'];
+} {
+  try {
+    return freezeResolvedFieldAtSite({
+      field: params.template,
+      context: params.context.values,
+      site: params.context.site,
+      failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
+    });
+  } catch (error) {
+    if (error instanceof WorkflowTemplateResolutionError) {
+      throw stepConfigInterpolationError(params, error);
+    }
+    throw error;
+  }
+}
+
+export function completeStepField(params: ResolveStepFieldParams): string {
+  const resolved = resolveStepField(params);
+  if (resolved.kind === 'frozen') return resolved.value;
+
+  const source = resolved.field.segments.find((segment) => segment.kind === 'deferred')?.expression
+    .source;
+  throw new InterpolationUnresolvableError(params.definitionId, {
+    field: params.errorField,
+    source: source ?? params.field,
+    ...(params.envKey === undefined ? {} : {envKey: params.envKey}),
+  });
+}
+
+export function stepConfigInterpolationError(
+  params: {
+    readonly definitionId: string;
+    readonly errorField: InterpolationUnresolvableField;
+    readonly envKey?: string;
+  },
+  error: WorkflowTemplateResolutionError | UnsafeRunInterpolationError,
+): InterpolationUnresolvableError {
+  return new InterpolationUnresolvableError(params.definitionId, {
+    field: params.errorField,
+    source: error.source,
+    ...(params.envKey === undefined ? {} : {envKey: params.envKey}),
+    cause: error,
+  });
+}
+
+export function literalField(value: string): ResolvedField {
+  return {segments: [{kind: 'literal', value}]};
+}

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -560,6 +560,39 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('reserves deferred user env names when generating run interpolation env vars', () => {
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [
+            {
+              run: `echo "${template('run.id')}"`,
+              env: {__sf_0: template('execution.name')},
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({model, context: creationContext()});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({
+      run: `echo "${shellRef('__sf_1')}"`,
+      env: {__sf_1: 'run-1'},
+    });
+    expect(rows[0]?.steps[1]?.configPlan?.env).toEqual({
+      __sf_0: {
+        segments: [
+          expect.objectContaining({
+            kind: 'deferred',
+            roots: ['execution'],
+            fillTarget: 'execution-creation',
+          }),
+        ],
+      },
+    });
+  });
+
   it('resolves agent prompt, model, and provider before catalog defaults', () => {
     const model = workflowModel({
       jobs: {

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -1,44 +1,22 @@
-import {
-  InvalidAgentModelError,
-  UnsupportedModelProviderError,
-} from '@shipfox/api-agent/core/errors';
 import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {WorkflowEnvTemplates, WorkflowModel} from '@shipfox/api-definitions';
-import {
-  type AvailabilitySite,
-  freezeResolvedFieldAtSite,
-  getWorkflowInterpolationFieldFailurePolicy,
-  hoistPlannedRunCommand,
-  resolveFieldAtSite,
-  UnsafeRunInterpolationError,
-  type WorkflowExpressionEvaluationContext,
-  type WorkflowInterpolationField,
-  type WorkflowTemplateDiagnostic,
-  WorkflowTemplateResolutionError,
-} from '@shipfox/expression';
+import type {AvailabilitySite, WorkflowExpressionEvaluationContext} from '@shipfox/expression';
 import type {StepConfigDispatchPlan} from '#core/entities/step.js';
+import {resolveAgentStepConfig} from './agent.js';
 import {
-  AgentConfigUnresolvableError,
-  InterpolationUnresolvableError,
-  type InterpolationUnresolvableField,
-} from '#core/errors.js';
+  freezeStepField,
+  type StepConfigField,
+  type WorkflowStepTemplateDiagnostic,
+} from './fields.js';
+import {resolveRunStepConfig, type StepConfigMode} from './run.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
 
 type WorkflowModelJob = WorkflowModel['jobs'][number];
 type WorkflowModelStep = WorkflowModelJob['steps'][number];
 type WorkflowModelRunStep = Extract<WorkflowModelStep, {kind: 'run'}>;
 type WorkflowModelAgentStep = Extract<WorkflowModelStep, {kind: 'agent'}>;
-type WorkflowFieldTemplate = NonNullable<NonNullable<WorkflowModelRunStep['templates']>['command']>;
-type StepConfigMode = 'effective' | 'authored';
-type FieldResolution =
-  | {readonly kind: 'frozen'; readonly value: string}
-  | {readonly kind: 'residual'; readonly field: {readonly segments: WorkflowFieldTemplate}};
 
-export type StepConfigField = InterpolationUnresolvableField;
-
-export interface WorkflowStepTemplateDiagnostic extends WorkflowTemplateDiagnostic {
-  readonly field: StepConfigField;
-  readonly envKey?: string;
-}
+export type {StepConfigField, WorkflowStepTemplateDiagnostic};
 
 export interface ResolvedStepConfig {
   readonly config: Record<string, unknown>;
@@ -60,11 +38,6 @@ export interface ResolveStepConfigParams {
   readonly definitionId: string;
 }
 
-interface WinningEnvValue {
-  readonly value: string;
-  readonly template?: WorkflowFieldTemplate;
-}
-
 type BuildStepConfigParams = ResolveStepConfigParams & {readonly mode: StepConfigMode};
 
 interface BuiltStepConfig {
@@ -74,20 +47,13 @@ interface BuiltStepConfig {
   readonly hasTemplates: boolean;
 }
 
-interface AgentFieldResolutions {
-  readonly diagnostics: WorkflowStepTemplateDiagnostic[];
-  readonly prompt: FieldResolution;
-  readonly model: FieldResolution | undefined;
-  readonly provider: FieldResolution | undefined;
-  readonly hasTemplates: boolean;
-}
-
 export function resolveStepConfig(params: ResolveStepConfigParams): ResolvedStepConfig {
-  const effective = buildStepConfig({...params, mode: 'effective'});
+  const context = evaluationContext(params);
+  const effective = buildStepConfig({...params, context, mode: 'effective'});
   const authoredConfig = effective.hasTemplates
-    ? buildStepConfig({...params, mode: 'authored'}).config
+    ? buildStepConfig({...params, context, mode: 'authored'}).config
     : null;
-  const name = resolveStepName(params.step, params.context, params.site, params.definitionId);
+  const name = resolveStepName(params.step, context, params.definitionId);
 
   return {
     config: effective.config,
@@ -98,23 +64,40 @@ export function resolveStepConfig(params: ResolveStepConfigParams): ResolvedStep
   };
 }
 
-function buildStepConfig(params: BuildStepConfigParams): BuiltStepConfig {
+function buildStepConfig(
+  params: Omit<BuildStepConfigParams, 'context'> & {readonly context: WorkflowEvaluationContext},
+): BuiltStepConfig {
   const gate = gateConfigForStep(params.step);
   const runStep = runStepOrNull(params.step);
   const isRunStep = runStep !== null;
 
-  if (isRunStep) return runStepConfig({...params, step: runStep}, gate);
+  if (isRunStep) {
+    const run = resolveRunStepConfig({...params, step: runStep});
+    return {
+      config: {...run.config, ...gate},
+      configPlan: run.configPlan,
+      diagnostics: run.diagnostics,
+      hasTemplates: run.hasTemplates,
+    };
+  }
 
   const agentStep = agentStepOrNull(params.step);
   if (agentStep === null) throw new Error(`Unsupported workflow step kind: ${params.step.kind}`);
 
-  const agent = agentStepConfig(agentStep, params.context, params);
+  const agent = resolveAgentStepConfig({...params, step: agentStep});
   return {
     config: {...agent.config, ...gate},
     configPlan: agent.configPlan,
     diagnostics: agent.diagnostics,
     hasTemplates: agent.hasTemplates,
   };
+}
+
+function evaluationContext(params: {
+  readonly context: WorkflowExpressionEvaluationContext;
+  readonly site: AvailabilitySite;
+}): WorkflowEvaluationContext {
+  return {site: params.site, values: params.context};
 }
 
 function runStepOrNull(step: WorkflowModelStep): WorkflowModelRunStep | null {
@@ -127,394 +110,14 @@ function agentStepOrNull(step: WorkflowModelStep): WorkflowModelAgentStep | null
   return isAgentStep ? step : null;
 }
 
-function runStepConfig(
-  params: BuildStepConfigParams & {readonly step: WorkflowModelRunStep},
-  gate: Record<string, unknown>,
-): BuiltStepConfig {
-  const env = winningEnv(params);
-  const envResolution = resolveEnv(
-    env,
-    params.context,
-    params.site,
-    params.mode,
-    params.definitionId,
-  );
-  const commandResolution = resolveCommand({
-    step: params.step,
-    envKeys: Object.keys(envResolution.env),
-    context: params.context,
-    site: params.site,
-    mode: params.mode,
-    definitionId: params.definitionId,
-  });
-  const mergedEnv = {...envResolution.env, ...commandResolution.env};
-  const hasEnvConfig = Object.keys(mergedEnv).length > 0;
-  const envConfig = hasEnvConfig ? {env: mergedEnv} : {};
-  const planEnv = {...envResolution.configPlan, ...commandResolution.configPlan};
-  const hasConfigPlan = Object.keys(planEnv).length > 0;
-  const configPlan = hasConfigPlan ? ({env: planEnv} satisfies StepConfigDispatchPlan) : null;
-  const hasTemplates = envResolution.hasTemplates || commandResolution.hasTemplate;
-
-  return {
-    config: {run: commandResolution.command, ...envConfig, ...gate},
-    configPlan,
-    diagnostics: [...envResolution.diagnostics, ...commandResolution.diagnostics],
-    hasTemplates,
-  };
-}
-
 function gateConfigForStep(step: WorkflowModelStep): Record<string, unknown> {
   const hasGate = step.gate !== undefined;
   return hasGate ? {gate: stepGateConfig(step.gate)} : {};
 }
 
-function resolveCommand(params: {
-  readonly step: WorkflowModelRunStep;
-  readonly envKeys: readonly string[];
-  readonly context: WorkflowExpressionEvaluationContext;
-  readonly site: AvailabilitySite;
-  readonly mode: StepConfigMode;
-  readonly definitionId: string;
-}): {
-  readonly command: string;
-  readonly env: Readonly<Record<string, string>>;
-  readonly configPlan: Readonly<Record<string, {readonly segments: WorkflowFieldTemplate}>>;
-  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
-  readonly hasTemplate: boolean;
-} {
-  const template = params.step.templates?.command;
-  const hasTemplate = template !== undefined;
-  if (!hasTemplate) {
-    return {
-      command: params.step.command.value,
-      env: {},
-      configPlan: {},
-      diagnostics: [],
-      hasTemplate: false,
-    };
-  }
-
-  const usesAuthoredMode = params.mode === 'authored';
-  if (usesAuthoredMode) {
-    return {
-      command: params.step.command.value,
-      env: {},
-      configPlan: {},
-      diagnostics: [],
-      hasTemplate: true,
-    };
-  }
-
-  const env: Record<string, string> = {};
-  const configPlan: Record<string, {readonly segments: WorkflowFieldTemplate}> = {};
-  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
-  let command: string;
-  try {
-    const hoisted = hoistPlannedRunCommand({
-      field: {segments: template},
-      reservedNames: params.envKeys,
-    });
-    command = hoisted.command;
-
-    for (const binding of hoisted.bindings) {
-      const resolved = resolveFieldAtSite({
-        field: {segments: [binding.segment]},
-        context: params.context,
-        site: params.site,
-        failurePolicy: getWorkflowInterpolationFieldFailurePolicy('run'),
-      });
-      const resolvedToDispatchPlan = resolved.kind === 'residual';
-      if (resolvedToDispatchPlan) configPlan[binding.name] = resolved.field;
-      else env[binding.name] = resolved.value;
-      diagnostics.push(
-        ...resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: 'run' as const})),
-      );
-    }
-  } catch (error) {
-    const isTemplateError =
-      error instanceof UnsafeRunInterpolationError ||
-      error instanceof WorkflowTemplateResolutionError;
-    if (isTemplateError) {
-      throw interpolationError(params.definitionId, 'run', error);
-    }
-    throw error;
-  }
-
-  return {
-    command,
-    env,
-    configPlan,
-    diagnostics,
-    hasTemplate: true,
-  };
-}
-
-function resolveEnv(
-  env: Readonly<Record<string, WinningEnvValue>>,
-  context: WorkflowExpressionEvaluationContext,
-  site: AvailabilitySite,
-  mode: StepConfigMode,
-  definitionId: string,
-): {
-  readonly env: Readonly<Record<string, string>>;
-  readonly configPlan: Readonly<Record<string, {readonly segments: WorkflowFieldTemplate}>>;
-  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
-  readonly hasTemplates: boolean;
-} {
-  const resolvedEnv: Record<string, string> = {};
-  const configPlan: Record<string, {readonly segments: WorkflowFieldTemplate}> = {};
-  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
-  let hasTemplates = false;
-
-  for (const [key, entry] of Object.entries(env)) {
-    const template = entry.template;
-    const hasTemplate = template !== undefined;
-    const usesAuthoredMode = mode === 'authored';
-    const shouldUseAuthoredValue = !hasTemplate || usesAuthoredMode;
-
-    if (shouldUseAuthoredValue) {
-      resolvedEnv[key] = entry.value;
-      hasTemplates ||= hasTemplate;
-      continue;
-    }
-
-    hasTemplates = true;
-    const resolved = resolveField({
-      field: 'env.value',
-      template,
-      context,
-      site,
-      definitionId,
-      errorField: 'env',
-      envKey: key,
-    });
-    const resolvedToDispatchPlan = resolved.kind === 'residual';
-    if (resolvedToDispatchPlan) configPlan[key] = resolved.field;
-    else resolvedEnv[key] = resolved.value;
-    diagnostics.push(
-      ...resolved.diagnostics.map((diagnostic) => ({
-        ...diagnostic,
-        field: 'env' as const,
-        envKey: key,
-      })),
-    );
-  }
-
-  return {env: resolvedEnv, configPlan, diagnostics, hasTemplates};
-}
-
-function agentStepConfig(
-  step: WorkflowModelAgentStep,
-  context: WorkflowExpressionEvaluationContext,
-  params: BuildStepConfigParams,
-): BuiltStepConfig {
-  const fields = resolveAgentFields(step, context, params);
-  const usesAuthoredMode = params.mode === 'authored';
-
-  if (usesAuthoredMode) return authoredAgentStepConfig(step, fields);
-
-  const hasDeferredModelOrProvider =
-    fields.model?.kind === 'residual' || fields.provider?.kind === 'residual';
-  if (hasDeferredModelOrProvider) return deferredAgentStepConfig(step, fields);
-
-  return agentStepConfigWithDefaults(step, params, fields);
-}
-
-function resolveAgentFields(
-  step: WorkflowModelAgentStep,
-  context: WorkflowExpressionEvaluationContext,
-  params: BuildStepConfigParams,
-): AgentFieldResolutions {
-  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
-  const prompt = resolveAgentField({
-    field: 'agent.prompt',
-    value: step.prompt,
-    template: step.templates?.prompt,
-    context,
-    mode: params.mode,
-    site: params.site,
-    diagnostics,
-    definitionId: params.definitionId,
-  });
-  const model = resolveOptionalAgentField({
-    field: 'agent.model',
-    value: step.model,
-    template: step.templates?.model,
-    context,
-    mode: params.mode,
-    site: params.site,
-    diagnostics,
-    definitionId: params.definitionId,
-  });
-  const provider = resolveOptionalAgentField({
-    field: 'agent.provider',
-    value: step.provider,
-    template: step.templates?.provider,
-    context,
-    mode: params.mode,
-    site: params.site,
-    diagnostics,
-    definitionId: params.definitionId,
-  });
-  const hasTemplates =
-    step.templates?.prompt !== undefined ||
-    step.templates?.model !== undefined ||
-    step.templates?.provider !== undefined;
-
-  return {diagnostics, prompt, model, provider, hasTemplates};
-}
-
-function authoredAgentStepConfig(
-  step: WorkflowModelAgentStep,
-  fields: AgentFieldResolutions,
-): BuiltStepConfig {
-  return {
-    config: {
-      ...(step.provider === undefined ? {} : {provider: step.provider}),
-      ...(step.model === undefined ? {} : {model: step.model}),
-      ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
-      prompt: step.prompt,
-    },
-    configPlan: null,
-    diagnostics: fields.diagnostics,
-    hasTemplates: fields.hasTemplates,
-  };
-}
-
-function deferredAgentStepConfig(
-  step: WorkflowModelAgentStep,
-  fields: AgentFieldResolutions,
-): BuiltStepConfig {
-  return {
-    config: {},
-    configPlan: {
-      agent: {
-        prompt: dispatchPlanField(fields.prompt),
-        ...(fields.model === undefined ? {} : {model: dispatchPlanField(fields.model)}),
-        ...(fields.provider === undefined ? {} : {provider: dispatchPlanField(fields.provider)}),
-        ...(step.thinking === undefined ? {} : {thinking: step.thinking}),
-      },
-    },
-    diagnostics: fields.diagnostics,
-    hasTemplates: fields.hasTemplates,
-  };
-}
-
-function agentStepConfigWithDefaults(
-  step: WorkflowModelAgentStep,
-  params: BuildStepConfigParams,
-  fields: AgentFieldResolutions,
-): BuiltStepConfig {
-  const providerValue = frozenFieldValue(fields.provider);
-  const modelValue = frozenFieldValue(fields.model);
-  const promptIsDeferred = fields.prompt.kind === 'residual';
-
-  try {
-    const resolved = params.resolveAgentDefaults({
-      provider: providerValue,
-      model: modelValue,
-      thinking: step.thinking,
-    });
-    if (promptIsDeferred) {
-      return {
-        config: {
-          provider: resolved.provider,
-          model: resolved.model,
-          thinking: resolved.thinking,
-        },
-        configPlan: {
-          agent: {
-            prompt: dispatchPlanField(fields.prompt),
-          },
-        },
-        diagnostics: fields.diagnostics,
-        hasTemplates: fields.hasTemplates,
-      };
-    }
-
-    const promptValue = frozenFieldValue(fields.prompt) ?? step.prompt;
-    return {
-      config: {
-        provider: resolved.provider,
-        model: resolved.model,
-        thinking: resolved.thinking,
-        prompt: promptValue,
-      },
-      configPlan: null,
-      diagnostics: fields.diagnostics,
-      hasTemplates: fields.hasTemplates,
-    };
-  } catch (error) {
-    const isAgentDefaultsError =
-      error instanceof UnsupportedModelProviderError || error instanceof InvalidAgentModelError;
-    if (isAgentDefaultsError) {
-      throw new AgentConfigUnresolvableError(params.definitionId, {cause: error});
-    }
-    throw error;
-  }
-}
-
-function dispatchPlanField(field: FieldResolution): {readonly segments: WorkflowFieldTemplate} {
-  const isResidual = field.kind === 'residual';
-  return isResidual ? field.field : literalField(field.value);
-}
-
-function frozenFieldValue(field: FieldResolution | undefined): string | undefined {
-  const isFrozen = field?.kind === 'frozen';
-  return isFrozen ? field.value : undefined;
-}
-
-function resolveAgentField(params: {
-  readonly field: Extract<StepConfigField, `agent.${string}`>;
-  readonly value: string;
-  readonly template: WorkflowFieldTemplate | undefined;
-  readonly context: WorkflowExpressionEvaluationContext;
-  readonly site: AvailabilitySite;
-  readonly mode: StepConfigMode;
-  readonly diagnostics: WorkflowStepTemplateDiagnostic[];
-  readonly definitionId: string;
-}): FieldResolution {
-  const hasTemplate = params.template !== undefined;
-  const usesAuthoredMode = params.mode === 'authored';
-  if (!hasTemplate || usesAuthoredMode) {
-    return {kind: 'frozen', value: params.value};
-  }
-
-  const resolved = resolveField({
-    field: params.field,
-    template: params.template,
-    context: params.context,
-    site: params.site,
-    definitionId: params.definitionId,
-    errorField: params.field,
-  });
-  params.diagnostics.push(
-    ...resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: params.field})),
-  );
-  const resolvedToDispatchPlan = resolved.kind === 'residual';
-  if (resolvedToDispatchPlan) return {kind: 'residual', field: resolved.field};
-  return {kind: 'frozen', value: resolved.value};
-}
-
-function resolveOptionalAgentField(params: {
-  readonly field: Extract<StepConfigField, `agent.${string}`>;
-  readonly value: string | undefined;
-  readonly template: WorkflowFieldTemplate | undefined;
-  readonly context: WorkflowExpressionEvaluationContext;
-  readonly site: AvailabilitySite;
-  readonly mode: StepConfigMode;
-  readonly diagnostics: WorkflowStepTemplateDiagnostic[];
-  readonly definitionId: string;
-}): FieldResolution | undefined {
-  const hasValue = params.value !== undefined;
-  if (!hasValue) return undefined;
-  return resolveAgentField({...params, value: params.value});
-}
-
 function resolveStepName(
   step: WorkflowModelStep,
-  context: WorkflowExpressionEvaluationContext,
-  site: AvailabilitySite,
+  context: WorkflowEvaluationContext,
   definitionId: string,
 ): {
   readonly value: string | undefined;
@@ -526,11 +129,10 @@ function resolveStepName(
   const hasNameTemplate = step.templates?.name !== undefined;
   if (!hasNameTemplate) return {value: step.name, diagnostics: []};
 
-  const resolved = freezeField({
+  const resolved = freezeStepField({
     field: 'step.name',
-    template: step.templates.name,
+    template: {segments: step.templates.name},
     context,
-    site,
     definitionId,
     errorField: 'step.name',
   });
@@ -538,109 +140,6 @@ function resolveStepName(
     value: resolved.value,
     diagnostics: resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: 'step.name'})),
   };
-}
-
-function winningEnv(params: {
-  readonly workflowEnv: WorkflowModel['env'];
-  readonly workflowEnvTemplates: ResolveStepConfigParams['workflowEnvTemplates'];
-  readonly jobEnv: WorkflowModelJob['env'];
-  readonly jobEnvTemplates: ResolveStepConfigParams['jobEnvTemplates'];
-  readonly step: WorkflowModelStep;
-}): Readonly<Record<string, WinningEnvValue>> {
-  if (params.step.kind !== 'run') return {};
-
-  return mergeEnvLayers(
-    {env: params.workflowEnv, templates: params.workflowEnvTemplates},
-    {env: params.jobEnv, templates: params.jobEnvTemplates},
-    {env: params.step.env, templates: params.step.templates?.env},
-  );
-}
-
-function mergeEnvLayers(
-  ...layers: readonly {
-    readonly env: Readonly<Record<string, string>> | undefined;
-    readonly templates: Readonly<Record<string, WorkflowFieldTemplate>> | undefined;
-  }[]
-): Readonly<Record<string, WinningEnvValue>> {
-  const merged: Record<string, WinningEnvValue> = {};
-
-  for (const layer of layers) {
-    for (const [key, value] of Object.entries(layer.env ?? {})) {
-      const template = layer.templates?.[key];
-      const hasTemplate = template !== undefined;
-      merged[key] = hasTemplate ? {value, template} : {value};
-    }
-  }
-
-  return merged;
-}
-
-function freezeField(params: {
-  readonly field: WorkflowInterpolationField;
-  readonly template: WorkflowFieldTemplate;
-  readonly context: WorkflowExpressionEvaluationContext;
-  readonly site: AvailabilitySite;
-  readonly definitionId: string;
-  readonly errorField: InterpolationUnresolvableField;
-  readonly envKey?: string;
-}): ReturnType<typeof freezeResolvedFieldAtSite> {
-  try {
-    return freezeResolvedFieldAtSite({
-      field: {segments: params.template},
-      context: params.context,
-      site: params.site,
-      failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
-    });
-  } catch (error) {
-    const isTemplateError = error instanceof WorkflowTemplateResolutionError;
-    if (isTemplateError) {
-      throw interpolationError(params.definitionId, params.errorField, error, params.envKey);
-    }
-    throw error;
-  }
-}
-
-function resolveField(params: {
-  readonly field: WorkflowInterpolationField;
-  readonly template: WorkflowFieldTemplate;
-  readonly context: WorkflowExpressionEvaluationContext;
-  readonly site: AvailabilitySite;
-  readonly definitionId: string;
-  readonly errorField: InterpolationUnresolvableField;
-  readonly envKey?: string;
-}): ReturnType<typeof resolveFieldAtSite> {
-  try {
-    return resolveFieldAtSite({
-      field: {segments: params.template},
-      context: params.context,
-      site: params.site,
-      failurePolicy: getWorkflowInterpolationFieldFailurePolicy(params.field),
-    });
-  } catch (error) {
-    const isTemplateError = error instanceof WorkflowTemplateResolutionError;
-    if (isTemplateError) {
-      throw interpolationError(params.definitionId, params.errorField, error, params.envKey);
-    }
-    throw error;
-  }
-}
-
-function literalField(value: string): {readonly segments: WorkflowFieldTemplate} {
-  return {segments: [{kind: 'literal', value}]};
-}
-
-function interpolationError(
-  definitionId: string,
-  field: InterpolationUnresolvableField,
-  error: WorkflowTemplateResolutionError | UnsafeRunInterpolationError,
-  envKey?: string,
-): InterpolationUnresolvableError {
-  return new InterpolationUnresolvableError(definitionId, {
-    field,
-    source: error.source,
-    ...(envKey === undefined ? {} : {envKey}),
-    cause: error,
-  });
 }
 
 function stepGateConfig(gate: NonNullable<WorkflowModelStep['gate']>): Record<string, unknown> {

--- a/libs/api/workflows/src/core/step-config/run.ts
+++ b/libs/api/workflows/src/core/step-config/run.ts
@@ -1,0 +1,290 @@
+import type {WorkflowModel} from '@shipfox/api-definitions';
+import {
+  freezePlannedRunCommandAtSite,
+  getWorkflowInterpolationFieldFailurePolicy,
+  hoistPlannedRunCommand,
+  type ResolvedField,
+  UnsafeRunInterpolationError,
+} from '@shipfox/expression';
+import type {StepConfigDispatchPlan} from '#core/entities/step.js';
+import {
+  completeStepField,
+  resolveStepField,
+  stepConfigInterpolationError,
+  type WorkflowStepTemplateDiagnostic,
+} from './fields.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+type WorkflowModelJob = WorkflowModel['jobs'][number];
+type WorkflowModelStep = WorkflowModelJob['steps'][number];
+type WorkflowModelRunStep = Extract<WorkflowModelStep, {kind: 'run'}>;
+
+export type StepConfigMode = 'effective' | 'authored';
+
+interface WinningEnvValue {
+  readonly value: string;
+  readonly template?: ResolvedField['segments'];
+}
+
+export interface ResolveRunStepConfigParams {
+  readonly step: WorkflowModelRunStep;
+  readonly workflowEnv: WorkflowModel['env'];
+  readonly workflowEnvTemplates: WorkflowEnvTemplates | undefined;
+  readonly jobEnv: WorkflowModelJob['env'];
+  readonly jobEnvTemplates: WorkflowEnvTemplates | undefined;
+  readonly context: WorkflowEvaluationContext;
+  readonly mode: StepConfigMode;
+  readonly definitionId: string;
+}
+
+type WorkflowEnvTemplates = Readonly<Record<string, ResolvedField['segments']>>;
+
+export interface RunStepConfig {
+  readonly config: Record<string, unknown>;
+  readonly configPlan: StepConfigDispatchPlan | null;
+  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
+  readonly hasTemplates: boolean;
+}
+
+export function resolveRunStepConfig(params: ResolveRunStepConfigParams): RunStepConfig {
+  const env = winningEnv(params);
+  const envResolution = resolveEnv(env, params.context, params.mode, params.definitionId);
+  const commandResolution = resolveCommand({
+    step: params.step,
+    envKeys: Object.keys(envResolution.env),
+    context: params.context,
+    mode: params.mode,
+    definitionId: params.definitionId,
+  });
+  const mergedEnv = {...envResolution.env, ...commandResolution.env};
+  const hasEnvConfig = Object.keys(mergedEnv).length > 0;
+  const envConfig = hasEnvConfig ? {env: mergedEnv} : {};
+  const planEnv = {...envResolution.configPlan, ...commandResolution.configPlan};
+  const hasConfigPlan = Object.keys(planEnv).length > 0;
+  const configPlan = hasConfigPlan ? ({env: planEnv} satisfies StepConfigDispatchPlan) : null;
+  const hasTemplates = envResolution.hasTemplates || commandResolution.hasTemplate;
+
+  return {
+    config: {run: commandResolution.command, ...envConfig},
+    configPlan,
+    diagnostics: [...envResolution.diagnostics, ...commandResolution.diagnostics],
+    hasTemplates,
+  };
+}
+
+export function completeRunDispatchConfig(params: {
+  readonly config: Record<string, unknown>;
+  readonly plan: StepConfigDispatchPlan;
+  readonly context: WorkflowEvaluationContext;
+  readonly definitionId: string;
+}): void {
+  const env = {...readConfigEnv(params.config)};
+
+  if (params.plan.run !== undefined) {
+    const resolved = freezePlannedRunCommandAtSite({
+      field: params.plan.run,
+      site: params.context.site,
+      context: params.context.values,
+      failurePolicy: getWorkflowInterpolationFieldFailurePolicy('run'),
+      reservedNames: Object.keys(env),
+    });
+    params.config.run = resolved.command;
+    Object.assign(env, resolved.env);
+  }
+
+  if (params.plan.env !== undefined) {
+    for (const [key, field] of Object.entries(params.plan.env)) {
+      env[key] = completeStepField({
+        field: 'env.value',
+        errorField: 'env',
+        template: field,
+        context: params.context,
+        definitionId: params.definitionId,
+        envKey: key,
+      });
+    }
+  }
+
+  if (Object.keys(env).length > 0) params.config.env = env;
+}
+
+function resolveCommand(params: {
+  readonly step: WorkflowModelRunStep;
+  readonly envKeys: readonly string[];
+  readonly context: WorkflowEvaluationContext;
+  readonly mode: StepConfigMode;
+  readonly definitionId: string;
+}): {
+  readonly command: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly configPlan: Readonly<Record<string, ResolvedField>>;
+  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
+  readonly hasTemplate: boolean;
+} {
+  const template = params.step.templates?.command;
+  const hasTemplate = template !== undefined;
+  if (!hasTemplate) {
+    return {
+      command: params.step.command.value,
+      env: {},
+      configPlan: {},
+      diagnostics: [],
+      hasTemplate: false,
+    };
+  }
+
+  const usesAuthoredMode = params.mode === 'authored';
+  if (usesAuthoredMode) {
+    return {
+      command: params.step.command.value,
+      env: {},
+      configPlan: {},
+      diagnostics: [],
+      hasTemplate: true,
+    };
+  }
+
+  const env: Record<string, string> = {};
+  const configPlan: Record<string, ResolvedField> = {};
+  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
+  const hoisted = hoistCommand(template, params.envKeys, params.definitionId);
+
+  for (const binding of hoisted.bindings) {
+    const resolved = resolveStepField({
+      field: 'run',
+      template: {segments: [binding.segment]},
+      context: params.context,
+      definitionId: params.definitionId,
+      errorField: 'run',
+    });
+    const resolvedToDispatchPlan = resolved.kind === 'residual';
+    if (resolvedToDispatchPlan) configPlan[binding.name] = resolved.field;
+    else env[binding.name] = resolved.value;
+    diagnostics.push(
+      ...resolved.diagnostics.map((diagnostic) => ({...diagnostic, field: 'run' as const})),
+    );
+  }
+
+  return {
+    command: hoisted.command,
+    env,
+    configPlan,
+    diagnostics,
+    hasTemplate: true,
+  };
+}
+
+function hoistCommand(
+  template: ResolvedField['segments'],
+  reservedNames: readonly string[],
+  definitionId: string,
+): ReturnType<typeof hoistPlannedRunCommand> {
+  try {
+    return hoistPlannedRunCommand({
+      field: {segments: template},
+      reservedNames,
+    });
+  } catch (error) {
+    if (error instanceof UnsafeRunInterpolationError) {
+      throw stepConfigInterpolationError({definitionId, errorField: 'run'}, error);
+    }
+    throw error;
+  }
+}
+
+function resolveEnv(
+  env: Readonly<Record<string, WinningEnvValue>>,
+  context: WorkflowEvaluationContext,
+  mode: StepConfigMode,
+  definitionId: string,
+): {
+  readonly env: Readonly<Record<string, string>>;
+  readonly configPlan: Readonly<Record<string, ResolvedField>>;
+  readonly diagnostics: readonly WorkflowStepTemplateDiagnostic[];
+  readonly hasTemplates: boolean;
+} {
+  const resolvedEnv: Record<string, string> = {};
+  const configPlan: Record<string, ResolvedField> = {};
+  const diagnostics: WorkflowStepTemplateDiagnostic[] = [];
+  let hasTemplates = false;
+
+  for (const [key, entry] of Object.entries(env)) {
+    const template = entry.template;
+    const hasTemplate = template !== undefined;
+    const usesAuthoredMode = mode === 'authored';
+    const shouldUseAuthoredValue = !hasTemplate || usesAuthoredMode;
+
+    if (shouldUseAuthoredValue) {
+      resolvedEnv[key] = entry.value;
+      hasTemplates ||= hasTemplate;
+      continue;
+    }
+
+    hasTemplates = true;
+    const resolved = resolveStepField({
+      field: 'env.value',
+      template: {segments: template},
+      context,
+      definitionId,
+      errorField: 'env',
+      envKey: key,
+    });
+    const resolvedToDispatchPlan = resolved.kind === 'residual';
+    if (resolvedToDispatchPlan) configPlan[key] = resolved.field;
+    else resolvedEnv[key] = resolved.value;
+    diagnostics.push(
+      ...resolved.diagnostics.map((diagnostic) => ({
+        ...diagnostic,
+        field: 'env' as const,
+        envKey: key,
+      })),
+    );
+  }
+
+  return {env: resolvedEnv, configPlan, diagnostics, hasTemplates};
+}
+
+function winningEnv(params: {
+  readonly workflowEnv: WorkflowModel['env'];
+  readonly workflowEnvTemplates: WorkflowEnvTemplates | undefined;
+  readonly jobEnv: WorkflowModelJob['env'];
+  readonly jobEnvTemplates: WorkflowEnvTemplates | undefined;
+  readonly step: WorkflowModelStep;
+}): Readonly<Record<string, WinningEnvValue>> {
+  if (params.step.kind !== 'run') return {};
+
+  return mergeEnvLayers(
+    {env: params.workflowEnv, templates: params.workflowEnvTemplates},
+    {env: params.jobEnv, templates: params.jobEnvTemplates},
+    {env: params.step.env, templates: params.step.templates?.env},
+  );
+}
+
+function mergeEnvLayers(
+  ...layers: readonly {
+    readonly env: Readonly<Record<string, string>> | undefined;
+    readonly templates: WorkflowEnvTemplates | undefined;
+  }[]
+): Readonly<Record<string, WinningEnvValue>> {
+  const merged: Record<string, WinningEnvValue> = {};
+
+  for (const layer of layers) {
+    for (const [key, value] of Object.entries(layer.env ?? {})) {
+      const template = layer.templates?.[key];
+      const hasTemplate = template !== undefined;
+      merged[key] = hasTemplate ? {value, template} : {value};
+    }
+  }
+
+  return merged;
+}
+
+function readConfigEnv(config: Record<string, unknown>): Record<string, string> {
+  const env = config.env;
+  if (env === null || typeof env !== 'object' || Array.isArray(env)) return {};
+  return Object.fromEntries(
+    Object.entries(env).flatMap(([key, value]) =>
+      typeof value === 'string' ? [[key, value]] : [],
+    ),
+  );
+}

--- a/libs/api/workflows/src/core/step-config/run.ts
+++ b/libs/api/workflows/src/core/step-config/run.ts
@@ -51,7 +51,7 @@ export function resolveRunStepConfig(params: ResolveRunStepConfigParams): RunSte
   const envResolution = resolveEnv(env, params.context, params.mode, params.definitionId);
   const commandResolution = resolveCommand({
     step: params.step,
-    envKeys: Object.keys(envResolution.env),
+    envKeys: [...Object.keys(envResolution.env), ...Object.keys(envResolution.configPlan)],
     context: params.context,
     mode: params.mode,
     definitionId: params.definitionId,


### PR DESCRIPTION
Unify workflow step config resolution across creation and dispatch fill sites.

The creation and dispatch paths had separate field resolution and agent-default completion helpers that implemented the same planner/error-mapping behavior independently. This extracts shared field helpers plus run/env and agent modules, leaving creation and dispatch as thin orchestration layers while preserving the frozen config behavior.

This is intentionally behavior-preserving and prepares the resolver for later evaluation trace instrumentation at a single fill point.

Closes ENG-766

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies workflow step config resolution across creation and dispatch using shared helpers for run/env interpolation and agent defaults. Also reserves deferred env keys during run hoisting to prevent collisions. Closes ENG-766.

- **Refactors**
  - Centralizes logic into `fields` (interpolation/error mapping incl. `step.name`), `run` (env/command resolution and dispatch completion), and `agent` (prompt/model/provider resolution and defaults via `@shipfox/api-agent`) using `@shipfox/expression`.
  - `resolve-step-config` and `complete-step-dispatch-config` now delegate to these modules; preserves frozen-config semantics and authored/effective modes with no breaking changes or migrations.

- **Bug Fixes**
  - Hoisted run-command bindings now reserve both resolved and deferred env config-plan keys so generated names cannot overwrite user env entries.

<sup>Written for commit fbbddc16d48e41fbfb18b4d91f5a0bacc4e292d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

