### PR TITLE
Add workflow runtime error E2E scenarios

### DIFF
--- a/e2e/platform/workflows/README.md
+++ b/e2e/platform/workflows/README.md
@@ -52,6 +52,10 @@ jobs:                    # optional, keyed by job key
       greet:
         status: succeeded
         exit_code: 0     # optional
+        gate_result:     # optional: assert the latest attempt's gate evaluation
+          kind: evaluation_error
+          reason: gate expression evaluation failed
+          exit_code: 0
         error:           # optional: assert the step failed for a specific reason
           reason: config_unresolvable  # step error reason enum
           field: env.VERSION           # exact match on the failing field

--- a/e2e/platform/workflows/scenarios/gate-evaluation-error/expect.yaml
+++ b/e2e/platform/workflows/scenarios/gate-evaluation-error/expect.yaml
@@ -1,0 +1,17 @@
+trigger: push
+run:
+  status: failed
+jobs:
+  build:
+    status: failed
+    status_reason: step_failed
+    steps:
+      gate-error:
+        status: failed
+        exit_code: 0
+        gate_result:
+          kind: evaluation_error
+          reason: gate expression evaluation failed
+          exit_code: 0
+        logs:
+          include: ["gate expression will fail"]

--- a/e2e/platform/workflows/scenarios/gate-evaluation-error/workflow.yml
+++ b/e2e/platform/workflows/scenarios/gate-evaluation-error/workflow.yml
@@ -1,0 +1,15 @@
+name: Gate evaluation error
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: gate-error
+        run: |
+          echo "gate expression will fail"
+        gate:
+          success_if: 1 / 0 == 1

--- a/e2e/platform/workflows/scenarios/output-fail-loud/expect.yaml
+++ b/e2e/platform/workflows/scenarios/output-fail-loud/expect.yaml
@@ -1,0 +1,19 @@
+trigger: push
+run:
+  status: failed
+jobs:
+  build:
+    status: failed
+    status_reason: step_failed
+    steps:
+      produce:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["producer completed without structured outputs"]
+      consume:
+        status: failed
+        error:
+          reason: config_unresolvable
+          field: env.VERSION
+          source: steps.produce.outputs.version

--- a/e2e/platform/workflows/scenarios/output-fail-loud/workflow.yml
+++ b/e2e/platform/workflows/scenarios/output-fail-loud/workflow.yml
@@ -1,0 +1,18 @@
+name: Output fail loud
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: produce
+        run: |
+          echo "producer completed without structured outputs"
+      - key: consume
+        env:
+          VERSION: ${{ steps.produce.outputs.version }}
+        run: |
+          echo "version=$VERSION"

--- a/e2e/platform/workflows/scenarios/output-name-degrade/expect.yaml
+++ b/e2e/platform/workflows/scenarios/output-name-degrade/expect.yaml
@@ -1,0 +1,15 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      produce:
+        status: succeeded
+        exit_code: 0
+      echo name-fallback-ran:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["name-fallback-ran"]

--- a/e2e/platform/workflows/scenarios/output-name-degrade/workflow.yml
+++ b/e2e/platform/workflows/scenarios/output-name-degrade/workflow.yml
@@ -1,0 +1,16 @@
+name: Output name degrade
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: produce
+        run: |
+          echo "producer completed without structured outputs"
+      - name: ${{ steps.produce.outputs.version }}
+        run: |
+          echo name-fallback-ran

--- a/e2e/platform/workflows/src/expect.test.ts
+++ b/e2e/platform/workflows/src/expect.test.ts
@@ -406,6 +406,114 @@ describe('evaluateExpectations', () => {
     ]);
   });
 
+  test('matches gate result details on the latest step attempt', () => {
+    const detail = makeDetail({
+      jobs: [
+        makeJob({
+          job_executions: [
+            makeJobExecution({
+              steps: [
+                makeStep({
+                  attempts: [
+                    makeAttempt({
+                      gate_result: {
+                        kind: 'evaluation_error',
+                        reason: 'gate exploded',
+                        exit_code: 0,
+                      },
+                    }),
+                  ],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    });
+
+    const result = evaluateExpectations(
+      detail,
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {
+          build: {
+            steps: {
+              greet: {
+                gate_result: {
+                  kind: 'evaluation_error',
+                  reason: 'gate exploded',
+                  exit_code: 0,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.mismatches).toEqual([]);
+  });
+
+  test('reports absent and mismatched gate result details', () => {
+    const absent = evaluateExpectations(
+      makeDetail({
+        jobs: [
+          makeJob({
+            job_executions: [
+              makeJobExecution({
+                steps: [makeStep({attempts: []})],
+              }),
+            ],
+          }),
+        ],
+      }),
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {gate_result: {kind: 'evaluation_error'}}}}},
+      }),
+    );
+    const mismatched = evaluateExpectations(
+      makeDetail(),
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {
+          build: {
+            steps: {
+              greet: {
+                gate_result: {
+                  kind: 'evaluation_error',
+                  reason: 'gate expression evaluation failed',
+                  exit_code: 1,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(absent.mismatches).toEqual([
+      {path: 'jobs.build.steps.greet.gate_result', expected: 'present', actual: 'null'},
+    ]);
+    expect(mismatched.mismatches).toEqual([
+      {
+        path: 'jobs.build.steps.greet.gate_result.kind',
+        expected: 'evaluation_error',
+        actual: 'none',
+      },
+      {
+        path: 'jobs.build.steps.greet.gate_result.reason',
+        expected: 'gate expression evaluation failed',
+        actual: 'null',
+      },
+      {
+        path: 'jobs.build.steps.greet.gate_result.exit_code',
+        expected: '1',
+        actual: 'missing',
+      },
+    ]);
+  });
+
   test('reports a missing job and a missing step', () => {
     const missingJob = evaluateExpectations(
       makeDetail(),
@@ -587,6 +695,15 @@ describe('parseExpectation', () => {
       parseExpectation({
         run: {status: 'succeeded'},
         jobs: {build: {steps: {greet: {error: {code: 'config_unresolvable'}}}}},
+      }),
+    ).toThrow();
+  });
+
+  test('rejects unknown nested gate result keys', () => {
+    expect(() =>
+      parseExpectation({
+        run: {status: 'succeeded'},
+        jobs: {build: {steps: {greet: {gate_result: {passed: false}}}}},
       }),
     ).toThrow();
   });

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -1,8 +1,8 @@
 import type {LogRecord} from '@shipfox/api-logs-dto';
 import type {
   JobStatusReasonDto,
-  StepErrorDto,
   StepErrorReasonDto,
+  StepGateResultDto,
   WorkflowRunDetailResponseDto,
   WorkflowRunJobDetailDto,
   WorkflowRunStepDetailDto,
@@ -87,11 +87,30 @@ const stepErrorExpectationSchema = z
   })
   .strict();
 
+const stepGateResultKindSchema = z.enum([
+  'none',
+  'not_evaluated',
+  'passed',
+  'failed',
+  'uncheckable',
+  'evaluation_error',
+  'unknown',
+]);
+
+const stepGateResultExpectationSchema = z
+  .object({
+    kind: stepGateResultKindSchema.optional(),
+    reason: z.string().optional(),
+    exit_code: z.number().int().nullable().optional(),
+  })
+  .strict();
+
 const stepExpectationSchema = z
   .object({
     status: stepStatusSchema.optional(),
     exit_code: z.number().int().optional(),
     error: stepErrorExpectationSchema.optional(),
+    gate_result: stepGateResultExpectationSchema.optional(),
     logs: logsExpectationSchema.optional(),
   })
   .strict();
@@ -177,9 +196,21 @@ function latestExitCode(step: WorkflowRunStepDetailDto): number | null {
   return attempt?.exit_code ?? null;
 }
 
-function stringField(value: NonNullable<StepErrorDto>, field: string): string | null {
+function latestGateResult(step: WorkflowRunStepDetailDto): StepGateResultDto | null {
+  const current = step.attempts.find((attempt) => attempt.attempt === step.current_attempt);
+  const attempt = current ?? step.attempts.at(-1);
+  return attempt?.gate_result ?? null;
+}
+
+function stringField(value: Record<string, unknown>, field: string): string | null {
   const fieldValue = (value as Record<string, unknown>)[field];
   return typeof fieldValue === 'string' ? fieldValue : null;
+}
+
+function intOrNullField(value: Record<string, unknown>, field: string): number | null | undefined {
+  const fieldValue = value[field];
+  if (fieldValue === null) return null;
+  return typeof fieldValue === 'number' && Number.isInteger(fieldValue) ? fieldValue : undefined;
 }
 
 /**
@@ -294,6 +325,58 @@ export function evaluateExpectations(
                 path: `${stepPath}.error.source`,
                 expected: `include ${stepExpectation.error.source}`,
                 actual: source ?? 'null',
+              });
+            }
+          }
+        }
+      }
+
+      if (stepExpectation.gate_result) {
+        const gateResult = latestGateResult(step);
+        if (gateResult === null) {
+          mismatches.push({
+            path: `${stepPath}.gate_result`,
+            expected: 'present',
+            actual: 'null',
+          });
+        } else {
+          if (
+            stepExpectation.gate_result.kind !== undefined &&
+            gateResult.kind !== stepExpectation.gate_result.kind
+          ) {
+            mismatches.push({
+              path: `${stepPath}.gate_result.kind`,
+              expected: stepExpectation.gate_result.kind,
+              actual: gateResult.kind,
+            });
+          }
+
+          if (stepExpectation.gate_result.reason !== undefined) {
+            const reason = stringField(gateResult, 'reason');
+            if (reason !== stepExpectation.gate_result.reason) {
+              mismatches.push({
+                path: `${stepPath}.gate_result.reason`,
+                expected: stepExpectation.gate_result.reason,
+                actual: reason ?? 'null',
+              });
+            }
+          }
+
+          if (stepExpectation.gate_result.exit_code !== undefined) {
+            const exitCode = intOrNullField(gateResult, 'exit_code');
+            if (exitCode !== stepExpectation.gate_result.exit_code) {
+              mismatches.push({
+                path: `${stepPath}.gate_result.exit_code`,
+                expected:
+                  stepExpectation.gate_result.exit_code === null
+                    ? 'null'
+                    : String(stepExpectation.gate_result.exit_code),
+                actual:
+                  exitCode === undefined
+                    ? 'missing'
+                    : exitCode === null
+                      ? 'null'
+                      : String(exitCode),
               });
             }
           }


### PR DESCRIPTION
Seed declarative platform workflow scenarios for the runtime error policies in the workflow resolution engine: gate evaluation errors fail closed, missing step outputs fail value fields loudly, and missing step outputs degrade display names.

The scenarios rely on the expect.yaml error/status-reason grammar from ENG-771 and the dispatch-time step output resolution path from ENG-751. This also extends the E2E expectation language with a small `gate_result` assertion so the gate evaluation-error case can assert the public run-detail DTO instead of depending only on step status.

No changeset is included because the touched package is private E2E coverage.

Closes ENG-774

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add E2E workflow scenarios for runtime error policies and extend the expectation DSL to assert gate results. Implements ENG-774; aligns with the error grammar from ENG-771 and the dispatch-time output resolution from ENG-751.

- New Features
  - Added scenarios: gate evaluation error (fail-closed), output fail loud (config error on missing output), and output name degrade (fallback display name).
  - Extended expect.yaml with gate_result on steps (kind, reason, exit_code), evaluated on the latest attempt.
  - Added tests for matching, absent, and mismatched gate_result; reject unknown gate_result keys.
  - Updated README with a gate_result example.

<sup>Written for commit b9d1599de0a99886f0bafd4ee0b6da5d43c51bd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

