### PR TITLE
Pin the shared Ollama model in memory for agent E2E runs

### DIFF
--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -127,6 +127,11 @@ function startServer(context) {
       env: {
         ...process.env,
         OLLAMA_HOST: context.listenHost,
+        // Pin the model in memory for the whole run. Requests that omit
+        // keep_alive (such as the app's provider validation probe) fall back to
+        // this server default instead of the built-in 5m, so the model is not
+        // evicted and cold-reloaded under load mid-suite.
+        OLLAMA_KEEP_ALIVE: context.keepAlive,
       },
       stdio: ['ignore', log, log],
     },


### PR DESCRIPTION
Deflake the `@shipfox/e2e-client-agent` custom-model-provider "Test & save" scenario, which intermittently failed with `expect((await saveResponse).ok()).toBe(true)` returning a 422.

That save runs a live provider-validation probe against the shared Ollama server. The probe (`probeCustomModelProviderCredentials`) sends no `keep_alive`, so it falls back to Ollama's built-in 5-minute server default. `ollama:up` preloads the model, but only with a per-request `keep_alive`, which the first no-keep_alive request resets. Since the full `turbo test:e2e` run executes many suites before the agent one (well past 5 minutes), the model was evicted and had to cold-reload during the suite's first probe, exactly when the API/client dev servers and chromium are competing for memory. That cold-reload-under-pressure is what intermittently errored into a 422.

Set `OLLAMA_KEEP_ALIVE` on the `ollama serve` process to the configured keep-alive (default `24h`). This changes the server default for *all* requests, including the app's no-keep_alive probe, so once `ollama:up` loads the model it stays pinned for the whole run and never cold-reloads under load.

This is centralized in `dev/shared-ollama.mjs` so CI and local dev both get it, reuses the existing `context.keepAlive` value (configurable via `SHIPFOX_OLLAMA_KEEP_ALIVE`), and auto-releases after a day locally. I considered warming the model in the agent suite's global setup, but the server-side keep-alive is more deterministic and subsumes it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the shared Ollama model in memory for agent E2E runs by setting `OLLAMA_KEEP_ALIVE` on `ollama serve`, preventing cold reloads and fixing flaky 422s in the `@shipfox/e2e-client-agent` “Test & save” probe.

- **Bug Fixes**
  - Set `OLLAMA_KEEP_ALIVE: context.keepAlive` in `dev/shared-ollama.mjs` so requests without `keep_alive` use a long server default (24h by default).
  - Keeps the model hot across the full `turbo test:e2e` run; no eviction between suites.
  - Applies to CI and local; configurable via `SHIPFOX_OLLAMA_KEEP_ALIVE`.

<sup>Written for commit eb70fc4fa262d1f72fc13132484030f3a0c33361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

