### PR TITLE
[agent] Add custom provider key intent signal

### DIFF
--- a/libs/api/agent-dto/src/schemas/custom-model-provider.test.ts
+++ b/libs/api/agent-dto/src/schemas/custom-model-provider.test.ts
@@ -3,6 +3,7 @@ import {
   customAgentModelSchema,
   customModelProviderConfigDtoSchema,
   customModelProviderHeaderRequestSchema,
+  customModelProviderRuntimeConfigSchema,
   discoverCustomModelProviderModelsBodySchema,
   discoverCustomModelProviderModelsBySlugBodySchema,
   discoverCustomModelProviderModelsResponseSchema,
@@ -240,6 +241,20 @@ describe('custom model provider schemas', () => {
     });
 
     expect(parsed.secret_header_names).toEqual(['authorization']);
+    expect('requires_api_key' in parsed).toBe(false);
+  });
+
+  it('requires key intent on custom provider runtime descriptors', () => {
+    const parsed = customModelProviderRuntimeConfigSchema.parse({
+      api: 'openai-responses',
+      base_url: 'https://llm.example.test/v1',
+      headers: [{name: 'x-region', value: 'local'}],
+      secret_header_names: ['authorization'],
+      models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requires_api_key: false,
+    });
+
+    expect(parsed.requires_api_key).toBe(false);
   });
 
   it('parses discovery request and response DTOs', () => {

--- a/libs/api/agent-dto/src/schemas/custom-model-provider.ts
+++ b/libs/api/agent-dto/src/schemas/custom-model-provider.ts
@@ -182,7 +182,7 @@ export type DiscoverCustomModelProviderModelsResponseDto = z.infer<
   typeof discoverCustomModelProviderModelsResponseSchema
 >;
 
-export const customModelProviderRuntimeConfigSchema = z.object({
+const customModelProviderConfigBaseSchema = z.object({
   api: modelProviderApiSchema,
   base_url: z.string().url().max(2048),
   headers: customModelProviderHeadersDtoSchema,
@@ -193,11 +193,15 @@ export const customModelProviderRuntimeConfigSchema = z.object({
   models: customModelProviderModelsSchema,
 });
 
+export const customModelProviderRuntimeConfigSchema = customModelProviderConfigBaseSchema.extend({
+  requires_api_key: z.boolean(),
+});
+
 export type CustomModelProviderRuntimeConfigDto = z.infer<
   typeof customModelProviderRuntimeConfigSchema
 >;
 
-export const customModelProviderConfigDtoSchema = customModelProviderRuntimeConfigSchema.extend({
+export const customModelProviderConfigDtoSchema = customModelProviderConfigBaseSchema.extend({
   kind: z.literal('custom'),
   provider_id: modelProviderRefSchema,
   display_name: z.string().min(1).max(120),

--- a/libs/api/agent-dto/src/schemas/runtime-config.test.ts
+++ b/libs/api/agent-dto/src/schemas/runtime-config.test.ts
@@ -24,11 +24,31 @@ describe('agentRuntimeCredentialsResponseSchema', () => {
         headers: [{name: 'x-region', value: 'local'}],
         secret_header_names: ['authorization'],
         models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+        requires_api_key: true,
       },
     });
 
     expect(parsed.provider_id).toBe('local-vllm');
     expect(parsed.custom_provider?.api).toBe('openai-responses');
+  });
+
+  it('rejects a custom model provider descriptor without key intent', () => {
+    const parse = () =>
+      agentRuntimeCredentialsResponseSchema.parse({
+        provider_id: 'local-vllm',
+        model: 'llama-3.1',
+        thinking: 'high',
+        credentials: {api_key: 'secret'},
+        custom_provider: {
+          api: 'openai-responses',
+          base_url: 'https://llm.example.test/v1',
+          headers: [],
+          secret_header_names: [],
+          models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+        },
+      });
+
+    expect(parse).toThrow();
   });
 
   it('rejects custom model provider runtime credentials without a custom model provider descriptor', () => {

--- a/libs/api/agent/drizzle/0000_daffy_leopardon.sql
+++ b/libs/api/agent/drizzle/0000_daffy_leopardon.sql
@@ -10,6 +10,7 @@ CREATE TABLE "model_provider_configs" (
 	"headers" jsonb,
 	"secret_header_names" jsonb,
 	"models" jsonb,
+	"requires_api_key" boolean DEFAULT false NOT NULL,
 	"default_model" text,
 	"default_thinking" text NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,

--- a/libs/api/agent/drizzle/meta/0000_snapshot.json
+++ b/libs/api/agent/drizzle/meta/0000_snapshot.json
@@ -70,6 +70,13 @@
           "primaryKey": false,
           "notNull": false
         },
+        "requires_api_key": {
+          "name": "requires_api_key",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "false"
+        },
         "default_model": {
           "name": "default_model",
           "type": "text",

--- a/libs/api/agent/src/core/custom-model-provider-config-service.ts
+++ b/libs/api/agent/src/core/custom-model-provider-config-service.ts
@@ -113,6 +113,7 @@ export async function createCustomModelProviderConfig(
     headers: splitHeaders.plaintextHeaders,
     secretHeaderNames: splitHeaders.secretHeaderNames,
     models: params.body.models,
+    requiresApiKey: params.body.api_key !== undefined,
     defaultModel: params.body.default_model ?? null,
     defaultThinking: DEFAULT_AGENT_THINKING,
     setAsDefault: params.setAsDefault,
@@ -221,6 +222,7 @@ export async function updateCustomModelProviderConfig(
       headers: nextHeaders.plaintextHeaders,
       secretHeaderNames: nextHeaders.secretHeaderNames,
       models: nextModels,
+      requiresApiKey: existing.requiresApiKey || params.body.api_key !== undefined,
       defaultModel: nextDefaultModel,
       defaultThinking: existing.defaultThinking,
     });

--- a/libs/api/agent/src/core/entities/model-provider-config.ts
+++ b/libs/api/agent/src/core/entities/model-provider-config.ts
@@ -17,6 +17,7 @@ export interface ModelProviderConfig {
   headers: CustomModelProviderHeaderDto[] | null;
   secretHeaderNames: string[] | null;
   models: CustomAgentModelDto[] | null;
+  requiresApiKey: boolean;
   defaultModel: string | null;
   defaultThinking: AgentThinking;
   createdAt: Date;

--- a/libs/api/agent/src/core/model-provider-config-service.test.ts
+++ b/libs/api/agent/src/core/model-provider-config-service.test.ts
@@ -514,6 +514,29 @@ describe('custom model provider config service', () => {
     await expect(duplicate).rejects.toThrow(CustomModelProviderSlugCollisionError);
     const stored = await getModelProviderConfig({workspaceId, providerId: 'local-vllm'});
     expect(stored?.id).toBe(first.id);
+    expect(stored?.requiresApiKey).toBe(true);
+  });
+
+  it('stores custom provider key intent from create bodies', async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+
+    const keyed = await createCustomModelProviderConfig(
+      {
+        workspaceId,
+        body: createCustomBody({slug: 'keyed-provider', api_key: 'sk-keyed'}),
+      },
+      {probe},
+    );
+    const keyless = await createCustomModelProviderConfig(
+      {
+        workspaceId,
+        body: createCustomBody({slug: 'keyless-provider', api_key: undefined}),
+      },
+      {probe},
+    );
+
+    expect(keyed.requiresApiKey).toBe(true);
+    expect(keyless.requiresApiKey).toBe(false);
   });
 
   it('does not let concurrent duplicate custom creates overwrite the winner secrets', async () => {
@@ -596,6 +619,29 @@ describe('custom model provider config service', () => {
     expect(secrets).toEqual({API_KEY: 'sk-local-original', HEADER_782D726567696F6E: 'eu'});
     expect(updated.headers).toEqual([{name: 'x-plain', value: 'plain'}]);
     expect(updated.secretHeaderNames).toEqual(['x-region']);
+    expect(updated.requiresApiKey).toBe(true);
+  });
+
+  it('marks a keyless custom provider as requiring a key when an api key is added', async () => {
+    const probe = vi.fn().mockResolvedValue(undefined);
+    await createCustomModelProviderConfig(
+      {
+        workspaceId,
+        body: createCustomBody({api_key: undefined}),
+      },
+      {probe},
+    );
+
+    const updated = await updateCustomModelProviderConfig(
+      {
+        workspaceId,
+        providerId: 'local-vllm',
+        body: {api_key: 'sk-local-added'},
+      },
+      {probe},
+    );
+
+    expect(updated.requiresApiKey).toBe(true);
   });
 
   it('rolls back custom provider secrets when config update persistence fails', async () => {

--- a/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.test.ts
@@ -87,6 +87,7 @@ describe('resolveRuntimeCredentials', () => {
       baseUrl: 'http://127.0.0.1:11434/v1',
       headers: [{name: 'x-region', value: 'local'}],
       models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requiresApiKey: true,
       credentials: {api_key: 'sk-local-secret', 'header:authorization': 'Bearer local'},
     });
 
@@ -108,6 +109,37 @@ describe('resolveRuntimeCredentials', () => {
         headers: [{name: 'x-region', value: 'local'}],
         secret_header_names: ['authorization'],
         models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+        requires_api_key: true,
+      },
+    });
+  });
+
+  it('returns keyless custom provider runtime descriptors for keyless custom rows', async () => {
+    await saveProviderConfig({
+      workspaceId,
+      providerId: 'local-ollama',
+      kind: 'custom',
+      displayName: 'Local Ollama',
+      api: 'openai-responses',
+      baseUrl: 'http://127.0.0.1:11434/v1',
+      headers: [],
+      models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requiresApiKey: false,
+      credentials: {},
+    });
+
+    const result = await resolveRuntimeCredentials({
+      workspaceId,
+      provider: 'local-ollama',
+      model: 'llama-3.1',
+      thinking: 'high',
+    });
+
+    expect(result).toMatchObject({
+      provider_id: 'local-ollama',
+      credentials: {},
+      custom_provider: {
+        requires_api_key: false,
       },
     });
   });
@@ -236,6 +268,7 @@ async function saveProviderConfig(params: {
   baseUrl?: string | undefined;
   headers?: {name: string; value: string}[] | undefined;
   models?: {id: string; label: string}[] | undefined;
+  requiresApiKey?: boolean | undefined;
   credentials: Record<string, string>;
 }) {
   await setSecrets({
@@ -255,6 +288,7 @@ async function saveProviderConfig(params: {
     baseUrl: params.baseUrl,
     headers: params.headers,
     models: params.models,
+    requiresApiKey: params.requiresApiKey,
     defaultModel: null,
     defaultThinking: 'high',
   });

--- a/libs/api/agent/src/core/resolve-runtime-credentials.ts
+++ b/libs/api/agent/src/core/resolve-runtime-credentials.ts
@@ -136,6 +136,7 @@ function toResponse(
         .map((key) => key.slice('header:'.length))
         .sort(),
       models: providerConfig.models ?? [],
+      requires_api_key: providerConfig.requiresApiKey,
     };
   }
 

--- a/libs/api/agent/src/db/model-provider-configs.test.ts
+++ b/libs/api/agent/src/db/model-provider-configs.test.ts
@@ -42,6 +42,7 @@ describe('model provider configs', () => {
       baseUrl: null,
       headers: null,
       models: null,
+      requiresApiKey: false,
     });
     expect(found?.createdAt).toBeInstanceOf(Date);
     expect(found?.updatedAt).toBeInstanceOf(Date);
@@ -173,6 +174,7 @@ describe('model provider configs', () => {
       headers: [{name: 'x-region', value: 'local'}],
       secretHeaderNames: ['authorization'],
       models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requiresApiKey: true,
       defaultModel: 'llama-3.1',
       defaultThinking: 'high',
     });
@@ -190,6 +192,7 @@ describe('model provider configs', () => {
       headers: [{name: 'x-region', value: 'local'}],
       secretHeaderNames: ['authorization'],
       models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requiresApiKey: true,
       defaultModel: 'llama-3.1',
     });
     expect(found?.headers).not.toContainEqual({
@@ -209,6 +212,7 @@ describe('model provider configs', () => {
       headers: [{name: 'x-region', value: 'local'}],
       secretHeaderNames: ['authorization'],
       models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requiresApiKey: true,
       defaultModel: 'llama-3.1',
       defaultThinking: 'high',
     });
@@ -228,6 +232,7 @@ describe('model provider configs', () => {
       headers: [{name: 'x-region', value: 'local'}],
       secretHeaderNames: ['authorization'],
       models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+      requiresApiKey: true,
       defaultModel: null,
       defaultThinking: 'medium',
     });

--- a/libs/api/agent/src/db/model-provider-configs.ts
+++ b/libs/api/agent/src/db/model-provider-configs.ts
@@ -21,6 +21,7 @@ export interface UpsertModelProviderConfigParams {
   headers?: CustomModelProviderHeaderDto[] | null | undefined;
   secretHeaderNames?: string[] | null | undefined;
   models?: CustomAgentModelDto[] | null | undefined;
+  requiresApiKey?: boolean | undefined;
   defaultModel: string | null;
   defaultThinking: AgentThinking;
   setAsDefault?: boolean | undefined;
@@ -28,8 +29,8 @@ export interface UpsertModelProviderConfigParams {
 
 export type InsertCustomModelProviderConfigParams = Omit<
   UpsertModelProviderConfigParams,
-  'kind'
-> & {kind: 'custom'};
+  'kind' | 'requiresApiKey'
+> & {kind: 'custom'; requiresApiKey: boolean};
 
 export async function insertCustomModelProviderConfig(
   params: InsertCustomModelProviderConfigParams,
@@ -47,6 +48,7 @@ export async function insertCustomModelProviderConfig(
         headers: params.headers,
         secretHeaderNames: params.secretHeaderNames,
         models: params.models,
+        requiresApiKey: params.requiresApiKey,
         defaultModel: params.defaultModel,
         defaultThinking: params.defaultThinking,
       })
@@ -96,6 +98,7 @@ export async function upsertModelProviderConfig(
           ? {secretHeaderNames: params.secretHeaderNames}
           : {}),
         ...(params.models !== undefined ? {models: params.models} : {}),
+        ...(params.requiresApiKey !== undefined ? {requiresApiKey: params.requiresApiKey} : {}),
         defaultModel: params.defaultModel,
         defaultThinking: params.defaultThinking,
       })
@@ -111,6 +114,7 @@ export async function upsertModelProviderConfig(
             ? {secretHeaderNames: params.secretHeaderNames}
             : {}),
           ...(params.models !== undefined ? {models: params.models} : {}),
+          ...(params.requiresApiKey !== undefined ? {requiresApiKey: params.requiresApiKey} : {}),
           defaultModel: params.defaultModel,
           defaultThinking: params.defaultThinking,
           updatedAt: sql`NOW()`,

--- a/libs/api/agent/src/db/schema/model-provider-configs.ts
+++ b/libs/api/agent/src/db/schema/model-provider-configs.ts
@@ -8,6 +8,7 @@ import type {
 import {uuidv7PrimaryKey} from '@shipfox/node-drizzle';
 import {sql} from 'drizzle-orm';
 import {
+  boolean,
   check,
   jsonb,
   pgEnum,
@@ -37,6 +38,7 @@ export const modelProviderConfigs = pgTable(
     headers: jsonb('headers').$type<CustomModelProviderHeaderDto[]>(),
     secretHeaderNames: jsonb('secret_header_names').$type<string[]>(),
     models: jsonb('models').$type<CustomAgentModelDto[]>(),
+    requiresApiKey: boolean('requires_api_key').notNull().default(false),
     defaultModel: text('default_model'),
     defaultThinking: text('default_thinking').notNull(),
     createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
@@ -69,6 +71,7 @@ export function toModelProviderConfig(row: ModelProviderConfigDb): ModelProvider
     headers: row.headers,
     secretHeaderNames: row.secretHeaderNames,
     models: row.models,
+    requiresApiKey: row.requiresApiKey,
     defaultModel: row.defaultModel,
     defaultThinking: row.defaultThinking as AgentThinking,
     createdAt: row.createdAt,

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.test.ts
@@ -212,6 +212,7 @@ describe('GET /runs/jobs/current/agent-runtime-config', () => {
         base_url: 'http://127.0.0.1:11434/v1',
         secret_header_names: ['authorization'],
         models: [{id: 'llama-3.1', label: 'Llama 3.1'}],
+        requires_api_key: true,
       },
     });
   });

--- a/libs/runner/agent/src/core/run-agent.test.ts
+++ b/libs/runner/agent/src/core/run-agent.test.ts
@@ -92,6 +92,7 @@ function customProvider(
     headers: [{name: 'x-plain', value: 'plain'}],
     secret_header_names: ['x-secret'],
     models: [{id: 'custom-gpt', label: 'Custom GPT'}],
+    requires_api_key: false,
     ...overrides,
   };
 }
@@ -170,7 +171,7 @@ describe('runAgent', () => {
         provider: 'ollama-workspace',
         model: 'custom-gpt',
         credentials: {api_key: 'sk-custom', 'header:x-secret': 'secret-header'},
-        customProvider: customProvider(),
+        customProvider: customProvider({requires_api_key: true}),
       }),
     );
 
@@ -191,6 +192,42 @@ describe('runAgent', () => {
     );
     expect(findMock).toHaveBeenCalledWith('ollama-workspace', 'custom-gpt');
     expect(createAgentSessionMock).toHaveBeenCalledWith(expect.objectContaining({model}));
+  });
+
+  it('rejects keyed custom providers when no api key is resolved', async () => {
+    const result = runAgent(
+      invocation({
+        provider: 'workspace-models',
+        model: 'custom-gpt',
+        credentials: {},
+        customProvider: customProvider({requires_api_key: true}),
+      }),
+    );
+
+    await expect(result).rejects.toMatchObject({
+      name: 'AgentConfigError',
+      agentConfigIssue: 'credentials_invalid',
+    });
+    expect(registerProviderMock).not.toHaveBeenCalled();
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects keyed custom providers when an empty api key is resolved', async () => {
+    const result = runAgent(
+      invocation({
+        provider: 'workspace-models',
+        model: 'custom-gpt',
+        credentials: {api_key: ''},
+        customProvider: customProvider({requires_api_key: true}),
+      }),
+    );
+
+    await expect(result).rejects.toMatchObject({
+      name: 'AgentConfigError',
+      agentConfigIssue: 'credentials_invalid',
+    });
+    expect(registerProviderMock).not.toHaveBeenCalled();
+    expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 
   it('registers keyless custom providers with a placeholder api key', async () => {

--- a/libs/runner/agent/src/core/run-agent.ts
+++ b/libs/runner/agent/src/core/run-agent.ts
@@ -155,12 +155,14 @@ async function registerCustomProvider(
     throw error;
   }
 
+  const apiKey = customProviderApiKey(provider, customProvider, credentials);
+
   try {
     modelRegistry.registerProvider(provider, {
       name: provider,
       baseUrl: customProvider.base_url,
       api: customProvider.api,
-      apiKey: customProviderApiKey(credentials),
+      apiKey,
       headers: customProviderHeaders(customProvider, credentials),
       models: customProvider.models.map((model) => toPiCustomProviderModel(customProvider, model)),
     });
@@ -173,9 +175,19 @@ async function registerCustomProvider(
   }
 }
 
-function customProviderApiKey(credentials: Record<string, string>): string {
+function customProviderApiKey(
+  provider: string,
+  customProvider: CustomModelProviderRuntimeConfigDto,
+  credentials: Record<string, string>,
+): string {
   const apiKey = credentials.api_key;
-  return apiKey === undefined || apiKey === '' ? KEYLESS_CUSTOM_PROVIDER_API_KEY : apiKey;
+  if (!customProvider.requires_api_key) return KEYLESS_CUSTOM_PROVIDER_API_KEY;
+  if (apiKey !== undefined && apiKey !== '') return apiKey;
+
+  throw new AgentConfigError(
+    `Custom model provider "${provider}" requires an API key but none was resolved.`,
+    'credentials_invalid',
+  );
 }
 
 function customProviderHeaders(

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -86,6 +86,7 @@ describe('executeAgentStep', () => {
       headers: [{name: 'x-plain', value: 'plain'}],
       secret_header_names: ['x-secret'],
       models: [{id: 'custom-gpt', label: 'Custom GPT'}],
+      requires_api_key: true,
     };
 
     await executeAgentStep(buildAgentStep({config: {prompt: 'p'}}), {

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -776,6 +776,7 @@ describe('runJobSteps', () => {
       headers: [{name: 'x-plain', value: 'plain'}],
       secret_header_names: ['x-secret'],
       models: [{id: 'custom-gpt', label: 'Custom GPT'}],
+      requires_api_key: true,
     };
     requestAgentRuntimeConfigMock.mockResolvedValueOnce({
       provider_id: 'workspace-models',


### PR DESCRIPTION
Add an explicit API-key requirement signal to custom model provider runtime descriptors.

Custom providers previously used missing `api_key` credentials as the signal for keyless operation. That made a genuinely keyless provider indistinguishable from a keyed provider whose secret failed to resolve. This persists the provider's key intent on the config row, surfaces it as `requires_api_key` in the runtime descriptor, and has the runner reject keyed providers with unresolved keys as `credentials_invalid` while still allowing explicitly keyless providers to use the placeholder key required by pi.

The read DTO intentionally stays unchanged so client-facing custom provider config responses do not expose the runtime-only field. The baseline agent migration and snapshot are folded forward because the platform is still pre-deployment.

Reviewers should look closely at the descriptor schema split and the update path: once a provider is marked keyed, unrelated updates keep it keyed even if the stored secret bag is incomplete.

Fixes ENG-754

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit `requires_api_key` flag to custom model provider runtime descriptors so the runner can distinguish true keyless providers from keyed providers with missing secrets and return precise `credentials_invalid` errors. Addresses Linear ENG-754 by making key intent explicit and avoiding “absence means keyless” ambiguity.

- **New Features**
  - Persist provider key intent in DB as `requires_api_key` and include it in runtime descriptors; config read DTOs remain unchanged.
  - Creation/update rules: setting `api_key` marks a provider as keyed; once keyed, it stays keyed across unrelated updates.
  - Runner behavior: rejects keyed custom providers with missing/empty API key (`credentials_invalid`); still registers explicitly keyless providers with the placeholder key.

<sup>Written for commit f76689c00de9ba57578e3f2b245f08b6a98d1223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

