### PR TITLE
Cap CI E2E Turbo concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
     name: E2E tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      SHIPFOX_TURBO_CONCURRENCY: "2"
 
     steps:
       - name: Check out repository

--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -10,6 +10,7 @@ const defaultApiUrl = 'http://localhost:16101';
 const defaultClientUrl = 'http://localhost:5173';
 const defaultReadinessTimeoutMs = 60_000;
 const defaultShutdownTimeoutMs = 15_000;
+const defaultTurboConcurrency = '2';
 const defaultTurboTask = 'test:e2e';
 const trailingSlashPattern = /\/$/;
 
@@ -74,7 +75,7 @@ export async function main(argv) {
     });
     await waitForUrl(env.CLIENT_URL, {timeoutMs: options.readinessTimeoutMs});
 
-    const result = spawnSync('turbo', [options.turboTask, ...options.turboArgs], {
+    const result = spawnSync('turbo', turboCommandArgs(options, env), {
       env,
       stdio: 'inherit',
     });
@@ -179,9 +180,22 @@ export function e2eEnv(sourceEnv) {
     E2E_GITEA_URL: giteaUrl,
     GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
     HOST: sourceEnv.HOST ?? '0.0.0.0',
+    SHIPFOX_TURBO_CONCURRENCY: sourceEnv.SHIPFOX_TURBO_CONCURRENCY ?? defaultTurboConcurrency,
     VITE_API_URL: sourceEnv.VITE_API_URL ?? apiUrl,
     VITE_ENABLE_TEST_VCS_PROVIDER: sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER ?? 'true',
   };
+}
+
+export function turboCommandArgs(options, env) {
+  const args = [options.turboTask, ...options.turboArgs];
+  if (hasTurboConcurrency(args)) return args;
+
+  const concurrency = env.SHIPFOX_TURBO_CONCURRENCY;
+  return concurrency ? [...args, `--concurrency=${concurrency}`] : args;
+}
+
+function hasTurboConcurrency(args) {
+  return args.some((arg) => arg === '--concurrency' || arg.startsWith('--concurrency='));
 }
 
 export function defaultLogDir(env) {

--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -10,7 +10,6 @@ const defaultApiUrl = 'http://localhost:16101';
 const defaultClientUrl = 'http://localhost:5173';
 const defaultReadinessTimeoutMs = 60_000;
 const defaultShutdownTimeoutMs = 15_000;
-const defaultTurboConcurrency = '2';
 const defaultTurboTask = 'test:e2e';
 const trailingSlashPattern = /\/$/;
 
@@ -180,7 +179,6 @@ export function e2eEnv(sourceEnv) {
     E2E_GITEA_URL: giteaUrl,
     GITEA_CLONE_BASE_URL: sourceEnv.GITEA_CLONE_BASE_URL ?? giteaUrl,
     HOST: sourceEnv.HOST ?? '0.0.0.0',
-    SHIPFOX_TURBO_CONCURRENCY: sourceEnv.SHIPFOX_TURBO_CONCURRENCY ?? defaultTurboConcurrency,
     VITE_API_URL: sourceEnv.VITE_API_URL ?? apiUrl,
     VITE_ENABLE_TEST_VCS_PROVIDER: sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER ?? 'true',
   };

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -63,7 +63,7 @@ describe('e2eEnv', () => {
     assert.equal(env.CLIENT_URL, 'http://localhost:55350');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:55356');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
-    assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, '2');
+    assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, undefined);
     assert.equal(env.VITE_API_URL, 'http://localhost:55351');
   });
 
@@ -93,7 +93,7 @@ describe('e2eEnv', () => {
 });
 
 describe('turboCommandArgs', () => {
-  test('caps E2E turbo concurrency from the environment', () => {
+  test('uses E2E turbo concurrency from the environment', () => {
     const args = turboCommandArgs(
       {
         turboArgs: ['--filter=@shipfox/e2e-client-agent'],
@@ -107,6 +107,18 @@ describe('turboCommandArgs', () => {
       '--filter=@shipfox/e2e-client-agent',
       '--concurrency=2',
     ]);
+  });
+
+  test('keeps turbo default concurrency without an environment override', () => {
+    const args = turboCommandArgs(
+      {
+        turboArgs: ['--filter=@shipfox/e2e-client-agent'],
+        turboTask: 'test:e2e',
+      },
+      {},
+    );
+
+    assert.deepEqual(args, ['test:e2e', '--filter=@shipfox/e2e-client-agent']);
   });
 
   test('does not override explicit turbo concurrency', () => {

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -3,7 +3,13 @@ import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {describe, test} from 'node:test';
-import {copyPlaywrightTestResults, defaultLogDir, e2eEnv, parseArgs} from './e2e.mjs';
+import {
+  copyPlaywrightTestResults,
+  defaultLogDir,
+  e2eEnv,
+  parseArgs,
+  turboCommandArgs,
+} from './e2e.mjs';
 
 const unknownCommandPattern = /Unknown command/;
 
@@ -57,6 +63,7 @@ describe('e2eEnv', () => {
     assert.equal(env.CLIENT_URL, 'http://localhost:55350');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:55356');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
+    assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, '2');
     assert.equal(env.VITE_API_URL, 'http://localhost:55351');
   });
 
@@ -74,6 +81,56 @@ describe('e2eEnv', () => {
     assert.equal(env.CLIENT_URL, 'http://localhost:5173');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:3001');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:3000');
+  });
+
+  test('keeps explicit turbo concurrency', () => {
+    const env = e2eEnv({
+      SHIPFOX_TURBO_CONCURRENCY: '3',
+    });
+
+    assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, '3');
+  });
+});
+
+describe('turboCommandArgs', () => {
+  test('caps E2E turbo concurrency from the environment', () => {
+    const args = turboCommandArgs(
+      {
+        turboArgs: ['--filter=@shipfox/e2e-client-agent'],
+        turboTask: 'test:e2e',
+      },
+      {SHIPFOX_TURBO_CONCURRENCY: '2'},
+    );
+
+    assert.deepEqual(args, [
+      'test:e2e',
+      '--filter=@shipfox/e2e-client-agent',
+      '--concurrency=2',
+    ]);
+  });
+
+  test('does not override explicit turbo concurrency', () => {
+    const args = turboCommandArgs(
+      {
+        turboArgs: ['--concurrency=4'],
+        turboTask: 'test:e2e',
+      },
+      {SHIPFOX_TURBO_CONCURRENCY: '2'},
+    );
+
+    assert.deepEqual(args, ['test:e2e', '--concurrency=4']);
+  });
+
+  test('supports turbo concurrency passed as a separate value', () => {
+    const args = turboCommandArgs(
+      {
+        turboArgs: ['--concurrency', '4'],
+        turboTask: 'test:e2e',
+      },
+      {SHIPFOX_TURBO_CONCURRENCY: '2'},
+    );
+
+    assert.deepEqual(args, ['test:e2e', '--concurrency', '4']);
   });
 });
 


### PR DESCRIPTION
Expose a `SHIPFOX_TURBO_CONCURRENCY` knob in the E2E harness and set it to `2` in the GitHub Actions E2E job.

The Ollama-backed custom provider validation runs a live inference during E2E. On `ubuntu-latest`, the previous CI path let Turbo use its default concurrency while Docker services, dev servers, Chromium, and Ollama all shared the same runner, which could make the provider validation probe intermittently return 422 under load.

The harness now threads `SHIPFOX_TURBO_CONCURRENCY` into Turbo only when the environment sets it, while preserving explicit `--concurrency` overrides. Local dev runs without that env var keep Turbo's normal default concurrency; CI opts into the lower cap.

Closes ENG-779