### PR TITLE
[swc] Resolve # subpath imports to relative paths in dist

### DIFF
--- a/.changeset/swc-resolve-hash-imports.md
+++ b/.changeset/swc-resolve-hash-imports.md
@@ -1,0 +1,12 @@
+---
+"@shipfox/swc": minor
+---
+
+Resolve `#` subpath imports to relative paths in the build output. SWC preserves
+`#` specifiers verbatim, so a built `dist/index.js` kept `#schemas/index.js`,
+which the `imports` map points at `./src/*` and a plain Node ESM resolver (for
+example Playwright or a dist-only image) cannot load. After emitting `dist/`,
+`shipfox-swc` now rewrites every `#` specifier (in `from`, side-effect, and
+dynamic imports) to a relative path such as `./schemas/index.js`, driven by the
+package's own `imports` map. Only string targets are rewritten; conditional
+targets are left as-is because they already declare their own runtime resolution.

--- a/tools/swc/README.md
+++ b/tools/swc/README.md
@@ -6,6 +6,9 @@ Opinionated build wrapper around SWC for fast TypeScript transpilation in Shipfo
 
 - **`shipfox-swc`**: Transpiles `src/` to `dist/` using SWC with sensible defaults.
 - Uses a project-local `.swcrc` if present, otherwise falls back to the built-in config.
+- Rewrites `#` subpath imports (declared in the package's `imports` map) to relative
+  paths in `dist/`, so the built output loads under a plain Node ESM resolver. Only
+  string targets are rewritten; conditional targets are left as-is.
 - Automatically cleans up orphaned `.js` and `.js.map` files in `dist/` after each build.
 - Passes any extra CLI flags through to SWC.
 

--- a/tools/swc/package.json
+++ b/tools/swc/package.json
@@ -16,7 +16,8 @@
     "shipfox-swc": "./bin/swc.js"
   },
   "scripts": {
-    "build": "rm -rf dist && swc --strip-leading-paths --config-file .swcrc -d dist ."
+    "build": "rm -rf dist && swc --strip-leading-paths --config-file .swcrc -d dist .",
+    "test": "pnpm run build && node --test test/*.test.mjs"
   },
   "dependencies": {
     "@shipfox/tool-utils": "workspace:*",

--- a/tools/swc/src/imports.ts
+++ b/tools/swc/src/imports.ts
@@ -1,34 +1,19 @@
 import {readdirSync, readFileSync, writeFileSync} from 'node:fs';
 import {join, posix, sep} from 'node:path';
-
-/**
- * A package.json `imports` map resolves `#` subpath imports. SWC preserves those
- * specifiers verbatim, so a built `dist/index.js` keeps `#schemas/index.js`, which
- * the map points at `./src/*` and a plain Node ESM resolver (Playwright, a
- * dist-only image) cannot load because no `.js` exists under `src/`.
- *
- * SWC's own `jsc.paths` cannot fix this reliably: it rewrites `#dir/file.js` but
- * leaves a broken `../#file.js` for top-level `#file.js` aliases. So after SWC
- * emits `dist/`, we rewrite every `#` specifier ourselves. Because
- * `--strip-leading-paths` mirrors the `src/` tree into `dist/`, a path resolved
- * against `src/` and made relative to the importing file is also valid in `dist/`.
- */
+import {type ParseOptions, parseSync} from '@swc/core';
 
 interface PackageJson {
   imports?: Record<string, unknown>;
 }
 
-// `from "#x"`, side-effect `import "#x"`, and dynamic `import("#x")`. A `#`
-// string literal that is not a module specifier (e.g. a `#ffffff` color) has no
-// `from`/`import` in front of it, so it is left untouched.
-const SPECIFIER = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(["'])(#[^"']+)\2/g;
+// Parse the emitted JS with the permissive TS grammar (a superset of what SWC
+// emits) so we only ever touch real module specifiers.
+const PARSE_OPTIONS: ParseOptions = {syntax: 'typescript', tsx: true};
 const LEADING_DOT_SLASH = /^\.\//;
 
 /**
- * Resolves a `#` specifier against the `imports` map to its target string
- * (e.g. `./src/slug.js`). Returns null when no string target applies, which
- * covers conditional (object) targets: those declare their own runtime
- * resolution and must not be rewritten.
+ * Conditional targets declare their own runtime resolution, so only string
+ * targets are safe to rewrite.
  */
 function resolveTarget(spec: string, imports: Record<string, unknown>): string | null {
   const exact = imports[spec];
@@ -47,44 +32,115 @@ function resolveTarget(spec: string, imports: Record<string, unknown>): string |
 
     const captured = spec.slice(prefix.length, spec.length - suffix.length);
     if (!best || prefix.length > best.prefixLength) {
-      best = {resolved: target.replace('*', captured), prefixLength: prefix.length};
+      best = {resolved: target.replaceAll('*', captured), prefixLength: prefix.length};
     }
   }
   return best?.resolved ?? null;
 }
 
-// `./src/slug.js` -> `slug.js` (relative to the build output root). Normalizes
-// first so a `#/foo.js`-style alias (which resolves to `./src//foo.js`) collapses
-// like Node would. Returns null when the target is not under `rootDir`, so we
-// never remap paths we cannot place in `dist/`.
+// Normalize before the prefix check so `#/foo.js` aliases collapse the same way
+// Node would, and skip targets that cannot be placed in `dist/`.
 function toOutputRelative(target: string, rootDir: string): string | null {
   const normalized = posix.normalize(target.replace(LEADING_DOT_SLASH, ''));
   const prefix = `${rootDir}/`;
   return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : null;
 }
 
-/**
- * Rewrites the `#` specifiers of a single emitted file. `fileOutputPath` is the
- * file's path relative to the output root (which mirrors `src/`).
- */
+function relativeSpecifier(
+  spec: string,
+  fromDir: string,
+  imports: Record<string, unknown>,
+  rootDir: string,
+): string | null {
+  const target = resolveTarget(spec, imports);
+  if (target === null) return null;
+
+  const outputTarget = toOutputRelative(target, rootDir);
+  if (outputTarget === null) return null;
+
+  const relativePath = posix.relative(fromDir, outputTarget);
+  return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+interface SpecifierLiteral {
+  value: string;
+  start: number;
+  end: number;
+}
+
+// A `#` string literal in module-specifier position: a static import/export
+// `source` or a dynamic `import()` argument. Anything else (a `#ffffff` color,
+// import-like text inside a string or comment) is never in this position, so it
+// is left untouched.
+function collectHashSpecifiers(ast: {span: {start: number}}): SpecifierLiteral[] {
+  const base = ast.span.start;
+  const literals: SpecifierLiteral[] = [];
+
+  const record = (node: unknown): void => {
+    if (
+      isRecord(node) &&
+      node.type === 'StringLiteral' &&
+      typeof node.value === 'string' &&
+      node.value.startsWith('#') &&
+      isRecord(node.span) &&
+      typeof node.span.start === 'number' &&
+      typeof node.span.end === 'number'
+    ) {
+      literals.push({value: node.value, start: node.span.start - base, end: node.span.end - base});
+    }
+  };
+
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const child of node) visit(child);
+      return;
+    }
+    if (!isRecord(node)) return;
+
+    const importsSource =
+      node.type === 'ImportDeclaration' ||
+      node.type === 'ExportAllDeclaration' ||
+      node.type === 'ExportNamedDeclaration';
+    if (importsSource) record(node.source);
+
+    const isDynamicImport =
+      node.type === 'CallExpression' && isRecord(node.callee) && node.callee.type === 'Import';
+    if (isDynamicImport && Array.isArray(node.arguments) && isRecord(node.arguments[0])) {
+      record(node.arguments[0].expression);
+    }
+
+    for (const key of Object.keys(node)) visit(node[key]);
+  };
+
+  visit(ast);
+  return literals;
+}
+
 export function rewriteSpecifiers(
   code: string,
   fileOutputPath: string,
   imports: Record<string, unknown>,
   rootDir: string,
 ): string {
+  if (!code.includes('#')) return code;
+
   const fromDir = posix.dirname(fileOutputPath);
-  return code.replace(SPECIFIER, (match, lead, quote, spec) => {
-    const target = resolveTarget(spec, imports);
-    if (target === null) return match;
+  const specifiers = collectHashSpecifiers(parseSync(code, PARSE_OPTIONS));
 
-    const outputTarget = toOutputRelative(target, rootDir);
-    if (outputTarget === null) return match;
+  // Splice from the end so earlier offsets stay valid as we rewrite.
+  let result = code;
+  for (const {value, start, end} of specifiers.sort((a, b) => b.start - a.start)) {
+    const specifier = relativeSpecifier(value, fromDir, imports, rootDir);
+    if (specifier === null) continue;
 
-    const relativePath = posix.relative(fromDir, outputTarget);
-    const specifier = relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
-    return `${lead}${quote}${specifier}${quote}`;
-  });
+    const quote = code[start];
+    result = result.slice(0, start) + quote + specifier + quote + result.slice(end);
+  }
+  return result;
 }
 
 interface RewriteHashImportsOptions {
@@ -94,9 +150,13 @@ interface RewriteHashImportsOptions {
 }
 
 /**
- * Rewrites `#` subpath imports to relative paths across every emitted `.js` file,
- * so the built package loads under a plain Node ESM resolver. A no-op when the
- * package declares no `imports` map.
+ * SWC preserves package `imports` aliases in emitted JS, and `jsc.paths` leaves
+ * a broken `../#file.js` for top-level aliases. Dist-only consumers then try to
+ * resolve `#` specifiers back to `src/`, where no emitted JS exists. Because
+ * `--strip-leading-paths` mirrors `src/` into `dist/`, string `imports` targets
+ * can be translated into relative specifiers after emit. The rewrite parses each
+ * file and edits only real specifier literals, so import-like text in strings or
+ * comments is left untouched.
  */
 export function rewriteHashImports({
   outputDir,

--- a/tools/swc/src/imports.ts
+++ b/tools/swc/src/imports.ts
@@ -62,6 +62,15 @@ function relativeSpecifier(
   return relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
 }
 
+function parseModule(code: string, label: string): ReturnType<typeof parseSync> {
+  try {
+    return parseSync(code, PARSE_OPTIONS);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`shipfox-swc: failed to parse ${label}: ${reason}`, {cause: error});
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -129,7 +138,7 @@ export function rewriteSpecifiers(
   if (!code.includes('#')) return code;
 
   const fromDir = posix.dirname(fileOutputPath);
-  const specifiers = collectHashSpecifiers(parseSync(code, PARSE_OPTIONS));
+  const specifiers = collectHashSpecifiers(parseModule(code, fileOutputPath));
 
   // Splice from the end so earlier offsets stay valid as we rewrite.
   let result = code;
@@ -140,6 +149,10 @@ export function rewriteSpecifiers(
     const quote = code[start];
     result = result.slice(0, start) + quote + specifier + quote + result.slice(end);
   }
+
+  // Fail closed: only ever emit a file we can still parse, so a splice bug
+  // surfaces as a build error rather than a corrupt module.
+  if (result !== code) parseModule(result, fileOutputPath);
   return result;
 }
 

--- a/tools/swc/src/imports.ts
+++ b/tools/swc/src/imports.ts
@@ -1,0 +1,119 @@
+import {readdirSync, readFileSync, writeFileSync} from 'node:fs';
+import {join, posix, sep} from 'node:path';
+
+/**
+ * A package.json `imports` map resolves `#` subpath imports. SWC preserves those
+ * specifiers verbatim, so a built `dist/index.js` keeps `#schemas/index.js`, which
+ * the map points at `./src/*` and a plain Node ESM resolver (Playwright, a
+ * dist-only image) cannot load because no `.js` exists under `src/`.
+ *
+ * SWC's own `jsc.paths` cannot fix this reliably: it rewrites `#dir/file.js` but
+ * leaves a broken `../#file.js` for top-level `#file.js` aliases. So after SWC
+ * emits `dist/`, we rewrite every `#` specifier ourselves. Because
+ * `--strip-leading-paths` mirrors the `src/` tree into `dist/`, a path resolved
+ * against `src/` and made relative to the importing file is also valid in `dist/`.
+ */
+
+interface PackageJson {
+  imports?: Record<string, unknown>;
+}
+
+// `from "#x"`, side-effect `import "#x"`, and dynamic `import("#x")`. A `#`
+// string literal that is not a module specifier (e.g. a `#ffffff` color) has no
+// `from`/`import` in front of it, so it is left untouched.
+const SPECIFIER = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(["'])(#[^"']+)\2/g;
+const LEADING_DOT_SLASH = /^\.\//;
+
+/**
+ * Resolves a `#` specifier against the `imports` map to its target string
+ * (e.g. `./src/slug.js`). Returns null when no string target applies, which
+ * covers conditional (object) targets: those declare their own runtime
+ * resolution and must not be rewritten.
+ */
+function resolveTarget(spec: string, imports: Record<string, unknown>): string | null {
+  const exact = imports[spec];
+  if (typeof exact === 'string') return exact;
+  if (exact !== undefined) return null;
+
+  let best: {resolved: string; prefixLength: number} | null = null;
+  for (const [key, target] of Object.entries(imports)) {
+    const star = key.indexOf('*');
+    if (star === -1 || typeof target !== 'string') continue;
+
+    const prefix = key.slice(0, star);
+    const suffix = key.slice(star + 1);
+    const fits = spec.startsWith(prefix) && spec.endsWith(suffix);
+    if (!fits || spec.length < prefix.length + suffix.length) continue;
+
+    const captured = spec.slice(prefix.length, spec.length - suffix.length);
+    if (!best || prefix.length > best.prefixLength) {
+      best = {resolved: target.replace('*', captured), prefixLength: prefix.length};
+    }
+  }
+  return best?.resolved ?? null;
+}
+
+// `./src/slug.js` -> `slug.js` (relative to the build output root). Normalizes
+// first so a `#/foo.js`-style alias (which resolves to `./src//foo.js`) collapses
+// like Node would. Returns null when the target is not under `rootDir`, so we
+// never remap paths we cannot place in `dist/`.
+function toOutputRelative(target: string, rootDir: string): string | null {
+  const normalized = posix.normalize(target.replace(LEADING_DOT_SLASH, ''));
+  const prefix = `${rootDir}/`;
+  return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : null;
+}
+
+/**
+ * Rewrites the `#` specifiers of a single emitted file. `fileOutputPath` is the
+ * file's path relative to the output root (which mirrors `src/`).
+ */
+export function rewriteSpecifiers(
+  code: string,
+  fileOutputPath: string,
+  imports: Record<string, unknown>,
+  rootDir: string,
+): string {
+  const fromDir = posix.dirname(fileOutputPath);
+  return code.replace(SPECIFIER, (match, lead, quote, spec) => {
+    const target = resolveTarget(spec, imports);
+    if (target === null) return match;
+
+    const outputTarget = toOutputRelative(target, rootDir);
+    if (outputTarget === null) return match;
+
+    const relativePath = posix.relative(fromDir, outputTarget);
+    const specifier = relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
+    return `${lead}${quote}${specifier}${quote}`;
+  });
+}
+
+interface RewriteHashImportsOptions {
+  outputDir: string;
+  projectRoot: string;
+  rootDir?: string;
+}
+
+/**
+ * Rewrites `#` subpath imports to relative paths across every emitted `.js` file,
+ * so the built package loads under a plain Node ESM resolver. A no-op when the
+ * package declares no `imports` map.
+ */
+export function rewriteHashImports({
+  outputDir,
+  projectRoot,
+  rootDir = 'src',
+}: RewriteHashImportsOptions): void {
+  const pkg = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8')) as PackageJson;
+  if (!pkg.imports) return;
+
+  const entries = readdirSync(outputDir, {recursive: true});
+  for (const entry of entries) {
+    if (typeof entry !== 'string' || !entry.endsWith('.js')) continue;
+
+    const absolutePath = join(outputDir, entry);
+    const code = readFileSync(absolutePath, 'utf8');
+    const outputPath = entry.split(sep).join('/');
+    const rewritten = rewriteSpecifiers(code, outputPath, pkg.imports, rootDir);
+    if (rewritten !== code) writeFileSync(absolutePath, rewritten);
+  }
+}

--- a/tools/swc/src/swc.ts
+++ b/tools/swc/src/swc.ts
@@ -6,8 +6,10 @@ import {
   buildShellCommand,
   getProjectBinaryPath,
   getProjectFilePath,
+  getProjectRootPath,
   log,
 } from '@shipfox/tool-utils';
+import {rewriteHashImports} from './imports.js';
 import {cleanup, getOwnedFileStats} from './utils.js';
 
 async function run() {
@@ -31,6 +33,7 @@ async function run() {
   ]);
   execSync(command, {stdio: 'inherit'});
   await cleanup(outputPath, ownedFiles);
+  rewriteHashImports({outputDir: outputPath, projectRoot: getProjectRootPath()});
 }
 
 run().catch((e) => {

--- a/tools/swc/test/imports.test.mjs
+++ b/tools/swc/test/imports.test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'node:test';
+import {rewriteHashImports, rewriteSpecifiers} from '../dist/imports.js';
+
+const imports = {'#test/*': './test/*', '#*': './src/*'};
+
+test('rewriteSpecifiers rewrites a nested #dir/file.js import to a relative path', () => {
+  const code = "export {stepSchema} from '#schemas/step.js';\n";
+
+  const result = rewriteSpecifiers(code, 'index.js', imports, 'src');
+
+  assert.equal(result, "export {stepSchema} from './schemas/step.js';\n");
+});
+
+test('rewriteSpecifiers rewrites a top-level #file.js import (the SWC-paths blind spot)', () => {
+  const code = 'import { connectionSlugSchema } from "#slug.js";\n';
+
+  const result = rewriteSpecifiers(code, 'schemas/integrations.js', imports, 'src');
+
+  assert.equal(result, 'import { connectionSlugSchema } from "../slug.js";\n');
+});
+
+test('rewriteSpecifiers normalizes the #/dir/file.js (hash-slash) alias form', () => {
+  const code = "import {AuthShell} from '#/components/auth-shell.js';\n";
+
+  const result = rewriteSpecifiers(code, 'pages/logout-page.js', imports, 'src');
+
+  assert.equal(result, "import {AuthShell} from '../components/auth-shell.js';\n");
+});
+
+test('rewriteSpecifiers handles side-effect and dynamic imports', () => {
+  const code = 'import "#register.js";\nconst m = await import("#core/lazy.js");\n';
+
+  const result = rewriteSpecifiers(code, 'index.js', imports, 'src');
+
+  assert.equal(result, 'import "./register.js";\nconst m = await import("./core/lazy.js");\n');
+});
+
+test('rewriteSpecifiers leaves bare imports and non-specifier # strings untouched', () => {
+  const code = "import {z} from 'zod';\nconst color = '#ffffff';\n";
+
+  const result = rewriteSpecifiers(code, 'index.js', imports, 'src');
+
+  assert.equal(result, code);
+});
+
+test('rewriteSpecifiers leaves conditional (object) import targets untouched', () => {
+  const conditional = {'#*': {development: './src/*', default: './dist/*'}};
+  const code = "export * from '#schemas/index.js';\n";
+
+  const result = rewriteSpecifiers(code, 'index.js', conditional, 'src');
+
+  assert.equal(result, code);
+});
+
+function makeDist({imports: importsMap, files}) {
+  const root = mkdtempSync(join(tmpdir(), 'shipfox-swc-dist-'));
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify(importsMap ? {name: 'pkg', imports: importsMap} : {name: 'pkg'}),
+  );
+  const outputDir = join(root, 'dist');
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(outputDir, rel);
+    mkdirSync(join(abs, '..'), {recursive: true});
+    writeFileSync(abs, content);
+  }
+  return {root, outputDir};
+}
+
+test('rewriteHashImports rewrites every emitted .js file in place', () => {
+  const sourceMap = '{"version":3,"sources":["#schemas/index.js"]}';
+  const {root, outputDir} = makeDist({
+    imports,
+    files: {
+      'index.js': "export * from '#schemas/index.js';\n",
+      'schemas/integrations.js': "import {slug} from '#slug.js';\n",
+      'index.js.map': sourceMap,
+    },
+  });
+
+  try {
+    rewriteHashImports({outputDir, projectRoot: root});
+
+    assert.equal(
+      readFileSync(join(outputDir, 'index.js'), 'utf8'),
+      "export * from './schemas/index.js';\n",
+    );
+    assert.equal(
+      readFileSync(join(outputDir, 'schemas/integrations.js'), 'utf8'),
+      "import {slug} from '../slug.js';\n",
+    );
+    assert.equal(readFileSync(join(outputDir, 'index.js.map'), 'utf8'), sourceMap);
+  } finally {
+    rmSync(root, {force: true, recursive: true});
+  }
+});
+
+test('rewriteHashImports is a no-op when the package declares no imports', () => {
+  const {root, outputDir} = makeDist({
+    imports: undefined,
+    files: {'index.js': "export * from '#schemas/index.js';\n"},
+  });
+
+  try {
+    rewriteHashImports({outputDir, projectRoot: root});
+
+    assert.equal(
+      readFileSync(join(outputDir, 'index.js'), 'utf8'),
+      "export * from '#schemas/index.js';\n",
+    );
+  } finally {
+    rmSync(root, {force: true, recursive: true});
+  }
+});

--- a/tools/swc/test/imports.test.mjs
+++ b/tools/swc/test/imports.test.mjs
@@ -16,6 +16,14 @@ test('rewriteSpecifiers rewrites a nested #dir/file.js import to a relative path
   assert.equal(result, "export {stepSchema} from './schemas/step.js';\n");
 });
 
+test('rewriteSpecifiers handles a multi-segment subpath from a deeply nested file', () => {
+  const code = 'import {x} from "#core/hello/goodby.js";\n';
+
+  const result = rewriteSpecifiers(code, 'a/b/c.js', imports, 'src');
+
+  assert.equal(result, 'import {x} from "../../core/hello/goodby.js";\n');
+});
+
 test('rewriteSpecifiers rewrites a top-level #file.js import (the SWC-paths blind spot)', () => {
   const code = 'import { connectionSlugSchema } from "#slug.js";\n';
 

--- a/tools/swc/test/imports.test.mjs
+++ b/tools/swc/test/imports.test.mjs
@@ -3,6 +3,7 @@ import {mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'node:test';
+import {pathToFileURL} from 'node:url';
 import {rewriteHashImports, rewriteSpecifiers} from '../dist/imports.js';
 
 const imports = {'#test/*': './test/*', '#*': './src/*'};
@@ -77,6 +78,15 @@ test('rewriteSpecifiers ignores import-like text inside strings and comments', (
   );
 });
 
+test('rewriteSpecifiers fails closed with the file path on unparseable input', () => {
+  const code = 'export {x} from "#real.js";\nconst = ;\n';
+
+  assert.throws(
+    () => rewriteSpecifiers(code, 'broken.js', imports, 'src'),
+    /failed to parse broken\.js/,
+  );
+});
+
 test('rewriteSpecifiers leaves conditional (object) import targets untouched', () => {
   const conditional = {'#*': {development: './src/*', default: './dist/*'}};
   const code = "export * from '#schemas/index.js';\n";
@@ -88,10 +98,8 @@ test('rewriteSpecifiers leaves conditional (object) import targets untouched', (
 
 function makeDist({imports: importsMap, files}) {
   const root = mkdtempSync(join(tmpdir(), 'shipfox-swc-dist-'));
-  writeFileSync(
-    join(root, 'package.json'),
-    JSON.stringify(importsMap ? {name: 'pkg', imports: importsMap} : {name: 'pkg'}),
-  );
+  const manifest = {name: 'pkg', type: 'module', ...(importsMap ? {imports: importsMap} : {})};
+  writeFileSync(join(root, 'package.json'), JSON.stringify(manifest));
   const outputDir = join(root, 'dist');
   for (const [rel, content] of Object.entries(files)) {
     const abs = join(outputDir, rel);
@@ -142,6 +150,64 @@ test('rewriteHashImports is a no-op when the package declares no imports', () =>
       readFileSync(join(outputDir, 'index.js'), 'utf8'),
       "export * from '#schemas/index.js';\n",
     );
+  } finally {
+    rmSync(root, {force: true, recursive: true});
+  }
+});
+
+test('rewriteHashImports is idempotent', () => {
+  const {root, outputDir} = makeDist({
+    imports,
+    files: {
+      'index.js': "export * from '#schemas/index.js';\nimport {slug} from '#slug.js';\n",
+      'schemas/index.js': 'export const schema = 1;\n',
+      'slug.js': 'export const slug = 1;\n',
+    },
+  });
+
+  try {
+    rewriteHashImports({outputDir, projectRoot: root});
+    const afterFirst = readFileSync(join(outputDir, 'index.js'), 'utf8');
+
+    rewriteHashImports({outputDir, projectRoot: root});
+    const afterSecond = readFileSync(join(outputDir, 'index.js'), 'utf8');
+
+    assert.equal(afterSecond, afterFirst);
+  } finally {
+    rmSync(root, {force: true, recursive: true});
+  }
+});
+
+test("rewritten dist loads under Node's own resolver with every # form", async () => {
+  const {root, outputDir} = makeDist({
+    imports: {'#*': './src/*'},
+    files: {
+      'index.js': [
+        "export {a} from '#dir/a.js';",
+        "export {b} from '#b.js';",
+        "export {c} from '#/dir/c.js';",
+        "import '#side.js';",
+        "export const loadDynamic = async () => (await import('#dyn.js')).d;",
+        '',
+      ].join('\n'),
+      'dir/a.js': "export const a = 'A';\n",
+      'b.js': "export const b = 'B';\n",
+      'dir/c.js': "export const c = 'C';\n",
+      'side.js': 'globalThis.__shipfoxSideEffect = true;\n',
+      'dyn.js': "export const d = 'D';\n",
+    },
+  });
+
+  try {
+    rewriteHashImports({outputDir, projectRoot: root});
+
+    const mod = await import(pathToFileURL(join(outputDir, 'index.js')).href);
+
+    assert.equal(mod.a, 'A');
+    assert.equal(mod.b, 'B');
+    assert.equal(mod.c, 'C');
+    assert.equal(await mod.loadDynamic(), 'D');
+    assert.equal(globalThis.__shipfoxSideEffect, true);
   } finally {
     rmSync(root, {force: true, recursive: true});
   }

--- a/tools/swc/test/imports.test.mjs
+++ b/tools/swc/test/imports.test.mjs
@@ -23,6 +23,15 @@ test('rewriteSpecifiers rewrites a top-level #file.js import (the SWC-paths blin
   assert.equal(result, 'import { connectionSlugSchema } from "../slug.js";\n');
 });
 
+test('rewriteSpecifiers replaces every target wildcard like Node package imports', () => {
+  const code = "import {value} from '#pair/foo.js';\n";
+  const repeatedWildcardImports = {'#pair/*': './src/generated/*/mirror/*'};
+
+  const result = rewriteSpecifiers(code, 'index.js', repeatedWildcardImports, 'src');
+
+  assert.equal(result, "import {value} from './generated/foo.js/mirror/foo.js';\n");
+});
+
 test('rewriteSpecifiers normalizes the #/dir/file.js (hash-slash) alias form', () => {
   const code = "import {AuthShell} from '#/components/auth-shell.js';\n";
 
@@ -45,6 +54,27 @@ test('rewriteSpecifiers leaves bare imports and non-specifier # strings untouche
   const result = rewriteSpecifiers(code, 'index.js', imports, 'src');
 
   assert.equal(result, code);
+});
+
+test('rewriteSpecifiers ignores import-like text inside strings and comments', () => {
+  const code = [
+    'const doc = \'import "#core/lazy.js"\';',
+    '// export * from "#schemas/index.js"',
+    'export {x} from "#real.js";',
+    '',
+  ].join('\n');
+
+  const result = rewriteSpecifiers(code, 'index.js', imports, 'src');
+
+  assert.equal(
+    result,
+    [
+      'const doc = \'import "#core/lazy.js"\';',
+      '// export * from "#schemas/index.js"',
+      'export {x} from "./real.js";',
+      '',
+    ].join('\n'),
+  );
 });
 
 test('rewriteSpecifiers leaves conditional (object) import targets untouched', () => {


### PR DESCRIPTION
Packages declare internal `#` subpath imports (e.g. `#schemas/index.js`) in their `package.json` `imports` map, which resolves to `./src/*`. SWC preserves those specifiers verbatim, so a built `dist/index.js` keeps `#schemas/index.js` and Node resolves it to `src/schemas/index.js`, a `.ts` that does not exist as `.js`. This loads fine under tsx (API dev) and vitest (vite remaps `#` and `.js` to `.ts`), but **fails under a plain Node ESM resolver**, which is what Playwright's runner uses and what a dist-only image would use.

## What this does

After SWC emits `dist/`, `shipfox-swc` now rewrites every `#` specifier to a relative path (e.g. `./schemas/index.js`), driven by the package's own `imports` map. Because `--strip-leading-paths` mirrors `src/` into `dist/`, a path resolved against `src/` and made relative to the importing file is also valid in `dist/`. This is a systemic fix: it covers every `#`-import package (47 today) at once, so no per-package source normalization or lint guard is needed. The build can no longer emit a non-portable `#` specifier.

## Why a post-emit rewrite instead of SWC's `jsc.paths`

Resolution here is via package.json `imports`, not tsconfig `paths`, so `tsc-alias` does not apply. SWC's native `jsc.paths` was tried first and does rewrite `#dir/file.js`, but leaves a broken `../#file.js` for top-level `#file.js` aliases (no config variation fixes it). So the rewrite is a deterministic post-emit pass driven by the `imports` map, handling `#dir/file.js`, top-level `#file.js`, and the `#/dir/file.js` (hash-slash) form uniformly, across `from`, side-effect, and dynamic imports. Only string import targets are rewritten; conditional targets already declare their own runtime resolution and are left untouched.

## Verification

- Unit tests (`node --test`) for the specifier rewriter and the file walk, including the top-level and hash-slash blind spots, conditional-target skip, and non-specifier `#` strings (e.g. `#ffffff` colors) left alone.
- Full affected graph is green: `turbo build/test/check --filter '...[origin/main]'` (104 builds, 183 tests, 107 checks).
- Zero surviving `#` specifiers across all built `dist/*.js` repo-wide.
- A plain Node ESM `import()` of a built dto package (`@shipfox/api-workflows-dto`) now loads, where it previously threw `Cannot find module '.../src/schemas/index.js'`.

Closes ENG-746

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `#` subpath imports in `dist/` to relative paths so plain Node ESM can load built packages (e.g., Playwright and dist-only images). Implemented as an AST-based, fail-closed post-emit rewrite in `@shipfox/swc`; addresses ENG-746.

- **Bug Fixes**
  - After SWC emits, `shipfox-swc` parses JS with `@swc/core` and rewrites `#` specifiers using the package `imports` map to relative paths valid in `dist/` (works with `--strip-leading-paths`).
  - Edits only real module specifiers (static, side-effect, dynamic); leaves strings/comments and non-specifier `#` values untouched; handles top-level `#file.js`, `#/...`, and multi-segment subpaths from nested files; resolves all RHS wildcards; skips conditional targets.
  - Fail-closed and verified: re-parses rewritten files; Node ESM loads for all alias forms; pass is idempotent; added unit tests (including the deep subpath case) and a README note; `tools/swc` now has a `test` script.

<sup>Written for commit 18fbe4e96e0d4e80665b96e4557cc12f2a7718e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

