### PR TITLE
Fix shared Ollama warmup completion

### DIFF
--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -291,6 +291,7 @@ export async function collectE2eDiagnostics(logDir) {
     writeCommandOutput('docker', ['network', 'inspect', 'bridge'], {
       file: join(diagnosticsDir, 'network-bridge.json'),
     }),
+    copySharedOllamaLog(logDir),
   ]);
 
   const runnerLogs = 'e2e/platform/workflows/.e2e-run/runners';
@@ -304,6 +305,19 @@ export async function collectE2eDiagnostics(logDir) {
   }
 
   await copyPlaywrightTestResults(logDir);
+}
+
+export async function copySharedOllamaLog(logDir, env = process.env, cwd = process.cwd()) {
+  const rootPath = resolve(env.CONDUCTOR_ROOT_PATH || cwd);
+  const source = join(rootPath, '.context/shared-ollama/ollama.log');
+  const target = join(logDir, 'shared-ollama/ollama.log');
+
+  try {
+    await mkdir(dirname(target), {recursive: true});
+    await cp(source, target, {force: true});
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
 }
 
 export async function copyPlaywrightTestResults(logDir) {

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -5,6 +5,7 @@ import {join} from 'node:path';
 import {describe, test} from 'node:test';
 import {
   copyPlaywrightTestResults,
+  copySharedOllamaLog,
   defaultLogDir,
   e2eEnv,
   parseArgs,
@@ -153,6 +154,27 @@ describe('defaultLogDir', () => {
 
   test('falls back to .context locally', () => {
     assert.equal(defaultLogDir({}), '.context/shipfox-e2e-logs');
+  });
+});
+
+describe('copySharedOllamaLog', () => {
+  test('stages the shared Ollama service log when present', async () => {
+    const workspaceDir = await mkdtemp(join(tmpdir(), 'shipfox-e2e-workspace-'));
+    const rootDir = join(workspaceDir, 'root');
+    const logDir = join(workspaceDir, 'logs');
+    try {
+      await mkdir(join(rootDir, '.context/shared-ollama'), {recursive: true});
+      await writeFile(join(rootDir, '.context/shared-ollama/ollama.log'), 'ollama warmup log');
+
+      await copySharedOllamaLog(logDir, {CONDUCTOR_ROOT_PATH: rootDir}, workspaceDir);
+
+      assert.equal(
+        await readFile(join(logDir, 'shared-ollama/ollama.log'), 'utf8'),
+        'ollama warmup log',
+      );
+    } finally {
+      await rm(workspaceDir, {recursive: true, force: true});
+    }
   });
 });
 

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -59,12 +59,19 @@ function serviceContext(env = process.env, cwd = process.cwd()) {
 }
 
 async function up(context) {
+  printSetupStep(`Starting setup for ${context.model} at ${context.baseUrl}.`);
   mkdirSync(context.stateDir, {recursive: true});
 
-  if (!(await isHealthy(context.baseUrl))) {
+  printSetupStep(`Checking Ollama health at ${context.baseUrl}.`);
+  const healthy = await isHealthy(context.baseUrl);
+  printSetupStep(`Health check finished: ${healthy ? 'healthy' : 'unavailable'}.`);
+
+  if (!healthy) {
     const managedProcess = readManagedProcess(context);
     if (managedProcess !== undefined) {
+      printSetupStep(`Stopping stale managed Ollama process ${managedProcess.pid}.`);
       await stopManagedProcess(context, managedProcess.pid);
+      printSetupStep(`Stopped stale managed Ollama process ${managedProcess.pid}.`);
     } else {
       const unverifiedPid = readLiveUnverifiedPid(context);
       if (unverifiedPid !== undefined) {
@@ -78,12 +85,22 @@ async function up(context) {
       removeProcessState(context);
     }
 
-    startServer(context);
+    printSetupStep(`Starting Ollama server on ${context.listenHost}.`);
+    const pid = startServer(context);
+    printSetupStep(`Started Ollama server process ${pid}; waiting for health.`);
     await waitForHealthy(context.baseUrl);
+    printSetupStep(`Ollama server is healthy at ${context.baseUrl}.`);
+  } else {
+    printSetupStep(`Reusing healthy Ollama server at ${context.baseUrl}.`);
   }
 
+  printSetupStep(`Pulling Ollama model ${context.model}.`);
   runRootMise(context, ['exec', '--', 'ollama', 'pull', context.model]);
+  printSetupStep(`Finished pulling Ollama model ${context.model}.`);
+
+  printSetupStep(`Warming Ollama model ${context.model} with keep_alive=${context.keepAlive}.`);
   await preloadModel(context);
+  printSetupStep(`Finished warming Ollama model ${context.model}.`);
 
   printLine(`Shared Ollama is ready at ${context.baseUrl}.`);
   printLine(`Model: ${context.model}`);
@@ -144,6 +161,7 @@ function startServer(context) {
     listenHost: context.listenHost,
     startedAt: new Date().toISOString(),
   });
+  return child.pid;
 }
 
 function runRootMise(context, args) {
@@ -334,6 +352,10 @@ function isCliEntryPoint() {
 
 function printLine(message) {
   process.stdout.write(`${message}\n`);
+}
+
+function printSetupStep(message) {
+  printLine(`[shared-ollama] ${new Date().toISOString()} ${message}`);
 }
 
 function printError(message) {

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -175,7 +175,11 @@ async function preloadModel(context) {
   if (!response.ok) {
     fail(`Failed to preload ${context.model}: ${response.status} ${response.statusText}`);
   }
-  await response.body?.cancel();
+  try {
+    await response.json();
+  } catch {
+    fail(`Failed to preload ${context.model}: invalid JSON response`);
+  }
 }
 
 async function waitForHealthy(baseUrl) {

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -178,7 +178,7 @@ async function preloadModel(context) {
   try {
     await response.json();
   } catch {
-    fail(`Failed to preload ${context.model}: invalid JSON response`);
+    fail(`Failed to preload ${context.model}: failed to read warmup response`);
   }
 }
 

--- a/dev/shared-ollama.test.mjs
+++ b/dev/shared-ollama.test.mjs
@@ -59,7 +59,7 @@ describe('preloadModel', () => {
   test('uses the OpenAI-compatible chat endpoint', async () => {
     const originalFetch = globalThis.fetch;
     const calls = [];
-    globalThis.fetch = async (url, init) => {
+    globalThis.fetch = (url, init) => {
       calls.push({url, init});
       return new Response('{}', {status: 200});
     };
@@ -83,6 +83,37 @@ describe('preloadModel', () => {
       stream: false,
       keep_alive: '2h',
     });
+  });
+
+  test('reads the completion response body instead of cancelling it', async () => {
+    const originalFetch = globalThis.fetch;
+    let bodyRead = false;
+    let bodyCancelled = false;
+    globalThis.fetch = () => ({
+      ok: true,
+      json: () => {
+        bodyRead = true;
+        return {};
+      },
+      body: {
+        cancel: () => {
+          bodyCancelled = true;
+        },
+      },
+    });
+
+    try {
+      await preloadModel({
+        baseUrl: 'http://127.0.0.1:11434',
+        model: 'custom:model',
+        keepAlive: '2h',
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(bodyRead, true);
+    assert.equal(bodyCancelled, false);
   });
 });
 


### PR DESCRIPTION
Shared Ollama readiness could be reported after the warmup request only received response headers, because the helper cancelled the chat completion body. Under CI load that left the first provider validation request to pay the real cold-completion cost and occasionally hit the validation timeout.

This changes warmup to read the OpenAI-compatible chat completion JSON body to completion under the existing preload timeout. It also stages the shared Ollama service log with E2E diagnostics when present, so future local-model failures include Ollama-side timing context.

Validated with the root dev helper tests and lint for the touched scripts.

Fixes ENG-778

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warmup now waits for the full chat completion body before reporting readiness, preventing first-request timeouts. Added timestamped setup logs and E2E collection of the shared Ollama log to make model startup issues easier to debug. Fixes ENG-778.

- **Bug Fixes**
  - Read the OpenAI-compatible chat completion body within the preload timeout; emit a generic error if reading the warmup response fails.

- **New Features**
  - Include `.context/shared-ollama/ollama.log` in the E2E log bundle when present.
  - Trace setup steps (health check, cleanup, server start, model pull, warmup) with timestamps.

<sup>Written for commit 04b43be47432e363e018dde77bbb3155b017a29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

