### PR TITLE
Add vars and secrets expression contexts

### DIFF
--- a/.changeset/literal-contexts-bind.md
+++ b/.changeset/literal-contexts-bind.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds workflow expression support for vars and runner-host secret contexts with literal-key validation.

--- a/libs/api/definitions/package.json
+++ b/libs/api/definitions/package.json
@@ -43,6 +43,7 @@
     "@shipfox/api-integration-core": "workspace:*",
     "@shipfox/api-projects": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
+    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/expression": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -3,6 +3,7 @@ export const invalidWorkflowModelErrorCode = 'invalid-workflow-model';
 export type WorkflowModelValidationIssueCode =
   | 'context-unavailable-at-fill-site'
   | 'context-unavailable-at-predicate-site'
+  | 'computed-context-key'
   | 'duplicate-job-id'
   | 'duplicate-step-id'
   | 'duplicate-trigger-id'
@@ -20,9 +21,11 @@ export type WorkflowModelValidationIssueCode =
   | 'missing-runner-label'
   | 'multiple-manual-triggers'
   | 'runner-context-not-bare'
+  | 'runner-context-in-field'
   | 'runner-context-in-server-predicate'
   | 'self-job-dependency'
   | 'too-many-runner-labels'
+  | 'unknown-secret-store'
   | 'unknown-interpolation-context'
   | 'unknown-job-dependency'
   | 'untrusted-context-in-field';

--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -28,7 +28,8 @@ export type WorkflowModelValidationIssueCode =
   | 'unknown-secret-store'
   | 'unknown-interpolation-context'
   | 'unknown-job-dependency'
-  | 'untrusted-context-in-field';
+  | 'untrusted-context-in-field'
+  | 'vars-context-in-server-predicate';
 
 export type WorkflowModelValidationIssuePathSegment = string | number;
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1767,6 +1767,72 @@ describe('normalizeWorkflowDocument', () => {
       ]);
     });
 
+    it('rejects secrets in agent fields', () => {
+      const document: WorkflowDocument = {
+        name: 'agent secret',
+        jobs: {
+          build: {
+            steps: [{prompt: interpolation('secrets.OPENAI_API_KEY')}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'runner-context-in-field',
+          details: expect.objectContaining({rejectedRoots: ['secrets']}),
+        }),
+      ]);
+    });
+
+    it('rejects computed vars keys', () => {
+      const document: WorkflowDocument = {
+        name: 'computed vars',
+        jobs: {
+          build: {
+            steps: [{run: 'echo ok', env: {REGION: interpolation('vars[event.region]')}}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'computed-context-key',
+            details: expect.objectContaining({root: 'vars'}),
+          }),
+        ]),
+      );
+      expect(error.issues.map((issue) => issue.code)).toEqual([
+        'computed-context-key',
+        'computed-context-key',
+      ]);
+    });
+
+    it('rejects unknown secret stores', () => {
+      const document: WorkflowDocument = {
+        name: 'unknown secret store',
+        jobs: {
+          build: {
+            steps: [{run: 'echo ok', env: {TOKEN: interpolation('secrets.vault.TOKEN')}}],
+          },
+        },
+      };
+
+      const error = expectInvalid(document);
+
+      expect(error.issues).toEqual([
+        expect.objectContaining({
+          code: 'unknown-secret-store',
+          details: expect.objectContaining({store: 'vault'}),
+        }),
+      ]);
+    });
+
     it.each([
       'execution.events[0].data.body',
       'execution["events"][0].data.body',

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -813,6 +813,33 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
+  it('rejects vars in gate success_if with a server-predicate issue', () => {
+    const document: WorkflowDocument = {
+      name: 'vars-context gate',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build', gate: {success_if: 'vars.REQUIRED == "true"'}}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'vars-context-in-server-predicate',
+        message: expect.stringContaining('cannot reference vars'),
+        path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
+        details: expect.objectContaining({
+          field: 'step.success_if',
+          source: 'vars.REQUIRED == "true"',
+          rejectedRoots: ['vars'],
+          site: 'step-report',
+        }),
+      }),
+    ]);
+  });
+
   it('rejects contexts unavailable at the gate predicate site', () => {
     const document: WorkflowDocument = {
       name: 'future-context gate',
@@ -978,6 +1005,34 @@ describe('normalizeWorkflowDocument', () => {
           field: 'job.success',
           source: 'runner.os == "linux"',
           runnerRoots: ['runner'],
+          site: 'job-resolution',
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects vars in job success with a server-predicate issue', () => {
+    const document: WorkflowDocument = {
+      name: 'vars-context job success',
+      jobs: {
+        build: {
+          success: 'vars.ENVIRONMENT == "prod"',
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'vars-context-in-server-predicate',
+        message: expect.stringContaining('cannot reference vars'),
+        path: ['jobs', 'build', 'success'],
+        details: expect.objectContaining({
+          field: 'job.success',
+          source: 'vars.ENVIRONMENT == "prod"',
+          rejectedRoots: ['vars'],
           site: 'job-resolution',
         }),
       }),

--- a/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
+++ b/libs/api/definitions/src/core/workflow-model/parse-interpolation-field.ts
@@ -1,10 +1,13 @@
+import {secretKeySchema, secretStoreSchema} from '@shipfox/api-secrets-dto';
 import {
   type AvailabilitySite,
+  analyzeContextKeyAccess,
   createWorkflowExpression,
   type ExpressionTypeEnvironment,
   extractCelUntrustedPathAccesses,
   getWorkflowContextAvailability,
   getWorkflowContextDefinition,
+  getWorkflowContextHost,
   getWorkflowContextTypeEnvironment,
   getWorkflowContextUntrustedPaths,
   InvalidWorkflowExpressionError,
@@ -19,6 +22,7 @@ import {
   type WorkflowTemplateSegment,
   workflowContextNames,
   workflowInterpolationFieldAcceptsContext,
+  workflowInterpolationFieldAcceptsHost,
   workflowInterpolationFieldAcceptsTrustTier,
 } from '@shipfox/expression';
 import type {WorkflowFieldTemplate} from '../entities/workflow-model.js';
@@ -116,6 +120,39 @@ function validateExpressionSegment(params: {
     return undefined;
   }
 
+  const rejectedHostRoots = knownRoots.filter(
+    (root) => !workflowInterpolationFieldAcceptsHost(params.field, getWorkflowContextHost(root)),
+  );
+  if (rejectedHostRoots.length > 0) {
+    params.issues.push(runnerContextInFieldIssue({...params, contextRoots, rejectedHostRoots}));
+    return undefined;
+  }
+
+  const keyAccess = analyzeContextKeyAccess(params.segment.expression);
+  if (keyAccess.violations.length > 0) {
+    params.issues.push(
+      ...keyAccess.violations.map((violation) =>
+        computedContextKeyIssue({
+          ...params,
+          contextRoots,
+          root: violation.root,
+          expression: violation.source,
+        }),
+      ),
+    );
+    return undefined;
+  }
+
+  const invalidReferenceIssue = validateContextKeyReferences({
+    ...params,
+    contextRoots,
+    references: keyAccess.references,
+  });
+  if (invalidReferenceIssue !== undefined) {
+    params.issues.push(invalidReferenceIssue);
+    return undefined;
+  }
+
   const rejectedPathRoots = findUntrustedPathRoots(params.segment, params.field, knownRoots);
   if (rejectedPathRoots.length > 0) {
     params.issues.push(
@@ -146,7 +183,8 @@ function validateExpressionSegment(params: {
 
   const fillSite = params.fillSite;
   if (fillSite !== undefined) {
-    const unavailableRoots = unavailableRootsAt(knownRoots, fillSite);
+    const serverRoots = knownRoots.filter((root) => getWorkflowContextHost(root) === 'server');
+    const unavailableRoots = unavailableRootsAt(serverRoots, fillSite);
     if (unavailableRoots.length > 0) {
       params.issues.push(
         unavailableContextIssue({...params, contextRoots, unavailableRoots, fillSite}),
@@ -244,6 +282,87 @@ function untrustedContextIssue(params: {
   });
 }
 
+function runnerContextInFieldIssue(params: {
+  field: WorkflowInterpolationField;
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+  rejectedHostRoots: readonly WorkflowContextName[];
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'runner-context-in-field',
+    message: `${fieldLabel(params.field)} interpolation cannot use runner context ${formatList(
+      params.rejectedHostRoots,
+    )}. Bind secrets to a run-step env value instead.`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      contextRoots: params.contextRoots,
+      rejectedRoots: params.rejectedHostRoots,
+    },
+  });
+}
+
+function computedContextKeyIssue(params: {
+  field: WorkflowInterpolationField;
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+  root: string;
+  expression: string;
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'computed-context-key',
+    message: `${fieldLabel(params.field)} interpolation must reference ${params.root} with a literal dot key.`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      expression: params.expression,
+      contextRoots: params.contextRoots,
+      root: params.root,
+    },
+  });
+}
+
+function validateContextKeyReferences(params: {
+  field: WorkflowInterpolationField;
+  source: string;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+  segment: WorkflowTemplateExprSegment;
+  references: ReturnType<typeof analyzeContextKeyAccess>['references'];
+}): WorkflowModelValidationIssue | undefined {
+  for (const reference of params.references) {
+    if (!secretKeySchema.safeParse(reference.key).success) {
+      return computedContextKeyIssue({
+        ...params,
+        root: reference.root,
+        expression: params.segment.expression.source,
+      });
+    }
+
+    if (reference.root !== 'secrets' || reference.store === undefined) continue;
+    if (secretStoreSchema.safeParse(reference.store).success) continue;
+
+    return issue({
+      code: 'unknown-secret-store',
+      message: `${fieldLabel(params.field)} interpolation references unknown secret store "${reference.store}".`,
+      path: params.path,
+      details: {
+        field: params.field,
+        source: params.source,
+        expression: params.segment.expression.source,
+        contextRoots: params.contextRoots,
+        store: reference.store,
+      },
+    });
+  }
+
+  return undefined;
+}
+
 const availabilitySiteLabels = {
   ingest: 'ingest',
   'run-creation': 'run creation',
@@ -293,6 +412,22 @@ function planViolationIssue(
   },
   violation: PlanViolation,
 ): WorkflowModelValidationIssue {
+  if (violation.reason === 'computed-context-key') {
+    return issue({
+      code: 'computed-context-key',
+      message: `${fieldLabel(params.field)} interpolation must reference ${formatList(
+        violation.contextRoots ?? [],
+      )} with a literal dot key.`,
+      path: params.path,
+      details: {
+        field: params.field,
+        source: params.source,
+        expression: violation.source,
+        contextRoots: violation.contextRoots,
+      },
+    });
+  }
+
   return issue({
     code: 'runner-context-not-bare',
     message: `${fieldLabel(params.field)} interpolation references runner context in a larger expression; ${violation.hint}.`,
@@ -301,7 +436,7 @@ function planViolationIssue(
       field: params.field,
       source: params.source,
       expression: violation.source,
-      runnerRoots: violation.runnerRoots,
+      runnerRoots: violation.runnerRoots ?? [],
     },
   });
 }
@@ -315,9 +450,9 @@ function availabilityVerb(roots: readonly WorkflowContextName[]): 'is' | 'are' {
 }
 
 function unavailableRootAvailabilityMessage(root: WorkflowContextName): string {
-  return `"${root}" becomes available at ${describeAvailabilitySite(
-    getWorkflowContextAvailability(root),
-  )}.`;
+  const availability = getWorkflowContextAvailability(root);
+  if (availability === undefined) return `"${root}" is not available at any server site.`;
+  return `"${root}" becomes available at ${describeAvailabilitySite(availability)}.`;
 }
 
 function describeAvailabilitySite(site: AvailabilitySite): string {

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -57,6 +57,12 @@ export function validatePredicateExpression(params: {
     return undefined;
   }
 
+  const varsRoots = knownRoots.filter((root) => root === 'vars');
+  if (varsRoots.length > 0) {
+    params.issues.push(varsContextInServerPredicateIssue({...params, contextRoots}));
+    return undefined;
+  }
+
   const unavailableRoots = knownRoots.filter((root) => !isRootAvailableAt(root, params.site));
   if (unavailableRoots.length > 0) {
     params.issues.push(
@@ -170,6 +176,27 @@ function runnerContextInServerPredicateIssue(params: {
       source: params.source,
       contextRoots: params.contextRoots,
       runnerRoots: params.runnerRoots,
+      site: params.site,
+    },
+  });
+}
+
+function varsContextInServerPredicateIssue(params: {
+  field: WorkflowPredicateField;
+  source: string;
+  site: AvailabilitySite;
+  path: readonly WorkflowModelValidationIssuePathSegment[];
+  contextRoots: readonly string[];
+}): WorkflowModelValidationIssue {
+  return issue({
+    code: 'vars-context-in-server-predicate',
+    message: `${fieldLabel(params.field)} cannot reference vars because predicate evaluation does not include workflow variables.`,
+    path: params.path,
+    details: {
+      field: params.field,
+      source: params.source,
+      contextRoots: params.contextRoots,
+      rejectedRoots: ['vars'],
       site: params.site,
     },
   });

--- a/libs/api/workflows/package.json
+++ b/libs/api/workflows/package.json
@@ -47,6 +47,7 @@
     "@shipfox/api-runners": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
     "@shipfox/api-secrets": "workspace:*",
+    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/expression": "workspace:*",
     "@shipfox/node-drizzle": "workspace:*",

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -11,6 +11,7 @@ export interface AssembleWorkflowRunContextParams {
   >;
   readonly triggerPayload: TriggerPayload;
   readonly inputs?: Record<string, unknown> | null | undefined;
+  readonly vars?: Record<string, string> | undefined;
 }
 
 export function assembleWorkflowRunContext(
@@ -31,6 +32,7 @@ export function assembleWorkflowRunContext(
     },
     event: 'data' in params.triggerPayload ? params.triggerPayload.data : null,
     inputs: params.inputs ?? null,
+    ...(params.vars === undefined ? {} : {vars: params.vars}),
   };
 }
 

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -1,0 +1,137 @@
+import type {AgentDefaultsResolver} from '@shipfox/api-agent/core/resolve-agent-config';
+import {parseWorkflowTemplate, planInterpolationField} from '@shipfox/expression';
+import type {Step} from '#core/entities/step.js';
+import {InterpolationUnresolvableError} from '#core/errors.js';
+import {completeStepDispatchConfig} from './complete-step-dispatch-config.js';
+import type {WorkflowEvaluationContext} from './workflow-evaluation-context.js';
+
+function plannedField(source: string) {
+  const plan = planInterpolationField({
+    field: 'env.value',
+    segments: parseWorkflowTemplate(source),
+  });
+  if (!plan.ok) throw new Error('Expected field plan to be valid');
+  return plan.plan.field;
+}
+
+function template(source: string): string {
+  return '$'.concat('{{ ', source, ' }}');
+}
+
+function step(overrides: Partial<Step>): Step {
+  return {
+    id: 'step-1',
+    jobExecutionId: 'exec-1',
+    key: 'deploy',
+    name: 'Deploy',
+    sourceLocation: null,
+    status: 'pending',
+    type: 'run',
+    config: {},
+    configPlan: null,
+    authoredConfig: null,
+    output: null,
+    error: null,
+    position: 1,
+    version: 1,
+    currentAttempt: 1,
+    createdAt: new Date('2026-06-30T12:00:00.000Z'),
+    updatedAt: new Date('2026-06-30T12:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+const context: WorkflowEvaluationContext = {
+  site: 'step-dispatch',
+  values: {
+    steps: {
+      build: {
+        outputs: {sha: 'abc123'},
+      },
+    },
+  },
+};
+
+const resolveAgentDefaults: AgentDefaultsResolver = (params) => ({
+  provider: params.provider ?? 'openai',
+  model: params.model ?? 'gpt-5.5',
+  thinking: params.thinking ?? 'off',
+});
+
+describe('completeStepDispatchConfig', () => {
+  it('serializes residual secret env values as secret bindings without writing env values', () => {
+    const pending = step({
+      config: {},
+      configPlan: {
+        env: {
+          TOKEN: plannedField(`prefix-${template('secrets.local.TOKEN')}`),
+          SHORT: plannedField(template('secrets.API_KEY')),
+        },
+      },
+    });
+
+    const config = completeStepDispatchConfig({
+      step: pending,
+      context,
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(config).toEqual({
+      secret_bindings: [
+        {
+          target: 'TOKEN',
+          segments: [
+            {kind: 'literal', value: 'prefix-'},
+            {kind: 'secret', store: 'local', key: 'TOKEN'},
+          ],
+        },
+        {
+          target: 'SHORT',
+          segments: [{kind: 'secret', store: 'local', key: 'API_KEY'}],
+        },
+      ],
+    });
+  });
+
+  it('keeps fully resolved step config byte-identical apart from resolved env additions', () => {
+    const pending = step({
+      config: {run: 'echo "$SHA"'},
+      configPlan: {
+        env: {
+          SHA: plannedField(template('steps.build.outputs.sha')),
+        },
+      },
+    });
+
+    const config = completeStepDispatchConfig({
+      step: pending,
+      context,
+      resolveAgentDefaults,
+      definitionId: 'def-1',
+    });
+
+    expect(config).toEqual({run: 'echo "$SHA"', env: {SHA: 'abc123'}});
+  });
+
+  it('throws when a server-side segment still survives dispatch', () => {
+    const pending = step({
+      config: {},
+      configPlan: {
+        env: {
+          STATUS: plannedField(template('step.status')),
+        },
+      },
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    expect(act).toThrow(InterpolationUnresolvableError);
+  });
+});

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -447,6 +447,33 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('freezes vars from the run-creation context into step config', () => {
+    const model = normalizeWorkflowDocument({
+      name: 'vars workflow',
+      runner: 'ubuntu-latest',
+      jobs: {
+        deploy: {
+          steps: [
+            {
+              run: 'deploy',
+              env: {REGION: template('"eu-" + vars.REGION')},
+            },
+          ],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({
+      model,
+      context: creationContext({...runContext(), vars: {REGION: 'west'}}),
+    });
+
+    expect(rows[0]?.steps[1]?.config).toMatchObject({
+      env: {REGION: 'eu-west'},
+    });
+    expect(rows[0]?.steps[1]?.configPlan).toBeUndefined();
+  });
+
   it('merges env before resolving and only resolves the winning values', () => {
     const model = workflowModel({
       env: {SHARED: template('event.missing'), WORKFLOW_ONLY: template('run.id')},

--- a/libs/api/workflows/src/core/step-config/run.ts
+++ b/libs/api/workflows/src/core/step-config/run.ts
@@ -1,15 +1,23 @@
 import type {WorkflowModel} from '@shipfox/api-definitions';
 import {
-  freezePlannedRunCommandAtSite,
-  getWorkflowInterpolationFieldFailurePolicy,
+  type MaterializedSecretBindingDto,
+  materializedSecretBindingSchema,
+  type SecretBindingSegmentDto,
+  secretStoreSchema,
+} from '@shipfox/api-secrets-dto';
+import {
+  analyzeContextKeyAccess,
   hoistPlannedRunCommand,
   type ResolvedField,
+  type ResolvedFieldSegment,
+  runnerFillTarget,
   UnsafeRunInterpolationError,
 } from '@shipfox/expression';
 import type {StepConfigDispatchPlan} from '#core/entities/step.js';
+import {InterpolationUnresolvableError} from '#core/errors.js';
 import {
-  completeStepField,
   resolveStepField,
+  type StepConfigField,
   stepConfigInterpolationError,
   type WorkflowStepTemplateDiagnostic,
 } from './fields.js';
@@ -79,22 +87,23 @@ export function completeRunDispatchConfig(params: {
   readonly definitionId: string;
 }): void {
   const env = {...readConfigEnv(params.config)};
+  const secretBindings: MaterializedSecretBindingDto[] = [];
 
   if (params.plan.run !== undefined) {
-    const resolved = freezePlannedRunCommandAtSite({
+    const resolved = completeRunCommand({
       field: params.plan.run,
-      site: params.context.site,
-      context: params.context.values,
-      failurePolicy: getWorkflowInterpolationFieldFailurePolicy('run'),
+      context: params.context,
+      definitionId: params.definitionId,
       reservedNames: Object.keys(env),
     });
     params.config.run = resolved.command;
     Object.assign(env, resolved.env);
+    secretBindings.push(...resolved.secretBindings);
   }
 
   if (params.plan.env !== undefined) {
     for (const [key, field] of Object.entries(params.plan.env)) {
-      env[key] = completeStepField({
+      const completed = completeDispatchField({
         field: 'env.value',
         errorField: 'env',
         template: field,
@@ -102,10 +111,116 @@ export function completeRunDispatchConfig(params: {
         definitionId: params.definitionId,
         envKey: key,
       });
+      if (completed.kind === 'binding') secretBindings.push(completed.binding);
+      else env[key] = completed.value;
     }
   }
 
   if (Object.keys(env).length > 0) params.config.env = env;
+  if (secretBindings.length > 0) params.config.secret_bindings = secretBindings;
+}
+
+function completeRunCommand(params: {
+  readonly field: ResolvedField;
+  readonly context: WorkflowEvaluationContext;
+  readonly definitionId: string;
+  readonly reservedNames: Iterable<string>;
+}): {
+  readonly command: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly secretBindings: readonly MaterializedSecretBindingDto[];
+} {
+  const hoisted = hoistPlannedRunCommand({
+    field: params.field,
+    reservedNames: params.reservedNames,
+  });
+  const env: Record<string, string> = {};
+  const secretBindings: MaterializedSecretBindingDto[] = [];
+
+  for (const binding of hoisted.bindings) {
+    const completed = completeDispatchField({
+      field: 'run',
+      errorField: 'run',
+      template: {segments: [binding.segment]},
+      context: params.context,
+      definitionId: params.definitionId,
+      envKey: binding.name,
+    });
+    if (completed.kind === 'binding') secretBindings.push(completed.binding);
+    else env[binding.name] = completed.value;
+  }
+
+  return {command: hoisted.command, env, secretBindings};
+}
+
+type CompletedDispatchField =
+  | {readonly kind: 'value'; readonly value: string}
+  | {readonly kind: 'binding'; readonly binding: MaterializedSecretBindingDto};
+
+function completeDispatchField(params: {
+  readonly field: 'run' | 'env.value';
+  readonly errorField: StepConfigField;
+  readonly template: ResolvedField;
+  readonly context: WorkflowEvaluationContext;
+  readonly definitionId: string;
+  readonly envKey?: string;
+}): CompletedDispatchField {
+  const resolved = resolveStepField(params);
+  if (resolved.kind === 'frozen') return {kind: 'value', value: resolved.value};
+  if (params.envKey !== undefined && containsOnlyRunnerSecretSegments(resolved.field)) {
+    return {
+      kind: 'binding',
+      binding: secretBindingFromField(params.envKey, resolved.field),
+    };
+  }
+
+  const source = resolved.field.segments.find((segment) => segment.kind === 'deferred')?.expression
+    .source;
+  throw new InterpolationUnresolvableError(params.definitionId, {
+    field: params.errorField,
+    source: source ?? params.field,
+    ...(params.envKey === undefined ? {} : {envKey: params.envKey}),
+  });
+}
+
+function containsOnlyRunnerSecretSegments(field: ResolvedField): boolean {
+  return field.segments.every((segment) => {
+    if (segment.kind === 'literal') return true;
+    return (
+      segment.fillTarget === runnerFillTarget &&
+      segment.roots.length === 1 &&
+      segment.roots[0] === 'secrets'
+    );
+  });
+}
+
+function secretBindingFromField(
+  target: string,
+  field: ResolvedField,
+): MaterializedSecretBindingDto {
+  const binding = {
+    target,
+    segments: field.segments.map(secretBindingSegment),
+  };
+  return materializedSecretBindingSchema.parse(binding);
+}
+
+function secretBindingSegment(segment: ResolvedFieldSegment): SecretBindingSegmentDto {
+  if (segment.kind === 'literal') return {kind: 'literal', value: segment.value};
+
+  const keyAccess = analyzeContextKeyAccess(segment.expression);
+  const reference = keyAccess.references.find((candidate) => candidate.root === 'secrets');
+  if (reference === undefined) {
+    throw new Error(
+      `Runner secret segment did not contain a secret reference: ${segment.expression.source}`,
+    );
+  }
+
+  return {
+    kind: 'secret',
+    store: secretStoreSchema.parse(reference.store ?? 'local'),
+    key: reference.key,
+  };
 }
 
 function resolveCommand(params: {

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -427,6 +427,133 @@ describe('workflow run queries', () => {
       expect(attempt?.model).toEqual(model);
     });
 
+    test('does not load variables referenced only by listening job executions at run creation', async () => {
+      const model = normalizeWorkflowDocument({
+        name: 'Listening vars workflow',
+        runner: 'ubuntu-latest',
+        jobs: {
+          listen: {
+            listening: {
+              on: [{source: 'github', event: 'pull_request_review'}],
+              until: [{source: 'github', event: 'pull_request'}],
+            },
+            steps: [
+              {
+                run: 'echo region',
+                env: {REGION: template('vars.REGION')},
+              },
+            ],
+          },
+        },
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const runJobs = await getJobsByWorkflowRunId(run.id);
+      const listen = runJobs[0];
+      expect(listen).toMatchObject({mode: 'listening'});
+      await expect(getJobExecutionsByJobId(listen?.id as string)).resolves.toEqual([]);
+    });
+
+    test.each([
+      {
+        field: 'run',
+        model: () =>
+          normalizeWorkflowDocument({
+            name: 'Missing run var',
+            runner: 'ubuntu-latest',
+            jobs: {build: {steps: [{run: `echo ${template('vars.REQUIRED')}`}]}},
+          }),
+        expected: {field: 'run', source: 'vars.REQUIRED'},
+      },
+      {
+        field: 'env',
+        model: () =>
+          normalizeWorkflowDocument({
+            name: 'Missing env var',
+            runner: 'ubuntu-latest',
+            jobs: {
+              build: {
+                steps: [{run: 'echo ok', env: {REGION: template('vars.REQUIRED')}}],
+              },
+            },
+          }),
+        expected: {field: 'env', envKey: 'REGION', source: 'vars.REQUIRED'},
+      },
+      {
+        field: 'agent.prompt',
+        model: () =>
+          normalizeWorkflowDocument({
+            name: 'Missing prompt var',
+            runner: 'ubuntu-latest',
+            jobs: {fix: {steps: [{prompt: template('vars.REQUIRED')}]}},
+          }),
+        expected: {field: 'agent.prompt', source: 'vars.REQUIRED'},
+      },
+      {
+        field: 'agent.model',
+        model: () =>
+          normalizeWorkflowDocument({
+            name: 'Missing model var',
+            runner: 'ubuntu-latest',
+            jobs: {fix: {steps: [{prompt: 'Fix it', model: template('vars.REQUIRED')}]}},
+          }),
+        expected: {field: 'agent.model', source: 'vars.REQUIRED'},
+      },
+      {
+        field: 'agent.provider',
+        model: () =>
+          normalizeWorkflowDocument({
+            name: 'Missing provider var',
+            runner: 'ubuntu-latest',
+            jobs: {fix: {steps: [{prompt: 'Fix it', provider: template('vars.REQUIRED')}]}},
+          }),
+        expected: {field: 'agent.provider', source: 'vars.REQUIRED'},
+      },
+      {
+        field: 'step.name',
+        model: () =>
+          normalizeWorkflowDocument({
+            name: 'Missing step name var',
+            runner: 'ubuntu-latest',
+            jobs: {build: {steps: [{name: template('vars.REQUIRED'), run: 'echo ok'}]}},
+          }),
+        expected: {field: 'step.name', source: 'vars.REQUIRED'},
+      },
+    ] as const)('reports missing variables against $field', async ({model, expected}) => {
+      let error: unknown;
+      try {
+        await createWorkflowRun({
+          workspaceId,
+          projectId,
+          definitionId,
+          model: model(),
+          triggerPayload: {
+            source: 'manual',
+            event: 'fire',
+            subscriptionId: crypto.randomUUID(),
+            userId: crypto.randomUUID(),
+          },
+        });
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeInstanceOf(InterpolationUnresolvableError);
+      expect(error).toMatchObject(expected);
+    });
+
     test('writes workflows.workflow_run_attempt.created outbox event in same transaction', async () => {
       const run = await createWorkflowRun({
         workspaceId,

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -100,6 +100,15 @@ const TERMINAL_WORKFLOW_RUN_STATUSES: WorkflowRunStatus[] = ['succeeded', 'faile
 const TERMINAL_JOB_STATUSES: JobStatus[] = ['succeeded', 'failed', 'cancelled', 'skipped'];
 const TERMINAL_EXECUTION_STATUSES: JobExecutionStatus[] = ['succeeded', 'failed', 'cancelled'];
 
+type WorkflowModelJob = WorkflowModel['jobs'][number];
+
+interface ReferencedVariable {
+  readonly key: string;
+  readonly field: InterpolationUnresolvableError['field'];
+  readonly source: string;
+  readonly envKey?: string | undefined;
+}
+
 export interface CreateWorkflowRunParams {
   workspaceId: string;
   projectId: string;
@@ -170,12 +179,14 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     // Resolving one-shot templates here gives interpolation access to the inserted run id.
     // If resolution fails, the transaction rolls back the run, jobs, steps, and outbox event together.
     // Listening steps are resolved later when a job execution is created.
+    const oneShotJobs = params.model.jobs.filter((job) => job.mode !== 'listening');
     const context = assembleCreationContext({
       run,
       triggerPayload: params.triggerPayload,
       inputs: params.inputs ?? null,
       vars: await loadReferencedVariables({
         model: params.model,
+        jobs: oneShotJobs,
         workspaceId: params.workspaceId,
         projectId: params.projectId,
         definitionId: params.definitionId,
@@ -301,11 +312,13 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
 
 async function loadReferencedVariables(params: {
   readonly model: WorkflowModel;
+  readonly jobs?: readonly WorkflowModelJob[] | undefined;
   readonly workspaceId: string;
   readonly projectId: string;
   readonly definitionId: string;
 }): Promise<Record<string, string> | undefined> {
-  const keys = referencedVariableKeys(params.model);
+  const references = referencedVariables(params.model, params.jobs ?? params.model.jobs);
+  const keys = [...new Set(references.map((reference) => reference.key))].sort();
   if (keys.length === 0) return undefined;
 
   const vars = await getVariablesByNamespace({
@@ -315,57 +328,77 @@ async function loadReferencedVariables(params: {
   });
   const missingKey = keys.find((key) => !(key in vars));
   if (missingKey !== undefined) {
+    const reference = references.find((candidate) => candidate.key === missingKey);
     throw new InterpolationUnresolvableError(params.definitionId, {
-      field: 'env',
-      source: `vars.${missingKey}`,
+      field: reference?.field ?? 'env',
+      source: reference?.source ?? `vars.${missingKey}`,
+      ...(reference?.envKey === undefined ? {} : {envKey: reference.envKey}),
     });
   }
 
   return vars;
 }
 
-function referencedVariableKeys(model: WorkflowModel): readonly string[] {
-  const keys = new Set<string>();
+function referencedVariables(
+  model: WorkflowModel,
+  jobs: readonly WorkflowModelJob[],
+): readonly ReferencedVariable[] {
+  const references: ReferencedVariable[] = [];
 
-  collectTemplateVariableKeys(model.templates?.env, keys);
-  for (const job of model.jobs) {
-    collectFieldVariableKeys(job.name, keys);
-    collectTemplateVariableKeys(job.templates?.env, keys);
+  if (jobs.length > 0) {
+    collectTemplateVariableReferences(model.templates?.env, references);
+  }
+
+  for (const job of jobs) {
+    collectFieldVariableReferences(job.name, references, {field: 'job.name'});
+    collectTemplateVariableReferences(job.templates?.env, references);
 
     for (const step of job.steps) {
-      collectFieldVariableKeys(step.templates?.name, keys);
+      collectFieldVariableReferences(step.templates?.name, references, {field: 'step.name'});
       if (step.kind === 'run') {
-        collectFieldVariableKeys(step.templates?.command, keys);
-        collectTemplateVariableKeys(step.templates?.env, keys);
+        collectFieldVariableReferences(step.templates?.command, references, {field: 'run'});
+        collectTemplateVariableReferences(step.templates?.env, references);
       } else {
-        collectFieldVariableKeys(step.templates?.prompt, keys);
-        collectFieldVariableKeys(step.templates?.model, keys);
-        collectFieldVariableKeys(step.templates?.provider, keys);
+        collectFieldVariableReferences(step.templates?.prompt, references, {field: 'agent.prompt'});
+        collectFieldVariableReferences(step.templates?.model, references, {field: 'agent.model'});
+        collectFieldVariableReferences(step.templates?.provider, references, {
+          field: 'agent.provider',
+        });
       }
     }
   }
 
-  return [...keys].sort();
+  return references;
 }
 
-function collectTemplateVariableKeys(
+function collectTemplateVariableReferences(
   templates: Readonly<Record<string, readonly ResolvedFieldSegment[]>> | undefined,
-  keys: Set<string>,
+  references: ReferencedVariable[],
 ): void {
-  for (const template of Object.values(templates ?? {})) {
-    collectFieldVariableKeys(template, keys);
+  for (const [envKey, template] of Object.entries(templates ?? {})) {
+    collectFieldVariableReferences(template, references, {field: 'env', envKey});
   }
 }
 
-function collectFieldVariableKeys(
+function collectFieldVariableReferences(
   template: readonly ResolvedFieldSegment[] | undefined,
-  keys: Set<string>,
+  references: ReferencedVariable[],
+  source: {
+    readonly field: InterpolationUnresolvableError['field'];
+    readonly envKey?: string | undefined;
+  },
 ): void {
   for (const segment of template ?? []) {
     if (segment.kind === 'literal') continue;
     const keyAccess = analyzeContextKeyAccess(segment.expression);
     for (const reference of keyAccess.references) {
-      if (reference.root === 'vars') keys.add(reference.key);
+      if (reference.root !== 'vars') continue;
+      references.push({
+        key: reference.key,
+        field: source.field,
+        source: segment.expression.source,
+        envKey: source.envKey,
+      });
     }
   }
 }

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -3,6 +3,7 @@ import {
   catalogDefaultAgentResolver,
 } from '@shipfox/api-agent/core/resolve-agent-config';
 import {DEFAULT_JOB_SUCCESS, type WorkflowModel} from '@shipfox/api-definitions';
+import {getVariablesByNamespace} from '@shipfox/api-secrets';
 import {
   type LogOutcomeDto,
   WORKFLOWS_JOB_EXECUTION_TIMED_OUT,
@@ -16,8 +17,10 @@ import {
   type WorkflowsEventMapDto,
 } from '@shipfox/api-workflows-dto';
 import {
+  analyzeContextKeyAccess,
   createWorkflowExpression,
   evaluateWorkflowPredicate,
+  type ResolvedFieldSegment,
   WorkflowExpressionEvaluationError,
 } from '@shipfox/expression';
 import {
@@ -56,6 +59,7 @@ import {
   type WorkflowSourceSnapshot,
 } from '#core/entities/workflow-run.js';
 import {
+  InterpolationUnresolvableError,
   JobNotFoundError,
   NoFailedJobsError,
   RunNotTerminalError,
@@ -170,6 +174,12 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       run,
       triggerPayload: params.triggerPayload,
       inputs: params.inputs ?? null,
+      vars: await loadReferencedVariables({
+        model: params.model,
+        workspaceId: params.workspaceId,
+        projectId: params.projectId,
+        definitionId: params.definitionId,
+      }),
     });
     const materializedJobs = materializeWorkflowModel({
       model: params.model,
@@ -287,6 +297,77 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
     recordWorkflowRunCreated(result.run.triggerPayload.provider ?? result.run.triggerSource);
 
   return result.run;
+}
+
+async function loadReferencedVariables(params: {
+  readonly model: WorkflowModel;
+  readonly workspaceId: string;
+  readonly projectId: string;
+  readonly definitionId: string;
+}): Promise<Record<string, string> | undefined> {
+  const keys = referencedVariableKeys(params.model);
+  if (keys.length === 0) return undefined;
+
+  const vars = await getVariablesByNamespace({
+    workspaceId: params.workspaceId,
+    projectId: params.projectId,
+    namespace: '',
+  });
+  const missingKey = keys.find((key) => !(key in vars));
+  if (missingKey !== undefined) {
+    throw new InterpolationUnresolvableError(params.definitionId, {
+      field: 'env',
+      source: `vars.${missingKey}`,
+    });
+  }
+
+  return vars;
+}
+
+function referencedVariableKeys(model: WorkflowModel): readonly string[] {
+  const keys = new Set<string>();
+
+  collectTemplateVariableKeys(model.templates?.env, keys);
+  for (const job of model.jobs) {
+    collectFieldVariableKeys(job.name, keys);
+    collectTemplateVariableKeys(job.templates?.env, keys);
+
+    for (const step of job.steps) {
+      collectFieldVariableKeys(step.templates?.name, keys);
+      if (step.kind === 'run') {
+        collectFieldVariableKeys(step.templates?.command, keys);
+        collectTemplateVariableKeys(step.templates?.env, keys);
+      } else {
+        collectFieldVariableKeys(step.templates?.prompt, keys);
+        collectFieldVariableKeys(step.templates?.model, keys);
+        collectFieldVariableKeys(step.templates?.provider, keys);
+      }
+    }
+  }
+
+  return [...keys].sort();
+}
+
+function collectTemplateVariableKeys(
+  templates: Readonly<Record<string, readonly ResolvedFieldSegment[]>> | undefined,
+  keys: Set<string>,
+): void {
+  for (const template of Object.values(templates ?? {})) {
+    collectFieldVariableKeys(template, keys);
+  }
+}
+
+function collectFieldVariableKeys(
+  template: readonly ResolvedFieldSegment[] | undefined,
+  keys: Set<string>,
+): void {
+  for (const segment of template ?? []) {
+    if (segment.kind === 'literal') continue;
+    const keyAccess = analyzeContextKeyAccess(segment.expression);
+    for (const reference of keyAccess.references) {
+      if (reference.root === 'vars') keys.add(reference.key);
+    }
+  }
 }
 
 export async function getStepByIdForJobExecution(params: {

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -30,6 +30,12 @@ export type {
   WorkflowExpressionCheckOptions,
 } from './expression/workflow-expression.js';
 export {isBareContextReference} from './plan/bare-reference.js';
+export {
+  analyzeContextKeyAccess,
+  type ContextKeyAccessAnalysis,
+  type ContextKeyAccessReference,
+  type ContextKeyAccessViolation,
+} from './plan/context-key-access.js';
 export {evaluatePlannedPredicateAtSite} from './plan/evaluate-planned-predicate.js';
 export {extractExactContextRoots} from './plan/extract-exact-context-roots.js';
 export {
@@ -98,6 +104,7 @@ export {
   getWorkflowInterpolationFieldFailurePolicy,
   type OpenWorkflowContextDefinition,
   type ReservedRootDefinition,
+  type RunnerWorkflowContextDefinition,
   resolveContextRootAvailability,
   resolveContextRootHost,
   rootsAvailableAt,
@@ -122,10 +129,12 @@ export {
   workflowContextHosts,
   workflowContextNames,
   workflowContextReservedRoots,
+  workflowContextRootRequiresLiteralKey,
   workflowContextSensitivities,
   workflowContextTrustTiers,
   workflowFieldFailurePolicies,
   workflowInterpolationFieldAcceptsContext,
+  workflowInterpolationFieldAcceptsHost,
   workflowInterpolationFieldAcceptsTrustTier,
   workflowInterpolationFieldPolicies,
   workflowInterpolationFields,

--- a/libs/shared/expression/src/plan/context-key-access.test.ts
+++ b/libs/shared/expression/src/plan/context-key-access.test.ts
@@ -44,4 +44,10 @@ describe('analyzeContextKeyAccess', () => {
 
     expect(result).toEqual({references: [], violations: []});
   });
+
+  it('does not treat map literal identifier keys as context roots', () => {
+    const result = analyzeContextKeyAccess('{vars: event.region, secrets: event.token}');
+
+    expect(result).toEqual({references: [], violations: []});
+  });
 });

--- a/libs/shared/expression/src/plan/context-key-access.test.ts
+++ b/libs/shared/expression/src/plan/context-key-access.test.ts
@@ -1,0 +1,47 @@
+import {analyzeContextKeyAccess} from './context-key-access.js';
+
+describe('analyzeContextKeyAccess', () => {
+  it('returns canonical references for vars and secrets', () => {
+    const result = analyzeContextKeyAccess('vars.REGION + secrets.local.TOKEN + secrets.API_KEY');
+
+    expect(result).toEqual({
+      references: [
+        {root: 'vars', key: 'REGION'},
+        {root: 'secrets', store: 'local', key: 'TOKEN'},
+        {root: 'secrets', key: 'API_KEY'},
+      ],
+      violations: [],
+    });
+  });
+
+  it('allows literal-key values to be used inside larger expressions', () => {
+    const result = analyzeContextKeyAccess('"eu-" + vars.REGION');
+
+    expect(result).toEqual({
+      references: [{root: 'vars', key: 'REGION'}],
+      violations: [],
+    });
+  });
+
+  it.each([
+    'vars[event.name]',
+    'vars["REGION"]',
+    'vars',
+  ])('rejects non-literal vars key access: %s', (source) => {
+    const result = analyzeContextKeyAccess(source);
+
+    expect(result.violations).toEqual([{root: 'vars', source}]);
+  });
+
+  it('rejects non-literal secret key access', () => {
+    const result = analyzeContextKeyAccess('secrets[event.name]');
+
+    expect(result.violations).toEqual([{root: 'secrets', source: 'secrets[event.name]'}]);
+  });
+
+  it('does not treat comprehension aliases as context roots', () => {
+    const result = analyzeContextKeyAccess('executions.all(vars, vars.status == "succeeded")');
+
+    expect(result).toEqual({references: [], violations: []});
+  });
+});

--- a/libs/shared/expression/src/plan/context-key-access.ts
+++ b/libs/shared/expression/src/plan/context-key-access.ts
@@ -116,7 +116,9 @@ function collectContextKeyAccesses(
       return;
     case 'map':
       for (const [key, value] of node.args) {
-        collectContextKeyAccesses(key, source, references, violations, scopedIdentifiers);
+        if (key.op !== 'id') {
+          collectContextKeyAccesses(key, source, references, violations, scopedIdentifiers);
+        }
         collectContextKeyAccesses(value, source, references, violations, scopedIdentifiers);
       }
       return;

--- a/libs/shared/expression/src/plan/context-key-access.ts
+++ b/libs/shared/expression/src/plan/context-key-access.ts
@@ -1,0 +1,240 @@
+import {type ASTNode, type BinaryOperator, parse as parseCel} from '@marcbachmann/cel-js';
+import type {WorkflowExpression} from '../expression/workflow-expression.js';
+import {workflowContextRootRequiresLiteralKey} from '../workflow-context/workflow-context.js';
+
+const binaryOperators = new Set<BinaryOperator>([
+  '!=',
+  '==',
+  'in',
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '<',
+  '<=',
+  '>',
+  '>=',
+]);
+
+const comprehensionMethods = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
+
+export interface ContextKeyAccessReference {
+  readonly root: 'vars' | 'secrets';
+  readonly store?: string;
+  readonly key: string;
+}
+
+export interface ContextKeyAccessViolation {
+  readonly root: string;
+  readonly source: string;
+}
+
+export interface ContextKeyAccessAnalysis {
+  readonly references: readonly ContextKeyAccessReference[];
+  readonly violations: readonly ContextKeyAccessViolation[];
+}
+
+interface AccessChain {
+  readonly root: string;
+  readonly segments: readonly string[];
+  readonly computed: boolean;
+}
+
+export function analyzeContextKeyAccess(
+  expression: WorkflowExpression | string,
+): ContextKeyAccessAnalysis {
+  const source = typeof expression === 'string' ? expression : expression.source;
+  const references: ContextKeyAccessReference[] = [];
+  const violations: ContextKeyAccessViolation[] = [];
+
+  collectContextKeyAccesses(parseCel(source).ast, source, references, violations, new Set());
+
+  return {references, violations};
+}
+
+function collectContextKeyAccesses(
+  node: ASTNode,
+  source: string,
+  references: ContextKeyAccessReference[],
+  violations: ContextKeyAccessViolation[],
+  scopedIdentifiers: ReadonlySet<string>,
+): void {
+  if (binaryOperators.has(node.op as BinaryOperator) || node.op === '||' || node.op === '&&') {
+    collectBinaryContextKeyAccesses(
+      node.args as [ASTNode, ASTNode],
+      source,
+      references,
+      violations,
+      scopedIdentifiers,
+    );
+    return;
+  }
+
+  const chain = accessChain(node, scopedIdentifiers);
+  if (chain && workflowContextRootRequiresLiteralKey(chain.root)) {
+    recordLiteralKeyRootAccess(chain, source, references, violations);
+    return;
+  }
+
+  switch (node.op) {
+    case 'id':
+    case 'value':
+      return;
+    case '.':
+    case '.?':
+      collectContextKeyAccesses(node.args[0], source, references, violations, scopedIdentifiers);
+      return;
+    case '[]':
+    case '[?]':
+      collectBinaryContextKeyAccesses(node.args, source, references, violations, scopedIdentifiers);
+      return;
+    case 'call':
+      for (const argument of node.args[1]) {
+        collectContextKeyAccesses(argument, source, references, violations, scopedIdentifiers);
+      }
+      return;
+    case 'rcall': {
+      const [method, receiver, args] = node.args as [string, ASTNode, ASTNode[]];
+      collectContextKeyAccesses(receiver, source, references, violations, scopedIdentifiers);
+      const binding = bindComprehensionAlias(method, args, scopedIdentifiers);
+      for (const argument of args.slice(binding.skipArgs)) {
+        collectContextKeyAccesses(
+          argument,
+          source,
+          references,
+          violations,
+          binding.scopedIdentifiers,
+        );
+      }
+      return;
+    }
+    case 'list':
+      for (const element of node.args) {
+        collectContextKeyAccesses(element, source, references, violations, scopedIdentifiers);
+      }
+      return;
+    case 'map':
+      for (const [key, value] of node.args) {
+        collectContextKeyAccesses(key, source, references, violations, scopedIdentifiers);
+        collectContextKeyAccesses(value, source, references, violations, scopedIdentifiers);
+      }
+      return;
+    case '?:':
+      collectContextKeyAccesses(node.args[0], source, references, violations, scopedIdentifiers);
+      collectContextKeyAccesses(node.args[1], source, references, violations, scopedIdentifiers);
+      collectContextKeyAccesses(node.args[2], source, references, violations, scopedIdentifiers);
+      return;
+    case '!_':
+    case '-_':
+      collectContextKeyAccesses(node.args, source, references, violations, scopedIdentifiers);
+      return;
+  }
+
+  throw new Error(`Unsupported CEL AST operator: ${(node as {op: string}).op}`);
+}
+
+function collectBinaryContextKeyAccesses(
+  [left, right]: [ASTNode, ASTNode],
+  source: string,
+  references: ContextKeyAccessReference[],
+  violations: ContextKeyAccessViolation[],
+  scopedIdentifiers: ReadonlySet<string>,
+): void {
+  collectContextKeyAccesses(left, source, references, violations, scopedIdentifiers);
+  collectContextKeyAccesses(right, source, references, violations, scopedIdentifiers);
+}
+
+function recordLiteralKeyRootAccess(
+  chain: AccessChain,
+  source: string,
+  references: ContextKeyAccessReference[],
+  violations: ContextKeyAccessViolation[],
+): void {
+  if (chain.computed) {
+    violations.push({root: chain.root, source});
+    return;
+  }
+
+  if (chain.root === 'vars' && chain.segments.length === 1) {
+    const key = chain.segments[0];
+    if (key === undefined) throw new Error('Expected vars key segment');
+    references.push({root: chain.root, key});
+    return;
+  }
+
+  if (chain.root === 'secrets' && chain.segments.length === 1) {
+    const key = chain.segments[0];
+    if (key === undefined) throw new Error('Expected secret key segment');
+    references.push({root: chain.root, key});
+    return;
+  }
+
+  if (chain.root === 'secrets' && chain.segments.length === 2) {
+    const store = chain.segments[0];
+    const key = chain.segments[1];
+    if (store === undefined || key === undefined) {
+      throw new Error('Expected secret store and key segments');
+    }
+    references.push({root: chain.root, store, key});
+    return;
+  }
+
+  violations.push({root: chain.root, source});
+}
+
+function accessChain(
+  node: ASTNode,
+  scopedIdentifiers: ReadonlySet<string>,
+): AccessChain | undefined {
+  switch (node.op) {
+    case 'id':
+      return scopedIdentifiers.has(node.args)
+        ? undefined
+        : {root: node.args, segments: [], computed: false};
+    case '.': {
+      const target = accessChain(node.args[0], scopedIdentifiers);
+      if (target === undefined) return undefined;
+      return {...target, segments: [...target.segments, node.args[1]]};
+    }
+    case '.?': {
+      const target = accessChain(node.args[0], scopedIdentifiers);
+      if (target === undefined) return undefined;
+      return {...target, segments: [...target.segments, node.args[1]], computed: true};
+    }
+    case '[]':
+    case '[?]': {
+      const target = accessChain(node.args[0], scopedIdentifiers);
+      if (target === undefined) return undefined;
+      const literalSegment = literalStringValue(node.args[1]);
+      return {
+        ...target,
+        segments:
+          literalSegment === undefined ? target.segments : [...target.segments, literalSegment],
+        computed: true,
+      };
+    }
+    default:
+      return undefined;
+  }
+}
+
+function literalStringValue(node: ASTNode): string | undefined {
+  return node.op === 'value' && typeof node.args === 'string' ? node.args : undefined;
+}
+
+function bindComprehensionAlias(
+  method: string,
+  args: readonly ASTNode[],
+  scopedIdentifiers: ReadonlySet<string>,
+): {readonly scopedIdentifiers: ReadonlySet<string>; readonly skipArgs: number} {
+  if (!comprehensionMethods.has(method)) return {scopedIdentifiers, skipArgs: 0};
+
+  const [alias] = args;
+  if (alias?.op !== 'id') return {scopedIdentifiers, skipArgs: 0};
+
+  return {
+    scopedIdentifiers: new Set([...scopedIdentifiers, alias.args]),
+    skipArgs: 1,
+  };
+}

--- a/libs/shared/expression/src/plan/plan-field.test.ts
+++ b/libs/shared/expression/src/plan/plan-field.test.ts
@@ -90,6 +90,48 @@ describe('planInterpolationField', () => {
     });
   });
 
+  it('allows a bare secret reference as a runner-fill deferred segment', () => {
+    const segments = parseWorkflowTemplate(templateExpression(' secrets.TOKEN '));
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: ['secrets'],
+              fillTarget: 'runner-fill',
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('allows vars references inside larger expressions', () => {
+    const segments = parseWorkflowTemplate(templateExpression(' "eu-" + vars.REGION '));
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toMatchObject({
+      ok: true,
+      plan: {
+        field: {
+          segments: [
+            {
+              kind: 'deferred',
+              roots: ['vars'],
+              fillTarget: 'run-creation',
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it.each([
     'runner.os + steps.build.outputs.sha',
     'runner.os + runner.arch',
@@ -107,6 +149,27 @@ describe('planInterpolationField', () => {
           source,
           runnerRoots: ['runner'],
           hint: runnerRootNotBareHint,
+        },
+      ],
+    });
+  });
+
+  it.each([
+    'vars[event.name]',
+    'secrets[event.name]',
+  ])('rejects computed context keys: %s', (source) => {
+    const segments = parseWorkflowTemplate(templateExpression(source));
+
+    const result = planInterpolationField({field: 'env.value', segments});
+
+    expect(result).toEqual({
+      ok: false,
+      violations: [
+        {
+          reason: 'computed-context-key',
+          source,
+          contextRoots: [source.startsWith('vars') ? 'vars' : 'secrets'],
+          hint: `${source.startsWith('vars') ? 'vars' : 'secrets'} references must use a literal dot key`,
         },
       ],
     });

--- a/libs/shared/expression/src/plan/plan-field.ts
+++ b/libs/shared/expression/src/plan/plan-field.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowInterpolationField,
 } from '../workflow-context/workflow-context.js';
 import {isBareContextReference} from './bare-reference.js';
+import {analyzeContextKeyAccess} from './context-key-access.js';
 import type {ResolvedField} from './resolved-field.js';
 import {routeExpression} from './route-expression.js';
 
@@ -12,9 +13,10 @@ const templateExpressionOpen = '$' + '{{';
 const runnerRootNotBareHint = `split runner-host references into their own adjacent ${templateExpressionOpen} }} segments`;
 
 export type PlanViolation = {
-  readonly reason: 'runner-root-not-bare';
+  readonly reason: 'runner-root-not-bare' | 'computed-context-key';
   readonly source: string;
-  readonly runnerRoots: readonly string[];
+  readonly runnerRoots?: readonly string[];
+  readonly contextRoots?: readonly string[];
   readonly hint: string;
 };
 
@@ -36,7 +38,17 @@ export function planInterpolationField(params: {
     if (segment.kind === 'literal') return {kind: 'literal', value: segment.text};
 
     const route = routeExpression(segment.expression);
-    if (route.runnerRoots.length > 0 && !isBareContextReference(segment.expression.source)) {
+    const keyAccess = analyzeContextKeyAccess(segment.expression);
+    if (keyAccess.violations.length > 0) {
+      violations.push(
+        ...keyAccess.violations.map((violation) => ({
+          reason: 'computed-context-key' as const,
+          source: violation.source,
+          contextRoots: [violation.root],
+          hint: `${violation.root} references must use a literal dot key`,
+        })),
+      );
+    } else if (route.runnerRoots.length > 0 && !isBareContextReference(segment.expression.source)) {
       violations.push({
         reason: 'runner-root-not-bare',
         source: segment.expression.source,

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -23,6 +23,7 @@ import {
   workflowContextTrustTiers,
   workflowFieldFailurePolicies,
   workflowInterpolationFieldAcceptsContext,
+  workflowInterpolationFieldAcceptsHost,
   workflowInterpolationFieldAcceptsTrustTier,
   workflowInterpolationFieldPolicies,
   workflowInterpolationFields,
@@ -42,6 +43,8 @@ describe('workflow context registry', () => {
       'execution',
       'steps',
       'step',
+      'vars',
+      'secrets',
     ]);
   });
 
@@ -78,6 +81,8 @@ describe('workflow context registry', () => {
       'execution',
       'steps',
       'step',
+      'vars',
+      'secrets',
     ]);
     expect(contextsByTrust.untrusted).toEqual(['event', 'inputs']);
   });
@@ -125,19 +130,40 @@ describe('workflow context registry', () => {
       shape: 'open',
       checkMode: 'syntax',
     });
+    expect(workflowContextDefinitions.vars).toMatchObject({
+      availability: 'run-creation',
+      trustTier: 'trusted',
+      sensitivity: 'persistable',
+      host: 'server',
+      shape: 'open',
+      checkMode: 'syntax',
+      literalKeyOnly: true,
+    });
+    expect(workflowContextDefinitions.secrets).toMatchObject({
+      trustTier: 'trusted',
+      sensitivity: 'ephemeral',
+      host: 'runner',
+      shape: 'open',
+      checkMode: 'syntax',
+      literalKeyOnly: true,
+    });
   });
 
   it('declares every implemented context with all registry dimensions', () => {
     for (const root of workflowContextNames) {
       expect(workflowContextDefinitions[root]).toMatchObject({
-        availability: expect.any(String),
         trustTier: expect.any(String),
-        sensitivity: 'persistable',
-        host: 'server',
+        sensitivity: expect.any(String),
+        host: expect.any(String),
         shape: expect.any(String),
         checkMode: expect.any(String),
       });
-      expect(availabilitySites).toContain(workflowContextDefinitions[root].availability);
+      const availability = resolveContextRootAvailability(root);
+      if (workflowContextDefinitions[root].host === 'server') {
+        expect(availabilitySites).toContain(availability);
+      } else {
+        expect(availability).toBeUndefined();
+      }
       expect(workflowContextTrustTiers).toContain(workflowContextDefinitions[root].trustTier);
       expect(workflowContextSensitivities).toContain(workflowContextDefinitions[root].sensitivity);
       expect(workflowContextHosts).toContain(workflowContextDefinitions[root].host);
@@ -190,11 +216,20 @@ describe('workflow context registry', () => {
     expect(getWorkflowContextTypeEnvironment('event')).toBeUndefined();
     expect(getWorkflowContextTypeEnvironment('inputs')).toBeUndefined();
     expect(getWorkflowContextTypeEnvironment('steps')).toBeUndefined();
+    expect(getWorkflowContextTypeEnvironment('vars')).toBeUndefined();
+    expect(getWorkflowContextTypeEnvironment('secrets')).toBeUndefined();
   });
 
   it('returns the roots available at each availability site', () => {
     expect(rootsAvailableAt('ingest')).toEqual([]);
-    expect(rootsAvailableAt('run-creation')).toEqual(['run', 'trigger', 'event', 'inputs', 'job']);
+    expect(rootsAvailableAt('run-creation')).toEqual([
+      'run',
+      'trigger',
+      'event',
+      'inputs',
+      'job',
+      'vars',
+    ]);
     expect(rootsAvailableAt('execution-creation')).toEqual([
       'run',
       'trigger',
@@ -203,6 +238,7 @@ describe('workflow context registry', () => {
       'job',
       'executions',
       'execution',
+      'vars',
     ]);
     expect(rootsAvailableAt('job-activation')).toEqual([
       'run',
@@ -212,6 +248,7 @@ describe('workflow context registry', () => {
       'job',
       'executions',
       'execution',
+      'vars',
     ]);
     expect(rootsAvailableAt('step-dispatch')).toEqual([
       'run',
@@ -222,6 +259,7 @@ describe('workflow context registry', () => {
       'executions',
       'execution',
       'steps',
+      'vars',
     ]);
     expect(rootsAvailableAt('step-report')).toEqual([
       'run',
@@ -233,6 +271,7 @@ describe('workflow context registry', () => {
       'execution',
       'steps',
       'step',
+      'vars',
     ]);
     expect(rootsAvailableAt('execution-resolution')).toEqual([
       'run',
@@ -244,6 +283,7 @@ describe('workflow context registry', () => {
       'execution',
       'steps',
       'step',
+      'vars',
     ]);
     expect(rootsAvailableAt('job-resolution')).toEqual([
       'run',
@@ -255,6 +295,7 @@ describe('workflow context registry', () => {
       'execution',
       'steps',
       'step',
+      'vars',
     ]);
   });
 
@@ -299,6 +340,7 @@ describe('workflow context registry', () => {
         expect(workflowContextDefinitions[root].host).toBe('server');
       }
       expect(availableRoots).not.toContain('runner');
+      expect(availableRoots).not.toContain('secrets');
     }
   });
 
@@ -327,7 +369,9 @@ describe('workflow context registry', () => {
     }
 
     for (const root of workflowContextNames) {
-      const availability = workflowContextDefinitions[root].availability;
+      const availability = resolveContextRootAvailability(root);
+      if (availability === undefined) continue;
+
       const available = rootsAvailableAt(availability);
       expect(available).toContain(root);
       expect(siteIndexes.get(availability)).toBeDefined();
@@ -343,12 +387,21 @@ describe('workflow context registry', () => {
 
   it('generates an availability reference from the registry and reserved roots', () => {
     const expected = [
-      ...workflowContextNames.map((root) => ({
-        root,
-        availability: workflowContextDefinitions[root].availability,
-        reserved: false,
-        availableAt: availableAtReference(workflowContextDefinitions[root].availability),
-      })),
+      ...workflowContextNames.map((root) => {
+        const availability = resolveContextRootAvailability(root);
+        return availability === undefined
+          ? {
+              root,
+              reserved: false,
+              availableAt: noServerAvailabilityReference(),
+            }
+          : {
+              root,
+              availability,
+              reserved: false,
+              availableAt: availableAtReference(availability),
+            };
+      }),
       ...Object.entries(workflowContextReservedRoots).map(([root, definition]) =>
         definition.host === 'runner'
           ? {
@@ -366,189 +419,6 @@ describe('workflow context registry', () => {
     ];
 
     expect(workflowContextAvailabilityReference()).toEqual(expected);
-    expect(workflowContextAvailabilityReference()).toMatchInlineSnapshot(`
-      [
-        {
-          "availability": "run-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": true,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "run",
-        },
-        {
-          "availability": "run-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": true,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "trigger",
-        },
-        {
-          "availability": "run-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": true,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "event",
-        },
-        {
-          "availability": "run-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": true,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "inputs",
-        },
-        {
-          "availability": "run-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": true,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "job",
-        },
-        {
-          "availability": "execution-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": false,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "executions",
-        },
-        {
-          "availability": "execution-creation",
-          "availableAt": {
-            "execution-creation": true,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": false,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "execution",
-        },
-        {
-          "availability": "step-dispatch",
-          "availableAt": {
-            "execution-creation": false,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": false,
-            "job-resolution": true,
-            "run-creation": false,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "steps",
-        },
-        {
-          "availability": "step-report",
-          "availableAt": {
-            "execution-creation": false,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": false,
-            "job-resolution": true,
-            "run-creation": false,
-            "step-dispatch": false,
-            "step-report": true,
-          },
-          "reserved": false,
-          "root": "step",
-        },
-        {
-          "availability": "job-resolution",
-          "availableAt": {
-            "execution-creation": false,
-            "execution-resolution": false,
-            "ingest": false,
-            "job-activation": false,
-            "job-resolution": true,
-            "run-creation": false,
-            "step-dispatch": false,
-            "step-report": false,
-          },
-          "reserved": true,
-          "root": "jobs",
-        },
-        {
-          "availability": "job-activation",
-          "availableAt": {
-            "execution-creation": false,
-            "execution-resolution": true,
-            "ingest": false,
-            "job-activation": true,
-            "job-resolution": true,
-            "run-creation": false,
-            "step-dispatch": true,
-            "step-report": true,
-          },
-          "reserved": true,
-          "root": "matrix",
-        },
-        {
-          "availableAt": {
-            "execution-creation": false,
-            "execution-resolution": false,
-            "ingest": false,
-            "job-activation": false,
-            "job-resolution": false,
-            "run-creation": false,
-            "step-dispatch": false,
-            "step-report": false,
-          },
-          "reserved": true,
-          "root": "runner",
-        },
-      ]
-    `);
   });
 
   it('resolves root host and availability across implemented and reserved roots', () => {
@@ -556,6 +426,10 @@ describe('workflow context registry', () => {
     expect(resolveContextRootAvailability('run')).toBe('run-creation');
     expect(resolveContextRootHost('steps')).toBe('server');
     expect(resolveContextRootAvailability('steps')).toBe('step-dispatch');
+    expect(resolveContextRootHost('vars')).toBe('server');
+    expect(resolveContextRootAvailability('vars')).toBe('run-creation');
+    expect(resolveContextRootHost('secrets')).toBe('runner');
+    expect(resolveContextRootAvailability('secrets')).toBeUndefined();
     expect(resolveContextRootHost('runner')).toBe('runner');
     expect(resolveContextRootAvailability('runner')).toBeUndefined();
     expect(resolveContextRootHost('unknown')).toBeUndefined();
@@ -687,6 +561,22 @@ describe('workflow interpolation field policies', () => {
     expect(workflowInterpolationFieldPolicies[field].acceptedTrustTiers).toEqual(trustTiers);
   });
 
+  it.each([
+    ['run', ['server', 'runner']],
+    ['env.value', ['server', 'runner']],
+    ['agent.prompt', ['server']],
+    ['agent.model', ['server']],
+    ['agent.provider', ['server']],
+    ['agent.thinking', ['server']],
+    ['job.name', ['server']],
+    ['step.name', ['server']],
+  ] satisfies readonly [
+    WorkflowInterpolationField,
+    readonly string[],
+  ][])('allows %s interpolation from the expected hosts', (field, hosts) => {
+    expect(workflowInterpolationFieldPolicies[field].acceptedHosts).toEqual(hosts);
+  });
+
   it('rejects untrusted contexts from trusted-only fields', () => {
     expect(workflowInterpolationFieldAcceptsTrustTier('run', 'untrusted')).toBe(false);
     expect(workflowInterpolationFieldAcceptsContext('run', 'event')).toBe(false);
@@ -702,6 +592,16 @@ describe('workflow interpolation field policies', () => {
         expect(workflowInterpolationFieldAcceptsContext(field, context)).toBe(true);
       }
     }
+  });
+
+  it('rejects runner-host contexts from server-only fields', () => {
+    expect(workflowInterpolationFieldAcceptsHost('run', 'runner')).toBe(true);
+    expect(workflowInterpolationFieldAcceptsHost('env.value', 'runner')).toBe(true);
+    expect(workflowInterpolationFieldAcceptsHost('agent.prompt', 'runner')).toBe(false);
+    expect(workflowInterpolationFieldAcceptsHost('agent.model', 'runner')).toBe(false);
+    expect(workflowInterpolationFieldAcceptsHost('agent.provider', 'runner')).toBe(false);
+    expect(workflowInterpolationFieldAcceptsHost('job.name', 'runner')).toBe(false);
+    expect(workflowInterpolationFieldAcceptsHost('step.name', 'runner')).toBe(false);
   });
 
   it('marks display names for render sanitization', () => {
@@ -721,6 +621,10 @@ describe('workflow interpolation field policies', () => {
       expect(policy.acceptedTrustTiers.length).toBeGreaterThan(0);
       for (const trustTier of policy.acceptedTrustTiers) {
         expect(workflowContextTrustTiers).toContain(trustTier);
+      }
+      expect(policy.acceptedHosts.length).toBeGreaterThan(0);
+      for (const host of policy.acceptedHosts) {
+        expect(workflowContextHosts).toContain(host);
       }
     }
   });

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -10,6 +10,8 @@ export const workflowContextNames = [
   'execution',
   'steps',
   'step',
+  'vars',
+  'secrets',
 ] as const;
 export type WorkflowContextName = (typeof workflowContextNames)[number];
 
@@ -76,11 +78,22 @@ export interface OpenWorkflowContextDefinition {
   readonly host: 'server';
   readonly shape: 'open';
   readonly checkMode: 'syntax';
+  readonly literalKeyOnly?: boolean;
+}
+
+export interface RunnerWorkflowContextDefinition {
+  readonly trustTier: WorkflowContextTrustTier;
+  readonly sensitivity: 'ephemeral';
+  readonly host: 'runner';
+  readonly shape: 'open';
+  readonly checkMode: 'syntax';
+  readonly literalKeyOnly?: boolean;
 }
 
 export type WorkflowContextDefinition =
   | TypedWorkflowContextDefinition
-  | OpenWorkflowContextDefinition;
+  | OpenWorkflowContextDefinition
+  | RunnerWorkflowContextDefinition;
 
 const runTypeEnvironment = {
   run: {
@@ -246,6 +259,23 @@ export const workflowContextDefinitions = {
     checkMode: 'typed',
     typeEnvironment: stepTypeEnvironment,
   },
+  vars: {
+    availability: 'run-creation',
+    trustTier: 'trusted',
+    sensitivity: 'persistable',
+    host: 'server',
+    shape: 'open',
+    checkMode: 'syntax',
+    literalKeyOnly: true,
+  },
+  secrets: {
+    trustTier: 'trusted',
+    sensitivity: 'ephemeral',
+    host: 'runner',
+    shape: 'open',
+    checkMode: 'syntax',
+    literalKeyOnly: true,
+  },
 } as const satisfies Record<WorkflowContextName, WorkflowContextDefinition>;
 
 export type WorkflowInterpolationField =
@@ -264,51 +294,62 @@ export type WorkflowInterpolationFailurePolicy = Exclude<WorkflowFieldFailurePol
 
 export interface WorkflowInterpolationFieldPolicy {
   readonly acceptedTrustTiers: readonly WorkflowContextTrustTier[];
+  readonly acceptedHosts: readonly WorkflowContextHost[];
   readonly failurePolicy: WorkflowInterpolationFailurePolicy;
   readonly renderSanitize: boolean;
 }
 
 const trustedOnlyTrustTiers: readonly WorkflowContextTrustTier[] = ['trusted'];
 const anyTrustTier: readonly WorkflowContextTrustTier[] = ['trusted', 'untrusted'];
+const serverOnlyHosts: readonly WorkflowContextHost[] = ['server'];
+const anyHost: readonly WorkflowContextHost[] = ['server', 'runner'];
 
 export const workflowInterpolationFieldPolicies = {
   run: {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    acceptedHosts: anyHost,
     failurePolicy: 'fail',
     renderSanitize: false,
   },
   'env.value': {
     acceptedTrustTiers: anyTrustTier,
+    acceptedHosts: anyHost,
     failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.prompt': {
     acceptedTrustTiers: anyTrustTier,
+    acceptedHosts: serverOnlyHosts,
     failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.model': {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    acceptedHosts: serverOnlyHosts,
     failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.provider': {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    acceptedHosts: serverOnlyHosts,
     failurePolicy: 'fail',
     renderSanitize: false,
   },
   'agent.thinking': {
     acceptedTrustTiers: trustedOnlyTrustTiers,
+    acceptedHosts: serverOnlyHosts,
     failurePolicy: 'fail',
     renderSanitize: false,
   },
   'job.name': {
     acceptedTrustTiers: anyTrustTier,
+    acceptedHosts: serverOnlyHosts,
     failurePolicy: 'degrade',
     renderSanitize: true,
   },
   'step.name': {
     acceptedTrustTiers: anyTrustTier,
+    acceptedHosts: serverOnlyHosts,
     failurePolicy: 'degrade',
     renderSanitize: true,
   },
@@ -328,8 +369,11 @@ export function getWorkflowContextDefinition(name: WorkflowContextName): Workflo
   return workflowContextDefinitions[name];
 }
 
-export function getWorkflowContextAvailability(name: WorkflowContextName): AvailabilitySite {
-  return workflowContextDefinitions[name].availability;
+export function getWorkflowContextAvailability(
+  name: WorkflowContextName,
+): AvailabilitySite | undefined {
+  const definition = workflowContextDefinitions[name];
+  return definition.host === 'server' ? definition.availability : undefined;
 }
 
 export function getWorkflowContextHost(name: WorkflowContextName): WorkflowContextHost {
@@ -343,7 +387,10 @@ export function resolveContextRootHost(root: string): WorkflowContextHost | unde
 }
 
 export function resolveContextRootAvailability(root: string): AvailabilitySite | undefined {
-  if (isWorkflowContextName(root)) return workflowContextDefinitions[root].availability;
+  if (isWorkflowContextName(root)) {
+    const definition = workflowContextDefinitions[root];
+    return definition.host === 'server' ? definition.availability : undefined;
+  }
 
   if (!isWorkflowContextReservedRoot(root)) return undefined;
   const reservedRoot = workflowContextReservedRoots[root];
@@ -396,6 +443,13 @@ export function workflowInterpolationFieldAcceptsTrustTier(
   return workflowInterpolationFieldPolicies[field].acceptedTrustTiers.includes(trustTier);
 }
 
+export function workflowInterpolationFieldAcceptsHost(
+  field: WorkflowInterpolationField,
+  host: WorkflowContextHost,
+): boolean {
+  return workflowInterpolationFieldPolicies[field].acceptedHosts.includes(host);
+}
+
 export function workflowInterpolationFieldAcceptsContext(
   field: WorkflowInterpolationField,
   context: WorkflowContextName,
@@ -404,6 +458,12 @@ export function workflowInterpolationFieldAcceptsContext(
     field,
     workflowContextDefinitions[context].trustTier,
   );
+}
+
+export function workflowContextRootRequiresLiteralKey(root: string): boolean {
+  if (!isWorkflowContextName(root)) return false;
+  const definition = workflowContextDefinitions[root];
+  return 'literalKeyOnly' in definition && definition.literalKeyOnly === true;
 }
 
 export function getWorkflowInterpolationFieldFailurePolicy(
@@ -421,9 +481,11 @@ export interface WorkflowContextAvailabilityReferenceEntry {
 
 export function workflowContextAvailabilityReference(): readonly WorkflowContextAvailabilityReferenceEntry[] {
   return [
-    ...workflowContextNames.map((root) =>
-      availabilityReferenceEntry(root, workflowContextDefinitions[root].availability, false),
-    ),
+    ...workflowContextNames.map((root) => {
+      const definition = workflowContextDefinitions[root];
+      if (definition.host === 'runner') return noServerAvailabilityReferenceEntry(root, false);
+      return availabilityReferenceEntry(root, definition.availability, false);
+    }),
     ...Object.entries(workflowContextReservedRoots).map(([root, definition]) => {
       if (definition.host === 'runner') {
         return noServerAvailabilityReferenceEntry(root as WorkflowContextReservedRoot, true);
@@ -451,7 +513,7 @@ function availabilityReferenceEntry(
 }
 
 function noServerAvailabilityReferenceEntry(
-  root: WorkflowContextReservedRoot,
+  root: WorkflowContextName | WorkflowContextReservedRoot,
   reserved: boolean,
 ): WorkflowContextAvailabilityReferenceEntry {
   const availableAt = Object.fromEntries(availabilitySites.map((site) => [site, false])) as Record<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1136,6 +1136,9 @@ importers:
       '@shipfox/api-projects-dto':
         specifier: workspace:*
         version: link:../projects-dto
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../secrets-dto
       '@shipfox/config':
         specifier: workspace:*
         version: link:../../shared/common/config
@@ -2455,6 +2458,9 @@ importers:
       '@shipfox/api-secrets':
         specifier: workspace:*
         version: link:../secrets
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../secrets-dto
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../workflows-dto


### PR DESCRIPTION
Add expression support for workspace variables and runner-host secrets in workflow templates.

Secrets & Variables v1 needs workflow authors to reference `${{ vars.NAME }}` and `${{ secrets.NAME }}` safely. This teaches the expression registry about both roots, validates literal-only key access at definition time, freezes vars once at run creation, and serializes surviving secret references into `config.secret_bindings` without persisting plaintext values.

The secret value pull and runner injection remain in ENG-695, so this PR should land in sequence with that runtime work rather than deploy alone.

Closes ENG-692

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds expression support for `vars` and runner-host `secrets`. Freezes vars at run creation for one-shot jobs and serializes remaining secret segments into `secret_bindings` so ${{ vars.* }} and ${{ secrets.* }} work without persisting plaintext (ENG-692).

- New Features
  - Added `vars` (server, run-creation) and `secrets` (runner, ephemeral) roots in `@shipfox/expression`, with literal dot-key only; bracket/optional/computed access is rejected. Comprehension aliases and map-literal identifier keys are ignored.
  - Blocked runner-host roots in server-only fields; `secrets` are rejected in agent fields. `vars` are rejected in job/step server predicates.
  - Froze `vars` at run creation, loading only referenced keys for one-shot jobs; do not snapshot vars used only by listening jobs. Missing vars fail early and are reported against the exact source field.
  - Deferred secret refs into segmented `config.secret_bindings` (literal | {store,key}); `local` is the default store and unknown stores error early.

- Migration
  - Use `${{ vars.NAME }}`, `${{ secrets.NAME }}`, or `${{ secrets.STORE.NAME }}`; computed keys are rejected.
  - Keep `secrets` only in run command and step `env`; remove from agent fields.
  - Do not use `vars` in job/step predicates.
  - Land with runner fill work (ENG-695) to resolve serialized secret bindings at runtime.

<sup>Written for commit 2b1f14180438285f54a2f94b5b54577378c2dd20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

