### PR TITLE
[e2e] Use smaller Ollama model for agent E2E

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,14 +74,14 @@ mise run ollama:up
 
 From a worktree, that task delegates to the root checkout and runs the root
 `ollama:up` task. From the root checkout, it starts `ollama serve`, pulls
-`qwen3.5:0.8b`, and then reports the API as ready. A background warmup request
+`smollm2:135m-instruct-q2_K`, and then reports the API as ready. A background warmup request
 preloads the model with a 24 hour keep-alive, so callers can start using the
 Ollama HTTP API as soon as the pull completes.
 
 Useful commands:
 
 ```sh
-mise run ollama:up       # start the shared server and pull qwen3.5:0.8b
+mise run ollama:up       # start the shared server and pull smollm2:135m-instruct-q2_K
 mise run ollama:status   # show endpoint, root path, and managed process status
 mise run ollama:stop     # stop the server if this repo started it
 ```

--- a/dev/shared-ollama.mjs
+++ b/dev/shared-ollama.mjs
@@ -4,7 +4,7 @@ import {existsSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync} fr
 import {resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-const defaultModel = 'qwen3.5:0.8b';
+const defaultModel = 'smollm2:135m-instruct-q2_K';
 const defaultKeepAlive = '24h';
 const defaultBaseUrl = 'http://127.0.0.1:11434';
 const startupTimeoutMs = 30_000;

--- a/e2e/helpers/agent/src/index.test.ts
+++ b/e2e/helpers/agent/src/index.test.ts
@@ -22,7 +22,7 @@ describe('agent e2e helper', () => {
 
     expect(config).toEqual({
       baseUrl: 'http://127.0.0.1:11434',
-      model: 'qwen3.5:0.8b',
+      model: 'smollm2:135m-instruct-q2_K',
       openAiBaseUrl: 'http://127.0.0.1:11434/v1',
     });
   });
@@ -45,7 +45,7 @@ describe('agent e2e helper', () => {
 
   it('passes when Ollama exposes the configured model', async () => {
     const fetch = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+      new Response(JSON.stringify({models: [{name: 'smollm2:135m-instruct-q2_K'}]}), {
         status: 200,
         headers: {'content-type': 'application/json'},
       }),
@@ -55,7 +55,7 @@ describe('agent e2e helper', () => {
     const result = await requireOllamaModel({fetch});
 
     expect(fetch).toHaveBeenCalledWith('http://127.0.0.1:11434/api/tags');
-    expect(result.model).toBe('qwen3.5:0.8b');
+    expect(result.model).toBe('smollm2:135m-instruct-q2_K');
   });
 
   it('fails clearly when Ollama is unavailable', async () => {
@@ -76,7 +76,7 @@ describe('agent e2e helper', () => {
     );
     const {requireOllamaModel} = await import('./index.js');
 
-    await expect(requireOllamaModel({fetch, model: 'qwen3.5:0.8b'})).rejects.toThrow(
+    await expect(requireOllamaModel({fetch, model: 'smollm2:135m-instruct-q2_K'})).rejects.toThrow(
       'Available models: llama3.2:1b.',
     );
   });
@@ -86,7 +86,7 @@ describe('agent e2e helper', () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({models: [{name: 'qwen3.5:0.8b'}]}), {
+        new Response(JSON.stringify({models: [{name: 'smollm2:135m-instruct-q2_K'}]}), {
           status: 200,
           headers: {'content-type': 'application/json'},
         }),
@@ -111,8 +111,8 @@ describe('agent e2e helper', () => {
           display_name: 'Local Ollama E2E',
           api: 'openai-completions',
           base_url: 'http://127.0.0.1:11434/v1',
-          models: [{id: 'qwen3.5:0.8b', label: 'qwen3.5:0.8b'}],
-          default_model: 'qwen3.5:0.8b',
+          models: [{id: 'smollm2:135m-instruct-q2_K', label: 'smollm2:135m-instruct-q2_K'}],
+          default_model: 'smollm2:135m-instruct-q2_K',
         },
       },
     );

--- a/e2e/helpers/agent/src/index.ts
+++ b/e2e/helpers/agent/src/index.ts
@@ -8,7 +8,7 @@ import type {
 import {requestJson} from '@shipfox/e2e-core';
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
-const DEFAULT_OLLAMA_MODEL = 'qwen3.5:0.8b';
+const DEFAULT_OLLAMA_MODEL = 'smollm2:135m-instruct-q2_K';
 const DEFAULT_OLLAMA_PROVIDER_API: ModelProviderApi = 'openai-completions';
 const TRAILING_SLASHES_RE = /\/+$/u;
 


### PR DESCRIPTION
Switch the shared Ollama and agent E2E helper defaults to `smollm2:135m-instruct-q2_K`.

The previous `qwen3.5:0.8b` default is much larger than the test needs, increasing CI pull, load, and first-inference cost for the custom provider flow. The smaller SmolLM2 quantized instruct model keeps the same local Ollama/OpenAI-compatible path while reducing the amount of model work required for CI validation.

This does not address the warmup script body-consumption issue directly; that remains tracked separately.

Refs ENG-778

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the shared Ollama server and agent E2E helper defaults to `smollm2:135m-instruct-q2_K` to reduce CI pull, warmup, and first-inference time while keeping the same local OpenAI-compatible flow. Updates tests and CONTRIBUTING to align with ENG-778 and lower CI model load.

<sup>Written for commit 8bcd6c932041d0ec0f309c2686dc0a65a8dc1849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

