### PR TITLE
[api/logs] Correct README stream close-path description

### DIFF
--- a/libs/api/logs/README.md
+++ b/libs/api/logs/README.md
@@ -29,8 +29,11 @@ This adds:
 - the append route under `/runs/jobs/current/steps/:stepId/logs` (lease-authed)
 - the read route under `/steps/:stepId/attempts/:attempt/logs` (session-authed): inline NDJSON
   while the stream is hot, a presigned object URL once it is compacted
-- the `logs.stream.closed` publisher and the job-terminated subscriber that force-closes
-  abandoned streams
+- the `logs.stream.closed` publisher and two close subscribers: the step-attempt-terminated
+  subscriber that closes each attempt's stream when the runner did not end it in-band, and the
+  job-terminated subscriber that force-closes any of a job's still-open streams
+- the Temporal lifecycle workers that carry a closed stream through to deletion: compaction to a
+  gzip object, plus the compaction-reconcile, stale-open-stream reaper, and retention-sweep crons
 
 ## Streams
 
@@ -110,12 +113,16 @@ budget is stored in full, then an in-band `capped` tombstone record is injected 
 are accepted-and-dropped. The cap is a **job-level** signal — a stream can be byte-complete and
 still sit under a capped job if a sibling step exhausted the shared budget.
 
-A stream closes on one of three triggers: the runner declares its end (an `end` record); the
-job-terminated sweep force-closes a job's abandoned streams when the job goes terminal; or the
-reaper cron force-closes any stream still open past the lease window (`LOG_STREAM_REAP_AFTER_SECONDS`),
-the backstop for a stream the one-shot sweep missed (one whose first append landed after the sweep
-ran). Both force-close paths are timeout closes: they set `truncated` and inject a `runner_lost`
-tombstone. Each close writes one `logs.stream.closed` event, which drives compaction.
+A stream closes on one of four triggers, all converging on the same guarded, exactly-once close:
+the runner declares its end in-band (an `end` record in an append), which closes the stream
+`declared` the moment those bytes commit; the step-attempt-terminated subscriber closes an attempt
+the runner never ended in-band, `declared` when the runner drained its spool or `timeout` when it
+abandoned it (carried on the event's `logOutcome`); the job-terminated sweep force-closes any of a
+job's still-open streams once the job goes terminal, after a grace period
+(`LOG_STREAM_CLOSE_GRACE_SECONDS`); and the reaper cron force-closes any stream still open past the
+lease window (`LOG_STREAM_REAP_AFTER_SECONDS`), the backstop for a stream the one-shot sweeps missed
+(one whose first append landed after they ran). Every timeout close sets `truncated` and injects a
+`runner_lost` tombstone; each close writes one `logs.stream.closed` event, which drives compaction.
 
 ## Setup
 


### PR DESCRIPTION
The `libs/api/logs` README described the stream lifecycle inaccurately. The "Budget and terminal state" section listed three close triggers and omitted the step-attempt-terminated finalize path, and the module "adds" list named only the job-terminated subscriber, leaving out the second close subscriber and the Temporal lifecycle workers entirely.

This documents all four close triggers, all converging on the same guarded, exactly-once close:

- the runner declares its end in-band (an `end` record), closing the stream `declared`;
- the step-attempt-terminated subscriber closes an attempt the runner never ended in-band, `declared` when it drained its spool or `timeout` when it abandoned it (via the event's `logOutcome`);
- the job-terminated sweep force-closes a job's still-open streams once the job goes terminal, after a grace period; and
- the reaper cron backstops any stream still open past the lease window.

It also adds the two close subscribers and the lifecycle workers (compaction, compaction-reconcile, reaper, retention) to the module "adds" list.

Found during the log capture & streaming code review. Docs only, no code change; the described behavior already matches the implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the `libs/api/logs` README to accurately describe the stream close lifecycle. Documents all four close triggers (in-band end, step-attempt-terminated finalize, job-terminated grace sweep, reaper), updates the module adds list with both close subscribers and Temporal lifecycle workers, and clarifies timeout behavior and the exactly-once `logs.stream.closed` event; docs only.

<sup>Written for commit cd6a264b2555f3a54389715fd3c0ca33eeaabe49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

