### PR TITLE
[api/logs] Slim DB barrel exports

### DIFF
--- a/libs/api/logs/src/db/index.ts
+++ b/libs/api/logs/src/db/index.ts
@@ -1,16 +1,4 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-export {accrueStoredBytes, claimCap, ensureJobAccounting, isJobCapped} from './accounting.js';
-export {insertChunk} from './chunks.js';
-export {closeDb, type Database, db, schema, type Transaction} from './db.js';
-export {logsOutbox} from './schema/outbox.js';
-export {
-  type CasResult,
-  casExtendCommittedLength,
-  getAttemptStream,
-  getOrCreateAttemptStream,
-  setDeclaredTotalBytes,
-} from './streams.js';
-
 export const migrationsPath = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle');

--- a/libs/api/logs/src/index.ts
+++ b/libs/api/logs/src/index.ts
@@ -7,7 +7,9 @@ import {
   type WorkflowsEventMapDto,
 } from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
-import {db, logsOutbox, migrationsPath} from '#db/index.js';
+import {db} from '#db/db.js';
+import {migrationsPath} from '#db/index.js';
+import {logsOutbox} from '#db/schema/outbox.js';
 import {registerLogsServiceMetrics} from '#metrics/service.js';
 import {logsRoutes} from '#presentation/routes/index.js';
 import {onJobTerminated} from '#presentation/subscribers/on-job-terminated.js';

--- a/libs/api/logs/test/globalSetup.ts
+++ b/libs/api/logs/test/globalSetup.ts
@@ -3,7 +3,8 @@ import {runMigrations} from '@shipfox/node-drizzle';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {sql} from 'drizzle-orm';
 import {checkBucketReachable, closeS3Client} from '#api/object-storage.js';
-import {closeDb, db, migrationsPath} from '#db/index.js';
+import {closeDb, db} from '#db/db.js';
+import {migrationsPath} from '#db/index.js';
 
 const BUCKET_READY_TIMEOUT_MS = 30_000;
 const BUCKET_READY_POLL_INTERVAL_MS = 500;

--- a/libs/api/logs/test/setup.ts
+++ b/libs/api/logs/test/setup.ts
@@ -1,7 +1,7 @@
 import './env.js';
 import {closePostgresClient, createPostgresClient} from '@shipfox/node-postgres';
 import {afterAll, afterEach, beforeAll, vi} from '@shipfox/vitest/vi';
-import {closeDb} from '#db/index.js';
+import {closeDb} from '#db/db.js';
 
 beforeAll(() => {
   createPostgresClient();


### PR DESCRIPTION
Slim the logs module DB barrel so it only owns the `migrationsPath` constant, while module setup and tests import `db`, `closeDb`, and `logsOutbox` from the files that own those symbols.

The previous `src/db/index.ts` re-exported a broad set of accounting, chunk, stream, schema, and DB helpers even though consumers already import those internals directly. Removing the unused re-export surface keeps the logs package aligned with the module import convention and avoids implying a wider internal API than exists.

No behavior change.

Closes ENG-782

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slimmed the logs DB barrel to only export `migrationsPath`, so consumers import owned symbols directly from their files. No behavior change; aligns with ENG-782.

- **Refactors**
  - Removed broad re-exports from `libs/api/logs/src/db/index.ts` (barrel now only exports `migrationsPath`).
  - Updated imports to use `#db/db.js` for `db`/`closeDb` and `#db/schema/outbox.js` for `logsOutbox`.

<sup>Written for commit 34f346bd24e2c334b01ebadd7d7452de4bfc60ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

