### PR TITLE
[e2e-platform-workflows] Add workflow rejection invariant scenarios

### DIFF
--- a/e2e/platform/workflows/scenarios/reject-invalid-job-success/reject.yaml
+++ b/e2e/platform/workflows/scenarios/reject-invalid-job-success/reject.yaml
@@ -1,0 +1,3 @@
+error_code: invalid-definition
+message_includes:
+  - Job success must be a valid CEL boolean expression

--- a/e2e/platform/workflows/scenarios/reject-invalid-job-success/workflow.yml
+++ b/e2e/platform/workflows/scenarios/reject-invalid-job-success/workflow.yml
@@ -1,0 +1,13 @@
+name: Reject invalid job success
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    success: executions.size()
+    steps:
+      - key: build
+        run: echo ok

--- a/e2e/platform/workflows/scenarios/reject-invalid-step-success-if/reject.yaml
+++ b/e2e/platform/workflows/scenarios/reject-invalid-step-success-if/reject.yaml
@@ -1,0 +1,3 @@
+error_code: invalid-definition
+message_includes:
+  - Step gate success_if must be a valid CEL boolean expression

--- a/e2e/platform/workflows/scenarios/reject-invalid-step-success-if/workflow.yml
+++ b/e2e/platform/workflows/scenarios/reject-invalid-step-success-if/workflow.yml
@@ -1,0 +1,14 @@
+name: Reject invalid step success_if
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: gated
+        run: echo ok
+        gate:
+          success_if: step.exit_code + 1

--- a/e2e/platform/workflows/scenarios/reject-runner-context-step-success-if/reject.yaml
+++ b/e2e/platform/workflows/scenarios/reject-runner-context-step-success-if/reject.yaml
@@ -1,0 +1,4 @@
+error_code: invalid-definition
+message_includes:
+  - Step gate success_if cannot reference runner context
+  - '"runner"'

--- a/e2e/platform/workflows/scenarios/reject-runner-context-step-success-if/workflow.yml
+++ b/e2e/platform/workflows/scenarios/reject-runner-context-step-success-if/workflow.yml
@@ -1,0 +1,14 @@
+name: Reject runner context step success_if
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: gated
+        run: echo ok
+        gate:
+          success_if: runner.os == "linux"

--- a/e2e/platform/workflows/scenarios/reject-untrusted-agent-model/reject.yaml
+++ b/e2e/platform/workflows/scenarios/reject-untrusted-agent-model/reject.yaml
@@ -1,0 +1,4 @@
+error_code: invalid-definition
+message_includes:
+  - Workflow agent.model interpolation cannot use untrusted context
+  - '"event"'

--- a/e2e/platform/workflows/scenarios/reject-untrusted-agent-model/workflow.yml
+++ b/e2e/platform/workflows/scenarios/reject-untrusted-agent-model/workflow.yml
@@ -1,0 +1,13 @@
+name: Reject untrusted agent model
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  fix:
+    steps:
+      - key: fix
+        model: '${{ event.head_commit.message }}'
+        prompt: Fix it.

--- a/e2e/platform/workflows/scenarios/reject-untrusted-agent-provider/reject.yaml
+++ b/e2e/platform/workflows/scenarios/reject-untrusted-agent-provider/reject.yaml
@@ -1,0 +1,4 @@
+error_code: invalid-definition
+message_includes:
+  - Workflow agent.provider interpolation cannot use untrusted context
+  - '"inputs"'

--- a/e2e/platform/workflows/scenarios/reject-untrusted-agent-provider/workflow.yml
+++ b/e2e/platform/workflows/scenarios/reject-untrusted-agent-provider/workflow.yml
@@ -1,0 +1,13 @@
+name: Reject untrusted agent provider
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  fix:
+    steps:
+      - key: fix
+        provider: '${{ inputs.provider }}'
+        prompt: Fix it.

--- a/e2e/platform/workflows/scenarios/reject-untrusted-execution-events/reject.yaml
+++ b/e2e/platform/workflows/scenarios/reject-untrusted-execution-events/reject.yaml
@@ -1,0 +1,4 @@
+error_code: invalid-definition
+message_includes:
+  - Run command interpolation cannot use untrusted context
+  - '"execution"'

--- a/e2e/platform/workflows/scenarios/reject-untrusted-execution-events/workflow.yml
+++ b/e2e/platform/workflows/scenarios/reject-untrusted-execution-events/workflow.yml
@@ -1,0 +1,12 @@
+name: Reject untrusted execution events
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: unsafe
+        run: echo "${{ execution.events[0].data.body }}"


### PR DESCRIPTION
Add `reject.yaml` scenarios for the remaining runnable workflow authoring invariants.

The workflow rejection harness already covered the base rejection path, but several invariants still only had unit-level proof. This adds end-to-end definition-sync rejection coverage for trusted-only agent model/provider interpolation, untrusted `execution.events` path access in run commands, runner-host predicate references, and non-boolean step/job predicates.

The secrets-specific runner-host cases remain gated on ENG-692 because `secrets.*` is not fully referenceable in this branch.

Closes ENG-773

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end `reject.yaml` scenarios to prove remaining workflow authoring invariants are rejected at definition sync with no runs created. Addresses ENG-773 by covering trusted-only fields, runner-host predicates, and predicate type checks.

- New Features
  - Reject untrusted context in `agent.model`.
  - Reject untrusted context in `agent.provider`.
  - Reject `run` command interpolation using `execution.events`.
  - Reject runner-host reference in step `success_if` (e.g., `runner.os`).
  - Reject non-boolean step `success_if`.
  - Reject non-boolean job `success`.
  - Each scenario asserts `invalid-definition` + message substring and no run.

- Dependencies
  - Secrets-based runner-host cases remain gated on ENG-692 and ENG-764.

<sup>Written for commit 186f1df8837d5b4ffb292f36a36d943afa8894b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

