### PR TITLE
[api/logs] Fix retention object cleanup ordering

### DIFF
--- a/.changeset/eng-783-logs-retention-retry.md
+++ b/.changeset/eng-783-logs-retention-retry.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-logs": patch
+---
+
+Makes log retention delete object prefixes before stream rows so transient object-storage delete failures leave rows discoverable for a later sweep instead of permanently orphaning billed objects.

--- a/libs/api/logs/src/core/retention.test.ts
+++ b/libs/api/logs/src/core/retention.test.ts
@@ -285,6 +285,32 @@ describe('runRetentionSweep', () => {
     expect(result.failed).toBe(0);
   });
 
+  it('does not starve a younger stream when reloading a raced row fails', async () => {
+    const poison = newIdentity();
+    const healthy = newIdentity();
+    const poisonStream = await arrangeClosedStream(poison);
+    const healthyStream = await arrangeClosedStream(healthy);
+    await backdateClosedAt(poisonStream.id, '200 days');
+    await backdateClosedAt(healthyStream.id, '100 days');
+    const realDeleteExpiredStream = streams.deleteExpiredStream;
+    vi.spyOn(streams, 'deleteExpiredStream').mockImplementation((tx, params) =>
+      params.streamId === poisonStream.id
+        ? Promise.resolve({deleted: false, jobId: null})
+        : realDeleteExpiredStream(tx, params),
+    );
+    vi.spyOn(streams, 'getAttemptStreamById').mockImplementation((streamId) =>
+      streamId === poisonStream.id
+        ? Promise.reject(new Error('reload failed'))
+        : streams.getAttemptStreamById(streamId),
+    );
+
+    const result = await sweep({batchLimit: 1});
+
+    expect(await findStream(poison)).not.toBeNull();
+    expect(await findStream(healthy)).toBeNull();
+    expect(result.failed).toBeGreaterThanOrEqual(1);
+  });
+
   it('does not reset a live job budget: deletes its expired streams but keeps fresh accounting', async () => {
     const id = newIdentity();
     const stream = await arrangeClosedStream(id);

--- a/libs/api/logs/src/core/retention.test.ts
+++ b/libs/api/logs/src/core/retention.test.ts
@@ -257,6 +257,34 @@ describe('runRetentionSweep', () => {
     expect(recovered.failed).toBe(0);
   });
 
+  it('re-cleans and deletes a stream when compaction publishes after the first prefix cleanup', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id, {chunks: [ndjsonBody(outputLine('x'))]});
+    const key = `${attemptPrefix(id)}/${crypto.randomUUID()}`;
+    await backdateClosedAt(stream.id, '100 days');
+    const realDeleteExpiredStream = streams.deleteExpiredStream;
+    let calls = 0;
+    vi.spyOn(streams, 'deleteExpiredStream').mockImplementation(async (tx, params) => {
+      calls += 1;
+      if (calls === 1 && params.streamId === stream.id) {
+        await tx
+          .update(attemptStreams)
+          .set({objectKey: key})
+          .where(eq(attemptStreams.id, stream.id));
+        await putObject(key, Buffer.from('compacted'));
+      }
+      return realDeleteExpiredStream(tx, params);
+    });
+
+    const result = await sweep();
+
+    expect(await findStream(id)).toBeNull();
+    expect(await objectExists(key)).toBe(false);
+    expect(result.deleted).toBe(1);
+    expect(result.raced).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
   it('does not reset a live job budget: deletes its expired streams but keeps fresh accounting', async () => {
     const id = newIdentity();
     const stream = await arrangeClosedStream(id);

--- a/libs/api/logs/src/core/retention.test.ts
+++ b/libs/api/logs/src/core/retention.test.ts
@@ -1,6 +1,7 @@
 import {Buffer} from 'node:buffer';
 import {HeadObjectCommand, PutObjectCommand} from '@aws-sdk/client-s3';
 import {eq, sql} from 'drizzle-orm';
+import * as objectStorage from '#api/object-storage.js';
 import {s3Client} from '#api/object-storage.js';
 import {config} from '#config.js';
 import {logObjectKey} from '#core/entities/log-object.js';
@@ -153,7 +154,7 @@ describe('runRetentionSweep', () => {
     expect(await findAccounting(shared.jobId)).toBeNull();
   });
 
-  it('deletes a closed-but-never-compacted stream (object_key null), doing no object work', async () => {
+  it('deletes a closed-but-never-compacted stream (object_key null)', async () => {
     const id = newIdentity();
     const stream = await arrangeClosedStream(id, {chunks: [ndjsonBody(outputLine('x'))]});
     await backdateClosedAt(stream.id, '100 days');
@@ -163,6 +164,32 @@ describe('runRetentionSweep', () => {
     expect(await findStream(id)).toBeNull();
     expect(await listChunks(stream.id)).toHaveLength(0);
     expect(result.failed).toBe(0);
+  });
+
+  it('keeps the row when prefix deletion fails, so a later sweep can rediscover the object', async () => {
+    const poison = newIdentity();
+    const healthy = newIdentity();
+    const poisonStream = await arrangeClosedStream(poison);
+    const healthyStream = await arrangeClosedStream(healthy);
+    const poisonKey = `${attemptPrefix(poison)}/${crypto.randomUUID()}`;
+    await putObject(poisonKey, Buffer.from('poison'));
+    await setObjectKey(poisonStream.id, poisonKey);
+    await backdateClosedAt(poisonStream.id, '200 days');
+    await backdateClosedAt(healthyStream.id, '100 days');
+    const poisonPrefix = `${attemptPrefix(poison)}/`;
+    const realDeleteObjectsByPrefix = objectStorage.deleteObjectsByPrefix;
+    vi.spyOn(objectStorage, 'deleteObjectsByPrefix').mockImplementation((prefix) =>
+      prefix === poisonPrefix
+        ? Promise.reject(new Error('object delete failed'))
+        : realDeleteObjectsByPrefix(prefix),
+    );
+
+    const result = await sweep({batchLimit: 1});
+
+    expect(await findStream(poison)).not.toBeNull();
+    expect(await objectExists(poisonKey)).toBe(true);
+    expect(await findStream(healthy)).toBeNull();
+    expect(result.failed).toBeGreaterThanOrEqual(1);
   });
 
   it('deletes the whole attempt prefix, reclaiming a lost compaction attempt orphan leaf', async () => {
@@ -187,6 +214,9 @@ describe('runRetentionSweep', () => {
     const healthy = newIdentity();
     const poisonStream = await arrangeClosedStream(poison);
     const healthyStream = await arrangeClosedStream(healthy);
+    const poisonKey = `${attemptPrefix(poison)}/${crypto.randomUUID()}`;
+    await putObject(poisonKey, Buffer.from('poison'));
+    await setObjectKey(poisonStream.id, poisonKey);
     await backdateClosedAt(poisonStream.id, '200 days');
     await backdateClosedAt(healthyStream.id, '100 days');
     const realDeleteExpiredStream = streams.deleteExpiredStream;
@@ -200,7 +230,31 @@ describe('runRetentionSweep', () => {
 
     expect(await findStream(healthy)).toBeNull();
     expect(await findStream(poison)).not.toBeNull();
+    expect(await objectExists(poisonKey)).toBe(false);
     expect(result.failed).toBeGreaterThanOrEqual(1);
+  });
+
+  it('self-heals a row delete failure after the object prefix was already deleted', async () => {
+    const id = newIdentity();
+    const stream = await arrangeClosedStream(id);
+    const key = `${attemptPrefix(id)}/${crypto.randomUUID()}`;
+    await putObject(key, Buffer.from('compacted'));
+    await setObjectKey(stream.id, key);
+    await backdateClosedAt(stream.id, '300 days');
+    vi.spyOn(streams, 'deleteExpiredStream').mockImplementationOnce(() =>
+      Promise.reject(new Error('row delete failed')),
+    );
+
+    const failed = await sweep({batchLimit: 1});
+
+    expect(await objectExists(key)).toBe(false);
+    expect(await findStream(id)).not.toBeNull();
+    expect(failed.failed).toBe(1);
+
+    const recovered = await sweep({batchLimit: 1});
+
+    expect(await findStream(id)).toBeNull();
+    expect(recovered.failed).toBe(0);
   });
 
   it('does not reset a live job budget: deletes its expired streams but keeps fresh accounting', async () => {

--- a/libs/api/logs/src/core/retention.test.ts
+++ b/libs/api/logs/src/core/retention.test.ts
@@ -298,10 +298,11 @@ describe('runRetentionSweep', () => {
         ? Promise.resolve({deleted: false, jobId: null})
         : realDeleteExpiredStream(tx, params),
     );
+    const realGetAttemptStreamById = streams.getAttemptStreamById;
     vi.spyOn(streams, 'getAttemptStreamById').mockImplementation((streamId) =>
       streamId === poisonStream.id
         ? Promise.reject(new Error('reload failed'))
-        : streams.getAttemptStreamById(streamId),
+        : realGetAttemptStreamById(streamId),
     );
 
     const result = await sweep({batchLimit: 1});

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -11,11 +11,11 @@ import {
 } from '#db/streams.js';
 
 export interface RetentionSweepResult {
-  /** Streams whose row was deleted; their objects are reclaimed after (a rare object-cleanup failure is logged). */
+  /** Streams whose objects and row were deleted. */
   deleted: number;
   /** Streams skipped because compaction changed `object_key` after we read it (retried next run). */
   raced: number;
-  /** Streams whose guarded row delete threw; logged, skipped, and retried next run. */
+  /** Streams whose object cleanup or guarded row delete threw; logged, skipped, and retried next run. */
   failed: number;
   accountingPruned: number;
   iterations: number;
@@ -38,9 +38,9 @@ export interface RunRetentionSweepParams {
  * Deletes expired closed streams and prunes accounting for emptied jobs.
  *
  * The loop self-bounds because a Temporal `startToCloseTimeout` marks the activity failed but
- * does not stop already-running JS. Rows are deleted before objects, guarded on the observed
- * `object_key`, so a racing compaction publish leaves the stream for the next sweep instead of
- * deleting its fresh object.
+ * does not stop already-running JS. Objects are deleted before rows so a cleanup failure leaves
+ * the row discoverable for the next sweep; the row delete stays guarded on the observed
+ * `object_key`, so a racing compaction publish leaves the stream for the next sweep.
  */
 export async function runRetentionSweep(
   params: RunRetentionSweepParams,
@@ -81,6 +81,18 @@ export async function runRetentionSweep(
         break;
       }
 
+      try {
+        await deleteObjectsByPrefix(`${logObjectKey(config.LOG_STORAGE_S3_PREFIX, stream)}/`);
+      } catch (error) {
+        result.failed += 1;
+        skip.add(stream.id);
+        logger().error(
+          {err: error, streamId: stream.id},
+          'Failed to delete expired log stream objects',
+        );
+        continue;
+      }
+
       let outcome: {deleted: boolean; prunedAccounting: boolean};
       try {
         outcome = await db().transaction(async (tx) => {
@@ -116,16 +128,6 @@ export async function runRetentionSweep(
 
       result.deleted += 1;
       if (outcome.prunedAccounting) result.accountingPruned += 1;
-
-      // The guarded row delete won, so reclaim the recorded object plus orphan leaves.
-      try {
-        await deleteObjectsByPrefix(`${logObjectKey(config.LOG_STORAGE_S3_PREFIX, stream)}/`);
-      } catch (error) {
-        logger().error(
-          {err: error, streamId: stream.id},
-          'Deleted expired stream row but failed to delete its objects',
-        );
-      }
     }
 
     if (timedOutMidBatch) break;

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -133,7 +133,18 @@ export async function runRetentionSweep(
       }
 
       if (!outcome.deleted) {
-        const current = await getAttemptStreamById(stream.id);
+        let current: AttemptStream | null;
+        try {
+          current = await getAttemptStreamById(stream.id);
+        } catch (error) {
+          result.failed += 1;
+          skip.add(stream.id);
+          logger().error(
+            {err: error, streamId: stream.id},
+            'Failed to reload raced expired log stream',
+          );
+          continue;
+        }
         if (current) {
           try {
             await deleteExpiredStreamObjects(current);

--- a/libs/api/logs/src/core/retention.ts
+++ b/libs/api/logs/src/core/retention.ts
@@ -1,12 +1,14 @@
 import {logger} from '@shipfox/node-opentelemetry';
 import {deleteObjectsByPrefix} from '#api/object-storage.js';
 import {config} from '#config.js';
+import type {AttemptStream} from '#core/entities/attempt-stream.js';
 import {logObjectKey} from '#core/entities/log-object.js';
 import {deleteJobAccounting} from '#db/accounting.js';
 import {db} from '#db/db.js';
 import {
   accountingHasNoStreams,
   deleteExpiredStream,
+  getAttemptStreamById,
   listExpiredClosedStreams,
 } from '#db/streams.js';
 
@@ -34,13 +36,37 @@ export interface RunRetentionSweepParams {
   onProgress?: () => void;
 }
 
+function deleteExpiredStreamObjects(stream: AttemptStream): Promise<void> {
+  return deleteObjectsByPrefix(`${logObjectKey(config.LOG_STORAGE_S3_PREFIX, stream)}/`);
+}
+
+function deleteExpiredStreamRow(params: {
+  stream: AttemptStream;
+  retentionDays: number;
+}): Promise<{deleted: boolean; prunedAccounting: boolean}> {
+  return db().transaction(async (tx) => {
+    const {deleted, jobId} = await deleteExpiredStream(tx, {
+      streamId: params.stream.id,
+      observedObjectKey: params.stream.objectKey,
+    });
+    if (deleted && jobId && (await accountingHasNoStreams(tx, jobId))) {
+      const pruned = await deleteJobAccounting(tx, {
+        jobId,
+        retentionDays: params.retentionDays,
+      });
+      return {deleted, prunedAccounting: pruned.deleted};
+    }
+    return {deleted, prunedAccounting: false};
+  });
+}
+
 /**
  * Deletes expired closed streams and prunes accounting for emptied jobs.
  *
  * The loop self-bounds because a Temporal `startToCloseTimeout` marks the activity failed but
  * does not stop already-running JS. Objects are deleted before rows so a cleanup failure leaves
  * the row discoverable for the next sweep; the row delete stays guarded on the observed
- * `object_key`, so a racing compaction publish leaves the stream for the next sweep.
+ * `object_key`, so a racing compaction publish is re-read before the row is removed.
  */
 export async function runRetentionSweep(
   params: RunRetentionSweepParams,
@@ -82,7 +108,7 @@ export async function runRetentionSweep(
       }
 
       try {
-        await deleteObjectsByPrefix(`${logObjectKey(config.LOG_STORAGE_S3_PREFIX, stream)}/`);
+        await deleteExpiredStreamObjects(stream);
       } catch (error) {
         result.failed += 1;
         skip.add(stream.id);
@@ -95,20 +121,7 @@ export async function runRetentionSweep(
 
       let outcome: {deleted: boolean; prunedAccounting: boolean};
       try {
-        outcome = await db().transaction(async (tx) => {
-          const {deleted, jobId} = await deleteExpiredStream(tx, {
-            streamId: stream.id,
-            observedObjectKey: stream.objectKey,
-          });
-          if (deleted && jobId && (await accountingHasNoStreams(tx, jobId))) {
-            const pruned = await deleteJobAccounting(tx, {
-              jobId,
-              retentionDays: params.retentionDays,
-            });
-            return {deleted, prunedAccounting: pruned.deleted};
-          }
-          return {deleted, prunedAccounting: false};
-        });
+        outcome = await deleteExpiredStreamRow({stream, retentionDays: params.retentionDays});
       } catch (error) {
         result.failed += 1;
         skip.add(stream.id);
@@ -120,10 +133,30 @@ export async function runRetentionSweep(
       }
 
       if (!outcome.deleted) {
-        // `object_key` changed since select; the next sweep will re-read the fresh key.
-        result.raced += 1;
-        skip.add(stream.id);
-        continue;
+        const current = await getAttemptStreamById(stream.id);
+        if (current) {
+          try {
+            await deleteExpiredStreamObjects(current);
+            outcome = await deleteExpiredStreamRow({
+              stream: current,
+              retentionDays: params.retentionDays,
+            });
+          } catch (error) {
+            result.failed += 1;
+            skip.add(stream.id);
+            logger().error(
+              {err: error, streamId: stream.id},
+              'Failed to delete raced expired log stream',
+            );
+            continue;
+          }
+        }
+        if (!current || !outcome.deleted) {
+          // `object_key` changed again or the row disappeared; the next sweep will re-read it.
+          result.raced += 1;
+          skip.add(stream.id);
+          continue;
+        }
       }
 
       result.deleted += 1;


### PR DESCRIPTION
[api/logs] Fix retention object cleanup ordering

Retention previously hard-deleted the stream row before deleting objects under the attempt prefix. If object cleanup failed afterward, later sweeps could no longer rediscover that prefix, leaving billed objects permanently orphaned on S3-compatible backends.

This flips retention to delete the object prefix before the guarded row delete. Object-delete failures now leave the row in place for a later sweep, while the existing observed object_key guard still handles compaction races by skipping changed rows.

Considered adding a separate orphan reconcile or holding a row lock across S3 cleanup, but the simple object-before-row reorder fixes the leak without adding a bucket-scan subsystem or keeping a database transaction open during object-storage calls.

Reviewers should focus on the transient failure paths in retention: object cleanup failure leaves the row and backlog continues, while row delete failure after object cleanup self-heals on the next sweep.

Closes ENG-783

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes expired log object prefixes before deleting their stream rows and hardens race/failure handling to prevent orphaned S3 objects or rows pointing at deleted data. Improves retention reliability and stops billed storage leaks (fixes ENG-783).

- **Bug Fixes**
  - Reorder retention: delete object prefix first, then guarded row delete on the observed `object_key`.
  - Keep the row on object-delete failure for retry.
  - Self-heal when row delete fails after cleanup.
  - If compaction publishes after the first cleanup, re-read the stream, clean the current prefix, and retry the delete.
  - If reloading a raced stream fails, log and skip it without starving later backlog entries.

<sup>Written for commit 0ddd269de309f74a475a5f9248ede047de45b975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

