### PR TITLE
[api/workflows] Resolve one-shot job execution names

### DIFF
--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -2,6 +2,7 @@ import type {JobExecution} from '#core/entities/job-execution.js';
 import type {Step, StepAttempt} from '#core/entities/step.js';
 import {
   assembleCreationContext,
+  assembleExecutionCreationContext,
   assembleGateContext,
   assembleJobResolutionContext,
   assembleStepDispatchContext,
@@ -101,6 +102,111 @@ describe('assembleCreationContext', () => {
         },
         inputs: {deploy: true},
       }),
+    });
+  });
+});
+
+describe('assembleExecutionCreationContext', () => {
+  const run = {
+    id: 'run-1',
+    name: 'Build',
+    definitionId: 'def-1',
+    projectId: 'proj-1',
+    workspaceId: 'workspace-1',
+    createdAt: new Date('2026-06-30T12:00:00.000Z'),
+  };
+
+  it('wraps run values, prior executions, and the synthetic current execution', () => {
+    const prior = jobExecution({
+      id: 'exec-1',
+      jobId: 'job-1',
+      sequence: 1,
+      name: 'Build #1',
+      status: 'failed',
+      finishedAt: date,
+    });
+
+    const context = assembleExecutionCreationContext({
+      run,
+      triggerPayload: {
+        source: 'github',
+        event: 'push',
+        deliveryId: 'delivery-1',
+        data: {ref: 'refs/heads/main'},
+      },
+      inputs: {deploy: true},
+      jobId: 'job-1',
+      sequence: 2,
+      executionName: 'Build #2',
+      status: 'pending',
+      triggerEvents: [
+        {
+          source: 'github',
+          event: 'deployment',
+          delivery_id: 'delivery-2',
+          received_at: '2026-06-30T12:01:00.000Z',
+          data: {environment: 'prod'},
+        },
+      ],
+      priorExecutions: [prior],
+    });
+
+    expect(context).toEqual({
+      site: 'execution-creation',
+      values: {
+        ...assembleWorkflowRunContext({
+          run,
+          triggerPayload: {
+            source: 'github',
+            event: 'push',
+            deliveryId: 'delivery-1',
+            data: {ref: 'refs/heads/main'},
+          },
+          inputs: {deploy: true},
+        }),
+        executions: [
+          {
+            index: 0,
+            name: 'Build #1',
+            status: 'failed',
+            started_at: date,
+            finished_at: date,
+            events: prior.triggerEvents,
+          },
+          {
+            index: 1,
+            name: 'Build #2',
+            status: 'pending',
+            started_at: null,
+            finished_at: null,
+            events: [
+              {
+                source: 'github',
+                event: 'deployment',
+                delivery_id: 'delivery-2',
+                received_at: '2026-06-30T12:01:00.000Z',
+                data: {environment: 'prod'},
+              },
+            ],
+          },
+        ],
+        execution: {
+          index: 1,
+          name: 'Build #2',
+          status: 'pending',
+          started_at: null,
+          finished_at: null,
+          events: [
+            {
+              source: 'github',
+              event: 'deployment',
+              delivery_id: 'delivery-2',
+              received_at: '2026-06-30T12:01:00.000Z',
+              data: {environment: 'prod'},
+            },
+          ],
+        },
+      },
     });
   });
 });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -43,6 +43,46 @@ export function assembleCreationContext(
   };
 }
 
+export interface AssembleExecutionCreationContextParams extends AssembleWorkflowRunContextParams {
+  readonly jobId: string;
+  readonly sequence: number;
+  readonly executionName: string;
+  readonly status: JobExecution['status'];
+  readonly triggerEvents: readonly JobExecution['triggerEvents'][number][];
+  readonly priorExecutions: readonly JobExecution[];
+}
+
+export function assembleExecutionCreationContext(
+  params: AssembleExecutionCreationContextParams,
+): WorkflowEvaluationContext {
+  const execution: JobExecution = {
+    id: `${params.jobId}:${params.sequence}`,
+    jobId: params.jobId,
+    sequence: params.sequence,
+    name: params.executionName,
+    status: params.status,
+    statusReason: null,
+    triggerEvents: [...params.triggerEvents],
+    version: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    queuedAt: null,
+    startedAt: null,
+    finishedAt: null,
+    timedOutAt: null,
+  };
+  const executions = assembleExecutionsContext([...params.priorExecutions, execution]);
+  const executionValues = executions.executions as unknown[];
+  return {
+    site: 'execution-creation',
+    values: {
+      ...assembleWorkflowRunContext(params),
+      ...executions,
+      execution: executionValues.at(-1),
+    },
+  };
+}
+
 /**
  * Keeps job-success predicate values aligned with the registry's `executions`
  * type environment.

--- a/libs/api/workflows/src/core/step-config/index.ts
+++ b/libs/api/workflows/src/core/step-config/index.ts
@@ -1,6 +1,8 @@
 export {
+  type AssembleExecutionCreationContextParams,
   type AssembleWorkflowRunContextParams,
   assembleCreationContext,
+  assembleExecutionCreationContext,
   assembleExecutionsContext,
   assembleGateContext,
   assembleJobResolutionContext,

--- a/libs/api/workflows/src/core/step-config/resolve-job-execution-name.test.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-job-execution-name.test.ts
@@ -1,0 +1,49 @@
+import {workflowModel} from '#test/index.js';
+import {resolveJobExecutionName} from './resolve-job-execution-name.js';
+
+function template(source: string): string {
+  return `\${{ ${source} }}`;
+}
+
+describe('resolveJobExecutionName', () => {
+  it('resolves an interpolated job name at execution creation', () => {
+    const [job] = workflowModel({
+      jobs: {
+        deploy: {
+          name: `Deploy ${template('inputs.environment')}`,
+          steps: [{run: 'echo deploy'}],
+        },
+      },
+    }).jobs;
+    if (!job) throw new Error('Missing deploy job');
+
+    const name = resolveJobExecutionName({
+      definitionId: 'definition-1',
+      job,
+      fallbackName: 'deploy #1',
+      context: {inputs: {environment: 'prod'}},
+    });
+
+    expect(name).toBe('Deploy prod');
+  });
+
+  it('falls back when the job has no name template', () => {
+    const [job] = workflowModel({
+      jobs: {
+        deploy: {
+          steps: [{run: 'echo deploy'}],
+        },
+      },
+    }).jobs;
+    if (!job) throw new Error('Missing deploy job');
+
+    const name = resolveJobExecutionName({
+      definitionId: 'definition-1',
+      job,
+      fallbackName: 'deploy #1',
+      context: {},
+    });
+
+    expect(name).toBe('deploy #1');
+  });
+});

--- a/libs/api/workflows/src/core/step-config/resolve-job-execution-name.test.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-job-execution-name.test.ts
@@ -27,6 +27,27 @@ describe('resolveJobExecutionName', () => {
     expect(name).toBe('Deploy prod');
   });
 
+  it('falls back when the name template resolves to an empty string', () => {
+    const [job] = workflowModel({
+      jobs: {
+        deploy: {
+          name: template('inputs.environment'),
+          steps: [{run: 'echo deploy'}],
+        },
+      },
+    }).jobs;
+    if (!job) throw new Error('Missing deploy job');
+
+    const name = resolveJobExecutionName({
+      definitionId: 'definition-1',
+      job,
+      fallbackName: 'deploy #1',
+      context: {inputs: {environment: ''}},
+    });
+
+    expect(name).toBe('deploy #1');
+  });
+
   it('falls back when the job has no name template', () => {
     const [job] = workflowModel({
       jobs: {

--- a/libs/api/workflows/src/core/step-config/resolve-job-execution-name.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-job-execution-name.ts
@@ -7,11 +7,13 @@ import {
 } from '@shipfox/expression';
 import {InterpolationUnresolvableError} from '#core/errors.js';
 
-type WorkflowModelJob = WorkflowModel['jobs'][number];
+interface WorkflowModelJobName {
+  readonly name?: WorkflowModel['jobs'][number]['name'] | undefined;
+}
 
 export interface ResolveJobExecutionNameParams {
   readonly definitionId: string;
-  readonly job: WorkflowModelJob;
+  readonly job: WorkflowModelJobName;
   readonly fallbackName: string;
   readonly context: WorkflowExpressionEvaluationContext;
 }

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -2,7 +2,6 @@ import {
   type AgentDefaultsResolver,
   catalogDefaultAgentResolver,
 } from '@shipfox/api-agent/core/resolve-agent-config';
-import type {WorkflowModel} from '@shipfox/api-definitions';
 import {WORKFLOWS_JOB_ACTIVATED, type WorkflowsEventMapDto} from '@shipfox/api-workflows-dto';
 import {writeOutboxEvent} from '@shipfox/node-outbox';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
@@ -10,12 +9,10 @@ import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import {AgentConfigUnresolvableError, InterpolationUnresolvableError} from '#core/errors.js';
 import {
-  assembleExecutionsContext,
-  assembleWorkflowRunContext,
+  assembleExecutionCreationContext,
   materializeJobExecutionSteps,
   resolveJobExecutionName,
 } from '#core/step-config/index.js';
-import type {WorkflowEvaluationContext} from '#core/step-config/workflow-evaluation-context.js';
 import {
   recordWorkflowJobExecutionStatusChanged,
   recordWorkflowListenerResolved,
@@ -200,7 +197,6 @@ export async function drainListenerEventsIntoExecution(
 
       const nameContext = listenerExecutionContext({
         run: toWorkflowRun(target.run),
-        model,
         jobId: params.jobId,
         sequence: params.expectedSequence,
         executionName,
@@ -216,7 +212,6 @@ export async function drainListenerEventsIntoExecution(
       });
       const stepContext = listenerExecutionContext({
         run: toWorkflowRun(target.run),
-        model,
         jobId: params.jobId,
         sequence: params.expectedSequence,
         executionName,
@@ -429,44 +424,24 @@ async function loadListenerMaterializationTarget(jobId: string, tx: Tx) {
 
 function listenerExecutionContext(params: {
   run: ReturnType<typeof toWorkflowRun>;
-  model: WorkflowModel;
   jobId: string;
   sequence: number;
   executionName: string;
   status: JobExecutionStatus;
   triggerEvents: readonly WorkflowExecutionEvent[];
   priorExecutions: ReturnType<typeof toJobExecution>[];
-}): WorkflowEvaluationContext {
-  const execution = {
-    id: `${params.jobId}:${params.sequence}`,
+}) {
+  return assembleExecutionCreationContext({
+    run: params.run,
+    triggerPayload: params.run.triggerPayload,
+    inputs: params.run.inputs,
     jobId: params.jobId,
     sequence: params.sequence,
-    name: params.executionName,
+    executionName: params.executionName,
     status: params.status,
-    statusReason: null,
-    triggerEvents: [...params.triggerEvents],
-    version: 1,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    queuedAt: null,
-    startedAt: null,
-    finishedAt: null,
-    timedOutAt: null,
-  };
-  const executions = assembleExecutionsContext([...params.priorExecutions, execution]);
-  const executionValues = executions.executions as unknown[];
-  return {
-    site: 'execution-creation',
-    values: {
-      ...assembleWorkflowRunContext({
-        run: params.run,
-        triggerPayload: params.run.triggerPayload,
-        inputs: params.run.inputs,
-      }),
-      ...executions,
-      execution: executionValues.at(-1),
-    },
-  };
+    triggerEvents: params.triggerEvents,
+    priorExecutions: params.priorExecutions,
+  });
 }
 
 class PermanentListenerMaterializationError extends Error {

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -22,6 +22,7 @@ import {nextStepForJob} from '#core/job-execution.js';
 import {stripSetupStep} from '#test/fixtures/strip-setup-step.js';
 import {workflowModel} from '#test/index.js';
 import {db} from './db.js';
+import {jobExecutions} from './schema/job-executions.js';
 import {jobs} from './schema/jobs.js';
 import {workflowsOutbox} from './schema/outbox.js';
 import {steps as stepsTable} from './schema/steps.js';
@@ -233,7 +234,7 @@ describe('workflow run queries', () => {
       expect(jobExecutions[0]).toMatchObject({
         jobId: runJobs[0]?.id,
         sequence: 1,
-        name: 'build',
+        name: 'build #1',
       });
 
       // Every job gets a synthetic "Set up job" step at position 0; user steps follow.
@@ -247,6 +248,89 @@ describe('workflow run queries', () => {
         config: {},
       });
       expect(jobSteps[1]).toMatchObject({position: 1, config: {run: 'echo hello'}});
+    });
+
+    test('persists the resolved one-shot job execution name', async () => {
+      const model = buildModel({
+        jobs: {
+          deploy: {
+            name: `Deploy ${template('inputs.environment')}`,
+            steps: [{run: 'echo deploy'}],
+          },
+        },
+      });
+
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model,
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        inputs: {environment: 'prod'},
+      });
+
+      const [job] = await getJobsByWorkflowRunId(run.id);
+      if (!job) throw new Error('Missing deploy job');
+      const executions = await getJobExecutionsByJobId(job.id);
+      expect(executions[0]?.name).toBe('Deploy prod');
+    });
+
+    test('falls back to the job key and sequence for unnamed one-shot executions', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            deploy: {
+              steps: [{run: 'echo deploy'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const [job] = await getJobsByWorkflowRunId(run.id);
+      if (!job) throw new Error('Missing deploy job');
+      const executions = await getJobExecutionsByJobId(job.id);
+      expect(executions[0]?.name).toBe('deploy #1');
+    });
+
+    test('uses the fallback name for execution-name self references', async () => {
+      const run = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            deploy: {
+              name: `Current ${template('execution.name')}`,
+              steps: [{run: 'echo deploy'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+      });
+
+      const [job] = await getJobsByWorkflowRunId(run.id);
+      if (!job) throw new Error('Missing deploy job');
+      const executions = await getJobExecutionsByJobId(job.id);
+      expect(executions[0]?.name).toBe('Current deploy #1');
     });
 
     test('persists the parsed model on the run attempt', async () => {
@@ -1302,6 +1386,54 @@ jobs:
       const userStep = (await getStepsByJobId(rerunJobs[0]?.id as string))[1];
 
       expect(userStep?.authoredConfig).toEqual({run: `echo "${template('run.id')}"`});
+    });
+
+    test('reruns copy the source job execution name', async () => {
+      const source = await createWorkflowRun({
+        workspaceId,
+        projectId,
+        definitionId,
+        model: buildModel({
+          jobs: {
+            deploy: {
+              name: `Deploy ${template('inputs.environment')}`,
+              steps: [{run: 'echo deploy'}],
+            },
+          },
+        }),
+        triggerPayload: {
+          source: 'manual',
+          event: 'fire',
+          subscriptionId: crypto.randomUUID(),
+          userId: crypto.randomUUID(),
+        },
+        inputs: {environment: 'prod'},
+      });
+      const [sourceJob] = await getJobsByWorkflowRunId(source.id);
+      if (!sourceJob) throw new Error('Missing deploy job');
+      await markJob([sourceJob], 'deploy', 'failed');
+      const [sourceExecution] = await getJobExecutionsByJobId(sourceJob.id);
+      if (!sourceExecution) throw new Error('Missing deploy execution');
+      await db()
+        .update(jobExecutions)
+        .set({name: 'Deploy prod (attempt 1)'})
+        .where(eq(jobExecutions.id, sourceExecution.id));
+      await updateWorkflowRunStatus({
+        workflowRunId: source.id,
+        status: 'failed',
+        expectedVersion: 1,
+      });
+
+      const rerun = await createRerunWorkflowRun({
+        workflowRunId: source.id,
+        mode: 'all',
+        actorUserId: crypto.randomUUID(),
+      });
+
+      const [rerunJob] = await getJobsByWorkflowRunId(rerun.id);
+      if (!rerunJob) throw new Error('Missing rerun deploy job');
+      const [rerunExecution] = await getJobExecutionsByJobId(rerunJob.id);
+      expect(rerunExecution?.name).toBe('Deploy prod (attempt 1)');
     });
 
     test('writes one run-attempt-created outbox event for the rerun', async () => {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -65,10 +65,12 @@ import {
 } from '#core/errors.js';
 import {
   assembleCreationContext,
+  assembleExecutionCreationContext,
   assembleExecutionsContext,
 } from '#core/step-config/assemble-run-context.js';
 import type {MaterializedWorkflowJob} from '#core/step-config/materialize-workflow-model.js';
 import {materializeWorkflowModel} from '#core/step-config/materialize-workflow-model.js';
+import {resolveJobExecutionName} from '#core/step-config/resolve-job-execution-name.js';
 import type {WorkflowStepTemplateDiagnostic} from '#core/step-config/resolve-step-config.js';
 import {deriveCompletion, isTerminal} from '#core/step-transition/decide-step-transition.js';
 import type {RuntimeCompletionStatus} from '#core/workflow-scheduling/runtime-dag.js';
@@ -208,18 +210,39 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
         .returning();
     }
 
-    const jobExecutionValues = jobRows.flatMap((jobRow) =>
-      jobRow.mode === 'listening'
-        ? []
-        : [
-            {
-              jobId: jobRow.id,
-              sequence: 1,
-              name: jobRow.name ?? jobRow.key,
-              status: 'pending' as const,
-            },
-          ],
-    );
+    const jobExecutionValues = jobRows.flatMap((jobRow, jobIndex) => {
+      if (jobRow.mode === 'listening') return [];
+      const job = materializedJobs[jobIndex];
+      if (!job) return [];
+
+      const fallbackName = `${jobRow.key} #1`;
+      const context = assembleExecutionCreationContext({
+        run,
+        triggerPayload: params.triggerPayload,
+        inputs: params.inputs ?? null,
+        jobId: jobRow.id,
+        sequence: 1,
+        executionName: fallbackName,
+        status: 'pending',
+        triggerEvents: [],
+        priorExecutions: [],
+      });
+      const name = resolveJobExecutionName({
+        definitionId: params.definitionId,
+        job,
+        fallbackName,
+        context: context.values,
+      });
+
+      return [
+        {
+          jobId: jobRow.id,
+          sequence: 1,
+          name,
+          status: 'pending' as const,
+        },
+      ];
+    });
     const jobExecutionRows =
       jobExecutionValues.length === 0
         ? []
@@ -461,15 +484,18 @@ export async function createRerunWorkflowRun(
             )
             .returning();
 
+    const sourceJobByPosition = new Map(sourceJobs.map((job) => [job.position, job]));
     const clonedJobExecutionValues = clonedJobRows.flatMap((job) => {
       const carriedOver = params.mode === 'failed' && job.status === 'succeeded';
+      const sourceJob = sourceJobByPosition.get(job.position);
+      const sourceExecution = sourceJob ? sourceJobExecutionByJobId.get(sourceJob.id) : undefined;
       return job.mode === 'listening'
         ? []
         : [
             {
               jobId: job.id,
               sequence: 1,
-              name: job.name ?? job.key,
+              name: sourceExecution?.name ?? `${job.key} #1`,
               status: carriedOver ? ('succeeded' as const) : ('pending' as const),
               statusReason: null,
               ...(carriedOver ? {finishedAt: sql`now()`} : {}),


### PR DESCRIPTION
Resolve one-shot job execution names from the job name template using the same execution-creation context as listener jobs.

One-shot runs previously persisted `job_executions.name` from the raw stored job template source, so names like `Deploy ${{ inputs.environment }}` appeared unresolved while listener executions interpolated correctly. This extracts the listener context assembly into a shared helper, uses it during one-shot execution creation, and preserves the already-resolved source execution name when cloning reruns.

Reviewers should pay closest attention to the fallback semantics: one-shot jobs now use `<job-key> #1`, and `${{ execution.name }}` reads that fallback during name resolution to avoid self-reference.

Fixes ENG-781

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies one-shot job execution naming with listener jobs by resolving the job name template at execution creation. Persisted names now interpolate correctly; reruns keep the resolved name. Fixes ENG-781.

- Bug Fixes
  - One-shot executions resolve the job `name` template using the listener execution-creation context.
  - Fallback: unnamed or empty templates use `<job-key> #1`; `${{ execution.name }}` reads the fallback to avoid self-reference.
  - Reruns copy the source execution’s resolved name instead of re-interpolating.

- Refactors
  - Added a shared execution-creation context helper and updated listener/one-shot paths to use it.

<sup>Written for commit 10866a0039f1178c123c1d27cf1c333a2c3915fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

