### PR TITLE
[client-router] Fix remembered workspace redirect race

### DIFF
--- a/e2e/client/workspaces/tests/workspace-flows.e2e.ts
+++ b/e2e/client/workspaces/tests/workspace-flows.e2e.ts
@@ -13,9 +13,16 @@ function workspaceUrlRe(wid: string): RegExp {
 }
 
 async function readLastWorkspaceId(page: Page): Promise<string> {
+  const workspaceId = await readMaybeLastWorkspaceId(page);
+  expect(workspaceId, `localStorage[${LAST_WORKSPACE_KEY}]`).not.toBeUndefined();
+  return workspaceId as string;
+}
+
+async function readMaybeLastWorkspaceId(page: Page): Promise<string | undefined> {
   const raw = await page.evaluate((key) => window.localStorage.getItem(key), LAST_WORKSPACE_KEY);
-  expect(raw, `localStorage[${LAST_WORKSPACE_KEY}]`).not.toBeNull();
-  return JSON.parse(raw as string) as string;
+  if (!raw) return undefined;
+  const parsed: unknown = JSON.parse(raw);
+  return typeof parsed === 'string' ? parsed : undefined;
 }
 
 async function expectSetupNavigationHidden(page: Page): Promise<void> {
@@ -105,9 +112,11 @@ test('persists the active workspace across reload and via /', async ({page, auth
 
   await page.goto(`/workspaces/${wsB.id}/integrations`);
   await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
+  await expect.poll(() => readMaybeLastWorkspaceId(page)).toBe(wsB.id);
 
   await page.reload();
   await expect(page).toHaveURL(workspaceUrlRe(wsB.id));
+  await expect.poll(() => readMaybeLastWorkspaceId(page)).toBe(wsB.id);
 
   await page.goto('/');
   await expect(page).toHaveURL(workspaceUrlRe(wsB.id));

--- a/libs/client/router/src/routes/workspaces/$wid/_layout.tsx
+++ b/libs/client/router/src/routes/workspaces/$wid/_layout.tsx
@@ -11,17 +11,17 @@ import {createFileRoute, redirect} from '@tanstack/react-router';
 export const Route = createFileRoute('/workspaces/$wid/_layout')({
   beforeLoad: async ({context, params, location}) => {
     const auth = context.auth;
+    try {
+      rememberLastWorkspaceId(params.wid);
+    } catch {
+      // localStorage may throw in private browsing or quota-exceeded; routing is still URL-driven.
+    }
     if (!auth || auth.isLoading || !context.queryClient) return;
     if (!auth.isAuthenticated) {
       throw redirect({to: '/auth/login', search: {redirect: location.href}});
     }
     if (!auth.workspaces.some((w) => w.id === params.wid)) {
       throw redirect({to: '/'});
-    }
-    try {
-      rememberLastWorkspaceId(params.wid);
-    } catch {
-      // localStorage may throw in private browsing or quota-exceeded; routing is still URL-driven.
     }
     return await loadWorkspaceSetupRoute({
       queryClient: context.queryClient,


### PR DESCRIPTION
Fix a race where direct workspace URLs could fail to become the remembered workspace before a later visit to `/`.

The workspace layout previously persisted `shipfox.lastWorkspaceId` only after auth and query context were ready. In the E2E flow, a direct visit to workspace B could be followed by `/` while storage still pointed at the first workspace, so the root redirect sent the user back to workspace A.

This moves the URL workspace persistence ahead of the auth-loading short circuit and makes the E2E assert that local storage has caught up before validating the `/` redirect behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where the last workspace wasn’t saved early enough, causing “/” to redirect to the wrong workspace after a direct visit. We now persist the workspace ID as soon as the workspace route loads and make the E2E wait for storage before checking redirects.

- **Bug Fixes**
  - Persist `shipfox.lastWorkspaceId` at the start of the workspace route `beforeLoad`, before auth/loading checks.
  - Keep `localStorage` write in a try/catch to handle private/quota cases without breaking routing.
  - E2E: add `readMaybeLastWorkspaceId` and use `expect.poll` to wait for storage to match the visited workspace before reload and “/” navigation.

<sup>Written for commit 2090f5eccd37e4928d05c56c80a3b15f1664fb0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

