### PR TITLE
Add generic webhook workflow E2E coverage

### DIFF
--- a/dev/e2e.mjs
+++ b/dev/e2e.mjs
@@ -181,6 +181,7 @@ export function e2eEnv(sourceEnv) {
     HOST: sourceEnv.HOST ?? '0.0.0.0',
     VITE_API_URL: sourceEnv.VITE_API_URL ?? apiUrl,
     VITE_ENABLE_TEST_VCS_PROVIDER: sourceEnv.VITE_ENABLE_TEST_VCS_PROVIDER ?? 'true',
+    WEBHOOK_PUBLIC_URL: sourceEnv.WEBHOOK_PUBLIC_URL ?? apiUrl,
   };
 }
 

--- a/dev/e2e.test.mjs
+++ b/dev/e2e.test.mjs
@@ -66,6 +66,7 @@ describe('e2eEnv', () => {
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:55356');
     assert.equal(env.SHIPFOX_TURBO_CONCURRENCY, undefined);
     assert.equal(env.VITE_API_URL, 'http://localhost:55351');
+    assert.equal(env.WEBHOOK_PUBLIC_URL, 'http://localhost:55351');
   });
 
   test('keeps explicit CI URLs over local-service defaults', () => {
@@ -76,12 +77,14 @@ describe('e2eEnv', () => {
       GITEA_CLONE_BASE_URL: 'http://localhost:3000',
       SHIPFOX_API_URL: 'http://localhost:55351',
       GITEA_BASE_URL: 'http://localhost:55356',
+      WEBHOOK_PUBLIC_URL: 'https://webhooks.example.test',
     });
 
     assert.equal(env.API_URL, 'http://localhost:16101');
     assert.equal(env.CLIENT_URL, 'http://localhost:5173');
     assert.equal(env.E2E_GITEA_URL, 'http://localhost:3001');
     assert.equal(env.GITEA_CLONE_BASE_URL, 'http://localhost:3000');
+    assert.equal(env.WEBHOOK_PUBLIC_URL, 'https://webhooks.example.test');
   });
 
   test('keeps explicit turbo concurrency', () => {

--- a/e2e/helpers/workflows/src/index.test.ts
+++ b/e2e/helpers/workflows/src/index.test.ts
@@ -4,7 +4,7 @@ import type {
   WorkflowRunListResponseDto,
   WorkflowRunStatusDto,
 } from '@shipfox/api-workflows-dto';
-import {waitForRunByCommit, waitForRunTerminal} from './index.js';
+import {waitForRunByCommit, waitForRunByDeliveryId, waitForRunTerminal} from './index.js';
 
 const projectId = '11111111-1111-4111-8111-111111111111';
 const definitionId = '22222222-2222-4222-8222-222222222222';
@@ -13,6 +13,9 @@ const attemptId = '44444444-4444-4444-8444-444444444444';
 const RUN_BY_COMMIT_TIMEOUT_RE =
   /Timed out waiting for workflow run by commit: expectedHeadCommitSha=abc123/u;
 const RUN_BY_COMMIT_OBSERVED_RE = /headCommitSha=other/u;
+const RUN_BY_DELIVERY_TIMEOUT_RE =
+  /Timed out waiting for workflow run by delivery ID: expectedDeliveryId=delivery-1/u;
+const RUN_BY_DELIVERY_OBSERVED_RE = /deliveryId=other-delivery/u;
 const RUN_TERMINAL_TIMEOUT_RE =
   /Timed out waiting for workflow run terminal status: runId=33333333/u;
 const RUN_TERMINAL_OBSERVED_RE = /status=running/u;
@@ -146,6 +149,51 @@ describe('waitForRunByCommit', () => {
     });
 
     await expect(result).rejects.toMatchObject({name: 'AbortError'});
+  });
+});
+
+describe('waitForRunByDeliveryId', () => {
+  test('polls until a run with the matching delivery ID appears', async () => {
+    let calls = 0;
+
+    const result = await waitForRunByDeliveryId({
+      fetch: () => {
+        calls += 1;
+        return Promise.resolve(
+          response(
+            calls === 1
+              ? listResponse({
+                  runs: [run({trigger_payload: {deliveryId: 'other-delivery', data: {}}})],
+                })
+              : listResponse({runs: [run()]}),
+          ),
+        );
+      },
+      deliveryId: 'delivery-1',
+      initialDelayMs: 1,
+      projectId,
+      token: 'user-token',
+    });
+
+    expect(result.id).toBe(runId);
+    expect(calls).toBe(2);
+  });
+
+  test('times out with a bounded run list summary', async () => {
+    const result = waitForRunByDeliveryId({
+      fetch: () =>
+        response(
+          listResponse({runs: [run({trigger_payload: {deliveryId: 'other-delivery', data: {}}})]}),
+        ),
+      deliveryId: 'delivery-1',
+      initialDelayMs: 1,
+      projectId,
+      timeoutMs: 1,
+      token: 'user-token',
+    });
+
+    await expect(result).rejects.toThrow(RUN_BY_DELIVERY_TIMEOUT_RE);
+    await expect(result).rejects.toThrow(RUN_BY_DELIVERY_OBSERVED_RE);
   });
 });
 

--- a/e2e/helpers/workflows/src/index.ts
+++ b/e2e/helpers/workflows/src/index.ts
@@ -30,6 +30,11 @@ export interface WaitForRunByCommitOptions extends PollingOptions {
   projectId: string;
 }
 
+export interface WaitForRunByDeliveryIdOptions extends PollingOptions {
+  deliveryId: string;
+  projectId: string;
+}
+
 export interface WaitForRunTerminalOptions extends PollingOptions {
   runId: string;
 }
@@ -67,9 +72,16 @@ function headCommitSha(run: WorkflowRunDto): string | null {
   return null;
 }
 
+function deliveryId(run: WorkflowRunDto): string | null {
+  const payload = run.trigger_payload;
+  if (!isRecord(payload)) return null;
+  return typeof payload.deliveryId === 'string' ? payload.deliveryId : null;
+}
+
 function formatRunListObserved(
   response: WorkflowRunListResponseDto | null,
-  expectedHeadCommitSha: string,
+  expected: string,
+  runField: (run: WorkflowRunDto) => string,
 ): string {
   if (!response) return 'no workflow run list response observed';
   const runs = response.runs
@@ -79,12 +91,12 @@ function formatRunListObserved(
         `id=${run.id}`,
         `status=${run.status}`,
         `trigger=${run.trigger_source}/${run.trigger_event}`,
-        `headCommitSha=${headCommitSha(run) ?? 'null'}`,
+        runField(run),
         `updatedAt=${run.updated_at}`,
       ].join(' '),
     );
   const more = response.runs.length > runs.length ? ', ...' : '';
-  return `expectedHeadCommitSha=${expectedHeadCommitSha} runs=[${runs.join(', ')}${more}]`;
+  return `${expected} runs=[${runs.join(', ')}${more}]`;
 }
 
 function formatRunDetailObserved(
@@ -101,8 +113,14 @@ function formatRunDetailObserved(
   ].join(' ');
 }
 
-export async function waitForRunByCommit(
-  options: WaitForRunByCommitOptions,
+async function waitForRunMatching(
+  options: PollingOptions & {
+    expected: string;
+    match: (run: WorkflowRunDto) => boolean;
+    projectId: string;
+    runField: (run: WorkflowRunDto) => string;
+    timeoutMessage: string;
+  },
 ): Promise<WorkflowRunDto> {
   const client = createApiClient({
     apiUrl: options.apiUrl,
@@ -123,9 +141,7 @@ export async function waitForRunByCommit(
       {signal: options.signal},
     );
 
-    const run = lastResponse.runs.find(
-      (candidate) => headCommitSha(candidate) === options.headCommitSha,
-    );
+    const run = lastResponse.runs.find(options.match);
     if (run) return run;
 
     await waitForNextPoll({deadline, delayMs, signal: options.signal});
@@ -133,11 +149,36 @@ export async function waitForRunByCommit(
   }
 
   throw new Error(
-    `Timed out waiting for workflow run by commit: ${formatRunListObserved(
+    `${options.timeoutMessage}: ${formatRunListObserved(
       lastResponse,
-      options.headCommitSha,
+      options.expected,
+      options.runField,
     )}`,
   );
+}
+
+export async function waitForRunByCommit(
+  options: WaitForRunByCommitOptions,
+): Promise<WorkflowRunDto> {
+  return await waitForRunMatching({
+    ...options,
+    expected: `expectedHeadCommitSha=${options.headCommitSha}`,
+    match: (run) => headCommitSha(run) === options.headCommitSha,
+    runField: (run) => `headCommitSha=${headCommitSha(run) ?? 'null'}`,
+    timeoutMessage: 'Timed out waiting for workflow run by commit',
+  });
+}
+
+export async function waitForRunByDeliveryId(
+  options: WaitForRunByDeliveryIdOptions,
+): Promise<WorkflowRunDto> {
+  return await waitForRunMatching({
+    ...options,
+    expected: `expectedDeliveryId=${options.deliveryId}`,
+    match: (run) => deliveryId(run) === options.deliveryId,
+    runField: (run) => `deliveryId=${deliveryId(run) ?? 'null'}`,
+    timeoutMessage: 'Timed out waiting for workflow run by delivery ID',
+  });
 }
 
 export async function waitForRunTerminal(
@@ -182,6 +223,9 @@ export function createWorkflowsHelper(options: {
   return {
     waitForRunByCommit: (params: Omit<WaitForRunByCommitOptions, 'apiUrl' | 'fetch' | 'token'>) =>
       waitForRunByCommit({...options, ...params}),
+    waitForRunByDeliveryId: (
+      params: Omit<WaitForRunByDeliveryIdOptions, 'apiUrl' | 'fetch' | 'token'>,
+    ) => waitForRunByDeliveryId({...options, ...params}),
     waitForRunTerminal: (params: Omit<WaitForRunTerminalOptions, 'apiUrl' | 'fetch' | 'token'>) =>
       waitForRunTerminal({...options, ...params}),
   };

--- a/e2e/platform/workflows/package.json
+++ b/e2e/platform/workflows/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@shipfox/api-definitions-dto": "workspace:*",
+    "@shipfox/api-integration-webhook-dto": "workspace:*",
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/api-projects-dto": "workspace:*",
     "@shipfox/api-triggers-dto": "workspace:*",

--- a/e2e/platform/workflows/scenarios/webhook-received/expect.yaml
+++ b/e2e/platform/workflows/scenarios/webhook-received/expect.yaml
@@ -1,0 +1,20 @@
+trigger: webhook
+webhook:
+  body:
+    payment_id: pay_webhook_e2e
+  headers:
+    x-e2e-event: payment.created
+  query:
+    mode: test
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      show-webhook:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - payment_id=pay_webhook_e2e

--- a/e2e/platform/workflows/scenarios/webhook-received/workflow.yml
+++ b/e2e/platform/workflows/scenarios/webhook-received/workflow.yml
@@ -1,0 +1,13 @@
+name: Webhook received
+runner: __RUNNER_LABEL__
+triggers:
+  on_webhook:
+    source: __WEBHOOK_SOURCE__
+    event: received
+jobs:
+  build:
+    steps:
+      - key: show-webhook
+        env:
+          PAYMENT_ID: '${{ event.body.payment_id }}'
+        run: echo "payment_id=$PAYMENT_ID"

--- a/e2e/platform/workflows/src/expect.test.ts
+++ b/e2e/platform/workflows/src/expect.test.ts
@@ -686,6 +686,25 @@ describe('parseExpectation', () => {
     expect(expectation.push?.message).toBe("literal $(printf I''NJECTED)");
   });
 
+  test('accepts webhook request options', () => {
+    const expectation = parseExpectation({
+      trigger: 'webhook',
+      webhook: {
+        body: {payment_id: 'pay_123'},
+        headers: {'x-e2e-event': 'payment.created'},
+        query: {mode: 'test'},
+      },
+      run: {status: 'succeeded'},
+    });
+
+    expect(expectation.trigger).toBe('webhook');
+    expect(expectation.webhook).toEqual({
+      body: {payment_id: 'pay_123'},
+      headers: {'x-e2e-event': 'payment.created'},
+      query: {mode: 'test'},
+    });
+  });
+
   test('rejects unknown keys', () => {
     expect(() => parseExpectation({run: {status: 'succeeded'}, unexpected: true})).toThrow();
   });

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -79,6 +79,14 @@ const pushExpectationSchema = z
   })
   .strict();
 
+const webhookExpectationSchema = z
+  .object({
+    body: z.unknown().optional(),
+    headers: z.record(z.string(), z.string()).optional(),
+    query: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
 const stepErrorExpectationSchema = z
   .object({
     reason: stepErrorReasonSchema.optional(),
@@ -125,8 +133,9 @@ const jobExpectationSchema = z
 
 export const expectationSchema = z
   .object({
-    trigger: z.enum(['push', 'manual']).default('push'),
+    trigger: z.enum(['push', 'manual', 'webhook']).default('push'),
     push: pushExpectationSchema.optional(),
+    webhook: webhookExpectationSchema.optional(),
     inputs: z.record(z.string(), z.unknown()).optional(),
     timeout_seconds: z.number().int().positive().default(180),
     run: z.object({status: runStatusSchema}).strict(),

--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -2,7 +2,12 @@ import {mkdir, readFile} from 'node:fs/promises';
 import {join} from 'node:path';
 import {setTimeout as delay} from 'node:timers/promises';
 import type {DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
-import type {FireManualTriggerResponseDto} from '@shipfox/api-triggers-dto';
+import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
+import type {
+  FireManualTriggerResponseDto,
+  TriggerEventDetailResponseDto,
+  TriggerEventListResponseDto,
+} from '@shipfox/api-triggers-dto';
 import type {WorkflowRunListResponseDto} from '@shipfox/api-workflows-dto';
 import {type ApiFetch, createApiClient, E2eApiError} from '@shipfox/e2e-core';
 import {waitForDefinition} from '@shipfox/e2e-helper-definitions';
@@ -17,7 +22,11 @@ import {
   stopLocalRunner,
   waitForLocalRunnerExit,
 } from '@shipfox/e2e-helper-runners';
-import {waitForRunByCommit, waitForRunTerminal} from '@shipfox/e2e-helper-workflows';
+import {
+  waitForRunByCommit,
+  waitForRunByDeliveryId,
+  waitForRunTerminal,
+} from '@shipfox/e2e-helper-workflows';
 import {createProject, giteaExternalRepositoryId} from './create-project.js';
 import {evaluateExpectations, evaluateLogs, logText, type Mismatch} from './expect.js';
 import {evaluateRejection} from './reject.js';
@@ -26,9 +35,11 @@ import {type SuiteContext, suiteRunDir} from './suite-context.js';
 
 const GITEA_SOURCE_PLACEHOLDER = '__GITEA_SOURCE__';
 const GITEA_REPOSITORY_PLACEHOLDER = '__GITEA_REPOSITORY__';
+const WEBHOOK_SOURCE_PLACEHOLDER = '__WEBHOOK_SOURCE__';
 const RUNNER_LABEL_PLACEHOLDER = '__RUNNER_LABEL__';
 const LOG_ATTACHMENT_NAME_PART_RE = /[^a-zA-Z0-9._-]+/g;
 const REJECTION_NO_RUN_TIMEOUT_MS = 15_000;
+const WEBHOOK_RECEIVED_EVENT = 'received';
 
 export interface Attachment {
   name: string;
@@ -56,6 +67,11 @@ interface PollingOptions {
   signal?: AbortSignal | undefined;
   timeoutMs: number;
   token: string;
+}
+
+interface WebhookDiagnosticsRequest {
+  deliveryIds: string[];
+  source: string;
 }
 
 function logAttachmentName(path: string): string {
@@ -244,6 +260,154 @@ async function triggerPushAndAwaitRun(params: {
     : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} trigger pushes`);
 }
 
+async function createWebhookConnection(params: {
+  client: ReturnType<typeof createApiClient>;
+  scenario: string;
+  slug: string;
+  uniqueId: string;
+  workspaceId: string;
+}): Promise<WebhookConnectionDto> {
+  return await params.client.requestJson<WebhookConnectionDto>(
+    'post',
+    '/integrations/webhook/connections',
+    {
+      json: {
+        workspace_id: params.workspaceId,
+        name: `E2E ${params.scenario} ${params.uniqueId}`,
+        slug: params.slug,
+      },
+    },
+  );
+}
+
+function webhookUrlWithQuery(
+  inboundUrl: string,
+  query: Record<string, string> | undefined,
+): string {
+  const url = new URL(inboundUrl);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+function webhookHeaders(
+  configuredHeaders: Record<string, string> | undefined,
+  deliveryId: string,
+): Headers {
+  const headers = new Headers(configuredHeaders);
+  headers.set('x-delivery-id', deliveryId);
+  return headers;
+}
+
+async function attachWebhookTriggerDiagnostics(params: {
+  attach: RunScenarioParams['attach'];
+  client: ReturnType<typeof createApiClient>;
+  deliveryIds: string[];
+  source: string;
+  workspaceId: string;
+}): Promise<void> {
+  try {
+    const search = new URLSearchParams({
+      workspace_id: params.workspaceId,
+      source: params.source,
+      event: WEBHOOK_RECEIVED_EVENT,
+      limit: '50',
+    });
+    const events = await params.client.requestJson<TriggerEventListResponseDto>(
+      'get',
+      `/trigger-events?${search}`,
+    );
+    await params.attach({
+      name: 'webhook-trigger-events.json',
+      contentType: 'application/json',
+      body: JSON.stringify(events, null, 2),
+    });
+
+    const deliveryIds = new Set(params.deliveryIds);
+    for (const event of events.trigger_events) {
+      if (!event.delivery_id || !deliveryIds.has(event.delivery_id)) continue;
+      const detail = await params.client.requestJson<TriggerEventDetailResponseDto>(
+        'get',
+        `/trigger-events/${event.id}`,
+      );
+      await params.attach({
+        name: `webhook-trigger-event-${logAttachmentName(event.delivery_id)}.json`,
+        contentType: 'application/json',
+        body: JSON.stringify(detail, null, 2),
+      });
+    }
+  } catch (error) {
+    await params
+      .attach({
+        name: 'webhook-trigger-events.error.txt',
+        contentType: 'text/plain',
+        body: error instanceof Error ? error.message : String(error),
+      })
+      .catch(() => undefined);
+  }
+}
+
+async function triggerWebhookAndAwaitRun(params: {
+  attach: RunScenarioParams['attach'];
+  client: ReturnType<typeof createApiClient>;
+  connection: WebhookConnectionDto;
+  projectId: string;
+  scenario: string;
+  token: string;
+  webhook:
+    | {
+        body?: unknown;
+        headers?: Record<string, string> | undefined;
+        query?: Record<string, string> | undefined;
+      }
+    | undefined;
+  workspaceId: string;
+}): Promise<{deliveryIds: string[]; runId: string}> {
+  const maxAttempts = 8;
+  const deliveryIds: string[] = [];
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const deliveryId = crypto.randomUUID();
+    deliveryIds.push(deliveryId);
+    await params.client.requestJson<{delivery_id: string}>(
+      'post',
+      webhookUrlWithQuery(params.connection.inbound_url, params.webhook?.query),
+      {
+        headers: webhookHeaders(params.webhook?.headers, deliveryId),
+        json: params.webhook?.body ?? {
+          scenario: params.scenario,
+          attempt,
+          delivery_id: deliveryId,
+        },
+      },
+    );
+
+    try {
+      const run = await waitForRunByDeliveryId({
+        projectId: params.projectId,
+        deliveryId,
+        token: params.token,
+        timeoutMs: 15_000,
+      });
+      return {deliveryIds, runId: run.id};
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  await attachWebhookTriggerDiagnostics({
+    attach: params.attach,
+    client: params.client,
+    deliveryIds,
+    source: params.connection.slug,
+    workspaceId: params.workspaceId,
+  });
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} webhook deliveries`);
+}
+
 async function fireManualAndAwaitRun(params: {
   client: ReturnType<typeof createApiClient>;
   definitionId: string;
@@ -275,9 +439,9 @@ async function fireManualAndAwaitRun(params: {
 
 /**
  * Drives one declarative scenario end to end: fresh repo and project, seed commit,
- * definition-resolved poll, trigger (push commit or fire-manual), terminal-run poll,
- * then expect.yaml evaluation. Returns every mismatch (empty means the scenario
- * matched) and attaches the run detail, the diff, and fetched logs when it did not.
+ * definition-resolved poll, trigger, terminal-run poll, then expect.yaml evaluation.
+ * Returns every mismatch (empty means the scenario matched) and attaches the run
+ * detail, the diff, and fetched logs when it did not.
  */
 export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]> {
   const {scenario, suite} = params;
@@ -287,15 +451,29 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
   const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
   const runnerLabel = `e2e-${scenario.name}-${uniqueId}`;
   const repo = `${scenario.name}-${uniqueId}`;
+  const webhookSlug = `webhook-${scenario.name}-${uniqueId}`;
   const workflowYaml = scenario.workflowYaml
     .replaceAll(GITEA_SOURCE_PLACEHOLDER, suite.connectionSlug)
     .replaceAll(GITEA_REPOSITORY_PLACEHOLDER, `${suite.org}/${repo}`)
+    .replaceAll(WEBHOOK_SOURCE_PLACEHOLDER, webhookSlug)
     .replaceAll(RUNNER_LABEL_PLACEHOLDER, runnerLabel);
 
   let runner: LocalRunnerHandle | undefined;
   let runnerLogFile: string | undefined;
+  let webhookDiagnostics: WebhookDiagnosticsRequest | undefined;
 
   try {
+    const webhookConnection =
+      scenario.kind === 'expect' && scenario.expectation.trigger === 'webhook'
+        ? await createWebhookConnection({
+            client,
+            scenario: scenario.name,
+            slug: webhookSlug,
+            uniqueId,
+            workspaceId: suite.workspaceId,
+          })
+        : undefined;
+
     await createRepo({org: suite.org, name: repo});
     // Project binding starts a definition sync, so the repo must already contain the workflow.
     await commitFiles({
@@ -385,6 +563,20 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
         inputs: scenario.expectation.inputs ?? {},
         scenario: scenario.name,
       });
+    } else if (scenario.expectation.trigger === 'webhook') {
+      if (!webhookConnection) throw new Error(`Webhook connection missing for ${scenario.name}`);
+      const result = await triggerWebhookAndAwaitRun({
+        attach: params.attach,
+        client,
+        connection: webhookConnection,
+        projectId: project.id,
+        scenario: scenario.name,
+        token,
+        webhook: scenario.expectation.webhook,
+        workspaceId: suite.workspaceId,
+      });
+      webhookDiagnostics = {deliveryIds: result.deliveryIds, source: webhookConnection.slug};
+      runId = result.runId;
     } else {
       runId = await triggerPushAndAwaitRun({
         org: suite.org,
@@ -451,6 +643,15 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       });
       for (const log of fetchedLogs) await params.attach(log);
       if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
+      if (webhookDiagnostics !== undefined) {
+        await attachWebhookTriggerDiagnostics({
+          attach: params.attach,
+          client,
+          deliveryIds: webhookDiagnostics.deliveryIds,
+          source: webhookDiagnostics.source,
+          workspaceId: suite.workspaceId,
+        });
+      }
 
       const fetchedLogKeys = new Set(
         logRequirements.map((requirement) => `${requirement.stepId}:${requirement.attempt}`),
@@ -464,6 +665,15 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
 
     return allMismatches;
   } catch (error) {
+    if (webhookDiagnostics !== undefined) {
+      await attachWebhookTriggerDiagnostics({
+        attach: params.attach,
+        client,
+        deliveryIds: webhookDiagnostics.deliveryIds,
+        source: webhookDiagnostics.source,
+        workspaceId: suite.workspaceId,
+      });
+    }
     if (runnerLogFile !== undefined) await attachLocalRunnerLog(params.attach, runnerLogFile);
     throw error;
   } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,6 +779,9 @@ importers:
       '@shipfox/api-definitions-dto':
         specifier: workspace:*
         version: link:../../../libs/api/definitions-dto
+      '@shipfox/api-integration-webhook-dto':
+        specifier: workspace:*
+        version: link:../../../libs/api/integration/webhook-dto
       '@shipfox/api-logs-dto':
         specifier: workspace:*
         version: link:../../../libs/api/logs-dto


### PR DESCRIPTION
Add full-loop coverage for the generic webhook integration path in the platform workflow E2E harness.

Gitea push scenarios already exercise provider-specific webhook delivery, but generic webhook connections did not have workflow-level coverage. This adds a `webhook-received` scenario that creates a webhook connection, posts JSON to the inbound URL with a fresh delivery ID, waits for the workflow run correlated to that delivery, and verifies logs include a value from the webhook body.

The E2E harness now also defaults `WEBHOOK_PUBLIC_URL` to `API_URL`, which makes Conductor worktree inbound URLs callable without extra local configuration.

Careful review area: the retry and diagnostic path in `run-scenario.ts`, especially the trigger-event attachments used when webhook dispatch does not produce the expected run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end coverage for generic webhook-triggered workflows by introducing a new scenario that posts to the inbound URL and correlates the workflow run by delivery ID. Also improves diagnostics and reduces local setup by defaulting `WEBHOOK_PUBLIC_URL` to `API_URL`.

- **New Features**
  - New `webhook-received` scenario: creates a webhook connection, sends JSON with a unique delivery ID, waits for the correlated run, and asserts logs include a body value.
  - Adds `waitForRunByDeliveryId` and a shared run-matching helper for polling by delivery ID.
  - Webhook diagnostics on failure: attaches trigger-event list and per-delivery details; please review the retry/diagnostics path in `run-scenario.ts`.
  - Expectation schema now supports `trigger: webhook` with `webhook.body`, `headers`, and `query`.
  - E2E harness defaults `WEBHOOK_PUBLIC_URL` to `API_URL` so Conductor worktree inbound URLs work without extra config.

- **Dependencies**
  - Adds `@shipfox/api-integration-webhook-dto` to `e2e/platform/workflows`.

<sup>Written for commit 2e3bc6ff01fb9473674834d9cbbe084614c02823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

