### PR TITLE
Add runtime secret injection for workflow runs

### DIFF
--- a/e2e/platform/workflows/README.md
+++ b/e2e/platform/workflows/README.md
@@ -15,6 +15,7 @@ scenarios/hello-world/
   workflow.yml    pushed verbatim to .shipfox/workflows/hello-world.yml
   expect.yaml     declarative expectations (run/job/step status, job status reason, step error, exit code, logs)
   reject.yaml     alternative to expect.yaml for authoring-time rejection scenarios
+  secrets.yaml    optional E2E setup secrets to seed before the run
   files/          optional extra repo files, committed alongside the workflow
 ```
 
@@ -46,6 +47,8 @@ timeout_seconds: 180     # terminal-state budget, default 180
 
 run:
   status: succeeded      # required: succeeded | failed | cancelled
+runner_log:              # optional assertions against the local runner process log
+  exclude: ["SECRET_VALUE"]
 jobs:                    # optional, keyed by job key
   build:
     status: succeeded

--- a/e2e/platform/workflows/package.json
+++ b/e2e/platform/workflows/package.json
@@ -45,6 +45,7 @@
     "@shipfox/e2e-helper-integrations-gitea": "workspace:*",
     "@shipfox/e2e-helper-logs": "workspace:*",
     "@shipfox/e2e-helper-runners": "workspace:*",
+    "@shipfox/e2e-helper-secrets": "workspace:*",
     "@shipfox/e2e-helper-workflows": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",

--- a/e2e/platform/workflows/scenarios/runtime-secret-injection/expect.yaml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-injection/expect.yaml
@@ -1,0 +1,21 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      use-secret:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - "env-secret-ok"
+            - "command-secret-ok"
+            - "secret from env=***"
+            - "secret from command=***"
+          exclude:
+            - "runtime-secret-e2e"
+runner_log:
+  exclude:
+    - "runtime-secret-e2e"

--- a/e2e/platform/workflows/scenarios/runtime-secret-injection/expect.yaml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-injection/expect.yaml
@@ -5,17 +5,15 @@ jobs:
   build:
     status: succeeded
     steps:
-      use-secret:
+      assert-env-secret-equals-seeded-value:
         status: succeeded
         exit_code: 0
         logs:
           include:
-            - "env-secret-ok"
-            - "command-secret-ok"
-            - "secret from env=***"
-            - "secret from command=***"
-          exclude:
-            - "runtime-secret-e2e"
-runner_log:
-  exclude:
-    - "runtime-secret-e2e"
+            - "env-secret-equality-ok"
+      assert-command-secret-equals-seeded-value:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - "command-secret-equality-ok"

--- a/e2e/platform/workflows/scenarios/runtime-secret-injection/secrets.yaml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-injection/secrets.yaml
@@ -1,0 +1,4 @@
+secrets:
+  - key: RUNTIME_TOKEN
+    value: runtime-secret-e2e
+    scope: project

--- a/e2e/platform/workflows/scenarios/runtime-secret-injection/workflow.yml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-injection/workflow.yml
@@ -8,7 +8,7 @@ triggers:
 jobs:
   build:
     steps:
-      - key: use-secret
+      - key: assert-env-secret-equals-seeded-value
         env:
           FROM_ENV_SECRET: '${{ secrets.RUNTIME_TOKEN }}'
         run: |
@@ -16,11 +16,13 @@ jobs:
             echo "env secret mismatch"
             exit 1
           fi
+
+          echo "env-secret-equality-ok"
+      - key: assert-command-secret-equals-seeded-value
+        run: |
           if [ "${{ secrets.RUNTIME_TOKEN }}" != "runtime-secret-e2e" ]; then
             echo "command secret mismatch"
             exit 1
           fi
-          echo "env-secret-ok"
-          echo "command-secret-ok"
-          echo "secret from env=$FROM_ENV_SECRET"
-          echo "secret from command=${{ secrets.RUNTIME_TOKEN }}"
+
+          echo "command-secret-equality-ok"

--- a/e2e/platform/workflows/scenarios/runtime-secret-injection/workflow.yml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-injection/workflow.yml
@@ -1,0 +1,26 @@
+name: Runtime secret injection
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: use-secret
+        env:
+          FROM_ENV_SECRET: '${{ secrets.RUNTIME_TOKEN }}'
+        run: |
+          if [ "$FROM_ENV_SECRET" != "runtime-secret-e2e" ]; then
+            echo "env secret mismatch"
+            exit 1
+          fi
+          if [ "${{ secrets.RUNTIME_TOKEN }}" != "runtime-secret-e2e" ]; then
+            echo "command secret mismatch"
+            exit 1
+          fi
+          echo "env-secret-ok"
+          echo "command-secret-ok"
+          echo "secret from env=$FROM_ENV_SECRET"
+          echo "secret from command=${{ secrets.RUNTIME_TOKEN }}"

--- a/e2e/platform/workflows/scenarios/runtime-secret-redaction/expect.yaml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-redaction/expect.yaml
@@ -1,0 +1,26 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      assert-env-secret-output-is-redacted:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - "secret from env=***"
+          exclude:
+            - "runtime-secret-e2e"
+      assert-command-secret-output-is-redacted:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include:
+            - "secret from command=***"
+          exclude:
+            - "runtime-secret-e2e"
+runner_log:
+  exclude:
+    - "runtime-secret-e2e"

--- a/e2e/platform/workflows/scenarios/runtime-secret-redaction/secrets.yaml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-redaction/secrets.yaml
@@ -1,0 +1,4 @@
+secrets:
+  - key: RUNTIME_TOKEN
+    value: runtime-secret-e2e
+    scope: project

--- a/e2e/platform/workflows/scenarios/runtime-secret-redaction/workflow.yml
+++ b/e2e/platform/workflows/scenarios/runtime-secret-redaction/workflow.yml
@@ -1,0 +1,18 @@
+name: Runtime secret redaction
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: assert-env-secret-output-is-redacted
+        env:
+          FROM_ENV_SECRET: '${{ secrets.RUNTIME_TOKEN }}'
+        run: |
+          echo "secret from env=$FROM_ENV_SECRET"
+      - key: assert-command-secret-output-is-redacted
+        run: |
+          echo "secret from command=${{ secrets.RUNTIME_TOKEN }}"

--- a/e2e/platform/workflows/src/expect.test.ts
+++ b/e2e/platform/workflows/src/expect.test.ts
@@ -705,6 +705,15 @@ describe('parseExpectation', () => {
     });
   });
 
+  test('accepts runner log expectations', () => {
+    const expectation = parseExpectation({
+      run: {status: 'succeeded'},
+      runner_log: {exclude: ['runtime-secret']},
+    });
+
+    expect(expectation.runner_log?.exclude).toEqual(['runtime-secret']);
+  });
+
   test('rejects unknown keys', () => {
     expect(() => parseExpectation({run: {status: 'succeeded'}, unexpected: true})).toThrow();
   });

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -140,6 +140,7 @@ export const expectationSchema = z
     timeout_seconds: z.number().int().positive().default(180),
     run: z.object({status: runStatusSchema}).strict(),
     jobs: z.record(z.string(), jobExpectationSchema).optional(),
+    runner_log: logsExpectationSchema.optional(),
   })
   .strict();
 

--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -1,6 +1,7 @@
 import {createApiClient} from '@shipfox/e2e-core';
 import {fetchStepLogs} from '@shipfox/e2e-helper-logs';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-helper-runners';
+import {createSecret} from '@shipfox/e2e-helper-secrets';
 import type {Attachment} from './attachments.js';
 import {
   attachLocalRunnerLog,
@@ -23,6 +24,7 @@ import {
 import {seedAndWaitForDefinition, seedWorkflowProject} from './workflow-project.js';
 
 const REJECTION_NO_RUN_TIMEOUT_MS = 15_000;
+const E2E_SECRET_ACTOR_ID = '11111111-1111-4111-8111-111111111111';
 
 export interface RunScenarioParams {
   scenario: Scenario;
@@ -93,6 +95,16 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
             return ready;
           });
     const {project} = seeded;
+
+    for (const secret of scenario.seededSecrets) {
+      await createSecret({
+        workspaceId: suite.workspaceId,
+        actorId: E2E_SECRET_ACTOR_ID,
+        key: secret.key,
+        value: secret.value,
+        ...(secret.scope === 'project' ? {projectId: project.id} : {}),
+      });
+    }
 
     if (scenario.kind === 'reject') {
       const definitions = await waitForDefinitionSyncTerminal({
@@ -215,6 +227,19 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
           text: logText(logs.records),
           include: requirement.include,
           exclude: requirement.exclude,
+        }),
+      );
+    }
+
+    if (scenario.expectation.runner_log) {
+      const runnerLog =
+        runnerLogFile === undefined ? '' : await readFile(runnerLogFile, 'utf8').catch(() => '');
+      allMismatches.push(
+        ...evaluateLogs({
+          path: 'runner_log',
+          text: runnerLog,
+          include: scenario.expectation.runner_log.include,
+          exclude: scenario.expectation.runner_log.exclude,
         }),
       );
     }

--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -1,3 +1,4 @@
+import {readFile} from 'node:fs/promises';
 import {createApiClient} from '@shipfox/e2e-core';
 import {fetchStepLogs} from '@shipfox/e2e-helper-logs';
 import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-helper-runners';

--- a/e2e/platform/workflows/src/scenarios.test.ts
+++ b/e2e/platform/workflows/src/scenarios.test.ts
@@ -34,6 +34,28 @@ describe('discoverScenarios', () => {
     }
   });
 
+  test('loads optional scenario secrets', () => {
+    const root = createTempScenariosRoot();
+    try {
+      writeScenarioFile(root, 'with-secrets', 'expect.yaml', 'run:\n  status: succeeded\n');
+      writeScenarioFile(root, 'with-secrets', 'workflow.yml', 'jobs:\n  build:\n    steps: []\n');
+      writeScenarioFile(
+        root,
+        'with-secrets',
+        'secrets.yaml',
+        'secrets:\n  - key: API_TOKEN\n    value: runtime-secret\n',
+      );
+
+      const scenarios = discoverScenarios(root);
+
+      expect(scenarios[0]).toMatchObject({
+        seededSecrets: [{key: 'API_TOKEN', value: 'runtime-secret', scope: 'project'}],
+      });
+    } finally {
+      rmSync(root, {recursive: true, force: true});
+    }
+  });
+
   test('loads directories that contain reject.yaml and workflow.yml', () => {
     const root = createTempScenariosRoot();
     try {

--- a/e2e/platform/workflows/src/scenarios.ts
+++ b/e2e/platform/workflows/src/scenarios.ts
@@ -2,8 +2,25 @@ import {existsSync, readdirSync, readFileSync, statSync} from 'node:fs';
 import {join, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import yaml from 'js-yaml';
+import {z} from 'zod';
 import {type Expectation, parseExpectation} from './expect.js';
 import {parseRejection, type Rejection} from './reject.js';
+
+const seededSecretSchema = z
+  .object({
+    key: z.string().min(1),
+    value: z.string(),
+    scope: z.enum(['workspace', 'project']).default('project'),
+  })
+  .strict();
+
+const seededSecretsSchema = z
+  .object({
+    secrets: z.array(seededSecretSchema).default([]),
+  })
+  .strict();
+
+export type SeededSecret = z.infer<typeof seededSecretSchema>;
 
 export interface ScenarioFile {
   path: string;
@@ -16,6 +33,7 @@ interface BaseScenario {
   configPath: string;
   workflowYaml: string;
   extraFiles: ScenarioFile[];
+  seededSecrets: SeededSecret[];
 }
 
 export interface ExpectScenario extends BaseScenario {
@@ -58,6 +76,12 @@ function requireScenarioFile(dir: string, scenario: string, file: string): strin
   return path;
 }
 
+function loadSeededSecrets(dir: string): SeededSecret[] {
+  const path = join(dir, 'secrets.yaml');
+  if (!existsSync(path)) return [];
+  return seededSecretsSchema.parse(yaml.load(readFileSync(path, 'utf8'))).secrets;
+}
+
 function loadScenario(root: string, name: string): Scenario {
   const dir = join(root, name);
   const workflowPath = requireScenarioFile(dir, name, 'workflow.yml');
@@ -76,6 +100,7 @@ function loadScenario(root: string, name: string): Scenario {
     configPath: `.shipfox/workflows/${name}.yml`,
     workflowYaml: readFileSync(workflowPath, 'utf8'),
     extraFiles: readScenarioFiles(join(dir, 'files')),
+    seededSecrets: loadSeededSecrets(dir),
   };
 
   if (hasExpect) {

--- a/libs/api/secrets-dto/src/schemas/index.ts
+++ b/libs/api/secrets-dto/src/schemas/index.ts
@@ -2,4 +2,5 @@ export * from './e2e.js';
 export * from './identifiers.js';
 export * from './management.js';
 export * from './secret-binding.js';
+export * from './step-secrets.js';
 export * from './warnings.js';

--- a/libs/api/secrets-dto/src/schemas/secret-binding.test.ts
+++ b/libs/api/secrets-dto/src/schemas/secret-binding.test.ts
@@ -1,5 +1,9 @@
 import {describe, expect, it} from '@shipfox/vitest/vi';
-import {materializedSecretBindingSchema, secretBindingSegmentSchema} from './secret-binding.js';
+import {
+  materializedSecretBindingSchema,
+  secretBindingSegmentSchema,
+  secretBindingTargetSchema,
+} from './secret-binding.js';
 
 describe('secret binding schema', () => {
   it('accepts literal and secret segments', () => {
@@ -40,5 +44,17 @@ describe('secret binding schema', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it.each(['OPENAI_API_KEY', '_SF_0', 'camelCaseTarget'])('accepts binding target %s', (target) => {
+    const result = secretBindingTargetSchema.safeParse(target);
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(['', '1TOKEN', 'BAD-NAME', 'HAS.DOT'])('rejects binding target %s', (target) => {
+    const result = secretBindingTargetSchema.safeParse(target);
+
+    expect(result.success).toBe(false);
   });
 });

--- a/libs/api/secrets-dto/src/schemas/secret-binding.ts
+++ b/libs/api/secrets-dto/src/schemas/secret-binding.ts
@@ -2,6 +2,10 @@ import {z} from 'zod';
 import {secretKeySchema} from './identifiers.js';
 
 export const secretStoreSchema = z.literal('local');
+export const SECRET_BINDING_TARGET_PATTERN_SOURCE = '^[A-Za-z_][A-Za-z0-9_]*$';
+export const SECRET_BINDING_TARGET_PATTERN = new RegExp(SECRET_BINDING_TARGET_PATTERN_SOURCE);
+
+export const secretBindingTargetSchema = z.string().min(1).regex(SECRET_BINDING_TARGET_PATTERN);
 
 export const secretBindingSegmentSchema = z.discriminatedUnion('kind', [
   z.object({
@@ -16,7 +20,7 @@ export const secretBindingSegmentSchema = z.discriminatedUnion('kind', [
 ]);
 
 export const materializedSecretBindingSchema = z.object({
-  target: z.string().min(1),
+  target: secretBindingTargetSchema,
   segments: z.array(secretBindingSegmentSchema),
 });
 

--- a/libs/api/secrets-dto/src/schemas/step-secrets.ts
+++ b/libs/api/secrets-dto/src/schemas/step-secrets.ts
@@ -1,0 +1,29 @@
+import {z} from 'zod';
+import {secretKeySchema} from './identifiers.js';
+import {secretStoreSchema} from './secret-binding.js';
+
+export const stepSecretsParamsSchema = z.object({
+  stepId: z.string().uuid(),
+});
+
+export type StepSecretsParamsDto = z.infer<typeof stepSecretsParamsSchema>;
+
+export const stepSecretsQuerySchema = z.object({
+  attempt: z.coerce.number().int().positive(),
+});
+
+export type StepSecretsQueryDto = z.infer<typeof stepSecretsQuerySchema>;
+
+export const stepSecretDtoSchema = z.object({
+  store: secretStoreSchema,
+  key: secretKeySchema,
+  value: z.string(),
+});
+
+export type StepSecretDto = z.infer<typeof stepSecretDtoSchema>;
+
+export const stepSecretsResponseSchema = z.object({
+  secrets: z.array(stepSecretDtoSchema),
+});
+
+export type StepSecretsResponseDto = z.infer<typeof stepSecretsResponseSchema>;

--- a/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
+++ b/libs/api/workflows/src/core/step-config/complete-step-dispatch-config.test.ts
@@ -94,6 +94,27 @@ describe('completeStepDispatchConfig', () => {
     });
   });
 
+  it('rejects secret env bindings with malformed target names', () => {
+    const pending = step({
+      config: {},
+      configPlan: {
+        env: {
+          'BAD-NAME': plannedField(template('secrets.API_KEY')),
+        },
+      },
+    });
+
+    const act = () =>
+      completeStepDispatchConfig({
+        step: pending,
+        context,
+        resolveAgentDefaults,
+        definitionId: 'def-1',
+      });
+
+    expect(act).toThrow();
+  });
+
   it('keeps fully resolved step config byte-identical apart from resolved env additions', () => {
     const pending = step({
       config: {run: 'echo "$SHA"'},

--- a/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
+++ b/libs/api/workflows/src/core/step-config/materialize-workflow-model.test.ts
@@ -447,6 +447,43 @@ describe('materializeWorkflowModel', () => {
     });
   });
 
+  it('hoists command secret assignments outside command substitutions', () => {
+    const command = [
+      `COMMAND_SECRET='${template('secrets.RUNTIME_TOKEN')}'`,
+      'export COMMAND_SECRET',
+      `command_secret_sha="$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHash("sha256").update(process.env.COMMAND_SECRET ?? "").digest("hex"));')"`,
+    ].join('\n');
+    const model = workflowModel({
+      jobs: {
+        build: {
+          steps: [{run: command}],
+        },
+      },
+    });
+
+    const rows = materializeWorkflowModel({model, context: creationContext()});
+
+    expect(rows[0]?.steps[1]?.config).toEqual({
+      run: [
+        `COMMAND_SECRET=''"${shellRef('__sf_0')}"''`,
+        'export COMMAND_SECRET',
+        `command_secret_sha="$(node -e 'const crypto = require("node:crypto"); process.stdout.write(crypto.createHash("sha256").update(process.env.COMMAND_SECRET ?? "").digest("hex"));')"`,
+      ].join('\n'),
+    });
+    expect(rows[0]?.steps[1]?.configPlan).toMatchObject({
+      env: {
+        __sf_0: {
+          segments: [
+            {
+              expression: {source: 'secrets.RUNTIME_TOKEN'},
+              kind: 'deferred',
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('freezes vars from the run-creation context into step config', () => {
     const model = normalizeWorkflowDocument({
       name: 'vars workflow',

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -52,6 +52,7 @@ export {
   getJobExecutionDetail,
   getJobExecutionsByJobId,
   getJobExecutionsByWorkflowRunAttemptId,
+  getJobScope,
   getJobsByWorkflowRunAttemptId,
   getJobsByWorkflowRunId,
   getJobWorkspaceId,

--- a/libs/api/workflows/src/db/index.ts
+++ b/libs/api/workflows/src/db/index.ts
@@ -55,7 +55,6 @@ export {
   getJobScope,
   getJobsByWorkflowRunAttemptId,
   getJobsByWorkflowRunId,
-  getJobWorkspaceId,
   getLatestAttempt,
   getStepAttempts,
   getStepAttemptsByJobIds,

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1186,15 +1186,24 @@ function getOrCreateStepDetail(
   return step;
 }
 
-export async function getJobWorkspaceId(jobId: string): Promise<string | undefined> {
+export interface JobScope {
+  workspaceId: string;
+  projectId: string;
+}
+
+export async function getJobScope(jobId: string): Promise<JobScope | undefined> {
   const rows = await db()
-    .select({workspaceId: workflowRuns.workspaceId})
+    .select({workspaceId: workflowRuns.workspaceId, projectId: workflowRuns.projectId})
     .from(jobs)
     .innerJoin(workflowRunAttempts, eq(jobs.workflowRunAttemptId, workflowRunAttempts.id))
     .innerJoin(workflowRuns, eq(workflowRunAttempts.workflowRunId, workflowRuns.id))
     .where(eq(jobs.id, jobId))
     .limit(1);
-  return rows[0]?.workspaceId;
+  return rows[0];
+}
+
+export async function getJobWorkspaceId(jobId: string): Promise<string | undefined> {
+  return (await getJobScope(jobId))?.workspaceId;
 }
 
 export async function getStepsByJobId(jobId: string): Promise<Step[]> {

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -1202,10 +1202,6 @@ export async function getJobScope(jobId: string): Promise<JobScope | undefined> 
   return rows[0];
 }
 
-export async function getJobWorkspaceId(jobId: string): Promise<string | undefined> {
-  return (await getJobScope(jobId))?.workspaceId;
-}
-
 export async function getStepsByJobId(jobId: string): Promise<Step[]> {
   const rows = await db()
     .select({step: steps})

--- a/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
+++ b/libs/api/workflows/src/presentation/routes/agent-runtime-config.ts
@@ -5,14 +5,12 @@ import {
   type MaterializedAgentStepConfigDto,
   materializedAgentStepConfigSchema,
 } from '@shipfox/api-agent-dto';
-import {requireLeasedJobContext} from '@shipfox/api-auth-context';
-import {isJobLeaseActive} from '@shipfox/api-runners';
 import {SecretDecryptionError} from '@shipfox/api-secrets';
 import {agentRuntimeConfigQuerySchema} from '@shipfox/api-workflows-dto';
 import {captureException} from '@shipfox/node-error-monitoring';
 import {ClientError, defineRoute} from '@shipfox/node-fastify';
 import {ZodError} from 'zod';
-import {getJobWorkspaceId, getStepByIdForJobExecution} from '#db/index.js';
+import {loadRunningLeasedStep} from './leased-step.js';
 
 export const agentRuntimeConfigRoute = defineRoute({
   method: 'GET',
@@ -49,40 +47,9 @@ export const agentRuntimeConfigRoute = defineRoute({
     throw error;
   },
   handler: async (request, reply) => {
-    const leasedJob = requireLeasedJobContext(request);
     const {step_id: stepId, attempt} = request.query;
+    const {step, workspaceId} = await loadRunningLeasedStep({request, stepId, attempt});
 
-    const step = await getStepByIdForJobExecution({
-      stepId,
-      jobExecutionId: leasedJob.jobExecutionId,
-    });
-    if (!step) {
-      throw new ClientError('Step not found for leased job', 'step-not-found', {status: 404});
-    }
-    const workspaceId = await getJobWorkspaceId(leasedJob.jobId);
-    if (!workspaceId) {
-      throw new ClientError('Leased job not found', 'job-not-found', {status: 404});
-    }
-    const leaseIsActive = await isJobLeaseActive({
-      jobId: leasedJob.jobId,
-      jobExecutionId: leasedJob.jobExecutionId,
-      runnerSessionId: leasedJob.runnerSessionId,
-    });
-    if (!leaseIsActive) {
-      throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
-    }
-    if (step.currentAttempt !== attempt) {
-      throw new ClientError(
-        'Step attempt does not match current attempt',
-        'step-attempt-mismatch',
-        {
-          status: 409,
-        },
-      );
-    }
-    if (step.status !== 'running') {
-      throw new ClientError('Step is not running', 'step-not-running', {status: 409});
-    }
     if (step.type !== 'agent') {
       throw new ClientError('Step is not an agent step', 'step-not-agent', {status: 409});
     }

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.test.ts
@@ -1,0 +1,259 @@
+import {createLeaseTokenAuthMethod} from '@shipfox/api-auth';
+import {setSecrets} from '@shipfox/api-secrets';
+import {closeApp, createApp, type FastifyInstance} from '@shipfox/node-fastify';
+import {createCapturingLogger} from '@shipfox/node-log/test';
+import {eq} from 'drizzle-orm';
+import type {StepStatus} from '#core/entities/step.js';
+import {db} from '#db/db.js';
+import {jobs} from '#db/schema/jobs.js';
+import {steps as stepsTable} from '#db/schema/steps.js';
+import {
+  createWorkflowRun,
+  getJobScope,
+  getJobsByWorkflowRunId,
+  getStepsByJobId,
+} from '#db/workflow-runs.js';
+import {workflowModel} from '#test/factories/workflow-model.js';
+import {mintActiveLeaseToken} from '#test/fixtures/active-lease-token.js';
+import {leaseTokenRouteGroup} from './index.js';
+
+const URL_PREFIX = '/runs/jobs/current/steps';
+
+describe('GET /runs/jobs/current/steps/:stepId/secrets', () => {
+  let app: FastifyInstance;
+  const {logger, lines: logLines, clear: clearLogLines} = createCapturingLogger();
+
+  beforeAll(async () => {
+    app = await createApp({
+      auth: [createLeaseTokenAuthMethod()],
+      routes: [leaseTokenRouteGroup],
+      swagger: false,
+      fastifyOptions: {loggerInstance: logger},
+    });
+    await app.ready();
+  });
+
+  beforeEach(() => {
+    clearLogLines();
+  });
+
+  afterAll(async () => {
+    await closeApp();
+  });
+
+  test('returns only referenced secrets for the leased run step and does not cache or log plaintext', async () => {
+    const {run, job, step} = await createRunningRunStep();
+    await setRunSecretBindings(step.id, [
+      {
+        target: 'TOKEN',
+        segments: [
+          {kind: 'literal', value: 'prefix-'},
+          {kind: 'secret', store: 'local', key: 'API_TOKEN'},
+        ],
+      },
+      {
+        target: 'REUSED',
+        segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
+      },
+    ]);
+    await setSecrets({
+      workspaceId: run.workspaceId,
+      projectId: run.projectId,
+      values: {API_TOKEN: 'runtime-secret', UNUSED_TOKEN: 'unused-secret'},
+    });
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: stepSecretsUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.json()).toEqual({
+      secrets: [{store: 'local', key: 'API_TOKEN', value: 'runtime-secret'}],
+    });
+    expect(res.body).not.toContain('unused-secret');
+    expect(logLines.join('\n')).not.toContain('runtime-secret');
+  });
+
+  test('derives scope from the job row and prefers project secrets over workspace secrets', async () => {
+    const {run, job, step} = await createRunningRunStep();
+    const hostileWorkspaceId = crypto.randomUUID();
+    await setRunSecretBindings(step.id, [
+      {
+        target: 'TOKEN',
+        segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
+      },
+    ]);
+    await setSecrets({workspaceId: run.workspaceId, values: {API_TOKEN: 'workspace-secret'}});
+    await setSecrets({
+      workspaceId: run.workspaceId,
+      projectId: run.projectId,
+      values: {API_TOKEN: 'project-secret'},
+    });
+    await setSecrets({workspaceId: hostileWorkspaceId, values: {API_TOKEN: 'hostile-secret'}});
+    const token = await mintActiveLeaseToken({
+      jobId: job.id,
+      token: {workspaceId: hostileWorkspaceId, projectId: crypto.randomUUID()},
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: stepSecretsUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().secrets).toEqual([
+      {store: 'local', key: 'API_TOKEN', value: 'project-secret'},
+    ]);
+    expect(res.body).not.toContain('hostile-secret');
+  });
+
+  test('returns an empty response without resolving secrets when bindings are absent', async () => {
+    const {job, step} = await createRunningRunStep();
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: stepSecretsUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({secrets: []});
+  });
+
+  test('returns 409 when the leased step is not a run step', async () => {
+    const {job, step} = await createRunningAgentStep();
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: stepSecretsUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('step-not-run');
+  });
+
+  test('returns 422 when a referenced secret does not exist', async () => {
+    const {job, step} = await createRunningRunStep();
+    await setRunSecretBindings(step.id, [
+      {
+        target: 'TOKEN',
+        segments: [{kind: 'secret', store: 'local', key: 'MISSING_TOKEN'}],
+      },
+    ]);
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: stepSecretsUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.json().code).toBe('secret-not-found');
+  });
+
+  test('returns 409 instead of 500 when stored secret bindings are corrupt', async () => {
+    const {job, step} = await createRunningRunStep();
+    await db()
+      .update(stepsTable)
+      .set({config: {run: 'echo "$TOKEN"', secret_bindings: [{target: 'TOKEN'}]}})
+      .where(eq(stepsTable.id, step.id));
+    const token = await mintActiveLeaseToken({jobId: job.id});
+
+    const res = await app.inject({
+      method: 'GET',
+      url: stepSecretsUrl(step.id, step.currentAttempt),
+      headers: {authorization: `Bearer ${token}`},
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().code).toBe('secret-bindings-invalid');
+  });
+
+  test('getJobScope returns the workspace and project that own a job', async () => {
+    const {run, job} = await createRunningRunStep();
+
+    const scope = await getJobScope(job.id);
+
+    expect(scope).toEqual({workspaceId: run.workspaceId, projectId: run.projectId});
+  });
+});
+
+function stepSecretsUrl(stepId: string, attempt: number): string {
+  const search = new URLSearchParams({attempt: String(attempt)});
+  return `${URL_PREFIX}/${stepId}/secrets?${search.toString()}`;
+}
+
+async function setRunSecretBindings(
+  stepId: string,
+  bindings: NonNullable<Record<string, unknown>['secret_bindings']>,
+): Promise<void> {
+  await db()
+    .update(stepsTable)
+    .set({config: {run: 'echo "$TOKEN"', secret_bindings: bindings}})
+    .where(eq(stepsTable.id, stepId));
+}
+
+type TestStepInput = {prompt: string} | {run: string};
+
+async function createRunningRunStep(options: {status?: StepStatus} = {}) {
+  return await createStep({
+    steps: [{run: 'echo hello'}],
+    targetType: 'run',
+    status: options.status ?? 'running',
+  });
+}
+
+async function createRunningAgentStep() {
+  return await createStep({
+    steps: [{prompt: 'Fix the failing tests.'}],
+    targetType: 'agent',
+    status: 'running',
+  });
+}
+
+async function createStep(params: {
+  steps: readonly TestStepInput[];
+  targetType: 'agent' | 'run';
+  status: StepStatus;
+}) {
+  const run = await createWorkflowRun({
+    workspaceId: crypto.randomUUID(),
+    projectId: crypto.randomUUID(),
+    definitionId: crypto.randomUUID(),
+    model: workflowModel({jobs: {build: {steps: params.steps}}}),
+    resolveAgentDefaults: (defaults) => ({
+      provider: defaults.provider ?? 'anthropic',
+      model: defaults.model ?? 'claude-opus-4-8',
+      thinking: defaults.thinking ?? 'high',
+    }),
+    triggerPayload: {
+      source: 'manual',
+      event: 'fire',
+      subscriptionId: crypto.randomUUID(),
+      userId: crypto.randomUUID(),
+    },
+  });
+  const [job] = await getJobsByWorkflowRunId(run.id);
+  if (!job) throw new Error('createStep: run created no job');
+  await db().update(jobs).set({status: 'running'}).where(eq(jobs.id, job.id));
+
+  const stepRows = await getStepsByJobId(job.id);
+  const step = stepRows.find((candidate) => candidate.type === params.targetType);
+  if (!step) throw new Error(`createStep: ${params.targetType} step not found`);
+  await db().update(stepsTable).set({status: params.status}).where(eq(stepsTable.id, step.id));
+
+  return {
+    run,
+    job: {...job, status: 'running' as const},
+    step: {...step, status: params.status},
+  };
+}

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.ts
@@ -1,0 +1,117 @@
+import {getSecret, SecretDecryptionError} from '@shipfox/api-secrets';
+import {
+  materializedSecretBindingSchema,
+  type StepSecretDto,
+  stepSecretsParamsSchema,
+  stepSecretsQuerySchema,
+  stepSecretsResponseSchema,
+} from '@shipfox/api-secrets-dto';
+import {captureException} from '@shipfox/node-error-monitoring';
+import {ClientError, defineRoute} from '@shipfox/node-fastify';
+import {logger} from '@shipfox/node-opentelemetry';
+import {ZodError, z} from 'zod';
+import {loadRunningLeasedStep} from './leased-step.js';
+
+const secretBindingsSchema = z.array(materializedSecretBindingSchema);
+
+export const getStepSecretsRoute = defineRoute({
+  method: 'GET',
+  path: '/steps/:stepId/secrets',
+  description:
+    "Returns decrypted secret values referenced by the runner's currently leased running run step. The job scope and secret bindings are re-derived from server state; the runner supplies only the step id and current attempt.",
+  schema: {
+    params: stepSecretsParamsSchema,
+    querystring: stepSecretsQuerySchema,
+    response: {
+      200: stepSecretsResponseSchema,
+    },
+  },
+  errorHandler: (error) => {
+    if (error instanceof SecretDecryptionError) {
+      captureException(error);
+      throw new ClientError('Step secret could not be decrypted', 'secret-value-invalid', {
+        status: 409,
+        cause: error,
+      });
+    }
+    throw error;
+  },
+  handler: async (request, reply) => {
+    const {stepId} = request.params;
+    const {attempt} = request.query;
+    const {leasedJob, step, workspaceId, projectId} = await loadRunningLeasedStep({
+      request,
+      stepId,
+      attempt,
+    });
+
+    if (step.type !== 'run') {
+      throw new ClientError('Step is not a run step', 'step-not-run', {status: 409});
+    }
+
+    const secretBindings = parseSecretBindings(step.config.secret_bindings);
+    const references = distinctSecretReferences(secretBindings);
+    const secrets: StepSecretDto[] = [];
+
+    for (const reference of references) {
+      const value = await getSecret({
+        workspaceId,
+        projectId,
+        namespace: '',
+        key: reference.key,
+        store: reference.store,
+      });
+      if (value === null) {
+        throw new ClientError('Secret not found', 'secret-not-found', {status: 422});
+      }
+      secrets.push({...reference, value});
+    }
+
+    logger().info(
+      {jobId: leasedJob.jobId, workspaceId, stepId, keyCount: references.length},
+      'Resolved step secrets',
+    );
+    logger().debug(
+      {jobId: leasedJob.jobId, workspaceId, stepId, keys: references.map((ref) => ref.key)},
+      'Resolved step secret keys',
+    );
+
+    reply.header('cache-control', 'no-store');
+    return {secrets};
+  },
+});
+
+function parseSecretBindings(value: unknown): z.infer<typeof secretBindingsSchema> {
+  try {
+    return secretBindingsSchema.parse(value ?? []);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new ClientError('Step secret bindings are invalid', 'secret-bindings-invalid', {
+        status: 409,
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+function distinctSecretReferences(
+  bindings: ReadonlyArray<z.infer<typeof materializedSecretBindingSchema>>,
+): Array<Pick<StepSecretDto, 'store' | 'key'>> {
+  const seen = new Set<string>();
+  const references: Array<Pick<StepSecretDto, 'store' | 'key'>> = [];
+  for (const binding of bindings) {
+    for (const segment of binding.segments) {
+      if (segment.kind !== 'secret') continue;
+      const id = secretReferenceId(segment);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      references.push({store: segment.store, key: segment.key});
+    }
+  }
+  return references;
+}
+
+function secretReferenceId(reference: Pick<StepSecretDto, 'store' | 'key'>): string {
+  return `${reference.store}\0${reference.key}`;
+}

--- a/libs/api/workflows/src/presentation/routes/get-step-secrets.ts
+++ b/libs/api/workflows/src/presentation/routes/get-step-secrets.ts
@@ -51,21 +51,21 @@ export const getStepSecretsRoute = defineRoute({
 
     const secretBindings = parseSecretBindings(step.config.secret_bindings);
     const references = distinctSecretReferences(secretBindings);
-    const secrets: StepSecretDto[] = [];
-
-    for (const reference of references) {
-      const value = await getSecret({
-        workspaceId,
-        projectId,
-        namespace: '',
-        key: reference.key,
-        store: reference.store,
-      });
-      if (value === null) {
-        throw new ClientError('Secret not found', 'secret-not-found', {status: 422});
-      }
-      secrets.push({...reference, value});
-    }
+    const secrets = await Promise.all(
+      references.map(async (reference): Promise<StepSecretDto> => {
+        const value = await getSecret({
+          workspaceId,
+          projectId,
+          namespace: '',
+          key: reference.key,
+          store: reference.store,
+        });
+        if (value === null) {
+          throw new ClientError('Secret not found', 'secret-not-found', {status: 422});
+        }
+        return {...reference, value};
+      }),
+    );
 
     logger().info(
       {jobId: leasedJob.jobId, workspaceId, stepId, keyCount: references.length},

--- a/libs/api/workflows/src/presentation/routes/index.ts
+++ b/libs/api/workflows/src/presentation/routes/index.ts
@@ -5,6 +5,7 @@ import {cancelRunRoute} from './cancel-run.js';
 import {checkoutTokenRoute} from './checkout-token.js';
 import {getRunRoute} from './get-run.js';
 import {getRunAggregatesRoute} from './get-run-aggregates.js';
+import {getStepSecretsRoute} from './get-step-secrets.js';
 import {listRunAttemptsRoute} from './list-run-attempts.js';
 import {listRunsRoute} from './list-runs.js';
 import {nextStepRoute} from './next-step.js';
@@ -15,7 +16,13 @@ export const leaseTokenRouteGroup: RouteGroup = {
   // The lease token names the job, so the path carries no job id ("current").
   prefix: '/runs/jobs/current',
   auth: AUTH_LEASED_JOB,
-  routes: [nextStepRoute, reportStepRoute, checkoutTokenRoute, agentRuntimeConfigRoute],
+  routes: [
+    nextStepRoute,
+    reportStepRoute,
+    checkoutTokenRoute,
+    agentRuntimeConfigRoute,
+    getStepSecretsRoute,
+  ],
 };
 
 export const workflowRoutes: RouteGroup[] = [

--- a/libs/api/workflows/src/presentation/routes/leased-step.ts
+++ b/libs/api/workflows/src/presentation/routes/leased-step.ts
@@ -18,6 +18,15 @@ export async function loadRunningLeasedStep(params: {
 }): Promise<LoadedRunningLeasedStep> {
   const leasedJob = requireLeasedJobContext(params.request);
 
+  const leaseIsActive = await isJobLeaseActive({
+    jobId: leasedJob.jobId,
+    jobExecutionId: leasedJob.jobExecutionId,
+    runnerSessionId: leasedJob.runnerSessionId,
+  });
+  if (!leaseIsActive) {
+    throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
+  }
+
   const step = await getStepByIdForJobExecution({
     stepId: params.stepId,
     jobExecutionId: leasedJob.jobExecutionId,
@@ -29,15 +38,6 @@ export async function loadRunningLeasedStep(params: {
   const scope = await getJobScope(leasedJob.jobId);
   if (!scope) {
     throw new ClientError('Leased job not found', 'job-not-found', {status: 404});
-  }
-
-  const leaseIsActive = await isJobLeaseActive({
-    jobId: leasedJob.jobId,
-    jobExecutionId: leasedJob.jobExecutionId,
-    runnerSessionId: leasedJob.runnerSessionId,
-  });
-  if (!leaseIsActive) {
-    throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
   }
 
   if (step.currentAttempt !== params.attempt) {

--- a/libs/api/workflows/src/presentation/routes/leased-step.ts
+++ b/libs/api/workflows/src/presentation/routes/leased-step.ts
@@ -1,0 +1,54 @@
+import {type LeasedJobContext, requireLeasedJobContext} from '@shipfox/api-auth-context';
+import {isJobLeaseActive} from '@shipfox/api-runners';
+import {ClientError} from '@shipfox/node-fastify';
+import type {Step} from '#core/entities/step.js';
+import {getJobScope, getStepByIdForJobExecution} from '#db/index.js';
+
+export interface LoadedRunningLeasedStep {
+  leasedJob: LeasedJobContext;
+  step: Step;
+  workspaceId: string;
+  projectId: string;
+}
+
+export async function loadRunningLeasedStep(params: {
+  request: object;
+  stepId: string;
+  attempt: number;
+}): Promise<LoadedRunningLeasedStep> {
+  const leasedJob = requireLeasedJobContext(params.request);
+
+  const step = await getStepByIdForJobExecution({
+    stepId: params.stepId,
+    jobExecutionId: leasedJob.jobExecutionId,
+  });
+  if (!step) {
+    throw new ClientError('Step not found for leased job', 'step-not-found', {status: 404});
+  }
+
+  const scope = await getJobScope(leasedJob.jobId);
+  if (!scope) {
+    throw new ClientError('Leased job not found', 'job-not-found', {status: 404});
+  }
+
+  const leaseIsActive = await isJobLeaseActive({
+    jobId: leasedJob.jobId,
+    jobExecutionId: leasedJob.jobExecutionId,
+    runnerSessionId: leasedJob.runnerSessionId,
+  });
+  if (!leaseIsActive) {
+    throw new ClientError('Job lease is no longer active', 'lease-not-active', {status: 404});
+  }
+
+  if (step.currentAttempt !== params.attempt) {
+    throw new ClientError('Step attempt does not match current attempt', 'step-attempt-mismatch', {
+      status: 409,
+    });
+  }
+
+  if (step.status !== 'running') {
+    throw new ClientError('Step is not running', 'step-not-running', {status: 409});
+  }
+
+  return {leasedJob, step, workspaceId: scope.workspaceId, projectId: scope.projectId};
+}

--- a/libs/runner/execution/package.json
+++ b/libs/runner/execution/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",
+    "@shipfox/redact": "workspace:*",
     "@shipfox/runner-protocol": "workspace:*",
     "@shipfox/runner-workspace": "workspace:*",
     "ky": "^2.0.0"

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -111,6 +111,33 @@ describe('executeRunStep', () => {
     }
   });
 
+  it('merges secret env over step env without mutating process.env', async () => {
+    const previous = process.env.SHIPFOX_ENV_TEST_SECRET;
+    delete process.env.SHIPFOX_ENV_TEST_SECRET;
+    try {
+      const step = buildStep({
+        config: {
+          run: nodeEnvDumpCommand(['SHIPFOX_ENV_TEST_SECRET']),
+          env: {SHIPFOX_ENV_TEST_SECRET: 'stored-step-value'},
+        },
+      });
+      const output = collectOutput();
+
+      const result = await executeRunStep(step, {
+        secretEnv: {SHIPFOX_ENV_TEST_SECRET: 'runtime-secret-value'},
+        onOutput: output.sink,
+      });
+
+      expect(result.success).toBe(true);
+      expect(JSON.parse(output.text())).toEqual({
+        SHIPFOX_ENV_TEST_SECRET: 'runtime-secret-value',
+      });
+      expect(process.env.SHIPFOX_ENV_TEST_SECRET).toBeUndefined();
+    } finally {
+      if (previous !== undefined) process.env.SHIPFOX_ENV_TEST_SECRET = previous;
+    }
+  });
+
   it('does not resolve the shell executable through step env PATH', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'shipfox-shell-path-test-'));
     try {
@@ -215,6 +242,24 @@ describe('executeRunStep', () => {
     expect(output.text()).toContain('err');
     expect(output.sources()).toContain('stdout');
     expect(output.sources()).toContain('stderr');
+  });
+
+  it('redacts secret wire forms from the runner stdout and stderr tee', async () => {
+    const secret = 'runtime-secret-value';
+    const hex = Buffer.from(secret).toString('hex');
+    const step = buildStep({config: {run: `echo "${secret}"; echo "${hex}" >&2`}});
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as never);
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true as never);
+
+    const result = await executeRunStep(step, {secretValues: [secret]});
+
+    const stdout = stdoutWrite.mock.calls.map((call) => String(call[0])).join('');
+    const stderr = stderrWrite.mock.calls.map((call) => String(call[0])).join('');
+    expect(result.success).toBe(true);
+    expect(stdout).toContain('***');
+    expect(stderr).toContain('***');
+    expect(stdout).not.toContain(secret);
+    expect(stderr).not.toContain(hex);
   });
 
   it('returns failure for unsupported step type with the reason on error.message', async () => {

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -262,6 +262,27 @@ describe('executeRunStep', () => {
     expect(stderr).not.toContain(hex);
   });
 
+  it('redacts env and command secret output from the runner stdout tee', async () => {
+    const secret = 'runtime-secret-e2e';
+    const step = buildStep({
+      config: {
+        run: `echo "secret from env=$FROM_ENV_SECRET"; echo "secret from command=${secret}"`,
+      },
+    });
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as never);
+
+    const result = await executeRunStep(step, {
+      secretEnv: {FROM_ENV_SECRET: secret},
+      secretValues: [secret],
+    });
+
+    const stdout = stdoutWrite.mock.calls.map((call) => String(call[0])).join('');
+    expect(result.success).toBe(true);
+    expect(stdout).toContain('secret from env=***');
+    expect(stdout).toContain('secret from command=***');
+    expect(stdout).not.toContain(secret);
+  });
+
   it('redacts a secret split across runner stdout tee chunks', async () => {
     const secret = 'runtime-secret-value';
     const script = [

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -262,6 +262,23 @@ describe('executeRunStep', () => {
     expect(stderr).not.toContain(hex);
   });
 
+  it('redacts a secret split across runner stdout tee chunks', async () => {
+    const secret = 'runtime-secret-value';
+    const script = [
+      `process.stdout.write(${JSON.stringify(secret.slice(0, 8))});`,
+      `setTimeout(() => process.stdout.end(${JSON.stringify(`${secret.slice(8)}\n`)}), 20);`,
+    ].join('');
+    const step = buildStep({config: {run: `node -e ${JSON.stringify(script)}`}});
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as never);
+
+    const result = await executeRunStep(step, {secretValues: [secret]});
+
+    const stdout = stdoutWrite.mock.calls.map((call) => String(call[0])).join('');
+    expect(result.success).toBe(true);
+    expect(stdout).toContain('***');
+    expect(stdout).not.toContain(secret);
+  });
+
   it('returns failure for unsupported step type with the reason on error.message', async () => {
     const step = buildStep({type: 'docker', config: {image: 'node:20'}});
     const output = collectOutput();

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -4,6 +4,7 @@ import {accessSync, constants, statSync} from 'node:fs';
 import {unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
+import {TextDecoder} from 'node:util';
 import type {StepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets, secretWireForms} from '@shipfox/redact';
@@ -87,6 +88,8 @@ function spawnAndCapture(
   return new Promise((resolve) => {
     const {shell} = metadata;
     const teeSecretVariants = buildSecretVariants(options.secretValues ?? []);
+    const stdoutTeeRedactor = createTeeRedactor(teeSecretVariants);
+    const stderrTeeRedactor = createTeeRedactor(teeSecretVariants);
 
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
@@ -101,13 +104,19 @@ function spawnAndCapture(
     // stdout and stderr are two separate pipes, so the sink sees them merged by
     // arrival order, not kernel/wall-clock order; origin is preserved per chunk.
     child.stdout.on('data', (chunk: Buffer) => {
-      writeTeeOutput(process.stdout, chunk, teeSecretVariants);
+      writeTeeOutput(process.stdout, chunk, stdoutTeeRedactor);
       options.onOutput?.(chunk, 'stdout');
+    });
+    child.stdout.on('close', () => {
+      flushTeeOutput(process.stdout, stdoutTeeRedactor);
     });
 
     child.stderr.on('data', (chunk: Buffer) => {
-      writeTeeOutput(process.stderr, chunk, teeSecretVariants);
+      writeTeeOutput(process.stderr, chunk, stderrTeeRedactor);
       options.onOutput?.(chunk, 'stderr');
+    });
+    child.stderr.on('close', () => {
+      flushTeeOutput(process.stderr, stderrTeeRedactor);
     });
 
     let childExited = false;
@@ -199,13 +208,93 @@ function spawnAndCapture(
 function writeTeeOutput(
   stream: NodeJS.WriteStream,
   chunk: Buffer,
-  secretVariants: readonly string[],
+  redactor: TeeRedactor | undefined,
 ): void {
-  if (secretVariants.length === 0) {
+  if (!redactor) {
     stream.write(chunk);
     return;
   }
-  stream.write(redactSecrets(chunk.toString(), [...secretVariants]));
+  const output = redactor.push(chunk);
+  if (output.length > 0) stream.write(output);
+}
+
+function flushTeeOutput(stream: NodeJS.WriteStream, redactor: TeeRedactor | undefined): void {
+  if (!redactor) return;
+  const output = redactor.flush();
+  if (output.length > 0) stream.write(output);
+}
+
+function createTeeRedactor(secretVariants: readonly string[]): TeeRedactor | undefined {
+  if (secretVariants.length === 0) return undefined;
+  return new TeeRedactor(secretVariants);
+}
+
+class TeeRedactor {
+  private readonly decoder = new TextDecoder('utf-8', {ignoreBOM: true, fatal: false});
+  private readonly variants: string[];
+  private readonly maxVariantLen: number;
+  private buffer = '';
+
+  constructor(variants: readonly string[]) {
+    this.variants = [...variants];
+    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
+  }
+
+  push(chunk: Buffer): string {
+    this.buffer += this.decoder.decode(chunk, {stream: true});
+    return this.drain(false);
+  }
+
+  flush(): string {
+    this.buffer += this.decoder.decode();
+    return this.drain(true);
+  }
+
+  private drain(final: boolean): string {
+    let output = '';
+    let newline = this.buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = this.buffer.slice(0, newline + 1);
+      this.buffer = this.buffer.slice(newline + 1);
+      output += redactSecrets(line, this.variants);
+      newline = this.buffer.indexOf('\n');
+    }
+
+    if (this.buffer.length === 0) return output;
+    if (final) {
+      output += redactSecrets(this.buffer, this.variants);
+      this.buffer = '';
+      return output;
+    }
+
+    const cut = this.safeEmitLength(this.buffer);
+    if (cut > 0) {
+      output += redactSecrets(this.buffer.slice(0, cut), this.variants);
+      this.buffer = this.buffer.slice(cut);
+    }
+    return output;
+  }
+
+  private safeEmitLength(buffer: string): number {
+    const hold = Math.max(0, this.maxVariantLen - 1);
+    let cut = buffer.length - hold;
+    if (cut <= 0) return 0;
+    for (let moved = true; moved && cut > 0; ) {
+      moved = false;
+      const windowStart = Math.max(0, cut - this.maxVariantLen + 1);
+      for (let start = windowStart; start < cut; start++) {
+        const straddles = this.variants.some(
+          (form) => start + form.length > cut && buffer.startsWith(form, start),
+        );
+        if (straddles) {
+          cut = start;
+          moved = true;
+          break;
+        }
+      }
+    }
+    return cut;
+  }
 }
 
 function buildSecretVariants(secrets: readonly string[]): string[] {

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -7,7 +7,7 @@ import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
 import {TextDecoder} from 'node:util';
 import type {StepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
-import {redactSecrets, secretWireForms} from '@shipfox/redact';
+import {redactSecrets, safeRedactionPrefixLength, secretWireForms} from '@shipfox/redact';
 import type {StepResult} from '#core/step-result.js';
 
 /**
@@ -232,12 +232,10 @@ function createTeeRedactor(secretVariants: readonly string[]): TeeRedactor | und
 class TeeRedactor {
   private readonly decoder = new TextDecoder('utf-8', {ignoreBOM: true, fatal: false});
   private readonly variants: string[];
-  private readonly maxVariantLen: number;
   private buffer = '';
 
   constructor(variants: readonly string[]) {
     this.variants = [...variants];
-    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
   }
 
   push(chunk: Buffer): string {
@@ -267,33 +265,12 @@ class TeeRedactor {
       return output;
     }
 
-    const cut = this.safeEmitLength(this.buffer);
+    const cut = safeRedactionPrefixLength(this.buffer, this.variants);
     if (cut > 0) {
       output += redactSecrets(this.buffer.slice(0, cut), this.variants);
       this.buffer = this.buffer.slice(cut);
     }
     return output;
-  }
-
-  private safeEmitLength(buffer: string): number {
-    const hold = Math.max(0, this.maxVariantLen - 1);
-    let cut = buffer.length - hold;
-    if (cut <= 0) return 0;
-    for (let moved = true; moved && cut > 0; ) {
-      moved = false;
-      const windowStart = Math.max(0, cut - this.maxVariantLen + 1);
-      for (let start = windowStart; start < cut; start++) {
-        const straddles = this.variants.some(
-          (form) => start + form.length > cut && buffer.startsWith(form, start),
-        );
-        if (straddles) {
-          cut = start;
-          moved = true;
-          break;
-        }
-      }
-    }
-    return cut;
   }
 }
 

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -6,6 +6,7 @@ import {tmpdir} from 'node:os';
 import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
 import type {StepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
+import {redactSecrets, secretWireForms} from '@shipfox/redact';
 import type {StepResult} from '#core/step-result.js';
 
 /**
@@ -34,6 +35,8 @@ export interface CommandShellMetadata {
 interface RunStepOptions {
   signal?: AbortSignal;
   cwd?: string;
+  secretEnv?: Readonly<Record<string, string>>;
+  secretValues?: readonly string[];
   onOutput?: OutputSink;
   onCommandStart?: CommandStartSink;
 }
@@ -56,7 +59,7 @@ export function executeRunStep(step: StepDto, options: RunStepOptions = {}): Pro
     });
   }
 
-  return runShellCommand(command, readStepEnv(step), options);
+  return runShellCommand(command, {...readStepEnv(step), ...options.secretEnv}, options);
 }
 
 async function runShellCommand(
@@ -83,6 +86,7 @@ function spawnAndCapture(
 ): Promise<StepResult> {
   return new Promise((resolve) => {
     const {shell} = metadata;
+    const teeSecretVariants = buildSecretVariants(options.secretValues ?? []);
 
     // detached:true makes the shell a process-group leader so killGroup() can
     // SIGKILL its grandchildren too (Linux does not propagate signals down the
@@ -97,12 +101,12 @@ function spawnAndCapture(
     // stdout and stderr are two separate pipes, so the sink sees them merged by
     // arrival order, not kernel/wall-clock order; origin is preserved per chunk.
     child.stdout.on('data', (chunk: Buffer) => {
-      process.stdout.write(chunk);
+      writeTeeOutput(process.stdout, chunk, teeSecretVariants);
       options.onOutput?.(chunk, 'stdout');
     });
 
     child.stderr.on('data', (chunk: Buffer) => {
-      process.stderr.write(chunk);
+      writeTeeOutput(process.stderr, chunk, teeSecretVariants);
       options.onOutput?.(chunk, 'stderr');
     });
 
@@ -190,6 +194,26 @@ function spawnAndCapture(
       });
     });
   });
+}
+
+function writeTeeOutput(
+  stream: NodeJS.WriteStream,
+  chunk: Buffer,
+  secretVariants: readonly string[],
+): void {
+  if (secretVariants.length === 0) {
+    stream.write(chunk);
+    return;
+  }
+  stream.write(redactSecrets(chunk.toString(), [...secretVariants]));
+}
+
+function buildSecretVariants(secrets: readonly string[]): string[] {
+  const variants = new Set<string>();
+  for (const secret of secrets) {
+    for (const form of secretWireForms(secret)) variants.add(form);
+  }
+  return [...variants].sort((a, b) => b.length - a.length);
 }
 
 function isSignalKillResult(code: number | null, signal: NodeJS.Signals): boolean {

--- a/libs/runner/logs/src/core/transform.ts
+++ b/libs/runner/logs/src/core/transform.ts
@@ -1,5 +1,5 @@
 import {TextDecoder} from 'node:util';
-import {redactSecrets} from '@shipfox/redact';
+import {redactSecrets, safeRedactionPrefixLength} from '@shipfox/redact';
 import {type OutputSource, PIPES} from '#core/framing.js';
 import {couldBeMarker, parseMarker} from '#core/markers.js';
 import {buildSecretVariants, mergeSecretVariants} from '#core/secrets.js';
@@ -36,7 +36,6 @@ interface SourceState {
  */
 export class LogTransformer {
   private variants: string[];
-  private maxVariantLen: number;
   private readonly sources: Record<OutputSource, SourceState>;
 
   constructor(secrets: string[]) {
@@ -44,7 +43,6 @@ export class LogTransformer {
     // line buffer are independent: stdout and stderr are separate byte streams that must never
     // complete each other's partial sequences or split secrets.
     this.variants = buildSecretVariants(secrets);
-    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
     this.sources = {
       stdout: {decoder: newDecoder(), buffer: ''},
       stderr: {decoder: newDecoder(), buffer: ''},
@@ -54,12 +52,10 @@ export class LogTransformer {
   addSecrets(secrets: string[]): void {
     if (secrets.length === 0) return;
     this.variants = mergeSecretVariants(this.variants, secrets);
-    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
   }
 
   setSecrets(secrets: string[]): void {
     this.variants = buildSecretVariants(secrets);
-    this.maxVariantLen = this.variants.reduce((max, form) => Math.max(max, form.length), 0);
   }
 
   push(chunk: Buffer, source: OutputSource): TransformEvent[] {
@@ -112,7 +108,7 @@ export class LogTransformer {
     if (couldBeMarker(state.buffer) && state.buffer.length <= MARKER_CANDIDATE_LIMIT) return;
 
     // Otherwise stream the masked safe prefix and keep only the lookbehind carry.
-    const cut = this.safeEmitLength(state.buffer);
+    const cut = safeRedactionPrefixLength(state.buffer, this.variants);
     if (cut > 0) {
       events.push({
         type: 'output',
@@ -145,33 +141,6 @@ export class LogTransformer {
     const text = opts.newline ? `${line}\n` : line;
     if (text.length === 0) return;
     events.push({type: 'output', src: source, data: redactSecrets(text, this.variants)});
-  }
-
-  // The largest prefix length of `buffer` that is safe to mask and emit now: no secret variant
-  // occurrence crosses it, so the masked prefix can never change once later bytes arrive. Start
-  // by holding the last (maxVariantLen - 1) chars (any not-yet-complete secret begins there),
-  // then pull the cut back past any complete occurrence that would straddle it. Guarantees a
-  // split secret is never emitted unmasked.
-  private safeEmitLength(buffer: string): number {
-    const hold = Math.max(0, this.maxVariantLen - 1);
-    let cut = buffer.length - hold;
-    if (cut <= 0) return 0;
-    for (let moved = true; moved && cut > 0; ) {
-      moved = false;
-      // Only an occurrence starting in [cut - maxVariantLen + 1, cut) can straddle `cut`.
-      const windowStart = Math.max(0, cut - this.maxVariantLen + 1);
-      for (let start = windowStart; start < cut; start++) {
-        const straddles = this.variants.some(
-          (form) => start + form.length > cut && buffer.startsWith(form, start),
-        );
-        if (straddles) {
-          cut = start; // hold the whole occurrence
-          moved = true;
-          break;
-        }
-      }
-    }
-    return cut;
   }
 }
 

--- a/libs/runner/orchestration/package.json
+++ b/libs/runner/orchestration/package.json
@@ -37,6 +37,7 @@
     "type:emit": "shipfox-tsc-emit"
   },
   "dependencies": {
+    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -1,7 +1,7 @@
 import type {AgentConfigIssueDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {HTTPError} from 'ky';
 
-const {AgentRuntimeConfigRequestError} = vi.hoisted(() => ({
+const {AgentRuntimeConfigRequestError, StepSecretsRequestError} = vi.hoisted(() => ({
   AgentRuntimeConfigRequestError: class AgentRuntimeConfigRequestError extends Error {
     constructor(
       public readonly status: number,
@@ -16,10 +16,24 @@ const {AgentRuntimeConfigRequestError} = vi.hoisted(() => ({
       this.name = 'AgentRuntimeConfigRequestError';
     }
   },
+  StepSecretsRequestError: class StepSecretsRequestError extends Error {
+    constructor(
+      public readonly status: number,
+      public readonly code: string | undefined,
+    ) {
+      super(
+        code === undefined
+          ? `Step secrets request failed with status ${status}.`
+          : `Step secrets request failed with status ${status}: ${code}.`,
+      );
+      this.name = 'StepSecretsRequestError';
+    }
+  },
 }));
 
 const requestNextStepMock = vi.fn();
 const requestAgentRuntimeConfigMock = vi.fn();
+const requestStepSecretsMock = vi.fn();
 const reportStepMock = vi.fn();
 const appendStepLogsMock = vi.fn();
 const executeRunStepMock = vi.fn();
@@ -31,9 +45,11 @@ const executeAgentStepMock = vi.fn();
 vi.mock('@shipfox/runner-protocol', () => ({
   requestNextStep: (...args: unknown[]) => requestNextStepMock(...args),
   requestAgentRuntimeConfig: (...args: unknown[]) => requestAgentRuntimeConfigMock(...args),
+  requestStepSecrets: (...args: unknown[]) => requestStepSecretsMock(...args),
   reportStep: (...args: unknown[]) => reportStepMock(...args),
   appendStepLogs: (...args: unknown[]) => appendStepLogsMock(...args),
   AgentRuntimeConfigRequestError,
+  StepSecretsRequestError,
   HTTPError,
 }));
 
@@ -166,6 +182,7 @@ describe('runJobSteps', () => {
   beforeEach(() => {
     requestNextStepMock.mockReset();
     requestAgentRuntimeConfigMock.mockReset();
+    requestStepSecretsMock.mockReset();
     reportStepMock.mockReset();
     appendStepLogsMock.mockReset();
     executeRunStepMock.mockReset();
@@ -179,6 +196,7 @@ describe('runJobSteps', () => {
       thinking: 'high',
       credentials: {api_key: 'sk-runtime-secret'},
     });
+    requestStepSecretsMock.mockResolvedValue({secrets: []});
     events = [];
     createdStreams = new Map();
     reportStepMock.mockResolvedValue({ok: true, cancel: false});
@@ -298,6 +316,164 @@ describe('runJobSteps', () => {
     expect(createStepLogStreamMock).toHaveBeenCalledTimes(2);
     expect(events).toContain(`drain:${run.id}`);
     expect(events).toContain(`dispose:${run.id}`);
+  });
+
+  it('does not request step secrets when a run step has no secret bindings', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(requestStepSecretsMock).not.toHaveBeenCalled();
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.not.objectContaining({
+        secretEnv: expect.anything(),
+        secretValues: expect.anything(),
+      }),
+    );
+  });
+
+  it('requests step secrets before opening the log stream and injects assembled env', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep({
+      config: {
+        run: 'echo "$TOKEN"',
+        secret_bindings: [
+          {
+            target: 'TOKEN',
+            segments: [
+              {kind: 'literal', value: 'prefix-'},
+              {kind: 'secret', store: 'local', key: 'API_TOKEN'},
+            ],
+          },
+          {
+            target: 'REUSED',
+            segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
+          },
+        ],
+      },
+    });
+    requestStepSecretsMock.mockImplementation(() => {
+      events.push('request-secrets');
+      return Promise.resolve({
+        secrets: [{store: 'local', key: 'API_TOKEN', value: 'runtime-secret'}],
+      });
+    });
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 2))
+      .mockResolvedValueOnce({kind: 'done', status: 'succeeded'});
+    executeRunStepMock.mockResolvedValue({success: true, error: null, exit_code: 0});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal, secrets: ['checkout-secret']});
+
+    expect(requestStepSecretsMock).toHaveBeenCalledWith(leaseClient, {
+      stepId: run.id,
+      attempt: 2,
+      signal: ac.signal,
+    });
+    expect(events.indexOf('request-secrets')).toBeLessThan(events.indexOf(`create:${run.id}`));
+    expect(createStepLogStreamMock).toHaveBeenCalledWith({
+      logsDir: LOGS_DIR,
+      stepId: run.id,
+      attempt: 2,
+      secrets: ['checkout-secret', 'runtime-secret'],
+      append: expect.any(Function),
+    });
+    expect(executeRunStepMock).toHaveBeenCalledWith(
+      run,
+      expect.objectContaining({
+        secretEnv: {TOKEN: 'prefix-runtime-secret', REUSED: 'runtime-secret'},
+        secretValues: ['runtime-secret'],
+      }),
+    );
+  });
+
+  it('fails the run step closed when a requested binding is absent from the response', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep({
+      config: {
+        run: 'echo "$TOKEN"',
+        secret_bindings: [
+          {
+            target: 'TOKEN',
+            segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
+          },
+        ],
+      },
+    });
+    requestStepSecretsMock.mockResolvedValueOnce({secrets: []});
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(createStepLogStreamMock).toHaveBeenCalledTimes(1);
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        status: 'failed',
+        error: {
+          message: 'Run step secret response is missing a requested secret.',
+          reason: 'config_unresolvable',
+        },
+      }),
+    );
+  });
+
+  it('fails the run step closed when the secrets endpoint rejects the request', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep({
+      config: {
+        run: 'echo "$TOKEN"',
+        secret_bindings: [
+          {
+            target: 'TOKEN',
+            segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
+          },
+        ],
+      },
+    });
+    requestStepSecretsMock.mockRejectedValueOnce(
+      new StepSecretsRequestError(422, 'secret-not-found'),
+    );
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(executeRunStepMock).not.toHaveBeenCalled();
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        status: 'failed',
+        error: {
+          message: 'Step secrets request failed with status 422: secret-not-found.',
+          reason: 'config_unresolvable',
+        },
+      }),
+    );
   });
 
   it('routes captured output through the stream write sink', async () => {

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -1,3 +1,8 @@
+import {
+  type MaterializedSecretBindingDto,
+  materializedSecretBindingSchema,
+  type StepSecretDto,
+} from '@shipfox/api-secrets-dto';
 import type {LogOutcomeDto, NextStepResponseDto, StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets} from '@shipfox/redact';
@@ -26,6 +31,8 @@ import {
   reportStep,
   requestAgentRuntimeConfig,
   requestNextStep,
+  requestStepSecrets,
+  StepSecretsRequestError,
 } from '@shipfox/runner-protocol';
 import type {KyInstance} from 'ky';
 
@@ -363,15 +370,27 @@ export async function executeStep(params: {
       };
     }
 
+    let runSecretMaterial: RunSecretMaterial | undefined;
+    try {
+      runSecretMaterial = await loadRunSecretMaterial({step, leaseClient, attempt, signal});
+    } catch (error) {
+      return {
+        result: stepSecretsFailure(error),
+        logOutcome: 'drained',
+        preparedWorkspace: false,
+      };
+    }
+
     // Log capture is best-effort: if the spool cannot be opened (e.g. a broken logs dir),
     // abandon capture and run the step without a stream rather than failing the step itself.
     let stepStream: StepLogStream | undefined;
+    const runSecrets = [...secrets, ...(runSecretMaterial?.secretValues ?? [])];
     try {
       stepStream = createStepLogStream({
         logsDir,
         stepId: step.id,
         attempt,
-        secrets,
+        secrets: runSecrets,
         append,
       });
     } catch (error) {
@@ -387,6 +406,8 @@ export async function executeStep(params: {
     const result = await executeRunStep(step, {
       signal,
       cwd,
+      ...(runSecretMaterial?.secretEnv ? {secretEnv: runSecretMaterial.secretEnv} : {}),
+      ...(runSecretMaterial?.secretValues ? {secretValues: runSecretMaterial.secretValues} : {}),
       onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
       onOutput: (chunk, source) => stepStream?.write(chunk, source),
     });
@@ -418,6 +439,86 @@ export async function executeStep(params: {
     unsubscribeSecrets?.();
     runStream?.writeGroupEnd();
   }
+}
+
+interface RunSecretMaterial {
+  secretEnv: Record<string, string>;
+  secretValues: string[];
+}
+
+const runSecretBindingsSchema = materializedSecretBindingSchema.array();
+
+async function loadRunSecretMaterial(params: {
+  step: StepDto;
+  leaseClient: KyInstance;
+  attempt: number;
+  signal: AbortSignal;
+}): Promise<RunSecretMaterial | undefined> {
+  if (params.step.type !== 'run') return undefined;
+  const bindings = parseRunSecretBindings(params.step.config.secret_bindings);
+  if (bindings.length === 0) return undefined;
+
+  const pulled = await requestStepSecrets(params.leaseClient, {
+    stepId: params.step.id,
+    attempt: params.attempt,
+    signal: params.signal,
+  });
+  const values = new Map(pulled.secrets.map((secret) => [secretReferenceId(secret), secret.value]));
+  const secretEnv: Record<string, string> = {};
+
+  for (const binding of bindings) {
+    secretEnv[binding.target] = assembleSecretBinding(binding, values);
+  }
+
+  return {
+    secretEnv,
+    secretValues: pulled.secrets.map((secret) => secret.value),
+  };
+}
+
+function parseRunSecretBindings(value: unknown): MaterializedSecretBindingDto[] {
+  const parsed = runSecretBindingsSchema.safeParse(value ?? []);
+  if (!parsed.success) throw new Error('Run step secret bindings are invalid.');
+  return parsed.data;
+}
+
+function assembleSecretBinding(
+  binding: MaterializedSecretBindingDto,
+  values: ReadonlyMap<string, string>,
+): string {
+  return binding.segments
+    .map((segment) => {
+      if (segment.kind === 'literal') return segment.value;
+      const value = values.get(secretReferenceId(segment));
+      if (value === undefined) {
+        throw new Error('Run step secret response is missing a requested secret.');
+      }
+      return value;
+    })
+    .join('');
+}
+
+function secretReferenceId(reference: Pick<StepSecretDto, 'store' | 'key'>): string {
+  return `${reference.store}\0${reference.key}`;
+}
+
+function stepSecretsFailure(error: unknown): StepResult {
+  if (error instanceof StepSecretsRequestError) {
+    return {
+      success: false,
+      error: {message: error.message, reason: 'config_unresolvable'},
+      exit_code: null,
+    };
+  }
+
+  return {
+    success: false,
+    error: {
+      message: error instanceof Error ? error.message : 'Run step secrets could not be resolved.',
+      reason: 'config_unresolvable',
+    },
+    exit_code: null,
+  };
 }
 
 function maskAgentFailure(result: StepResult, secretVariants: string[]): StepResult {

--- a/libs/runner/protocol/package.json
+++ b/libs/runner/protocol/package.json
@@ -40,6 +40,7 @@
     "@shipfox/api-logs-dto": "workspace:*",
     "@shipfox/api-agent-dto": "workspace:*",
     "@shipfox/api-runners-dto": "workspace:*",
+    "@shipfox/api-secrets-dto": "workspace:*",
     "@shipfox/api-workflows-dto": "workspace:*",
     "@shipfox/config": "workspace:*",
     "@shipfox/node-opentelemetry": "workspace:*",

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -16,7 +16,9 @@ import {
   requestCheckoutToken,
   requestJob,
   requestNextStep,
+  requestStepSecrets,
   requireRunnerLabels,
+  StepSecretsRequestError,
 } from '#api-client.js';
 import {config} from '#config.js';
 
@@ -236,6 +238,47 @@ describe('api-client auth contexts', () => {
     expect(calls[0]?.url).toContain(`step_id=${STEP_ID}`);
     expect(calls[0]?.url).toContain('attempt=2');
     expect(calls[0]?.authorization).toBe('Bearer lease-runtime');
+  });
+
+  it('requestStepSecrets sends the lease token and parses returned secret values', async () => {
+    stubFetch(() =>
+      jsonResponse({
+        secrets: [{store: 'local', key: 'API_TOKEN', value: 'runtime-secret'}],
+      }),
+    );
+    const leaseClient = createLeaseClient('lease-secrets');
+
+    const response = await requestStepSecrets(leaseClient, {stepId: STEP_ID, attempt: 2});
+
+    expect(response.secrets).toEqual([{store: 'local', key: 'API_TOKEN', value: 'runtime-secret'}]);
+    expect(calls[0]?.url).toContain(`runs/jobs/current/steps/${STEP_ID}/secrets`);
+    expect(calls[0]?.url).toContain('attempt=2');
+    expect(calls[0]?.authorization).toBe('Bearer lease-secrets');
+  });
+
+  it('requestStepSecrets surfaces HTTP errors as typed request errors', async () => {
+    stubFetch(() => jsonResponse({code: 'secret-not-found'}, 422));
+    const leaseClient = createLeaseClient('lease-secrets');
+
+    const request = requestStepSecrets(leaseClient, {stepId: STEP_ID, attempt: 2});
+
+    await expect(request).rejects.toMatchObject(
+      new StepSecretsRequestError(422, 'secret-not-found'),
+    );
+  });
+
+  it('requestStepSecrets classifies malformed success bodies without leaking plaintext', async () => {
+    const secret = 'super-secret-response-body';
+    stubFetch(() => jsonResponse({secrets: [{store: 'local', value: secret}]}));
+    const leaseClient = createLeaseClient('lease-secrets');
+
+    const request = requestStepSecrets(leaseClient, {stepId: STEP_ID, attempt: 2});
+
+    await expect(request).rejects.toMatchObject(
+      new StepSecretsRequestError(200, 'step-secrets-invalid'),
+    );
+    await expect(request).rejects.not.toThrow(secret);
+    await expect(request).rejects.not.toThrow(ZOD_ERROR_TEXT_REGEX);
   });
 
   it('requestAgentRuntimeConfig maps server config errors to agent config issues', async () => {

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -13,6 +13,7 @@ import {
   registerRunnerBodySchema,
   registerRunnerResponseSchema,
 } from '@shipfox/api-runners-dto';
+import {type StepSecretsResponseDto, stepSecretsResponseSchema} from '@shipfox/api-secrets-dto';
 import {
   type AgentConfigIssueDto,
   type CheckoutTokenResponseDto,
@@ -107,6 +108,20 @@ export class AgentRuntimeConfigRequestError extends Error {
         : `Agent runtime config request failed with status ${status}: ${code}.`,
     );
     this.name = 'AgentRuntimeConfigRequestError';
+  }
+}
+
+export class StepSecretsRequestError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly code: string | undefined,
+  ) {
+    super(
+      code === undefined
+        ? `Step secrets request failed with status ${status}.`
+        : `Step secrets request failed with status ${status}: ${code}.`,
+    );
+    this.name = 'StepSecretsRequestError';
   }
 }
 
@@ -292,6 +307,49 @@ export async function requestAgentRuntimeConfig(
   }
 
   throw new AgentRuntimeConfigRequestError(response.status, await errorCode(response));
+}
+
+export async function requestStepSecrets(
+  leaseClient: KyInstance,
+  params: {
+    stepId: string;
+    attempt: number;
+    signal?: AbortSignal;
+  },
+): Promise<StepSecretsResponseDto> {
+  let response: Response;
+  try {
+    response = await leaseClient.get(`runs/jobs/current/steps/${params.stepId}/secrets`, {
+      searchParams: {attempt: params.attempt},
+      retry: {
+        methods: ['get'],
+        statusCodes: [429, 500, 502, 503, 504],
+      },
+      ...(params.signal ? {signal: params.signal} : {}),
+    });
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      throw new StepSecretsRequestError(error.response.status, codeFromBody(error.data));
+    }
+    throw error;
+  }
+
+  if (response.ok) {
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new StepSecretsRequestError(200, 'step-secrets-invalid');
+    }
+
+    const parsed = stepSecretsResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new StepSecretsRequestError(200, 'step-secrets-invalid');
+    }
+    return parsed.data;
+  }
+
+  throw new StepSecretsRequestError(response.status, await errorCode(response));
 }
 
 // throwHttpErrors:false (below) turns off ky's status-code retry for this call, so no

--- a/libs/runner/protocol/src/index.ts
+++ b/libs/runner/protocol/src/index.ts
@@ -15,6 +15,8 @@ export {
   requestCheckoutToken,
   requestJob,
   requestNextStep,
+  requestStepSecrets,
   requireRunnerLabels,
   runnerRegistrationToken,
+  StepSecretsRequestError,
 } from '#api-client.js';

--- a/libs/shared/common/redact/src/index.test.ts
+++ b/libs/shared/common/redact/src/index.test.ts
@@ -2,6 +2,7 @@ import {
   REDACTION_PLACEHOLDER,
   redactSecrets,
   redactUrlCredentials,
+  safeRedactionPrefixLength,
   secretWireForms,
   stripUrlCredentials,
 } from './index.js';
@@ -160,6 +161,43 @@ describe('redactSecrets', () => {
 
   it('exposes the placeholder it writes', () => {
     expect(REDACTION_PLACEHOLDER).toBe('***');
+  });
+});
+
+describe('safeRedactionPrefixLength', () => {
+  it('holds a prefix that could still become a secret', () => {
+    const cut = safeRedactionPrefixLength('prefix runtime-sec', ['runtime-secret-value']);
+
+    expect(cut).toBe(0);
+  });
+
+  it('emits safe text while retaining enough lookbehind for split secrets', () => {
+    const secret = 'runtime-secret-value';
+    const prefix = 'safe output before '.repeat(2);
+    const buffer = `${prefix}${secret.slice(0, 8)}`;
+
+    const cut = safeRedactionPrefixLength(buffer, [secret]);
+
+    expect(cut).toBeGreaterThan(0);
+    expect(buffer.slice(0, cut)).not.toContain(secret.slice(0, 8));
+    expect(buffer.slice(cut)).toContain(secret.slice(0, 8));
+  });
+
+  it('backs up before a complete occurrence that straddles the initial cut', () => {
+    const secret = 'runtime-secret-value';
+    const buffer = `prefix ${secret} suffix`;
+
+    const cut = safeRedactionPrefixLength(buffer, [secret]);
+
+    expect(buffer.slice(0, cut)).toBe('prefix ');
+  });
+
+  it('emits the whole buffer when there are no secrets', () => {
+    const buffer = 'ordinary output';
+
+    const cut = safeRedactionPrefixLength(buffer, []);
+
+    expect(cut).toBe(buffer.length);
   });
 });
 

--- a/libs/shared/common/redact/src/index.ts
+++ b/libs/shared/common/redact/src/index.ts
@@ -80,6 +80,36 @@ export function redactSecrets(text: string, secrets: string[]): string {
   return redactUrlCredentials(redacted);
 }
 
+/**
+ * Returns the largest prefix length of `buffer` that can be redacted and emitted now without
+ * risking a registered secret being split across this prefix and a later chunk.
+ *
+ * Callers that stream output should keep `buffer.slice(result)` as lookbehind, redact and emit
+ * only `buffer.slice(0, result)`, and flush the remainder when the stream closes.
+ */
+export function safeRedactionPrefixLength(buffer: string, secrets: readonly string[]): number {
+  const candidates = secrets.filter(Boolean);
+  const maxSecretLen = candidates.reduce((max, secret) => Math.max(max, secret.length), 0);
+  const hold = Math.max(0, maxSecretLen - 1);
+  let cut = buffer.length - hold;
+  if (cut <= 0) return 0;
+  for (let moved = true; moved && cut > 0; ) {
+    moved = false;
+    const windowStart = Math.max(0, cut - maxSecretLen + 1);
+    for (let start = windowStart; start < cut; start++) {
+      const straddles = candidates.some(
+        (secret) => start + secret.length > cut && buffer.startsWith(secret, start),
+      );
+      if (straddles) {
+        cut = start;
+        moved = true;
+        break;
+      }
+    }
+  }
+  return cut;
+}
+
 const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 const BASE64URL_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,6 +815,9 @@ importers:
       '@shipfox/e2e-helper-runners':
         specifier: workspace:*
         version: link:../../helpers/runners
+      '@shipfox/e2e-helper-secrets':
+        specifier: workspace:*
+        version: link:../../helpers/secrets
       '@shipfox/e2e-helper-workflows':
         specifier: workspace:*
         version: link:../../helpers/workflows
@@ -4363,6 +4366,9 @@ importers:
       '@shipfox/node-opentelemetry':
         specifier: workspace:*
         version: link:../../shared/node/opentelemetry
+      '@shipfox/redact':
+        specifier: workspace:*
+        version: link:../../shared/common/redact
       '@shipfox/runner-protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -4428,6 +4434,9 @@ importers:
 
   libs/runner/orchestration:
     dependencies:
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../../api/secrets-dto
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../api/workflows-dto
@@ -4489,6 +4498,9 @@ importers:
       '@shipfox/api-runners-dto':
         specifier: workspace:*
         version: link:../../api/runners-dto
+      '@shipfox/api-secrets-dto':
+        specifier: workspace:*
+        version: link:../../api/secrets-dto
       '@shipfox/api-workflows-dto':
         specifier: workspace:*
         version: link:../../api/workflows-dto


### PR DESCRIPTION
Adds lease-gated runtime secret resolution for workflow run steps.

S2 already persisted secret references as deferred `config.secret_bindings`, but run steps still lacked the runtime path that turns those bindings into environment variables. This adds a runner-only endpoint that re-derives scope and bindings from server state, resolves only the referenced secrets, and returns values with `cache-control: no-store`.

The runner now fetches those values before opening the step log stream, assembles the per-step env without mutating `process.env`, and registers every pulled value for redaction before command output can be captured. It also masks the runner stdout/stderr tee so container logs follow the same no-plaintext invariant as durable step logs.

The platform workflow E2E harness now supports declarative secret seeding and runner-log assertions, with a `runtime-secret-injection` scenario covering both `env:` and run-command secret interpolation.

Areas worth careful review: the lease guard shared with agent runtime config, the fail-closed behavior when bindings or responses are malformed, and the stdout/stderr tee masking path.

Local full platform E2E did not reach scenario execution in this workspace: `mise run e2e -- --filter=@shipfox/e2e-platform-workflows` timed out waiting for the API `/readyz` endpoint on the generated worktree port before API/client logs were written.

Resolves ENG-695

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lease‑gated runtime secret injection for run steps. Fetches only referenced secrets on the server, injects per‑step env, and redacts all wire forms across durable logs and the local tee (ENG-695).

- **New Features**
  - API: `GET /runs/jobs/current/steps/:stepId/secrets?attempt=N` returns `{secrets:[{store,key,value}]}` with `cache-control: no-store`; scope re‑derived via `getJobScope` (workspace+project), lease/step checks via `loadRunningLeasedStep`, references deduped; errors: 422 (`secret-not-found`), 409 (`secret-bindings-invalid`). DTOs in `@shipfox/api-secrets-dto`.
  - Runner/Orchestration: protocol adds `requestStepSecrets` with `StepSecretsRequestError`; orchestration pulls secrets before opening the log stream, assembles segmented targets into per‑step `secretEnv` (merged over step `env`, never `process.env`), adds pulled values to log redaction, and fails closed if bindings are missing/invalid (`config_unresolvable`).
  - Redaction: local stdout/stderr tee and spool use `@shipfox/redact` with a shared `safeRedactionPrefixLength` helper to mask split‑chunk secrets and all wire forms; server logs only include key names.
  - E2E: scenarios can seed secrets via `secrets.yaml`; added injection and redaction scenarios with `runner_log` assertions to ensure no plaintext appears.

- **Bug Fixes**
  - Validate secret binding env targets; reject malformed names at materialization time.
  - Fixed E2E runner log assertion so secrets never appear in the local runner process log.

<sup>Written for commit 98c41fcdcd883cba3192f5d33fc0d70fd58b4442. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

