### PR TITLE
Add step output gate predicates

### DIFF
--- a/.changeset/steady-maps-open.md
+++ b/.changeset/steady-maps-open.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": patch
+---
+
+Adds an open-map expression type so workflow predicates can type-check dynamic step output fields.

--- a/.changeset/steady-maps-open.md
+++ b/.changeset/steady-maps-open.md
@@ -1,5 +1,5 @@
 ---
-"@shipfox/expression": patch
+"@shipfox/expression": minor
 ---
 
 Adds an open-map expression type so workflow predicates can type-check dynamic step output fields.

--- a/libs/api/definitions/src/core/workflow-model/README.md
+++ b/libs/api/definitions/src/core/workflow-model/README.md
@@ -93,9 +93,10 @@ catalog; explicit model ids are preserved because the shared seed catalog does
 not yet carry each provider's full model list.
 
 For now, run-step gates can use typed roots such as `step.exit_code`,
-`step.status`, and other server roots that are available by step reporting.
-Fields such as `step.output.pass` need a declared output schema, so they belong
-to later agent-step work.
+`step.status`, open output fields such as `step.outputs.pass`, and other server
+roots that are available by step reporting. Guard optional output keys with
+`has(step.outputs.pass)` before reading them so missing keys fail as a normal
+false predicate instead of an uncheckable evaluation error.
 
 `on_failure.restart_from` must name an earlier step in the same job. The runtime
 host does not execute restart semantics yet. This module only records the

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -689,7 +689,7 @@ describe('normalizeWorkflowDocument', () => {
   });
 
   it('normalizes step gates with success conditions and failure actions', () => {
-    const reviewOutput = 'Agent rejected the PR $' + '{{ step.output.review }}';
+    const reviewOutput = 'Agent rejected the PR $' + '{{ step.outputs.review }}';
     const document: WorkflowDocument = {
       name: 'review loop',
       jobs: {
@@ -1151,25 +1151,23 @@ describe('normalizeWorkflowDocument', () => {
     });
   });
 
-  it('reports invalid gate success_if expressions', () => {
+  it('accepts step outputs in gate success_if expressions', () => {
     const document: WorkflowDocument = {
-      name: 'invalid gate',
+      name: 'output gate',
       jobs: {
         build: {
-          steps: [{run: 'npm run build', gate: {success_if: 'step.output.pass == true'}}],
+          steps: [{run: 'npm run build', gate: {success_if: 'step.outputs.pass == true'}}],
         },
       },
     };
 
-    const error = expectInvalid(document);
+    const model = normalizeWorkflowDocument(document);
 
-    expect(error.issues).toEqual([
-      expect.objectContaining({
-        code: 'invalid-step-gate-success-if',
-        path: ['jobs', 'build', 'steps', 0, 'gate', 'success_if'],
-        details: expect.objectContaining({source: 'step.output.pass == true'}),
-      }),
-    ]);
+    expect(model.jobs[0]?.steps[0]?.gate?.successIf).toEqual({
+      language: 'cel',
+      source: 'step.outputs.pass == true',
+      check: 'typed',
+    });
   });
 
   it('reports non-boolean gate success_if expressions', () => {

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -194,8 +194,8 @@ export interface RecordStepResultParams {
   stepId: string;
   status: 'succeeded' | 'failed';
   error?: Record<string, unknown> | null;
-  // Structured runner output is audit/history on the attempt row; the current
-  // step projection keeps only status/error.
+  // Structured runner output feeds gate predicates and audit/history on the
+  // attempt row; the current step projection keeps only status/error.
   output?: Record<string, unknown> | null;
   exitCode?: number | null;
   // The attempt the runner was dispatched. Omitted = "the step's current

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -270,8 +270,23 @@ describe('assembleGateContext', () => {
         step: {
           exit_code: 1n,
           status: 'failed',
+          outputs: {},
         },
       },
+    });
+  });
+
+  it('includes reported step output', () => {
+    const context = assembleGateContext({
+      status: 'succeeded',
+      exitCode: 0,
+      output: {pass: true},
+    });
+
+    expect(context.values.step).toEqual({
+      exit_code: 0n,
+      status: 'succeeded',
+      outputs: {pass: true},
     });
   });
 });

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -147,6 +147,7 @@ export function assembleStepDispatchContext(params: {
 export function assembleGateContext(params: {
   readonly status: StepStatus;
   readonly exitCode: number;
+  readonly output?: Record<string, unknown> | null | undefined;
 }): WorkflowEvaluationContext {
   return {
     site: 'step-report',
@@ -154,6 +155,7 @@ export function assembleGateContext(params: {
       step: {
         exit_code: BigInt(params.exitCode),
         status: params.status,
+        outputs: params.output ?? {},
       },
     },
   };

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.test.ts
@@ -80,6 +80,47 @@ describe('evaluateGate', () => {
     expect(evaluateGate(gate, {status: 'failed', exitCode: 0})).toMatchObject({kind: 'failed'});
   });
 
+  test('step.outputs gates on reported output values', () => {
+    const gate = readStepGate(gateConfig('step.outputs.pass == true'));
+
+    const passed = evaluateGate(gate, {
+      status: 'succeeded',
+      exitCode: 0,
+      output: {pass: true},
+    });
+    const failed = evaluateGate(gate, {
+      status: 'succeeded',
+      exitCode: 0,
+      output: {pass: false},
+    });
+
+    expect(passed).toEqual({
+      kind: 'passed',
+      source: 'step.outputs.pass == true',
+    });
+    expect(failed).toEqual({
+      kind: 'failed',
+      source: 'step.outputs.pass == true',
+    });
+  });
+
+  test('unguarded missing step output keys fail closed as uncheckable', () => {
+    const gate = readStepGate(gateConfig('step.outputs.pass == true'));
+
+    const result = evaluateGate(gate, {status: 'succeeded', exitCode: 0, output: {}});
+
+    expect(result).toMatchObject({kind: 'uncheckable'});
+  });
+
+  test('has-guarded missing step output keys evaluate as a checkable failure', () => {
+    const source = 'has(step.outputs.pass) && step.outputs.pass == true';
+    const gate = readStepGate(gateConfig(source));
+
+    const result = evaluateGate(gate, {status: 'succeeded', exitCode: 0, output: {}});
+
+    expect(result).toEqual({kind: 'failed', source});
+  });
+
   test('a missing exit code is uncheckable (never evaluated)', () => {
     const gate = readStepGate(gateConfig('step.exit_code == 0'));
     expect(evaluateGate(gate, {status: 'failed', exitCode: null})).toMatchObject({

--- a/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
+++ b/libs/api/workflows/src/core/step-transition/evaluate-gate.ts
@@ -61,7 +61,11 @@ export function evaluateGate(gate: StepGate | undefined, result: StepResult): Ga
     return {kind: 'uncheckable', reason: 'step produced no exit code'};
   }
 
-  const context = assembleGateContext({status: result.status, exitCode: result.exitCode});
+  const context = assembleGateContext({
+    status: result.status,
+    exitCode: result.exitCode,
+    output: result.output,
+  });
   const outcome = evaluatePlannedPredicateAtSite({
     expression: gate.successIf,
     field: 'step.success_if',

--- a/libs/shared/expression/src/expression/create-workflow-expression.test.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.test.ts
@@ -209,6 +209,45 @@ describe('createWorkflowExpression', () => {
     });
   });
 
+  it('type-checks open map fields and rejects the same path on empty object schemas', () => {
+    const expression = createWorkflowExpression({
+      source: 'step.outputs.pass == true',
+      check: {
+        mode: 'typed',
+        typeEnvironment: {
+          step: {
+            kind: 'object',
+            fields: {
+              outputs: {kind: 'map'},
+            },
+          },
+        },
+      },
+    });
+    const act = () =>
+      createWorkflowExpression({
+        source: 'step.outputs.pass == true',
+        check: {
+          mode: 'typed',
+          typeEnvironment: {
+            step: {
+              kind: 'object',
+              fields: {
+                outputs: {kind: 'object', fields: {}},
+              },
+            },
+          },
+        },
+      });
+
+    expect(expression).toEqual({
+      language: 'cel',
+      source: 'step.outputs.pass == true',
+      check: 'typed',
+    });
+    expect(act).toThrow(InvalidWorkflowExpressionError);
+  });
+
   it('rejects parse errors before type checking', () => {
     const act = () =>
       createWorkflowExpression({

--- a/libs/shared/expression/src/expression/create-workflow-expression.ts
+++ b/libs/shared/expression/src/expression/create-workflow-expression.ts
@@ -98,6 +98,7 @@ function toCelType(
   if (type.kind === 'list') {
     return `list<${toCelListElementType(type.element, environment, variableName)}>`;
   }
+  if (type.kind === 'map') return 'map';
 
   return {
     schema: Object.fromEntries(
@@ -109,6 +110,7 @@ function toCelType(
 function toCelSchemaType(type: ExpressionType): string | CelSchema {
   if (typeof type === 'string') return scalarTypeToCelType[type];
   if (type.kind === 'list') return `list<${toCelSchemaListElementType(type.element)}>`;
+  if (type.kind === 'map') return 'map';
   return Object.fromEntries(
     Object.entries(type.fields).map(([name, field]) => [name, toCelSchemaType(field)]),
   );
@@ -116,6 +118,7 @@ function toCelSchemaType(type: ExpressionType): string | CelSchema {
 
 function toCelSchemaListElementType(type: ExpressionType): string {
   if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'map') return 'map';
   if (type.kind === 'object') return 'dyn';
   return `list<${toCelSchemaListElementType(type.element)}>`;
 }
@@ -126,6 +129,7 @@ function toCelListElementType(
   variableName: string,
 ): string {
   if (typeof type === 'string') return scalarTypeToCelType[type];
+  if (type.kind === 'map') return 'map';
   if (type.kind === 'object') {
     const typeName = `$${variableName}.item`;
     environment.registerType({

--- a/libs/shared/expression/src/expression/workflow-expression.ts
+++ b/libs/shared/expression/src/expression/workflow-expression.ts
@@ -17,6 +17,9 @@ export type ExpressionType =
       fields: Readonly<Record<string, ExpressionType>>;
     }
   | {
+      kind: 'map';
+    }
+  | {
       kind: 'list';
       element: ExpressionType;
     };

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -115,6 +115,7 @@ describe('workflow context registry', () => {
       trustTier: 'trusted',
       shape: 'known',
       checkMode: 'typed',
+      untrustedPaths: ['outputs'],
     });
     expect(workflowContextDefinitions.steps).toMatchObject({
       availability: 'step-dispatch',
@@ -207,6 +208,7 @@ describe('workflow context registry', () => {
         fields: {
           exit_code: 'int',
           status: 'string',
+          outputs: {kind: 'map'},
         },
       },
     });

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -174,6 +174,7 @@ const stepTypeEnvironment = {
     fields: {
       exit_code: 'int',
       status: 'string',
+      outputs: {kind: 'map'},
     },
   },
 } as const satisfies ExpressionTypeEnvironment;
@@ -258,6 +259,7 @@ export const workflowContextDefinitions = {
     shape: 'known',
     checkMode: 'typed',
     typeEnvironment: stepTypeEnvironment,
+    untrustedPaths: ['outputs'],
   },
   vars: {
     availability: 'run-creation',

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -310,7 +310,7 @@ describe('workflowDocumentSchema', () => {
               name: 'reviewer',
               run: 'npm run review',
               gate: {
-                success_if: 'step.output.pass == true',
+                success_if: 'step.outputs.pass == true',
                 on_failure: {
                   restart_from: 'producer',
                   output: 'Review failed',


### PR DESCRIPTION
Add step output gate predicates

Gate success_if predicates could previously read only step.exit_code and step.status, which meant steps that produced structured output could not branch on it. This introduces an open-map expression type and exposes reported step outputs as step.outputs so predicates like step.outputs.pass == true type-check and evaluate at step-report time.

Missing output keys still fail closed. The runtime now defaults step.outputs to an empty map, and the tests document the recommended guarded form with has(step.outputs.pass) for optional keys.

Closes ENG-735

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable gate predicates to branch on structured step outputs by exposing `step.outputs` and adding an open-map expression type (fixes ENG-735). Defaults to `{}`; replace any `step.output.*` and guard optional keys with `has(step.outputs.key)` to avoid uncheckable evaluations.

- New Features
  - Added open-map type in `@shipfox/expression` to type-check dynamic output fields.
  - Exposed `step.outputs` in gate `success_if` (e.g., `step.outputs.pass == true`).
  - Runtime populates `step.outputs` from reported step output for gates and attempt audit; falls back to `{}`.

- Dependencies
  - Bump `@shipfox/expression` minor for the new open-map type.

<sup>Written for commit 877c5f2ba65985af0358f5f4b70299cd27028bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

