### PR TITLE
[e2e-platform-workflows] Add listener job coverage

### DIFF
--- a/e2e/platform/workflows/README.md
+++ b/e2e/platform/workflows/README.md
@@ -33,9 +33,9 @@ against the shared suite arrangement:
    run detail, fetching step logs only where `logs` expectations exist.
 
 Anything not listed in `expect.yaml` is not asserted. A flow that needs to orchestrate
-from outside (cancellation, listening jobs) ships a `spec.e2e.ts` in its directory
-instead of an `expect.yaml`; it is an ordinary Playwright spec and receives the same
-`suite` fixture.
+from outside (cancellation, listening jobs) ships its own Playwright spec under `tests/`
+(for example `tests/listener-jobs.e2e.ts`) instead of an `expect.yaml`; `testMatch` picks
+up every `tests/**/*.e2e.ts`, and the spec receives the same `suite` fixture.
 
 ### expect.yaml
 

--- a/e2e/platform/workflows/package.json
+++ b/e2e/platform/workflows/package.json
@@ -10,11 +10,18 @@
   "type": "module",
   "imports": {
     "#test/*": "./tests/*",
+    "#attachments.js": "./src/attachments.ts",
     "#create-project.js": "./src/create-project.ts",
     "#expect.js": "./src/expect.ts",
+    "#listener-helpers.js": "./src/listener-helpers.ts",
+    "#polling.js": "./src/polling.ts",
     "#run-scenario.js": "./src/run-scenario.ts",
+    "#runner.js": "./src/runner.ts",
     "#scenarios.js": "./src/scenarios.ts",
-    "#suite-context.js": "./src/suite-context.ts"
+    "#suite-context.js": "./src/suite-context.ts",
+    "#triggers.js": "./src/triggers.ts",
+    "#webhook.js": "./src/webhook.ts",
+    "#workflow-project.js": "./src/workflow-project.ts"
   },
   "scripts": {
     "check": "shipfox-biome-check",

--- a/e2e/platform/workflows/src/attachments.ts
+++ b/e2e/platform/workflows/src/attachments.ts
@@ -1,0 +1,83 @@
+import {readFile} from 'node:fs/promises';
+import {fetchStepLogs} from '@shipfox/e2e-helper-logs';
+import type {waitForRunTerminal} from '@shipfox/e2e-helper-workflows';
+
+const LOG_ATTACHMENT_NAME_PART_RE = /[^a-zA-Z0-9._-]+/g;
+
+export interface Attachment {
+  name: string;
+  contentType: string;
+  body: string;
+}
+
+export type AttachFn = (attachment: Attachment) => Promise<void>;
+
+export interface StepLogAttachmentRequest {
+  path: string;
+  stepId: string;
+  attempt: number;
+}
+
+export function logAttachmentName(path: string): string {
+  return path.replaceAll(LOG_ATTACHMENT_NAME_PART_RE, '_').replace(/^_+|_+$/g, '');
+}
+
+export function collectStepLogAttachmentRequests(
+  runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>,
+): StepLogAttachmentRequest[] {
+  const requests: StepLogAttachmentRequest[] = [];
+  for (const job of runDetail.jobs) {
+    for (const execution of job.job_executions) {
+      for (const step of execution.steps) {
+        requests.push({
+          path: `jobs.${job.key}.executions.${execution.sequence}.steps.${
+            step.key ?? logAttachmentName(step.name)
+          }`,
+          stepId: step.id,
+          attempt: step.current_attempt,
+        });
+      }
+    }
+  }
+  return requests;
+}
+
+export async function fetchLogAttachment(
+  request: StepLogAttachmentRequest,
+  token: string,
+): Promise<Attachment> {
+  try {
+    const logs = await fetchStepLogs({
+      stepId: request.stepId,
+      attempt: request.attempt,
+      token,
+    });
+    return {
+      name: `logs-${logAttachmentName(request.path)}.ndjson`,
+      contentType: 'application/x-ndjson',
+      body: logs.ndjson,
+    };
+  } catch (error) {
+    return {
+      name: `logs-${logAttachmentName(request.path)}.error.txt`,
+      contentType: 'text/plain',
+      body: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export async function attachLocalRunnerLog(attach: AttachFn, runnerLogFile: string): Promise<void> {
+  try {
+    await attach({
+      name: `runner-${logAttachmentName(runnerLogFile)}.log`,
+      contentType: 'text/plain',
+      body: await readFile(runnerLogFile, 'utf8'),
+    });
+  } catch (error) {
+    await attach({
+      name: `runner-${logAttachmentName(runnerLogFile)}.error.txt`,
+      contentType: 'text/plain',
+      body: error instanceof Error ? error.message : String(error),
+    }).catch(() => undefined);
+  }
+}

--- a/e2e/platform/workflows/src/listener-helpers.test.ts
+++ b/e2e/platform/workflows/src/listener-helpers.test.ts
@@ -1,0 +1,223 @@
+import type {
+  JobDto,
+  WorkflowExecutionEventDto,
+  WorkflowRunDetailResponseDto,
+  WorkflowRunJobDetailDto,
+  WorkflowRunJobExecutionDetailDto,
+} from '@shipfox/api-workflows-dto';
+import {
+  batchedListenerExecutionMatches,
+  findListenerExecutionByDeliveryId,
+  listenerDeliveryObserved,
+  listenerExecutionCountMatches,
+  listenerResolutionMatches,
+} from './listener-helpers.js';
+
+const timestamp = '2026-07-04T08:00:00.000Z';
+
+function event(overrides: Partial<WorkflowExecutionEventDto> = {}): WorkflowExecutionEventDto {
+  return {
+    source: 'fire-source',
+    event: 'received',
+    delivery_id: 'delivery-1',
+    received_at: timestamp,
+    data: {body: {message: 'hello'}},
+    ...overrides,
+  };
+}
+
+function execution(
+  overrides: Partial<WorkflowRunJobExecutionDetailDto> = {},
+): WorkflowRunJobExecutionDetailDto {
+  return {
+    id: '66666666-6666-4666-8666-666666666666',
+    job_id: '77777777-7777-4777-8777-777777777777',
+    sequence: 1,
+    name: 'listen #1',
+    status: 'succeeded',
+    status_reason: null,
+    trigger_events: [event()],
+    queued_at: timestamp,
+    started_at: timestamp,
+    finished_at: timestamp,
+    timed_out_at: null,
+    created_at: timestamp,
+    updated_at: timestamp,
+    steps: [],
+    ...overrides,
+  };
+}
+
+function listenerJob(overrides: Partial<WorkflowRunJobDetailDto> = {}): WorkflowRunJobDetailDto {
+  const base: JobDto = {
+    id: '77777777-7777-4777-8777-777777777777',
+    run_attempt_id: '88888888-8888-4888-8888-888888888888',
+    key: 'listen',
+    name: null,
+    mode: 'listening',
+    status: 'succeeded',
+    status_reason: null,
+    carried_over: false,
+    listening: {
+      on: [{source: 'fire-source', event: 'received'}],
+      until: [{source: 'resolve-source', event: 'received'}],
+      timeout_ms: null,
+      max_executions: null,
+      batch: null,
+      on_resolve: 'finish',
+      execution_timeout_ms: null,
+      name: null,
+    },
+    listener_status: 'resolved',
+    resolution_reason: 'until',
+    dependencies: [],
+    position: 0,
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+  return {...base, job_executions: [execution()], ...overrides};
+}
+
+function runDetail(
+  overrides: Partial<WorkflowRunDetailResponseDto> = {},
+): WorkflowRunDetailResponseDto {
+  return {
+    id: '33333333-3333-4333-8333-333333333333',
+    project_id: '11111111-1111-4111-8111-111111111111',
+    definition_id: '22222222-2222-4222-8222-222222222222',
+    name: 'Listener workflow',
+    status: 'succeeded',
+    current_attempt: 1,
+    latest_attempt: 1,
+    trigger_provider: 'manual',
+    trigger_source: 'manual',
+    trigger_event: 'fire',
+    trigger_payload: {},
+    inputs: null,
+    source_snapshot: null,
+    created_at: timestamp,
+    updated_at: timestamp,
+    started_at: timestamp,
+    finished_at: timestamp,
+    run_attempt: {
+      id: '88888888-8888-4888-8888-888888888888',
+      workflow_run_id: '33333333-3333-4333-8333-333333333333',
+      attempt: 1,
+      status: 'succeeded',
+      created_at: timestamp,
+      started_at: timestamp,
+      finished_at: timestamp,
+      rerun_mode: null,
+    },
+    jobs: [listenerJob()],
+    ...overrides,
+  };
+}
+
+describe('listener helper predicates', () => {
+  test('finds the listener execution containing a delivery id', () => {
+    const detail = runDetail({
+      jobs: [
+        listenerJob({
+          job_executions: [
+            execution({sequence: 1, trigger_events: [event({delivery_id: 'delivery-1'})]}),
+            execution({sequence: 2, trigger_events: [event({delivery_id: 'delivery-2'})]}),
+          ],
+        }),
+      ],
+    });
+
+    const result = findListenerExecutionByDeliveryId({
+      runDetail: detail,
+      jobKey: 'listen',
+      deliveryId: 'delivery-2',
+    });
+
+    expect(result?.sequence).toBe(2);
+  });
+
+  test('reports a missing delivery with observed delivery ids', () => {
+    const result = listenerDeliveryObserved({
+      runDetail: runDetail(),
+      jobKey: 'listen',
+      deliveryId: 'missing-delivery',
+    });
+
+    expect(result).toEqual({
+      matched: false,
+      diagnostic:
+        'listener job listen did not observe delivery missing-delivery; observed=[delivery-1]',
+    });
+  });
+
+  test('matches listener execution counts', () => {
+    const detail = runDetail({
+      jobs: [
+        listenerJob({
+          job_executions: [
+            execution({sequence: 1}),
+            execution({id: '99999999-9999-4999-8999-999999999999', sequence: 2}),
+          ],
+        }),
+      ],
+    });
+
+    const result = listenerExecutionCountMatches({runDetail: detail, jobKey: 'listen', count: 2});
+
+    expect(result.matched).toBe(true);
+  });
+
+  test('matches listener resolution status and reason', () => {
+    const result = listenerResolutionMatches({
+      runDetail: runDetail(),
+      jobKey: 'listen',
+      status: 'succeeded',
+      reason: 'until',
+    });
+
+    expect(result.matched).toBe(true);
+  });
+
+  test('reports listener resolution mismatches', () => {
+    const result = listenerResolutionMatches({
+      runDetail: runDetail({
+        jobs: [
+          listenerJob({status: 'running', listener_status: 'listening', resolution_reason: null}),
+        ],
+      }),
+      jobKey: 'listen',
+      status: 'succeeded',
+      reason: 'until',
+    });
+
+    expect(result).toEqual({
+      matched: false,
+      diagnostic:
+        'listener job listen status=running, listenerStatus=listening, resolutionReason=null, expected=succeeded/resolved/until',
+    });
+  });
+
+  test('matches a batched execution containing every expected delivery', () => {
+    const result = batchedListenerExecutionMatches({
+      runDetail: runDetail({
+        jobs: [
+          listenerJob({
+            job_executions: [
+              execution({
+                trigger_events: [
+                  event({delivery_id: 'delivery-1'}),
+                  event({delivery_id: 'delivery-2'}),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+      jobKey: 'listen',
+      sequence: 1,
+      deliveryIds: ['delivery-1', 'delivery-2'],
+    });
+
+    expect(result.matched).toBe(true);
+  });
+});

--- a/e2e/platform/workflows/src/listener-helpers.ts
+++ b/e2e/platform/workflows/src/listener-helpers.ts
@@ -1,0 +1,261 @@
+import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
+import type {
+  JobStatusDto,
+  ListenerStatusDto,
+  ResolutionReasonDto,
+  WorkflowRunDetailResponseDto,
+  WorkflowRunJobDetailDto,
+  WorkflowRunJobExecutionDetailDto,
+} from '@shipfox/api-workflows-dto';
+import type {createApiClient} from '@shipfox/e2e-core';
+import {waitForRunDetailMatching} from './polling.js';
+import {postWebhookDelivery} from './webhook.js';
+
+export interface ListenerPredicateResult {
+  matched: boolean;
+  diagnostic: string;
+}
+
+export function findListenerJob(
+  runDetail: WorkflowRunDetailResponseDto,
+  jobKey: string,
+): WorkflowRunJobDetailDto | undefined {
+  return runDetail.jobs.find((job) => job.key === jobKey && job.mode === 'listening');
+}
+
+export function listenerExecutionCountMatches(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  count: number;
+}): ListenerPredicateResult {
+  const job = findListenerJob(params.runDetail, params.jobKey);
+  if (!job) {
+    return {
+      matched: false,
+      diagnostic: `listener job ${params.jobKey} missing`,
+    };
+  }
+  const actual = job.job_executions.length;
+  return {
+    matched: actual === params.count,
+    diagnostic: `listener job ${params.jobKey} executionCount=${actual}, expected=${params.count}`,
+  };
+}
+
+export function listenerStatusMatches(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  listenerStatus: ListenerStatusDto;
+}): ListenerPredicateResult {
+  const job = findListenerJob(params.runDetail, params.jobKey);
+  if (!job) return {matched: false, diagnostic: `listener job ${params.jobKey} missing`};
+  return {
+    matched: job.listener_status === params.listenerStatus,
+    diagnostic: `listener job ${params.jobKey} listenerStatus=${job.listener_status}, expected=${params.listenerStatus}`,
+  };
+}
+
+export function listenerResolutionMatches(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  status: JobStatusDto;
+  reason: ResolutionReasonDto;
+}): ListenerPredicateResult {
+  const job = findListenerJob(params.runDetail, params.jobKey);
+  if (!job) return {matched: false, diagnostic: `listener job ${params.jobKey} missing`};
+  const statusMatches = job.status === params.status;
+  const listenerStatusMatches = job.listener_status === 'resolved';
+  const reasonMatches = job.resolution_reason === params.reason;
+  return {
+    matched: statusMatches && listenerStatusMatches && reasonMatches,
+    diagnostic: `listener job ${params.jobKey} status=${job.status}, listenerStatus=${job.listener_status}, resolutionReason=${job.resolution_reason}, expected=${params.status}/resolved/${params.reason}`,
+  };
+}
+
+export function listenerExecutionStatusMatches(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  sequence: number;
+  status: WorkflowRunJobExecutionDetailDto['status'];
+}): ListenerPredicateResult {
+  const execution = findListenerExecutionBySequence(params);
+  if (!execution) {
+    return {
+      matched: false,
+      diagnostic: `listener job ${params.jobKey} execution ${params.sequence} missing`,
+    };
+  }
+  return {
+    matched: execution.status === params.status,
+    diagnostic: `listener job ${params.jobKey} execution ${params.sequence} status=${execution.status}, expected=${params.status}`,
+  };
+}
+
+export function listenerDeliveryObserved(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  deliveryId: string;
+}): ListenerPredicateResult {
+  const execution = findListenerExecutionByDeliveryId(params);
+  if (execution) {
+    return {
+      matched: true,
+      diagnostic: `listener job ${params.jobKey} observed delivery ${params.deliveryId} in execution ${execution.sequence}`,
+    };
+  }
+  const job = findListenerJob(params.runDetail, params.jobKey);
+  if (!job) return {matched: false, diagnostic: `listener job ${params.jobKey} missing`};
+  const observed = job.job_executions.flatMap((candidate) =>
+    candidate.trigger_events.map((event) => event.delivery_id),
+  );
+  return {
+    matched: false,
+    diagnostic: `listener job ${params.jobKey} did not observe delivery ${params.deliveryId}; observed=[${observed.join(', ')}]`,
+  };
+}
+
+export function batchedListenerExecutionMatches(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  sequence: number;
+  deliveryIds: string[];
+}): ListenerPredicateResult {
+  const execution = findListenerExecutionBySequence(params);
+  if (!execution) {
+    return {
+      matched: false,
+      diagnostic: `listener job ${params.jobKey} execution ${params.sequence} missing`,
+    };
+  }
+  const observed = new Set(execution.trigger_events.map((event) => event.delivery_id));
+  const missing = params.deliveryIds.filter((deliveryId) => !observed.has(deliveryId));
+  return {
+    matched: missing.length === 0 && execution.trigger_events.length === params.deliveryIds.length,
+    diagnostic: `listener job ${params.jobKey} execution ${params.sequence} observed=[${[
+      ...observed,
+    ].join(', ')}], expected=[${params.deliveryIds.join(', ')}]`,
+  };
+}
+
+export function findListenerExecutionByDeliveryId(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  deliveryId: string;
+}): WorkflowRunJobExecutionDetailDto | undefined {
+  const job = findListenerJob(params.runDetail, params.jobKey);
+  return job?.job_executions.find((execution) =>
+    execution.trigger_events.some((event) => event.delivery_id === params.deliveryId),
+  );
+}
+
+export function findListenerExecutionBySequence(params: {
+  runDetail: WorkflowRunDetailResponseDto;
+  jobKey: string;
+  sequence: number;
+}): WorkflowRunJobExecutionDetailDto | undefined {
+  return findListenerJob(params.runDetail, params.jobKey)?.job_executions.find(
+    (execution) => execution.sequence === params.sequence,
+  );
+}
+
+export async function waitForListenerExecution(params: {
+  token: string;
+  runId: string;
+  jobKey: string;
+  sequence: number;
+  status?: WorkflowRunJobExecutionDetailDto['status'] | undefined;
+  timeoutMs: number;
+}): Promise<WorkflowRunDetailResponseDto> {
+  return await waitForRunDetailMatching({
+    token: params.token,
+    runId: params.runId,
+    timeoutMs: params.timeoutMs,
+    description: `listener job ${params.jobKey} execution ${params.sequence}`,
+    matches: (runDetail) => {
+      if (params.status !== undefined) {
+        return listenerExecutionStatusMatches({
+          runDetail,
+          jobKey: params.jobKey,
+          sequence: params.sequence,
+          status: params.status,
+        });
+      }
+      return {
+        matched:
+          findListenerExecutionBySequence({
+            runDetail,
+            jobKey: params.jobKey,
+            sequence: params.sequence,
+          }) !== undefined,
+        diagnostic: `listener job ${params.jobKey} execution ${params.sequence} missing`,
+      };
+    },
+  });
+}
+
+export async function waitForListenerResolution(params: {
+  token: string;
+  runId: string;
+  jobKey: string;
+  status: JobStatusDto;
+  reason: ResolutionReasonDto;
+  timeoutMs: number;
+}): Promise<WorkflowRunDetailResponseDto> {
+  return await waitForRunDetailMatching({
+    token: params.token,
+    runId: params.runId,
+    timeoutMs: params.timeoutMs,
+    description: `listener job ${params.jobKey} resolution ${params.reason}`,
+    matches: (runDetail) => listenerResolutionMatches({...params, runDetail}),
+  });
+}
+
+export async function sendWebhookDeliveryUntilObserved(params: {
+  client: ReturnType<typeof createApiClient>;
+  connection: WebhookConnectionDto;
+  runId: string;
+  token: string;
+  jobKey: string;
+  deliveryIdPrefix: string;
+  maxAttempts?: number | undefined;
+  attemptTimeoutMs?: number | undefined;
+  body: (attempt: number, deliveryId: string) => unknown;
+}): Promise<{deliveryId: string; deliveryIds: string[]; runDetail: WorkflowRunDetailResponseDto}> {
+  const maxAttempts = params.maxAttempts ?? 8;
+  const attemptTimeoutMs = params.attemptTimeoutMs ?? 5_000;
+  const deliveryIds: string[] = [];
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const deliveryId = `${params.deliveryIdPrefix}-${attempt}`;
+    deliveryIds.push(deliveryId);
+    await postWebhookDelivery({
+      client: params.client,
+      connection: params.connection,
+      deliveryId,
+      webhook: {body: params.body(attempt, deliveryId)},
+    });
+
+    try {
+      const runDetail = await waitForRunDetailMatching({
+        token: params.token,
+        runId: params.runId,
+        timeoutMs: attemptTimeoutMs,
+        description: `listener delivery ${deliveryId}`,
+        matches: (candidate) =>
+          listenerDeliveryObserved({
+            runDetail: candidate,
+            jobKey: params.jobKey,
+            deliveryId,
+          }),
+      });
+      return {deliveryId, deliveryIds, runDetail};
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`Listener delivery was not observed after ${maxAttempts} attempts`);
+}

--- a/e2e/platform/workflows/src/polling.ts
+++ b/e2e/platform/workflows/src/polling.ts
@@ -1,0 +1,90 @@
+import {setTimeout as delay} from 'node:timers/promises';
+import type {DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
+import type {
+  WorkflowRunDetailResponseDto,
+  WorkflowRunListResponseDto,
+} from '@shipfox/api-workflows-dto';
+import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+
+export interface PollingOptions {
+  fetch?: ApiFetch | undefined;
+  projectId: string;
+  signal?: AbortSignal | undefined;
+  timeoutMs: number;
+  token: string;
+}
+
+export async function waitForDefinitionSyncTerminal(
+  options: PollingOptions,
+): Promise<DefinitionListResponseDto> {
+  const client = createApiClient({fetch: options.fetch, token: options.token});
+  const deadline = Date.now() + options.timeoutMs;
+  let lastResponse: DefinitionListResponseDto | null = null;
+
+  while (Date.now() <= deadline) {
+    options.signal?.throwIfAborted();
+    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
+    lastResponse = await client.requestJson<DefinitionListResponseDto>(
+      'get',
+      `/definitions?${params}`,
+      {signal: options.signal},
+    );
+
+    const status = lastResponse.sync?.status;
+    if (status === 'failed' || status === 'succeeded') return lastResponse;
+
+    await delay(250, undefined, {signal: options.signal});
+  }
+
+  const status = lastResponse?.sync?.status ?? 'null';
+  throw new Error(`Timed out waiting for definition sync to settle: syncStatus=${status}`);
+}
+
+export async function waitForNoWorkflowRuns(
+  options: PollingOptions,
+): Promise<WorkflowRunListResponseDto> {
+  const client = createApiClient({fetch: options.fetch, token: options.token});
+  const deadline = Date.now() + options.timeoutMs;
+  let lastResponse: WorkflowRunListResponseDto | null = null;
+
+  while (Date.now() <= deadline) {
+    options.signal?.throwIfAborted();
+    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
+    lastResponse = await client.requestJson<WorkflowRunListResponseDto>(
+      'get',
+      `/workflows/runs?${params}`,
+      {signal: options.signal},
+    );
+    if (lastResponse.runs.length > 0) return lastResponse;
+
+    await delay(250, undefined, {signal: options.signal});
+  }
+
+  return lastResponse ?? {runs: [], next_cursor: null, filtered_total_count: null};
+}
+
+export async function waitForRunDetailMatching(params: {
+  token: string;
+  runId: string;
+  timeoutMs: number;
+  description: string;
+  matches: (runDetail: WorkflowRunDetailResponseDto) => {matched: boolean; diagnostic: string};
+}): Promise<WorkflowRunDetailResponseDto> {
+  const client = createApiClient({token: params.token});
+  const deadline = Date.now() + params.timeoutMs;
+  let lastResponse: WorkflowRunDetailResponseDto | null = null;
+  let lastDiagnostic = 'no workflow run detail response observed';
+
+  while (Date.now() <= deadline) {
+    lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
+      'get',
+      `/workflows/runs/${encodeURIComponent(params.runId)}`,
+    );
+    const result = params.matches(lastResponse);
+    if (result.matched) return lastResponse;
+    lastDiagnostic = result.diagnostic;
+    await delay(250);
+  }
+
+  throw new Error(`Timed out waiting for ${params.description}: ${lastDiagnostic}`);
+}

--- a/e2e/platform/workflows/src/polling.ts
+++ b/e2e/platform/workflows/src/polling.ts
@@ -66,6 +66,7 @@ export async function waitForNoWorkflowRuns(
 export async function waitForRunDetailMatching(params: {
   token: string;
   runId: string;
+  signal?: AbortSignal | undefined;
   timeoutMs: number;
   description: string;
   matches: (runDetail: WorkflowRunDetailResponseDto) => {matched: boolean; diagnostic: string};
@@ -76,14 +77,16 @@ export async function waitForRunDetailMatching(params: {
   let lastDiagnostic = 'no workflow run detail response observed';
 
   while (Date.now() <= deadline) {
+    params.signal?.throwIfAborted();
     lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
       'get',
       `/workflows/runs/${encodeURIComponent(params.runId)}`,
+      {signal: params.signal},
     );
     const result = params.matches(lastResponse);
     if (result.matched) return lastResponse;
     lastDiagnostic = result.diagnostic;
-    await delay(250);
+    await delay(250, undefined, {signal: params.signal});
   }
 
   throw new Error(`Timed out waiting for ${params.description}: ${lastDiagnostic}`);

--- a/e2e/platform/workflows/src/run-scenario.ts
+++ b/e2e/platform/workflows/src/run-scenario.ts
@@ -1,51 +1,28 @@
-import {mkdir, readFile} from 'node:fs/promises';
-import {join} from 'node:path';
-import {setTimeout as delay} from 'node:timers/promises';
-import type {DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
-import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
-import type {
-  FireManualTriggerResponseDto,
-  TriggerEventDetailResponseDto,
-  TriggerEventListResponseDto,
-} from '@shipfox/api-triggers-dto';
-import type {WorkflowRunListResponseDto} from '@shipfox/api-workflows-dto';
-import {type ApiFetch, createApiClient, E2eApiError} from '@shipfox/e2e-core';
-import {waitForDefinition} from '@shipfox/e2e-helper-definitions';
-import {commitFiles, createRepo} from '@shipfox/e2e-helper-integrations-gitea';
+import {createApiClient} from '@shipfox/e2e-core';
 import {fetchStepLogs} from '@shipfox/e2e-helper-logs';
+import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-helper-runners';
+import type {Attachment} from './attachments.js';
 import {
-  type LocalRunnerExit,
-  type LocalRunnerHandle,
-  localRunnerLogTail,
-  mintManualRegistrationToken,
-  startLocalRunner,
-  stopLocalRunner,
-  waitForLocalRunnerExit,
-} from '@shipfox/e2e-helper-runners';
-import {
-  waitForRunByCommit,
-  waitForRunByDeliveryId,
-  waitForRunTerminal,
-} from '@shipfox/e2e-helper-workflows';
-import {createProject, giteaExternalRepositoryId} from './create-project.js';
+  attachLocalRunnerLog,
+  collectStepLogAttachmentRequests,
+  fetchLogAttachment,
+} from './attachments.js';
 import {evaluateExpectations, evaluateLogs, logText, type Mismatch} from './expect.js';
+import {waitForDefinitionSyncTerminal, waitForNoWorkflowRuns} from './polling.js';
 import {evaluateRejection} from './reject.js';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from './runner.js';
 import type {Scenario} from './scenarios.js';
-import {type SuiteContext, suiteRunDir} from './suite-context.js';
+import type {SuiteContext} from './suite-context.js';
+import {fireManualAndAwaitRun, triggerPushAndAwaitRun} from './triggers.js';
+import {
+  attachWebhookTriggerDiagnostics,
+  createWebhookConnection,
+  triggerWebhookAndAwaitRun,
+  type WebhookDiagnosticsRequest,
+} from './webhook.js';
+import {seedAndWaitForDefinition, seedWorkflowProject} from './workflow-project.js';
 
-const GITEA_SOURCE_PLACEHOLDER = '__GITEA_SOURCE__';
-const GITEA_REPOSITORY_PLACEHOLDER = '__GITEA_REPOSITORY__';
-const WEBHOOK_SOURCE_PLACEHOLDER = '__WEBHOOK_SOURCE__';
-const RUNNER_LABEL_PLACEHOLDER = '__RUNNER_LABEL__';
-const LOG_ATTACHMENT_NAME_PART_RE = /[^a-zA-Z0-9._-]+/g;
 const REJECTION_NO_RUN_TIMEOUT_MS = 15_000;
-const WEBHOOK_RECEIVED_EVENT = 'received';
-
-export interface Attachment {
-  name: string;
-  contentType: string;
-  body: string;
-}
 
 export interface RunScenarioParams {
   scenario: Scenario;
@@ -53,388 +30,6 @@ export interface RunScenarioParams {
   // Attaches a debugging artifact to the running test (a thin wrapper over
   // testInfo.attach), so the scenario driver stays free of Playwright types.
   attach: (attachment: Attachment) => Promise<void>;
-}
-
-interface StepLogAttachmentRequest {
-  path: string;
-  stepId: string;
-  attempt: number;
-}
-
-interface PollingOptions {
-  fetch?: ApiFetch | undefined;
-  projectId: string;
-  signal?: AbortSignal | undefined;
-  timeoutMs: number;
-  token: string;
-}
-
-interface WebhookDiagnosticsRequest {
-  deliveryIds: string[];
-  source: string;
-}
-
-function logAttachmentName(path: string): string {
-  return path.replaceAll(LOG_ATTACHMENT_NAME_PART_RE, '_').replace(/^_+|_+$/g, '');
-}
-
-function collectStepLogAttachmentRequests(
-  runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>,
-) {
-  const requests: StepLogAttachmentRequest[] = [];
-  for (const job of runDetail.jobs) {
-    for (const execution of job.job_executions) {
-      for (const step of execution.steps) {
-        requests.push({
-          path: `jobs.${job.key}.executions.${execution.sequence}.steps.${
-            step.key ?? logAttachmentName(step.name)
-          }`,
-          stepId: step.id,
-          attempt: step.current_attempt,
-        });
-      }
-    }
-  }
-  return requests;
-}
-
-async function fetchLogAttachment(
-  request: StepLogAttachmentRequest,
-  token: string,
-): Promise<Attachment> {
-  try {
-    const logs = await fetchStepLogs({
-      stepId: request.stepId,
-      attempt: request.attempt,
-      token,
-    });
-    return {
-      name: `logs-${logAttachmentName(request.path)}.ndjson`,
-      contentType: 'application/x-ndjson',
-      body: logs.ndjson,
-    };
-  } catch (error) {
-    return {
-      name: `logs-${logAttachmentName(request.path)}.error.txt`,
-      contentType: 'text/plain',
-      body: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
-
-async function attachLocalRunnerLog(
-  attach: RunScenarioParams['attach'],
-  runnerLogFile: string,
-): Promise<void> {
-  try {
-    await attach({
-      name: `runner-${logAttachmentName(runnerLogFile)}.log`,
-      contentType: 'text/plain',
-      body: await readFile(runnerLogFile, 'utf8'),
-    });
-  } catch (error) {
-    await attach({
-      name: `runner-${logAttachmentName(runnerLogFile)}.error.txt`,
-      contentType: 'text/plain',
-      body: error instanceof Error ? error.message : String(error),
-    }).catch(() => undefined);
-  }
-}
-
-function isFailedRunnerExit(exit: LocalRunnerExit): boolean {
-  return exit.code !== 0 || exit.signal !== null;
-}
-
-async function waitForRunTerminalOrFailedRunner(params: {
-  runId: string;
-  token: string;
-  timeoutMs: number;
-  runner: LocalRunnerHandle;
-}): ReturnType<typeof waitForRunTerminal> {
-  const runTerminal = waitForRunTerminal({
-    runId: params.runId,
-    token: params.token,
-    timeoutMs: params.timeoutMs,
-  });
-  const runnerExit = waitForLocalRunnerExit(params.runner);
-
-  const first = await Promise.race([
-    runTerminal.then((runDetail) => ({kind: 'run' as const, runDetail})),
-    runnerExit.then((exit) => ({kind: 'runner' as const, exit})),
-  ]);
-
-  if (first.kind === 'run') return first.runDetail;
-  if (!isFailedRunnerExit(first.exit)) return await runTerminal;
-
-  throw new Error(
-    `Local runner exited before workflow reached a terminal state (code ${first.exit.code}, signal ${first.exit.signal})${localRunnerLogTail(params.runner.logFile)}`,
-  );
-}
-
-async function waitForDefinitionSyncTerminal(
-  options: PollingOptions,
-): Promise<DefinitionListResponseDto> {
-  const client = createApiClient({fetch: options.fetch, token: options.token});
-  const deadline = Date.now() + options.timeoutMs;
-  let lastResponse: DefinitionListResponseDto | null = null;
-
-  while (Date.now() <= deadline) {
-    options.signal?.throwIfAborted();
-    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
-    lastResponse = await client.requestJson<DefinitionListResponseDto>(
-      'get',
-      `/definitions?${params}`,
-      {signal: options.signal},
-    );
-
-    const status = lastResponse.sync?.status;
-    if (status === 'failed' || status === 'succeeded') return lastResponse;
-
-    await delay(250, undefined, {signal: options.signal});
-  }
-
-  const status = lastResponse?.sync?.status ?? 'null';
-  throw new Error(`Timed out waiting for definition sync to settle: syncStatus=${status}`);
-}
-
-async function waitForNoWorkflowRuns(options: PollingOptions): Promise<WorkflowRunListResponseDto> {
-  const client = createApiClient({fetch: options.fetch, token: options.token});
-  const deadline = Date.now() + options.timeoutMs;
-  let lastResponse: WorkflowRunListResponseDto | null = null;
-
-  while (Date.now() <= deadline) {
-    options.signal?.throwIfAborted();
-    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
-    lastResponse = await client.requestJson<WorkflowRunListResponseDto>(
-      'get',
-      `/workflows/runs?${params}`,
-      {signal: options.signal},
-    );
-    if (lastResponse.runs.length > 0) return lastResponse;
-
-    await delay(250, undefined, {signal: options.signal});
-  }
-
-  return lastResponse ?? {runs: [], next_cursor: null, filtered_total_count: null};
-}
-
-// Definition sync creates trigger subscriptions asynchronously, so a push can reach
-// dispatch before a subscription exists. Each retry needs a fresh head SHA for correlation.
-async function triggerPushAndAwaitRun(params: {
-  org: string;
-  repo: string;
-  scenario: string;
-  uniqueId: string;
-  message?: string | undefined;
-  projectId: string;
-  token: string;
-}): Promise<string> {
-  const maxAttempts = 8;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const triggerSha = await commitFiles({
-      org: params.org,
-      repo: params.repo,
-      message: params.message ?? `trigger ${params.scenario} ${params.uniqueId} #${attempt}`,
-      files: [
-        {
-          path: `.shipfox-e2e-trigger-${attempt}`,
-          content: `${params.scenario} ${params.uniqueId} ${attempt}\n`,
-        },
-      ],
-    });
-    try {
-      const run = await waitForRunByCommit({
-        projectId: params.projectId,
-        headCommitSha: triggerSha,
-        token: params.token,
-        timeoutMs: 15_000,
-      });
-      return run.id;
-    } catch (error) {
-      lastError = error;
-    }
-  }
-  throw lastError instanceof Error
-    ? lastError
-    : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} trigger pushes`);
-}
-
-async function createWebhookConnection(params: {
-  client: ReturnType<typeof createApiClient>;
-  scenario: string;
-  slug: string;
-  uniqueId: string;
-  workspaceId: string;
-}): Promise<WebhookConnectionDto> {
-  return await params.client.requestJson<WebhookConnectionDto>(
-    'post',
-    '/integrations/webhook/connections',
-    {
-      json: {
-        workspace_id: params.workspaceId,
-        name: `E2E ${params.scenario} ${params.uniqueId}`,
-        slug: params.slug,
-      },
-    },
-  );
-}
-
-function webhookUrlWithQuery(
-  inboundUrl: string,
-  query: Record<string, string> | undefined,
-): string {
-  const url = new URL(inboundUrl);
-  for (const [key, value] of Object.entries(query ?? {})) {
-    url.searchParams.set(key, value);
-  }
-  return url.toString();
-}
-
-function webhookHeaders(
-  configuredHeaders: Record<string, string> | undefined,
-  deliveryId: string,
-): Headers {
-  const headers = new Headers(configuredHeaders);
-  headers.set('x-delivery-id', deliveryId);
-  return headers;
-}
-
-async function attachWebhookTriggerDiagnostics(params: {
-  attach: RunScenarioParams['attach'];
-  client: ReturnType<typeof createApiClient>;
-  deliveryIds: string[];
-  source: string;
-  workspaceId: string;
-}): Promise<void> {
-  try {
-    const search = new URLSearchParams({
-      workspace_id: params.workspaceId,
-      source: params.source,
-      event: WEBHOOK_RECEIVED_EVENT,
-      limit: '50',
-    });
-    const events = await params.client.requestJson<TriggerEventListResponseDto>(
-      'get',
-      `/trigger-events?${search}`,
-    );
-    await params.attach({
-      name: 'webhook-trigger-events.json',
-      contentType: 'application/json',
-      body: JSON.stringify(events, null, 2),
-    });
-
-    const deliveryIds = new Set(params.deliveryIds);
-    for (const event of events.trigger_events) {
-      if (!event.delivery_id || !deliveryIds.has(event.delivery_id)) continue;
-      const detail = await params.client.requestJson<TriggerEventDetailResponseDto>(
-        'get',
-        `/trigger-events/${event.id}`,
-      );
-      await params.attach({
-        name: `webhook-trigger-event-${logAttachmentName(event.delivery_id)}.json`,
-        contentType: 'application/json',
-        body: JSON.stringify(detail, null, 2),
-      });
-    }
-  } catch (error) {
-    await params
-      .attach({
-        name: 'webhook-trigger-events.error.txt',
-        contentType: 'text/plain',
-        body: error instanceof Error ? error.message : String(error),
-      })
-      .catch(() => undefined);
-  }
-}
-
-async function triggerWebhookAndAwaitRun(params: {
-  attach: RunScenarioParams['attach'];
-  client: ReturnType<typeof createApiClient>;
-  connection: WebhookConnectionDto;
-  projectId: string;
-  scenario: string;
-  token: string;
-  webhook:
-    | {
-        body?: unknown;
-        headers?: Record<string, string> | undefined;
-        query?: Record<string, string> | undefined;
-      }
-    | undefined;
-  workspaceId: string;
-}): Promise<{deliveryIds: string[]; runId: string}> {
-  const maxAttempts = 8;
-  const deliveryIds: string[] = [];
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const deliveryId = crypto.randomUUID();
-    deliveryIds.push(deliveryId);
-    await params.client.requestJson<{delivery_id: string}>(
-      'post',
-      webhookUrlWithQuery(params.connection.inbound_url, params.webhook?.query),
-      {
-        headers: webhookHeaders(params.webhook?.headers, deliveryId),
-        json: params.webhook?.body ?? {
-          scenario: params.scenario,
-          attempt,
-          delivery_id: deliveryId,
-        },
-      },
-    );
-
-    try {
-      const run = await waitForRunByDeliveryId({
-        projectId: params.projectId,
-        deliveryId,
-        token: params.token,
-        timeoutMs: 15_000,
-      });
-      return {deliveryIds, runId: run.id};
-    } catch (error) {
-      lastError = error;
-    }
-  }
-
-  await attachWebhookTriggerDiagnostics({
-    attach: params.attach,
-    client: params.client,
-    deliveryIds,
-    source: params.connection.slug,
-    workspaceId: params.workspaceId,
-  });
-  throw lastError instanceof Error
-    ? lastError
-    : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} webhook deliveries`);
-}
-
-async function fireManualAndAwaitRun(params: {
-  client: ReturnType<typeof createApiClient>;
-  definitionId: string;
-  inputs: Record<string, unknown>;
-  scenario: string;
-}): Promise<string> {
-  const maxAttempts = 8;
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await params.client.requestJson<FireManualTriggerResponseDto>(
-        'post',
-        `/workflow-definitions/${params.definitionId}/fire-manual`,
-        {json: {inputs: params.inputs}},
-      );
-      return response.workflow_run_id;
-    } catch (error) {
-      if (!(error instanceof E2eApiError) || error.status !== 404) throw error;
-      lastError = error;
-      await delay(500);
-    }
-  }
-  throw lastError instanceof Error
-    ? lastError
-    : new Error(
-        `Manual trigger for ${params.scenario} was not ready after ${maxAttempts} attempts`,
-      );
 }
 
 /**
@@ -452,11 +47,6 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
   const runnerLabel = `e2e-${scenario.name}-${uniqueId}`;
   const repo = `${scenario.name}-${uniqueId}`;
   const webhookSlug = `webhook-${scenario.name}-${uniqueId}`;
-  const workflowYaml = scenario.workflowYaml
-    .replaceAll(GITEA_SOURCE_PLACEHOLDER, suite.connectionSlug)
-    .replaceAll(GITEA_REPOSITORY_PLACEHOLDER, `${suite.org}/${repo}`)
-    .replaceAll(WEBHOOK_SOURCE_PLACEHOLDER, webhookSlug)
-    .replaceAll(RUNNER_LABEL_PLACEHOLDER, runnerLabel);
 
   let runner: LocalRunnerHandle | undefined;
   let runnerLogFile: string | undefined;
@@ -474,25 +64,35 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
           })
         : undefined;
 
-    await createRepo({org: suite.org, name: repo});
-    // Project binding starts a definition sync, so the repo must already contain the workflow.
-    await commitFiles({
-      org: suite.org,
-      repo,
-      message: `seed ${scenario.name}`,
-      files: [
-        {path: scenario.configPath, content: workflowYaml},
-        ...scenario.extraFiles.map((file) => ({path: file.path, content: file.content})),
-      ],
-    });
-
-    const project = await createProject({
-      workspaceId: suite.workspaceId,
-      sessionToken: token,
-      name: repo,
-      connectionId: suite.connectionId,
-      externalRepositoryId: giteaExternalRepositoryId(suite.org, repo),
-    });
+    let definition: Awaited<ReturnType<typeof seedAndWaitForDefinition>>['definition'] | undefined;
+    const seeded =
+      scenario.kind === 'reject'
+        ? await seedWorkflowProject({
+            suite,
+            token,
+            name: scenario.name,
+            repo,
+            runnerLabel,
+            workflowYaml: scenario.workflowYaml,
+            configPath: scenario.configPath,
+            webhookSlug,
+            extraFiles: scenario.extraFiles,
+          })
+        : await seedAndWaitForDefinition({
+            suite,
+            token,
+            name: scenario.name,
+            repo,
+            runnerLabel,
+            workflowYaml: scenario.workflowYaml,
+            configPath: scenario.configPath,
+            webhookSlug,
+            extraFiles: scenario.extraFiles,
+          }).then((ready) => {
+            definition = ready.definition;
+            return ready;
+          });
+    const {project} = seeded;
 
     if (scenario.kind === 'reject') {
       const definitions = await waitForDefinitionSyncTerminal({
@@ -531,29 +131,18 @@ export async function runScenario(params: RunScenarioParams): Promise<Mismatch[]
       return mismatches;
     }
 
-    const definition = await waitForDefinition({
-      projectId: project.id,
-      configPath: scenario.configPath,
-      token,
-    });
+    if (definition === undefined) {
+      throw new Error(`Definition missing for ${scenario.name}`);
+    }
 
-    const registrationToken = await mintManualRegistrationToken({
+    const localRunner = await startSuiteLocalRunner({
       workspaceId: suite.workspaceId,
       userToken: token,
       name: `E2E ${scenario.name} ${uniqueId}`,
-      ttlSeconds: 3600,
+      runnerLabel,
     });
-    const runDir = suiteRunDir();
-    const runnerLogDir = join(runDir, 'runners');
-    runnerLogFile = join(runnerLogDir, `${runnerLabel}.log`);
-    await mkdir(runnerLogDir, {recursive: true});
-    runner = startLocalRunner({
-      workspaceId: suite.workspaceId,
-      registrationToken: registrationToken.raw_token,
-      labels: [runnerLabel],
-      logFile: runnerLogFile,
-      workspaceRoot: join(runDir, 'runner-workspaces', runnerLabel),
-    });
+    runner = localRunner.runner;
+    runnerLogFile = localRunner.logFile;
 
     let runId: string;
     if (scenario.expectation.trigger === 'manual') {

--- a/e2e/platform/workflows/src/runner.ts
+++ b/e2e/platform/workflows/src/runner.ts
@@ -1,0 +1,70 @@
+import {mkdir} from 'node:fs/promises';
+import {join} from 'node:path';
+import {
+  type LocalRunnerExit,
+  type LocalRunnerHandle,
+  localRunnerLogTail,
+  mintManualRegistrationToken,
+  startLocalRunner,
+  waitForLocalRunnerExit,
+} from '@shipfox/e2e-helper-runners';
+import {waitForRunTerminal} from '@shipfox/e2e-helper-workflows';
+import {suiteRunDir} from './suite-context.js';
+
+function isFailedRunnerExit(exit: LocalRunnerExit): boolean {
+  return exit.code !== 0 || exit.signal !== null;
+}
+
+export async function startSuiteLocalRunner(params: {
+  workspaceId: string;
+  userToken: string;
+  name: string;
+  runnerLabel: string;
+}): Promise<{runner: LocalRunnerHandle; logFile: string}> {
+  const registrationToken = await mintManualRegistrationToken({
+    workspaceId: params.workspaceId,
+    userToken: params.userToken,
+    name: params.name,
+    ttlSeconds: 3600,
+  });
+  const runDir = suiteRunDir();
+  const runnerLogDir = join(runDir, 'runners');
+  const logFile = join(runnerLogDir, `${params.runnerLabel}.log`);
+  await mkdir(runnerLogDir, {recursive: true});
+  return {
+    runner: startLocalRunner({
+      workspaceId: params.workspaceId,
+      registrationToken: registrationToken.raw_token,
+      labels: [params.runnerLabel],
+      logFile,
+      workspaceRoot: join(runDir, 'runner-workspaces', params.runnerLabel),
+    }),
+    logFile,
+  };
+}
+
+export async function waitForRunTerminalOrFailedRunner(params: {
+  runId: string;
+  token: string;
+  timeoutMs: number;
+  runner: LocalRunnerHandle;
+}): ReturnType<typeof waitForRunTerminal> {
+  const runTerminal = waitForRunTerminal({
+    runId: params.runId,
+    token: params.token,
+    timeoutMs: params.timeoutMs,
+  });
+  const runnerExit = waitForLocalRunnerExit(params.runner);
+
+  const first = await Promise.race([
+    runTerminal.then((runDetail) => ({kind: 'run' as const, runDetail})),
+    runnerExit.then((exit) => ({kind: 'runner' as const, exit})),
+  ]);
+
+  if (first.kind === 'run') return first.runDetail;
+  if (!isFailedRunnerExit(first.exit)) return await runTerminal;
+
+  throw new Error(
+    `Local runner exited before workflow reached a terminal state (code ${first.exit.code}, signal ${first.exit.signal})${localRunnerLogTail(params.runner.logFile)}`,
+  );
+}

--- a/e2e/platform/workflows/src/triggers.ts
+++ b/e2e/platform/workflows/src/triggers.ts
@@ -1,0 +1,74 @@
+import {setTimeout as delay} from 'node:timers/promises';
+import type {FireManualTriggerResponseDto} from '@shipfox/api-triggers-dto';
+import {type createApiClient, E2eApiError} from '@shipfox/e2e-core';
+import {commitFiles} from '@shipfox/e2e-helper-integrations-gitea';
+import {waitForRunByCommit} from '@shipfox/e2e-helper-workflows';
+
+export async function triggerPushAndAwaitRun(params: {
+  org: string;
+  repo: string;
+  scenario: string;
+  uniqueId: string;
+  message?: string | undefined;
+  projectId: string;
+  token: string;
+}): Promise<string> {
+  const maxAttempts = 8;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const triggerSha = await commitFiles({
+      org: params.org,
+      repo: params.repo,
+      message: params.message ?? `trigger ${params.scenario} ${params.uniqueId} #${attempt}`,
+      files: [
+        {
+          path: `.shipfox-e2e-trigger-${attempt}`,
+          content: `${params.scenario} ${params.uniqueId} ${attempt}\n`,
+        },
+      ],
+    });
+    try {
+      const run = await waitForRunByCommit({
+        projectId: params.projectId,
+        headCommitSha: triggerSha,
+        token: params.token,
+        timeoutMs: 15_000,
+      });
+      return run.id;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} trigger pushes`);
+}
+
+export async function fireManualAndAwaitRun(params: {
+  client: ReturnType<typeof createApiClient>;
+  definitionId: string;
+  inputs: Record<string, unknown>;
+  scenario: string;
+}): Promise<string> {
+  const maxAttempts = 8;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const response = await params.client.requestJson<FireManualTriggerResponseDto>(
+        'post',
+        `/workflow-definitions/${params.definitionId}/fire-manual`,
+        {json: {inputs: params.inputs}},
+      );
+      return response.workflow_run_id;
+    } catch (error) {
+      if (!(error instanceof E2eApiError) || error.status !== 404) throw error;
+      lastError = error;
+      await delay(500);
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(
+        `Manual trigger for ${params.scenario} was not ready after ${maxAttempts} attempts`,
+      );
+}

--- a/e2e/platform/workflows/src/webhook.ts
+++ b/e2e/platform/workflows/src/webhook.ts
@@ -1,0 +1,182 @@
+import type {WebhookConnectionDto} from '@shipfox/api-integration-webhook-dto';
+import type {
+  TriggerEventDetailResponseDto,
+  TriggerEventListResponseDto,
+} from '@shipfox/api-triggers-dto';
+import type {createApiClient} from '@shipfox/e2e-core';
+import {waitForRunByDeliveryId} from '@shipfox/e2e-helper-workflows';
+import type {AttachFn} from './attachments.js';
+import {logAttachmentName} from './attachments.js';
+
+const WEBHOOK_RECEIVED_EVENT = 'received';
+
+export interface WebhookDiagnosticsRequest {
+  deliveryIds: string[];
+  source: string;
+}
+
+export async function createWebhookConnection(params: {
+  client: ReturnType<typeof createApiClient>;
+  scenario: string;
+  slug: string;
+  uniqueId: string;
+  workspaceId: string;
+}): Promise<WebhookConnectionDto> {
+  return await params.client.requestJson<WebhookConnectionDto>(
+    'post',
+    '/integrations/webhook/connections',
+    {
+      json: {
+        workspace_id: params.workspaceId,
+        name: `E2E ${params.scenario} ${params.uniqueId}`,
+        slug: params.slug,
+      },
+    },
+  );
+}
+
+export function webhookUrlWithQuery(
+  inboundUrl: string,
+  query: Record<string, string> | undefined,
+): string {
+  const url = new URL(inboundUrl);
+  for (const [key, value] of Object.entries(query ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+export function webhookHeaders(
+  configuredHeaders: Record<string, string> | undefined,
+  deliveryId: string,
+): Headers {
+  const headers = new Headers(configuredHeaders);
+  headers.set('x-delivery-id', deliveryId);
+  return headers;
+}
+
+export async function postWebhookDelivery(params: {
+  client: ReturnType<typeof createApiClient>;
+  connection: WebhookConnectionDto;
+  deliveryId: string;
+  webhook:
+    | {
+        body?: unknown;
+        headers?: Record<string, string> | undefined;
+        query?: Record<string, string> | undefined;
+      }
+    | undefined;
+}): Promise<void> {
+  await params.client.requestJson<{delivery_id: string}>(
+    'post',
+    webhookUrlWithQuery(params.connection.inbound_url, params.webhook?.query),
+    {
+      headers: webhookHeaders(params.webhook?.headers, params.deliveryId),
+      json: params.webhook?.body ?? {delivery_id: params.deliveryId},
+    },
+  );
+}
+
+export async function attachWebhookTriggerDiagnostics(params: {
+  attach: AttachFn;
+  client: ReturnType<typeof createApiClient>;
+  deliveryIds: string[];
+  source: string;
+  workspaceId: string;
+}): Promise<void> {
+  try {
+    const search = new URLSearchParams({
+      workspace_id: params.workspaceId,
+      source: params.source,
+      event: WEBHOOK_RECEIVED_EVENT,
+      limit: '50',
+    });
+    const events = await params.client.requestJson<TriggerEventListResponseDto>(
+      'get',
+      `/trigger-events?${search}`,
+    );
+    await params.attach({
+      name: `webhook-trigger-events-${logAttachmentName(params.source)}.json`,
+      contentType: 'application/json',
+      body: JSON.stringify(events, null, 2),
+    });
+
+    const deliveryIds = new Set(params.deliveryIds);
+    for (const event of events.trigger_events) {
+      if (!event.delivery_id || !deliveryIds.has(event.delivery_id)) continue;
+      const detail = await params.client.requestJson<TriggerEventDetailResponseDto>(
+        'get',
+        `/trigger-events/${event.id}`,
+      );
+      await params.attach({
+        name: `webhook-trigger-event-${logAttachmentName(event.delivery_id)}.json`,
+        contentType: 'application/json',
+        body: JSON.stringify(detail, null, 2),
+      });
+    }
+  } catch (error) {
+    await params
+      .attach({
+        name: `webhook-trigger-events-${logAttachmentName(params.source)}.error.txt`,
+        contentType: 'text/plain',
+        body: error instanceof Error ? error.message : String(error),
+      })
+      .catch(() => undefined);
+  }
+}
+
+export async function triggerWebhookAndAwaitRun(params: {
+  attach: AttachFn;
+  client: ReturnType<typeof createApiClient>;
+  connection: WebhookConnectionDto;
+  projectId: string;
+  scenario: string;
+  token: string;
+  webhook:
+    | {
+        body?: unknown;
+        headers?: Record<string, string> | undefined;
+        query?: Record<string, string> | undefined;
+      }
+    | undefined;
+  workspaceId: string;
+}): Promise<{deliveryIds: string[]; runId: string}> {
+  const maxAttempts = 8;
+  const deliveryIds: string[] = [];
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const deliveryId = crypto.randomUUID();
+    deliveryIds.push(deliveryId);
+    await postWebhookDelivery({
+      client: params.client,
+      connection: params.connection,
+      deliveryId,
+      webhook: params.webhook ?? {
+        body: {scenario: params.scenario, attempt, delivery_id: deliveryId},
+      },
+    });
+
+    try {
+      const run = await waitForRunByDeliveryId({
+        projectId: params.projectId,
+        deliveryId,
+        token: params.token,
+        timeoutMs: 15_000,
+      });
+      return {deliveryIds, runId: run.id};
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  await attachWebhookTriggerDiagnostics({
+    attach: params.attach,
+    client: params.client,
+    deliveryIds,
+    source: params.connection.slug,
+    workspaceId: params.workspaceId,
+  });
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(`No run appeared for ${params.scenario} after ${maxAttempts} webhook deliveries`);
+}

--- a/e2e/platform/workflows/src/webhook.ts
+++ b/e2e/platform/workflows/src/webhook.ts
@@ -151,8 +151,13 @@ export async function triggerWebhookAndAwaitRun(params: {
       client: params.client,
       connection: params.connection,
       deliveryId,
-      webhook: params.webhook ?? {
-        body: {scenario: params.scenario, attempt, delivery_id: deliveryId},
+      webhook: {
+        ...params.webhook,
+        body: params.webhook?.body ?? {
+          scenario: params.scenario,
+          attempt,
+          delivery_id: deliveryId,
+        },
       },
     });
 

--- a/e2e/platform/workflows/src/workflow-project.ts
+++ b/e2e/platform/workflows/src/workflow-project.ts
@@ -1,0 +1,93 @@
+import type {DefinitionResponseDto} from '@shipfox/api-definitions-dto';
+import type {ProjectResponseDto} from '@shipfox/api-projects-dto';
+import {waitForDefinition} from '@shipfox/e2e-helper-definitions';
+import {commitFiles, createRepo} from '@shipfox/e2e-helper-integrations-gitea';
+import {createProject, giteaExternalRepositoryId} from './create-project.js';
+import type {SuiteContext} from './suite-context.js';
+
+const GITEA_SOURCE_PLACEHOLDER = '__GITEA_SOURCE__';
+const GITEA_REPOSITORY_PLACEHOLDER = '__GITEA_REPOSITORY__';
+const WEBHOOK_SOURCE_PLACEHOLDER = '__WEBHOOK_SOURCE__';
+const RUNNER_LABEL_PLACEHOLDER = '__RUNNER_LABEL__';
+
+export interface WorkflowProjectFile {
+  path: string;
+  content: string;
+}
+
+export interface SeededWorkflowProject {
+  project: ProjectResponseDto;
+  repo: string;
+  renderedWorkflowYaml: string;
+}
+
+export interface ReadyWorkflowProject extends SeededWorkflowProject {
+  definition: DefinitionResponseDto;
+}
+
+export function renderWorkflowYaml(params: {
+  suite: SuiteContext;
+  repo: string;
+  runnerLabel: string;
+  webhookSlug?: string | undefined;
+  workflowYaml: string;
+  replacements?: Record<string, string> | undefined;
+}): string {
+  let rendered = params.workflowYaml
+    .replaceAll(GITEA_SOURCE_PLACEHOLDER, params.suite.connectionSlug)
+    .replaceAll(GITEA_REPOSITORY_PLACEHOLDER, `${params.suite.org}/${params.repo}`)
+    .replaceAll(RUNNER_LABEL_PLACEHOLDER, params.runnerLabel);
+  if (params.webhookSlug !== undefined) {
+    rendered = rendered.replaceAll(WEBHOOK_SOURCE_PLACEHOLDER, params.webhookSlug);
+  }
+  for (const [placeholder, value] of Object.entries(params.replacements ?? {})) {
+    rendered = rendered.replaceAll(placeholder, value);
+  }
+  return rendered;
+}
+
+export async function seedWorkflowProject(params: {
+  suite: SuiteContext;
+  token: string;
+  name: string;
+  repo: string;
+  runnerLabel: string;
+  workflowYaml: string;
+  configPath: string;
+  webhookSlug?: string | undefined;
+  replacements?: Record<string, string> | undefined;
+  extraFiles?: WorkflowProjectFile[] | undefined;
+}): Promise<SeededWorkflowProject> {
+  const renderedWorkflowYaml = renderWorkflowYaml(params);
+
+  await createRepo({org: params.suite.org, name: params.repo});
+  await commitFiles({
+    org: params.suite.org,
+    repo: params.repo,
+    message: `seed ${params.name}`,
+    files: [
+      {path: params.configPath, content: renderedWorkflowYaml},
+      ...(params.extraFiles ?? []).map((file) => ({path: file.path, content: file.content})),
+    ],
+  });
+
+  const project = await createProject({
+    workspaceId: params.suite.workspaceId,
+    sessionToken: params.token,
+    name: params.repo,
+    connectionId: params.suite.connectionId,
+    externalRepositoryId: giteaExternalRepositoryId(params.suite.org, params.repo),
+  });
+
+  return {project, repo: params.repo, renderedWorkflowYaml};
+}
+
+export async function seedAndWaitForDefinition(params: Parameters<typeof seedWorkflowProject>[0]) {
+  const seeded = await seedWorkflowProject(params);
+  const definition = await waitForDefinition({
+    projectId: seeded.project.id,
+    configPath: params.configPath,
+    token: params.token,
+  });
+  return {...seeded, definition};
+}

--- a/e2e/platform/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/platform/workflows/tests/listener-jobs.e2e.ts
@@ -11,6 +11,7 @@ import {
 import {logText} from '#expect.js';
 import {
   batchedListenerExecutionMatches,
+  findListenerExecutionByDeliveryId,
   findListenerExecutionBySequence,
   sendWebhookDeliveryUntilObserved,
   waitForListenerExecution,
@@ -192,6 +193,7 @@ async function sendFire(testCase: ListenerCase, runId: string, label: string, me
     token: testCase.token,
     jobKey: LISTENER_JOB,
     deliveryIdPrefix: `${testCase.uniqueId}-${label}`,
+    attemptTimeoutMs: 15_000,
     body: (_attempt, deliveryId) => ({message, delivery_id: deliveryId}),
   });
   testCase.fireDiagnostics.deliveryIds.push(...result.deliveryIds);
@@ -384,7 +386,9 @@ jobs:
 `;
 
 test.describe('listener jobs', () => {
-  test('fires on webhook events and resolves on an until event', async ({suite}, testInfo) => {
+  test('creates multiple executions before resolving on an until event', async ({
+    suite,
+  }, testInfo) => {
     let testCase: (ListenerCase & {definitionId: string}) | undefined;
     let runId: string | undefined;
     try {
@@ -400,7 +404,8 @@ test.describe('listener jobs', () => {
       });
       runId = await fireManualRun(testCase);
 
-      const fire = await sendFire(testCase, runId, 'fire', 'hello-listener');
+      const firstFire = await sendFire(testCase, runId, 'fire-one', 'hello-listener');
+      const secondFire = await sendFire(testCase, runId, 'fire-two', 'hello-again');
       const resolveDeliveryId = await sendResolve(testCase, 'resolve');
       const resolved = await waitForListenerResolution({
         token: testCase.token,
@@ -419,11 +424,31 @@ test.describe('listener jobs', () => {
 
       const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
       const deploy = terminal.jobs.find((job) => job.key === 'deploy');
-      const logs = await stepLogText({
+      const firstExecution = findListenerExecutionByDeliveryId({
+        runDetail: terminal,
+        jobKey: LISTENER_JOB,
+        deliveryId: firstFire.deliveryId,
+      });
+      const secondExecution = findListenerExecutionByDeliveryId({
+        runDetail: terminal,
+        jobKey: LISTENER_JOB,
+        deliveryId: secondFire.deliveryId,
+      });
+      if (!firstExecution || !secondExecution) {
+        throw new Error('Expected both listener fire deliveries to create executions');
+      }
+      const firstLogs = await stepLogText({
         runDetail: terminal,
         token: testCase.token,
         jobKey: LISTENER_JOB,
-        sequence: 1,
+        sequence: firstExecution.sequence,
+        stepKey: 'show-event',
+      });
+      const secondLogs = await stepLogText({
+        runDetail: terminal,
+        token: testCase.token,
+        jobKey: LISTENER_JOB,
+        sequence: secondExecution.sequence,
         stepKey: 'show-event',
       });
       expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
@@ -431,10 +456,13 @@ test.describe('listener jobs', () => {
       );
       expect(terminal.status).toBe('succeeded');
       expect(listen?.listener_status).toBe('resolved');
-      expect(listen?.job_executions[0]?.trigger_events[0]?.delivery_id).toBe(fire.deliveryId);
+      expect(listen?.job_executions.length).toBeGreaterThanOrEqual(2);
+      expect(firstExecution.sequence).not.toBe(secondExecution.sequence);
       expect(deploy?.status).toBe('succeeded');
-      expect(logs).toContain('listener_message=hello-listener');
-      expect(logs).toContain(`listener_delivery=${fire.deliveryId}`);
+      expect(firstLogs).toContain('listener_message=hello-listener');
+      expect(firstLogs).toContain(`listener_delivery=${firstFire.deliveryId}`);
+      expect(secondLogs).toContain('listener_message=hello-again');
+      expect(secondLogs).toContain(`listener_delivery=${secondFire.deliveryId}`);
       expect(resolveDeliveryId).toContain('resolve');
     } catch (error) {
       await cleanupListenerCase(testCase, runId);

--- a/e2e/platform/workflows/tests/listener-jobs.e2e.ts
+++ b/e2e/platform/workflows/tests/listener-jobs.e2e.ts
@@ -1,0 +1,599 @@
+import {createApiClient} from '@shipfox/e2e-core';
+import {fetchStepLogs} from '@shipfox/e2e-helper-logs';
+import {type LocalRunnerHandle, stopLocalRunner} from '@shipfox/e2e-helper-runners';
+import type {waitForRunTerminal} from '@shipfox/e2e-helper-workflows';
+import {
+  type AttachFn,
+  attachLocalRunnerLog,
+  collectStepLogAttachmentRequests,
+  fetchLogAttachment,
+} from '#attachments.js';
+import {logText} from '#expect.js';
+import {
+  batchedListenerExecutionMatches,
+  findListenerExecutionBySequence,
+  sendWebhookDeliveryUntilObserved,
+  waitForListenerExecution,
+  waitForListenerResolution,
+} from '#listener-helpers.js';
+import {waitForRunDetailMatching} from '#polling.js';
+import {startSuiteLocalRunner, waitForRunTerminalOrFailedRunner} from '#runner.js';
+import type {SuiteContext} from '#suite-context.js';
+import {fireManualAndAwaitRun} from '#triggers.js';
+import {
+  attachWebhookTriggerDiagnostics,
+  createWebhookConnection,
+  postWebhookDelivery,
+  type WebhookDiagnosticsRequest,
+} from '#webhook.js';
+import {seedAndWaitForDefinition} from '#workflow-project.js';
+import {expect, test} from './fixtures.js';
+
+const LISTENER_JOB = 'listen';
+const FIRE_SOURCE_PLACEHOLDER = '__FIRE_WEBHOOK_SOURCE__';
+const RESOLVE_SOURCE_PLACEHOLDER = '__RESOLVE_WEBHOOK_SOURCE__';
+
+interface ListenerCase {
+  attach: AttachFn;
+  client: ReturnType<typeof createApiClient>;
+  fireConnection: Awaited<ReturnType<typeof createWebhookConnection>>;
+  fireDiagnostics: WebhookDiagnosticsRequest;
+  resolveConnection: Awaited<ReturnType<typeof createWebhookConnection>>;
+  resolveDiagnostics: WebhookDiagnosticsRequest;
+  repo: string;
+  runner: LocalRunnerHandle;
+  runnerLogFile: string;
+  runnerLabel: string;
+  token: string;
+  uniqueId: string;
+  workspaceId: string;
+}
+
+async function attachRunDetail(params: {
+  attach: AttachFn;
+  runId: string | undefined;
+  token: string;
+}): Promise<void> {
+  if (params.runId === undefined) return;
+  try {
+    const client = createApiClient({token: params.token});
+    const runDetail = await client.requestJson<Awaited<ReturnType<typeof waitForRunTerminal>>>(
+      'get',
+      `/workflows/runs/${encodeURIComponent(params.runId)}`,
+    );
+    await params.attach({
+      name: 'run-detail.json',
+      contentType: 'application/json',
+      body: JSON.stringify(runDetail, null, 2),
+    });
+    for (const request of collectStepLogAttachmentRequests(runDetail)) {
+      await params.attach(await fetchLogAttachment(request, params.token));
+    }
+  } catch (error) {
+    await params.attach({
+      name: 'run-detail.error.txt',
+      contentType: 'text/plain',
+      body: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function setupListenerCase(params: {
+  suite: SuiteContext;
+  testName: string;
+  workflowYaml: string;
+  attach: AttachFn;
+}): Promise<ListenerCase & {definitionId: string}> {
+  const token = params.suite.sessionToken;
+  const client = createApiClient({token});
+  const uniqueId = crypto.randomUUID().replaceAll('-', '').slice(0, 10);
+  const runnerLabel = `e2e-listener-${params.testName}-${uniqueId}`;
+  const repo = `listener-${params.testName}-${uniqueId}`;
+  const fireSlug = `listener-fire-${params.testName}-${uniqueId}`;
+  const resolveSlug = `listener-resolve-${params.testName}-${uniqueId}`;
+
+  const [fireConnection, resolveConnection] = await Promise.all([
+    createWebhookConnection({
+      client,
+      scenario: params.testName,
+      slug: fireSlug,
+      uniqueId,
+      workspaceId: params.suite.workspaceId,
+    }),
+    createWebhookConnection({
+      client,
+      scenario: params.testName,
+      slug: resolveSlug,
+      uniqueId,
+      workspaceId: params.suite.workspaceId,
+    }),
+  ]);
+
+  const {definition} = await seedAndWaitForDefinition({
+    suite: params.suite,
+    token,
+    name: params.testName,
+    repo,
+    runnerLabel,
+    workflowYaml: params.workflowYaml,
+    configPath: `.shipfox/workflows/${params.testName}.yml`,
+    replacements: {
+      [FIRE_SOURCE_PLACEHOLDER]: fireSlug,
+      [RESOLVE_SOURCE_PLACEHOLDER]: resolveSlug,
+    },
+  });
+
+  const localRunner = await startSuiteLocalRunner({
+    workspaceId: params.suite.workspaceId,
+    userToken: token,
+    name: `E2E listener ${params.testName} ${uniqueId}`,
+    runnerLabel,
+  });
+
+  return {
+    attach: params.attach,
+    client,
+    definitionId: definition.id,
+    fireConnection,
+    fireDiagnostics: {deliveryIds: [], source: fireSlug},
+    repo,
+    resolveConnection,
+    resolveDiagnostics: {deliveryIds: [], source: resolveSlug},
+    runner: localRunner.runner,
+    runnerLabel,
+    runnerLogFile: localRunner.logFile,
+    token,
+    uniqueId,
+    workspaceId: params.suite.workspaceId,
+  };
+}
+
+async function cleanupListenerCase(testCase: ListenerCase | undefined, runId: string | undefined) {
+  if (testCase === undefined) return;
+  await attachRunDetail({attach: testCase.attach, runId, token: testCase.token});
+  await attachWebhookTriggerDiagnostics({
+    attach: testCase.attach,
+    client: testCase.client,
+    deliveryIds: testCase.fireDiagnostics.deliveryIds,
+    source: testCase.fireDiagnostics.source,
+    workspaceId: testCase.workspaceId,
+  }).catch(() => undefined);
+  await attachWebhookTriggerDiagnostics({
+    attach: testCase.attach,
+    client: testCase.client,
+    deliveryIds: testCase.resolveDiagnostics.deliveryIds,
+    source: testCase.resolveDiagnostics.source,
+    workspaceId: testCase.workspaceId,
+  }).catch(() => undefined);
+  await attachLocalRunnerLog(testCase.attach, testCase.runnerLogFile);
+}
+
+async function stopRunner(testCase: ListenerCase | undefined): Promise<void> {
+  if (testCase === undefined) return;
+  await stopLocalRunner(testCase.runner).catch((error: unknown) => {
+    process.stderr.write(`listener-jobs-e2e: stopLocalRunner failed: ${String(error)}\n`);
+  });
+}
+
+async function fireManualRun(testCase: ListenerCase & {definitionId: string}) {
+  return await fireManualAndAwaitRun({
+    client: testCase.client,
+    definitionId: testCase.definitionId,
+    inputs: {},
+    scenario: testCase.repo,
+  });
+}
+
+async function sendFire(testCase: ListenerCase, runId: string, label: string, message: string) {
+  const result = await sendWebhookDeliveryUntilObserved({
+    client: testCase.client,
+    connection: testCase.fireConnection,
+    runId,
+    token: testCase.token,
+    jobKey: LISTENER_JOB,
+    deliveryIdPrefix: `${testCase.uniqueId}-${label}`,
+    body: (_attempt, deliveryId) => ({message, delivery_id: deliveryId}),
+  });
+  testCase.fireDiagnostics.deliveryIds.push(...result.deliveryIds);
+  return result;
+}
+
+async function sendResolve(testCase: ListenerCase, label: string) {
+  const deliveryId = `${testCase.uniqueId}-${label}`;
+  testCase.resolveDiagnostics.deliveryIds.push(deliveryId);
+  await postWebhookDelivery({
+    client: testCase.client,
+    connection: testCase.resolveConnection,
+    deliveryId,
+    webhook: {body: {message: 'resolve', delivery_id: deliveryId}},
+  });
+  return deliveryId;
+}
+
+async function stepLogText(params: {
+  runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>;
+  token: string;
+  jobKey: string;
+  sequence: number;
+  stepKey: string;
+}): Promise<string> {
+  const execution = findListenerExecutionBySequence({
+    runDetail: params.runDetail,
+    jobKey: params.jobKey,
+    sequence: params.sequence,
+  });
+  const step = execution?.steps.find((candidate) => candidate.key === params.stepKey);
+  if (!step) throw new Error(`Step ${params.jobKey}.${params.sequence}.${params.stepKey} missing`);
+  const logs = await fetchStepLogs({
+    stepId: step.id,
+    attempt: step.current_attempt,
+    token: params.token,
+  });
+  return logText(logs.records);
+}
+
+async function sendBatchPairUntilObserved(params: {
+  testCase: ListenerCase;
+  runId: string;
+  label: string;
+}): Promise<{deliveryIds: string[]; runDetail: Awaited<ReturnType<typeof waitForRunTerminal>>}> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    const deliveryIds = [
+      `${params.testCase.uniqueId}-${params.label}-${attempt}-a`,
+      `${params.testCase.uniqueId}-${params.label}-${attempt}-b`,
+    ];
+    for (const deliveryId of deliveryIds) {
+      params.testCase.fireDiagnostics.deliveryIds.push(deliveryId);
+      await postWebhookDelivery({
+        client: params.testCase.client,
+        connection: params.testCase.fireConnection,
+        deliveryId,
+        webhook: {body: {message: deliveryId, delivery_id: deliveryId}},
+      });
+    }
+
+    try {
+      const runDetail = await waitForRunDetailMatching({
+        token: params.testCase.token,
+        runId: params.runId,
+        timeoutMs: 8_000,
+        description: `batched listener deliveries ${deliveryIds.join(', ')}`,
+        matches: (candidate) =>
+          batchedListenerExecutionMatches({
+            runDetail: candidate,
+            jobKey: LISTENER_JOB,
+            sequence: 1,
+            deliveryIds,
+          }),
+      });
+      return {deliveryIds, runDetail};
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Batched listener deliveries were not observed');
+}
+
+const untilWorkflow = `
+name: Listener until
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  listen:
+    listening:
+      on:
+        - source: __FIRE_WEBHOOK_SOURCE__
+          event: received
+      until:
+        - source: __RESOLVE_WEBHOOK_SOURCE__
+          event: received
+    steps:
+      - key: show-event
+        env:
+          MESSAGE: '\${{ execution.events[0].data.body.message }}'
+          DELIVERY_ID: '\${{ execution.events[0].delivery_id }}'
+        run: |
+          echo "listener_message=$MESSAGE"
+          echo "listener_delivery=$DELIVERY_ID"
+  deploy:
+    needs: listen
+    steps:
+      - key: after-listener
+        run: echo "deploy_after_listener"
+`;
+
+const maxExecutionsWorkflow = `
+name: Listener max executions
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  listen:
+    listening:
+      on:
+        - source: __FIRE_WEBHOOK_SOURCE__
+          event: received
+      max_executions: 2
+    steps:
+      - key: show-event
+        env:
+          MESSAGE: '\${{ execution.events[0].data.body.message }}'
+        run: echo "listener_message=$MESSAGE"
+`;
+
+const batchWorkflow = `
+name: Listener batch
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  listen:
+    listening:
+      on:
+        - source: __FIRE_WEBHOOK_SOURCE__
+          event: received
+      until:
+        - source: __RESOLVE_WEBHOOK_SOURCE__
+          event: received
+      batch:
+        max_size: 2
+    steps:
+      - key: show-batch
+        env:
+          FIRST_DELIVERY: '\${{ execution.events[0].delivery_id }}'
+          SECOND_DELIVERY: '\${{ execution.events[1].delivery_id }}'
+        run: |
+          echo "batch_first=$FIRST_DELIVERY"
+          echo "batch_second=$SECOND_DELIVERY"
+`;
+
+const cancelWorkflow = `
+name: Listener cancel
+runner: __RUNNER_LABEL__
+triggers:
+  manual:
+    source: manual
+    event: fire
+jobs:
+  listen:
+    listening:
+      on:
+        - source: __FIRE_WEBHOOK_SOURCE__
+          event: received
+      until:
+        - source: __RESOLVE_WEBHOOK_SOURCE__
+          event: received
+      on_resolve: cancel
+    steps:
+      - key: slow
+        run: |
+          echo "listener_started"
+          sleep 30
+          echo "listener_done"
+`;
+
+test.describe('listener jobs', () => {
+  test('fires on webhook events and resolves on an until event', async ({suite}, testInfo) => {
+    let testCase: (ListenerCase & {definitionId: string}) | undefined;
+    let runId: string | undefined;
+    try {
+      testCase = await setupListenerCase({
+        suite,
+        testName: 'until-resolution',
+        workflowYaml: untilWorkflow,
+        attach: (attachment) =>
+          testInfo.attach(attachment.name, {
+            body: attachment.body,
+            contentType: attachment.contentType,
+          }),
+      });
+      runId = await fireManualRun(testCase);
+
+      const fire = await sendFire(testCase, runId, 'fire', 'hello-listener');
+      const resolveDeliveryId = await sendResolve(testCase, 'resolve');
+      const resolved = await waitForListenerResolution({
+        token: testCase.token,
+        runId,
+        jobKey: LISTENER_JOB,
+        status: 'succeeded',
+        reason: 'until',
+        timeoutMs: 60_000,
+      });
+      const terminal = await waitForRunTerminalOrFailedRunner({
+        runId,
+        token: testCase.token,
+        timeoutMs: 180_000,
+        runner: testCase.runner,
+      });
+
+      const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
+      const deploy = terminal.jobs.find((job) => job.key === 'deploy');
+      const logs = await stepLogText({
+        runDetail: terminal,
+        token: testCase.token,
+        jobKey: LISTENER_JOB,
+        sequence: 1,
+        stepKey: 'show-event',
+      });
+      expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
+        'until',
+      );
+      expect(terminal.status).toBe('succeeded');
+      expect(listen?.listener_status).toBe('resolved');
+      expect(listen?.job_executions[0]?.trigger_events[0]?.delivery_id).toBe(fire.deliveryId);
+      expect(deploy?.status).toBe('succeeded');
+      expect(logs).toContain('listener_message=hello-listener');
+      expect(logs).toContain(`listener_delivery=${fire.deliveryId}`);
+      expect(resolveDeliveryId).toContain('resolve');
+    } catch (error) {
+      await cleanupListenerCase(testCase, runId);
+      throw error;
+    } finally {
+      await stopRunner(testCase);
+    }
+  });
+
+  test('resolves after max executions', async ({suite}, testInfo) => {
+    let testCase: (ListenerCase & {definitionId: string}) | undefined;
+    let runId: string | undefined;
+    try {
+      testCase = await setupListenerCase({
+        suite,
+        testName: 'max-executions',
+        workflowYaml: maxExecutionsWorkflow,
+        attach: (attachment) =>
+          testInfo.attach(attachment.name, {
+            body: attachment.body,
+            contentType: attachment.contentType,
+          }),
+      });
+      runId = await fireManualRun(testCase);
+
+      const first = await sendFire(testCase, runId, 'fire-one', 'first');
+      const second = await sendFire(testCase, runId, 'fire-two', 'second');
+      const resolved = await waitForListenerResolution({
+        token: testCase.token,
+        runId,
+        jobKey: LISTENER_JOB,
+        status: 'succeeded',
+        reason: 'max_executions',
+        timeoutMs: 90_000,
+      });
+      const terminal = await waitForRunTerminalOrFailedRunner({
+        runId,
+        token: testCase.token,
+        timeoutMs: 180_000,
+        runner: testCase.runner,
+      });
+
+      const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
+      expect(terminal.status).toBe('succeeded');
+      expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.resolution_reason).toBe(
+        'max_executions',
+      );
+      expect(listen?.job_executions.map((execution) => execution.sequence)).toEqual([1, 2]);
+      expect(listen?.job_executions[0]?.trigger_events[0]?.delivery_id).toBe(first.deliveryId);
+      expect(listen?.job_executions[1]?.trigger_events[0]?.delivery_id).toBe(second.deliveryId);
+    } catch (error) {
+      await cleanupListenerCase(testCase, runId);
+      throw error;
+    } finally {
+      await stopRunner(testCase);
+    }
+  });
+
+  test('batches multiple events into one listener execution', async ({suite}, testInfo) => {
+    let testCase: (ListenerCase & {definitionId: string}) | undefined;
+    let runId: string | undefined;
+    try {
+      testCase = await setupListenerCase({
+        suite,
+        testName: 'batching',
+        workflowYaml: batchWorkflow,
+        attach: (attachment) =>
+          testInfo.attach(attachment.name, {
+            body: attachment.body,
+            contentType: attachment.contentType,
+          }),
+      });
+      runId = await fireManualRun(testCase);
+
+      const batch = await sendBatchPairUntilObserved({testCase, runId, label: 'batch'});
+      await sendResolve(testCase, 'resolve-batch');
+      const terminal = await waitForRunTerminalOrFailedRunner({
+        runId,
+        token: testCase.token,
+        timeoutMs: 180_000,
+        runner: testCase.runner,
+      });
+
+      const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
+      const logs = await stepLogText({
+        runDetail: terminal,
+        token: testCase.token,
+        jobKey: LISTENER_JOB,
+        sequence: 1,
+        stepKey: 'show-batch',
+      });
+      expect(terminal.status).toBe('succeeded');
+      expect(listen?.resolution_reason).toBe('until');
+      expect(listen?.job_executions).toHaveLength(1);
+      expect(listen?.job_executions[0]?.trigger_events.map((event) => event.delivery_id)).toEqual(
+        batch.deliveryIds,
+      );
+      expect(logs).toContain(`batch_first=${batch.deliveryIds[0]}`);
+      expect(logs).toContain(`batch_second=${batch.deliveryIds[1]}`);
+    } catch (error) {
+      await cleanupListenerCase(testCase, runId);
+      throw error;
+    } finally {
+      await stopRunner(testCase);
+    }
+  });
+
+  test('cancels an active execution when on_resolve is cancel', async ({suite}, testInfo) => {
+    let testCase: (ListenerCase & {definitionId: string}) | undefined;
+    let runId: string | undefined;
+    try {
+      testCase = await setupListenerCase({
+        suite,
+        testName: 'cancel-on-resolve',
+        workflowYaml: cancelWorkflow,
+        attach: (attachment) =>
+          testInfo.attach(attachment.name, {
+            body: attachment.body,
+            contentType: attachment.contentType,
+          }),
+      });
+      runId = await fireManualRun(testCase);
+
+      await sendFire(testCase, runId, 'fire', 'slow');
+      await waitForListenerExecution({
+        token: testCase.token,
+        runId,
+        jobKey: LISTENER_JOB,
+        sequence: 1,
+        status: 'running',
+        timeoutMs: 90_000,
+      });
+      await sendResolve(testCase, 'resolve-cancel');
+      const resolved = await waitForListenerResolution({
+        token: testCase.token,
+        runId,
+        jobKey: LISTENER_JOB,
+        status: 'succeeded',
+        reason: 'until',
+        timeoutMs: 90_000,
+      });
+      const terminal = await waitForRunTerminalOrFailedRunner({
+        runId,
+        token: testCase.token,
+        timeoutMs: 180_000,
+        runner: testCase.runner,
+      });
+
+      const listen = terminal.jobs.find((job) => job.key === LISTENER_JOB);
+      expect(terminal.status).toBe('succeeded');
+      expect(resolved.jobs.find((job) => job.key === LISTENER_JOB)?.listener_status).toBe(
+        'resolved',
+      );
+      expect(listen?.job_executions[0]?.status).toBe('cancelled');
+    } catch (error) {
+      await cleanupListenerCase(testCase, runId);
+      throw error;
+    } finally {
+      await stopRunner(testCase);
+    }
+  });
+});

--- a/e2e/platform/workflows/tests/scenarios.e2e.ts
+++ b/e2e/platform/workflows/tests/scenarios.e2e.ts
@@ -3,8 +3,9 @@ import {discoverScenarios} from '#scenarios.js';
 import {expect, test} from './fixtures.js';
 
 // Every scenarios/<name>/expect.yaml or reject.yaml directory becomes one Playwright
-// test. Scenarios that need to orchestrate from outside (cancellation, listening jobs)
-// ship a spec.e2e.ts instead and are picked up directly by testMatch.
+// test. Flows that need to orchestrate from outside (cancellation, listening jobs)
+// ship their own tests/*.e2e.ts spec instead (e.g. tests/listener-jobs.e2e.ts) and are
+// picked up directly by testMatch.
 for (const scenario of discoverScenarios()) {
   test(scenario.name, async ({suite}, testInfo) => {
     const mismatches = await runScenario({


### PR DESCRIPTION
Add bespoke platform workflow E2E coverage for listener jobs.

Listener jobs now have product-real coverage through definition sync, manual trigger startup, listener activation, webhook delivery, Temporal orchestration, local runner execution, resolution, and public run-detail assertions. The shared scenario setup was split into reusable harness helpers so listener tests can drive mid-run behavior without duplicating the existing expect.yaml harness.

The listener specs cover until resolution, max executions, batching, and on-resolve cancellation. Pure helper predicates have Vitest coverage for delivery correlation, batching, and diagnostic messages.

Kept this API-first instead of adding backend readiness routes or private DB access; webhook delivery retries use the public delivery path to tolerate listener subscription projection lag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end coverage for listener jobs with real webhook delivery, batching, cancellation, and resolution, and explicitly verifies multiple listener executions. Refactors the workflow E2E harness into focused helpers and improves diagnostics with automatic log and webhook event attachments.

- New Features
  - Added `tests/listener-jobs.e2e.ts` covering until-resolution, max executions, batching, on-resolve cancellation, and asserts distinct multi-execution sequences and payloads.
  - Sends webhooks via public endpoints and retries until observed by the listener; adds per-source webhook trigger diagnostics on failures.
  - New listener helpers to wait for executions/resolution and match batched deliveries, with unit tests for predicates; automatically attaches step logs and local runner logs.

- Refactors
  - Split shared logic into helpers: `attachments`, `polling`, `runner`, `triggers`, `webhook`, `workflow-project`, and `listener-helpers` (+ `listener-helpers.test`).
  - Simplified `run-scenario.ts` to use these helpers; updated `package.json` import aliases and docs to pick up `tests/**/*.e2e.ts`.
  - Run detail polling now honors `AbortSignal` for early cancellation.

<sup>Written for commit 64f0192c9e7f378798cb054aadc430be7fad5873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

