### PR TITLE
Generalize trigger source config

### DIFF
--- a/.changeset/sharp-clocks-configure.md
+++ b/.changeset/sharp-clocks-configure.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/workflow-document": major
+---
+
+Moves trigger source-specific authoring fields into per-source config blocks so cron triggers use `config.schedule` and `config.timezone`.

--- a/libs/api/definitions-dto/src/schemas/trigger.ts
+++ b/libs/api/definitions-dto/src/schemas/trigger.ts
@@ -5,7 +5,6 @@ export const triggerDtoSchema = z.object({
   event: z.string(),
   with: z.record(z.string(), z.unknown()).optional(),
   filter: z.string().optional(),
-  schedule: z.string().optional(),
-  timezone: z.string().optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
 });
 export type TriggerDto = z.infer<typeof triggerDtoSchema>;

--- a/libs/api/definitions/src/core/entities/workflow-model.ts
+++ b/libs/api/definitions/src/core/entities/workflow-model.ts
@@ -23,8 +23,7 @@ export interface WorkflowModelTrigger {
   readonly event: string;
   readonly inputs?: Readonly<Record<string, unknown>>;
   readonly filter?: string;
-  readonly schedule?: string;
-  readonly timezone?: string;
+  readonly config?: Readonly<Record<string, unknown>>;
 }
 
 export interface WorkflowModelJob {

--- a/libs/api/definitions/src/core/workflow-model/cron-trigger.ts
+++ b/libs/api/definitions/src/core/workflow-model/cron-trigger.ts
@@ -9,12 +9,14 @@ export function validateCronTrigger(params: {
   readonly sourceKey: string;
   readonly trigger: {
     readonly event: string;
+  };
+  readonly config: {
     readonly schedule?: string | undefined;
     readonly timezone?: string | undefined;
   };
   readonly issues: WorkflowModelValidationIssue[];
 }): void {
-  const {sourceKey, trigger, issues} = params;
+  const {sourceKey, trigger, config, issues} = params;
 
   if (trigger.event !== 'tick') {
     issues.push(
@@ -27,7 +29,7 @@ export function validateCronTrigger(params: {
     );
   }
 
-  if (trigger.schedule === undefined) {
+  if (config.schedule === undefined) {
     issues.push(
       issue({
         code: 'missing-cron-schedule',
@@ -35,24 +37,24 @@ export function validateCronTrigger(params: {
         path: ['triggers', sourceKey, 'schedule'],
       }),
     );
-  } else if (!isValidCronExpression(trigger.schedule)) {
+  } else if (!isValidCronExpression(config.schedule)) {
     issues.push(
       issue({
         code: 'invalid-cron-schedule',
         message: 'Cron trigger schedule must be a valid 5-field cron expression.',
         path: ['triggers', sourceKey, 'schedule'],
-        details: {schedule: trigger.schedule},
+        details: {schedule: config.schedule},
       }),
     );
   }
 
-  if (trigger.timezone !== undefined && !isValidTimezone(trigger.timezone)) {
+  if (config.timezone !== undefined && !isValidTimezone(config.timezone)) {
     issues.push(
       issue({
         code: 'invalid-cron-timezone',
         message: 'Cron trigger timezone must be a valid IANA time zone.',
         path: ['triggers', sourceKey, 'timezone'],
-        details: {timezone: trigger.timezone},
+        details: {timezone: config.timezone},
       }),
     );
   }

--- a/libs/api/definitions/src/core/workflow-model/cron-trigger.ts
+++ b/libs/api/definitions/src/core/workflow-model/cron-trigger.ts
@@ -34,7 +34,7 @@ export function validateCronTrigger(params: {
       issue({
         code: 'missing-cron-schedule',
         message: 'A cron trigger requires a schedule.',
-        path: ['triggers', sourceKey, 'schedule'],
+        path: ['triggers', sourceKey, 'config', 'schedule'],
       }),
     );
   } else if (!isValidCronExpression(config.schedule)) {
@@ -42,7 +42,7 @@ export function validateCronTrigger(params: {
       issue({
         code: 'invalid-cron-schedule',
         message: 'Cron trigger schedule must be a valid 5-field cron expression.',
-        path: ['triggers', sourceKey, 'schedule'],
+        path: ['triggers', sourceKey, 'config', 'schedule'],
         details: {schedule: config.schedule},
       }),
     );
@@ -53,7 +53,7 @@ export function validateCronTrigger(params: {
       issue({
         code: 'invalid-cron-timezone',
         message: 'Cron trigger timezone must be a valid IANA time zone.',
-        path: ['triggers', sourceKey, 'timezone'],
+        path: ['triggers', sourceKey, 'config', 'timezone'],
         details: {timezone: config.timezone},
       }),
     );

--- a/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
@@ -1,4 +1,4 @@
-import type {WorkflowDocument} from '@shipfox/workflow-document';
+import {triggerSourceConfigSchemas, type WorkflowDocument} from '@shipfox/workflow-document';
 import type {
   WorkflowModelListeningTrigger,
   WorkflowModelTrigger,
@@ -55,19 +55,25 @@ export function normalizeTriggers(
           id,
           key: sourceKey,
           ...normalizedTrigger,
+          ...(trigger.config === undefined ? {} : {config: trigger.config}),
         },
       ];
     }
 
-    validateCronTrigger({trigger, sourceKey, issues});
+    const cronConfig = triggerSourceConfigSchemas.cron.parse(trigger.config ?? {});
+    const normalizedCronConfig = {
+      ...cronConfig,
+      timezone: cronConfig.timezone ?? cronTriggerDefaultTimezone,
+    };
+
+    validateCronTrigger({trigger, config: cronConfig, sourceKey, issues});
 
     return [
       {
         id,
         key: sourceKey,
         ...normalizedTrigger,
-        ...(trigger.schedule === undefined ? {} : {schedule: trigger.schedule}),
-        timezone: trigger.timezone ?? cronTriggerDefaultTimezone,
+        config: normalizedCronConfig,
       },
     ];
   });

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1658,7 +1658,7 @@ describe('normalizeWorkflowDocument', () => {
       {
         code: 'missing-cron-schedule',
         message: 'A cron trigger requires a schedule.',
-        path: ['triggers', 'nightly', 'schedule'],
+        path: ['triggers', 'nightly', 'config', 'schedule'],
       },
     ]);
   });
@@ -1690,7 +1690,7 @@ describe('normalizeWorkflowDocument', () => {
       {
         code: 'invalid-cron-schedule',
         message: 'Cron trigger schedule must be a valid 5-field cron expression.',
-        path: ['triggers', 'nightly', 'schedule'],
+        path: ['triggers', 'nightly', 'config', 'schedule'],
         details: {schedule},
       },
     ]);
@@ -1722,7 +1722,7 @@ describe('normalizeWorkflowDocument', () => {
       {
         code: 'invalid-cron-timezone',
         message: 'Cron trigger timezone must be a valid IANA time zone.',
-        path: ['triggers', 'nightly', 'timezone'],
+        path: ['triggers', 'nightly', 'config', 'timezone'],
         details: {timezone: 'Not/A/Zone'},
       },
     ]);

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -1545,7 +1545,7 @@ describe('normalizeWorkflowDocument', () => {
         nightly: {
           source: 'cron',
           event: 'tick',
-          schedule: '0 2 * * *',
+          config: {schedule: '0 2 * * *'},
         },
       },
       jobs: {
@@ -1563,8 +1563,10 @@ describe('normalizeWorkflowDocument', () => {
         key: 'nightly',
         source: 'cron',
         event: 'tick',
-        schedule: '0 2 * * *',
-        timezone: 'UTC',
+        config: {
+          schedule: '0 2 * * *',
+          timezone: 'UTC',
+        },
       },
     ]);
   });
@@ -1576,8 +1578,10 @@ describe('normalizeWorkflowDocument', () => {
         nightly: {
           source: 'cron',
           event: 'tick',
-          schedule: '0 2 * * *',
-          timezone: 'Europe/Paris',
+          config: {
+            schedule: '0 2 * * *',
+            timezone: 'Europe/Paris',
+          },
         },
       },
       jobs: {
@@ -1595,8 +1599,10 @@ describe('normalizeWorkflowDocument', () => {
         key: 'nightly',
         source: 'cron',
         event: 'tick',
-        schedule: '0 2 * * *',
-        timezone: 'Europe/Paris',
+        config: {
+          schedule: '0 2 * * *',
+          timezone: 'Europe/Paris',
+        },
       },
     ]);
   });
@@ -1608,7 +1614,7 @@ describe('normalizeWorkflowDocument', () => {
         nightly: {
           source: 'cron',
           event: 'push',
-          schedule: '0 2 * * *',
+          config: {schedule: '0 2 * * *'},
         },
       },
       jobs: {
@@ -1668,7 +1674,7 @@ describe('normalizeWorkflowDocument', () => {
         nightly: {
           source: 'cron',
           event: 'tick',
-          schedule,
+          config: {schedule},
         },
       },
       jobs: {
@@ -1697,8 +1703,10 @@ describe('normalizeWorkflowDocument', () => {
         nightly: {
           source: 'cron',
           event: 'tick',
-          schedule: '0 2 * * *',
-          timezone: 'Not/A/Zone',
+          config: {
+            schedule: '0 2 * * *',
+            timezone: 'Not/A/Zone',
+          },
         },
       },
       jobs: {
@@ -1727,12 +1735,12 @@ describe('normalizeWorkflowDocument', () => {
         hourly: {
           source: 'cron',
           event: 'tick',
-          schedule: '0 * * * *',
+          config: {schedule: '0 * * * *'},
         },
         nightly: {
           source: 'cron',
           event: 'tick',
-          schedule: '0 2 * * *',
+          config: {schedule: '0 2 * * *'},
         },
       },
       jobs: {

--- a/libs/api/definitions/src/db/definition-triggers.test.ts
+++ b/libs/api/definitions/src/db/definition-triggers.test.ts
@@ -1,26 +1,30 @@
-import type {WorkflowDocument} from '@shipfox/workflow-document';
+import type {WorkflowModel, WorkflowModelTrigger} from '#core/entities/workflow-model.js';
 import {definitionTriggersFor} from './definition-triggers.js';
 
-describe('definitionTriggersFor', () => {
-  it('projects document triggers to the public outbox trigger DTO shape', () => {
-    const document: WorkflowDocument = {
-      name: 'CI',
-      triggers: {
-        push: {
-          source: 'github',
-          event: 'push',
-          with: {branch: 'main'},
-          filter: 'event.ref == "refs/heads/main"',
-        },
-      },
-      jobs: {
-        build: {
-          steps: [{run: 'pnpm test'}],
-        },
-      },
-    };
+function workflowModelWithTriggers(triggers: readonly WorkflowModelTrigger[]): WorkflowModel {
+  return {
+    kind: 'workflow',
+    name: 'Test',
+    triggers,
+    jobs: [],
+    dependencies: [],
+  };
+}
 
-    const result = definitionTriggersFor(document);
+describe('definitionTriggersFor', () => {
+  it('projects model triggers to the public outbox trigger DTO shape', () => {
+    const model = workflowModelWithTriggers([
+      {
+        id: 'push',
+        key: 'push',
+        source: 'github',
+        event: 'push',
+        inputs: {branch: 'main'},
+        filter: 'event.ref == "refs/heads/main"',
+      },
+    ]);
+
+    const result = definitionTriggersFor(model);
 
     expect(result).toEqual({
       push: {
@@ -34,22 +38,16 @@ describe('definitionTriggersFor', () => {
   });
 
   it('omits absent optional trigger fields', () => {
-    const document: WorkflowDocument = {
-      name: 'Manual',
-      triggers: {
-        manual: {
-          source: 'manual',
-          event: 'fire',
-        },
+    const model = workflowModelWithTriggers([
+      {
+        id: 'manual',
+        key: 'manual',
+        source: 'manual',
+        event: 'fire',
       },
-      jobs: {
-        run: {
-          steps: [{run: 'echo ok'}],
-        },
-      },
-    };
+    ]);
 
-    const result = definitionTriggersFor(document);
+    const result = definitionTriggersFor(model);
 
     expect(result).toEqual({
       manual: {
@@ -59,47 +57,38 @@ describe('definitionTriggersFor', () => {
     });
   });
 
-  it('projects cron schedule and timezone to the public outbox trigger DTO shape', () => {
-    const document: WorkflowDocument = {
-      name: 'Nightly',
-      triggers: {
-        nightly: {
-          source: 'cron',
-          event: 'tick',
+  it('projects cron config to the public outbox trigger DTO shape', () => {
+    const model = workflowModelWithTriggers([
+      {
+        id: 'nightly',
+        key: 'nightly',
+        source: 'cron',
+        event: 'tick',
+        config: {
           schedule: '0 2 * * *',
-          timezone: 'Europe/Paris',
+          timezone: 'UTC',
         },
       },
-      jobs: {
-        run: {
-          steps: [{run: 'echo ok'}],
-        },
-      },
-    };
+    ]);
 
-    const result = definitionTriggersFor(document);
+    const result = definitionTriggersFor(model);
 
     expect(result).toEqual({
       nightly: {
         source: 'cron',
         event: 'tick',
-        schedule: '0 2 * * *',
-        timezone: 'Europe/Paris',
+        config: {
+          schedule: '0 2 * * *',
+          timezone: 'UTC',
+        },
       },
     });
   });
 
-  it('returns an empty object when the document has no triggers', () => {
-    const document: WorkflowDocument = {
-      name: 'No triggers',
-      jobs: {
-        build: {
-          steps: [{run: 'pnpm build'}],
-        },
-      },
-    };
+  it('returns an empty object when the model has no triggers', () => {
+    const model = workflowModelWithTriggers([]);
 
-    const result = definitionTriggersFor(document);
+    const result = definitionTriggersFor(model);
 
     expect(result).toEqual({});
   });

--- a/libs/api/definitions/src/db/definition-triggers.ts
+++ b/libs/api/definitions/src/db/definition-triggers.ts
@@ -1,18 +1,17 @@
 import type {TriggerDto} from '@shipfox/api-definitions-dto';
-import type {WorkflowDocument} from '@shipfox/workflow-document';
+import type {WorkflowModel} from '#core/entities/workflow-model.js';
 
-export function definitionTriggersFor(document: WorkflowDocument): Record<string, TriggerDto> {
+export function definitionTriggersFor(model: WorkflowModel): Record<string, TriggerDto> {
   return Object.fromEntries(
-    Object.entries(document.triggers ?? {}).map(([name, trigger]) => {
+    model.triggers.map((trigger) => {
       const dto: TriggerDto = {
         source: trigger.source,
         event: trigger.event,
       };
-      if (trigger.with !== undefined) dto.with = trigger.with;
+      if (trigger.inputs !== undefined) dto.with = trigger.inputs;
       if (trigger.filter !== undefined) dto.filter = trigger.filter;
-      if (trigger.schedule !== undefined) dto.schedule = trigger.schedule;
-      if (trigger.timezone !== undefined) dto.timezone = trigger.timezone;
-      return [name, dto];
+      if (trigger.config !== undefined) dto.config = trigger.config;
+      return [trigger.key, dto];
     }),
   );
 }

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -32,6 +32,12 @@ function definitionFields(name = 'Test Workflow'): WorkflowDefinitionPayload {
     runner: 'ubuntu-latest',
     jobs: {build: {steps: [{run: 'echo hello'}]}},
   };
+  return definitionFieldsForDocument(document);
+}
+
+function definitionFieldsForDocument(
+  document: WorkflowDefinitionPayload['document'],
+): WorkflowDefinitionPayload {
   return {document, model: normalizeWorkflowDocument(document)};
 }
 
@@ -624,6 +630,45 @@ describe('definition queries', () => {
         triggers: {},
       });
       expect(outboxRows[0]?.dispatchedAt).toBeNull();
+    });
+
+    test('writes normalized trigger config to the resolved outbox event', async () => {
+      const fields = definitionFieldsForDocument({
+        name: 'Nightly',
+        runner: 'ubuntu-latest',
+        triggers: {
+          nightly: {
+            source: 'cron',
+            event: 'tick',
+            config: {schedule: '0 2 * * *'},
+          },
+        },
+        jobs: {build: {steps: [{run: 'echo hello'}]}},
+      });
+      const definition = await upsertDefinition({
+        projectId,
+        workspaceId,
+        configPath: '.shipfox/workflows/nightly.yml',
+        name: 'Nightly',
+        ...fields,
+      });
+
+      const outboxRows = await listOutboxRowsForProject(projectId);
+
+      expect(outboxRows).toHaveLength(1);
+      expect(outboxRows[0]?.payload).toMatchObject({
+        definitionId: definition.id,
+        triggers: {
+          nightly: {
+            source: 'cron',
+            event: 'tick',
+            config: {
+              schedule: '0 2 * * *',
+              timezone: 'UTC',
+            },
+          },
+        },
+      });
     });
 
     test('writes one outbox event per upsert call', async () => {

--- a/libs/api/definitions/src/db/definitions.ts
+++ b/libs/api/definitions/src/db/definitions.ts
@@ -132,7 +132,7 @@ export async function upsertDefinition(
         projectId: row.projectId,
         workspaceId: params.workspaceId,
         configPath: row.configPath,
-        triggers: definitionTriggersFor(row.definition.document),
+        triggers: definitionTriggersFor(row.definition.model),
       },
     });
 
@@ -326,7 +326,7 @@ export async function applyVcsDefinitionsBatch(
             projectId: row.projectId,
             workspaceId: params.workspaceId,
             configPath: row.configPath,
-            triggers: definitionTriggersFor(row.definition.document),
+            triggers: definitionTriggersFor(row.definition.model),
           },
         });
         appliedCount += 1;

--- a/libs/shared/workflow/document/src/document/index.ts
+++ b/libs/shared/workflow/document/src/document/index.ts
@@ -5,6 +5,7 @@ export {
   DEFAULT_MODEL_PROVIDER,
 } from './step-enums.js';
 export {
+  triggerSourceConfigSchemas,
   WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES,
   WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES,
   type WorkflowDocument,

--- a/libs/shared/workflow/document/src/document/workflow-document.test.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.test.ts
@@ -114,15 +114,17 @@ describe('workflowDocumentSchema', () => {
     expect(result.triggers?.main_push?.filter).toBe('event.ref == "refs/heads/main"');
   });
 
-  it('keeps cron trigger schedule and timezone strings', () => {
+  it('keeps cron trigger config values', () => {
     const workflowDocument = {
       name: 'nightly build',
       triggers: {
         nightly: {
           source: 'cron',
           event: 'tick',
-          schedule: '0 2 * * *',
-          timezone: 'Europe/Paris',
+          config: {
+            schedule: '0 2 * * *',
+            timezone: 'Europe/Paris',
+          },
         },
       },
       jobs: {
@@ -134,18 +136,20 @@ describe('workflowDocumentSchema', () => {
 
     const result = workflowDocumentSchema.parse(workflowDocument);
 
-    expect(result.triggers?.nightly?.schedule).toBe('0 2 * * *');
-    expect(result.triggers?.nightly?.timezone).toBe('Europe/Paris');
+    expect(result.triggers?.nightly?.config).toEqual({
+      schedule: '0 2 * * *',
+      timezone: 'Europe/Paris',
+    });
   });
 
-  it.each(['schedule', 'timezone'] as const)('rejects top-level non-cron trigger %s', (field) => {
+  it('rejects config for a source with no registered config schema', () => {
     const result = workflowDocumentSchema.safeParse({
       name: 'simple build',
       triggers: {
         main_push: {
           source: 'github',
           event: 'push',
-          [field]: field === 'schedule' ? '0 2 * * *' : 'Europe/Paris',
+          config: {branch: 'main'},
         },
       },
       jobs: {
@@ -158,9 +162,64 @@ describe('workflowDocumentSchema', () => {
     const issue = result.success
       ? undefined
       : result.error.issues.find(
-          (candidate) => candidate.path.join('.') === `triggers.main_push.${field}`,
+          (candidate) => candidate.path.join('.') === 'triggers.main_push.config',
         );
-    expect(issue?.message).toBe(`\`${field}\` is only allowed on a cron trigger (source: cron).`);
+    expect(issue?.message).toBe('`config` is not supported for source `github`.');
+  });
+
+  it('rejects unknown cron config fields', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'nightly build',
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {
+            schedule: '0 2 * * *',
+            offset: '5m',
+          },
+        },
+      },
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    });
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find(
+          (candidate) => candidate.path.join('.') === 'triggers.nightly.config',
+        );
+    expect(issue?.message).toBe('Unrecognized key: "offset"');
+  });
+
+  it('rejects non-string cron config schedule values', () => {
+    const result = workflowDocumentSchema.safeParse({
+      name: 'nightly build',
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {
+            schedule: 5,
+          },
+        },
+      },
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    });
+
+    const issue = result.success
+      ? undefined
+      : result.error.issues.find(
+          (candidate) => candidate.path.join('.') === 'triggers.nightly.config.schedule',
+        );
+    expect(issue?.message).toBe('Invalid input: expected string, received number');
   });
 
   it('accepts listening job configuration under a listening block', () => {
@@ -186,12 +245,7 @@ describe('workflowDocumentSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it.each([
-    ['on', 'schedule'],
-    ['on', 'timezone'],
-    ['until', 'schedule'],
-    ['until', 'timezone'],
-  ] as const)('rejects listening %s non-cron trigger %s', (listeningField, triggerField) => {
+  it.each(['on', 'until'] as const)('rejects listening %s trigger config', (listeningField) => {
     const result = workflowDocumentSchema.safeParse({
       name: 'listen for reviews',
       jobs: {
@@ -200,9 +254,9 @@ describe('workflowDocumentSchema', () => {
             on: [{source: 'github', event: 'pull_request_review'}],
             [listeningField]: [
               {
-                source: 'github',
-                event: 'pull_request',
-                [triggerField]: triggerField === 'schedule' ? '0 2 * * *' : 'Europe/Paris',
+                source: 'cron',
+                event: 'tick',
+                config: {schedule: '0 2 * * *'},
               },
             ],
           },
@@ -215,51 +269,11 @@ describe('workflowDocumentSchema', () => {
       ? []
       : result.error.issues.filter(
           (candidate) =>
-            candidate.path.join('.') ===
-            `jobs.review.listening.${listeningField}.0.${triggerField}`,
+            candidate.path.join('.') === `jobs.review.listening.${listeningField}.0.config`,
         );
     const issue = issues.at(0);
     expect(issues).toHaveLength(1);
-    expect(issue?.message).toBe(
-      `\`${triggerField}\` is only allowed on a cron trigger (source: cron).`,
-    );
-  });
-
-  it.each([
-    ['on', 'schedule'],
-    ['on', 'timezone'],
-    ['until', 'schedule'],
-    ['until', 'timezone'],
-  ] as const)('rejects listening %s cron trigger %s', (listeningField, triggerField) => {
-    const result = workflowDocumentSchema.safeParse({
-      name: 'listen for ticks',
-      jobs: {
-        review: {
-          listening: {
-            on: [{source: 'github', event: 'pull_request_review'}],
-            [listeningField]: [
-              {
-                source: 'cron',
-                event: 'tick',
-                [triggerField]: triggerField === 'schedule' ? '0 2 * * *' : 'Europe/Paris',
-              },
-            ],
-          },
-          steps: [{prompt: 'Review'}],
-        },
-      },
-    });
-
-    const issue = result.success
-      ? undefined
-      : result.error.issues.find(
-          (candidate) =>
-            candidate.path.join('.') ===
-            `jobs.review.listening.${listeningField}.0.${triggerField}`,
-        );
-    expect(issue?.message).toBe(
-      `\`${triggerField}\` is only supported on top-level cron triggers.`,
-    );
+    expect(issue?.message).toBe('`config` is only supported on top-level triggers.');
   });
 
   it('rejects an empty listening batch block', () => {

--- a/libs/shared/workflow/document/src/document/workflow-document.ts
+++ b/libs/shared/workflow/document/src/document/workflow-document.ts
@@ -42,10 +42,17 @@ const workflowDocumentTriggerBaseSchema = {
   source: z.string().min(1),
   with: z.record(z.string(), z.unknown()).optional(),
   filter: z.string().min(1).optional(),
-  schedule: z.string().min(1).optional(),
-  timezone: z.string().min(1).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
 } satisfies z.ZodRawShape;
-const topLevelCronTriggerFields = ['schedule', 'timezone'] as const;
+
+export const triggerSourceConfigSchemas = {
+  cron: z.strictObject({
+    schedule: z.string().min(1).optional(),
+    timezone: z.string().min(1).optional(),
+  }),
+} satisfies Record<string, z.ZodType>;
+const triggerSourceConfigSchemaRegistry: Readonly<Record<string, z.ZodType>> =
+  triggerSourceConfigSchemas;
 
 export const workflowDocumentTriggerSchema = z
   .strictObject({
@@ -53,16 +60,26 @@ export const workflowDocumentTriggerSchema = z
     event: z.string().min(1),
   })
   .superRefine((trigger, ctx) => {
-    if (trigger.source === 'cron') return;
+    if (trigger.config === undefined) return;
 
-    for (const field of topLevelCronTriggerFields) {
-      if (trigger[field] !== undefined) {
-        ctx.addIssue({
-          code: 'custom',
-          path: [field],
-          message: `\`${field}\` is only allowed on a cron trigger (source: cron).`,
-        });
-      }
+    const configSchema = triggerSourceConfigSchemaRegistry[trigger.source];
+    if (configSchema === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['config'],
+        message: `\`config\` is not supported for source \`${trigger.source}\`.`,
+      });
+      return;
+    }
+
+    const configResult = configSchema.safeParse(trigger.config);
+    if (configResult.success) return;
+
+    for (const configIssue of configResult.error.issues) {
+      ctx.addIssue({
+        ...configIssue,
+        path: ['config', ...configIssue.path],
+      });
     }
   });
 
@@ -91,14 +108,12 @@ const workflowDocumentListeningSchema = z
   .superRefine((listening, ctx) => {
     for (const field of ['on', 'until'] as const) {
       for (const [index, trigger] of (listening[field] ?? []).entries()) {
-        for (const triggerField of topLevelCronTriggerFields) {
-          if (trigger.source === 'cron' && trigger[triggerField] !== undefined) {
-            ctx.addIssue({
-              code: 'custom',
-              path: [field, index, triggerField],
-              message: `\`${triggerField}\` is only supported on top-level cron triggers.`,
-            });
-          }
+        if (trigger.config !== undefined) {
+          ctx.addIssue({
+            code: 'custom',
+            path: [field, index, 'config'],
+            message: '`config` is only supported on top-level triggers.',
+          });
         }
       }
     }

--- a/libs/shared/workflow/document/src/index.ts
+++ b/libs/shared/workflow/document/src/index.ts
@@ -6,6 +6,7 @@ export {
   InvalidWorkflowDocumentError,
   invalidWorkflowDocumentErrorCode,
   parseWorkflowDocument,
+  triggerSourceConfigSchemas,
   WORKFLOW_DOCUMENT_ENV_MAX_ENTRIES,
   WORKFLOW_DOCUMENT_ENV_MAX_SERIALIZED_BYTES,
   type WorkflowDocument,


### PR DESCRIPTION
Generalize trigger source-specific document fields into a namespaced `config` block.

Cron triggers previously owned flat top-level `schedule` and `timezone` fields in the shared workflow document schema. This moves those fields behind an exported per-source config registry, carries validated config through the workflow model, and projects normalized config into the `DEFINITION_RESOLVED` trigger DTO so future sources can add authoring config without more shared-schema branches.

The resolved event projection now uses normalized model triggers, which preserves cron's default `UTC` timezone inside `config` when authors omit it.

Closes ENG-791

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalizes trigger source-specific fields into a namespaced config block so sources can add options without expanding the shared schema. Cron now uses config.schedule and config.timezone across the document, model, DTO, and outbox events (default timezone UTC), and validation errors now point to config.*. Closes ENG-791.

- **Refactors**
  - Adds `triggerSourceConfigSchemas` in `@shipfox/workflow-document` and validates per-source configs (cron supported).
  - Replaces top-level `schedule`/`timezone` with `config` in document schema, workflow model, and `@shipfox/api-definitions-dto` TriggerDto.
  - Projects normalized model triggers into `DEFINITION_RESOLVED` events; cron `timezone` defaults to `UTC` and validation issues reference `config.schedule`/`config.timezone`.

- **Migration**
  - In workflow docs: move cron fields under `config`, e.g. `config: { schedule: "0 2 * * *", timezone: "UTC" }`.
  - Do not use `config` in listening triggers; it’s only allowed on top-level triggers.
  - Update any consumers of trigger DTOs to read `config` instead of `schedule`/`timezone`.

<sup>Written for commit d200b2af470b12923c2083d62002fee6895e0515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

