### PR TITLE
[api-workflows] Assemble coherent step dispatch context

### DIFF
--- a/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.test.ts
@@ -212,16 +212,21 @@ describe('assembleExecutionCreationContext', () => {
 });
 
 describe('assembleStepDispatchContext', () => {
-  it('wraps upstream step outputs and the current execution with the dispatch site', () => {
-    const targetStep = step({id: 'step-2', key: 'test'});
+  it('wraps coherent step entities, the step self-root, and the current execution', () => {
+    const targetStep = step({id: 'step-2', key: 'test', currentAttempt: 2});
     const steps = [
-      step({id: 'step-1', key: 'build'}),
+      step({id: 'step-1', key: 'build', status: 'succeeded'}),
       targetStep,
       step({id: 'step-3', key: null}),
-      step({id: 'step-4', key: 'running'}),
+      step({id: 'step-4', key: 'running', status: 'running'}),
     ];
     const attempts = [
-      attempt({stepId: 'step-1', output: {image: 'app:123'}}),
+      attempt({
+        id: 'attempt-1',
+        stepId: 'step-1',
+        output: {image: 'app:123'},
+        gateResult: {passed: true, source: 'step.exit_code == 0', exit_code: 0},
+      }),
       attempt({stepId: 'step-4', status: 'running', output: {ignored: true}}),
     ];
     const execution = jobExecution();
@@ -252,11 +257,168 @@ describe('assembleStepDispatchContext', () => {
             },
           ],
         },
+        step: {
+          attempt: 2n,
+          is_retry: true,
+        },
         steps: {
-          build: {outputs: {image: 'app:123'}},
+          build: {
+            status: 'succeeded',
+            exit_code: 0n,
+            outputs: {image: 'app:123'},
+            gate: {passed: true, source: 'step.exit_code == 0', exit_code: 0},
+            attempts: [
+              {
+                status: 'succeeded',
+                exit_code: 0n,
+                outputs: {image: 'app:123'},
+                gate: {passed: true, source: 'step.exit_code == 0', exit_code: 0},
+              },
+            ],
+          },
+          test: {status: 'pending', attempts: []},
+          running: {status: 'running', attempts: []},
         },
       },
     });
+  });
+
+  it('uses the latest terminal attempt by execution order and keeps history ordered', () => {
+    const targetStep = step({id: 'step-2', key: 'deploy'});
+    const steps = [step({id: 'step-1', key: 'build', status: 'succeeded'}), targetStep];
+    const attempts = [
+      attempt({
+        id: 'attempt-2',
+        stepId: 'step-1',
+        attempt: 2,
+        executionOrder: 3,
+        output: {image: 'app:good'},
+      }),
+      attempt({
+        id: 'attempt-1',
+        stepId: 'step-1',
+        attempt: 1,
+        executionOrder: 1,
+        status: 'failed',
+        output: {image: 'app:bad'},
+        exitCode: 1,
+      }),
+      attempt({
+        id: 'attempt-3',
+        stepId: 'step-1',
+        attempt: 3,
+        executionOrder: 4,
+        status: 'running',
+        output: {image: 'app:ignored'},
+      }),
+    ];
+
+    const context = assembleStepDispatchContext({
+      steps,
+      attempts,
+      targetStepId: targetStep.id,
+    });
+
+    expect(context.values.steps).toEqual({
+      build: {
+        status: 'succeeded',
+        exit_code: 0n,
+        outputs: {image: 'app:good'},
+        attempts: [
+          {status: 'failed', exit_code: 1n, outputs: {image: 'app:bad'}},
+          {status: 'succeeded', exit_code: 0n, outputs: {image: 'app:good'}},
+        ],
+      },
+      deploy: {status: 'pending', attempts: []},
+    });
+  });
+
+  it('includes the target step prior attempts but excludes the in-flight attempt', () => {
+    const targetStep = step({
+      id: 'step-1',
+      key: 'build',
+      status: 'running',
+      currentAttempt: 3,
+    });
+    const attempts = [
+      attempt({id: 'attempt-1', attempt: 1, executionOrder: 1, output: {sha: 'old'}}),
+      attempt({
+        id: 'attempt-2',
+        attempt: 2,
+        executionOrder: 2,
+        status: 'failed',
+        output: {sha: 'failed'},
+        exitCode: 1,
+      }),
+      attempt({
+        id: 'attempt-3',
+        attempt: 3,
+        executionOrder: 3,
+        status: 'running',
+        output: {sha: 'in-flight'},
+      }),
+    ];
+
+    const context = assembleStepDispatchContext({
+      steps: [targetStep],
+      attempts,
+      targetStepId: targetStep.id,
+    });
+
+    expect(context.values.step).toEqual({attempt: 3n, is_retry: true});
+    expect(context.values.steps).toEqual({
+      build: {
+        status: 'running',
+        exit_code: 1n,
+        outputs: {sha: 'failed'},
+        attempts: [
+          {status: 'succeeded', exit_code: 0n, outputs: {sha: 'old'}},
+          {status: 'failed', exit_code: 1n, outputs: {sha: 'failed'}},
+        ],
+      },
+    });
+  });
+
+  it('omits response for run steps so response resolves as a missing path', () => {
+    const targetStep = step({id: 'step-2', key: 'deploy'});
+    const steps = [step({id: 'step-1', key: 'build', status: 'succeeded'}), targetStep];
+
+    const context = assembleStepDispatchContext({
+      steps,
+      attempts: [attempt({stepId: 'step-1'})],
+      targetStepId: targetStep.id,
+    });
+
+    const stepsContext = context.values.steps as Record<string, Record<string, unknown>>;
+    const build = stepsContext.build as Record<string, unknown>;
+    const buildAttempt = (build.attempts as Record<string, unknown>[])[0];
+    expect(build).not.toHaveProperty('response');
+    expect(buildAttempt).not.toHaveProperty('response');
+  });
+
+  it('exposes projection status when a step has no terminal attempt', () => {
+    const skipped = step({
+      id: 'step-1',
+      key: 'conditional',
+      status: 'skipped' as Step['status'],
+    });
+
+    const context = assembleStepDispatchContext({
+      steps: [skipped],
+      attempts: [],
+      targetStepId: skipped.id,
+    });
+
+    const stepsContext = context.values.steps as Record<string, Record<string, unknown>>;
+    expect(stepsContext).toEqual({
+      conditional: {
+        status: 'skipped',
+        attempts: [],
+      },
+    });
+    expect(stepsContext.conditional).not.toHaveProperty('outputs');
+    expect(stepsContext.conditional).not.toHaveProperty('exit_code');
+    expect(stepsContext.conditional).not.toHaveProperty('gate');
   });
 });
 

--- a/libs/api/workflows/src/core/step-config/assemble-run-context.ts
+++ b/libs/api/workflows/src/core/step-config/assemble-run-context.ts
@@ -110,19 +110,32 @@ export function assembleStepDispatchContext(params: {
   readonly targetStepId: string;
   readonly jobExecution?: JobExecution;
 }): WorkflowEvaluationContext {
-  const attemptsByStepId = new Map(
-    params.attempts
-      .filter((attempt) => attempt.status !== 'running')
-      .map((attempt) => [attempt.stepId, attempt]),
+  const terminalAttemptsByStepId = new Map<string, StepAttempt[]>();
+  const orderedAttempts = [...params.attempts].sort(
+    (left, right) => left.executionOrder - right.executionOrder,
   );
-  const stepsContext: Record<string, {outputs: Record<string, unknown>}> = {};
+
+  for (const attempt of orderedAttempts) {
+    if (attempt.status === 'running') continue;
+    const attemptsForStep = terminalAttemptsByStepId.get(attempt.stepId) ?? [];
+    attemptsForStep.push(attempt);
+    terminalAttemptsByStepId.set(attempt.stepId, attemptsForStep);
+  }
+
+  const stepsContext: Record<string, Record<string, unknown>> = {};
 
   for (const step of params.steps) {
-    if (step.id === params.targetStepId || step.key === null) continue;
-    const attempt = attemptsByStepId.get(step.id);
-    if (attempt === undefined) continue;
-    stepsContext[step.key] = {outputs: attempt.output ?? {}};
+    if (step.key === null) continue;
+    const attempts = terminalAttemptsByStepId.get(step.id) ?? [];
+    const latestAttempt = attempts.at(-1);
+    stepsContext[step.key] = {
+      status: step.status,
+      ...(latestAttempt === undefined ? {} : latestAttemptFields(latestAttempt)),
+      attempts: attempts.map(attemptFields),
+    };
   }
+
+  const targetStep = params.steps.find((step) => step.id === params.targetStepId);
 
   return {
     site: 'step-dispatch',
@@ -139,9 +152,32 @@ export function assembleStepDispatchContext(params: {
               events: params.jobExecution.triggerEvents,
             },
           }),
+      ...(targetStep === undefined
+        ? {}
+        : {
+            step: {
+              attempt: BigInt(targetStep.currentAttempt),
+              is_retry: targetStep.currentAttempt > 1,
+            },
+          }),
       steps: stepsContext,
     },
   };
+}
+
+function attemptFields(attempt: StepAttempt): Record<string, unknown> {
+  return {
+    status: attempt.status,
+    outputs: attempt.output ?? {},
+    ...(attempt.exitCode === null ? {} : {exit_code: BigInt(attempt.exitCode)}),
+    ...(attempt.gateResult === null ? {} : {gate: attempt.gateResult}),
+  };
+}
+
+function latestAttemptFields(attempt: StepAttempt): Record<string, unknown> {
+  const fields = attemptFields(attempt);
+  delete fields.status;
+  return fields;
 }
 
 export function assembleGateContext(params: {


### PR DESCRIPTION
Assemble the step-dispatch context as a coherent step surface keyed by step key, with ordered terminal attempt history and the dispatching step's retry self-root.

Workflow output references need `steps.<key>` to point at one latest terminal attempt while still exposing failed and superseded attempts under `attempts[]`. This keeps `status` sourced from the step projection for pending and future skipped steps, omits attempt-derived fields when there is no terminal attempt, excludes in-flight attempts, and lets a retried step read its own prior attempts without seeing the current dispatch.

The runtime assembly intentionally leaves `step.restart` out for the follow-up gate feedback loop work, since that depends on restart provenance semantics.

Closes ENG-798

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build a coherent step dispatch context keyed by step key. Each `steps.<key>` now points to the latest terminal attempt and exposes ordered attempt history, and the dispatching step gets `step.attempt` and `step.is_retry` (addresses ENG-798).

- **New Features**
  - `steps.<key>` includes `status` (projection-sourced) and, when present, latest-terminal `exit_code`, `outputs`, and `gate`, plus ordered `attempts[]`.
  - Latest-terminal chosen by execution order; running attempts are excluded.
  - Target step exposes prior attempts only; in-flight attempt is hidden; adds `step.attempt` and `step.is_retry`.
  - If no terminal attempt exists, only `status` is present. `response` for run steps is omitted to resolve as a missing path.
  - `step.restart` is intentionally deferred to the gate feedback loop work.

<sup>Written for commit d44eb61f1f6ffe1c47a575904c461ee0e017e660. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

