### PR TITLE
[runner] Add run step output emission

### DIFF
--- a/.changeset/brisk-outputs-emit.md
+++ b/.changeset/brisk-outputs-emit.md
@@ -1,0 +1,8 @@
+---
+"@shipfox/api-workflows-dto": patch
+"@shipfox/runner-execution": patch
+"@shipfox/runner-orchestration": patch
+"@shipfox/runner-protocol": patch
+---
+
+Adds run-step output emission through `$SHIPFOX_OUTPUT` with runner-side parsing, caps, masking, and report plumbing.

--- a/e2e/platform/workflows/scenarios/output-emit-read/expect.yaml
+++ b/e2e/platform/workflows/scenarios/output-emit-read/expect.yaml
@@ -1,0 +1,15 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      produce:
+        status: succeeded
+        exit_code: 0
+      consume:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["sha=abc123", "line two"]

--- a/e2e/platform/workflows/scenarios/output-emit-read/workflow.yml
+++ b/e2e/platform/workflows/scenarios/output-emit-read/workflow.yml
@@ -1,0 +1,26 @@
+name: Output emit read
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: produce
+        run: |
+          echo "sha=abc123" >> "$SHIPFOX_OUTPUT"
+          {
+            echo "notes<<EOF"
+            echo "line one"
+            echo "line two"
+            echo "EOF"
+          } >> "$SHIPFOX_OUTPUT"
+      - key: consume
+        env:
+          SHA: ${{ steps.produce.outputs.sha }}
+          NOTES: ${{ steps.produce.outputs.notes }}
+        run: |
+          echo "sha=$SHA"
+          printf "%s\n" "$NOTES"

--- a/e2e/platform/workflows/scenarios/output-secret-redaction/expect.yaml
+++ b/e2e/platform/workflows/scenarios/output-secret-redaction/expect.yaml
@@ -1,0 +1,22 @@
+trigger: push
+run:
+  status: succeeded
+jobs:
+  build:
+    status: succeeded
+    steps:
+      produce:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["producer-done"]
+          exclude: ["runtime-secret-output-e2e"]
+      consume:
+        status: succeeded
+        exit_code: 0
+        logs:
+          include: ["token-output=***", "output-redaction-ok"]
+          exclude: ["runtime-secret-output-e2e"]
+runner_log:
+  exclude:
+    - "runtime-secret-output-e2e"

--- a/e2e/platform/workflows/scenarios/output-secret-redaction/secrets.yaml
+++ b/e2e/platform/workflows/scenarios/output-secret-redaction/secrets.yaml
@@ -1,0 +1,4 @@
+secrets:
+  - key: RUNTIME_TOKEN
+    value: runtime-secret-output-e2e
+    scope: project

--- a/e2e/platform/workflows/scenarios/output-secret-redaction/workflow.yml
+++ b/e2e/platform/workflows/scenarios/output-secret-redaction/workflow.yml
@@ -1,0 +1,27 @@
+name: Output secret redaction
+runner: __RUNNER_LABEL__
+triggers:
+  on_push:
+    source: __GITEA_SOURCE__
+    event: push
+    filter: 'event.ref == "refs/heads/main" && event.repository.full_name == "__GITEA_REPOSITORY__"'
+jobs:
+  build:
+    steps:
+      - key: produce
+        env:
+          TOKEN: '${{ secrets.RUNTIME_TOKEN }}'
+        run: |
+          echo "token=$TOKEN" >> "$SHIPFOX_OUTPUT"
+          echo "producer-done"
+      - key: consume
+        env:
+          TOKEN_OUTPUT: ${{ steps.produce.outputs.token }}
+        run: |
+          if [ "$TOKEN_OUTPUT" != "***" ]; then
+            echo "output redaction mismatch"
+            exit 1
+          fi
+
+          echo "token-output=$TOKEN_OUTPUT"
+          echo "output-redaction-ok"

--- a/libs/api/workflows-dto/src/index.ts
+++ b/libs/api/workflows-dto/src/index.ts
@@ -37,6 +37,7 @@ export {
   reportStepResponseSchema,
   rerunWorkflowRunBodySchema,
   resolutionReasonSchema,
+  STEP_ERROR_MESSAGE_MAX_LENGTH,
   type StepAttemptDto,
   type StepDto,
   type StepErrorCategoryDto,

--- a/libs/api/workflows-dto/src/schemas/index.ts
+++ b/libs/api/workflows-dto/src/schemas/index.ts
@@ -48,6 +48,7 @@ export {type LogOutcomeDto, logOutcomeSchema} from './log-outcome.js';
 export {
   type AgentConfigIssueDto,
   agentConfigIssueSchema,
+  STEP_ERROR_MESSAGE_MAX_LENGTH,
   type StepAttemptDto,
   type StepDto,
   type StepErrorCategoryDto,

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -1,4 +1,4 @@
-import {stepAttemptDtoSchema, stepErrorDtoSchema} from './step.js';
+import {STEP_ERROR_MESSAGE_MAX_LENGTH, stepAttemptDtoSchema, stepErrorDtoSchema} from './step.js';
 
 const baseAttempt = {
   id: '11111111-1111-4111-8111-111111111111',
@@ -15,6 +15,22 @@ const baseAttempt = {
 };
 
 describe('stepErrorDtoSchema', () => {
+  it('accepts a message at the maximum length', () => {
+    const result = stepErrorDtoSchema.safeParse({
+      message: 'x'.repeat(STEP_ERROR_MESSAGE_MAX_LENGTH),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a message beyond the maximum length', () => {
+    const result = stepErrorDtoSchema.safeParse({
+      message: 'x'.repeat(STEP_ERROR_MESSAGE_MAX_LENGTH + 1),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('accepts an agent config issue with an agent config failure reason', () => {
     const result = stepErrorDtoSchema.parse({
       message: 'Model provider credentials are not configured',

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -38,9 +38,11 @@ export const stepErrorCategorySchema = z.enum(['setup', 'user']);
 
 export type StepErrorCategoryDto = z.infer<typeof stepErrorCategorySchema>;
 
+export const STEP_ERROR_MESSAGE_MAX_LENGTH = 2048;
+
 export const stepErrorDtoSchema = z
   .object({
-    message: z.string(),
+    message: z.string().max(STEP_ERROR_MESSAGE_MAX_LENGTH),
     exit_code: z.number().int().nullable().optional(),
     signal: z.string().optional(),
     reason: stepErrorReasonSchema.optional(),

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -4,12 +4,14 @@ import {basename, isAbsolute, join} from 'node:path';
 import type {StepDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {type CommandStartMetadata, executeRunStep, type OutputSink} from '#core/run-step.js';
+import {MAX_OUTPUT_TOTAL_BYTES} from '#core/step-output.js';
 
 const GRANDCHILD_PID_REGEX = /GRANDCHILD_PID=(\d+)/;
 const READY_REGEX = /READY/;
 const ESRCH_REGEX = /ESRCH/;
 const SHELL_EXECUTABLE_REGEX = /(?:^|\/)(bash|sh)$/;
 const SCRIPT_PATH_REGEX = /shipfox-runner-.*\.sh$/;
+const OUTPUT_PATH_REGEX = /shipfox-output-/;
 const PROCESS_TEST_WAIT_TIMEOUT_MS = 4_000;
 
 function collectOutput(): {sink: OutputSink; text: () => string; sources: () => string[]} {
@@ -136,6 +138,110 @@ describe('executeRunStep', () => {
     } finally {
       if (previous !== undefined) process.env.SHIPFOX_ENV_TEST_SECRET = previous;
     }
+  });
+
+  it('populates outputs from SHIPFOX_OUTPUT on success', async () => {
+    const step = buildStep({
+      config: {run: 'echo "sha=abc123" >> "$SHIPFOX_OUTPUT"'},
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.outputs).toEqual({sha: 'abc123'});
+  });
+
+  it('exposes SHIPFOX_OUTPUT to the child and overrides user env', async () => {
+    const step = buildStep({
+      config: {
+        run: 'echo "path=$SHIPFOX_OUTPUT" >> "$SHIPFOX_OUTPUT"',
+        env: {SHIPFOX_OUTPUT: '/tmp/user-output'},
+      },
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.outputs?.path).toMatch(OUTPUT_PATH_REGEX);
+    expect(result.outputs?.path).not.toBe('/tmp/user-output');
+  });
+
+  it('fails a succeeded step when emitted output exceeds the total byte cap', async () => {
+    const script = `require('node:fs').writeFileSync(process.env.SHIPFOX_OUTPUT, 'x'.repeat(${MAX_OUTPUT_TOTAL_BYTES + 1}))`;
+    const step = buildStep({config: {run: `node -e ${JSON.stringify(script)}`}});
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain('Step output exceeds');
+    expect(result.exit_code).toBeNull();
+  });
+
+  it('attaches valid outputs when the process exits non-zero', async () => {
+    const step = buildStep({
+      config: {run: 'echo "sha=abc123" >> "$SHIPFOX_OUTPUT"; exit 5'},
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({message: 'Command exited with code 5', exit_code: 5});
+    expect(result.exit_code).toBe(5);
+    expect(result.outputs).toEqual({sha: 'abc123'});
+  });
+
+  it('keeps the original failure when a failed process writes invalid output', async () => {
+    const step = buildStep({
+      config: {run: 'echo "bad key=value" >> "$SHIPFOX_OUTPUT"; exit 7'},
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({message: 'Command exited with code 7', exit_code: 7});
+    expect(result.exit_code).toBe(7);
+    expect(result.outputs).toBeUndefined();
+  });
+
+  it('fails a succeeded step that writes invalid output without echoing content', async () => {
+    const step = buildStep({
+      config: {run: 'echo "bad key=secret-value" >> "$SHIPFOX_OUTPUT"'},
+    });
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toContain('invalid key');
+    expect(result.error?.message).not.toContain('secret-value');
+    expect(result.exit_code).toBeNull();
+  });
+
+  it('leaves outputs unset when there is no emission', async () => {
+    const step = buildStep({config: {run: 'true'}});
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.outputs).toBeUndefined();
+  });
+
+  it('treats a deleted output file as no output', async () => {
+    const step = buildStep({config: {run: 'rm "$SHIPFOX_OUTPUT"'}});
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(true);
+    expect(result.outputs).toBeUndefined();
+  });
+
+  it('fails a succeeded step when the output file cannot be read', async () => {
+    const step = buildStep({config: {run: 'chmod 000 "$SHIPFOX_OUTPUT"'}});
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe('Step output file could not be read.');
+    expect(result.exit_code).toBeNull();
   });
 
   it('does not resolve the shell executable through step env PATH', async () => {

--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -244,6 +244,16 @@ describe('executeRunStep', () => {
     expect(result.exit_code).toBeNull();
   });
 
+  it('fails a succeeded step when the output file is replaced by a non-regular file', async () => {
+    const step = buildStep({config: {run: 'rm "$SHIPFOX_OUTPUT"; mkfifo "$SHIPFOX_OUTPUT"'}});
+
+    const result = await executeRunStep(step);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe('Step output file is not a regular file.');
+    expect(result.exit_code).toBeNull();
+  });
+
   it('does not resolve the shell executable through step env PATH', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'shipfox-shell-path-test-'));
     try {

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -1,13 +1,14 @@
 import {spawn} from 'node:child_process';
 import {randomUUID} from 'node:crypto';
 import {accessSync, constants, statSync} from 'node:fs';
-import {unlink, writeFile} from 'node:fs/promises';
+import {open, unlink, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {basename, delimiter, isAbsolute, join, resolve} from 'node:path';
 import {TextDecoder} from 'node:util';
 import type {StepDto, StepErrorDto} from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
 import {redactSecrets, safeRedactionPrefixLength, secretWireForms} from '@shipfox/redact';
+import {MAX_OUTPUT_TOTAL_BYTES, parseStepOutput, StepOutputError} from '#core/step-output.js';
 import type {StepResult} from '#core/step-result.js';
 
 /**
@@ -69,20 +70,25 @@ async function runShellCommand(
   options: RunStepOptions,
 ): Promise<StepResult> {
   const scriptPath = join(tmpdir(), `shipfox-runner-${randomUUID()}.sh`);
+  const outputPath = join(tmpdir(), `shipfox-output-${randomUUID()}`);
   const metadata = commandStartMetadata({command, scriptPath, cwd: options.cwd});
   notifyCommandStart(options.onCommandStart, cloneCommandStartMetadata(metadata));
 
   try {
     await writeFile(scriptPath, command, {mode: 0o700});
-    return await spawnAndCapture(metadata, stepEnv, options);
+    await writeFile(outputPath, '', {mode: 0o600});
+    const result = await spawnAndCapture(metadata, stepEnv, outputPath, options);
+    return await finalizeStepOutput(result, outputPath);
   } finally {
     await unlink(scriptPath).catch(() => undefined);
+    await unlink(outputPath).catch(() => undefined);
   }
 }
 
 function spawnAndCapture(
   metadata: CommandStartMetadata,
   stepEnv: Readonly<Record<string, string>>,
+  outputPath: string,
   options: RunStepOptions,
 ): Promise<StepResult> {
   return new Promise((resolve) => {
@@ -98,7 +104,7 @@ function spawnAndCapture(
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: true,
       cwd: options.cwd,
-      env: {...process.env, ...stepEnv},
+      env: {...process.env, ...stepEnv, SHIPFOX_OUTPUT: outputPath},
     });
 
     // stdout and stderr are two separate pipes, so the sink sees them merged by
@@ -203,6 +209,62 @@ function spawnAndCapture(
       });
     });
   });
+}
+
+async function finalizeStepOutput(result: StepResult, outputPath: string): Promise<StepResult> {
+  let raw: string | undefined;
+  try {
+    raw = await readBoundedStepOutput(outputPath);
+  } catch (error) {
+    if (errorCode(error) === 'ENOENT') return result;
+    if (!result.success) return result;
+    return {
+      success: false,
+      error: {message: stepOutputErrorMessage(error)},
+      exit_code: null,
+    };
+  }
+
+  if (raw === undefined || raw === '') return result;
+
+  try {
+    const outputs = parseStepOutput(raw);
+    if (Object.keys(outputs).length === 0) return result;
+    return {...result, outputs};
+  } catch (error) {
+    if (!result.success) return result;
+    return {
+      success: false,
+      error: {message: stepOutputErrorMessage(error)},
+      exit_code: null,
+    };
+  }
+}
+
+async function readBoundedStepOutput(outputPath: string): Promise<string | undefined> {
+  const handle = await open(outputPath, 'r');
+  try {
+    const buffer = Buffer.alloc(MAX_OUTPUT_TOTAL_BYTES + 1);
+    const {bytesRead} = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead === 0) return undefined;
+    if (bytesRead > MAX_OUTPUT_TOTAL_BYTES) {
+      throw new StepOutputError(`Step output exceeds ${MAX_OUTPUT_TOTAL_BYTES} bytes.`);
+    }
+    return buffer.subarray(0, bytesRead).toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+function stepOutputErrorMessage(error: unknown): string {
+  if (error instanceof StepOutputError) return error.message;
+  return 'Step output file could not be read.';
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String(error.code)
+    : undefined;
 }
 
 function writeTeeOutput(

--- a/libs/runner/execution/src/core/run-step.ts
+++ b/libs/runner/execution/src/core/run-step.ts
@@ -242,8 +242,13 @@ async function finalizeStepOutput(result: StepResult, outputPath: string): Promi
 }
 
 async function readBoundedStepOutput(outputPath: string): Promise<string | undefined> {
-  const handle = await open(outputPath, 'r');
+  const handle = await open(outputPath, constants.O_RDONLY | constants.O_NONBLOCK);
   try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new StepOutputError('Step output file is not a regular file.');
+    }
+
     const buffer = Buffer.alloc(MAX_OUTPUT_TOTAL_BYTES + 1);
     const {bytesRead} = await handle.read(buffer, 0, buffer.length, 0);
     if (bytesRead === 0) return undefined;

--- a/libs/runner/execution/src/core/step-output.test.ts
+++ b/libs/runner/execution/src/core/step-output.test.ts
@@ -1,0 +1,76 @@
+import {MAX_OUTPUT_VALUE_BYTES, parseStepOutput, StepOutputError} from '#core/step-output.js';
+
+describe('parseStepOutput', () => {
+  it('parses single-line outputs', () => {
+    const result = parseStepOutput('sha=abc123\n');
+
+    expect(result).toEqual({sha: 'abc123'});
+  });
+
+  it('parses empty values', () => {
+    const result = parseStepOutput('sha=\n');
+
+    expect(result).toEqual({sha: ''});
+  });
+
+  it('parses multiline heredoc outputs', () => {
+    const result = parseStepOutput('notes<<EOF\nline one\nline two\nEOF\n');
+
+    expect(result).toEqual({notes: 'line one\nline two'});
+  });
+
+  it('throws on unterminated heredocs', () => {
+    const parse = () => parseStepOutput('notes<<EOF\nline one\n');
+
+    expect(parse).toThrow(StepOutputError);
+  });
+
+  it('skips blank lines between entries and preserves them inside heredocs', () => {
+    const result = parseStepOutput('\nfirst=one\n\nnotes<<EOF\nline one\n\nline three\nEOF\n');
+
+    expect(result).toEqual({first: 'one', notes: 'line one\n\nline three'});
+  });
+
+  it('parses CRLF input', () => {
+    const result = parseStepOutput('sha=abc123\r\nnotes<<EOF\r\nline one\r\nEOF\r\n');
+
+    expect(result).toEqual({sha: 'abc123', notes: 'line one'});
+  });
+
+  it.each(['=value', '1key=value', 'bad key=value'])('throws on invalid key %j', (raw) => {
+    const parse = () => parseStepOutput(raw);
+
+    expect(parse).toThrow(StepOutputError);
+  });
+
+  it('accepts hyphenated keys', () => {
+    const result = parseStepOutput('build-sha=abc123\n');
+
+    expect(result).toEqual({'build-sha': 'abc123'});
+  });
+
+  it('throws when a value exceeds the per-value byte cap', () => {
+    const value = 'x'.repeat(MAX_OUTPUT_VALUE_BYTES + 1);
+    const parse = () => parseStepOutput(`payload=${value}`);
+
+    expect(parse).toThrow(StepOutputError);
+  });
+
+  it('lets duplicate keys use the last value', () => {
+    const result = parseStepOutput('sha=old\nsha=new\n');
+
+    expect(result).toEqual({sha: 'new'});
+  });
+
+  it('does not close heredocs on delimiter substrings', () => {
+    const result = parseStepOutput('notes<<EOF\nnot EOF yet\nEOF\n');
+
+    expect(result).toEqual({notes: 'not EOF yet'});
+  });
+
+  it('returns an empty object for empty input', () => {
+    const result = parseStepOutput('');
+
+    expect(result).toEqual({});
+  });
+});

--- a/libs/runner/execution/src/core/step-output.test.ts
+++ b/libs/runner/execution/src/core/step-output.test.ts
@@ -31,6 +31,12 @@ describe('parseStepOutput', () => {
     expect(result).toEqual({first: 'one', notes: 'line one\n\nline three'});
   });
 
+  it('skips whitespace-only lines between entries and preserves them inside heredocs', () => {
+    const result = parseStepOutput('first=one\n  \t  \nnotes<<EOF\n  \t  \nEOF\n');
+
+    expect(result).toEqual({first: 'one', notes: '  \t  '});
+  });
+
   it('parses CRLF input', () => {
     const result = parseStepOutput('sha=abc123\r\nnotes<<EOF\r\nline one\r\nEOF\r\n');
 
@@ -66,6 +72,12 @@ describe('parseStepOutput', () => {
     const result = parseStepOutput('notes<<EOF\nnot EOF yet\nEOF\n');
 
     expect(result).toEqual({notes: 'not EOF yet'});
+  });
+
+  it('parses heredoc markers inside single-line values literally', () => {
+    const result = parseStepOutput('payload=value-with-<<-marker\n');
+
+    expect(result).toEqual({payload: 'value-with-<<-marker'});
   });
 
   it('returns an empty object for empty input', () => {

--- a/libs/runner/execution/src/core/step-output.test.ts
+++ b/libs/runner/execution/src/core/step-output.test.ts
@@ -74,6 +74,12 @@ describe('parseStepOutput', () => {
     expect(result).toEqual({notes: 'not EOF yet'});
   });
 
+  it('treats heredoc delimiter whitespace literally', () => {
+    const parse = () => parseStepOutput('notes<< EOF\nline one\nEOF\n');
+
+    expect(parse).toThrow(StepOutputError);
+  });
+
   it('parses heredoc markers inside single-line values literally', () => {
     const result = parseStepOutput('payload=value-with-<<-marker\n');
 

--- a/libs/runner/execution/src/core/step-output.ts
+++ b/libs/runner/execution/src/core/step-output.ts
@@ -19,17 +19,17 @@ export function parseStepOutput(raw: string): Record<string, string> {
     const line = lines[index] ?? '';
     if (isSkippableLine(line)) continue;
 
+    const singleLine = parseSingleLineOutput(line);
+    if (singleLine) {
+      setOutput(outputs, singleLine.key, singleLine.value);
+      continue;
+    }
+
     const heredoc = parseHeredocStart(line);
     if (heredoc) {
       const body = collectHeredocBody(lines, index + 1, heredoc);
       setOutput(outputs, heredoc.key, body.value);
       index = body.endIndex;
-      continue;
-    }
-
-    const singleLine = parseSingleLineOutput(line);
-    if (singleLine) {
-      setOutput(outputs, singleLine.key, singleLine.value);
       continue;
     }
 
@@ -59,7 +59,7 @@ function outputLines(raw: string): string[] {
 }
 
 function isSkippableLine(line: string): boolean {
-  return line === '';
+  return line.trim() === '';
 }
 
 function parseHeredocStart(line: string): HeredocStart | undefined {
@@ -95,6 +95,9 @@ function collectHeredocBody(
 function parseSingleLineOutput(line: string): ParsedOutput | undefined {
   const equals = line.indexOf('=');
   if (equals === -1) return undefined;
+
+  const heredocMarker = line.indexOf('<<');
+  if (heredocMarker !== -1 && heredocMarker < equals) return undefined;
 
   const key = line.slice(0, equals);
   assertOutputKey(key);

--- a/libs/runner/execution/src/core/step-output.ts
+++ b/libs/runner/execution/src/core/step-output.ts
@@ -1,0 +1,74 @@
+export const MAX_OUTPUT_TOTAL_BYTES = 64 * 1024;
+export const MAX_OUTPUT_VALUE_BYTES = 16 * 1024;
+
+const OUTPUT_KEY_REGEX = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+const OUTPUT_LINE_SPLIT_REGEX = /\r?\n/;
+
+export class StepOutputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StepOutputError';
+  }
+}
+
+export function parseStepOutput(raw: string): Record<string, string> {
+  const outputs: Record<string, string> = {};
+  const lines = raw.split(OUTPUT_LINE_SPLIT_REGEX);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = stripTrailingCarriageReturn(lines[index] ?? '');
+    if (line === '') continue;
+
+    const heredocMarker = line.indexOf('<<');
+    if (heredocMarker !== -1) {
+      const key = line.slice(0, heredocMarker);
+      const delimiter = line.slice(heredocMarker + 2);
+      assertOutputKey(key);
+      if (delimiter === '') throw new StepOutputError(`Output "${key}" has an empty delimiter.`);
+
+      const body: string[] = [];
+      let closed = false;
+      for (index += 1; index < lines.length; index += 1) {
+        const bodyLine = stripTrailingCarriageReturn(lines[index] ?? '');
+        if (bodyLine === delimiter) {
+          closed = true;
+          break;
+        }
+        body.push(bodyLine);
+      }
+      if (!closed) throw new StepOutputError(`Output "${key}" heredoc is unterminated.`);
+
+      setOutput(outputs, key, body.join('\n'));
+      continue;
+    }
+
+    const equals = line.indexOf('=');
+    if (equals !== -1) {
+      const key = line.slice(0, equals);
+      assertOutputKey(key);
+      setOutput(outputs, key, line.slice(equals + 1));
+      continue;
+    }
+
+    throw new StepOutputError('Output file contains a malformed line.');
+  }
+
+  return outputs;
+}
+
+function setOutput(outputs: Record<string, string>, key: string, value: string): void {
+  if (Buffer.byteLength(value, 'utf8') > MAX_OUTPUT_VALUE_BYTES) {
+    throw new StepOutputError(`Output "${key}" exceeds the per-value size limit.`);
+  }
+  outputs[key] = value;
+}
+
+function assertOutputKey(key: string): void {
+  if (!OUTPUT_KEY_REGEX.test(key)) {
+    throw new StepOutputError('Output file contains an invalid key.');
+  }
+}
+
+function stripTrailingCarriageReturn(line: string): string {
+  return line.endsWith('\r') ? line.slice(0, -1) : line;
+}

--- a/libs/runner/execution/src/core/step-output.ts
+++ b/libs/runner/execution/src/core/step-output.ts
@@ -13,40 +13,23 @@ export class StepOutputError extends Error {
 
 export function parseStepOutput(raw: string): Record<string, string> {
   const outputs: Record<string, string> = {};
-  const lines = raw.split(OUTPUT_LINE_SPLIT_REGEX);
+  const lines = outputLines(raw);
 
   for (let index = 0; index < lines.length; index += 1) {
-    const line = stripTrailingCarriageReturn(lines[index] ?? '');
-    if (line === '') continue;
+    const line = lines[index] ?? '';
+    if (isSkippableLine(line)) continue;
 
-    const heredocMarker = line.indexOf('<<');
-    if (heredocMarker !== -1) {
-      const key = line.slice(0, heredocMarker);
-      const delimiter = line.slice(heredocMarker + 2);
-      assertOutputKey(key);
-      if (delimiter === '') throw new StepOutputError(`Output "${key}" has an empty delimiter.`);
-
-      const body: string[] = [];
-      let closed = false;
-      for (index += 1; index < lines.length; index += 1) {
-        const bodyLine = stripTrailingCarriageReturn(lines[index] ?? '');
-        if (bodyLine === delimiter) {
-          closed = true;
-          break;
-        }
-        body.push(bodyLine);
-      }
-      if (!closed) throw new StepOutputError(`Output "${key}" heredoc is unterminated.`);
-
-      setOutput(outputs, key, body.join('\n'));
+    const heredoc = parseHeredocStart(line);
+    if (heredoc) {
+      const body = collectHeredocBody(lines, index + 1, heredoc);
+      setOutput(outputs, heredoc.key, body.value);
+      index = body.endIndex;
       continue;
     }
 
-    const equals = line.indexOf('=');
-    if (equals !== -1) {
-      const key = line.slice(0, equals);
-      assertOutputKey(key);
-      setOutput(outputs, key, line.slice(equals + 1));
+    const singleLine = parseSingleLineOutput(line);
+    if (singleLine) {
+      setOutput(outputs, singleLine.key, singleLine.value);
       continue;
     }
 
@@ -54,6 +37,68 @@ export function parseStepOutput(raw: string): Record<string, string> {
   }
 
   return outputs;
+}
+
+interface HeredocStart {
+  key: string;
+  delimiter: string;
+}
+
+interface ParsedOutput {
+  key: string;
+  value: string;
+}
+
+interface HeredocBody {
+  value: string;
+  endIndex: number;
+}
+
+function outputLines(raw: string): string[] {
+  return raw.split(OUTPUT_LINE_SPLIT_REGEX).map(stripTrailingCarriageReturn);
+}
+
+function isSkippableLine(line: string): boolean {
+  return line === '';
+}
+
+function parseHeredocStart(line: string): HeredocStart | undefined {
+  const marker = line.indexOf('<<');
+  if (marker === -1) return undefined;
+
+  const key = line.slice(0, marker);
+  assertOutputKey(key);
+
+  const delimiter = line.slice(marker + 2);
+  if (delimiter === '') throw new StepOutputError(`Output "${key}" has an empty delimiter.`);
+
+  return {key, delimiter};
+}
+
+function collectHeredocBody(
+  lines: readonly string[],
+  startIndex: number,
+  heredoc: HeredocStart,
+): HeredocBody {
+  const body: string[] = [];
+  for (let index = startIndex; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    if (line === heredoc.delimiter) {
+      return {value: body.join('\n'), endIndex: index};
+    }
+    body.push(line);
+  }
+
+  throw new StepOutputError(`Output "${heredoc.key}" heredoc is unterminated.`);
+}
+
+function parseSingleLineOutput(line: string): ParsedOutput | undefined {
+  const equals = line.indexOf('=');
+  if (equals === -1) return undefined;
+
+  const key = line.slice(0, equals);
+  assertOutputKey(key);
+  return {key, value: line.slice(equals + 1)};
 }
 
 function setOutput(outputs: Record<string, string>, key: string, value: string): void {

--- a/libs/runner/execution/src/core/step-result.ts
+++ b/libs/runner/execution/src/core/step-result.ts
@@ -2,10 +2,10 @@ import type {StepErrorDto} from '@shipfox/api-workflows-dto';
 
 export interface StepResult {
   success: boolean;
-  // Buffered output a step produces in memory (e.g. an agent step's summary). Run
-  // steps leave it unset: their stdout/stderr streams through the log pipeline
-  // (onOutput sink) rather than being buffered here. Never sent to the API.
+  // Legacy agent summary string produced in memory; never sent to the API.
   output?: string;
+  // Run-step key/value outputs reported in the API report `output` field.
+  outputs?: Record<string, string>;
   // Populated when success is false. Null on success.
   error: StepErrorDto;
   // 0 on success, the exit code on failure, null when signal-killed or never spawned.

--- a/libs/runner/execution/src/index.ts
+++ b/libs/runner/execution/src/index.ts
@@ -6,4 +6,10 @@ export {
   type OutputSink,
 } from '#core/run-step.js';
 export {executeSetupStep, type SetupJobContext, type SetupStepExecution} from '#core/setup-step.js';
+export {
+  MAX_OUTPUT_TOTAL_BYTES,
+  MAX_OUTPUT_VALUE_BYTES,
+  parseStepOutput,
+  StepOutputError,
+} from '#core/step-output.js';
 export type {StepResult} from '#core/step-result.js';

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -796,6 +796,89 @@ describe('runJobSteps', () => {
     expect(events.indexOf(`line:${run.id}`)).toBeLessThan(events.indexOf(`close:${run.id}`));
   });
 
+  it('masks run step output values with the full secret set before reporting', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    executeRunStepMock.mockResolvedValueOnce({
+      success: true,
+      error: null,
+      exit_code: 0,
+      outputs: {token: 'checkout-secret'},
+    });
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal, secrets: ['checkout-secret']});
+
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        output: {token: '***'},
+      }),
+    );
+  });
+
+  it('strips URL credentials from run step output values when no secrets are configured', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    executeRunStepMock.mockResolvedValueOnce({
+      success: true,
+      error: null,
+      exit_code: 0,
+      outputs: {remote: 'https://user:pass@example.test/repo.git'},
+    });
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal});
+
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        output: {remote: 'https://***@example.test/repo.git'},
+      }),
+    );
+  });
+
+  it('masks run step failure messages before reporting', async () => {
+    const setup = buildSetupStep();
+    const run = buildRunStep();
+    requestNextStepMock
+      .mockResolvedValueOnce(stepResponse(setup, 1))
+      .mockResolvedValueOnce(stepResponse(run, 1));
+    executeRunStepMock.mockResolvedValueOnce({
+      success: false,
+      error: {message: 'failed with checkout-secret', exit_code: 1},
+      exit_code: 1,
+    });
+    reportStepMock
+      .mockResolvedValueOnce({ok: true, cancel: false})
+      .mockResolvedValueOnce({ok: true, cancel: true});
+    const ac = new AbortController();
+
+    await runLoop({signal: ac.signal, secrets: ['checkout-secret']});
+
+    expect(reportStepMock).toHaveBeenCalledWith(
+      leaseClient,
+      expect.objectContaining({
+        stepId: run.id,
+        error: {message: 'failed with ***', exit_code: 1},
+      }),
+    );
+  });
+
   it('writes terminal signal context for a failed run step before closing the stream', async () => {
     const setup = buildSetupStep();
     const run = buildRunStep();

--- a/libs/runner/orchestration/src/core/step-loop.test.ts
+++ b/libs/runner/orchestration/src/core/step-loop.test.ts
@@ -819,7 +819,7 @@ describe('runJobSteps', () => {
       leaseClient,
       expect.objectContaining({
         stepId: run.id,
-        output: {token: '***'},
+        outputs: {token: '***'},
       }),
     );
   });
@@ -847,7 +847,7 @@ describe('runJobSteps', () => {
       leaseClient,
       expect.objectContaining({
         stepId: run.id,
-        output: {remote: 'https://***@example.test/repo.git'},
+        outputs: {remote: 'https://***@example.test/repo.git'},
       }),
     );
   });
@@ -904,11 +904,26 @@ describe('runJobSteps', () => {
 
   it('reports the step failed when executeRunStep throws (no leaked error, no hung step)', async () => {
     const setup = buildSetupStep();
-    const run = buildRunStep();
+    const run = buildRunStep({
+      config: {
+        run: 'echo "$TOKEN"',
+        secret_bindings: [
+          {
+            target: 'TOKEN',
+            segments: [{kind: 'secret', store: 'local', key: 'API_TOKEN'}],
+          },
+        ],
+      },
+    });
     requestNextStepMock
       .mockResolvedValueOnce(stepResponse(setup, 1))
       .mockResolvedValueOnce(stepResponse(run, 2));
-    executeRunStepMock.mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
+    requestStepSecretsMock.mockResolvedValueOnce({
+      secrets: [{store: 'local', key: 'API_TOKEN', value: 'runtime-secret'}],
+    });
+    executeRunStepMock.mockRejectedValueOnce(
+      new Error('ENOSPC: runtime-secret could not be written'),
+    );
     reportStepMock
       .mockResolvedValueOnce({ok: true, cancel: false})
       .mockResolvedValueOnce({ok: true, cancel: true});
@@ -920,14 +935,14 @@ describe('runJobSteps', () => {
       stepId: run.id,
       attempt: 2,
       status: 'failed',
-      error: {message: 'ENOSPC: no space left on device'},
+      error: {message: 'ENOSPC: *** could not be written'},
       exitCode: null,
       logOutcome: 'drained',
       signal: ac.signal,
     });
     const stream = streamFor(run.id);
     expect(stream.writeOutputLine).toHaveBeenCalledWith(
-      'Process failed: ENOSPC: no space left on device',
+      'Process failed: ENOSPC: *** could not be written',
       'stderr',
     );
   });

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -226,6 +226,7 @@ export async function executeStep(params: {
   let stream: LogStreamLifecycle | undefined;
   let runStream: StepLogStream | undefined;
   let unsubscribeSecrets: (() => void) | undefined;
+  let crashSecretVariants = buildSecretVariants(secrets);
   const registerStreamSecrets = (
     target:
       | {
@@ -386,6 +387,8 @@ export async function executeStep(params: {
     // abandon capture and run the step without a stream rather than failing the step itself.
     let stepStream: StepLogStream | undefined;
     const runSecrets = [...secrets, ...(runSecretMaterial?.secretValues ?? [])];
+    const runSecretVariants = buildSecretVariants(runSecrets);
+    crashSecretVariants = runSecretVariants;
     try {
       stepStream = createStepLogStream({
         logsDir,
@@ -412,7 +415,7 @@ export async function executeStep(params: {
       onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
       onOutput: (chunk, source) => stepStream?.write(chunk, source),
     });
-    result = maskRunStepOutputs(result, buildSecretVariants(runSecrets));
+    result = maskRunStepOutputs(result, runSecretVariants);
     writeRunFailureContext(stepStream, result);
     return {
       result,
@@ -427,7 +430,12 @@ export async function executeStep(params: {
     );
     const result: StepResult = {
       success: false,
-      error: {message: error instanceof Error ? error.message : String(error)},
+      error: {
+        message: redactSecrets(
+          error instanceof Error ? error.message : String(error),
+          crashSecretVariants,
+        ),
+      },
       exit_code: null,
     };
     writeRunFailureContext(runStream, result);
@@ -639,7 +647,7 @@ export async function reportStepResult(params: {
     // null on success, the error shape on failure — matches reportStepBodySchema's refine.
     error: result.error,
     exitCode: result.exit_code,
-    ...(result.outputs ? {output: result.outputs} : {}),
+    ...(result.outputs ? {outputs: result.outputs} : {}),
     logOutcome,
     signal,
   });

--- a/libs/runner/orchestration/src/core/step-loop.ts
+++ b/libs/runner/orchestration/src/core/step-loop.ts
@@ -404,7 +404,7 @@ export async function executeStep(params: {
     runStream = stepStream;
     registerStreamSecrets(stepStream);
 
-    const result = await executeRunStep(step, {
+    let result = await executeRunStep(step, {
       signal,
       cwd,
       ...(runSecretMaterial?.secretEnv ? {secretEnv: runSecretMaterial.secretEnv} : {}),
@@ -412,6 +412,7 @@ export async function executeStep(params: {
       onCommandStart: (metadata) => writeCommandMetadata(stepStream, metadata),
       onOutput: (chunk, source) => stepStream?.write(chunk, source),
     });
+    result = maskRunStepOutputs(result, buildSecretVariants(runSecrets));
     writeRunFailureContext(stepStream, result);
     return {
       result,
@@ -531,6 +532,27 @@ function maskAgentFailure(result: StepResult, secretVariants: string[]): StepRes
   return {...result, output: '', error};
 }
 
+function maskRunStepOutputs(result: StepResult, secretVariants: string[]): StepResult {
+  const outputs =
+    result.outputs === undefined
+      ? result.outputs
+      : Object.fromEntries(
+          Object.entries(result.outputs).map(([key, value]) => [
+            key,
+            redactSecrets(value, secretVariants),
+          ]),
+        );
+  const error =
+    result.success || result.error === null || result.error === undefined
+      ? result.error
+      : {...result.error, message: redactSecrets(result.error.message, secretVariants)};
+  return {
+    ...result,
+    ...(outputs === undefined ? {} : {outputs}),
+    error,
+  };
+}
+
 function agentRuntimeConfigFailure(error: unknown): StepResult {
   if (error instanceof AgentRuntimeConfigRequestError) {
     const agentConfigIssue =
@@ -617,6 +639,7 @@ export async function reportStepResult(params: {
     // null on success, the error shape on failure — matches reportStepBodySchema's refine.
     error: result.error,
     exitCode: result.exit_code,
+    ...(result.outputs ? {output: result.outputs} : {}),
     logOutcome,
     signal,
   });

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -3,6 +3,7 @@
 // from test/env.ts (setupFiles), loaded before config is imported.
 
 import {RUNNER_SESSION_EXHAUSTED_CODE} from '@shipfox/api-runners-dto';
+import {STEP_ERROR_MESSAGE_MAX_LENGTH} from '@shipfox/api-workflows-dto';
 import {
   AgentRuntimeConfigRequestError,
   appendStepLogs,
@@ -388,6 +389,61 @@ describe('api-client auth contexts', () => {
     expect(result).toEqual({ok: true, cancel: false});
     expect(calls[0]?.url).toContain(`runs/jobs/current/steps/${STEP_ID}/report`);
     expect(calls[0]?.authorization).toBe('Bearer lease-def');
+  });
+
+  it('reportStep includes output when present', async () => {
+    stubFetch(() => jsonResponse({ok: true, cancel: false}));
+    const leaseClient = createLeaseClient('lease-output');
+
+    await reportStep(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      status: 'succeeded',
+      exitCode: 0,
+      output: {sha: 'abc123'},
+      logOutcome: 'drained',
+    });
+
+    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({
+      status: 'succeeded',
+      attempt: 1,
+      exit_code: 0,
+      output: {sha: 'abc123'},
+      log_outcome: 'drained',
+    });
+  });
+
+  it('reportStep omits output when it is undefined', async () => {
+    stubFetch(() => jsonResponse({ok: true, cancel: false}));
+    const leaseClient = createLeaseClient('lease-output');
+
+    await reportStep(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      status: 'succeeded',
+      exitCode: 0,
+      logOutcome: 'drained',
+    });
+
+    expect(JSON.parse(calls[0]?.body ?? '{}')).not.toHaveProperty('output');
+  });
+
+  it('reportStep truncates long error messages before validation and send', async () => {
+    stubFetch(() => jsonResponse({ok: true, cancel: false}));
+    const leaseClient = createLeaseClient('lease-error');
+    const message = 'x'.repeat(STEP_ERROR_MESSAGE_MAX_LENGTH + 1);
+
+    await reportStep(leaseClient, {
+      stepId: STEP_ID,
+      attempt: 1,
+      status: 'failed',
+      error: {message},
+      exitCode: null,
+      logOutcome: 'drained',
+    });
+
+    const body = JSON.parse(calls[0]?.body ?? '{}');
+    expect(body.error.message).toHaveLength(STEP_ERROR_MESSAGE_MAX_LENGTH);
   });
 });
 

--- a/libs/runner/protocol/src/api-client.test.ts
+++ b/libs/runner/protocol/src/api-client.test.ts
@@ -400,7 +400,7 @@ describe('api-client auth contexts', () => {
       attempt: 1,
       status: 'succeeded',
       exitCode: 0,
-      output: {sha: 'abc123'},
+      outputs: {sha: 'abc123'},
       logOutcome: 'drained',
     });
 

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -235,7 +235,7 @@ export async function reportStep(
     error?: StepErrorDto;
     exitCode: number | null;
     logOutcome: LogOutcomeDto;
-    output?: Record<string, string> | null;
+    outputs?: Record<string, string> | null;
     signal?: AbortSignal;
   },
 ): Promise<ReportStepResponseDto> {
@@ -248,7 +248,7 @@ export async function reportStep(
     error: error ?? undefined,
     attempt: params.attempt,
     exit_code: params.exitCode,
-    ...(params.output ? {output: params.output} : {}),
+    ...(params.outputs ? {output: params.outputs} : {}),
     log_outcome: params.logOutcome,
   });
 

--- a/libs/runner/protocol/src/api-client.ts
+++ b/libs/runner/protocol/src/api-client.ts
@@ -24,6 +24,7 @@ import {
   type ReportStepResponseDto,
   reportStepBodySchema,
   reportStepResponseSchema,
+  STEP_ERROR_MESSAGE_MAX_LENGTH,
   type StepErrorDto,
 } from '@shipfox/api-workflows-dto';
 import {logger} from '@shipfox/node-opentelemetry';
@@ -234,14 +235,20 @@ export async function reportStep(
     error?: StepErrorDto;
     exitCode: number | null;
     logOutcome: LogOutcomeDto;
+    output?: Record<string, string> | null;
     signal?: AbortSignal;
   },
 ): Promise<ReportStepResponseDto> {
+  const error =
+    params.error === null || params.error === undefined
+      ? params.error
+      : {...params.error, message: params.error.message.slice(0, STEP_ERROR_MESSAGE_MAX_LENGTH)};
   const body = reportStepBodySchema.parse({
     status: params.status,
-    error: params.error ?? undefined,
+    error: error ?? undefined,
     attempt: params.attempt,
     exit_code: params.exitCode,
+    ...(params.output ? {output: params.output} : {}),
     log_outcome: params.logOutcome,
   });
 


### PR DESCRIPTION
Add run-step output emission via `$SHIPFOX_OUTPUT` so workflow authors can pass structured values from one run step to later steps with `steps.<key>.outputs.<name>`.

Run steps previously only streamed stdout/stderr into logs, leaving `step_attempts.output` empty and downstream output references unresolved. This adds the runner-side emission surface, parser, size caps, masking before report, and report plumbing while keeping emitted values as plain strings.

The implementation keeps server-side output validation and typed coercion out of scope for the follow-up typed outputs work; this PR relies on the existing report `output` field and persistence path.

Closes ENG-784

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds run-step output emission via `$SHIPFOX_OUTPUT` so workflows can pass key/value outputs to later run steps with `steps.<key>.outputs.<name>`. Enforces strict parsing, size caps, secret/URL redaction (including crash errors), and trims error messages before reporting (ENG-784).

- **New Features**
  - Emit with `key=value` or `key<<EOF ... EOF`; heredoc delimiters are literal; CRLF supported.
  - Runner injects a secure per-step output file and overrides any user `SHIPFOX_OUTPUT`.
  - Parsing: skip blank/whitespace lines; keys start with letter/underscore (hyphens allowed); last value wins; unterminated/malformed entries fail.
  - Limits and behavior: 64KB total, 16KB per value; missing/deleted file → no outputs; unreadable or non-regular file fails an otherwise successful step; non-zero exits keep the original error and still attach valid outputs.
  - Reporting and protection: outputs sent via API `output`; masks secrets and URL credentials in outputs and error messages (including crash errors); trims error messages to 2048 chars via `STEP_ERROR_MESSAGE_MAX_LENGTH` in `@shipfox/api-workflows-dto`.

- **Migration**
  - Emit: `echo "name=value" >> "$SHIPFOX_OUTPUT"`; for multiline: `printf "notes<<EOF\n...lines...\nEOF\n" >> "$SHIPFOX_OUTPUT"`.
  - Read: `${{ steps.<stepKey>.outputs.<name> }}`. No config changes needed.

<sup>Written for commit 68b5798c8963e905224b5dbc6ae8d6bbd37a7edc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

