### PR TITLE
Add shared E2E authoring kit

### DIFF
--- a/e2e/api/auth/package.json
+++ b/e2e/api/auth/package.json
@@ -23,6 +23,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/api/auth/playwright.config.ts
+++ b/e2e/api/auth/playwright.config.ts
@@ -1,11 +1,3 @@
-import {defineConfig} from '@shipfox/playwright';
+import {defineApiE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI ? 'github' : 'list',
-  use: {
-    trace: 'retain-on-failure',
-  },
-});
+export default defineApiE2eConfig();

--- a/e2e/client/agent/package.json
+++ b/e2e/client/agent/package.json
@@ -27,6 +27,7 @@
     "@shipfox/e2e-helper-auth": "workspace:*",
     "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/agent/playwright.config.ts
+++ b/e2e/client/agent/playwright.config.ts
@@ -1,33 +1,3 @@
-import {config} from '@shipfox/e2e-core';
-import {defineConfig, devices} from '@shipfox/playwright';
+import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  timeout: 180_000,
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI
-    ? [
-        ['github'],
-        [
-          '@argos-ci/playwright/reporter',
-          {
-            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
-            buildName: 'e2e-client-agent',
-            ignoreUploadFailures: true,
-          },
-        ],
-      ]
-    : 'list',
-  use: {
-    baseURL: config.CLIENT_URL,
-    trace: 'retain-on-failure',
-    contextOptions: {reducedMotion: 'reduce'},
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-    },
-  ],
-});
+export default defineClientE2eConfig({buildName: 'e2e-client-agent', timeout: 180_000});

--- a/e2e/client/agent/tests/global-setup.ts
+++ b/e2e/client/agent/tests/global-setup.ts
@@ -1,7 +1,7 @@
-import {preflightCheck} from '@shipfox/e2e-core';
 import {requireOllamaModel} from '@shipfox/e2e-helper-agent';
+import globalSetup from '@shipfox/e2e-kit/global-setup';
 
-export default async function globalSetup(): Promise<void> {
-  await preflightCheck();
+export default async function agentGlobalSetup(): Promise<void> {
+  await globalSetup();
   await requireOllamaModel();
 }

--- a/e2e/client/agent/tests/test.ts
+++ b/e2e/client/agent/tests/test.ts
@@ -1,15 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AgentFixtures, agentHelper} from '@shipfox/e2e-helper-agent';
-import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
-import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
-import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 
-export const test = base.extend<
-  AuthFixtures & AgentFixtures & ProjectsFixtures & WorkspacesFixtures
->({
-  ...authHelper,
+export const test = base.extend<WorkspaceFixtures & AgentFixtures>({
+  ...workspaceFixtures,
   ...agentHelper,
-  ...projectsHelper,
-  ...workspacesHelper,
 });
 export {expect};

--- a/e2e/client/auth/package.json
+++ b/e2e/client/auth/package.json
@@ -21,8 +21,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/client-auth": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
-    "@shipfox/e2e-helper-auth": "workspace:*",
-    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/auth/playwright.config.ts
+++ b/e2e/client/auth/playwright.config.ts
@@ -1,32 +1,3 @@
-import {config} from '@shipfox/e2e-core';
-import {defineConfig, devices} from '@shipfox/playwright';
+import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI
-    ? [
-        ['github'],
-        [
-          '@argos-ci/playwright/reporter',
-          {
-            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
-            buildName: 'e2e-client-auth',
-            ignoreUploadFailures: true,
-          },
-        ],
-      ]
-    : 'list',
-  use: {
-    baseURL: config.CLIENT_URL,
-    trace: 'retain-on-failure',
-    contextOptions: {reducedMotion: 'reduce'},
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-    },
-  ],
-});
+export default defineClientE2eConfig({buildName: 'e2e-client-auth'});

--- a/e2e/client/auth/tests/global-setup.ts
+++ b/e2e/client/auth/tests/global-setup.ts
@@ -1,5 +1,1 @@
-import {preflightCheck} from '@shipfox/e2e-core';
-
-export default async function globalSetup(): Promise<void> {
-  await preflightCheck();
-}
+export {default} from '@shipfox/e2e-kit/global-setup';

--- a/e2e/client/auth/tests/test.ts
+++ b/e2e/client/auth/tests/test.ts
@@ -1,9 +1,5 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
-import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
-import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type AuthWorkspaceFixtures, authWorkspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 
-export const test = base.extend<AuthFixtures & WorkspacesFixtures>({
-  ...authHelper,
-  ...workspacesHelper,
-});
+export const test = base.extend<AuthWorkspaceFixtures>(authWorkspaceFixtures);
 export {expect};

--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -23,10 +23,8 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/client-integrations": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
-    "@shipfox/e2e-helper-auth": "workspace:*",
     "@shipfox/e2e-helper-integrations-gitea": "workspace:*",
-    "@shipfox/e2e-helper-projects": "workspace:*",
-    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/integrations/playwright.config.ts
+++ b/e2e/client/integrations/playwright.config.ts
@@ -1,32 +1,3 @@
-import {config} from '@shipfox/e2e-core';
-import {defineConfig, devices} from '@shipfox/playwright';
+import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI
-    ? [
-        ['github'],
-        [
-          '@argos-ci/playwright/reporter',
-          {
-            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
-            buildName: 'e2e-client-integrations',
-            ignoreUploadFailures: true,
-          },
-        ],
-      ]
-    : 'list',
-  use: {
-    baseURL: config.CLIENT_URL,
-    trace: 'retain-on-failure',
-    contextOptions: {reducedMotion: 'reduce'},
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-    },
-  ],
-});
+export default defineClientE2eConfig({buildName: 'e2e-client-integrations'});

--- a/e2e/client/integrations/tests/global-setup.ts
+++ b/e2e/client/integrations/tests/global-setup.ts
@@ -1,5 +1,1 @@
-import {preflightCheck} from '@shipfox/e2e-core';
-
-export default async function globalSetup(): Promise<void> {
-  await preflightCheck();
-}
+export {default} from '@shipfox/e2e-kit/global-setup';

--- a/e2e/client/integrations/tests/test.ts
+++ b/e2e/client/integrations/tests/test.ts
@@ -1,15 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
-import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
 import {type GiteaFixtures, giteaHelper} from '@shipfox/e2e-helper-integrations-gitea';
-import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
-import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 
-export const test = base.extend<
-  AuthFixtures & GiteaFixtures & ProjectsFixtures & WorkspacesFixtures
->({
-  ...authHelper,
+export const test = base.extend<WorkspaceFixtures & GiteaFixtures>({
+  ...workspaceFixtures,
   ...giteaHelper,
-  ...projectsHelper,
-  ...workspacesHelper,
 });
 export {expect};

--- a/e2e/client/runners/package.json
+++ b/e2e/client/runners/package.json
@@ -28,6 +28,7 @@
     "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-runners": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/regex": "workspace:*",
     "@shipfox/ts-config": "workspace:*",

--- a/e2e/client/runners/playwright.config.ts
+++ b/e2e/client/runners/playwright.config.ts
@@ -1,33 +1,3 @@
-import {config} from '@shipfox/e2e-core';
-import {defineConfig, devices} from '@shipfox/playwright';
+import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI
-    ? [
-        ['github'],
-        [
-          '@argos-ci/playwright/reporter',
-          {
-            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
-            buildName: 'e2e-client-runners',
-            ignoreUploadFailures: true,
-          },
-        ],
-      ]
-    : 'list',
-  use: {
-    baseURL: config.CLIENT_URL,
-    trace: 'retain-on-failure',
-    timezoneId: 'UTC',
-    contextOptions: {reducedMotion: 'reduce'},
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-    },
-  ],
-});
+export default defineClientE2eConfig({buildName: 'e2e-client-runners'});

--- a/e2e/client/runners/tests/global-setup.ts
+++ b/e2e/client/runners/tests/global-setup.ts
@@ -1,5 +1,1 @@
-import {preflightCheck} from '@shipfox/e2e-core';
-
-export default async function globalSetup(): Promise<void> {
-  await preflightCheck();
-}
+export {default} from '@shipfox/e2e-kit/global-setup';

--- a/e2e/client/runners/tests/test.ts
+++ b/e2e/client/runners/tests/test.ts
@@ -1,11 +1,5 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
-import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
-import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
-import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 
-export const test = base.extend<AuthFixtures & ProjectsFixtures & WorkspacesFixtures>({
-  ...authHelper,
-  ...projectsHelper,
-  ...workspacesHelper,
-});
+export const test = base.extend<WorkspaceFixtures>(workspaceFixtures);
 export {expect};

--- a/e2e/client/secrets/package.json
+++ b/e2e/client/secrets/package.json
@@ -28,6 +28,7 @@
     "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-secrets": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/secrets/playwright.config.ts
+++ b/e2e/client/secrets/playwright.config.ts
@@ -1,32 +1,3 @@
-import {config} from '@shipfox/e2e-core';
-import {defineConfig, devices} from '@shipfox/playwright';
+import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI
-    ? [
-        ['github'],
-        [
-          '@argos-ci/playwright/reporter',
-          {
-            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
-            buildName: 'e2e-client-secrets',
-            ignoreUploadFailures: true,
-          },
-        ],
-      ]
-    : 'list',
-  use: {
-    baseURL: config.CLIENT_URL,
-    trace: 'retain-on-failure',
-    contextOptions: {reducedMotion: 'reduce'},
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-    },
-  ],
-});
+export default defineClientE2eConfig({buildName: 'e2e-client-secrets'});

--- a/e2e/client/secrets/tests/global-setup.ts
+++ b/e2e/client/secrets/tests/global-setup.ts
@@ -1,5 +1,1 @@
-import {preflightCheck} from '@shipfox/e2e-core';
-
-export default async function globalSetup(): Promise<void> {
-  await preflightCheck();
-}
+export {default} from '@shipfox/e2e-kit/global-setup';

--- a/e2e/client/secrets/tests/test.ts
+++ b/e2e/client/secrets/tests/test.ts
@@ -1,15 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
-import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
-import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
 import {type SecretsFixtures, secretsHelper} from '@shipfox/e2e-helper-secrets';
-import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 
-export const test = base.extend<
-  AuthFixtures & ProjectsFixtures & WorkspacesFixtures & SecretsFixtures
->({
-  ...authHelper,
-  ...projectsHelper,
-  ...workspacesHelper,
+export const test = base.extend<WorkspaceFixtures & SecretsFixtures>({
+  ...workspaceFixtures,
   ...secretsHelper,
 });
 export {expect};

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -22,10 +22,8 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/client-router": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
-    "@shipfox/e2e-helper-auth": "workspace:*",
     "@shipfox/e2e-helper-integrations-gitea": "workspace:*",
-    "@shipfox/e2e-helper-projects": "workspace:*",
-    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/e2e-kit": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/workspaces/playwright.config.ts
+++ b/e2e/client/workspaces/playwright.config.ts
@@ -1,32 +1,3 @@
-import {config} from '@shipfox/e2e-core';
-import {defineConfig, devices} from '@shipfox/playwright';
+import {defineClientE2eConfig} from '@shipfox/e2e-kit/config';
 
-export default defineConfig({
-  testDir: './tests',
-  testMatch: '**/*.e2e.ts',
-  globalSetup: './tests/global-setup.ts',
-  reporter: process.env.CI
-    ? [
-        ['github'],
-        [
-          '@argos-ci/playwright/reporter',
-          {
-            uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
-            buildName: 'e2e-client-workspaces',
-            ignoreUploadFailures: true,
-          },
-        ],
-      ]
-    : 'list',
-  use: {
-    baseURL: config.CLIENT_URL,
-    trace: 'retain-on-failure',
-    contextOptions: {reducedMotion: 'reduce'},
-  },
-  projects: [
-    {
-      name: 'chromium',
-      use: devices['Desktop Chrome'],
-    },
-  ],
-});
+export default defineClientE2eConfig({buildName: 'e2e-client-workspaces'});

--- a/e2e/client/workspaces/tests/global-setup.ts
+++ b/e2e/client/workspaces/tests/global-setup.ts
@@ -1,5 +1,1 @@
-import {preflightCheck} from '@shipfox/e2e-core';
-
-export default async function globalSetup(): Promise<void> {
-  await preflightCheck();
-}
+export {default} from '@shipfox/e2e-kit/global-setup';

--- a/e2e/client/workspaces/tests/test.ts
+++ b/e2e/client/workspaces/tests/test.ts
@@ -1,15 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
-import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
 import {type GiteaFixtures, giteaHelper} from '@shipfox/e2e-helper-integrations-gitea';
-import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
-import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
 
-export const test = base.extend<
-  AuthFixtures & GiteaFixtures & ProjectsFixtures & WorkspacesFixtures
->({
-  ...authHelper,
+export const test = base.extend<WorkspaceFixtures & GiteaFixtures>({
+  ...workspaceFixtures,
   ...giteaHelper,
-  ...projectsHelper,
-  ...workspacesHelper,
 });
 export {expect};

--- a/e2e/kit/package.json
+++ b/e2e/kit/package.json
@@ -42,6 +42,16 @@
         "types": "./dist/setup/global-setup.d.ts",
         "default": "./dist/setup/global-setup.js"
       }
+    },
+    "./api-global-setup": {
+      "development": {
+        "types": "./src/setup/api-global-setup.ts",
+        "default": "./src/setup/api-global-setup.ts"
+      },
+      "default": {
+        "types": "./dist/setup/api-global-setup.d.ts",
+        "default": "./dist/setup/api-global-setup.js"
+      }
     }
   },
   "scripts": {

--- a/e2e/kit/package.json
+++ b/e2e/kit/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@shipfox/e2e-kit",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/kit"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#test/*": "./test/*",
+    "#*": "./src/*"
+  },
+  "exports": {
+    "./config": {
+      "development": {
+        "types": "./src/config/index.ts",
+        "default": "./src/config/index.ts"
+      },
+      "default": {
+        "types": "./dist/config/index.d.ts",
+        "default": "./dist/config/index.js"
+      }
+    },
+    "./fixtures": {
+      "development": {
+        "types": "./src/fixtures/index.ts",
+        "default": "./src/fixtures/index.ts"
+      },
+      "default": {
+        "types": "./dist/fixtures/index.d.ts",
+        "default": "./dist/fixtures/index.js"
+      }
+    },
+    "./global-setup": {
+      "development": {
+        "types": "./src/setup/global-setup.ts",
+        "default": "./src/setup/global-setup.ts"
+      },
+      "default": {
+        "types": "./dist/setup/global-setup.d.ts",
+        "default": "./dist/setup/global-setup.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-core": "workspace:*",
+    "@shipfox/e2e-helper-auth": "workspace:*",
+    "@shipfox/e2e-helper-projects": "workspace:*",
+    "@shipfox/e2e-helper-workspaces": "workspace:*",
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/kit/src/config/api.ts
+++ b/e2e/kit/src/config/api.ts
@@ -1,11 +1,10 @@
 import {defineConfig} from '@shipfox/playwright';
-import apiGlobalSetup from '../setup/api-global-setup.js';
 
 export function defineApiE2eConfig() {
   return defineConfig({
     testDir: './tests',
     testMatch: '**/*.e2e.ts',
-    globalSetup: apiGlobalSetup,
+    globalSetup: '@shipfox/e2e-kit/api-global-setup',
     reporter: process.env.CI ? 'github' : 'list',
     use: {
       trace: 'retain-on-failure',

--- a/e2e/kit/src/config/api.ts
+++ b/e2e/kit/src/config/api.ts
@@ -1,0 +1,14 @@
+import {defineConfig} from '@shipfox/playwright';
+import apiGlobalSetup from '../setup/api-global-setup.js';
+
+export function defineApiE2eConfig() {
+  return defineConfig({
+    testDir: './tests',
+    testMatch: '**/*.e2e.ts',
+    globalSetup: apiGlobalSetup,
+    reporter: process.env.CI ? 'github' : 'list',
+    use: {
+      trace: 'retain-on-failure',
+    },
+  });
+}

--- a/e2e/kit/src/config/client.ts
+++ b/e2e/kit/src/config/client.ts
@@ -1,0 +1,43 @@
+import {config} from '@shipfox/e2e-core';
+import {defineConfig, devices, type PlaywrightTestConfig} from '@shipfox/playwright';
+
+export interface ClientE2eConfigOptions {
+  buildName: string;
+  timeout?: number;
+  use?: PlaywrightTestConfig['use'];
+}
+
+export function defineClientE2eConfig(options: ClientE2eConfigOptions) {
+  return defineConfig({
+    testDir: './tests',
+    testMatch: '**/*.e2e.ts',
+    globalSetup: './tests/global-setup.ts',
+    ...(options.timeout ? {timeout: options.timeout} : {}),
+    reporter: process.env.CI
+      ? [
+          ['github'],
+          [
+            '@argos-ci/playwright/reporter',
+            {
+              uploadToArgos: Boolean(process.env.ARGOS_TOKEN),
+              buildName: options.buildName,
+              ignoreUploadFailures: true,
+            },
+          ],
+        ]
+      : 'list',
+    use: {
+      baseURL: config.CLIENT_URL,
+      trace: 'retain-on-failure',
+      timezoneId: 'UTC',
+      contextOptions: {reducedMotion: 'reduce'},
+      ...options.use,
+    },
+    projects: [
+      {
+        name: 'chromium',
+        use: devices['Desktop Chrome'],
+      },
+    ],
+  });
+}

--- a/e2e/kit/src/config/client.ts
+++ b/e2e/kit/src/config/client.ts
@@ -12,7 +12,7 @@ export function defineClientE2eConfig(options: ClientE2eConfigOptions) {
     testDir: './tests',
     testMatch: '**/*.e2e.ts',
     globalSetup: './tests/global-setup.ts',
-    ...(options.timeout ? {timeout: options.timeout} : {}),
+    ...(options.timeout !== undefined ? {timeout: options.timeout} : {}),
     reporter: process.env.CI
       ? [
           ['github'],

--- a/e2e/kit/src/config/index.ts
+++ b/e2e/kit/src/config/index.ts
@@ -1,0 +1,2 @@
+export {defineApiE2eConfig} from './api.js';
+export {type ClientE2eConfigOptions, defineClientE2eConfig} from './client.js';

--- a/e2e/kit/src/fixtures/index.ts
+++ b/e2e/kit/src/fixtures/index.ts
@@ -1,0 +1,6 @@
+export {
+  type AuthWorkspaceFixtures,
+  authWorkspaceFixtures,
+  type WorkspaceFixtures,
+  workspaceFixtures,
+} from './workspace.js';

--- a/e2e/kit/src/fixtures/workspace.ts
+++ b/e2e/kit/src/fixtures/workspace.ts
@@ -1,0 +1,17 @@
+import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
+import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
+import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+
+export type AuthWorkspaceFixtures = AuthFixtures & WorkspacesFixtures;
+
+export const authWorkspaceFixtures = {
+  ...authHelper,
+  ...workspacesHelper,
+};
+
+export type WorkspaceFixtures = AuthWorkspaceFixtures & ProjectsFixtures;
+
+export const workspaceFixtures = {
+  ...authWorkspaceFixtures,
+  ...projectsHelper,
+};

--- a/e2e/kit/src/setup/api-global-setup.ts
+++ b/e2e/kit/src/setup/api-global-setup.ts
@@ -1,5 +1,5 @@
 import {preflightCheck} from '@shipfox/e2e-core';
 
-export default async function globalSetup(): Promise<void> {
+export default async function apiGlobalSetup(): Promise<void> {
   await preflightCheck({requireClient: false});
 }

--- a/e2e/kit/src/setup/global-setup.ts
+++ b/e2e/kit/src/setup/global-setup.ts
@@ -1,0 +1,5 @@
+import {preflightCheck} from '@shipfox/e2e-core';
+
+export default async function globalSetup(): Promise<void> {
+  await preflightCheck();
+}

--- a/e2e/kit/tsconfig.build.json
+++ b/e2e/kit/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@shipfox/ts-config/node",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/kit/tsconfig.json
+++ b/e2e/kit/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,6 +246,9 @@ importers:
       '@shipfox/e2e-helper-auth':
         specifier: workspace:*
         version: link:../../helpers/auth
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -285,6 +288,9 @@ importers:
       '@shipfox/e2e-helper-workspaces':
         specifier: workspace:*
         version: link:../../helpers/workspaces
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -306,12 +312,9 @@ importers:
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core
-      '@shipfox/e2e-helper-auth':
+      '@shipfox/e2e-kit':
         specifier: workspace:*
-        version: link:../../helpers/auth
-      '@shipfox/e2e-helper-workspaces':
-        specifier: workspace:*
-        version: link:../../helpers/workspaces
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -339,18 +342,12 @@ importers:
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core
-      '@shipfox/e2e-helper-auth':
-        specifier: workspace:*
-        version: link:../../helpers/auth
       '@shipfox/e2e-helper-integrations-gitea':
         specifier: workspace:*
         version: link:../../helpers/integrations-gitea
-      '@shipfox/e2e-helper-projects':
+      '@shipfox/e2e-kit':
         specifier: workspace:*
-        version: link:../../helpers/projects
-      '@shipfox/e2e-helper-workspaces':
-        specifier: workspace:*
-        version: link:../../helpers/workspaces
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -393,6 +390,9 @@ importers:
       '@shipfox/e2e-helper-workspaces':
         specifier: workspace:*
         version: link:../../helpers/workspaces
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -438,6 +438,9 @@ importers:
       '@shipfox/e2e-helper-workspaces':
         specifier: workspace:*
         version: link:../../helpers/workspaces
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -462,18 +465,12 @@ importers:
       '@shipfox/e2e-core':
         specifier: workspace:*
         version: link:../../core
-      '@shipfox/e2e-helper-auth':
-        specifier: workspace:*
-        version: link:../../helpers/auth
       '@shipfox/e2e-helper-integrations-gitea':
         specifier: workspace:*
         version: link:../../helpers/integrations-gitea
-      '@shipfox/e2e-helper-projects':
+      '@shipfox/e2e-kit':
         specifier: workspace:*
-        version: link:../../helpers/projects
-      '@shipfox/e2e-helper-workspaces':
-        specifier: workspace:*
-        version: link:../../helpers/workspaces
+        version: link:../../kit
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -773,6 +770,37 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../../tools/typescript
+
+  e2e/kit:
+    dependencies:
+      '@shipfox/e2e-core':
+        specifier: workspace:*
+        version: link:../core
+      '@shipfox/e2e-helper-auth':
+        specifier: workspace:*
+        version: link:../helpers/auth
+      '@shipfox/e2e-helper-projects':
+        specifier: workspace:*
+        version: link:../helpers/projects
+      '@shipfox/e2e-helper-workspaces':
+        specifier: workspace:*
+        version: link:../helpers/workspaces
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../tools/playwright
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../tools/biome
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../tools/typescript
 
   e2e/platform/workflows:
     devDependencies:


### PR DESCRIPTION
Add `@shipfox/e2e-kit` as the shared authoring layer for E2E suites.

Client and API suites were each carrying copied Playwright config, global setup, and fixture composition. This extracts those defaults into config factories, shared preflight setup, and workspace fixture presets so new suites can depend on one package while preserving existing behavior.

The migration keeps the existing Argos build names, keeps the agent suite's 180s timeout and Ollama preflight, and makes UTC the default client-suite timezone through the shared config.

Closes ENG-811

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `@shipfox/e2e-kit` to centralize Playwright config, global setup, and workspace fixtures for all E2E suites, removing duplicated boilerplate while preserving current behavior. Also fixes the API global setup path so Playwright resolves it in CI. Closes ENG-811.

- New Features
  - Config factories: `defineClientE2eConfig({buildName, timeout?, use?})`, `defineApiE2eConfig()`.
  - Shared setup: client uses `@shipfox/e2e-kit/global-setup`; API uses `@shipfox/e2e-kit/api-global-setup` (no client requirement).
  - Fixture presets: `workspaceFixtures`, `authWorkspaceFixtures`.
  - Preserves Argos build names, the agent suite’s 180s timeout, Ollama preflight, UTC timezone for client suites, and honors explicit `timeout: 0` overrides.

- Bug Fixes
  - Exported `api-global-setup` as a kit subpath and referenced it from `defineApiE2eConfig()` to satisfy CI’s module path requirement.

<sup>Written for commit 2c3af484bd5901e845a7837d798ca1b4a811b415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

