### PR TITLE
Consolidate E2E polling and session auth

### DIFF
--- a/e2e/core/src/index.ts
+++ b/e2e/core/src/index.ts
@@ -9,4 +9,5 @@ export {
   requestJson,
 } from './api/index.js';
 export {config} from './config.js';
+export {type PollOptions, pollUntil} from './poll.js';
 export {type PreflightOptions, preflightCheck} from './preflight.js';

--- a/e2e/core/src/poll.test.ts
+++ b/e2e/core/src/poll.test.ts
@@ -1,0 +1,52 @@
+import {pollUntil} from './poll.js';
+
+describe('pollUntil', () => {
+  test('polls until the probe returns a value', async () => {
+    let calls = 0;
+
+    const result = await pollUntil(
+      {
+        describe: () => 'resource to appear',
+        intervalMs: 1,
+        timeoutMs: 100,
+      },
+      () => {
+        calls += 1;
+        return Promise.resolve(calls === 1 ? null : 'ready');
+      },
+    );
+
+    expect(result).toBe('ready');
+    expect(calls).toBe(2);
+  });
+
+  test('times out with the description and last probe error', async () => {
+    const result = pollUntil(
+      {
+        describe: () => 'resource to appear',
+        timeoutMs: 0,
+      },
+      () => Promise.reject(new Error('not yet')),
+    );
+
+    await expect(result).rejects.toThrow(
+      'Timed out after 0ms waiting for resource to appear; last error: not yet',
+    );
+  });
+
+  test('stops when the abort signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = pollUntil(
+      {
+        describe: () => 'resource to appear',
+        signal: controller.signal,
+        timeoutMs: 100,
+      },
+      () => Promise.resolve('ready'),
+    );
+
+    await expect(result).rejects.toThrow('Stopped waiting for resource to appear');
+  });
+});

--- a/e2e/core/src/poll.test.ts
+++ b/e2e/core/src/poll.test.ts
@@ -1,6 +1,10 @@
 import {pollUntil} from './poll.js';
 
 describe('pollUntil', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test('polls until the probe returns a value', async () => {
     let calls = 0;
 
@@ -18,6 +22,60 @@ describe('pollUntil', () => {
 
     expect(result).toBe('ready');
     expect(calls).toBe(2);
+  });
+
+  test('applies a custom backoff factor to the delay cadence', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const callTimes: number[] = [];
+
+    const result = pollUntil(
+      {
+        backoffFactor: 1.5,
+        describe: () => 'resource to appear',
+        intervalMs: 10,
+        maxIntervalMs: 100,
+        timeoutMs: 100,
+      },
+      () => {
+        callTimes.push(Date.now());
+        return Promise.resolve(callTimes.length === 4 ? 'ready' : null);
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(15);
+    await vi.advanceTimersByTimeAsync(23);
+
+    await expect(result).resolves.toBe('ready');
+    expect(callTimes).toEqual([0, 10, 25, 48]);
+  });
+
+  test('clamps backoff factors below one', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const callTimes: number[] = [];
+
+    const result = pollUntil(
+      {
+        backoffFactor: 0,
+        describe: () => 'resource to appear',
+        intervalMs: 10,
+        maxIntervalMs: 100,
+        timeoutMs: 100,
+      },
+      () => {
+        callTimes.push(Date.now());
+        return Promise.resolve(callTimes.length === 4 ? 'ready' : null);
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(result).resolves.toBe('ready');
+    expect(callTimes).toEqual([0, 10, 20, 30]);
   });
 
   test('times out with the description and last probe error', async () => {
@@ -48,5 +106,33 @@ describe('pollUntil', () => {
     );
 
     await expect(result).rejects.toThrow('Stopped waiting for resource to appear');
+  });
+
+  test('stops when the abort signal fires during the sleep interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const controller = new AbortController();
+    let calls = 0;
+
+    const result = pollUntil(
+      {
+        describe: () => 'resource to appear',
+        intervalMs: 50,
+        signal: controller.signal,
+        timeoutMs: 100,
+      },
+      () => {
+        calls += 1;
+        return Promise.resolve(null);
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    const rejection = expect(result).rejects.toThrow('Stopped waiting for resource to appear');
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await rejection;
+    expect(calls).toBe(1);
   });
 });

--- a/e2e/core/src/poll.ts
+++ b/e2e/core/src/poll.ts
@@ -2,6 +2,7 @@ export interface PollOptions {
   timeoutMs: number;
   intervalMs?: number;
   maxIntervalMs?: number;
+  backoffFactor?: number;
   describe: () => string;
   /** Stops polling early (used to fail fast when the polled process dies). */
   signal?: AbortSignal;
@@ -9,6 +10,7 @@ export interface PollOptions {
 
 const DEFAULT_INTERVAL_MS = 500;
 const DEFAULT_MAX_INTERVAL_MS = 2_000;
+const DEFAULT_BACKOFF_FACTOR = 2;
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve) => {
@@ -45,6 +47,7 @@ export async function pollUntil<T>(
   const deadline = Date.now() + options.timeoutMs;
   let delay = options.intervalMs ?? DEFAULT_INTERVAL_MS;
   const maxIntervalMs = options.maxIntervalMs ?? DEFAULT_MAX_INTERVAL_MS;
+  const backoffFactor = options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
   let lastError: unknown;
 
   for (;;) {
@@ -68,6 +71,6 @@ export async function pollUntil<T>(
     }
 
     await sleep(Math.min(delay, remaining), options.signal);
-    delay = Math.min(delay * 2, maxIntervalMs);
+    delay = Math.min(delay * backoffFactor, maxIntervalMs);
   }
 }

--- a/e2e/core/src/poll.ts
+++ b/e2e/core/src/poll.ts
@@ -47,7 +47,7 @@ export async function pollUntil<T>(
   const deadline = Date.now() + options.timeoutMs;
   let delay = options.intervalMs ?? DEFAULT_INTERVAL_MS;
   const maxIntervalMs = options.maxIntervalMs ?? DEFAULT_MAX_INTERVAL_MS;
-  const backoffFactor = options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
+  const backoffFactor = Math.max(1, options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR);
   let lastError: unknown;
 
   for (;;) {
@@ -71,6 +71,6 @@ export async function pollUntil<T>(
     }
 
     await sleep(Math.min(delay, remaining), options.signal);
-    delay = Math.min(delay * backoffFactor, maxIntervalMs);
+    delay = Math.min(Math.ceil(delay * backoffFactor), maxIntervalMs);
   }
 }

--- a/e2e/helpers/agent/src/index.test.ts
+++ b/e2e/helpers/agent/src/index.test.ts
@@ -1,5 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
 
+const createApiClient = vi.fn();
 const requestJson = vi.fn();
 const workspaceId = '11111111-1111-4111-8111-111111111111';
 const sessionToken = 'user-session-token';
@@ -7,8 +8,10 @@ const sessionToken = 'user-session-token';
 describe('agent e2e helper', () => {
   beforeEach(() => {
     vi.resetModules();
+    createApiClient.mockReset();
     requestJson.mockReset();
-    vi.doMock('@shipfox/e2e-core', () => ({requestJson}));
+    createApiClient.mockReturnValue({requestJson});
+    vi.doMock('@shipfox/e2e-core', () => ({createApiClient}));
   });
 
   afterEach(() => {
@@ -101,11 +104,11 @@ describe('agent e2e helper', () => {
       displayName: 'Local Ollama E2E',
     });
 
+    expect(createApiClient).toHaveBeenCalledWith({token: sessionToken});
     expect(requestJson).toHaveBeenCalledWith(
       'post',
       `/workspaces/${workspaceId}/agent/custom-model-providers`,
       {
-        headers: {authorization: `Bearer ${sessionToken}`},
         json: {
           slug: 'local-ollama-e2e',
           display_name: 'Local Ollama E2E',
@@ -124,12 +127,10 @@ describe('agent e2e helper', () => {
 
     await listModelProviderConfigs({workspaceId, sessionToken});
 
+    expect(createApiClient).toHaveBeenCalledWith({token: sessionToken});
     expect(requestJson).toHaveBeenCalledWith(
       'get',
       `/workspaces/${workspaceId}/agent/model-providers`,
-      {
-        headers: {authorization: `Bearer ${sessionToken}`},
-      },
     );
   });
 });

--- a/e2e/helpers/agent/src/index.ts
+++ b/e2e/helpers/agent/src/index.ts
@@ -5,7 +5,7 @@ import type {
   ModelProviderApi,
   ModelProviderRef,
 } from '@shipfox/api-agent-dto';
-import {requestJson} from '@shipfox/e2e-core';
+import {createApiClient} from '@shipfox/e2e-core';
 
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 const DEFAULT_OLLAMA_MODEL = 'smollm2:135m-instruct-q2_K';
@@ -99,26 +99,23 @@ export async function createOllamaCustomProvider(
     model: ollama.model,
     providerId,
   });
+  const client = createApiClient({token: params.sessionToken});
 
-  return await requestJson<CustomModelProviderConfigDto>(
+  return await client.requestJson<CustomModelProviderConfigDto>(
     'post',
     `/workspaces/${params.workspaceId}/agent/custom-model-providers`,
-    {
-      headers: {authorization: `Bearer ${params.sessionToken}`},
-      json: body,
-    },
+    {json: body},
   );
 }
 
 export async function listModelProviderConfigs(
   params: ListModelProviderConfigsParams,
 ): Promise<ListModelProviderConfigsResponseDto> {
-  return await requestJson<ListModelProviderConfigsResponseDto>(
+  const client = createApiClient({token: params.sessionToken});
+
+  return await client.requestJson<ListModelProviderConfigsResponseDto>(
     'get',
     `/workspaces/${params.workspaceId}/agent/model-providers`,
-    {
-      headers: {authorization: `Bearer ${params.sessionToken}`},
-    },
   );
 }
 

--- a/e2e/helpers/definitions/src/index.test.ts
+++ b/e2e/helpers/definitions/src/index.test.ts
@@ -171,6 +171,6 @@ describe('waitForDefinition', () => {
       token: 'user-token',
     });
 
-    await expect(result).rejects.toMatchObject({name: 'AbortError'});
+    await expect(result).rejects.toThrow('Stopped waiting for Timed out waiting for definition');
   });
 });

--- a/e2e/helpers/definitions/src/index.ts
+++ b/e2e/helpers/definitions/src/index.ts
@@ -28,6 +28,16 @@ export type WaitForDefinitionOptions = DefinitionSelector & {
   token: string;
 };
 
+type DefinitionPollResult =
+  | {
+      kind: 'definition';
+      definition: DefinitionDto;
+    }
+  | {
+      kind: 'sync-failed';
+      error: Error;
+    };
+
 function assertDefinitionSelector(options: WaitForDefinitionOptions): void {
   if (!options.configPath && !options.definitionId) {
     throw new Error('waitForDefinition requires configPath or definitionId');
@@ -82,7 +92,7 @@ export async function waitForDefinition(options: WaitForDefinitionOptions): Prom
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   let lastResponse: DefinitionListResponseDto | null = null;
 
-  const result = await pollUntil<DefinitionDto | Error>(
+  const result = await pollUntil<DefinitionPollResult>(
     {
       timeoutMs,
       intervalMs: options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS,
@@ -103,19 +113,23 @@ export async function waitForDefinition(options: WaitForDefinitionOptions): Prom
       );
 
       if (lastResponse.sync?.status === 'failed') {
-        return new Error(
-          `Definition sync failed while waiting: ${formatObserved(lastResponse, selector)}`,
-        );
+        return {
+          kind: 'sync-failed',
+          error: new Error(
+            `Definition sync failed while waiting: ${formatObserved(lastResponse, selector)}`,
+          ),
+        };
       }
 
-      return (
-        lastResponse.definitions.find((candidate) => matchesDefinition(candidate, selector)) ?? null
+      const definition = lastResponse.definitions.find((candidate) =>
+        matchesDefinition(candidate, selector),
       );
+      return definition ? {kind: 'definition', definition} : null;
     },
   );
 
-  if (result instanceof Error) throw result;
-  return result;
+  if (result.kind === 'sync-failed') throw result.error;
+  return result.definition;
 }
 
 export function createDefinitionsHelper(options: {

--- a/e2e/helpers/definitions/src/index.ts
+++ b/e2e/helpers/definitions/src/index.ts
@@ -1,6 +1,5 @@
-import {setTimeout as sleep} from 'node:timers/promises';
 import type {DefinitionDto, DefinitionListResponseDto} from '@shipfox/api-definitions-dto';
-import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+import {type ApiFetch, createApiClient, pollUntil} from '@shipfox/e2e-core';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_INITIAL_DELAY_MS = 250;
@@ -28,12 +27,6 @@ export type WaitForDefinitionOptions = DefinitionSelector & {
   timeoutMs?: number | undefined;
   token: string;
 };
-
-function nextDelay(currentDelayMs: number, options: WaitForDefinitionOptions): number {
-  const factor = options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
-  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
-  return Math.min(Math.ceil(currentDelayMs * factor), maxDelayMs);
-}
 
 function assertDefinitionSelector(options: WaitForDefinitionOptions): void {
   if (!options.configPath && !options.definitionId) {
@@ -75,16 +68,6 @@ function formatObserved(response: DefinitionListResponseDto | null, selector: De
   return `${selectorLabel(selector)} ${sync} definitions=[${definitions.join(', ')}${more}]`;
 }
 
-async function waitForNextPoll(params: {
-  delayMs: number;
-  deadline: number;
-  signal?: AbortSignal | undefined;
-}): Promise<void> {
-  const remainingMs = params.deadline - Date.now();
-  if (remainingMs <= 0) return;
-  await sleep(Math.min(params.delayMs, remainingMs), undefined, {signal: params.signal});
-}
-
 export async function waitForDefinition(options: WaitForDefinitionOptions): Promise<DefinitionDto> {
   assertDefinitionSelector(options);
   const selector = {
@@ -97,37 +80,42 @@ export async function waitForDefinition(options: WaitForDefinitionOptions): Prom
     token: options.token,
   });
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const deadline = Date.now() + timeoutMs;
-  let delayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
   let lastResponse: DefinitionListResponseDto | null = null;
 
-  while (Date.now() <= deadline) {
-    options.signal?.throwIfAborted();
-    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
-    lastResponse = await client.requestJson<DefinitionListResponseDto>(
-      'get',
-      `/definitions?${params}`,
-      {
-        signal: options.signal,
-      },
-    );
-
-    if (lastResponse.sync?.status === 'failed') {
-      throw new Error(
-        `Definition sync failed while waiting: ${formatObserved(lastResponse, selector)}`,
+  const result = await pollUntil<DefinitionDto | Error>(
+    {
+      timeoutMs,
+      intervalMs: options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS,
+      maxIntervalMs: options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+      backoffFactor: options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR,
+      ...(options.signal ? {signal: options.signal} : {}),
+      describe: () => `Timed out waiting for definition: ${formatObserved(lastResponse, selector)}`,
+    },
+    async () => {
+      options.signal?.throwIfAborted();
+      const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
+      lastResponse = await client.requestJson<DefinitionListResponseDto>(
+        'get',
+        `/definitions?${params}`,
+        {
+          signal: options.signal,
+        },
       );
-    }
 
-    const definition = lastResponse.definitions.find((candidate) =>
-      matchesDefinition(candidate, selector),
-    );
-    if (definition) return definition;
+      if (lastResponse.sync?.status === 'failed') {
+        return new Error(
+          `Definition sync failed while waiting: ${formatObserved(lastResponse, selector)}`,
+        );
+      }
 
-    await waitForNextPoll({deadline, delayMs, signal: options.signal});
-    delayMs = nextDelay(delayMs, options);
-  }
+      return (
+        lastResponse.definitions.find((candidate) => matchesDefinition(candidate, selector)) ?? null
+      );
+    },
+  );
 
-  throw new Error(`Timed out waiting for definition: ${formatObserved(lastResponse, selector)}`);
+  if (result instanceof Error) throw result;
+  return result;
 }
 
 export function createDefinitionsHelper(options: {

--- a/e2e/helpers/integrations-gitea/src/connect.ts
+++ b/e2e/helpers/integrations-gitea/src/connect.ts
@@ -2,7 +2,7 @@ import type {
   CreateGiteaConnectionBodyDto,
   CreateGiteaConnectionResponseDto,
 } from '@shipfox/api-integration-gitea-dto';
-import {requestJson} from '@shipfox/e2e-core';
+import {createApiClient} from '@shipfox/e2e-core';
 
 export interface ConnectGiteaOrgParams {
   workspaceId: string;
@@ -19,10 +19,11 @@ export async function connectGiteaOrg(
     workspace_id: params.workspaceId,
     org: params.org,
   };
+  const client = createApiClient({token: params.sessionToken});
 
-  return await requestJson<CreateGiteaConnectionResponseDto>(
+  return await client.requestJson<CreateGiteaConnectionResponseDto>(
     'post',
     '/integrations/gitea/connections',
-    {json: body, headers: {authorization: `Bearer ${params.sessionToken}`}},
+    {json: body},
   );
 }

--- a/e2e/helpers/runners/src/manual-registration-token.ts
+++ b/e2e/helpers/runners/src/manual-registration-token.ts
@@ -1,5 +1,5 @@
 import type {CreateManualRegistrationTokenResponseDto} from '@shipfox/api-runners-dto';
-import {requestJson} from '@shipfox/e2e-core';
+import {createApiClient} from '@shipfox/e2e-core';
 
 export interface MintManualRegistrationTokenParams {
   workspaceId: string;
@@ -14,11 +14,12 @@ export interface MintManualRegistrationTokenParams {
 export async function mintManualRegistrationToken(
   params: MintManualRegistrationTokenParams,
 ): Promise<CreateManualRegistrationTokenResponseDto> {
-  return await requestJson<CreateManualRegistrationTokenResponseDto>(
+  const client = createApiClient({token: params.userToken});
+
+  return await client.requestJson<CreateManualRegistrationTokenResponseDto>(
     'post',
     `/workspaces/${params.workspaceId}/runners/manual-registration-tokens`,
     {
-      headers: {authorization: `Bearer ${params.userToken}`},
       json: {
         ...(params.name !== undefined ? {name: params.name} : {}),
         ...(params.ttlSeconds !== undefined ? {ttl_seconds: params.ttlSeconds} : {}),

--- a/e2e/helpers/runners/src/provisioner-process.ts
+++ b/e2e/helpers/runners/src/provisioner-process.ts
@@ -7,8 +7,7 @@ import type {
   ActiveProvisionerDto,
   ListActiveProvisionersResponseDto,
 } from '@shipfox/api-runners-dto';
-import {config, requestJson} from '@shipfox/e2e-core';
-import {pollUntil} from './poll.js';
+import {config, createApiClient, pollUntil} from '@shipfox/e2e-core';
 
 const execFileAsync = promisify(execFile);
 
@@ -99,6 +98,7 @@ async function waitForActiveProvisioner(params: {
   logFile: string;
 }): Promise<ActiveProvisionerDto> {
   let lastSeen: ActiveProvisionerDto[] = [];
+  const client = createApiClient({token: params.userToken});
   const abortController = new AbortController();
 
   let onError: ((error: Error) => void) | undefined;
@@ -128,10 +128,9 @@ async function waitForActiveProvisioner(params: {
         `provisioner ${params.tokenPrefix ?? '(any)'} to become active for workspace ${params.workspaceId} (last active list: ${JSON.stringify(lastSeen)})`,
     },
     async () => {
-      const {provisioners} = await requestJson<ListActiveProvisionersResponseDto>(
+      const {provisioners} = await client.requestJson<ListActiveProvisionersResponseDto>(
         'get',
         `/workspaces/${params.workspaceId}/provisioners/active`,
-        {headers: {authorization: `Bearer ${params.userToken}`}},
       );
       lastSeen = provisioners;
       const match =

--- a/e2e/helpers/runners/src/provisioner-token.ts
+++ b/e2e/helpers/runners/src/provisioner-token.ts
@@ -1,5 +1,5 @@
 import type {CreateProvisionerTokenResponseDto} from '@shipfox/api-runners-dto';
-import {requestJson} from '@shipfox/e2e-core';
+import {createApiClient} from '@shipfox/e2e-core';
 
 export interface MintProvisionerTokenParams {
   workspaceId: string;
@@ -20,12 +20,11 @@ export interface MintProvisionerTokenParams {
 export async function mintProvisionerToken(
   params: MintProvisionerTokenParams,
 ): Promise<CreateProvisionerTokenResponseDto> {
-  return await requestJson<CreateProvisionerTokenResponseDto>(
+  const client = createApiClient({token: params.userToken});
+
+  return await client.requestJson<CreateProvisionerTokenResponseDto>(
     'post',
     `/workspaces/${params.workspaceId}/provisioners/tokens`,
-    {
-      headers: {authorization: `Bearer ${params.userToken}`},
-      json: {name: params.name, ttl_seconds: params.ttlSeconds},
-    },
+    {json: {name: params.name, ttl_seconds: params.ttlSeconds}},
   );
 }

--- a/e2e/helpers/workflows/src/index.test.ts
+++ b/e2e/helpers/workflows/src/index.test.ts
@@ -148,7 +148,9 @@ describe('waitForRunByCommit', () => {
       token: 'user-token',
     });
 
-    await expect(result).rejects.toMatchObject({name: 'AbortError'});
+    await expect(result).rejects.toThrow(
+      'Stopped waiting for Timed out waiting for workflow run by commit',
+    );
   });
 });
 

--- a/e2e/helpers/workflows/src/index.ts
+++ b/e2e/helpers/workflows/src/index.ts
@@ -1,11 +1,10 @@
-import {setTimeout as sleep} from 'node:timers/promises';
 import type {
   WorkflowRunDetailResponseDto,
   WorkflowRunDto,
   WorkflowRunListResponseDto,
   WorkflowRunStatusDto,
 } from '@shipfox/api-workflows-dto';
-import {type ApiFetch, createApiClient} from '@shipfox/e2e-core';
+import {type ApiFetch, createApiClient, pollUntil} from '@shipfox/e2e-core';
 
 const DEFAULT_LIST_TIMEOUT_MS = 60_000;
 const DEFAULT_TERMINAL_TIMEOUT_MS = 180_000;
@@ -37,22 +36,6 @@ export interface WaitForRunByDeliveryIdOptions extends PollingOptions {
 
 export interface WaitForRunTerminalOptions extends PollingOptions {
   runId: string;
-}
-
-function nextDelay(currentDelayMs: number, options: PollingOptions): number {
-  const factor = options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR;
-  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
-  return Math.min(Math.ceil(currentDelayMs * factor), maxDelayMs);
-}
-
-async function waitForNextPoll(params: {
-  delayMs: number;
-  deadline: number;
-  signal?: AbortSignal | undefined;
-}): Promise<void> {
-  const remainingMs = params.deadline - Date.now();
-  if (remainingMs <= 0) return;
-  await sleep(Math.min(params.delayMs, remainingMs), undefined, {signal: params.signal});
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -128,32 +111,33 @@ async function waitForRunMatching(
     token: options.token,
   });
   const timeoutMs = options.timeoutMs ?? DEFAULT_LIST_TIMEOUT_MS;
-  const deadline = Date.now() + timeoutMs;
-  let delayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
   let lastResponse: WorkflowRunListResponseDto | null = null;
 
-  while (Date.now() <= deadline) {
-    options.signal?.throwIfAborted();
-    const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
-    lastResponse = await client.requestJson<WorkflowRunListResponseDto>(
-      'get',
-      `/workflows/runs?${params}`,
-      {signal: options.signal},
-    );
+  return await pollUntil<WorkflowRunDto>(
+    {
+      timeoutMs,
+      intervalMs: options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS,
+      maxIntervalMs: options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+      backoffFactor: options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR,
+      ...(options.signal ? {signal: options.signal} : {}),
+      describe: () =>
+        `${options.timeoutMessage}: ${formatRunListObserved(
+          lastResponse,
+          options.expected,
+          options.runField,
+        )}`,
+    },
+    async () => {
+      options.signal?.throwIfAborted();
+      const params = new URLSearchParams({project_id: options.projectId, limit: '100'});
+      lastResponse = await client.requestJson<WorkflowRunListResponseDto>(
+        'get',
+        `/workflows/runs?${params}`,
+        {signal: options.signal},
+      );
 
-    const run = lastResponse.runs.find(options.match);
-    if (run) return run;
-
-    await waitForNextPoll({deadline, delayMs, signal: options.signal});
-    delayMs = nextDelay(delayMs, options);
-  }
-
-  throw new Error(
-    `${options.timeoutMessage}: ${formatRunListObserved(
-      lastResponse,
-      options.expected,
-      options.runField,
-    )}`,
+      return lastResponse.runs.find(options.match) ?? null;
+    },
   );
 }
 
@@ -190,28 +174,30 @@ export async function waitForRunTerminal(
     token: options.token,
   });
   const timeoutMs = options.timeoutMs ?? DEFAULT_TERMINAL_TIMEOUT_MS;
-  const deadline = Date.now() + timeoutMs;
-  let delayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
   let lastResponse: WorkflowRunDetailResponseDto | null = null;
 
-  while (Date.now() <= deadline) {
-    options.signal?.throwIfAborted();
-    lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
-      'get',
-      `/workflows/runs/${encodeURIComponent(options.runId)}`,
-      {signal: options.signal},
-    );
-    if (TERMINAL_STATUSES.has(lastResponse.status)) return lastResponse;
-
-    await waitForNextPoll({deadline, delayMs, signal: options.signal});
-    delayMs = nextDelay(delayMs, options);
-  }
-
-  throw new Error(
-    `Timed out waiting for workflow run terminal status: ${formatRunDetailObserved(
-      lastResponse,
-      options.runId,
-    )}`,
+  return await pollUntil<WorkflowRunDetailResponseDto>(
+    {
+      timeoutMs,
+      intervalMs: options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS,
+      maxIntervalMs: options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+      backoffFactor: options.backoffFactor ?? DEFAULT_BACKOFF_FACTOR,
+      ...(options.signal ? {signal: options.signal} : {}),
+      describe: () =>
+        `Timed out waiting for workflow run terminal status: ${formatRunDetailObserved(
+          lastResponse,
+          options.runId,
+        )}`,
+    },
+    async () => {
+      options.signal?.throwIfAborted();
+      lastResponse = await client.requestJson<WorkflowRunDetailResponseDto>(
+        'get',
+        `/workflows/runs/${encodeURIComponent(options.runId)}`,
+        {signal: options.signal},
+      );
+      return TERMINAL_STATUSES.has(lastResponse.status) ? lastResponse : null;
+    },
   );
 }
 


### PR DESCRIPTION
Move the shared E2E polling primitive into `@shipfox/e2e-core` and update the definitions, workflows, and runners helpers to use it instead of carrying separate polling loops.

The helper layer also had two session-auth styles: product-route calls either used `createApiClient({token})` or built bearer headers by hand. This standardizes session-scoped calls on `createApiClient({token})` while leaving `/__e2e` setup routes on the default admin-key client.

The core poller now covers the previous runner behavior and preserves the definitions/workflows timeout diagnostics, including observed-state summaries. `backoffFactor` remains available for helpers that already exposed it.

Validated with affected build/test/check, focused E2E helper checks, a full repo build, and a full `mise run e2e` after warming the required Ollama model.

Closes ENG-812

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the E2E poller into `@shipfox/e2e-core`, hardens backoff/abort behavior, and standardizes session-scoped requests on `createApiClient({token})`. Closes ENG-812.

- **Refactors**
  - Exported `pollUntil`/`PollOptions` from `@shipfox/e2e-core` with tests; preserves timeout/observed-state messages; clamps `backoffFactor` below 1, keeps ceil cadence, and covers abort during sleep.
  - Replaced custom polling in definitions, workflows, and runners with the core poller; preserves abort handling and backoff.
  - Switched agent, Gitea, and runners helpers to `createApiClient({token})`; `/__e2e` setup routes stay on the admin-key client.
  - Tightened definition wait failure path with a tagged poll result for sync failures; updated tests for new abort/timeout messages.

<sup>Written for commit e9d9ddc3a489f2fcccb38197d64552e9917aa867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

