### PR TITLE
Scale outbox dispatch by ordering key

### DIFF
--- a/libs/api/auth/drizzle/0001_famous_wendell_rand.sql
+++ b/libs/api/auth/drizzle/0001_famous_wendell_rand.sql
@@ -1,6 +1,7 @@
 CREATE TABLE "auth_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/auth/drizzle/meta/0001_snapshot.json
+++ b/libs/api/auth/drizzle/meta/0001_snapshot.json
@@ -113,6 +113,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",
@@ -304,6 +310,119 @@
           "onUpdate": "no action"
         }
       },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_rate_limits": {
+      "name": "auth_rate_limits",
+      "schema": "",
+      "columns": {
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier_hmac": {
+          "name": "identifier_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_rate_limits_window_unique": {
+          "name": "auth_rate_limits_window_unique",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "identifier_hmac",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "window_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_rate_limits_expires_at_idx": {
+          "name": "auth_rate_limits_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/libs/api/definitions/drizzle.config.ts
+++ b/libs/api/definitions/drizzle.config.ts
@@ -1,7 +1,11 @@
 import {defineConfig} from 'drizzle-kit';
 
 export default defineConfig({
-  schema: './src/db/schema/*.ts',
+  schema: [
+    './src/db/schema/definitions.ts',
+    './src/db/schema/outbox.ts',
+    './src/db/schema/sync-states.ts',
+  ],
   out: './drizzle',
   dialect: 'postgresql',
 });

--- a/libs/api/definitions/drizzle/0000_initial.sql
+++ b/libs/api/definitions/drizzle/0000_initial.sql
@@ -36,6 +36,7 @@ CREATE TABLE "definitions_sync_states" (
 CREATE TABLE "definitions_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/definitions/drizzle/meta/0000_snapshot.json
+++ b/libs/api/definitions/drizzle/meta/0000_snapshot.json
@@ -371,6 +371,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/definitions/src/core/sync-definitions.ts
+++ b/libs/api/definitions/src/core/sync-definitions.ts
@@ -7,6 +7,7 @@ import {
   type IntegrationSourceControlService,
   MAX_REPOSITORY_FILE_BYTES,
 } from '@shipfox/api-integration-core';
+import {boundedMap} from '@shipfox/node-module';
 import type {DefinitionSyncErrorCode} from './entities/sync-state.js';
 import type {WorkflowDefinitionPayload} from './entities/workflow-definition.js';
 import {DefinitionParseError, DefinitionSyncPermanentError} from './errors.js';
@@ -88,38 +89,43 @@ export interface FetchAndParseWorkflowsParams extends SyncSourceContext {
 export async function fetchAndParseWorkflows(
   params: FetchAndParseWorkflowsParams,
 ): Promise<ParsedWorkflow[]> {
-  return await mapWithConcurrency(params.paths, FILE_FETCH_CONCURRENCY, async (path) => {
-    params.onProgress?.(path);
+  return await boundedMap(
+    params.paths,
+    FILE_FETCH_CONCURRENCY,
+    async (path) => {
+      params.onProgress?.(path);
 
-    const snapshot = await params.sourceControl.fetchFile({
-      workspaceId: params.workspaceId,
-      connectionId: params.sourceConnectionId,
-      externalRepositoryId: params.sourceExternalRepositoryId,
-      ref: params.ref,
-      path,
-    });
+      const snapshot = await params.sourceControl.fetchFile({
+        workspaceId: params.workspaceId,
+        connectionId: params.sourceConnectionId,
+        externalRepositoryId: params.sourceExternalRepositoryId,
+        ref: params.ref,
+        path,
+      });
 
-    if (Buffer.byteLength(snapshot.content, 'utf8') > MAX_REPOSITORY_FILE_BYTES) {
-      throw new DefinitionSyncPermanentError(
-        'content-too-large',
-        `Workflow file is larger than ${MAX_REPOSITORY_FILE_BYTES} bytes: ${snapshot.path}`,
-      );
-    }
-
-    try {
-      const definition = parseDefinition(snapshot.content);
-      const contentHash = sha256Hex(snapshot.content);
-      return {path: snapshot.path, name: definition.document.name, definition, contentHash};
-    } catch (error) {
-      if (error instanceof DefinitionParseError) {
+      if (Buffer.byteLength(snapshot.content, 'utf8') > MAX_REPOSITORY_FILE_BYTES) {
         throw new DefinitionSyncPermanentError(
-          'invalid-definition',
-          `Invalid workflow definition at ${snapshot.path}: ${error.message}`,
+          'content-too-large',
+          `Workflow file is larger than ${MAX_REPOSITORY_FILE_BYTES} bytes: ${snapshot.path}`,
         );
       }
-      throw error;
-    }
-  });
+
+      try {
+        const definition = parseDefinition(snapshot.content);
+        const contentHash = sha256Hex(snapshot.content);
+        return {path: snapshot.path, name: definition.document.name, definition, contentHash};
+      } catch (error) {
+        if (error instanceof DefinitionParseError) {
+          throw new DefinitionSyncPermanentError(
+            'invalid-definition',
+            `Invalid workflow definition at ${snapshot.path}: ${error.message}`,
+          );
+        }
+        throw error;
+      }
+    },
+    {stopOnError: true},
+  );
 }
 
 export interface SyncFailureClassification {
@@ -172,31 +178,4 @@ function providerErrorCode(reason: string): DefinitionSyncErrorCode {
 
 function sha256Hex(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex');
-}
-
-async function mapWithConcurrency<T, U>(
-  items: T[],
-  concurrency: number,
-  mapper: (item: T) => Promise<U>,
-): Promise<U[]> {
-  const results = new Array<U>(items.length);
-  let next = 0;
-  let aborted = false;
-
-  async function worker(): Promise<void> {
-    while (!aborted && next < items.length) {
-      const index = next;
-      next += 1;
-      try {
-        results[index] = await mapper(items[index] as T);
-      } catch (error) {
-        aborted = true;
-        throw error;
-      }
-    }
-  }
-
-  await Promise.all(Array.from({length: Math.min(concurrency, items.length)}, () => worker()));
-
-  return results;
 }

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -1,5 +1,6 @@
 import {DEFINITION_RESOLVED} from '@shipfox/api-definitions-dto';
 import {
+  BATCH_SIZE,
   type DrainedEvent,
   drainAll,
   markDispatched,
@@ -52,6 +53,7 @@ function eventsForProject(events: DrainedEvent[], projectId: string) {
 async function insertOutboxRow(params: {
   projectId: string;
   marker: string;
+  orderingKey?: string | null;
   dispatchedAt?: Date | null;
   deadLetteredAt?: Date | null;
 }) {
@@ -61,6 +63,7 @@ async function insertOutboxRow(params: {
     .values({
       id,
       eventType: DEFINITION_RESOLVED,
+      orderingKey: params.orderingKey ?? null,
       payload: {projectId: params.projectId, marker: params.marker},
       dispatchedAt: params.dispatchedAt ?? null,
       deadLetteredAt: params.deadLetteredAt ?? null,
@@ -688,12 +691,47 @@ describe('definition queries', () => {
         ...definitionFields(),
       });
 
-      const events = await drainAll();
+      const events = (await drainAll()).events;
       const projectEvents = eventsForProject(events, projectId);
 
       expect(projectEvents).toHaveLength(1);
       expect(projectEvents[0]?.source).toBe('definitions');
+      expect(projectEvents[0]?.orderingKey).toBe('definitions');
       expect(projectEvents[0]?.event.type).toBe(DEFINITION_RESOLVED);
+    });
+
+    test('drainAll resolves orderingKey from the column', async () => {
+      await insertOutboxRow({projectId, marker: 'keyed', orderingKey: 'run-1'});
+
+      const projectEvents = eventsForProject((await drainAll()).events, projectId);
+
+      expect(projectEvents).toHaveLength(1);
+      expect(projectEvents[0]?.orderingKey).toBe('run-1');
+    });
+
+    test('drainAll reports hasMore when a source returns a full batch', async () => {
+      const rows = Array.from({length: BATCH_SIZE}, (_, index) => ({
+        id: crypto.randomUUID(),
+        eventType: DEFINITION_RESOLVED,
+        payload: {projectId, marker: `batch-${index}`},
+      }));
+      await db().insert(definitionsOutbox).values(rows);
+
+      const drain = await drainAll();
+
+      try {
+        expect(drain.events).toHaveLength(BATCH_SIZE);
+        expect(drain.hasMore).toBe(true);
+      } finally {
+        await markDispatched(
+          'definitions',
+          drain.events.map((event) => event.id),
+        );
+        await db()
+          .update(definitionsOutbox)
+          .set({dispatchedAt: sql`now()`})
+          .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
+      }
     });
 
     test('markDispatched sets dispatchedAt for a single event', async () => {
@@ -704,7 +742,7 @@ describe('definition queries', () => {
         name: 'Test',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
 
       await markDispatched('definitions', [events[0]?.id as string]);
 
@@ -729,7 +767,7 @@ describe('definition queries', () => {
         name: 'B',
         ...definitionFields('B'),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       const ids = events.map((e) => e.id);
 
       await markDispatched('definitions', ids);
@@ -747,10 +785,10 @@ describe('definition queries', () => {
         name: 'Test',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await markDispatched('definitions', [events[0]?.id as string]);
 
-      const secondDrain = eventsForProject(await drainAll(), projectId);
+      const secondDrain = eventsForProject((await drainAll()).events, projectId);
 
       expect(secondDrain).toHaveLength(0);
     });
@@ -763,13 +801,13 @@ describe('definition queries', () => {
         name: 'Retry',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await db()
         .update(definitionsOutbox)
         .set({nextDispatchAt: sql`now() + interval '1 hour'`})
         .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
 
-      const secondDrain = eventsForProject(await drainAll(), projectId);
+      const secondDrain = eventsForProject((await drainAll()).events, projectId);
 
       expect(secondDrain).toHaveLength(0);
     });
@@ -789,13 +827,13 @@ describe('definition queries', () => {
         ...definitionFields(),
       });
       const before = new Date();
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
 
       await recordDispatchFailure('definitions', events[0]?.id as string, failure);
 
       const after = new Date();
       const rows = await listOutboxRowsForProject(projectId);
-      const secondDrain = eventsForProject(await drainAll(), projectId);
+      const secondDrain = eventsForProject((await drainAll()).events, projectId);
       expect(rows[0]?.dispatchAttempts).toBe(1);
       expect(rows[0]?.lastDispatchError).toEqual(failure);
       expect(rows[0]?.lastDispatchFailedAt).toBeInstanceOf(Date);
@@ -821,7 +859,7 @@ describe('definition queries', () => {
         name: 'Poison',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await db()
         .update(definitionsOutbox)
         .set({dispatchAttempts: 4})
@@ -830,7 +868,7 @@ describe('definition queries', () => {
       await recordDispatchFailure('definitions', events[0]?.id as string, failure);
 
       const rows = await listOutboxRowsForProject(projectId);
-      const secondDrain = eventsForProject(await drainAll(), projectId);
+      const secondDrain = eventsForProject((await drainAll()).events, projectId);
       expect(rows[0]?.dispatchAttempts).toBe(5);
       expect(rows[0]?.lastDispatchError).toEqual(failure);
       expect(rows[0]?.deadLetteredAt).toBeInstanceOf(Date);
@@ -846,7 +884,7 @@ describe('definition queries', () => {
         name: 'Dead',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await db()
         .update(definitionsOutbox)
         .set({deadLetteredAt: sql`now()`})
@@ -874,7 +912,7 @@ describe('definition queries', () => {
         name: 'Dispatched',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await markDispatched('definitions', [events[0]?.id as string]);
 
       await recordDispatchFailure('definitions', events[0]?.id as string, failure);
@@ -907,7 +945,7 @@ describe('definition queries', () => {
         name: `Backoff ${priorAttempts}`,
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await db()
         .update(definitionsOutbox)
         .set({dispatchAttempts: priorAttempts})
@@ -944,21 +982,21 @@ describe('definition queries', () => {
         name: 'Recover',
         ...definitionFields(),
       });
-      const events = eventsForProject(await drainAll(), projectId);
+      const events = eventsForProject((await drainAll()).events, projectId);
       await recordDispatchFailure('definitions', events[0]?.id as string, failure);
       await db()
         .update(definitionsOutbox)
         .set({nextDispatchAt: sql`now() - interval '1 second'`})
         .where(sql`${definitionsOutbox.id} = ${events[0]?.id as string}`);
 
-      const retryDrain = eventsForProject(await drainAll(), projectId);
+      const retryDrain = eventsForProject((await drainAll()).events, projectId);
       await markDispatched(
         'definitions',
         retryDrain.map((event) => event.id),
       );
 
       const rows = await listOutboxRowsForProject(projectId);
-      const finalDrain = eventsForProject(await drainAll(), projectId);
+      const finalDrain = eventsForProject((await drainAll()).events, projectId);
       expect(retryDrain).toHaveLength(1);
       expect(retryDrain[0]?.id).toBe(events[0]?.id);
       expect(rows[0]?.dispatchAttempts).toBe(1);

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -54,6 +54,8 @@ async function insertOutboxRow(params: {
   projectId: string;
   marker: string;
   orderingKey?: string | null;
+  createdAt?: Date;
+  nextDispatchAt?: Date;
   dispatchedAt?: Date | null;
   deadLetteredAt?: Date | null;
 }) {
@@ -65,6 +67,8 @@ async function insertOutboxRow(params: {
       eventType: DEFINITION_RESOLVED,
       orderingKey: params.orderingKey ?? null,
       payload: {projectId: params.projectId, marker: params.marker},
+      createdAt: params.createdAt,
+      nextDispatchAt: params.nextDispatchAt,
       dispatchedAt: params.dispatchedAt ?? null,
       deadLetteredAt: params.deadLetteredAt ?? null,
     });
@@ -678,8 +682,12 @@ describe('definition queries', () => {
       });
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       resetPublishers();
+      await db()
+        .update(definitionsOutbox)
+        .set({dispatchedAt: sql`COALESCE(${definitionsOutbox.dispatchedAt}, now())`})
+        .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
     });
 
     test('drainAll returns undispatched outbox events', async () => {
@@ -707,6 +715,43 @@ describe('definition queries', () => {
 
       expect(projectEvents).toHaveLength(1);
       expect(projectEvents[0]?.orderingKey).toBe('run-1');
+    });
+
+    test('drainAll blocks later same-key rows while an earlier row waits for retry', async () => {
+      const base = new Date(Date.now() - 60_000);
+      const retry = await insertOutboxRow({
+        projectId,
+        marker: 'retry',
+        orderingKey: 'run-1',
+        createdAt: base,
+        nextDispatchAt: new Date(Date.now() + 60 * 60_000),
+      });
+      await insertOutboxRow({
+        projectId,
+        marker: 'later-same-key',
+        orderingKey: 'run-1',
+        createdAt: new Date(base.getTime() + 1_000),
+      });
+      await insertOutboxRow({
+        projectId,
+        marker: 'other-key',
+        orderingKey: 'run-2',
+        createdAt: new Date(base.getTime() + 2_000),
+      });
+
+      try {
+        const projectEvents = eventsForProject((await drainAll()).events, projectId);
+
+        expect(projectEvents.map((event) => event.id)).not.toContain(retry);
+        expect(projectEvents.map((event) => event.event.payload)).toEqual([
+          {projectId, marker: 'other-key'},
+        ]);
+      } finally {
+        await db()
+          .update(definitionsOutbox)
+          .set({dispatchedAt: sql`now()`})
+          .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
+      }
     });
 
     test('drainAll reports hasMore when a source returns a full batch', async () => {

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -1,4 +1,5 @@
 import {DEFINITION_RESOLVED, definitionsEventSchemas} from '@shipfox/api-definitions-dto';
+import type {DrainAllResult, DrainedEvent} from '@shipfox/node-module';
 import type {DomainEvent} from '@shipfox/node-outbox';
 import {drainAndDispatch} from './drain-and-dispatch.js';
 
@@ -19,13 +20,18 @@ vi.mock('@shipfox/node-error-monitoring', () => ({
   captureException: mocks.captureException,
 }));
 
-vi.mock('@shipfox/node-module', () => ({
-  drainAll: mocks.drainAll,
-  getEventSchema: mocks.getEventSchema,
-  getSubscribers: mocks.getSubscribers,
-  markDispatched: mocks.markDispatched,
-  recordDispatchFailure: mocks.recordDispatchFailure,
-}));
+vi.mock('@shipfox/node-module', async () => {
+  const actual =
+    await vi.importActual<typeof import('@shipfox/node-module')>('@shipfox/node-module');
+  return {
+    ...actual,
+    drainAll: mocks.drainAll,
+    getEventSchema: mocks.getEventSchema,
+    getSubscribers: mocks.getSubscribers,
+    markDispatched: mocks.markDispatched,
+    recordDispatchFailure: mocks.recordDispatchFailure,
+  };
+});
 
 vi.mock('@shipfox/node-opentelemetry', () => ({
   instanceMetrics: {
@@ -46,6 +52,19 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
   }),
 }));
 
+function drain(events: DrainedEvent[], hasMore = false): DrainAllResult {
+  return {events, hasMore};
+}
+
+function event(id: string, createdAt: Date): DomainEvent {
+  return {
+    id,
+    type: 'workflows.job.terminated',
+    createdAt,
+    payload: {jobId: id, workflowRunId: 'run-1', status: 'succeeded'},
+  };
+}
+
 describe('drainAndDispatch', () => {
   beforeEach(() => {
     mocks.captureException.mockReset();
@@ -61,13 +80,22 @@ describe('drainAndDispatch', () => {
   });
 
   it('records an empty drain batch tick', async () => {
-    mocks.drainAll.mockResolvedValueOnce([]);
+    mocks.drainAll.mockResolvedValueOnce(drain([]));
 
-    await drainAndDispatch();
+    const hasMore = await drainAndDispatch();
 
     expect(mocks.drainBatchRecord).toHaveBeenCalledWith(0);
+    expect(hasMore).toBe(false);
     expect(mocks.eventDispatchedAdd).not.toHaveBeenCalled();
     expect(mocks.dispatchFailureAdd).not.toHaveBeenCalled();
+  });
+
+  it('returns hasMore from drainAll', async () => {
+    mocks.drainAll.mockResolvedValueOnce(drain([], true));
+
+    const hasMore = await drainAndDispatch();
+
+    expect(hasMore).toBe(true);
   });
 
   it('logs sanitized context, captures failed subscriber exceptions, and records a row failure', async () => {
@@ -82,7 +110,9 @@ describe('drainAndDispatch', () => {
         workspaceId: crypto.randomUUID(),
       },
     };
-    mocks.drainAll.mockResolvedValueOnce([{id: rowId, source: 'projects', event}]);
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([{id: rowId, source: 'projects', orderingKey: 'projects', event}]),
+    );
     mocks.getSubscribers.mockReturnValueOnce([vi.fn().mockRejectedValueOnce(failure)]);
 
     await drainAndDispatch();
@@ -138,7 +168,9 @@ describe('drainAndDispatch', () => {
         secret: 'raw-secret',
       },
     };
-    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'definitions', event}]);
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([{id: event.id, source: 'definitions', orderingKey: 'definitions', event}]),
+    );
     mocks.getEventSchema.mockReturnValueOnce(definitionsEventSchemas[DEFINITION_RESOLVED]);
 
     await drainAndDispatch();
@@ -187,7 +219,9 @@ describe('drainAndDispatch', () => {
       createdAt: new Date(),
       payload: {...parsed, extra: 'raw'},
     };
-    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'workflows', event}]);
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([{id: event.id, source: 'workflows', orderingKey: 'run-1', event}]),
+    );
     mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: true, data: parsed})});
     mocks.getSubscribers.mockReturnValueOnce([handler]);
 
@@ -212,7 +246,9 @@ describe('drainAndDispatch', () => {
       createdAt: new Date(),
       payload: parsed,
     };
-    mocks.drainAll.mockResolvedValueOnce([{id: event.id, source: 'workflows', event}]);
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([{id: event.id, source: 'workflows', orderingKey: 'run-1', event}]),
+    );
     mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: true, data: parsed})});
     mocks.getSubscribers.mockReturnValueOnce([]);
 
@@ -247,11 +283,18 @@ describe('drainAndDispatch', () => {
       payload: {deliveryId: 'delivery-1'},
     };
     const handler = vi.fn().mockResolvedValue(undefined);
-    mocks.drainAll.mockResolvedValueOnce([
-      {id: validJob.id, source: 'workflows', event: validJob},
-      {id: poison.id, source: 'workflows', event: poison},
-      {id: validPush.id, source: 'integrations', event: validPush},
-    ]);
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([
+        {id: validJob.id, source: 'workflows', orderingKey: 'run-1', event: validJob},
+        {id: poison.id, source: 'workflows', orderingKey: 'run-2', event: poison},
+        {
+          id: validPush.id,
+          source: 'integrations',
+          orderingKey: 'integrations',
+          event: validPush,
+        },
+      ]),
+    );
     mocks.getEventSchema
       .mockReturnValueOnce({safeParse: () => ({success: true, data: validJob.payload})})
       .mockReturnValueOnce({safeParse: () => ({success: false, error})})
@@ -310,7 +353,9 @@ describe('drainAndDispatch', () => {
     };
     const succeedingHandler = vi.fn().mockResolvedValue(undefined);
     const failingHandler = vi.fn().mockRejectedValueOnce(failure);
-    mocks.drainAll.mockResolvedValueOnce([{id: rowId, source: 'workflows', event}]);
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([{id: rowId, source: 'workflows', orderingKey: 'run-1', event}]),
+    );
     mocks.getEventSchema.mockReturnValueOnce({safeParse: () => ({success: true, data: parsed})});
     mocks.getSubscribers.mockReturnValueOnce([succeedingHandler, failingHandler]);
 
@@ -335,5 +380,144 @@ describe('drainAndDispatch', () => {
       reason: 'handler',
     });
     expect(mocks.markDispatched).not.toHaveBeenCalled();
+  });
+
+  it('dispatches interleaved same-key events in created-at/id order while other keys run concurrently', async () => {
+    const earlier = event('a', new Date('2026-01-01T00:00:00.000Z'));
+    const later = event('b', new Date('2026-01-01T00:00:01.000Z'));
+    const other = event('c', new Date('2026-01-01T00:00:00.500Z'));
+    const calls: string[] = [];
+    const handler = vi.fn(async (handled: DomainEvent) => {
+      await Promise.resolve();
+      calls.push((handled.payload as {jobId: string}).jobId);
+    });
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([
+        {id: later.id, source: 'workflows', orderingKey: 'run-1', event: later},
+        {id: other.id, source: 'workflows', orderingKey: 'run-2', event: other},
+        {id: earlier.id, source: 'workflows', orderingKey: 'run-1', event: earlier},
+      ]),
+    );
+    mocks.getSubscribers.mockReturnValue([handler]);
+
+    await drainAndDispatch();
+
+    expect(calls.indexOf('a')).toBeLessThan(calls.indexOf('b'));
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['a', 'b']);
+  });
+
+  it('sorts each group by created-at then id even when drain order is scrambled', async () => {
+    const first = event('a', new Date('2026-01-01T00:00:00.000Z'));
+    const second = event('b', new Date('2026-01-01T00:00:00.000Z'));
+    const third = event('c', new Date('2026-01-01T00:00:01.000Z'));
+    const calls: string[] = [];
+    const handler = vi.fn(async (handled: DomainEvent) => {
+      await Promise.resolve();
+      calls.push((handled.payload as {jobId: string}).jobId);
+    });
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([
+        {id: third.id, source: 'workflows', orderingKey: 'run-1', event: third},
+        {id: second.id, source: 'workflows', orderingKey: 'run-1', event: second},
+        {id: first.id, source: 'workflows', orderingKey: 'run-1', event: first},
+      ]),
+    );
+    mocks.getSubscribers.mockReturnValue([handler]);
+
+    await drainAndDispatch();
+
+    expect(calls).toEqual(['a', 'b', 'c']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['a', 'b', 'c']);
+  });
+
+  it('halts a key group on the first failed row in the batch', async () => {
+    const rows = [
+      event('a', new Date('2026-01-01T00:00:00.000Z')),
+      event('b', new Date('2026-01-01T00:00:01.000Z')),
+      event('c', new Date('2026-01-01T00:00:02.000Z')),
+    ];
+    const handler = vi.fn(async (handled: DomainEvent) => {
+      await Promise.resolve();
+      if ((handled.payload as {jobId: string}).jobId === 'a') throw new Error('failed');
+    });
+    mocks.drainAll.mockResolvedValueOnce(
+      drain(
+        rows.map((row) => ({id: row.id, source: 'workflows', orderingKey: 'run-1', event: row})),
+      ),
+    );
+    mocks.getSubscribers.mockReturnValue([handler]);
+
+    await drainAndDispatch();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', 'a', {
+      kind: 'handler',
+      eventType: rows[0]?.type,
+      eventId: 'a',
+      errorName: 'Error',
+      errorMessage: 'failed',
+    });
+    expect(mocks.markDispatched).not.toHaveBeenCalled();
+  });
+
+  it('marks completed groups incrementally when a later group fails', async () => {
+    const success = event('success', new Date('2026-01-01T00:00:00.000Z'));
+    const failure = event('failure', new Date('2026-01-01T00:00:00.000Z'));
+    const handler = vi.fn(async (handled: DomainEvent) => {
+      await Promise.resolve();
+      if ((handled.payload as {jobId: string}).jobId === 'failure') throw new Error('failed');
+    });
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([
+        {id: success.id, source: 'workflows', orderingKey: 'run-1', event: success},
+        {id: failure.id, source: 'workflows', orderingKey: 'run-2', event: failure},
+      ]),
+    );
+    mocks.getSubscribers.mockReturnValue([handler]);
+
+    await drainAndDispatch();
+
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['success']);
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
+      'workflows',
+      'failure',
+      expect.objectContaining({kind: 'handler', eventId: 'failure'}),
+    );
+  });
+
+  it('runs cross-source groups in parallel while the source fallback key stays serial', async () => {
+    let releaseWorkflow!: () => void;
+    const workflowGate = new Promise<void>((resolve) => {
+      releaseWorkflow = resolve;
+    });
+    const calls: string[] = [];
+    const handler = vi.fn(async (handled: DomainEvent) => {
+      const id = (handled.payload as {jobId: string}).jobId;
+      calls.push(id);
+      if (id === 'w1') await workflowGate;
+    });
+    const w1 = event('w1', new Date('2026-01-01T00:00:00.000Z'));
+    const w2 = event('w2', new Date('2026-01-01T00:00:01.000Z'));
+    const i1 = event('i1', new Date('2026-01-01T00:00:00.000Z'));
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([
+        {id: w1.id, source: 'workflows', orderingKey: 'workflows', event: w1},
+        {id: w2.id, source: 'workflows', orderingKey: 'workflows', event: w2},
+        {id: i1.id, source: 'integrations', orderingKey: 'integrations', event: i1},
+      ]),
+    );
+    mocks.getSubscribers.mockReturnValue([handler]);
+
+    const dispatch = drainAndDispatch();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(calls).toEqual(['w1', 'i1']);
+
+    releaseWorkflow();
+    await dispatch;
+
+    expect(calls).toEqual(['w1', 'i1', 'w2']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['w1', 'w2']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', ['i1']);
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   markDispatched: vi.fn(),
   recordDispatchFailure: vi.fn(),
   errorLog: vi.fn(),
+  warnLog: vi.fn(),
   eventDispatchedAdd: vi.fn(),
   dispatchFailureAdd: vi.fn(),
   drainBatchRecord: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
   },
   logger: () => ({
     error: mocks.errorLog,
+    warn: mocks.warnLog,
   }),
 }));
 
@@ -74,6 +76,7 @@ describe('drainAndDispatch', () => {
     mocks.markDispatched.mockReset();
     mocks.recordDispatchFailure.mockReset();
     mocks.errorLog.mockReset();
+    mocks.warnLog.mockReset();
     mocks.eventDispatchedAdd.mockReset();
     mocks.dispatchFailureAdd.mockReset();
     mocks.drainBatchRecord.mockReset();
@@ -153,6 +156,35 @@ describe('drainAndDispatch', () => {
       reason: 'handler',
     });
     expect(mocks.markDispatched).not.toHaveBeenCalled();
+  });
+
+  it('returns hasMore after group-level persistence failures', async () => {
+    const success = event('success', new Date('2026-01-01T00:00:00.000Z'));
+    const other = event('other', new Date('2026-01-01T00:00:00.000Z'));
+    mocks.drainAll.mockResolvedValueOnce(
+      drain(
+        [
+          {id: success.id, source: 'workflows', orderingKey: 'run-1', event: success},
+          {id: other.id, source: 'integrations', orderingKey: 'integrations', event: other},
+        ],
+        true,
+      ),
+    );
+    mocks.getSubscribers.mockReturnValue([vi.fn().mockResolvedValue(undefined)]);
+    mocks.markDispatched.mockImplementation(async (source: string) => {
+      await Promise.resolve();
+      if (source === 'workflows') throw new Error('db unavailable');
+    });
+
+    const hasMore = await drainAndDispatch();
+
+    expect(hasMore).toBe(true);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['success']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', ['other']);
+    expect(mocks.warnLog).toHaveBeenCalledWith(
+      {err: expect.any(AggregateError)},
+      'Outbox dispatch groups completed with errors',
+    );
   });
 
   it('rejects a malformed schema-covered payload without capturing raw payload data', async () => {

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -1,5 +1,6 @@
 import {captureException} from '@shipfox/node-error-monitoring';
 import {
+  boundedMap,
   type DrainedEvent,
   drainAll,
   getEventSchema,
@@ -11,52 +12,100 @@ import {
 import {logger} from '@shipfox/node-opentelemetry';
 import {dispatchFailureCount, drainBatchSize, eventDispatchedCount} from '#metrics/index.js';
 
-export async function drainAndDispatch(): Promise<void> {
-  const rows = await drainAll();
-  drainBatchSize.record(rows.length);
-  if (rows.length === 0) return;
+const DISPATCH_CONCURRENCY = 8;
 
-  const dispatched = new Map<string, string[]>();
+export async function drainAndDispatch(): Promise<boolean> {
+  const {events: rows, hasMore} = await drainAll();
+  drainBatchSize.record(rows.length);
+  if (rows.length === 0) return hasMore;
+
+  const groups = groupRows(rows);
+
+  await boundedMap(
+    groups,
+    DISPATCH_CONCURRENCY,
+    async (group) => {
+      const dispatchedIds: string[] = [];
+
+      for (const row of group.rows) {
+        const succeeded = await dispatchRow(row);
+        if (!succeeded) break;
+        dispatchedIds.push(row.id);
+      }
+
+      if (dispatchedIds.length > 0) {
+        await markDispatched(group.source, dispatchedIds);
+        eventDispatchedCount.add(dispatchedIds.length, {
+          module: group.source,
+          outcome: 'succeeded',
+        });
+      }
+    },
+    {stopOnError: false},
+  );
+
+  return hasMore;
+}
+
+async function dispatchRow(row: DrainedEvent): Promise<boolean> {
+  const validation = validatePayload(row);
+  if (!validation.success) {
+    await recordDispatchFailure(row.source, row.id, validation.failure);
+    recordFailureMetric(row.source, validation.failure.kind);
+    return false;
+  }
+
+  const event = validation.event;
+  const handlers = getSubscribers(event.type);
+  let dispatchFailure: OutboxDispatchFailure | undefined;
+
+  for (const handler of handlers) {
+    try {
+      await handler(event);
+    } catch (error) {
+      const errorContext = failureFromHandler(row, error);
+      logger().error({err: error, ...errorContext}, 'Handler failed for outbox event');
+      captureException(error, {extra: errorContext});
+      dispatchFailure ??= errorContext;
+    }
+  }
+
+  if (!dispatchFailure) return true;
+
+  await recordDispatchFailure(row.source, row.id, dispatchFailure);
+  recordFailureMetric(row.source, dispatchFailure.kind);
+  return false;
+}
+
+interface DispatchGroup {
+  source: string;
+  orderingKey: string;
+  rows: DrainedEvent[];
+}
+
+function groupRows(rows: DrainedEvent[]): DispatchGroup[] {
+  const groups = new Map<string, DispatchGroup>();
 
   for (const row of rows) {
-    const validation = validatePayload(row);
-    if (!validation.success) {
-      await recordDispatchFailure(row.source, row.id, validation.failure);
-      recordFailureMetric(row.source, validation.failure.kind);
-      continue;
+    const mapKey = JSON.stringify([row.source, row.orderingKey]);
+    let group = groups.get(mapKey);
+    if (!group) {
+      group = {source: row.source, orderingKey: row.orderingKey, rows: []};
+      groups.set(mapKey, group);
     }
-
-    const event = validation.event;
-    const handlers = getSubscribers(event.type);
-    let allSucceeded = true;
-    let dispatchFailure: OutboxDispatchFailure | undefined;
-
-    for (const handler of handlers) {
-      try {
-        await handler(event);
-      } catch (error) {
-        const errorContext = failureFromHandler(row, error);
-        logger().error({err: error, ...errorContext}, 'Handler failed for outbox event');
-        captureException(error, {extra: errorContext});
-        dispatchFailure ??= errorContext;
-        allSucceeded = false;
-      }
-    }
-
-    if (allSucceeded) {
-      const ids = dispatched.get(row.source) ?? [];
-      ids.push(row.id);
-      dispatched.set(row.source, ids);
-    } else if (dispatchFailure) {
-      await recordDispatchFailure(row.source, row.id, dispatchFailure);
-      recordFailureMetric(row.source, dispatchFailure.kind);
-    }
+    group.rows.push(row);
   }
 
-  for (const [source, ids] of dispatched) {
-    await markDispatched(source, ids);
-    eventDispatchedCount.add(ids.length, {module: source, outcome: 'succeeded'});
+  for (const group of groups.values()) {
+    group.rows.sort(compareDrainedRows);
   }
+
+  return [...groups.values()];
+}
+
+function compareDrainedRows(a: DrainedEvent, b: DrainedEvent): number {
+  const createdAtDelta = a.event.createdAt.getTime() - b.event.createdAt.getTime();
+  return createdAtDelta === 0 ? a.id.localeCompare(b.id) : createdAtDelta;
 }
 
 /**

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -21,28 +21,32 @@ export async function drainAndDispatch(): Promise<boolean> {
 
   const groups = groupRows(rows);
 
-  await boundedMap(
-    groups,
-    DISPATCH_CONCURRENCY,
-    async (group) => {
-      const dispatchedIds: string[] = [];
+  try {
+    await boundedMap(
+      groups,
+      DISPATCH_CONCURRENCY,
+      async (group) => {
+        const dispatchedIds: string[] = [];
 
-      for (const row of group.rows) {
-        const succeeded = await dispatchRow(row);
-        if (!succeeded) break;
-        dispatchedIds.push(row.id);
-      }
+        for (const row of group.rows) {
+          const succeeded = await dispatchRow(row);
+          if (!succeeded) break;
+          dispatchedIds.push(row.id);
+        }
 
-      if (dispatchedIds.length > 0) {
-        await markDispatched(group.source, dispatchedIds);
-        eventDispatchedCount.add(dispatchedIds.length, {
-          module: group.source,
-          outcome: 'succeeded',
-        });
-      }
-    },
-    {stopOnError: false},
-  );
+        if (dispatchedIds.length > 0) {
+          await markDispatched(group.source, dispatchedIds);
+          eventDispatchedCount.add(dispatchedIds.length, {
+            module: group.source,
+            outcome: 'succeeded',
+          });
+        }
+      },
+      {stopOnError: false},
+    );
+  } catch (error) {
+    logger().warn({err: error}, 'Outbox dispatch groups completed with errors');
+  }
 
   return hasMore;
 }

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.test.ts
@@ -1,0 +1,35 @@
+const mocks = vi.hoisted(() => ({
+  continueAsNew: vi.fn(),
+  drainAndDispatch: vi.fn(),
+  pruneOutboxRetention: vi.fn(),
+  sleep: vi.fn(),
+}));
+
+vi.mock('@temporalio/workflow', () => ({
+  continueAsNew: mocks.continueAsNew,
+  proxyActivities: vi.fn(() => ({
+    drainAndDispatch: mocks.drainAndDispatch,
+    pruneOutboxRetention: mocks.pruneOutboxRetention,
+  })),
+  sleep: mocks.sleep,
+}));
+
+describe('outboxDispatcherWorkflow', () => {
+  beforeEach(() => {
+    mocks.continueAsNew.mockReset();
+    mocks.drainAndDispatch.mockReset();
+    mocks.pruneOutboxRetention.mockReset();
+    mocks.sleep.mockReset();
+  });
+
+  it('drains repeatedly until the dispatcher reports no more backlog', async () => {
+    const {outboxDispatcherWorkflow} = await import('./dispatch.js');
+    mocks.drainAndDispatch.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await outboxDispatcherWorkflow();
+
+    expect(mocks.drainAndDispatch).toHaveBeenCalledTimes(2);
+    expect(mocks.sleep).toHaveBeenCalledWith('250ms');
+    expect(mocks.continueAsNew).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
@@ -2,7 +2,7 @@ import {continueAsNew, proxyActivities, sleep} from '@temporalio/workflow';
 import type {createActivities} from '../activities/index.js';
 
 const {drainAndDispatch} = proxyActivities<ReturnType<typeof createActivities>>({
-  startToCloseTimeout: '30s',
+  startToCloseTimeout: '60s',
 });
 
 const {pruneOutboxRetention} = proxyActivities<ReturnType<typeof createActivities>>({
@@ -10,11 +10,13 @@ const {pruneOutboxRetention} = proxyActivities<ReturnType<typeof createActivitie
 });
 
 export async function outboxDispatcherWorkflow(): Promise<void> {
-  await drainAndDispatch();
-  await sleep('1s');
+  const hasMore = await drainAndDispatch();
+  if (!hasMore) await sleep(POLL_INTERVAL);
   await continueAsNew<typeof outboxDispatcherWorkflow>();
 }
 
 export async function outboxRetentionWorkflow(): Promise<void> {
   await pruneOutboxRetention();
 }
+
+const POLL_INTERVAL = '250ms';

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
@@ -10,8 +10,11 @@ const {pruneOutboxRetention} = proxyActivities<ReturnType<typeof createActivitie
 });
 
 export async function outboxDispatcherWorkflow(): Promise<void> {
-  const hasMore = await drainAndDispatch();
-  if (!hasMore) await sleep(POLL_INTERVAL);
+  let hasMore = false;
+  do {
+    hasMore = await drainAndDispatch();
+  } while (hasMore);
+  await sleep(POLL_INTERVAL);
   await continueAsNew<typeof outboxDispatcherWorkflow>();
 }
 

--- a/libs/api/integration/core/drizzle/0000_initial.sql
+++ b/libs/api/integration/core/drizzle/0000_initial.sql
@@ -13,6 +13,7 @@ CREATE TABLE "integrations_connections" (
 CREATE TABLE "integrations_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/integration/core/drizzle/meta/0001_snapshot.json
+++ b/libs/api/integration/core/drizzle/meta/0001_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "e3544ba8-0307-4ffd-a646-3851b89bcbfb",
-  "prevId": "00000000-0000-0000-0000-000000000000",
+  "id": "a808bfbe-960e-418d-a72a-d88ddca95096",
+  "prevId": "e3544ba8-0307-4ffd-a646-3851b89bcbfb",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -95,21 +95,6 @@
           "method": "btree",
           "with": {}
         },
-        "integrations_connections_workspace_id_idx": {
-          "name": "integrations_connections_workspace_id_idx",
-          "columns": [
-            {
-              "expression": "workspace_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "integrations_connections_workspace_slug_unique": {
           "name": "integrations_connections_workspace_slug_unique",
           "columns": [
@@ -127,6 +112,21 @@
             }
           ],
           "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integrations_connections_workspace_id_idx": {
+          "name": "integrations_connections_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -155,6 +155,12 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "payload": {
           "name": "payload",

--- a/libs/api/logs/drizzle/0000_initial.sql
+++ b/libs/api/logs/drizzle/0000_initial.sql
@@ -41,6 +41,7 @@ CREATE TABLE "logs_job_accounting" (
 CREATE TABLE "logs_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/logs/drizzle/meta/0000_snapshot.json
+++ b/libs/api/logs/drizzle/meta/0000_snapshot.json
@@ -403,6 +403,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/projects/drizzle/0000_initial.sql
+++ b/libs/api/projects/drizzle/0000_initial.sql
@@ -11,6 +11,7 @@ CREATE TABLE "projects_projects" (
 CREATE TABLE "projects_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/projects/drizzle/meta/0000_snapshot.json
+++ b/libs/api/projects/drizzle/meta/0000_snapshot.json
@@ -74,6 +74,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/runners/drizzle/0000_initial.sql
+++ b/libs/api/runners/drizzle/0000_initial.sql
@@ -30,6 +30,7 @@ CREATE TABLE "runners_manual_registration_tokens" (
 CREATE TABLE "runners_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/runners/drizzle/meta/0000_snapshot.json
+++ b/libs/api/runners/drizzle/meta/0000_snapshot.json
@@ -294,6 +294,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/secrets/drizzle/0000_lowly_ogun.sql
+++ b/libs/api/secrets/drizzle/0000_lowly_ogun.sql
@@ -38,6 +38,7 @@ CREATE TABLE "secrets_variables" (
 CREATE TABLE "secrets_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/secrets/drizzle/meta/0000_snapshot.json
+++ b/libs/api/secrets/drizzle/meta/0000_snapshot.json
@@ -421,6 +421,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/triggers/drizzle/0000_initial.sql
+++ b/libs/api/triggers/drizzle/0000_initial.sql
@@ -29,6 +29,7 @@ CREATE TABLE "triggers_job_listener_subscriptions" (
 CREATE TABLE "triggers_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/triggers/drizzle/meta/0000_snapshot.json
+++ b/libs/api/triggers/drizzle/meta/0000_snapshot.json
@@ -295,6 +295,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/workflows/drizzle/0000_initial.sql
+++ b/libs/api/workflows/drizzle/0000_initial.sql
@@ -75,6 +75,7 @@ CREATE TABLE "workflows_jobs" (
 CREATE TABLE "workflows_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/workflows/drizzle/meta/0000_snapshot.json
+++ b/libs/api/workflows/drizzle/meta/0000_snapshot.json
@@ -571,6 +571,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/api/workflows/src/db/job-listener-events.test.ts
+++ b/libs/api/workflows/src/db/job-listener-events.test.ts
@@ -108,5 +108,6 @@ describe('deliverEventToListener', () => {
       eventRef,
       eventName: 'pull_request_review',
     });
+    expect(matching?.orderingKey).toBeNull();
   });
 });

--- a/libs/api/workflows/src/db/job-listener-events.ts
+++ b/libs/api/workflows/src/db/job-listener-events.ts
@@ -1,13 +1,12 @@
-import {WORKFLOWS_JOB_EVENT_DELIVERED, type WorkflowsEventMapDto} from '@shipfox/api-workflows-dto';
-import {writeOutboxEvent} from '@shipfox/node-outbox';
+import {WORKFLOWS_JOB_EVENT_DELIVERED} from '@shipfox/api-workflows-dto';
 import {eq} from 'drizzle-orm';
 import {isJobTerminal} from '#core/entities/job.js';
 import type {JobListenerEventDisposition} from '#core/entities/job-listener-event.js';
 import {recordListenerEventReceived} from '#metrics/instance.js';
 import {db} from './db.js';
+import {writeWorkflowsOutboxEvent} from './outbox-writes.js';
 import {jobListenerEvents} from './schema/job-listener-events.js';
 import {jobs} from './schema/jobs.js';
-import {workflowsOutbox} from './schema/outbox.js';
 
 export interface DeliverEventToListenerParams {
   jobId: string;
@@ -55,7 +54,7 @@ export async function deliverEventToListener(
       .returning({id: jobListenerEvents.id});
 
     if (!rows[0]) return {buffered: false, skipped: false};
-    await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    await writeWorkflowsOutboxEvent(tx, {
       type: WORKFLOWS_JOB_EVENT_DELIVERED,
       payload: {
         jobId: params.jobId,

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -2,8 +2,7 @@ import {
   type AgentDefaultsResolver,
   catalogDefaultAgentResolver,
 } from '@shipfox/api-agent/core/resolve-agent-config';
-import {WORKFLOWS_JOB_ACTIVATED, type WorkflowsEventMapDto} from '@shipfox/api-workflows-dto';
-import {writeOutboxEvent} from '@shipfox/node-outbox';
+import {WORKFLOWS_JOB_ACTIVATED} from '@shipfox/api-workflows-dto';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
 import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
@@ -19,10 +18,10 @@ import {
   recordWorkflowListenerResolved,
 } from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
+import {writeWorkflowsOutboxEvent} from './outbox-writes.js';
 import {jobExecutions, toJobExecution} from './schema/job-executions.js';
 import {jobListenerEvents} from './schema/job-listener-events.js';
 import {jobs, toJob} from './schema/jobs.js';
-import {workflowsOutbox} from './schema/outbox.js';
 import {steps} from './schema/steps.js';
 import {workflowRunAttempts} from './schema/workflow-run-attempts.js';
 import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
@@ -101,7 +100,7 @@ export async function activateJobListener(
       .returning();
 
     if (listenerRows[0]) {
-      await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+      await writeWorkflowsOutboxEvent(tx, {
         type: WORKFLOWS_JOB_ACTIVATED,
         payload: {
           jobId: params.jobId,

--- a/libs/api/workflows/src/db/outbox-writes.ts
+++ b/libs/api/workflows/src/db/outbox-writes.ts
@@ -1,0 +1,40 @@
+import type {WorkflowsEventMapDto} from '@shipfox/api-workflows-dto';
+import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
+import type {Tx} from './db.js';
+import {workflowsOutbox} from './schema/outbox.js';
+
+type WorkflowsOutboxEvent = {
+  [K in keyof WorkflowsEventMapDto & string]: {
+    type: K;
+    payload: WorkflowsEventMapDto[K];
+  };
+}[keyof WorkflowsEventMapDto & string];
+
+export async function writeWorkflowsOutboxEvent(
+  tx: Tx,
+  event: WorkflowsOutboxEvent,
+): Promise<void> {
+  await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    ...event,
+    orderingKey: workflowRunOrderingKey(event),
+  });
+}
+
+export async function writeWorkflowsOutboxEvents(
+  tx: Tx,
+  events: WorkflowsOutboxEvent[],
+): Promise<void> {
+  await writeOutboxEvents<WorkflowsEventMapDto>(
+    tx,
+    workflowsOutbox,
+    events.map((event) => ({
+      ...event,
+      orderingKey: workflowRunOrderingKey(event),
+    })),
+  );
+}
+
+function workflowRunOrderingKey(event: WorkflowsOutboxEvent): string | undefined {
+  const workflowRunId = (event.payload as {workflowRunId?: unknown}).workflowRunId;
+  return typeof workflowRunId === 'string' ? workflowRunId : undefined;
+}

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -720,6 +720,7 @@ describe('workflow run queries', () => {
         projectId: run.projectId,
         definitionId: run.definitionId,
       });
+      expect(matchingRow?.orderingKey).toBe(run.id);
       expect(matchingRow?.dispatchedAt).toBeNull();
     });
 

--- a/libs/api/workflows/src/db/workflow-runs.ts
+++ b/libs/api/workflows/src/db/workflow-runs.ts
@@ -14,7 +14,6 @@ import {
   WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED,
   WORKFLOWS_WORKFLOW_RUN_CANCELLED,
   WORKFLOWS_WORKFLOW_RUN_TERMINATED,
-  type WorkflowsEventMapDto,
 } from '@shipfox/api-workflows-dto';
 import {
   analyzeContextKeyAccess,
@@ -29,7 +28,6 @@ import {
   timestampIdCursorWhere,
 } from '@shipfox/node-drizzle';
 import {logger} from '@shipfox/node-opentelemetry';
-import {writeOutboxEvent, writeOutboxEvents} from '@shipfox/node-outbox';
 import {
   and,
   asc,
@@ -89,10 +87,10 @@ import {
   recordWorkflowRunStatusChanged,
 } from '#metrics/instance.js';
 import {db, type Tx} from './db.js';
+import {writeWorkflowsOutboxEvent, writeWorkflowsOutboxEvents} from './outbox-writes.js';
 import {runningJobExecutions} from './runner-lease-table.js';
 import {jobExecutions, toJobExecution} from './schema/job-executions.js';
 import {jobs, toJob} from './schema/jobs.js';
-import {workflowsOutbox} from './schema/outbox.js';
 import {stepAttempts, toStepAttempt} from './schema/step-attempts.js';
 import {steps, toStep} from './schema/steps.js';
 import {toWorkflowRunAttempt, workflowRunAttempts} from './schema/workflow-run-attempts.js';
@@ -301,7 +299,7 @@ export async function createWorkflowRun(params: CreateWorkflowRunParams): Promis
       await tx.insert(steps).values(stepValues);
     }
 
-    await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    await writeWorkflowsOutboxEvent(tx, {
       type: WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED,
       payload: {
         workflowRunId: runRow.id,
@@ -680,7 +678,7 @@ export async function createRerunWorkflowRun(
       .returning();
     if (!newRunRow) throw new Error(`Workflow run missing after rerun: ${sourceRow.id}`);
 
-    await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    await writeWorkflowsOutboxEvent(tx, {
       type: WORKFLOWS_WORKFLOW_RUN_ATTEMPT_CREATED,
       payload: {
         workflowRunId: newRunRow.id,
@@ -1398,7 +1396,7 @@ async function terminateRunAttempt(
     .returning();
 
   const run = toWorkflowRun(terminatedRunRow ?? lockedRun);
-  await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+  await writeWorkflowsOutboxEvent(tx, {
     type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
     payload: {
       workflowRunId: run.id,
@@ -1408,7 +1406,7 @@ async function terminateRunAttempt(
     },
   });
   if (spec.emitCancelledEvent) {
-    await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    await writeWorkflowsOutboxEvent(tx, {
       type: WORKFLOWS_WORKFLOW_RUN_CANCELLED,
       payload: {
         workflowRunId: run.id,
@@ -1628,7 +1626,7 @@ export async function updateWorkflowRunStatus(
     const run = {...toWorkflowRun(runRow ?? target.run), version: attemptRow.version};
 
     if (shouldMirror && isWorkflowRunTerminal(run.status)) {
-      await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+      await writeWorkflowsOutboxEvent(tx, {
         type: WORKFLOWS_WORKFLOW_RUN_TERMINATED,
         payload: {
           workflowRunId: run.id,
@@ -1776,7 +1774,7 @@ export async function updateJobStatusAtVersion(
     if (!identity) {
       throw new Error(`Cannot enqueue job-terminal event: job ${job.id} not found`);
     }
-    await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    await writeWorkflowsOutboxEvent(tx, {
       type: WORKFLOWS_JOB_TERMINATED,
       payload: {
         jobId: job.id,
@@ -1888,7 +1886,7 @@ export async function failJobExecutionAsTimedOut(params: {
       );
     }
 
-    await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+    await writeWorkflowsOutboxEvent(tx, {
       type: WORKFLOWS_JOB_EXECUTION_TIMED_OUT,
       payload: {
         jobId: updated.execution.jobId,
@@ -2072,7 +2070,7 @@ export async function writeJobStepsSettledOutbox(
     throw new Error(`Cannot enqueue job-steps-settled event: job ${params.jobId} not found`);
   }
 
-  await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+  await writeWorkflowsOutboxEvent(tx, {
     type: WORKFLOWS_JOB_STEPS_SETTLED,
     payload: {
       jobId: params.jobId,
@@ -2140,9 +2138,8 @@ export async function bulkUpdateStepStatuses(
       const firstAttempt = finalizedAttempts[0];
       if (!firstAttempt) return;
       const identity = await getStepAttemptTerminatedOutboxIdentity(tx, firstAttempt.stepId);
-      await writeOutboxEvents<WorkflowsEventMapDto>(
+      await writeWorkflowsOutboxEvents(
         tx,
-        workflowsOutbox,
         finalizedAttempts.map((attempt) => ({
           type: WORKFLOWS_STEP_ATTEMPT_TERMINATED,
           payload: {
@@ -2386,7 +2383,7 @@ export async function writeStepAttemptTerminatedOutbox(
 ): Promise<void> {
   const identity = await getStepAttemptTerminatedOutboxIdentity(tx, params.stepId);
 
-  await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+  await writeWorkflowsOutboxEvent(tx, {
     type: WORKFLOWS_STEP_ATTEMPT_TERMINATED,
     payload: {
       jobId: identity.jobId,
@@ -2493,7 +2490,7 @@ export async function writeStepRestartEnqueuedOutbox(
     throw new Error(`Cannot enqueue step-restart event: job ${params.jobId} not found`);
   }
 
-  await writeOutboxEvent<WorkflowsEventMapDto>(tx, workflowsOutbox, {
+  await writeWorkflowsOutboxEvent(tx, {
     type: WORKFLOWS_STEP_RESTART_ENQUEUED,
     payload: {
       jobId: params.jobId,

--- a/libs/api/workspaces/drizzle/0003_outgoing_enchantress.sql
+++ b/libs/api/workspaces/drizzle/0003_outgoing_enchantress.sql
@@ -1,6 +1,7 @@
 CREATE TABLE "workspaces_outbox" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"event_type" text NOT NULL,
+	"ordering_key" text,
 	"payload" jsonb NOT NULL,
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	"dispatched_at" timestamp with time zone,

--- a/libs/api/workspaces/drizzle/meta/0003_snapshot.json
+++ b/libs/api/workspaces/drizzle/meta/0003_snapshot.json
@@ -255,6 +255,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "ordering_key": {
+          "name": "ordering_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "payload": {
           "name": "payload",
           "type": "jsonb",

--- a/libs/shared/node/module/src/bounded-map.test.ts
+++ b/libs/shared/node/module/src/bounded-map.test.ts
@@ -54,4 +54,23 @@ describe('boundedMap', () => {
     await expect(result).rejects.toThrow('boom');
     expect(seen).toEqual([1, 2]);
   });
+
+  it('waits for in-flight work to settle before rejecting when stopOnError is true', async () => {
+    const settled: number[] = [];
+
+    const result = boundedMap(
+      [1, 2, 3],
+      2,
+      async (value) => {
+        if (value === 1) throw new Error('boom');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        settled.push(value);
+        return value;
+      },
+      {stopOnError: true},
+    );
+
+    await expect(result).rejects.toThrow('boom');
+    expect(settled).toEqual([2]);
+  });
 });

--- a/libs/shared/node/module/src/bounded-map.test.ts
+++ b/libs/shared/node/module/src/bounded-map.test.ts
@@ -1,0 +1,57 @@
+import {boundedMap} from './bounded-map.js';
+
+describe('boundedMap', () => {
+  it('preserves result order while respecting the concurrency limit', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    const results = await boundedMap([30, 10, 20, 5], 2, async (delay, index) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      active -= 1;
+      return index;
+    });
+
+    expect(results).toEqual([0, 1, 2, 3]);
+    expect(maxActive).toBeLessThanOrEqual(2);
+  });
+
+  it('continues remaining work when stopOnError is false', async () => {
+    const seen: number[] = [];
+
+    const result = boundedMap(
+      [1, 2, 3],
+      1,
+      async (value) => {
+        await Promise.resolve();
+        seen.push(value);
+        if (value === 2) throw new Error('boom');
+        return value;
+      },
+      {stopOnError: false},
+    );
+
+    await expect(result).rejects.toThrow(AggregateError);
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it('aborts pending work when stopOnError is true', async () => {
+    const seen: number[] = [];
+
+    const result = boundedMap(
+      [1, 2, 3],
+      1,
+      async (value) => {
+        await Promise.resolve();
+        seen.push(value);
+        if (value === 2) throw new Error('boom');
+        return value;
+      },
+      {stopOnError: true},
+    );
+
+    await expect(result).rejects.toThrow('boom');
+    expect(seen).toEqual([1, 2]);
+  });
+});

--- a/libs/shared/node/module/src/bounded-map.ts
+++ b/libs/shared/node/module/src/bounded-map.ts
@@ -1,0 +1,44 @@
+export interface BoundedMapOptions {
+  stopOnError?: boolean | undefined;
+}
+
+export async function boundedMap<T, U>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T, index: number) => Promise<U>,
+  options: BoundedMapOptions = {},
+): Promise<U[]> {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error('limit must be a positive integer');
+  }
+
+  const results = new Array<U>(items.length);
+  let next = 0;
+  let aborted = false;
+  const errors: unknown[] = [];
+
+  async function worker(): Promise<void> {
+    while (!aborted && next < items.length) {
+      const index = next;
+      next += 1;
+
+      try {
+        results[index] = await mapper(items[index] as T, index);
+      } catch (error) {
+        errors.push(error);
+        if (options.stopOnError ?? true) {
+          aborted = true;
+          throw error;
+        }
+      }
+    }
+  }
+
+  await Promise.all(Array.from({length: Math.min(limit, items.length)}, () => worker()));
+
+  if (errors.length > 0 && !(options.stopOnError ?? true)) {
+    throw new AggregateError(errors, 'One or more boundedMap tasks failed');
+  }
+
+  return results;
+}

--- a/libs/shared/node/module/src/bounded-map.ts
+++ b/libs/shared/node/module/src/bounded-map.ts
@@ -16,6 +16,7 @@ export async function boundedMap<T, U>(
   let next = 0;
   let aborted = false;
   const errors: unknown[] = [];
+  const stopOnError = options.stopOnError ?? true;
 
   async function worker(): Promise<void> {
     while (!aborted && next < items.length) {
@@ -26,9 +27,8 @@ export async function boundedMap<T, U>(
         results[index] = await mapper(items[index] as T, index);
       } catch (error) {
         errors.push(error);
-        if (options.stopOnError ?? true) {
+        if (stopOnError) {
           aborted = true;
-          throw error;
         }
       }
     }
@@ -36,7 +36,11 @@ export async function boundedMap<T, U>(
 
   await Promise.all(Array.from({length: Math.min(limit, items.length)}, () => worker()));
 
-  if (errors.length > 0 && !(options.stopOnError ?? true)) {
+  if (errors.length > 0 && stopOnError) {
+    throw errors[0];
+  }
+
+  if (errors.length > 0) {
     throw new AggregateError(errors, 'One or more boundedMap tasks failed');
   }
 

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -1,3 +1,5 @@
+export type {BoundedMapOptions} from './bounded-map.js';
+export {boundedMap} from './bounded-map.js';
 export type {
   InitializedModules,
   InitializeModulesOptions,
@@ -5,12 +7,14 @@ export type {
 } from './initialize.js';
 export {initializeModules, registerModuleMetrics, startModuleWorkers} from './initialize.js';
 export type {
+  DrainAllResult,
   DrainedEvent,
   OutboxDispatchFailure,
   PruneDispatchedOutboxRowsOptions,
   PrunedOutboxSource,
 } from './publisher-registry.js';
 export {
+  BATCH_SIZE,
   drainAll,
   getEventSchema,
   markDispatched,

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -12,8 +12,14 @@ interface PublisherSource {
 
 export interface DrainedEvent {
   source: string;
+  orderingKey: string;
   id: string;
   event: DomainEvent;
+}
+
+export interface DrainAllResult {
+  events: DrainedEvent[];
+  hasMore: boolean;
 }
 
 export interface OutboxDispatchIssue {
@@ -52,7 +58,7 @@ export interface PrunedOutboxSource {
 const _sources: PublisherSource[] = [];
 const _schemasByType = new Map<string, ZodType>();
 
-const BATCH_SIZE = 100;
+export const BATCH_SIZE = 500;
 const MAX_DISPATCH_ATTEMPTS = 5;
 
 export function registerPublisher(config: PublisherSource): void {
@@ -76,8 +82,9 @@ export function getEventSchema(type: string): ZodType | undefined {
   return _schemasByType.get(type);
 }
 
-export async function drainAll(): Promise<DrainedEvent[]> {
+export async function drainAll(): Promise<DrainAllResult> {
   const results: DrainedEvent[] = [];
+  let hasMore = false;
 
   for (const source of _sources) {
     const rows = await source
@@ -93,10 +100,12 @@ export async function drainAll(): Promise<DrainedEvent[]> {
       )
       .orderBy(asc(source.table.nextDispatchAt), asc(source.table.createdAt))
       .limit(BATCH_SIZE);
+    if (rows.length === BATCH_SIZE) hasMore = true;
 
     for (const row of rows) {
       results.push({
         source: source.name,
+        orderingKey: row.orderingKey ?? source.name,
         id: row.id,
         event: {
           id: row.id,
@@ -108,7 +117,7 @@ export async function drainAll(): Promise<DrainedEvent[]> {
     }
   }
 
-  return results;
+  return {events: results, hasMore};
 }
 
 export async function markDispatched(source: string, ids: string[]): Promise<void> {

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -96,9 +96,18 @@ export async function drainAll(): Promise<DrainAllResult> {
           isNull(source.table.dispatchedAt),
           isNull(source.table.deadLetteredAt),
           lte(source.table.nextDispatchAt, sql`now()`),
+          sql`NOT EXISTS (
+            SELECT 1
+            FROM ${sql.raw(quoteIdentifier(getTableName(source.table)))} AS earlier
+            WHERE earlier.dispatched_at IS NULL
+              AND earlier.dead_lettered_at IS NULL
+              AND COALESCE(earlier.ordering_key, ${source.name}) = COALESCE(${source.table.orderingKey}, ${source.name})
+              AND (earlier.created_at, earlier.id) < (${source.table.createdAt}, ${source.table.id})
+              AND earlier.next_dispatch_at > now()
+          )`,
         ),
       )
-      .orderBy(asc(source.table.nextDispatchAt), asc(source.table.createdAt))
+      .orderBy(asc(source.table.createdAt), asc(source.table.id))
       .limit(BATCH_SIZE);
     if (rows.length === BATCH_SIZE) hasMore = true;
 

--- a/libs/shared/node/outbox/src/schema.ts
+++ b/libs/shared/node/outbox/src/schema.ts
@@ -13,6 +13,7 @@ export function createOutboxTable(pgTable: ReturnType<typeof pgTableCreator>) {
     {
       id: uuidv7PrimaryKey(),
       eventType: text('event_type').notNull(),
+      orderingKey: text('ordering_key'),
       payload: jsonb('payload').notNull(),
       createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
       dispatchedAt: timestamp('dispatched_at', {withTimezone: true}),

--- a/libs/shared/node/outbox/src/write.test.ts
+++ b/libs/shared/node/outbox/src/write.test.ts
@@ -11,6 +11,7 @@ interface TestEventMap {
 
 describe('createOutboxTable', () => {
   it('exposes dispatch retry and dead-letter columns', () => {
+    expect(outboxTable.orderingKey.name).toBe('ordering_key');
     expect(outboxTable.dispatchAttempts.name).toBe('dispatch_attempts');
     expect(outboxTable.nextDispatchAt.name).toBe('next_dispatch_at');
     expect(outboxTable.lastDispatchError.name).toBe('last_dispatch_error');
@@ -59,8 +60,22 @@ describe('writeOutboxEvents', () => {
     expect(insert).toHaveBeenCalledWith(outboxTable);
     expect(values).toHaveBeenCalledTimes(1);
     expect(values).toHaveBeenCalledWith([
-      {eventType: 'thing.created', payload: {id: 'a'}},
-      {eventType: 'thing.deleted', payload: {id: 'b', reason: 'gone'}},
+      {eventType: 'thing.created', orderingKey: null, payload: {id: 'a'}},
+      {eventType: 'thing.deleted', orderingKey: null, payload: {id: 'b', reason: 'gone'}},
+    ]);
+  });
+
+  it('persists non-empty ordering keys and normalizes blank keys to null', async () => {
+    const {tx, values} = fakeTx();
+
+    await writeOutboxEvents<TestEventMap>(tx, outboxTable, [
+      {type: 'thing.created', orderingKey: '  key-1  ', payload: {id: 'a'}},
+      {type: 'thing.deleted', orderingKey: '   ', payload: {id: 'b', reason: 'gone'}},
+    ]);
+
+    expect(values).toHaveBeenCalledWith([
+      {eventType: 'thing.created', orderingKey: 'key-1', payload: {id: 'a'}},
+      {eventType: 'thing.deleted', orderingKey: null, payload: {id: 'b', reason: 'gone'}},
     ]);
   });
 });
@@ -75,6 +90,8 @@ describe('writeOutboxEvent', () => {
     });
 
     expect(values).toHaveBeenCalledTimes(1);
-    expect(values).toHaveBeenCalledWith([{eventType: 'thing.created', payload: {id: 'a'}}]);
+    expect(values).toHaveBeenCalledWith([
+      {eventType: 'thing.created', orderingKey: null, payload: {id: 'a'}},
+    ]);
   });
 });

--- a/libs/shared/node/outbox/src/write.ts
+++ b/libs/shared/node/outbox/src/write.ts
@@ -1,7 +1,7 @@
 import type {OutboxTable} from './schema.js';
 import type {EventMapLike, EventType} from './types.js';
 
-type OutboxRow = {eventType: string; payload: unknown};
+type OutboxRow = {eventType: string; orderingKey: string | null; payload: unknown};
 
 interface DrizzleInsertable {
   insert: (table: OutboxTable) => {
@@ -13,7 +13,7 @@ interface DrizzleInsertable {
 }
 
 type OutboxEvent<TMap extends EventMapLike> = {
-  [K in EventType<TMap>]: {type: K; payload: TMap[K]};
+  [K in EventType<TMap>]: {type: K; orderingKey?: string | undefined; payload: TMap[K]};
 }[EventType<TMap>];
 
 export async function writeOutboxEvent<TMap extends EventMapLike>(
@@ -35,7 +35,13 @@ export async function writeOutboxEvents<TMap extends EventMapLike>(
   await tx.insert(outboxTable).values(
     events.map((event) => ({
       eventType: event.type,
+      orderingKey: normalizeKey(event.orderingKey),
       payload: event.payload,
     })),
   );
+}
+
+function normalizeKey(key: string | undefined): string | null {
+  const trimmed = key?.trim();
+  return trimmed ? trimmed : null;
 }


### PR DESCRIPTION
Scale outbox dispatches by grouping events on source and ordering key.

A single dispatcher loop previously handled one flattened batch serially, which limited catch-up speed and could make unrelated event streams block each other. This adds nullable outbox ordering keys, drains batches with a has-more signal, and dispatches independent source/key groups concurrently while preserving order inside each group.

Workflow events that belong to a workflow run now write that run id as the ordering key, while keyless events remain null and fall back to source-level ordering. The outbox schema changes are folded into the existing pre-deploy migrations.

Closes ENG-793

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up outbox delivery by dispatching events concurrently by ordering key while preserving per-key order, including across retries. Drains until empty and lowers idle poll to 250ms to cut latency and remove the single-poller ceiling (ENG-793).

- **New Features**
  - Added `ordering_key` to all outbox tables and persisted via `@shipfox/node-outbox`; `drainAll` now returns `{events, hasMore}` and sets a per-row ordering key (falls back to source when null).
  - Preserved ordering across retries: `drainAll` blocks later same-key rows while an earlier row waits for retry, and sorts within each key by created-at then id.
  - Dispatcher groups by `source` + `ordering_key`, runs groups in parallel (pool=8), halts a group on first failure, marks completed groups independently, continues others, and returns `hasMore`; logs a warning if any group fails.
  - Workflows: new `writeWorkflowsOutboxEvent(s)` set `orderingKey` from `workflowRunId`; other events keep source-level ordering.
  - Polling and batch: workflow drains repeatedly until `hasMore` is false, then sleeps `250ms`; `BATCH_SIZE` increased to `500`.
  - Utility: introduced `boundedMap` in `@shipfox/node-module` (continues or aborts based on `stopOnError`) and adopted it in dispatcher and definition sync.

- **Migration**
  - `ordering_key` column added to all outbox tables; included in existing migrations—run migrations before deploy.
  - No changes needed for subscribers; at-least-once delivery and idempotency remain the same.

<sup>Written for commit d40b727205440c6ceb92b6c30c975f11e95e5012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

