### PR TITLE
[api-triggers] Add cron schedule persistence

### DIFF
--- a/.changeset/steady-crons-schedule.md
+++ b/.changeset/steady-crons-schedule.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/api-triggers": patch
+---
+
+Adds cron trigger schedule persistence and deterministic next-fire computation for resolved workflow definitions.

--- a/libs/api/triggers/README.md
+++ b/libs/api/triggers/README.md
@@ -201,6 +201,10 @@ declarations live in raw form.
 which carry the parsed `triggers` map. The triggers module never reads the
 definitions table — the event is the contract.
 
+Cron triggers also project into `triggers_cron_schedules`, keyed by
+`subscription_id`. That table stores the resolved cron expression, timezone,
+next fire time, and last fire time used by the cron firing engine.
+
 Indexes:
 
 - `(workflow_definition_id, name)` — unique. One row per YAML trigger.
@@ -208,6 +212,8 @@ Indexes:
   integration events at workspace scope.
 - `(workflow_definition_id)` — used to clean up the projection on
   `DEFINITION_DELETED`.
+- `triggers_cron_schedules.next_fire_at` — used to drain due cron schedules
+  in next-fire order.
 
 ### Layer 3 — run history (immutable)
 

--- a/libs/api/triggers/drizzle.config.ts
+++ b/libs/api/triggers/drizzle.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'drizzle-kit';
 
 export default defineConfig({
   schema: [
+    './src/db/schema/cron-schedules.ts',
     './src/db/schema/decisions.ts',
     './src/db/schema/job-listener-subscriptions.ts',
     './src/db/schema/outbox.ts',

--- a/libs/api/triggers/drizzle/0000_initial.sql
+++ b/libs/api/triggers/drizzle/0000_initial.sql
@@ -1,4 +1,15 @@
 CREATE TYPE "public"."triggers_job_listener_matcher_kind" AS ENUM('on', 'until');--> statement-breakpoint
+CREATE TABLE "triggers_cron_schedules" (
+	"subscription_id" uuid PRIMARY KEY NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"cron_expression" text NOT NULL,
+	"timezone" text NOT NULL,
+	"next_fire_at" timestamp with time zone NOT NULL,
+	"last_fired_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "triggers_decisions" (
 	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
 	"received_event_id" uuid NOT NULL,
@@ -71,7 +82,9 @@ CREATE TABLE "triggers_subscriptions" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "triggers_cron_schedules" ADD CONSTRAINT "triggers_cron_schedules_subscription_id_triggers_subscriptions_id_fk" FOREIGN KEY ("subscription_id") REFERENCES "public"."triggers_subscriptions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "triggers_decisions" ADD CONSTRAINT "triggers_decisions_received_event_id_triggers_received_events_id_fk" FOREIGN KEY ("received_event_id") REFERENCES "public"."triggers_received_events"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "triggers_cron_schedules_next_fire_at_idx" ON "triggers_cron_schedules" USING btree ("next_fire_at");--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_decisions_event_subscription_unique" ON "triggers_decisions" USING btree ("received_event_id","subscription_id");--> statement-breakpoint
 CREATE INDEX "triggers_decisions_run_idx" ON "triggers_decisions" USING btree ("run_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "triggers_job_listener_subscriptions_job_kind_ordinal_unique" ON "triggers_job_listener_subscriptions" USING btree ("job_id","kind","matcher_ordinal");--> statement-breakpoint

--- a/libs/api/triggers/drizzle/meta/0000_snapshot.json
+++ b/libs/api/triggers/drizzle/meta/0000_snapshot.json
@@ -1,9 +1,98 @@
 {
-  "id": "cc405b18-8657-4679-89f6-6fc9261485bc",
+  "id": "96a3c38e-b63d-4ab1-8519-4d2c0db11389",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
+    "public.triggers_cron_schedules": {
+      "name": "triggers_cron_schedules",
+      "schema": "",
+      "columns": {
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triggers_cron_schedules_next_fire_at_idx": {
+          "name": "triggers_cron_schedules_next_fire_at_idx",
+          "columns": [
+            {
+              "expression": "next_fire_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triggers_cron_schedules_subscription_id_triggers_subscriptions_id_fk": {
+          "name": "triggers_cron_schedules_subscription_id_triggers_subscriptions_id_fk",
+          "tableFrom": "triggers_cron_schedules",
+          "tableTo": "triggers_subscriptions",
+          "columnsFrom": ["subscription_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.triggers_decisions": {
       "name": "triggers_decisions",
       "schema": "",

--- a/libs/api/triggers/drizzle/meta/_journal.json
+++ b/libs/api/triggers/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1782927309819,
+      "when": 1783263628394,
       "tag": "0000_initial",
       "breakpoints": true
     }

--- a/libs/api/triggers/package.json
+++ b/libs/api/triggers/package.json
@@ -53,7 +53,9 @@
     "@shipfox/node-outbox": "workspace:*",
     "@shipfox/node-postgres": "workspace:*",
     "@shipfox/node-temporal": "workspace:*",
+    "@shipfox/workflow-document": "workspace:*",
     "@temporalio/workflow": "^1.16.1",
+    "cron-parser": "^5.6.1",
     "drizzle-orm": "^0.45.2",
     "zod": "^4.4.3"
   },

--- a/libs/api/triggers/src/config.test.ts
+++ b/libs/api/triggers/src/config.test.ts
@@ -1,6 +1,7 @@
-import {assertRetentionDaysWithinBounds} from './config.js';
+import {assertCronConfigWithinBounds, assertRetentionDaysWithinBounds} from './config.js';
 
 const RETENTION_ERROR = /TRIGGER_EVENT_RETENTION_DAYS/;
+const CRON_JITTER_ERROR = /TRIGGER_CRON_JITTER_WINDOW_SECONDS/;
 
 describe('assertRetentionDaysWithinBounds', () => {
   test.each([1, 30, 365])('accepts a finite window of at least 1 day (%p)', (days) => {
@@ -14,5 +15,19 @@ describe('assertRetentionDaysWithinBounds', () => {
     Number.POSITIVE_INFINITY,
   ])('rejects a window below 1 day or non-finite (%p)', (days) => {
     expect(() => assertRetentionDaysWithinBounds(days)).toThrow(RETENTION_ERROR);
+  });
+});
+
+describe('assertCronConfigWithinBounds', () => {
+  test.each([0, 1, 60, 600])('accepts a finite non-negative jitter window (%p)', (seconds) => {
+    expect(() => assertCronConfigWithinBounds(seconds)).not.toThrow();
+  });
+
+  test.each([
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects a negative or non-finite jitter window (%p)', (seconds) => {
+    expect(() => assertCronConfigWithinBounds(seconds)).toThrow(CRON_JITTER_ERROR);
   });
 });

--- a/libs/api/triggers/src/config.ts
+++ b/libs/api/triggers/src/config.ts
@@ -5,6 +5,10 @@ export const config = createConfig({
     desc: 'How many days a recorded trigger event (and its decisions) is kept before the hourly prune cron deletes it. Must be at least 1; a smaller value moves the cutoff to now or the future and would delete freshly recorded events. Defaults to 30.',
     default: 30,
   }),
+  TRIGGER_CRON_JITTER_WINDOW_SECONDS: num({
+    desc: 'Maximum number of seconds added as deterministic jitter to a cron trigger fire time. Use 0 to disable jitter. Values below about 60 seconds are usually no-ops when cron ticking runs at minute resolution; multi-minute windows spread large schedule herds.',
+    default: 0,
+  }),
 });
 
 export function assertRetentionDaysWithinBounds(days: number): void {
@@ -16,3 +20,13 @@ export function assertRetentionDaysWithinBounds(days: number): void {
 }
 
 assertRetentionDaysWithinBounds(config.TRIGGER_EVENT_RETENTION_DAYS);
+
+export function assertCronConfigWithinBounds(jitterWindowSeconds: number): void {
+  if (!Number.isFinite(jitterWindowSeconds) || jitterWindowSeconds < 0) {
+    throw new Error(
+      `TRIGGER_CRON_JITTER_WINDOW_SECONDS must be a finite non-negative number, received ${jitterWindowSeconds}.`,
+    );
+  }
+}
+
+assertCronConfigWithinBounds(config.TRIGGER_CRON_JITTER_WINDOW_SECONDS);

--- a/libs/api/triggers/src/core/compute-next-fire-at.test.ts
+++ b/libs/api/triggers/src/core/compute-next-fire-at.test.ts
@@ -1,0 +1,69 @@
+import {computeNextFireAt} from './compute-next-fire-at.js';
+
+describe('computeNextFireAt', () => {
+  test('returns the next occurrence strictly after the from instant', () => {
+    const result = computeNextFireAt({
+      cronExpression: '0 2 * * *',
+      timezone: 'UTC',
+      from: new Date('2026-01-01T02:00:00.000Z'),
+      subscriptionId: crypto.randomUUID(),
+      jitterWindowSeconds: 0,
+    });
+
+    expect(result).toEqual(new Date('2026-01-02T02:00:00.000Z'));
+  });
+
+  test('evaluates the schedule in the supplied timezone', () => {
+    const result = computeNextFireAt({
+      cronExpression: '0 2 * * *',
+      timezone: 'America/New_York',
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      subscriptionId: crypto.randomUUID(),
+      jitterWindowSeconds: 0,
+    });
+
+    expect(result).toEqual(new Date('2026-01-01T07:00:00.000Z'));
+  });
+
+  test('applies deterministic jitter for the subscription', () => {
+    const params = {
+      cronExpression: '0 2 * * *',
+      timezone: 'UTC',
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      subscriptionId: crypto.randomUUID(),
+      jitterWindowSeconds: 600,
+    };
+
+    const first = computeNextFireAt(params);
+    const second = computeNextFireAt(params);
+
+    expect(second).toEqual(first);
+    expect(first.getTime()).toBeGreaterThanOrEqual(new Date('2026-01-01T02:00:00.000Z').getTime());
+    expect(first.getTime()).toBeLessThan(new Date('2026-01-02T02:00:00.000Z').getTime());
+  });
+
+  test('does not jitter past the following occurrence', () => {
+    const result = computeNextFireAt({
+      cronExpression: '*/5 * * * *',
+      timezone: 'UTC',
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      subscriptionId: crypto.randomUUID(),
+      jitterWindowSeconds: 60 * 60,
+    });
+
+    expect(result.getTime()).toBeGreaterThanOrEqual(new Date('2026-01-01T00:05:00.000Z').getTime());
+    expect(result.getTime()).toBeLessThan(new Date('2026-01-01T00:10:00.000Z').getTime());
+  });
+
+  test('returns the exact occurrence when the jitter window is disabled', () => {
+    const result = computeNextFireAt({
+      cronExpression: '*/5 * * * *',
+      timezone: 'UTC',
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      subscriptionId: crypto.randomUUID(),
+      jitterWindowSeconds: 0,
+    });
+
+    expect(result).toEqual(new Date('2026-01-01T00:05:00.000Z'));
+  });
+});

--- a/libs/api/triggers/src/core/compute-next-fire-at.ts
+++ b/libs/api/triggers/src/core/compute-next-fire-at.ts
@@ -1,0 +1,37 @@
+import {CronExpressionParser} from 'cron-parser';
+
+export interface ComputeNextFireAtParams {
+  readonly cronExpression: string;
+  readonly timezone: string;
+  readonly from: Date;
+  readonly subscriptionId: string;
+  readonly jitterWindowSeconds: number;
+}
+
+export function computeNextFireAt(params: ComputeNextFireAtParams): Date {
+  const iterator = CronExpressionParser.parse(params.cronExpression, {
+    currentDate: params.from,
+    tz: params.timezone,
+  });
+  const occurrence = iterator.next().toDate();
+  const following = iterator.next().toDate();
+  const gapMs = following.getTime() - occurrence.getTime();
+  const offsetMs = jitterOffsetMs(params.subscriptionId, params.jitterWindowSeconds, gapMs);
+  return new Date(occurrence.getTime() + offsetMs);
+}
+
+function jitterOffsetMs(subscriptionId: string, windowSeconds: number, gapMs: number): number {
+  const windowMs = Math.floor(windowSeconds * 1000);
+  const clampMs = Math.min(windowMs, gapMs);
+  if (clampMs <= 0) return 0;
+  return hashStringToUint32(subscriptionId) % clampMs;
+}
+
+function hashStringToUint32(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}

--- a/libs/api/triggers/src/core/entities/cron-schedule.ts
+++ b/libs/api/triggers/src/core/entities/cron-schedule.ts
@@ -1,0 +1,10 @@
+export interface CronSchedule {
+  subscriptionId: string;
+  workspaceId: string;
+  cronExpression: string;
+  timezone: string;
+  nextFireAt: Date;
+  lastFiredAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/libs/api/triggers/src/core/index.ts
+++ b/libs/api/triggers/src/core/index.ts
@@ -1,8 +1,13 @@
+export {
+  type ComputeNextFireAtParams,
+  computeNextFireAt,
+} from './compute-next-fire-at.js';
 export {readConfigInputs} from './config.js';
 export {
   type DispatchIntegrationEventParams,
   dispatchIntegrationEvent,
 } from './dispatch-integration-event.js';
+export type {CronSchedule} from './entities/cron-schedule.js';
 export type {TriggerSubscription} from './entities/subscription.js';
 export {
   ManualTriggerNotFoundError,

--- a/libs/api/triggers/src/db/cron-schedules.test.ts
+++ b/libs/api/triggers/src/db/cron-schedules.test.ts
@@ -236,6 +236,37 @@ describe('cron schedule projection', () => {
     expect(schedule).toBeUndefined();
   });
 
+  test.each([
+    {name: 'missing schedule', config: {}},
+    {name: 'invalid expression', config: {schedule: 'not a cron', timezone: 'UTC'}},
+  ])('drops a stale cron schedule when resynced with $name', async ({config}) => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {source: 'cron', event: 'tick', config},
+      },
+    });
+    const schedule = await getCronScheduleBySubscriptionId(subscription.id);
+
+    expect(schedule).toBeUndefined();
+  });
+
   test('skips invalid cron config without blocking sibling trigger sync', async () => {
     await projectDefinitionTriggers({
       workspaceId,

--- a/libs/api/triggers/src/db/cron-schedules.test.ts
+++ b/libs/api/triggers/src/db/cron-schedules.test.ts
@@ -1,0 +1,327 @@
+import {and, eq} from 'drizzle-orm';
+import {getCronScheduleBySubscriptionId} from './cron-schedules.js';
+import {db} from './db.js';
+import {triggersCronSchedules} from './schema/cron-schedules.js';
+import {triggerSubscriptions} from './schema/subscriptions.js';
+import {deleteSubscriptionsForDefinition, projectDefinitionTriggers} from './subscriptions.js';
+
+describe('cron schedule projection', () => {
+  let workspaceId: string;
+  let projectId: string;
+  let workflowDefinitionId: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    workspaceId = crypto.randomUUID();
+    projectId = crypto.randomUUID();
+    workflowDefinitionId = crypto.randomUUID();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('creates a cron schedule row with a future next fire time', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+
+    const schedule = await getCronScheduleBySubscriptionId(subscription.id);
+
+    expect(schedule).toMatchObject({
+      subscriptionId: subscription.id,
+      workspaceId,
+      cronExpression: '0 2 * * *',
+      timezone: 'UTC',
+      lastFiredAt: null,
+    });
+    expect(schedule?.nextFireAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test('preserves next fire and last fired when the expression and timezone are unchanged', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+    const before = await getRequiredCronSchedule(subscription.id);
+    const lastFiredAt = new Date('2026-01-01T02:00:00.000Z');
+    await db()
+      .update(triggersCronSchedules)
+      .set({lastFiredAt})
+      .where(eq(triggersCronSchedules.subscriptionId, subscription.id));
+    vi.setSystemTime(new Date('2026-01-01T01:00:00.000Z'));
+
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const after = await getRequiredCronSchedule(subscription.id);
+
+    expect(after.nextFireAt).toEqual(before.nextFireAt);
+    expect(after.lastFiredAt).toEqual(lastFiredAt);
+    expect(after.updatedAt).toEqual(before.updatedAt);
+  });
+
+  test('recomputes next fire when the expression changes', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+    const before = await getRequiredCronSchedule(subscription.id);
+
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 3 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const after = await getRequiredCronSchedule(subscription.id);
+
+    expect(after.cronExpression).toBe('0 3 * * *');
+    expect(after.nextFireAt).not.toEqual(before.nextFireAt);
+    expect(after.nextFireAt).toEqual(new Date('2026-01-01T03:00:00.000Z'));
+  });
+
+  test('recomputes next fire when the timezone changes', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+    const before = await getRequiredCronSchedule(subscription.id);
+
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'America/New_York'},
+        },
+      },
+    });
+    const after = await getRequiredCronSchedule(subscription.id);
+
+    expect(after.timezone).toBe('America/New_York');
+    expect(after.nextFireAt).not.toEqual(before.nextFireAt);
+    expect(after.nextFireAt).toEqual(new Date('2026-01-01T07:00:00.000Z'));
+  });
+
+  test('drops a cron schedule when the trigger source changes in place', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {source: 'github', event: 'push'},
+      },
+    });
+    const schedule = await getCronScheduleBySubscriptionId(subscription.id);
+
+    expect(schedule).toBeUndefined();
+  });
+
+  test('drops a cron schedule when the trigger is removed', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {},
+    });
+    const schedule = await getCronScheduleBySubscriptionId(subscription.id);
+
+    expect(schedule).toBeUndefined();
+  });
+
+  test('drops a cron schedule when definition subscriptions are deleted', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+
+    const deletedCount = await deleteSubscriptionsForDefinition({workflowDefinitionId});
+    const schedule = await getCronScheduleBySubscriptionId(subscription.id);
+
+    expect(deletedCount).toBe(1);
+    expect(schedule).toBeUndefined();
+  });
+
+  test('skips invalid cron config without blocking sibling trigger sync', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        malformed: {source: 'cron', event: 'tick', config: {}},
+        bad_expression: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: 'not a cron', timezone: 'UTC'},
+        },
+        on_push: {source: 'github', event: 'push'},
+      },
+    });
+    const malformed = await getSubscriptionByName(workflowDefinitionId, 'malformed');
+    const badExpression = await getSubscriptionByName(workflowDefinitionId, 'bad_expression');
+    const onPush = await getSubscriptionByName(workflowDefinitionId, 'on_push');
+
+    const malformedSchedule = await getCronScheduleBySubscriptionId(malformed.id);
+    const badExpressionSchedule = await getCronScheduleBySubscriptionId(badExpression.id);
+
+    expect(malformedSchedule).toBeUndefined();
+    expect(badExpressionSchedule).toBeUndefined();
+    expect(onPush.source).toBe('github');
+  });
+
+  test('defaults a missing timezone to UTC defensively', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        hourly: {
+          source: 'cron',
+          event: 'tick',
+          config: {schedule: '0 * * * *'},
+        },
+      },
+    });
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'hourly');
+
+    const schedule = await getRequiredCronSchedule(subscription.id);
+
+    expect(schedule.timezone).toBe('UTC');
+  });
+
+  test('stores only with and filter in the subscription config', async () => {
+    await projectDefinitionTriggers({
+      workspaceId,
+      projectId,
+      workflowDefinitionId,
+      triggers: {
+        nightly: {
+          source: 'cron',
+          event: 'tick',
+          with: {branch: 'main'},
+          filter: 'true',
+          config: {schedule: '0 2 * * *', timezone: 'UTC'},
+        },
+      },
+    });
+
+    const subscription = await getSubscriptionByName(workflowDefinitionId, 'nightly');
+
+    expect(subscription.config).toEqual({with: {branch: 'main'}, filter: 'true'});
+  });
+});
+
+async function getSubscriptionByName(workflowDefinitionId: string, name: string) {
+  const [row] = await db()
+    .select()
+    .from(triggerSubscriptions)
+    .where(
+      and(
+        eq(triggerSubscriptions.workflowDefinitionId, workflowDefinitionId),
+        eq(triggerSubscriptions.name, name),
+      ),
+    )
+    .limit(1);
+  if (!row) throw new Error(`Expected subscription ${name} to exist`);
+  return row;
+}
+
+async function getRequiredCronSchedule(subscriptionId: string) {
+  const schedule = await getCronScheduleBySubscriptionId(subscriptionId);
+  if (!schedule) throw new Error(`Expected cron schedule for subscription ${subscriptionId}`);
+  return schedule;
+}

--- a/libs/api/triggers/src/db/cron-schedules.ts
+++ b/libs/api/triggers/src/db/cron-schedules.ts
@@ -1,0 +1,102 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import {triggerSourceConfigSchemas} from '@shipfox/workflow-document';
+import {eq, sql} from 'drizzle-orm';
+import {config} from '#config.js';
+import {computeNextFireAt} from '#core/compute-next-fire-at.js';
+import type {CronSchedule} from '#core/entities/cron-schedule.js';
+import {db, type Tx} from './db.js';
+import {toCronSchedule, triggersCronSchedules} from './schema/cron-schedules.js';
+
+const defaultCronTimezone = 'UTC';
+
+export interface SyncCronScheduleParams {
+  readonly tx: Tx;
+  readonly subscriptionId: string;
+  readonly workspaceId: string;
+  readonly triggerConfig: Record<string, unknown> | undefined;
+}
+
+export async function syncCronSchedule(params: SyncCronScheduleParams): Promise<void> {
+  const parsed = triggerSourceConfigSchemas.cron.safeParse(params.triggerConfig ?? {});
+  if (!parsed.success || parsed.data.schedule === undefined) {
+    logger().warn(
+      {subscriptionId: params.subscriptionId},
+      'cron trigger missing/invalid schedule config; skipping cron row',
+    );
+    return;
+  }
+
+  const schedule = parsed.data.schedule;
+  const timezone = parsed.data.timezone ?? defaultCronTimezone;
+  let nextFireAt: Date;
+  try {
+    nextFireAt = computeNextFireAt({
+      cronExpression: schedule,
+      timezone,
+      from: new Date(),
+      subscriptionId: params.subscriptionId,
+      jitterWindowSeconds: config.TRIGGER_CRON_JITTER_WINDOW_SECONDS,
+    });
+  } catch (error) {
+    logger().warn(
+      {err: error, reason: errorMessage(error), subscriptionId: params.subscriptionId},
+      'cron trigger schedule could not be parsed; skipping cron row',
+    );
+    return;
+  }
+
+  await params.tx
+    .insert(triggersCronSchedules)
+    .values({
+      subscriptionId: params.subscriptionId,
+      workspaceId: params.workspaceId,
+      cronExpression: schedule,
+      timezone,
+      nextFireAt,
+    })
+    .onConflictDoUpdate({
+      target: triggersCronSchedules.subscriptionId,
+      set: {
+        workspaceId: sql`excluded.workspace_id`,
+        cronExpression: sql`excluded.cron_expression`,
+        timezone: sql`excluded.timezone`,
+        updatedAt: sql`case when ${triggersCronSchedules.workspaceId} <> excluded.workspace_id or ${triggersCronSchedules.cronExpression} <> excluded.cron_expression or ${triggersCronSchedules.timezone} <> excluded.timezone then ${new Date()} else ${triggersCronSchedules.updatedAt} end`,
+        nextFireAt: sql`case when ${triggersCronSchedules.cronExpression} <> excluded.cron_expression or ${triggersCronSchedules.timezone} <> excluded.timezone then excluded.next_fire_at else ${triggersCronSchedules.nextFireAt} end`,
+      },
+    });
+}
+
+export interface DeleteCronScheduleForSubscriptionParams {
+  readonly tx: Tx;
+  readonly subscriptionId: string;
+}
+
+export async function deleteCronScheduleForSubscription(
+  params: DeleteCronScheduleForSubscriptionParams,
+): Promise<void> {
+  await params.tx
+    .delete(triggersCronSchedules)
+    .where(eq(triggersCronSchedules.subscriptionId, params.subscriptionId));
+}
+
+export async function getCronScheduleBySubscriptionId(
+  subscriptionId: string,
+): Promise<CronSchedule | undefined> {
+  const rows = await db()
+    .select()
+    .from(triggersCronSchedules)
+    .where(eq(triggersCronSchedules.subscriptionId, subscriptionId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return undefined;
+  return toCronSchedule(row);
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  try {
+    return String(error);
+  } catch {
+    return '[unprintable thrown value]';
+  }
+}

--- a/libs/api/triggers/src/db/cron-schedules.ts
+++ b/libs/api/triggers/src/db/cron-schedules.ts
@@ -23,6 +23,7 @@ export async function syncCronSchedule(params: SyncCronScheduleParams): Promise<
       {subscriptionId: params.subscriptionId},
       'cron trigger missing/invalid schedule config; skipping cron row',
     );
+    await deleteCronScheduleForSubscription(params);
     return;
   }
 
@@ -42,6 +43,7 @@ export async function syncCronSchedule(params: SyncCronScheduleParams): Promise<
       {err: error, reason: errorMessage(error), subscriptionId: params.subscriptionId},
       'cron trigger schedule could not be parsed; skipping cron row',
     );
+    await deleteCronScheduleForSubscription(params);
     return;
   }
 

--- a/libs/api/triggers/src/db/db.ts
+++ b/libs/api/triggers/src/db/db.ts
@@ -1,5 +1,6 @@
 import {drizzle, type NodePgDatabase} from '@shipfox/node-drizzle';
 import {pgClient} from '@shipfox/node-postgres';
+import {triggersCronSchedules} from './schema/cron-schedules.js';
 import {triggersDecisions} from './schema/decisions.js';
 import {jobListenerSubscriptions} from './schema/job-listener-subscriptions.js';
 import {triggersOutbox} from './schema/outbox.js';
@@ -7,6 +8,7 @@ import {triggersReceivedEvents} from './schema/received-events.js';
 import {triggerSubscriptions} from './schema/subscriptions.js';
 
 export const schema = {
+  triggersCronSchedules,
   jobListenerSubscriptions,
   triggerSubscriptions,
   triggersOutbox,
@@ -20,6 +22,9 @@ export function db() {
   if (!_db) _db = drizzle(pgClient(), {schema});
   return _db;
 }
+
+export type Tx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
+export type Executor = ReturnType<typeof db> | Tx;
 
 export function closeDb(): void {
   _db = undefined;

--- a/libs/api/triggers/src/db/index.ts
+++ b/libs/api/triggers/src/db/index.ts
@@ -1,7 +1,12 @@
 import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-export {closeDb, db, schema} from './db.js';
+export {
+  deleteCronScheduleForSubscription,
+  getCronScheduleBySubscriptionId,
+  syncCronSchedule,
+} from './cron-schedules.js';
+export {closeDb, db, type Executor, schema, type Tx} from './db.js';
 export {
   getTriggerEventById,
   type ListTriggerEventFacetsResult,
@@ -22,6 +27,12 @@ export {
   projectJobListenerSubscriptions,
   removeJobListenerSubscriptionsForJob,
 } from './job-listener-subscriptions.js';
+export {
+  type CronScheduleDb,
+  type CronScheduleInsertDb,
+  toCronSchedule,
+  triggersCronSchedules,
+} from './schema/cron-schedules.js';
 export {jobListenerSubscriptions} from './schema/job-listener-subscriptions.js';
 export {triggersOutbox} from './schema/outbox.js';
 export {triggerSubscriptions} from './schema/subscriptions.js';

--- a/libs/api/triggers/src/db/schema/cron-schedules.ts
+++ b/libs/api/triggers/src/db/schema/cron-schedules.ts
@@ -1,0 +1,37 @@
+import {index, text, timestamp, uuid} from 'drizzle-orm/pg-core';
+import type {CronSchedule} from '#core/entities/cron-schedule.js';
+import {pgTable} from './common.js';
+import {triggerSubscriptions} from './subscriptions.js';
+
+export const triggersCronSchedules = pgTable(
+  'cron_schedules',
+  {
+    subscriptionId: uuid('subscription_id')
+      .primaryKey()
+      .references(() => triggerSubscriptions.id, {onDelete: 'cascade'}),
+    workspaceId: uuid('workspace_id').notNull(),
+    cronExpression: text('cron_expression').notNull(),
+    timezone: text('timezone').notNull(),
+    nextFireAt: timestamp('next_fire_at', {withTimezone: true}).notNull(),
+    lastFiredAt: timestamp('last_fired_at', {withTimezone: true}),
+    createdAt: timestamp('created_at', {withTimezone: true}).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', {withTimezone: true}).notNull().defaultNow(),
+  },
+  (table) => [index('triggers_cron_schedules_next_fire_at_idx').on(table.nextFireAt)],
+);
+
+export type CronScheduleDb = typeof triggersCronSchedules.$inferSelect;
+export type CronScheduleInsertDb = typeof triggersCronSchedules.$inferInsert;
+
+export function toCronSchedule(row: CronScheduleDb): CronSchedule {
+  return {
+    subscriptionId: row.subscriptionId,
+    workspaceId: row.workspaceId,
+    cronExpression: row.cronExpression,
+    timezone: row.timezone,
+    nextFireAt: row.nextFireAt,
+    lastFiredAt: row.lastFiredAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/libs/api/triggers/src/db/subscriptions.ts
+++ b/libs/api/triggers/src/db/subscriptions.ts
@@ -1,11 +1,9 @@
 import type {TriggerDto} from '@shipfox/api-definitions-dto';
 import {and, eq, inArray, notInArray} from 'drizzle-orm';
 import type {TriggerSubscription} from '#core/entities/subscription.js';
-import {db} from './db.js';
+import {deleteCronScheduleForSubscription, syncCronSchedule} from './cron-schedules.js';
+import {db, type Executor, type Tx} from './db.js';
 import {toTriggerSubscription, triggerSubscriptions} from './schema/subscriptions.js';
-
-type Tx = Parameters<Parameters<ReturnType<typeof db>['transaction']>[0]>[0];
-type Executor = ReturnType<typeof db> | Tx;
 
 export interface ProjectDefinitionTriggersParams {
   tx?: Tx | undefined;
@@ -43,7 +41,7 @@ export async function projectDefinitionTriggers(
       if (trigger.with !== undefined) config.with = trigger.with;
       if (trigger.filter !== undefined) config.filter = trigger.filter;
 
-      await tx
+      const [upserted] = await tx
         .insert(triggerSubscriptions)
         .values({
           workspaceId: params.workspaceId,
@@ -64,7 +62,20 @@ export async function projectDefinitionTriggers(
             config,
             updatedAt: new Date(),
           },
+        })
+        .returning({id: triggerSubscriptions.id});
+      if (!upserted) throw new Error('Trigger subscription upsert returned no rows');
+
+      if (trigger.source === 'cron') {
+        await syncCronSchedule({
+          tx,
+          subscriptionId: upserted.id,
+          workspaceId: params.workspaceId,
+          triggerConfig: trigger.config,
         });
+      } else {
+        await deleteCronScheduleForSubscription({tx, subscriptionId: upserted.id});
+      }
     }
   };
 

--- a/libs/api/triggers/test/globalSetup.ts
+++ b/libs/api/triggers/test/globalSetup.ts
@@ -9,6 +9,7 @@ export async function setup() {
 
   await runMigrations(db(), migrationsPath, '__drizzle_migrations_triggers');
   await db().execute(sql`TRUNCATE triggers_job_listener_subscriptions CASCADE`);
+  await db().execute(sql`TRUNCATE triggers_cron_schedules CASCADE`);
   await db().execute(sql`TRUNCATE triggers_subscriptions CASCADE`);
   await db().execute(sql`TRUNCATE triggers_outbox CASCADE`);
   await db().execute(sql`TRUNCATE triggers_received_events CASCADE`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2357,9 +2357,15 @@ importers:
       '@shipfox/node-temporal':
         specifier: workspace:*
         version: link:../../shared/node/temporal
+      '@shipfox/workflow-document':
+        specifier: workspace:*
+        version: link:../../shared/workflow/document
       '@temporalio/workflow':
         specifier: ^1.16.1
         version: 1.18.1
+      cron-parser:
+        specifier: ^5.6.1
+        version: 5.6.1
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)


### PR DESCRIPTION
Persist resolved cron triggers into a dedicated `triggers_cron_schedules` projection table, keyed by subscription id with cascade cleanup from `triggers_subscriptions`.

ENG-678 needs a durable schedule queue to drain due cron triggers without rereading workflow definitions. This adds the next-fire computation helper, deterministic subscription-based jitter, defensive cron config parsing, and projection sync inside the existing definition trigger transaction.

The implementation keeps `triggerSubscriptions.config` limited to `with` and `filter`; cron-specific schedule state lives only in the new table. Re-syncs preserve `next_fire_at`, `last_fired_at`, and `updated_at` unless the cron expression, timezone, or workspace changes.

I chose a single atomic upsert over a read-before-write shortcut, so unchanged re-syncs still compute a candidate next fire time but avoid a race-prone separate select.

Fixes ENG-677

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists cron trigger schedules in a new `triggers_cron_schedules` table, computes stable next-fire times with deterministic jitter, and deletes stale rows when cron config becomes invalid. Supports ENG-678 and fixes ENG-677.

- New Features
  - Added `triggers_cron_schedules` projection (FK to subscriptions, `next_fire_at` index, cascade delete).
  - Implemented `computeNextFireAt` with timezone-aware parsing and per-subscription jitter via `TRIGGER_CRON_JITTER_WINDOW_SECONDS` (bounded to the next occurrence gap).
  - Synced schedules during subscription upsert: preserves `next_fire_at`/`last_fired_at`/`updated_at` unless cron expression, timezone, or workspace changes; non-cron triggers remove schedules; invalid cron configs are skipped and stale schedules are deleted.
  - Kept subscription `config` to `with` and `filter` only; added DB helpers and tests.

- Migration
  - Run DB migrations to create `triggers_cron_schedules`.

<sup>Written for commit 63caa4e4dc30073660f9fece93bfecc17fda45fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

