### PR TITLE
Scale outbox dispatch across partitions

### DIFF
--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -8,6 +8,7 @@ import {
   pruneDispatchedOutboxRows,
   recordDispatchFailure,
   registerPublisher,
+  renewDispatchClaim,
   resetPublishers,
 } from '@shipfox/node-module';
 import {sql} from 'drizzle-orm';
@@ -858,6 +859,69 @@ describe('definition queries', () => {
       expect(firstDrain.map((event) => event.id)).toEqual([id]);
       expect(secondDrain).toHaveLength(0);
       expect(redeliveryDrain.map((event) => event.id)).toEqual([id]);
+    });
+
+    test('renewDispatchClaim extends only the currently owned claim', async () => {
+      await insertOutboxRow({projectId, marker: 'renewed', orderingKey: 'run-1'});
+      const [event] = eventsForProject((await drainAll()).events, projectId);
+
+      const renewedClaimExpiresAt = await renewDispatchClaim('definitions', {
+        id: event?.id as string,
+        claimExpiresAt: event?.claimExpiresAt as Date,
+      });
+      const staleRenewal = await renewDispatchClaim('definitions', {
+        id: event?.id as string,
+        claimExpiresAt: event?.claimExpiresAt as Date,
+      });
+
+      expect(renewedClaimExpiresAt).toBeInstanceOf(Date);
+      expect(renewedClaimExpiresAt?.getTime()).toBeGreaterThanOrEqual(
+        (event?.claimExpiresAt as Date).getTime(),
+      );
+      expect(staleRenewal).toBeUndefined();
+    });
+
+    test('markDispatched ignores stale claims that have already been renewed', async () => {
+      await insertOutboxRow({projectId, marker: 'stale-success', orderingKey: 'run-1'});
+      const [event] = eventsForProject((await drainAll()).events, projectId);
+      await renewDispatchClaim('definitions', {
+        id: event?.id as string,
+        claimExpiresAt: event?.claimExpiresAt as Date,
+      });
+
+      await markDispatched('definitions', [
+        {id: event?.id as string, claimExpiresAt: event?.claimExpiresAt as Date},
+      ]);
+
+      const rows = await listOutboxRowsForProject(projectId);
+      expect(rows[0]?.dispatchedAt).toBeNull();
+    });
+
+    test('recordDispatchFailure ignores stale claims that have already been renewed', async () => {
+      const failure: OutboxDispatchFailure = {
+        kind: 'handler',
+        eventType: DEFINITION_RESOLVED,
+        eventId: crypto.randomUUID(),
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
+      };
+      await insertOutboxRow({projectId, marker: 'stale-failure', orderingKey: 'run-1'});
+      const [event] = eventsForProject((await drainAll()).events, projectId);
+      await renewDispatchClaim('definitions', {
+        id: event?.id as string,
+        claimExpiresAt: event?.claimExpiresAt as Date,
+      });
+
+      await recordDispatchFailure(
+        'definitions',
+        event?.id as string,
+        failure,
+        event?.claimExpiresAt as Date,
+      );
+
+      const rows = await listOutboxRowsForProject(projectId);
+      expect(rows[0]?.dispatchAttempts).toBe(0);
+      expect(rows[0]?.lastDispatchError).toBeNull();
     });
 
     test('partitioned drainAll assigns the same ordering key to one worker', async () => {

--- a/libs/api/definitions/src/db/definitions.test.ts
+++ b/libs/api/definitions/src/db/definitions.test.ts
@@ -718,7 +718,11 @@ describe('definition queries', () => {
   });
 
   describe('publisher registry (drainAll + markDispatched)', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
+      await db()
+        .update(definitionsOutbox)
+        .set({dispatchedAt: sql`COALESCE(${definitionsOutbox.dispatchedAt}, now())`})
+        .where(sql`${definitionsOutbox.dispatchedAt} IS NULL`);
       resetPublishers();
       registerPublisher({
         name: 'definitions',
@@ -822,6 +826,66 @@ describe('definition queries', () => {
           .set({dispatchedAt: sql`now()`})
           .where(sql`${definitionsOutbox.payload}->>'projectId' = ${projectId}`);
       }
+    });
+
+    test('concurrent drainAll calls claim each row at most once', async () => {
+      await insertOutboxRow({projectId, marker: 'first', orderingKey: 'run-1'});
+      await insertOutboxRow({projectId, marker: 'second', orderingKey: 'run-2'});
+
+      const [firstDrain, secondDrain] = await Promise.all([drainAll(), drainAll()]);
+
+      const firstEvents = eventsForProject(firstDrain.events, projectId);
+      const secondEvents = eventsForProject(secondDrain.events, projectId);
+      const firstIds = new Set(firstEvents.map((event) => event.id));
+      const duplicateIds = secondEvents
+        .map((event) => event.id)
+        .filter((eventId) => firstIds.has(eventId));
+      expect(firstEvents.length + secondEvents.length).toBe(2);
+      expect(duplicateIds).toEqual([]);
+    });
+
+    test('drainAll leases claimed rows so a crashed worker redelivers after the lease expires', async () => {
+      const id = await insertOutboxRow({projectId, marker: 'leased', orderingKey: 'run-1'});
+
+      const firstDrain = eventsForProject((await drainAll()).events, projectId);
+      const secondDrain = eventsForProject((await drainAll()).events, projectId);
+      await db()
+        .update(definitionsOutbox)
+        .set({nextDispatchAt: sql`now() - interval '1 second'`})
+        .where(sql`${definitionsOutbox.id} = ${id}`);
+      const redeliveryDrain = eventsForProject((await drainAll()).events, projectId);
+
+      expect(firstDrain.map((event) => event.id)).toEqual([id]);
+      expect(secondDrain).toHaveLength(0);
+      expect(redeliveryDrain.map((event) => event.id)).toEqual([id]);
+    });
+
+    test('partitioned drainAll assigns the same ordering key to one worker', async () => {
+      await insertOutboxRow({projectId, marker: 'shared-1', orderingKey: 'run-shared'});
+      await insertOutboxRow({projectId, marker: 'shared-2', orderingKey: 'run-shared'});
+      await insertOutboxRow({projectId, marker: 'other-1', orderingKey: 'run-other-1'});
+      await insertOutboxRow({projectId, marker: 'other-2', orderingKey: 'run-other-2'});
+      const workerCount = 4;
+
+      const drains = await Promise.all(
+        Array.from({length: workerCount}, (_, workerIndex) =>
+          drainAll({partition: {workerIndex, workerCount}}),
+        ),
+      );
+
+      const partitionsByKey = new Map<string, Set<number>>();
+      const projectEvents = drains.flatMap((drain, workerIndex) =>
+        eventsForProject(drain.events, projectId).map((event) => ({...event, workerIndex})),
+      );
+      for (const event of projectEvents) {
+        const workers = partitionsByKey.get(event.orderingKey) ?? new Set<number>();
+        workers.add(event.workerIndex);
+        partitionsByKey.set(event.orderingKey, workers);
+      }
+      const sharedEvents = projectEvents.filter((event) => event.orderingKey === 'run-shared');
+      expect(projectEvents).toHaveLength(4);
+      expect(sharedEvents).toHaveLength(2);
+      expect(partitionsByKey.get('run-shared')?.size).toBe(1);
     });
 
     test('markDispatched sets dispatchedAt for a single event', async () => {

--- a/libs/api/dispatcher/src/core/constants.ts
+++ b/libs/api/dispatcher/src/core/constants.ts
@@ -1,3 +1,4 @@
 export const DISPATCHER_WORKFLOW_ID = 'outbox-dispatcher';
+export const DISPATCHER_WORKER_COUNT = 4;
 export const OUTBOX_RETENTION_WORKFLOW_ID = 'outbox-retention';
 export const DISPATCHER_TASK_QUEUE = 'outbox-dispatcher';

--- a/libs/api/dispatcher/src/core/index.ts
+++ b/libs/api/dispatcher/src/core/index.ts
@@ -1,1 +1,5 @@
-export {DISPATCHER_TASK_QUEUE, DISPATCHER_WORKFLOW_ID} from './constants.js';
+export {
+  DISPATCHER_TASK_QUEUE,
+  DISPATCHER_WORKER_COUNT,
+  DISPATCHER_WORKFLOW_ID,
+} from './constants.js';

--- a/libs/api/dispatcher/src/module.test.ts
+++ b/libs/api/dispatcher/src/module.test.ts
@@ -1,4 +1,8 @@
-import {DISPATCHER_WORKFLOW_ID, OUTBOX_RETENTION_WORKFLOW_ID} from '#core/constants.js';
+import {
+  DISPATCHER_WORKER_COUNT,
+  DISPATCHER_WORKFLOW_ID,
+  OUTBOX_RETENTION_WORKFLOW_ID,
+} from '#core/constants.js';
 import {dispatcherModule} from './module.js';
 
 describe('dispatcherModule', () => {
@@ -6,7 +10,19 @@ describe('dispatcherModule', () => {
     const worker = dispatcherModule.workers?.[0];
 
     expect(worker?.workflows).toEqual([
-      {name: 'outboxDispatcherWorkflow', id: DISPATCHER_WORKFLOW_ID},
+      {
+        name: 'outboxDispatcherWorkflow',
+        id: DISPATCHER_WORKFLOW_ID,
+        args: [{workerIndex: 0, workerCount: DISPATCHER_WORKER_COUNT}],
+      },
+      ...Array.from({length: DISPATCHER_WORKER_COUNT - 1}, (_, index) => {
+        const workerIndex = index + 1;
+        return {
+          name: 'outboxDispatcherWorkflow',
+          id: `${DISPATCHER_WORKFLOW_ID}-${workerIndex}`,
+          args: [{workerIndex, workerCount: DISPATCHER_WORKER_COUNT}],
+        };
+      }),
       {
         name: 'outboxRetentionWorkflow',
         id: OUTBOX_RETENTION_WORKFLOW_ID,

--- a/libs/api/dispatcher/src/module.ts
+++ b/libs/api/dispatcher/src/module.ts
@@ -3,6 +3,7 @@ import {fileURLToPath} from 'node:url';
 import type {ShipfoxModule} from '@shipfox/node-module';
 import {
   DISPATCHER_TASK_QUEUE,
+  DISPATCHER_WORKER_COUNT,
   DISPATCHER_WORKFLOW_ID,
   OUTBOX_RETENTION_WORKFLOW_ID,
 } from '#core/constants.js';
@@ -21,7 +22,19 @@ export const dispatcherModule: ShipfoxModule = {
       workflowsPath,
       activities: createActivities,
       workflows: [
-        {name: 'outboxDispatcherWorkflow', id: DISPATCHER_WORKFLOW_ID},
+        {
+          name: 'outboxDispatcherWorkflow',
+          id: DISPATCHER_WORKFLOW_ID,
+          args: [{workerIndex: 0, workerCount: DISPATCHER_WORKER_COUNT}],
+        },
+        ...Array.from({length: DISPATCHER_WORKER_COUNT - 1}, (_, index) => {
+          const workerIndex = index + 1;
+          return {
+            name: 'outboxDispatcherWorkflow',
+            id: `${DISPATCHER_WORKFLOW_ID}-${workerIndex}`,
+            args: [{workerIndex, workerCount: DISPATCHER_WORKER_COUNT}],
+          };
+        }),
         {
           name: 'outboxRetentionWorkflow',
           id: OUTBOX_RETENTION_WORKFLOW_ID,

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -101,6 +101,15 @@ describe('drainAndDispatch', () => {
     expect(hasMore).toBe(true);
   });
 
+  it('passes dispatcher partition options to drainAll', async () => {
+    const partition = {workerIndex: 1, workerCount: 4};
+    mocks.drainAll.mockResolvedValueOnce(drain([]));
+
+    await drainAndDispatch(partition);
+
+    expect(mocks.drainAll).toHaveBeenCalledWith({partition});
+  });
+
   it('logs sanitized context, captures failed subscriber exceptions, and records a row failure', async () => {
     const failure = new Error('subscriber failed');
     const rowId = crypto.randomUUID();

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   getSubscribers: vi.fn(),
   markDispatched: vi.fn(),
   recordDispatchFailure: vi.fn(),
+  renewDispatchClaim: vi.fn(),
   errorLog: vi.fn(),
   warnLog: vi.fn(),
   eventDispatchedAdd: vi.fn(),
@@ -31,6 +32,7 @@ vi.mock('@shipfox/node-module', async () => {
     getSubscribers: mocks.getSubscribers,
     markDispatched: mocks.markDispatched,
     recordDispatchFailure: mocks.recordDispatchFailure,
+    renewDispatchClaim: mocks.renewDispatchClaim,
   };
 });
 
@@ -54,8 +56,26 @@ vi.mock('@shipfox/node-opentelemetry', () => ({
   }),
 }));
 
-function drain(events: DrainedEvent[], hasMore = false): DrainAllResult {
-  return {events, hasMore};
+const CLAIM_EXPIRES_AT = new Date('2026-01-01T00:02:00.000Z');
+const RENEWED_CLAIM_EXPIRES_AT = new Date('2026-01-01T00:03:00.000Z');
+
+function drain(
+  events: Array<
+    Omit<DrainedEvent, 'claimExpiresAt'> & Partial<Pick<DrainedEvent, 'claimExpiresAt'>>
+  >,
+  hasMore = false,
+): DrainAllResult {
+  return {
+    events: events.map((event) => ({
+      ...event,
+      claimExpiresAt: event.claimExpiresAt ?? CLAIM_EXPIRES_AT,
+    })),
+    hasMore,
+  };
+}
+
+function claims(ids: string[], claimExpiresAt = CLAIM_EXPIRES_AT) {
+  return ids.map((id) => ({id, claimExpiresAt}));
 }
 
 function event(id: string, createdAt: Date): DomainEvent {
@@ -69,12 +89,14 @@ function event(id: string, createdAt: Date): DomainEvent {
 
 describe('drainAndDispatch', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     mocks.captureException.mockReset();
     mocks.drainAll.mockReset();
     mocks.getEventSchema.mockReset();
     mocks.getSubscribers.mockReset();
     mocks.markDispatched.mockReset();
     mocks.recordDispatchFailure.mockReset();
+    mocks.renewDispatchClaim.mockReset();
     mocks.errorLog.mockReset();
     mocks.warnLog.mockReset();
     mocks.eventDispatchedAdd.mockReset();
@@ -149,13 +171,18 @@ describe('drainAndDispatch', () => {
         errorMessage: 'subscriber failed',
       },
     });
-    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('projects', rowId, {
-      kind: 'handler',
-      eventType: event.type,
-      eventId: rowId,
-      errorName: 'Error',
-      errorMessage: 'subscriber failed',
-    });
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
+      'projects',
+      rowId,
+      {
+        kind: 'handler',
+        eventType: event.type,
+        eventId: rowId,
+        errorName: 'Error',
+        errorMessage: 'subscriber failed',
+      },
+      CLAIM_EXPIRES_AT,
+    );
     expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
       module: 'projects',
       outcome: 'failed',
@@ -188,8 +215,8 @@ describe('drainAndDispatch', () => {
     const hasMore = await drainAndDispatch();
 
     expect(hasMore).toBe(true);
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['success']);
-    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', ['other']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims(['success']));
+    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', claims(['other']));
     expect(mocks.warnLog).toHaveBeenCalledWith(
       {err: expect.any(AggregateError)},
       'Outbox dispatch groups completed with errors',
@@ -271,7 +298,7 @@ describe('drainAndDispatch', () => {
     expect(handler).toHaveBeenCalledWith(
       expect.objectContaining({type: event.type, payload: parsed}),
     );
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims([event.id]));
     expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
       module: 'workflows',
       outcome: 'succeeded',
@@ -295,7 +322,7 @@ describe('drainAndDispatch', () => {
 
     await drainAndDispatch();
 
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [event.id]);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims([event.id]));
     expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
       module: 'workflows',
       outcome: 'succeeded',
@@ -344,16 +371,21 @@ describe('drainAndDispatch', () => {
 
     await drainAndDispatch();
 
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', [validJob.id]);
-    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', [validPush.id]);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims([validJob.id]));
+    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', claims([validPush.id]));
     expect(mocks.markDispatched).toHaveBeenCalledTimes(2);
     expect(handler).toHaveBeenCalledTimes(2);
-    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', poison.id, {
-      kind: 'validation',
-      eventType: poison.type,
-      eventId: poison.id,
-      issues: error.issues,
-    });
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
+      'workflows',
+      poison.id,
+      {
+        kind: 'validation',
+        eventType: poison.type,
+        eventId: poison.id,
+        issues: error.issues,
+      },
+      CLAIM_EXPIRES_AT,
+    );
     expect(mocks.captureException).toHaveBeenCalledWith(error, {
       extra: {
         kind: 'validation',
@@ -405,13 +437,18 @@ describe('drainAndDispatch', () => {
     expect(succeedingHandler).toHaveBeenCalledTimes(1);
     expect(failingHandler).toHaveBeenCalledTimes(1);
     expect(mocks.recordDispatchFailure).toHaveBeenCalledTimes(1);
-    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', rowId, {
-      kind: 'handler',
-      eventType: event.type,
-      eventId: rowId,
-      errorName: 'Error',
-      errorMessage: 'second handler failed',
-    });
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
+      'workflows',
+      rowId,
+      {
+        kind: 'handler',
+        eventType: event.type,
+        eventId: rowId,
+        errorName: 'Error',
+        errorMessage: 'second handler failed',
+      },
+      CLAIM_EXPIRES_AT,
+    );
     expect(mocks.eventDispatchedAdd).toHaveBeenCalledWith(1, {
       module: 'workflows',
       outcome: 'failed',
@@ -444,7 +481,7 @@ describe('drainAndDispatch', () => {
     await drainAndDispatch();
 
     expect(calls.indexOf('a')).toBeLessThan(calls.indexOf('b'));
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['a', 'b']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims(['a', 'b']));
   });
 
   it('sorts each group by created-at then id even when drain order is scrambled', async () => {
@@ -468,7 +505,7 @@ describe('drainAndDispatch', () => {
     await drainAndDispatch();
 
     expect(calls).toEqual(['a', 'b', 'c']);
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['a', 'b', 'c']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims(['a', 'b', 'c']));
   });
 
   it('halts a key group on the first failed row in the batch', async () => {
@@ -491,13 +528,18 @@ describe('drainAndDispatch', () => {
     await drainAndDispatch();
 
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith('workflows', 'a', {
-      kind: 'handler',
-      eventType: rows[0]?.type,
-      eventId: 'a',
-      errorName: 'Error',
-      errorMessage: 'failed',
-    });
+    expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
+      'workflows',
+      'a',
+      {
+        kind: 'handler',
+        eventType: rows[0]?.type,
+        eventId: 'a',
+        errorName: 'Error',
+        errorMessage: 'failed',
+      },
+      CLAIM_EXPIRES_AT,
+    );
     expect(mocks.markDispatched).not.toHaveBeenCalled();
   });
 
@@ -518,11 +560,40 @@ describe('drainAndDispatch', () => {
 
     await drainAndDispatch();
 
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['success']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims(['success']));
     expect(mocks.recordDispatchFailure).toHaveBeenCalledWith(
       'workflows',
       'failure',
       expect.objectContaining({kind: 'handler', eventId: 'failure'}),
+      CLAIM_EXPIRES_AT,
+    );
+  });
+
+  it('renews a row claim while handlers are still running', async () => {
+    vi.useFakeTimers();
+    let releaseHandler!: () => void;
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const row = event('slow', new Date('2026-01-01T00:00:00.000Z'));
+    mocks.drainAll.mockResolvedValueOnce(
+      drain([{id: row.id, source: 'workflows', orderingKey: 'run-1', event: row}]),
+    );
+    mocks.getSubscribers.mockReturnValue([vi.fn(async () => await handlerGate)]);
+    mocks.renewDispatchClaim.mockResolvedValueOnce(RENEWED_CLAIM_EXPIRES_AT);
+
+    const dispatch = drainAndDispatch();
+    await vi.advanceTimersByTimeAsync(30_000);
+    releaseHandler();
+    await dispatch;
+
+    expect(mocks.renewDispatchClaim).toHaveBeenCalledWith('workflows', {
+      id: row.id,
+      claimExpiresAt: CLAIM_EXPIRES_AT,
+    });
+    expect(mocks.markDispatched).toHaveBeenCalledWith(
+      'workflows',
+      claims([row.id], RENEWED_CLAIM_EXPIRES_AT),
     );
   });
 
@@ -558,7 +629,7 @@ describe('drainAndDispatch', () => {
     await dispatch;
 
     expect(calls).toEqual(['w1', 'i1', 'w2']);
-    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', ['w1', 'w2']);
-    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', ['i1']);
+    expect(mocks.markDispatched).toHaveBeenCalledWith('workflows', claims(['w1', 'w2']));
+    expect(mocks.markDispatched).toHaveBeenCalledWith('integrations', claims(['i1']));
   });
 });

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -6,14 +6,17 @@ import {
   getEventSchema,
   getSubscribers,
   markDispatched,
+  type OutboxDispatchClaim,
   type OutboxDispatcherPartition,
   type OutboxDispatchFailure,
   recordDispatchFailure,
+  renewDispatchClaim,
 } from '@shipfox/node-module';
 import {logger} from '@shipfox/node-opentelemetry';
 import {dispatchFailureCount, drainBatchSize, eventDispatchedCount} from '#metrics/index.js';
 
 const DISPATCH_CONCURRENCY = 8;
+const CLAIM_RENEWAL_INTERVAL_MS = 30_000;
 
 export async function drainAndDispatch(partition?: OutboxDispatcherPartition): Promise<boolean> {
   const {events: rows, hasMore} = await drainAll(partition ? {partition} : {});
@@ -27,17 +30,17 @@ export async function drainAndDispatch(partition?: OutboxDispatcherPartition): P
       groups,
       DISPATCH_CONCURRENCY,
       async (group) => {
-        const dispatchedIds: string[] = [];
+        const dispatchedClaims: OutboxDispatchClaim[] = [];
 
         for (const row of group.rows) {
           const succeeded = await dispatchRow(row);
           if (!succeeded) break;
-          dispatchedIds.push(row.id);
+          dispatchedClaims.push(claimFromRow(row));
         }
 
-        if (dispatchedIds.length > 0) {
-          await markDispatched(group.source, dispatchedIds);
-          eventDispatchedCount.add(dispatchedIds.length, {
+        if (dispatchedClaims.length > 0) {
+          await markDispatched(group.source, dispatchedClaims);
+          eventDispatchedCount.add(dispatchedClaims.length, {
             module: group.source,
             outcome: 'succeeded',
           });
@@ -53,9 +56,13 @@ export async function drainAndDispatch(partition?: OutboxDispatcherPartition): P
 }
 
 async function dispatchRow(row: DrainedEvent): Promise<boolean> {
+  return await withClaimRenewal(row, async () => await dispatchClaimedRow(row));
+}
+
+async function dispatchClaimedRow(row: DrainedEvent): Promise<boolean> {
   const validation = validatePayload(row);
   if (!validation.success) {
-    await recordDispatchFailure(row.source, row.id, validation.failure);
+    await recordDispatchFailure(row.source, row.id, validation.failure, row.claimExpiresAt);
     recordFailureMetric(row.source, validation.failure.kind);
     return false;
   }
@@ -77,9 +84,40 @@ async function dispatchRow(row: DrainedEvent): Promise<boolean> {
 
   if (!dispatchFailure) return true;
 
-  await recordDispatchFailure(row.source, row.id, dispatchFailure);
+  await recordDispatchFailure(row.source, row.id, dispatchFailure, row.claimExpiresAt);
   recordFailureMetric(row.source, dispatchFailure.kind);
   return false;
+}
+
+async function withClaimRenewal<T>(row: DrainedEvent, dispatch: () => Promise<T>): Promise<T> {
+  const interval = setInterval(() => {
+    void renewRowClaim(row);
+  }, CLAIM_RENEWAL_INTERVAL_MS);
+  try {
+    return await dispatch();
+  } finally {
+    clearInterval(interval);
+  }
+}
+
+async function renewRowClaim(row: DrainedEvent): Promise<void> {
+  try {
+    const claimExpiresAt = await renewDispatchClaim(row.source, claimFromRow(row));
+    if (!claimExpiresAt) {
+      logger().warn({source: row.source, eventId: row.id}, 'Outbox dispatch claim was not renewed');
+      return;
+    }
+    row.claimExpiresAt = claimExpiresAt;
+  } catch (error) {
+    logger().warn(
+      {err: error, source: row.source, eventId: row.id},
+      'Failed to renew outbox dispatch claim',
+    );
+  }
+}
+
+function claimFromRow(row: DrainedEvent): OutboxDispatchClaim {
+  return {id: row.id, claimExpiresAt: row.claimExpiresAt};
 }
 
 interface DispatchGroup {

--- a/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/activities/drain-and-dispatch.ts
@@ -6,6 +6,7 @@ import {
   getEventSchema,
   getSubscribers,
   markDispatched,
+  type OutboxDispatcherPartition,
   type OutboxDispatchFailure,
   recordDispatchFailure,
 } from '@shipfox/node-module';
@@ -14,8 +15,8 @@ import {dispatchFailureCount, drainBatchSize, eventDispatchedCount} from '#metri
 
 const DISPATCH_CONCURRENCY = 8;
 
-export async function drainAndDispatch(): Promise<boolean> {
-  const {events: rows, hasMore} = await drainAll();
+export async function drainAndDispatch(partition?: OutboxDispatcherPartition): Promise<boolean> {
+  const {events: rows, hasMore} = await drainAll(partition ? {partition} : {});
   drainBatchSize.record(rows.length);
   if (rows.length === 0) return hasMore;
 

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.test.ts
@@ -26,15 +26,16 @@ describe('outboxDispatcherWorkflow', () => {
 
   it('drains repeatedly until the dispatcher reports no more backlog', async () => {
     const {outboxDispatcherWorkflow} = await import('./dispatch.js');
-    const params = {workerIndex: 1, workerCount: 4};
+    const inputParams = {workerIndex: 1, workerCount: 2};
+    const currentParams = {workerIndex: 1, workerCount: DISPATCHER_WORKER_COUNT};
     mocks.drainAndDispatch.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
-    await outboxDispatcherWorkflow(params);
+    await outboxDispatcherWorkflow(inputParams);
 
-    expect(mocks.drainAndDispatch).toHaveBeenNthCalledWith(1, params);
-    expect(mocks.drainAndDispatch).toHaveBeenNthCalledWith(2, params);
+    expect(mocks.drainAndDispatch).toHaveBeenNthCalledWith(1, currentParams);
+    expect(mocks.drainAndDispatch).toHaveBeenNthCalledWith(2, currentParams);
     expect(mocks.sleep).toHaveBeenCalledWith('250ms');
-    expect(mocks.continueAsNew).toHaveBeenCalledWith(params);
+    expect(mocks.continueAsNew).toHaveBeenCalledWith(currentParams);
   });
 
   it('defaults existing no-arg dispatcher executions to worker zero', async () => {
@@ -46,5 +47,18 @@ describe('outboxDispatcherWorkflow', () => {
     const params = {workerIndex: 0, workerCount: DISPATCHER_WORKER_COUNT};
     expect(mocks.drainAndDispatch).toHaveBeenCalledWith(params);
     expect(mocks.continueAsNew).toHaveBeenCalledWith(params);
+  });
+
+  it('retires dispatcher executions whose worker index is no longer active', async () => {
+    const {outboxDispatcherWorkflow} = await import('./dispatch.js');
+
+    await outboxDispatcherWorkflow({
+      workerIndex: DISPATCHER_WORKER_COUNT,
+      workerCount: DISPATCHER_WORKER_COUNT + 1,
+    });
+
+    expect(mocks.drainAndDispatch).not.toHaveBeenCalled();
+    expect(mocks.sleep).not.toHaveBeenCalled();
+    expect(mocks.continueAsNew).not.toHaveBeenCalled();
   });
 });

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.test.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.test.ts
@@ -14,6 +14,8 @@ vi.mock('@temporalio/workflow', () => ({
   sleep: mocks.sleep,
 }));
 
+import {DISPATCHER_WORKER_COUNT} from '#core/constants.js';
+
 describe('outboxDispatcherWorkflow', () => {
   beforeEach(() => {
     mocks.continueAsNew.mockReset();
@@ -24,12 +26,25 @@ describe('outboxDispatcherWorkflow', () => {
 
   it('drains repeatedly until the dispatcher reports no more backlog', async () => {
     const {outboxDispatcherWorkflow} = await import('./dispatch.js');
+    const params = {workerIndex: 1, workerCount: 4};
     mocks.drainAndDispatch.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await outboxDispatcherWorkflow(params);
+
+    expect(mocks.drainAndDispatch).toHaveBeenNthCalledWith(1, params);
+    expect(mocks.drainAndDispatch).toHaveBeenNthCalledWith(2, params);
+    expect(mocks.sleep).toHaveBeenCalledWith('250ms');
+    expect(mocks.continueAsNew).toHaveBeenCalledWith(params);
+  });
+
+  it('defaults existing no-arg dispatcher executions to worker zero', async () => {
+    const {outboxDispatcherWorkflow} = await import('./dispatch.js');
+    mocks.drainAndDispatch.mockResolvedValueOnce(false);
 
     await outboxDispatcherWorkflow();
 
-    expect(mocks.drainAndDispatch).toHaveBeenCalledTimes(2);
-    expect(mocks.sleep).toHaveBeenCalledWith('250ms');
-    expect(mocks.continueAsNew).toHaveBeenCalledTimes(1);
+    const params = {workerIndex: 0, workerCount: DISPATCHER_WORKER_COUNT};
+    expect(mocks.drainAndDispatch).toHaveBeenCalledWith(params);
+    expect(mocks.continueAsNew).toHaveBeenCalledWith(params);
   });
 });

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
@@ -18,12 +18,15 @@ export interface OutboxDispatcherWorkflowParams {
 export async function outboxDispatcherWorkflow(
   params: OutboxDispatcherWorkflowParams = {workerIndex: 0, workerCount: DISPATCHER_WORKER_COUNT},
 ): Promise<void> {
+  const currentParams = currentDispatcherParams(params);
+  if (!currentParams) return;
+
   let hasMore = false;
   do {
-    hasMore = await drainAndDispatch(params);
+    hasMore = await drainAndDispatch(currentParams);
   } while (hasMore);
   await sleep(POLL_INTERVAL);
-  await continueAsNew<typeof outboxDispatcherWorkflow>(params);
+  await continueAsNew<typeof outboxDispatcherWorkflow>(currentParams);
 }
 
 export async function outboxRetentionWorkflow(): Promise<void> {
@@ -31,3 +34,10 @@ export async function outboxRetentionWorkflow(): Promise<void> {
 }
 
 const POLL_INTERVAL = '250ms';
+
+function currentDispatcherParams(
+  params: OutboxDispatcherWorkflowParams,
+): OutboxDispatcherWorkflowParams | undefined {
+  if (params.workerIndex >= DISPATCHER_WORKER_COUNT) return undefined;
+  return {workerIndex: params.workerIndex, workerCount: DISPATCHER_WORKER_COUNT};
+}

--- a/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
+++ b/libs/api/dispatcher/src/temporal/workflows/dispatch.ts
@@ -1,4 +1,5 @@
 import {continueAsNew, proxyActivities, sleep} from '@temporalio/workflow';
+import {DISPATCHER_WORKER_COUNT} from '#core/constants.js';
 import type {createActivities} from '../activities/index.js';
 
 const {drainAndDispatch} = proxyActivities<ReturnType<typeof createActivities>>({
@@ -9,13 +10,20 @@ const {pruneOutboxRetention} = proxyActivities<ReturnType<typeof createActivitie
   startToCloseTimeout: '5m',
 });
 
-export async function outboxDispatcherWorkflow(): Promise<void> {
+export interface OutboxDispatcherWorkflowParams {
+  workerIndex: number;
+  workerCount: number;
+}
+
+export async function outboxDispatcherWorkflow(
+  params: OutboxDispatcherWorkflowParams = {workerIndex: 0, workerCount: DISPATCHER_WORKER_COUNT},
+): Promise<void> {
   let hasMore = false;
   do {
-    hasMore = await drainAndDispatch();
+    hasMore = await drainAndDispatch(params);
   } while (hasMore);
   await sleep(POLL_INTERVAL);
-  await continueAsNew<typeof outboxDispatcherWorkflow>();
+  await continueAsNew<typeof outboxDispatcherWorkflow>(params);
 }
 
 export async function outboxRetentionWorkflow(): Promise<void> {

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -7,8 +7,10 @@ export type {
 } from './initialize.js';
 export {initializeModules, registerModuleMetrics, startModuleWorkers} from './initialize.js';
 export type {
+  DrainAllOptions,
   DrainAllResult,
   DrainedEvent,
+  OutboxDispatcherPartition,
   OutboxDispatchFailure,
   PruneDispatchedOutboxRowsOptions,
   PrunedOutboxSource,

--- a/libs/shared/node/module/src/index.ts
+++ b/libs/shared/node/module/src/index.ts
@@ -10,6 +10,7 @@ export type {
   DrainAllOptions,
   DrainAllResult,
   DrainedEvent,
+  OutboxDispatchClaim,
   OutboxDispatcherPartition,
   OutboxDispatchFailure,
   PruneDispatchedOutboxRowsOptions,
@@ -23,6 +24,7 @@ export {
   pruneDispatchedOutboxRows,
   recordDispatchFailure,
   registerPublisher,
+  renewDispatchClaim,
   resetPublishers,
 } from './publisher-registry.js';
 export type {EventHandler} from './registry.js';

--- a/libs/shared/node/module/src/initialize.test.ts
+++ b/libs/shared/node/module/src/initialize.test.ts
@@ -172,6 +172,20 @@ describe('startModuleWorkers', () => {
     });
   });
 
+  it('starts declared workflows with args when provided', async () => {
+    const args = [{workerIndex: 1, workerCount: 4}];
+
+    await startModuleWorkers({
+      workers: [moduleWorker({workflows: [{name: 'dispatch', id: 'dispatch-1', args}]})],
+    });
+
+    expect(mocks.workflowStart).toHaveBeenCalledWith('dispatch', {
+      taskQueue: 'test-queue',
+      workflowId: 'dispatch-1',
+      args,
+    });
+  });
+
   it('tolerates already-started workflows', async () => {
     mocks.workflowStart.mockRejectedValueOnce(alreadyStartedError());
 

--- a/libs/shared/node/module/src/initialize.ts
+++ b/libs/shared/node/module/src/initialize.ts
@@ -136,6 +136,7 @@ export async function startModuleWorkers(options: StartModuleWorkersOptions): Pr
           await temporalClient().workflow.start(workflow.name, {
             taskQueue: workerDef.taskQueue,
             workflowId: workflow.id,
+            ...(workflow.args ? {args: workflow.args} : {}),
             ...(workflow.cronSchedule ? {cronSchedule: workflow.cronSchedule} : {}),
           });
         } catch (error) {

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -1,5 +1,5 @@
 import type {DomainEvent, OutboxTable} from '@shipfox/node-outbox';
-import {and, asc, eq, getTableName, inArray, isNull, lte, sql} from 'drizzle-orm';
+import {and, eq, getTableName, inArray, isNull, type SQL, sql} from 'drizzle-orm';
 import type {NodePgDatabase} from 'drizzle-orm/node-postgres';
 import type {ZodType} from 'zod';
 
@@ -20,6 +20,15 @@ export interface DrainedEvent {
 export interface DrainAllResult {
   events: DrainedEvent[];
   hasMore: boolean;
+}
+
+export interface OutboxDispatcherPartition {
+  workerIndex: number;
+  workerCount: number;
+}
+
+export interface DrainAllOptions {
+  partition?: OutboxDispatcherPartition;
 }
 
 export interface OutboxDispatchIssue {
@@ -60,6 +69,7 @@ const _schemasByType = new Map<string, ZodType>();
 
 export const BATCH_SIZE = 500;
 const MAX_DISPATCH_ATTEMPTS = 5;
+const CLAIM_LEASE_SECONDS = 120;
 
 export function registerPublisher(config: PublisherSource): void {
   _sources.push(config);
@@ -82,36 +92,17 @@ export function getEventSchema(type: string): ZodType | undefined {
   return _schemasByType.get(type);
 }
 
-export async function drainAll(): Promise<DrainAllResult> {
+export async function drainAll(options: DrainAllOptions = {}): Promise<DrainAllResult> {
+  const partition = normalizePartition(options.partition);
   const results: DrainedEvent[] = [];
   let hasMore = false;
 
   for (const source of _sources) {
-    const rows = await source
-      .db()
-      .select()
-      .from(source.table)
-      .where(
-        and(
-          isNull(source.table.dispatchedAt),
-          isNull(source.table.deadLetteredAt),
-          lte(source.table.nextDispatchAt, sql`now()`),
-          sql`NOT EXISTS (
-            SELECT 1
-            FROM ${sql.raw(quoteIdentifier(getTableName(source.table)))} AS earlier
-            WHERE earlier.dispatched_at IS NULL
-              AND earlier.dead_lettered_at IS NULL
-              AND COALESCE(earlier.ordering_key, ${source.name}) = COALESCE(${source.table.orderingKey}, ${source.name})
-              AND (earlier.created_at, earlier.id) < (${source.table.createdAt}, ${source.table.id})
-              AND earlier.next_dispatch_at > now()
-          )`,
-        ),
-      )
-      .orderBy(asc(source.table.createdAt), asc(source.table.id))
-      .limit(BATCH_SIZE);
+    const rows = await claimSourceRows(source, partition);
     if (rows.length === BATCH_SIZE) hasMore = true;
 
     for (const row of rows) {
+      const createdAt = new Date(row.createdAt);
       results.push({
         source: source.name,
         orderingKey: row.orderingKey ?? source.name,
@@ -120,13 +111,64 @@ export async function drainAll(): Promise<DrainAllResult> {
           id: row.id,
           type: row.eventType,
           payload: row.payload,
-          createdAt: row.createdAt,
+          createdAt,
         },
       });
     }
   }
 
   return {events: results, hasMore};
+}
+
+type ClaimedOutboxRow = Record<string, unknown> & {
+  id: string;
+  eventType: string;
+  orderingKey: string | null;
+  payload: unknown;
+  createdAt: Date | string;
+};
+
+async function claimSourceRows(
+  source: PublisherSource,
+  partition: OutboxDispatcherPartition,
+): Promise<ClaimedOutboxRow[]> {
+  const table = sql.raw(quoteIdentifier(getTableName(source.table)));
+  const result = await source.db().transaction(async (tx) => {
+    return await tx.execute<ClaimedOutboxRow>(sql`
+      WITH claimed AS (
+        SELECT outbox.id
+        FROM ${table} AS outbox
+        WHERE outbox.dispatched_at IS NULL
+          AND outbox.dead_lettered_at IS NULL
+          AND outbox.next_dispatch_at <= now()
+          AND ${partitionPredicateSql(source, partition)}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${table} AS earlier
+            WHERE earlier.dispatched_at IS NULL
+              AND earlier.dead_lettered_at IS NULL
+              AND COALESCE(earlier.ordering_key, ${source.name}) = COALESCE(outbox.ordering_key, ${source.name})
+              AND (earlier.created_at, earlier.id) < (outbox.created_at, outbox.id)
+              AND earlier.next_dispatch_at > now()
+          )
+        ORDER BY outbox.created_at, outbox.id
+        FOR UPDATE SKIP LOCKED
+        LIMIT ${BATCH_SIZE}
+      )
+      UPDATE ${table} AS outbox
+      SET next_dispatch_at = now() + (${CLAIM_LEASE_SECONDS} * interval '1 second')
+      FROM claimed
+      WHERE outbox.id = claimed.id
+      RETURNING
+        outbox.id,
+        outbox.event_type AS "eventType",
+        outbox.ordering_key AS "orderingKey",
+        outbox.payload,
+        outbox.created_at AS "createdAt"
+    `);
+  });
+
+  return [...result.rows].sort(compareClaimedRows);
 }
 
 export async function markDispatched(source: string, ids: string[]): Promise<void> {
@@ -242,6 +284,38 @@ function assertPositiveInteger(value: number, name: string): void {
   if (!Number.isInteger(value) || value < 1) {
     throw new Error(`${name} must be a positive integer`);
   }
+}
+
+function normalizePartition(
+  partition: OutboxDispatcherPartition | undefined,
+): OutboxDispatcherPartition {
+  if (!partition) return {workerIndex: 0, workerCount: 1};
+  assertPositiveInteger(partition.workerCount, 'workerCount');
+
+  if (!Number.isInteger(partition.workerIndex) || partition.workerIndex < 0) {
+    throw new Error('workerIndex must be a non-negative integer');
+  }
+  if (partition.workerIndex >= partition.workerCount) {
+    throw new Error('workerIndex must be less than workerCount');
+  }
+
+  return partition;
+}
+
+function partitionPredicateSql(source: PublisherSource, partition: OutboxDispatcherPartition): SQL {
+  if (partition.workerCount === 1) return sql`TRUE`;
+
+  return sql`
+    mod(
+      abs(hashtext(COALESCE(outbox.ordering_key, ${source.name}))::bigint),
+      ${partition.workerCount}
+    ) = ${partition.workerIndex}
+  `;
+}
+
+function compareClaimedRows(a: ClaimedOutboxRow, b: ClaimedOutboxRow): number {
+  const createdAtDelta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  return createdAtDelta === 0 ? a.id.localeCompare(b.id) : createdAtDelta;
 }
 
 function quoteIdentifier(identifier: string): string {

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -75,7 +75,7 @@ const _schemasByType = new Map<string, ZodType>();
 
 export const BATCH_SIZE = 500;
 const MAX_DISPATCH_ATTEMPTS = 5;
-const CLAIM_LEASE_SECONDS = 120;
+const CLAIM_LEASE_EXTENSION_SECONDS = 120;
 
 export function registerPublisher(config: PublisherSource): void {
   _sources.push(config);
@@ -400,5 +400,5 @@ function nextDispatchAtSql(table: OutboxTable) {
 }
 
 function claimExpiresAtSql() {
-  return sql`date_trunc('milliseconds', now() + (${CLAIM_LEASE_SECONDS} * interval '1 second'))`;
+  return sql`date_trunc('milliseconds', now() + (${CLAIM_LEASE_EXTENSION_SECONDS} * interval '1 second'))`;
 }

--- a/libs/shared/node/module/src/publisher-registry.ts
+++ b/libs/shared/node/module/src/publisher-registry.ts
@@ -14,6 +14,7 @@ export interface DrainedEvent {
   source: string;
   orderingKey: string;
   id: string;
+  claimExpiresAt: Date;
   event: DomainEvent;
 }
 
@@ -25,6 +26,11 @@ export interface DrainAllResult {
 export interface OutboxDispatcherPartition {
   workerIndex: number;
   workerCount: number;
+}
+
+export interface OutboxDispatchClaim {
+  id: string;
+  claimExpiresAt: Date;
 }
 
 export interface DrainAllOptions {
@@ -103,10 +109,12 @@ export async function drainAll(options: DrainAllOptions = {}): Promise<DrainAllR
 
     for (const row of rows) {
       const createdAt = new Date(row.createdAt);
+      const claimExpiresAt = new Date(row.claimExpiresAt);
       results.push({
         source: source.name,
         orderingKey: row.orderingKey ?? source.name,
         id: row.id,
+        claimExpiresAt,
         event: {
           id: row.id,
           type: row.eventType,
@@ -126,6 +134,7 @@ type ClaimedOutboxRow = Record<string, unknown> & {
   orderingKey: string | null;
   payload: unknown;
   createdAt: Date | string;
+  claimExpiresAt: Date | string;
 };
 
 async function claimSourceRows(
@@ -156,7 +165,7 @@ async function claimSourceRows(
         LIMIT ${BATCH_SIZE}
       )
       UPDATE ${table} AS outbox
-      SET next_dispatch_at = now() + (${CLAIM_LEASE_SECONDS} * interval '1 second')
+      SET next_dispatch_at = ${claimExpiresAtSql()}
       FROM claimed
       WHERE outbox.id = claimed.id
       RETURNING
@@ -164,18 +173,26 @@ async function claimSourceRows(
         outbox.event_type AS "eventType",
         outbox.ordering_key AS "orderingKey",
         outbox.payload,
-        outbox.created_at AS "createdAt"
+        outbox.created_at AS "createdAt",
+        outbox.next_dispatch_at AS "claimExpiresAt"
     `);
   });
 
   return [...result.rows].sort(compareClaimedRows);
 }
 
-export async function markDispatched(source: string, ids: string[]): Promise<void> {
-  if (ids.length === 0) return;
-
+export async function markDispatched(
+  source: string,
+  claims: string[] | OutboxDispatchClaim[],
+): Promise<void> {
+  if (claims.length === 0) return;
   const config = _sources.find((s) => s.name === source);
   if (!config) return;
+
+  if (isDispatchClaims(claims)) {
+    await markClaimedDispatched(config, claims);
+    return;
+  }
 
   await config
     .db()
@@ -183,17 +200,66 @@ export async function markDispatched(source: string, ids: string[]): Promise<voi
     .set({dispatchedAt: sql`now()`})
     .where(
       and(
-        inArray(config.table.id, ids),
+        inArray(config.table.id, claims),
         isNull(config.table.dispatchedAt),
         isNull(config.table.deadLetteredAt),
       ),
     );
 }
 
+async function markClaimedDispatched(
+  source: PublisherSource,
+  claims: OutboxDispatchClaim[],
+): Promise<void> {
+  const table = sql.raw(quoteIdentifier(getTableName(source.table)));
+  const values = sql.join(
+    claims.map((claim) => sql`(${claim.id}::uuid, ${claim.claimExpiresAt}::timestamptz)`),
+    sql`, `,
+  );
+  await source.db().execute(sql`
+    WITH claim(id, claim_expires_at) AS (VALUES ${values})
+    UPDATE ${table} AS outbox
+    SET dispatched_at = now()
+    FROM claim
+    WHERE outbox.id = claim.id
+      AND outbox.next_dispatch_at = claim.claim_expires_at
+      AND outbox.dispatched_at IS NULL
+      AND outbox.dead_lettered_at IS NULL
+  `);
+}
+
+function isDispatchClaims(
+  claims: string[] | OutboxDispatchClaim[],
+): claims is OutboxDispatchClaim[] {
+  return typeof claims[0] === 'object';
+}
+
+export async function renewDispatchClaim(
+  source: string,
+  claim: OutboxDispatchClaim,
+): Promise<Date | undefined> {
+  const config = _sources.find((s) => s.name === source);
+  if (!config) return undefined;
+
+  const table = sql.raw(quoteIdentifier(getTableName(config.table)));
+  const result = await config.db().execute<{claimExpiresAt: Date | string}>(sql`
+    UPDATE ${table}
+    SET next_dispatch_at = ${claimExpiresAtSql()}
+    WHERE id = ${claim.id}
+      AND next_dispatch_at = ${claim.claimExpiresAt}
+      AND dispatched_at IS NULL
+      AND dead_lettered_at IS NULL
+    RETURNING next_dispatch_at AS "claimExpiresAt"
+  `);
+  const claimExpiresAt = result.rows[0]?.claimExpiresAt;
+  return claimExpiresAt ? new Date(claimExpiresAt) : undefined;
+}
+
 export async function recordDispatchFailure(
   source: string,
   id: string,
   failure: OutboxDispatchFailure,
+  claimExpiresAt?: Date,
 ): Promise<void> {
   const config = _sources.find((s) => s.name === source);
   if (!config) return;
@@ -213,6 +279,7 @@ export async function recordDispatchFailure(
     .where(
       and(
         eq(config.table.id, id),
+        claimExpiresAt ? eq(config.table.nextDispatchAt, claimExpiresAt) : undefined,
         isNull(config.table.dispatchedAt),
         isNull(config.table.deadLetteredAt),
       ),
@@ -330,4 +397,8 @@ function nextDispatchAtSql(table: OutboxTable) {
     WHEN ${table.dispatchAttempts} = 3 THEN now() + interval '30 minutes'
     ELSE now()
   END`;
+}
+
+function claimExpiresAtSql() {
+  return sql`date_trunc('milliseconds', now() + (${CLAIM_LEASE_SECONDS} * interval '1 second'))`;
 }

--- a/libs/shared/node/module/src/types.ts
+++ b/libs/shared/node/module/src/types.ts
@@ -34,6 +34,7 @@ export interface ModulePublisher {
 export interface WorkflowStart {
   name: string;
   id: string;
+  args?: unknown[];
   /**
    * Optional Temporal cron expression (e.g. `* * * * *`). When set, the
    * workflow is started with `cronSchedule` so Temporal handles recurrence


### PR DESCRIPTION
Scale outbox dispatch across partitioned workers.

The outbox dispatcher was limited by a singleton drain path that could not safely run in parallel without double-dispatching rows. This changes draining into a claim operation using `FOR UPDATE SKIP LOCKED` plus a short `next_dispatch_at` lease, so concurrent workers claim disjoint rows while successful handlers still mark rows dispatched only after completion.

Dispatcher workflows now run as stable hash partitions over the ordering key. The existing `outbox-dispatcher` workflow ID remains worker 0 for rollout compatibility, with additional workflow IDs handling the remaining partitions.

Considered relying on row locks alone, but locks release at transaction end before handler execution. The lease keeps in-flight rows unavailable until success, failure backoff, or crash redelivery.

Closes ENG-796

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scales outbox dispatch across partitioned workers with `FOR UPDATE SKIP LOCKED` leases, renews in-flight claims, and guards writes so stale claims can’t finalize rows. Partitioned Temporal workflows now refresh worker counts and retire extra workers (ENG-796).

- **New Features**
  - Partitioned dispatch: stable hash on `orderingKey` assigns events to one worker.
  - Atomic claiming: `SKIP LOCKED` + 120s lease; claims auto-renew every 30s during long handlers.
  - Guarded writes: `markDispatched` and `recordDispatchFailure` require the current claim; stale claims are ignored.
  - Dispatcher workflows: `outbox-dispatcher` is worker 0; additional `outbox-dispatcher-{i}` with `{workerIndex, workerCount}`; refresh to current `DISPATCHER_WORKER_COUNT` on continue-as-new and retire out-of-range workers. Default `DISPATCHER_WORKER_COUNT` is 4.
  - API updates: `drainAll({ partition })`, `renewDispatchClaim`, `OutboxDispatchClaim`, `OutboxDispatcherPartition`; `markDispatched` accepts claims; `startModuleWorkers` supports workflow `args`.

- **Migration**
  - Backward compatible: existing no-arg executions default to worker 0; `markDispatched(ids)` still supported.
  - No schema changes.
  - To scale, run up to `DISPATCHER_WORKER_COUNT` workers (adjustable).

<sup>Written for commit 28291566a7a2aa2e9d13630d4c82c79bec651e90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

