### PR TITLE
[runner] Add harness adapter seam

### DIFF
--- a/.changeset/brisk-harnesses-select.md
+++ b/.changeset/brisk-harnesses-select.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/runner-agent": patch
+---
+
+Adds the runner harness adapter seam and fails unsupported Claude agent steps instead of silently running the pi harness.

--- a/libs/runner/agent/src/core/harness.ts
+++ b/libs/runner/agent/src/core/harness.ts
@@ -1,0 +1,32 @@
+import type {CustomModelProviderRuntimeConfigDto} from '@shipfox/api-agent-dto';
+
+// The invocation shape is still pi-oriented because v1 only has two harnesses.
+// Revisit this shared contract if a third harness needs materially different inputs.
+export interface HarnessInvocation {
+  readonly cwd: string;
+  readonly model: string;
+  readonly provider: string;
+  readonly thinking: string;
+  readonly prompt: string;
+  readonly credentials: Record<string, string>;
+  readonly customProvider?: CustomModelProviderRuntimeConfigDto | undefined;
+  readonly gitConfigGlobal?: string | undefined;
+  readonly signal: AbortSignal;
+  /** Forwards each verbatim session entry line as persisted, in order. Best-effort. */
+  readonly onSessionEntry?: (line: string) => void;
+}
+
+export interface HarnessResult {
+  readonly summary?: string;
+}
+
+export interface HarnessAdapter {
+  /**
+   * Runs one agent step for the selected harness.
+   *
+   * Implementations must observe `invocation.signal` for cooperative cancellation.
+   * `step.ts` also races this call against the signal so the step loop can continue
+   * even if an adapter is slow to settle after abort.
+   */
+  run(invocation: HarnessInvocation): Promise<HarnessResult>;
+}

--- a/libs/runner/agent/src/core/pi-adapter.test.ts
+++ b/libs/runner/agent/src/core/pi-adapter.test.ts
@@ -68,9 +68,10 @@ import {
   DEFAULT_CUSTOM_MODEL_REASONING,
 } from '@shipfox/api-agent-dto';
 import {AgentConfigError} from '#core/errors.js';
-import {type AgentInvocation, runAgent} from '#core/run-agent.js';
+import type {HarnessInvocation} from '#core/harness.js';
+import {piHarnessAdapter} from '#core/pi-adapter.js';
 
-function invocation(overrides: Partial<AgentInvocation> = {}): AgentInvocation {
+function invocation(overrides: Partial<HarnessInvocation> = {}): HarnessInvocation {
   return {
     cwd: '/work',
     model: 'claude-opus-4-8',
@@ -97,7 +98,7 @@ function customProvider(
   };
 }
 
-describe('runAgent', () => {
+describe('piHarnessAdapter', () => {
   // Tracked so the temp dir is removed in afterEach even if an assertion throws first.
   let sessionDir: string | undefined;
   let priorGitConfigGlobal: string | undefined;
@@ -139,7 +140,7 @@ describe('runAgent', () => {
     const model = {provider: 'openai', id: 'gpt-5.1'};
     findMock.mockReturnValue(model);
 
-    const result = await runAgent(invocation({provider: 'openai', model: 'gpt-5.1'}));
+    const result = await piHarnessAdapter.run(invocation({provider: 'openai', model: 'gpt-5.1'}));
 
     expect(findMock).toHaveBeenCalledWith('openai', 'gpt-5.1');
     expect(createAgentSessionMock).toHaveBeenCalledWith(
@@ -153,7 +154,7 @@ describe('runAgent', () => {
     const model = {provider: 'openai', id: 'gpt-5.1'};
     findMock.mockReturnValue(model);
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'openai',
         model: 'gpt-5.1',
@@ -171,7 +172,7 @@ describe('runAgent', () => {
     const model = {provider: 'ollama-workspace', id: 'custom-gpt'};
     findMock.mockReturnValue(model);
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'ollama-workspace',
         model: 'custom-gpt',
@@ -200,7 +201,7 @@ describe('runAgent', () => {
   });
 
   it('rejects keyed custom providers when no api key is resolved', async () => {
-    const result = runAgent(
+    const result = piHarnessAdapter.run(
       invocation({
         provider: 'workspace-models',
         model: 'custom-gpt',
@@ -218,7 +219,7 @@ describe('runAgent', () => {
   });
 
   it('rejects keyed custom providers when an empty api key is resolved', async () => {
-    const result = runAgent(
+    const result = piHarnessAdapter.run(
       invocation({
         provider: 'workspace-models',
         model: 'custom-gpt',
@@ -238,7 +239,7 @@ describe('runAgent', () => {
   it('registers keyless custom providers with a placeholder api key', async () => {
     findMock.mockReturnValue({provider: 'local-ollama', id: 'llama'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'local-ollama',
         model: 'llama',
@@ -258,7 +259,7 @@ describe('runAgent', () => {
   it('treats an empty custom provider api key as keyless', async () => {
     findMock.mockReturnValue({provider: 'local-ollama', id: 'llama'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'local-ollama',
         model: 'llama',
@@ -278,7 +279,7 @@ describe('runAgent', () => {
   it('skips missing secret headers when rebuilding custom provider headers', async () => {
     findMock.mockReturnValue({provider: 'custom', id: 'custom-gpt'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'custom',
         model: 'custom-gpt',
@@ -298,7 +299,7 @@ describe('runAgent', () => {
   it('skips empty secret headers when rebuilding custom provider headers', async () => {
     findMock.mockReturnValue({provider: 'custom', id: 'custom-gpt'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'custom',
         model: 'custom-gpt',
@@ -318,7 +319,7 @@ describe('runAgent', () => {
   it('lets secret headers override plaintext headers with the same name', async () => {
     findMock.mockReturnValue({provider: 'custom', id: 'custom-gpt'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'custom',
         model: 'custom-gpt',
@@ -346,7 +347,7 @@ describe('runAgent', () => {
   ] as const)('registers custom provider api "%s"', async (api) => {
     findMock.mockReturnValue({provider: 'custom', id: 'custom-gpt'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'custom',
         model: 'custom-gpt',
@@ -360,7 +361,7 @@ describe('runAgent', () => {
   it('synthesizes custom provider model defaults from shared constants', async () => {
     findMock.mockReturnValue({provider: 'custom', id: 'custom-gpt'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'custom',
         model: 'custom-gpt',
@@ -390,7 +391,7 @@ describe('runAgent', () => {
   it('passes explicit custom provider model metadata through to pi', async () => {
     findMock.mockReturnValue({provider: 'custom', id: 'vision-model'});
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'custom',
         model: 'vision-model',
@@ -434,7 +435,7 @@ describe('runAgent', () => {
     );
 
     await expect(
-      runAgent(
+      piHarnessAdapter.run(
         invocation({
           provider: 'local-ollama',
           model: 'llama',
@@ -457,7 +458,7 @@ describe('runAgent', () => {
     });
 
     await expect(
-      runAgent(
+      piHarnessAdapter.run(
         invocation({
           provider: 'custom',
           model: 'custom-gpt',
@@ -476,7 +477,7 @@ describe('runAgent', () => {
     const model = {provider: 'azure-openai-responses', id: 'gpt-5.5-pro'};
     findMock.mockReturnValue(model);
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'azure-openai-responses',
         model: 'gpt-5.5-pro',
@@ -500,7 +501,7 @@ describe('runAgent', () => {
     const model = {provider: 'cloudflare-ai-gateway', id: 'claude-opus-4-8'};
     findMock.mockReturnValue(model);
 
-    await runAgent(
+    await piHarnessAdapter.run(
       invocation({
         provider: 'cloudflare-ai-gateway',
         model: 'claude-opus-4-8',
@@ -526,7 +527,7 @@ describe('runAgent', () => {
 
   it('throws an AgentConfigError when runtime credentials have no API key', async () => {
     await expect(
-      runAgent(invocation({provider: 'openai', credentials: {account_id: 'acct-1'}})),
+      piHarnessAdapter.run(invocation({provider: 'openai', credentials: {account_id: 'acct-1'}})),
     ).rejects.toThrow(
       new AgentConfigError(
         'Runtime credentials for provider "openai" are missing "api_key".',
@@ -539,7 +540,7 @@ describe('runAgent', () => {
 
   it('throws an AgentConfigError when provider-specific runtime fields are missing', async () => {
     await expect(
-      runAgent(
+      piHarnessAdapter.run(
         invocation({
           provider: 'cloudflare-ai-gateway',
           credentials: {api_key: 'cf-secret', account_id: 'account-1'},
@@ -569,7 +570,7 @@ describe('runAgent', () => {
     });
     const entries: string[] = [];
 
-    await runAgent(invocation({onSessionEntry: (line) => entries.push(line)}));
+    await piHarnessAdapter.run(invocation({onSessionEntry: (line) => entries.push(line)}));
 
     expect(entries).toEqual(['{"type":"session"}', '{"type":"message","id":"a"}']);
   });
@@ -577,7 +578,7 @@ describe('runAgent', () => {
   it('skips forwarding when the session is not persisted (no session file)', async () => {
     const entries: string[] = [];
 
-    await runAgent(invocation({onSessionEntry: (line) => entries.push(line)}));
+    await piHarnessAdapter.run(invocation({onSessionEntry: (line) => entries.push(line)}));
 
     expect(entries).toEqual([]);
   });
@@ -589,7 +590,7 @@ describe('runAgent', () => {
       return Promise.resolve();
     });
 
-    await runAgent(invocation({gitConfigGlobal: '/runner/job/git-cred.config'}));
+    await piHarnessAdapter.run(invocation({gitConfigGlobal: '/runner/job/git-cred.config'}));
 
     expect(process.env.GIT_CONFIG_GLOBAL).toBe('/runner/base.gitconfig');
   });
@@ -600,7 +601,7 @@ describe('runAgent', () => {
       return Promise.resolve();
     });
 
-    await runAgent(invocation({gitConfigGlobal: '/runner/job/git-cred.config'}));
+    await piHarnessAdapter.run(invocation({gitConfigGlobal: '/runner/job/git-cred.config'}));
 
     expect(process.env.GIT_CONFIG_GLOBAL).toBeUndefined();
   });
@@ -613,7 +614,7 @@ describe('runAgent', () => {
     });
 
     await expect(
-      runAgent(invocation({gitConfigGlobal: '/runner/job/git-cred.config'})),
+      piHarnessAdapter.run(invocation({gitConfigGlobal: '/runner/job/git-cred.config'})),
     ).rejects.toThrow('prompt failed');
 
     expect(process.env.GIT_CONFIG_GLOBAL).toBe('/runner/base.gitconfig');
@@ -630,7 +631,7 @@ describe('runAgent', () => {
         }),
     );
 
-    const promise = runAgent(
+    const promise = piHarnessAdapter.run(
       invocation({signal: ac.signal, gitConfigGlobal: '/runner/job/git-cred.config'}),
     );
     await vi.waitFor(() => expect(promptMock).toHaveBeenCalled());
@@ -645,7 +646,9 @@ describe('runAgent', () => {
     findMock.mockReturnValue(undefined);
     getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
 
-    await expect(runAgent(invocation({provider: 'bogus', model: 'gpt-5.1'}))).rejects.toThrow(
+    await expect(
+      piHarnessAdapter.run(invocation({provider: 'bogus', model: 'gpt-5.1'})),
+    ).rejects.toThrow(
       new AgentConfigError(
         'Unknown provider "bogus" for agent step. ' +
           'Known providers are pi built-ins plus any from models.json.',
@@ -662,7 +665,9 @@ describe('runAgent', () => {
       {provider: 'openai', id: 'gpt-5.1'},
     ]);
 
-    await expect(runAgent(invocation({provider: 'anthropic', model: 'gpt-5.1'}))).rejects.toThrow(
+    await expect(
+      piHarnessAdapter.run(invocation({provider: 'anthropic', model: 'gpt-5.1'})),
+    ).rejects.toThrow(
       new AgentConfigError(
         'Model "gpt-5.1" is not available for provider "anthropic". ' +
           'Did you mean to set provider: openai?',
@@ -676,7 +681,9 @@ describe('runAgent', () => {
     findMock.mockReturnValue(undefined);
     getAllMock.mockReturnValue([{provider: 'anthropic', id: 'claude-opus-4-8'}]);
 
-    await expect(runAgent(invocation({provider: 'anthropic', model: 'gpt-5.1'}))).rejects.toThrow(
+    await expect(
+      piHarnessAdapter.run(invocation({provider: 'anthropic', model: 'gpt-5.1'})),
+    ).rejects.toThrow(
       new AgentConfigError(
         'Model "gpt-5.1" is not available for provider "anthropic".',
         'model_unavailable',
@@ -689,7 +696,9 @@ describe('runAgent', () => {
     findMock.mockReturnValue({provider: 'openai', id: 'gpt-5.1'});
     hasConfiguredAuthMock.mockReturnValue(false);
 
-    await expect(runAgent(invocation({provider: 'openai', model: 'gpt-5.1'}))).rejects.toThrow(
+    await expect(
+      piHarnessAdapter.run(invocation({provider: 'openai', model: 'gpt-5.1'})),
+    ).rejects.toThrow(
       new AgentConfigError(
         'No credentials configured for provider "openai". ' +
           'Verify the provider is configured for this workspace.',
@@ -709,7 +718,7 @@ describe('runAgent', () => {
         }),
     );
 
-    const promise = runAgent(invocation({signal: ac.signal}));
+    const promise = piHarnessAdapter.run(invocation({signal: ac.signal}));
     await vi.waitFor(() => expect(promptMock).toHaveBeenCalled());
     ac.abort();
 
@@ -728,7 +737,7 @@ describe('runAgent', () => {
         }),
     );
 
-    const promise = runAgent(invocation({signal: ac.signal}));
+    const promise = piHarnessAdapter.run(invocation({signal: ac.signal}));
     await vi.waitFor(() => expect(createAgentSessionMock).toHaveBeenCalled());
     ac.abort();
     resolveCreate({session: {prompt: promptMock, abort: abortMock, messages: []}});
@@ -742,7 +751,7 @@ describe('runAgent', () => {
     const ac = new AbortController();
     ac.abort();
 
-    await expect(runAgent(invocation({signal: ac.signal}))).rejects.toThrow('aborted');
+    await expect(piHarnessAdapter.run(invocation({signal: ac.signal}))).rejects.toThrow('aborted');
     expect(createAgentSessionMock).not.toHaveBeenCalled();
   });
 });

--- a/libs/runner/agent/src/core/pi-adapter.ts
+++ b/libs/runner/agent/src/core/pi-adapter.ts
@@ -18,6 +18,7 @@ import {
 import {assertEgressAllowed, EgressDeniedError} from '@shipfox/node-egress-guard';
 import {runnerEgressPolicy} from '#config.js';
 import {AgentConfigError} from '#core/errors.js';
+import type {HarnessAdapter, HarnessInvocation, HarnessResult} from '#core/harness.js';
 import {type SessionForwarder, startSessionForwarder} from '#core/session-forwarder.js';
 
 const KEYLESS_CUSTOM_PROVIDER_API_KEY = 'shipfox-keyless-custom-provider-placeholder';
@@ -28,23 +29,7 @@ type ModelRegistryInstance = ReturnType<typeof ModelRegistry.create>;
 type CustomProviderConfig = Parameters<ModelRegistryInstance['registerProvider']>[1];
 type CustomProviderModel = NonNullable<CustomProviderConfig['models']>[number];
 
-export interface AgentInvocation {
-  readonly cwd: string;
-  readonly model: string;
-  readonly provider: string;
-  readonly thinking: string;
-  readonly prompt: string;
-  readonly credentials: Record<string, string>;
-  readonly customProvider?: CustomModelProviderRuntimeConfigDto | undefined;
-  readonly gitConfigGlobal?: string | undefined;
-  readonly signal: AbortSignal;
-  /**
-   * Forwards each verbatim pi session entry line as it is persisted, in order. Best-effort
-   * observability: when absent (or the session is not persisted), forwarding is skipped and
-   * the step is unaffected.
-   */
-  readonly onSessionEntry?: (line: string) => void;
-}
+export const piHarnessAdapter: HarnessAdapter = {run: runPiAgent};
 
 /**
  * Runs the pi coding agent for one step. Resolves when the agent's turn completes and
@@ -54,7 +39,7 @@ export interface AgentInvocation {
  * The returned `summary` is the agent's final assistant message, kept runner-local for
  * observability and never sent to the API, so it is optional.
  */
-export async function runAgent(invocation: AgentInvocation): Promise<{summary?: string}> {
+async function runPiAgent(invocation: HarnessInvocation): Promise<HarnessResult> {
   const {
     cwd,
     model: modelId,

--- a/libs/runner/agent/src/core/step.test.ts
+++ b/libs/runner/agent/src/core/step.test.ts
@@ -1,10 +1,10 @@
 const {runAgentMock} = vi.hoisted(() => ({runAgentMock: vi.fn()}));
 
-vi.mock('#core/run-agent.js', () => ({runAgent: runAgentMock}));
+vi.mock('#core/pi-adapter.js', () => ({piHarnessAdapter: {run: runAgentMock}}));
 
 import type {StepDto} from '@shipfox/api-workflows-dto';
 import {AgentConfigError} from '#core/errors.js';
-import type {AgentInvocation} from '#core/run-agent.js';
+import type {HarnessInvocation} from '#core/harness.js';
 import {executeAgentStep} from '#core/step.js';
 
 const RUNTIME = {
@@ -175,6 +175,22 @@ describe('executeAgentStep', () => {
     });
   });
 
+  it('fails unsupported harnesses without falling back to pi', async () => {
+    const result = await executeAgentStep(buildAgentStep(), {
+      runtime: {...RUNTIME, harness: 'claude'},
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toEqual({
+      message:
+        'Harness "claude" is not supported by this runner build ' +
+        '(available once the Claude adapter ships).',
+      reason: 'agent_config_invalid',
+      agent_config_issue: 'step_config_invalid',
+    });
+    expect(runAgentMock).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-agent step type without running the agent', async () => {
     const result = await executeAgentStep(buildAgentStep({type: 'run', config: {run: 'x'}}), {
       runtime: RUNTIME,
@@ -199,7 +215,7 @@ describe('executeAgentStep', () => {
   it('returns promptly when the signal aborts even if the agent run never resolves', async () => {
     const ac = new AbortController();
     let sawSignal: AbortSignal | undefined;
-    runAgentMock.mockImplementation((invocation: AgentInvocation) => {
+    runAgentMock.mockImplementation((invocation: HarnessInvocation) => {
       sawSignal = invocation.signal;
       // Never settles, proving executeAgentStep returns via the abort race, not the run.
       return new Promise<never>(() => {

--- a/libs/runner/agent/src/core/step.ts
+++ b/libs/runner/agent/src/core/step.ts
@@ -7,7 +7,15 @@ import type {
 } from '@shipfox/api-workflows-dto';
 import type {StepResult} from '@shipfox/runner-execution';
 import {AgentConfigError} from '#core/errors.js';
-import {runAgent} from '#core/run-agent.js';
+import type {HarnessAdapter} from '#core/harness.js';
+import {piHarnessAdapter} from '#core/pi-adapter.js';
+
+// When ENG-807 adds the Claude adapter, import it lazily with dynamic import so the
+// Claude SDK and bundled native binary never load on the pi/run path.
+const HARNESS_ADAPTERS: Record<Harness, HarnessAdapter | null> = {
+  pi: piHarnessAdapter,
+  claude: null,
+};
 
 export function executeAgentStep(
   step: StepDto,
@@ -41,8 +49,9 @@ export function executeAgentStep(
     );
   }
 
-  return runAgentStep({
+  return runSelectedHarness({
     cwd: options.cwd ?? process.cwd(),
+    harness: options.runtime.harness,
     model: options.runtime.model,
     prompt,
     thinking: options.runtime.thinking,
@@ -55,8 +64,9 @@ export function executeAgentStep(
   });
 }
 
-async function runAgentStep(params: {
+async function runSelectedHarness(params: {
   cwd: string;
+  harness: Harness;
   model: string;
   prompt: string;
   thinking: string;
@@ -69,6 +79,7 @@ async function runAgentStep(params: {
 }): Promise<StepResult> {
   const {
     cwd,
+    harness,
     model,
     prompt,
     thinking,
@@ -81,8 +92,9 @@ async function runAgentStep(params: {
   const signal = params.signal ?? new AbortController().signal;
 
   try {
+    const adapter = selectHarnessAdapter(harness);
     const {summary} = await raceAbort(
-      runAgent({
+      adapter.run({
         cwd,
         model,
         provider,
@@ -108,13 +120,31 @@ async function runAgentStep(params: {
   }
 }
 
+// executeAgentStep(step, {runtime.harness, ...})
+//   -> validate step type + prompt
+//   -> selectHarnessAdapter(runtime.harness)
+//      -> pi: piHarnessAdapter.run(invocation)
+//      -> claude: null -> AgentConfigError until ENG-807 ships
+//      -> future harness: compile error until listed in this Record
+//   -> raceAbort(adapter.run(...), signal)
+function selectHarnessAdapter(harness: Harness): HarnessAdapter {
+  const adapter = HARNESS_ADAPTERS[harness];
+  if (adapter === null) {
+    throw new AgentConfigError(
+      `Harness "${harness}" is not supported by this runner build ` +
+        '(available once the Claude adapter ships).',
+    );
+  }
+  return adapter;
+}
+
 // pi has no built-in timeout and may not reject session.prompt() the instant we
-// abort. Racing the runAgent call against the abort signal guarantees the step loop
-// reaches its abort-before-report guard in seconds instead of hanging until lease
-// expiry; runAgent still calls session.abort() to stop the agent's own work.
+// abort. Racing the adapter run call against the abort signal guarantees the step
+// loop reaches its abort-before-report guard in seconds instead of hanging until
+// lease expiry; the pi adapter still calls session.abort() to stop the agent's own work.
 function raceAbort<T>(work: Promise<T>, signal: AbortSignal): Promise<T> {
   if (signal.aborted) {
-    // `work` (the runAgent call) is already in flight; attach a no-op catch so its
+    // `work` (the adapter run call) is already in flight; attach a no-op catch so its
     // eventual rejection can't surface as an unhandled rejection on the aborted path.
     void work.catch(() => undefined);
     return Promise.reject(abortError());


### PR DESCRIPTION
Add an internal harness adapter seam for runner agent steps and move the existing pi execution behind a pi adapter.

Agent step runtime config already carries `runtime.harness`, but the runner ignored it and always invoked pi. This makes selection explicit so pi behavior stays unchanged while unsupported Claude steps fail fast with a user-fixable config error instead of silently running the wrong engine.

The registry is exhaustive over the shared `Harness` enum and leaves Claude unwired until the Claude adapter lands. That follow-up should lazy-load the Claude adapter so its SDK and native binary do not load on the pi path.

Closes ENG-804

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a harness adapter seam in the runner and moves PI execution behind a `pi` adapter. The runner now honors `runtime.harness`; unsupported `claude` steps fail fast with a clear config error. Addresses ENG-804.

- New Features
  - Introduced `HarnessAdapter` with shared invocation/result types; wired `pi` via `piHarnessAdapter`.
  - Selected harness comes from `runtime.harness`; registry is exhaustive over the `Harness` enum, with `claude` intentionally unwired for now.
  - Step execution races adapter runs against abort for responsive cancellation.

- Migration
  - Ensure agent steps use `runtime.harness: 'pi'` (or omit to keep current behavior) until the Claude adapter ships.
  - If you set `harness: 'claude'` before, runs will now error. Switch to `'pi'` or wait for the Claude adapter.

<sup>Written for commit eb95718badc086e549689652105e9b64b125c281. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

