### PR TITLE
[runner] Guard empty reconcile snapshots

### DIFF
--- a/libs/api/runners/src/db/provisioned-runners.test.ts
+++ b/libs/api/runners/src/db/provisioned-runners.test.ts
@@ -1290,7 +1290,7 @@ describe('reconcileProvisionedRunners', () => {
     const result = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1303,6 +1303,31 @@ describe('reconcileProvisionedRunners', () => {
     expect(reservation?.count).toBe(1);
   });
 
+  it('treats an empty observed set as read-only', async () => {
+    const reservationId = await createReservation(2);
+    await createProvisionedRunner({
+      provisionedRunnerId: 'provisioned-runner-1',
+      reservationId,
+      reportedAt: staleReportedAt(),
+    });
+
+    const result = await reconcileProvisionedRunners({
+      workspaceId,
+      provisionerId,
+      observedProvisionedRunnerIds: [],
+      terminateGraceSeconds: 60,
+    });
+
+    const [provisionedRunner] = await provisionedRunnerRowsFor({workspaceId, provisionerId});
+    const [reservation] = await reservationRowsFor({workspaceId, provisionerId});
+    expect(result.absentIds).toEqual([]);
+    expect(result.reservationsReleased).toBe(0);
+    expect(provisionedRunner?.state).toBe('running');
+    expect(provisionedRunner?.terminatedAt).toBeNull();
+    expect(provisionedRunner?.reservationReleasedAt).toBeNull();
+    expect(reservation?.count).toBe(2);
+  });
+
   it('keeps fresh absent provisioned runners inside the grace window', async () => {
     await createProvisionedRunner({
       provisionedRunnerId: 'provisioned-runner-1',
@@ -1312,7 +1337,7 @@ describe('reconcileProvisionedRunners', () => {
     const result = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1351,7 +1376,7 @@ describe('reconcileProvisionedRunners', () => {
     const reconcile = reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
     try {
@@ -1370,7 +1395,7 @@ describe('reconcileProvisionedRunners', () => {
     expect(reservation?.count).toBe(1);
   });
 
-  it('terminates only stale rows when the observed set is empty', async () => {
+  it('terminates only stale rows when the observed set is non-empty', async () => {
     await createProvisionedRunner({
       provisionedRunnerId: 'stale-runner',
       reportedAt: staleReportedAt(),
@@ -1383,7 +1408,7 @@ describe('reconcileProvisionedRunners', () => {
     const result = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1427,7 +1452,7 @@ describe('reconcileProvisionedRunners', () => {
     const result = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1454,13 +1479,13 @@ describe('reconcileProvisionedRunners', () => {
     const first = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
     const second = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1495,7 +1520,7 @@ describe('reconcileProvisionedRunners', () => {
     await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1538,7 +1563,7 @@ describe('reconcileProvisionedRunners', () => {
     const result = await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1587,7 +1612,7 @@ describe('reconcileProvisionedRunners', () => {
     await reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
 
@@ -1639,7 +1664,7 @@ describe('reconcileProvisionedRunners', () => {
     const reconcile = reconcileProvisionedRunners({
       workspaceId,
       provisionerId,
-      observedProvisionedRunnerIds: [],
+      observedProvisionedRunnerIds: ['observed-runner'],
       terminateGraceSeconds: 60,
     });
     try {

--- a/libs/api/runners/src/db/provisioned-runners.ts
+++ b/libs/api/runners/src/db/provisioned-runners.ts
@@ -374,58 +374,58 @@ export async function reconcileProvisionedRunners(
   return await db().transaction(async (tx) => {
     await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${params.workspaceId}))`);
 
-    const staleAbsentWhere = and(
-      eq(provisionedRunners.workspaceId, params.workspaceId),
-      eq(provisionedRunners.provisionerId, params.provisionerId),
-      inArray(provisionedRunners.state, activeStates),
-      lt(
-        provisionedRunners.reportedAt,
-        sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
-      ),
-      observedProvisionedRunnerIds.length > 0
-        ? notInArray(provisionedRunners.provisionedRunnerId, observedProvisionedRunnerIds)
-        : undefined,
-    );
-
-    const staleAbsentRows = await tx
-      .select({
-        id: provisionedRunners.id,
-        provisionedRunnerId: provisionedRunners.provisionedRunnerId,
-      })
-      .from(provisionedRunners)
-      .where(staleAbsentWhere);
-
     let absentIds: string[] = [];
     let reservationsReleased = 0;
-    if (staleAbsentRows.length > 0) {
-      const updated = await tx
-        .update(provisionedRunners)
-        .set({
-          state: 'terminated',
-          terminatedAt: sql`coalesce(${provisionedRunners.terminatedAt}, now())`,
-          updatedAt: sql`now()`,
+    if (observedProvisionedRunnerIds.length > 0) {
+      const staleAbsentRows = await tx
+        .select({
+          id: provisionedRunners.id,
+          provisionedRunnerId: provisionedRunners.provisionedRunnerId,
         })
+        .from(provisionedRunners)
         .where(
           and(
-            inArray(
-              provisionedRunners.id,
-              staleAbsentRows.map((row) => row.id),
-            ),
+            eq(provisionedRunners.workspaceId, params.workspaceId),
+            eq(provisionedRunners.provisionerId, params.provisionerId),
             inArray(provisionedRunners.state, activeStates),
             lt(
               provisionedRunners.reportedAt,
               sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
             ),
+            notInArray(provisionedRunners.provisionedRunnerId, observedProvisionedRunnerIds),
           ),
-        )
-        .returning({provisionedRunnerId: provisionedRunners.provisionedRunnerId});
+        );
 
-      absentIds = updated.map((row) => row.provisionedRunnerId);
-      reservationsReleased = await releaseTerminalProvisionedRunnerReservationsByIds(tx, {
-        workspaceId: params.workspaceId,
-        provisionerId: params.provisionerId,
-        provisionedRunnerIds: absentIds,
-      });
+      if (staleAbsentRows.length > 0) {
+        const updated = await tx
+          .update(provisionedRunners)
+          .set({
+            state: 'terminated',
+            terminatedAt: sql`coalesce(${provisionedRunners.terminatedAt}, now())`,
+            updatedAt: sql`now()`,
+          })
+          .where(
+            and(
+              inArray(
+                provisionedRunners.id,
+                staleAbsentRows.map((row) => row.id),
+              ),
+              inArray(provisionedRunners.state, activeStates),
+              lt(
+                provisionedRunners.reportedAt,
+                sql`now() - (${params.terminateGraceSeconds} || ' seconds')::interval`,
+              ),
+            ),
+          )
+          .returning({provisionedRunnerId: provisionedRunners.provisionedRunnerId});
+
+        absentIds = updated.map((row) => row.provisionedRunnerId);
+        reservationsReleased = await releaseTerminalProvisionedRunnerReservationsByIds(tx, {
+          workspaceId: params.workspaceId,
+          provisionerId: params.provisionerId,
+          provisionedRunnerIds: absentIds,
+        });
+      }
     }
 
     const observedRows =

--- a/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
+++ b/libs/api/runners/src/presentation/routes/reconcile-provisioned-runners.test.ts
@@ -17,6 +17,7 @@ import {vi} from '@shipfox/vitest/vi';
 import {and, desc, eq} from 'drizzle-orm';
 import type {FastifyInstance, FastifyRequest} from 'fastify';
 import {db} from '#db/db.js';
+import {provisionedRunners} from '#db/schema/provisioned-runners.js';
 import {reservations} from '#db/schema/reservations.js';
 import {runningJobExecutions} from '#db/schema/running-job-executions.js';
 import {
@@ -192,6 +193,52 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
     expect(intentCalls).toHaveLength(1);
   });
 
+  it('returns an empty result for an empty observed set without reaping absent runners', async () => {
+    const reconcileSpy = vi.spyOn(provisionedRunnerReconcileCallCount, 'add');
+    const reservationId = await createReservation(2);
+    await createProvisionedRunner({
+      provisionedRunnerId: 'provisioned-runner-1',
+      reservationId,
+      reportedAt: new Date(Date.now() - 300_000),
+    });
+    const reconcileCallsBefore = reconcileSpy.mock.calls.length;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/provisioners/provisioned-runners/reconcile',
+      headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
+      payload: {observed_provisioned_runner_ids: []},
+    });
+
+    const [provisionedRunner] = await db()
+      .select()
+      .from(provisionedRunners)
+      .where(
+        and(
+          eq(provisionedRunners.workspaceId, workspaceId),
+          eq(provisionedRunners.provisionerId, provisionerTokenId),
+          eq(provisionedRunners.provisionedRunnerId, 'provisioned-runner-1'),
+        ),
+      );
+    const [reservation] = await db()
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, reservationId));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      runners: [],
+      terminated_absent_provisioned_runner_ids: [],
+    });
+    expect(provisionedRunner?.state).toBe('running');
+    expect(reservation?.count).toBe(2);
+    expect(
+      reconcileSpy.mock.calls
+        .slice(reconcileCallsBefore)
+        .filter(([value, attributes]) => value === 1 && attributes === undefined),
+    ).toHaveLength(1);
+  });
+
   it('increments the reservation release metric when reconcile reaps an absent runner', async () => {
     const reconcileSpy = vi.spyOn(provisionedRunnerReconcileCallCount, 'add');
     const absentSpy = vi.spyOn(provisionedRunnerAbsentTerminatedCount, 'add');
@@ -219,7 +266,7 @@ describe('POST /provisioners/provisioned-runners/reconcile', () => {
       method: 'POST',
       url: '/provisioners/provisioned-runners/reconcile',
       headers: {authorization: `Bearer ${VALID_PROVISIONER_TOKEN}`},
-      payload: {observed_provisioned_runner_ids: []},
+      payload: {observed_provisioned_runner_ids: ['observed-runner']},
     });
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
[runner] Guard empty reconcile snapshots

Provisioners can report an empty observed runner set during startup or transient observation gaps. The previous reconcile query treated that as no observed filter and could terminate every stale owned runner after the grace window.

This makes empty observed sets read-only in the reconcile path while preserving absent-runner termination for non-empty snapshots. Scheduled stale cleanup remains responsible for dead provisioners.

Closes ENG-696

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty provisioner reconcile snapshots as read-only to prevent accidental termination during startup or gaps. Non-empty snapshots still reap stale, absent runners after the grace window. Addresses ENG-696.

- **Bug Fixes**
  - Reconcile logic only terminates stale absent runners when `observedProvisionedRunnerIds` is non-empty; empty sets perform no termination and do not release reservations.
  - Updated tests in DB and route layers to assert read-only behavior for empty snapshots and reaping for non-empty snapshots.
  - Ensured metrics reflect reconcile calls and absent termination counts only when reaping occurs.

<sup>Written for commit ed911973599a412818bba2b9be41a1dbc6cbef47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

