### PR TITLE
Add shared E2E kit UI helpers

### DIFF
--- a/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
+++ b/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
@@ -1,7 +1,4 @@
 import {type AgentHelper, ollamaConfig} from '@shipfox/e2e-helper-agent';
-import type {AuthHelper} from '@shipfox/e2e-helper-auth';
-import type {ProjectsHelper} from '@shipfox/e2e-helper-projects';
-import type {WorkspacesHelper} from '@shipfox/e2e-helper-workspaces';
 import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
@@ -15,30 +12,6 @@ const EDITED_PROVIDER_NAME = 'Local Ollama Edited';
 const DELETE_PROVIDER_ID = 'local-ollama-delete';
 const DELETE_PROVIDER_NAME = 'Local Ollama Delete';
 const PROVIDER_SAVE_TIMEOUT_MS = 75_000;
-
-interface ReadyWorkspace {
-  sessionToken: string;
-  workspaceId: string;
-}
-
-async function createReadyWorkspace(params: {
-  auth: AuthHelper;
-  page: Page;
-  projects: ProjectsHelper;
-  workspaces: WorkspacesHelper;
-  name: string;
-}): Promise<ReadyWorkspace> {
-  const user = await params.auth.createUser();
-  const workspace = await params.workspaces.create({
-    userId: user.user.id,
-    name: params.name,
-  });
-  await params.projects.createProject({workspaceId: workspace.id});
-  const session = await params.auth.createSession({user_id: user.user.id});
-  await params.auth.loginAs(params.page, user);
-
-  return {sessionToken: session.token, workspaceId: workspace.id};
-}
 
 async function gotoModelProviders(page: Page, workspaceId: string) {
   await page.goto(`/workspaces/${workspaceId}/settings/model-providers`);
@@ -82,16 +55,10 @@ async function expectProviderInApi(params: {
 
 test('creates a custom model provider backed by local Ollama', async ({
   page,
-  auth,
   agent,
-  projects,
-  workspaces,
+  createReadyWorkspace,
 }) => {
   const {workspaceId, sessionToken} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Agent Provider Create Workspace',
   });
 
@@ -145,16 +112,10 @@ test('creates a custom model provider backed by local Ollama', async ({
 
 test('edits an existing custom model provider and validates with local Ollama', async ({
   page,
-  auth,
   agent,
-  projects,
-  workspaces,
+  createReadyWorkspace,
 }) => {
   const {workspaceId, sessionToken} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Agent Provider Edit Workspace',
   });
   await agent.createOllamaCustomProvider({
@@ -194,18 +155,8 @@ test('edits an existing custom model provider and validates with local Ollama', 
   });
 });
 
-test('deletes an existing custom model provider', async ({
-  page,
-  auth,
-  agent,
-  projects,
-  workspaces,
-}) => {
+test('deletes an existing custom model provider', async ({page, agent, createReadyWorkspace}) => {
   const {workspaceId, sessionToken} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Agent Provider Delete Workspace',
   });
   await agent.createOllamaCustomProvider({

--- a/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
@@ -1,7 +1,4 @@
-import type {AuthHelper} from '@shipfox/e2e-helper-auth';
-import type {ProjectsHelper} from '@shipfox/e2e-helper-projects';
 import {mintManualRegistrationToken, mintProvisionerToken} from '@shipfox/e2e-helper-runners';
-import type {WorkspacesHelper} from '@shipfox/e2e-helper-workspaces';
 import type {Page} from '@shipfox/playwright';
 import {argosScreenshot} from '@shipfox/playwright';
 import {createShipfoxTokenPrefixRegexes} from '@shipfox/regex';
@@ -16,30 +13,6 @@ const VISUAL_TEST_PROVISIONER_TOKEN_PREFIX = 'sf_pt_visual';
 const VISUAL_TEST_PROVISIONER_TOKEN = 'sf_pt_visual_regression_token';
 const VISUAL_TEST_CREATED_AT = 'Jan 15, 2026, 12:00 PM';
 const VISUAL_TEST_EXPIRES_AT = 'Jan 16, 2026, 12:00 PM';
-
-interface ReadyWorkspace {
-  userToken: string;
-  workspaceId: string;
-}
-
-async function createReadyWorkspace(params: {
-  auth: AuthHelper;
-  page: Page;
-  projects: ProjectsHelper;
-  workspaces: WorkspacesHelper;
-  name: string;
-}): Promise<ReadyWorkspace> {
-  const user = await params.auth.createUser();
-  const workspace = await params.workspaces.create({
-    userId: user.user.id,
-    name: params.name,
-  });
-  await params.projects.createProject({workspaceId: workspace.id});
-  const session = await params.auth.createSession({user_id: user.user.id});
-  await params.auth.loginAs(params.page, user);
-
-  return {userToken: session.token, workspaceId: workspace.id};
-}
 
 function manualTokensSection(page: Page) {
   return page.locator('section', {hasText: 'Runner registration tokens'});
@@ -101,18 +74,12 @@ async function normalizeProvisionerTokenRowForVisuals(
 
 test('creates a manual runner registration token from settings', async ({
   page,
-  auth,
-  projects,
-  workspaces,
+  createReadyWorkspace,
 }) => {
   test.setTimeout(60_000);
 
   await page.clock.setFixedTime(VISUAL_TEST_NOW);
   const {workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Manual Token Create Workspace',
   });
 
@@ -153,15 +120,9 @@ test('creates a manual runner registration token from settings', async ({
 
 test('revokes a manual runner registration token from settings', async ({
   page,
-  auth,
-  projects,
-  workspaces,
+  createReadyWorkspace,
 }) => {
-  const {userToken, workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
+  const {sessionToken: userToken, workspaceId} = await createReadyWorkspace({
     name: 'Manual Token Revoke Workspace',
   });
   await mintManualRegistrationToken({
@@ -199,18 +160,12 @@ test('revokes a manual runner registration token from settings', async ({
 
 test('creates a provisioner registration token from settings', async ({
   page,
-  auth,
-  projects,
-  workspaces,
+  createReadyWorkspace,
 }) => {
   test.setTimeout(60_000);
 
   await page.clock.setFixedTime(VISUAL_TEST_NOW);
   const {workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Provisioner Token Create Workspace',
   });
 
@@ -253,15 +208,9 @@ test('creates a provisioner registration token from settings', async ({
 
 test('revokes a provisioner registration token from settings', async ({
   page,
-  auth,
-  projects,
-  workspaces,
+  createReadyWorkspace,
 }) => {
-  const {userToken, workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
+  const {sessionToken: userToken, workspaceId} = await createReadyWorkspace({
     name: 'Provisioner Token Revoke Workspace',
   });
   await mintProvisionerToken({

--- a/e2e/client/secrets/tests/secrets-settings.e2e.ts
+++ b/e2e/client/secrets/tests/secrets-settings.e2e.ts
@@ -1,6 +1,3 @@
-import type {AuthHelper} from '@shipfox/e2e-helper-auth';
-import type {ProjectsHelper} from '@shipfox/e2e-helper-projects';
-import type {WorkspacesHelper} from '@shipfox/e2e-helper-workspaces';
 import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
@@ -10,29 +7,6 @@ const SECRET_DELETE_KEY = 'E2E_SECRET_DELETE';
 const VARIABLE_CREATE_KEY = 'E2E_VARIABLE_CREATE';
 const VARIABLE_EDIT_KEY = 'E2E_VARIABLE_EDIT';
 const VARIABLE_DELETE_KEY = 'E2E_VARIABLE_DELETE';
-
-interface ReadyWorkspace {
-  userId: string;
-  workspaceId: string;
-}
-
-async function createReadyWorkspace(params: {
-  auth: AuthHelper;
-  page: Page;
-  projects: ProjectsHelper;
-  workspaces: WorkspacesHelper;
-  name: string;
-}): Promise<ReadyWorkspace> {
-  const user = await params.auth.createUser();
-  const workspace = await params.workspaces.create({
-    userId: user.user.id,
-    name: params.name,
-  });
-  await params.projects.createProject({workspaceId: workspace.id});
-  await params.auth.loginAs(params.page, user);
-
-  return {userId: user.user.id, workspaceId: workspace.id};
-}
 
 function secretsSection(page: Page) {
   return page.locator('section[aria-label="Secrets"]');
@@ -86,12 +60,8 @@ async function createVariableFromSettings(page: Page, key: string, value: string
   await expect(rowByKey(section, key)).toBeVisible();
 }
 
-test('creates a workspace secret from settings', async ({page, auth, projects, workspaces}) => {
+test('creates a workspace secret from settings', async ({page, createReadyWorkspace}) => {
   const {workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Secrets Create Workspace',
   });
   const value = 'secret-create-value-e2e';
@@ -105,18 +75,8 @@ test('creates a workspace secret from settings', async ({page, auth, projects, w
   await expect(secretsSection(page)).not.toContainText(value);
 });
 
-test('edits a workspace secret from settings', async ({
-  page,
-  auth,
-  projects,
-  workspaces,
-  secrets,
-}) => {
+test('edits a workspace secret from settings', async ({page, secrets, createReadyWorkspace}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Secrets Edit Workspace',
   });
   const oldValue = 'secret-edit-old-value-e2e';
@@ -145,18 +105,8 @@ test('edits a workspace secret from settings', async ({
   await expect(secretsSection(page)).not.toContainText(newValue);
 });
 
-test('deletes a workspace secret from settings', async ({
-  page,
-  auth,
-  projects,
-  workspaces,
-  secrets,
-}) => {
+test('deletes a workspace secret from settings', async ({page, secrets, createReadyWorkspace}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Secrets Delete Workspace',
   });
   await secrets.createSecret({
@@ -179,12 +129,8 @@ test('deletes a workspace secret from settings', async ({
   await expect(section.getByText('No secrets yet')).toBeVisible();
 });
 
-test('creates a workspace variable from settings', async ({page, auth, projects, workspaces}) => {
+test('creates a workspace variable from settings', async ({page, createReadyWorkspace}) => {
   const {workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Variables Create Workspace',
   });
   const value = 'debug';
@@ -197,18 +143,8 @@ test('creates a workspace variable from settings', async ({page, auth, projects,
   await expect(row.getByText(value, {exact: true})).toBeVisible();
 });
 
-test('edits a workspace variable from settings', async ({
-  page,
-  auth,
-  projects,
-  workspaces,
-  secrets,
-}) => {
+test('edits a workspace variable from settings', async ({page, secrets, createReadyWorkspace}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Variables Edit Workspace',
   });
   const oldValue = 'info';
@@ -240,16 +176,10 @@ test('edits a workspace variable from settings', async ({
 
 test('deletes a workspace variable from settings', async ({
   page,
-  auth,
-  projects,
-  workspaces,
   secrets,
+  createReadyWorkspace,
 }) => {
   const {userId, workspaceId} = await createReadyWorkspace({
-    page,
-    auth,
-    projects,
-    workspaces,
     name: 'Variables Delete Workspace',
   });
   await secrets.createVariable({

--- a/e2e/kit/package.json
+++ b/e2e/kit/package.json
@@ -33,6 +33,16 @@
         "default": "./dist/fixtures/index.js"
       }
     },
+    "./ui": {
+      "development": {
+        "types": "./src/ui/index.ts",
+        "default": "./src/ui/index.ts"
+      },
+      "default": {
+        "types": "./dist/ui/index.d.ts",
+        "default": "./dist/ui/index.js"
+      }
+    },
     "./global-setup": {
       "development": {
         "types": "./src/setup/global-setup.ts",
@@ -58,6 +68,8 @@
     "build": "shipfox-swc",
     "check": "shipfox-biome-check",
     "check:fix": "shipfox-biome-check --write",
+    "test": "shipfox-vitest-run",
+    "test:watch": "shipfox-vitest-watch",
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
@@ -72,6 +84,7 @@
     "@shipfox/biome": "workspace:*",
     "@shipfox/swc": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
-    "@shipfox/typescript": "workspace:*"
+    "@shipfox/typescript": "workspace:*",
+    "@shipfox/vitest": "workspace:*"
   }
 }

--- a/e2e/kit/src/fixtures/index.ts
+++ b/e2e/kit/src/fixtures/index.ts
@@ -1,4 +1,11 @@
 export {
+  type CreateReadyWorkspace,
+  type CreateReadyWorkspaceParams,
+  type ReadyWorkspace,
+  type ReadyWorkspaceFixtures,
+  readyWorkspaceFixtures,
+} from './ready-workspace.js';
+export {
   type AuthWorkspaceFixtures,
   authWorkspaceFixtures,
   type WorkspaceFixtures,

--- a/e2e/kit/src/fixtures/ready-workspace.test.ts
+++ b/e2e/kit/src/fixtures/ready-workspace.test.ts
@@ -1,0 +1,52 @@
+import {beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+import {type CreateReadyWorkspace, readyWorkspaceFixtures} from './ready-workspace.js';
+
+describe('createReadyWorkspace fixture', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a user, workspace, project, session, and browser login', async () => {
+    const user = {user: {id: 'user-1'}};
+    const workspace = {id: 'workspace-1'};
+    const project = {id: 'project-1'};
+    const session = {token: 'session-token'};
+    const page = {};
+    const auth = {
+      createUser: vi.fn().mockResolvedValue(user),
+      createSession: vi.fn().mockResolvedValue(session),
+      loginAs: vi.fn().mockResolvedValue(undefined),
+    };
+    const workspaces = {
+      create: vi.fn().mockResolvedValue(workspace),
+    };
+    const projects = {
+      createProject: vi.fn().mockResolvedValue(project),
+    };
+    let createReadyWorkspace: CreateReadyWorkspace | undefined;
+    await readyWorkspaceFixtures.createReadyWorkspace(
+      {auth, workspaces, projects, page} as never,
+      (create) => {
+        createReadyWorkspace = create;
+        return Promise.resolve();
+      },
+    );
+
+    const result = await createReadyWorkspace?.({name: 'Ready Workspace'});
+
+    expect(auth.createUser).toHaveBeenCalledWith();
+    expect(workspaces.create).toHaveBeenCalledWith({
+      userId: 'user-1',
+      name: 'Ready Workspace',
+    });
+    expect(projects.createProject).toHaveBeenCalledWith({workspaceId: 'workspace-1'});
+    expect(auth.createSession).toHaveBeenCalledWith({user_id: 'user-1'});
+    expect(auth.loginAs).toHaveBeenCalledWith(page, user);
+    expect(result).toEqual({
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+      projectId: 'project-1',
+      sessionToken: 'session-token',
+    });
+  });
+});

--- a/e2e/kit/src/fixtures/ready-workspace.ts
+++ b/e2e/kit/src/fixtures/ready-workspace.ts
@@ -19,18 +19,20 @@ export interface ReadyWorkspaceFixtures {
 }
 
 async function createReadyWorkspace(params: {
-  fixtures: WorkspaceFixtures;
+  auth: WorkspaceFixtures['auth'];
+  workspaces: WorkspaceFixtures['workspaces'];
+  projects: WorkspaceFixtures['projects'];
   page: Page;
   workspace: CreateReadyWorkspaceParams | undefined;
 }): Promise<ReadyWorkspace> {
-  const user = await params.fixtures.auth.createUser();
-  const workspace = await params.fixtures.workspaces.create({
+  const user = await params.auth.createUser();
+  const workspace = await params.workspaces.create({
     userId: user.user.id,
     ...(params.workspace?.name === undefined ? {} : {name: params.workspace.name}),
   });
-  const project = await params.fixtures.projects.createProject({workspaceId: workspace.id});
-  const session = await params.fixtures.auth.createSession({user_id: user.user.id});
-  await params.fixtures.auth.loginAs(params.page, user);
+  const project = await params.projects.createProject({workspaceId: workspace.id});
+  const session = await params.auth.createSession({user_id: user.user.id});
+  await params.auth.loginAs(params.page, user);
 
   return {
     userId: user.user.id,
@@ -42,9 +44,9 @@ async function createReadyWorkspace(params: {
 
 export const readyWorkspaceFixtures = {
   createReadyWorkspace: async (
-    fixtures: WorkspaceFixtures & {page: Page},
+    {auth, workspaces, projects, page}: WorkspaceFixtures & {page: Page},
     use: (create: CreateReadyWorkspace) => Promise<void>,
   ) => {
-    await use((workspace) => createReadyWorkspace({fixtures, page: fixtures.page, workspace}));
+    await use((workspace) => createReadyWorkspace({auth, workspaces, projects, page, workspace}));
   },
 };

--- a/e2e/kit/src/fixtures/ready-workspace.ts
+++ b/e2e/kit/src/fixtures/ready-workspace.ts
@@ -1,0 +1,50 @@
+import type {Page} from '@shipfox/playwright';
+import type {WorkspaceFixtures} from './workspace.js';
+
+export interface ReadyWorkspace {
+  userId: string;
+  workspaceId: string;
+  projectId: string;
+  sessionToken: string;
+}
+
+export interface CreateReadyWorkspaceParams {
+  name?: string;
+}
+
+export type CreateReadyWorkspace = (params?: CreateReadyWorkspaceParams) => Promise<ReadyWorkspace>;
+
+export interface ReadyWorkspaceFixtures {
+  createReadyWorkspace: CreateReadyWorkspace;
+}
+
+async function createReadyWorkspace(params: {
+  fixtures: WorkspaceFixtures;
+  page: Page;
+  workspace: CreateReadyWorkspaceParams | undefined;
+}): Promise<ReadyWorkspace> {
+  const user = await params.fixtures.auth.createUser();
+  const workspace = await params.fixtures.workspaces.create({
+    userId: user.user.id,
+    ...(params.workspace?.name === undefined ? {} : {name: params.workspace.name}),
+  });
+  const project = await params.fixtures.projects.createProject({workspaceId: workspace.id});
+  const session = await params.fixtures.auth.createSession({user_id: user.user.id});
+  await params.fixtures.auth.loginAs(params.page, user);
+
+  return {
+    userId: user.user.id,
+    workspaceId: workspace.id,
+    projectId: project.id,
+    sessionToken: session.token,
+  };
+}
+
+export const readyWorkspaceFixtures = {
+  createReadyWorkspace: async (
+    fixtures: WorkspaceFixtures & {page: Page},
+    use: (create: CreateReadyWorkspace) => Promise<void>,
+  ) => {
+    await use((workspace) => createReadyWorkspace({fixtures, page: fixtures.page, workspace}));
+  },
+};

--- a/e2e/kit/src/fixtures/workspace.ts
+++ b/e2e/kit/src/fixtures/workspace.ts
@@ -1,6 +1,7 @@
 import {type AuthFixtures, authHelper} from '@shipfox/e2e-helper-auth';
 import {type ProjectsFixtures, projectsHelper} from '@shipfox/e2e-helper-projects';
 import {type WorkspacesFixtures, workspacesHelper} from '@shipfox/e2e-helper-workspaces';
+import {type ReadyWorkspaceFixtures, readyWorkspaceFixtures} from './ready-workspace.js';
 
 export type AuthWorkspaceFixtures = AuthFixtures & WorkspacesFixtures;
 
@@ -9,9 +10,10 @@ export const authWorkspaceFixtures = {
   ...workspacesHelper,
 };
 
-export type WorkspaceFixtures = AuthWorkspaceFixtures & ProjectsFixtures;
+export type WorkspaceFixtures = AuthWorkspaceFixtures & ProjectsFixtures & ReadyWorkspaceFixtures;
 
 export const workspaceFixtures = {
   ...authWorkspaceFixtures,
   ...projectsHelper,
+  ...readyWorkspaceFixtures,
 };

--- a/e2e/kit/src/ui/index.ts
+++ b/e2e/kit/src/ui/index.ts
@@ -1,0 +1,12 @@
+export {
+  DataTableRow,
+  Dialog,
+  SETTINGS_TAB_LABELS,
+  SettingsShell,
+  type SettingsTab,
+  settingsPath,
+  Toast,
+  TopNav,
+  WorkspaceSwitcher,
+} from './page-objects.js';
+export {type StableReplacement, stableScreenshot} from './stable-screenshot.js';

--- a/e2e/kit/src/ui/page-objects.test.ts
+++ b/e2e/kit/src/ui/page-objects.test.ts
@@ -1,0 +1,142 @@
+import {beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+
+const expectMock = vi.fn();
+const toHaveURL = vi.fn();
+const toBeVisible = vi.fn();
+const toHaveAttribute = vi.fn();
+
+type SettingsTab =
+  | 'members'
+  | 'runners'
+  | 'provisioners'
+  | 'model-providers'
+  | 'secrets'
+  | 'variables'
+  | 'integrations'
+  | 'events';
+
+const settingsTabLabels: Record<SettingsTab, string> = {
+  members: 'Members',
+  runners: 'Runners',
+  provisioners: 'Runner provisioners',
+  'model-providers': 'Model providers',
+  secrets: 'Secrets',
+  variables: 'Variables',
+  integrations: 'Integrations',
+  events: 'Events',
+};
+
+function settingsPath(workspaceId: string, tab: SettingsTab): string {
+  return `/workspaces/${workspaceId}/settings/${tab}`;
+}
+
+function locator(name: string) {
+  return {
+    name,
+    click: vi.fn(),
+    fill: vi.fn(),
+    innerText: vi.fn(),
+    getByLabel: vi.fn((label: unknown) => locator(`label:${String(label)}`)),
+    getByRole: vi.fn((role: string, options?: {name?: unknown}) =>
+      locator(`${role}:${String(options?.name)}`),
+    ),
+    getByText: vi.fn((text: unknown) => locator(`text:${String(text)}`)),
+    locator: vi.fn((selector: string) => locator(selector)),
+    nth: vi.fn((index: number) => locator(`nth:${index}`)),
+  };
+}
+
+function page() {
+  return {
+    goto: vi.fn(),
+    getByLabel: vi.fn((label: unknown) => locator(`label:${String(label)}`)),
+    getByPlaceholder: vi.fn((placeholder: string) => locator(`placeholder:${placeholder}`)),
+    getByRole: vi.fn((role: string, options?: {name?: unknown}) =>
+      locator(`${role}:${String(options?.name)}`),
+    ),
+    getByText: vi.fn((text: unknown) => locator(`text:${String(text)}`)),
+  };
+}
+
+describe('ui page objects', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    expectMock.mockReturnValue({toHaveURL, toBeVisible, toHaveAttribute});
+    vi.doMock('@shipfox/playwright', () => ({
+      expect: expectMock,
+    }));
+  });
+
+  it('exposes the top-nav accessible labels', async () => {
+    const pageObject = page();
+    const {TopNav} = await import('./page-objects.js');
+    const nav = new TopNav(pageObject as never);
+
+    nav.currentWorkspace('Platform');
+    nav.workspaceSwitcherTrigger();
+    nav.projectSwitcherTrigger();
+    nav.userMenuTrigger();
+
+    expect(pageObject.getByRole).toHaveBeenCalledWith('link', {name: 'Platform', exact: true});
+    expect(pageObject.getByLabel).toHaveBeenCalledWith('Switch workspace');
+    expect(pageObject.getByLabel).toHaveBeenCalledWith('Switch project');
+    expect(pageObject.getByLabel).toHaveBeenCalledWith('User menu');
+  });
+
+  it('wires workspace switcher controls to stable selectors', async () => {
+    const pageObject = page();
+    const {WorkspaceSwitcher} = await import('./page-objects.js');
+    const switcher = new WorkspaceSwitcher(pageObject as never);
+
+    switcher.searchInput();
+    switcher.workspaceOption('Platform');
+    switcher.createWorkspaceOption();
+
+    expect(pageObject.getByPlaceholder).toHaveBeenCalledWith('Search workspaces...');
+    expect(pageObject.getByRole).toHaveBeenCalledWith('option', {name: 'Platform'});
+    expect(pageObject.getByRole).toHaveBeenCalledWith('option', {name: 'Create workspace'});
+  });
+
+  it.each(
+    Object.entries(settingsTabLabels) as Array<[SettingsTab, string]>,
+  )('maps the %s settings tab to its route and nav label', async (tab, label) => {
+    const pageObject = page();
+    const nav = locator('nav');
+    const link = locator('link');
+    pageObject.getByRole.mockReturnValueOnce(locator('heading')).mockReturnValueOnce(nav);
+    nav.getByRole.mockReturnValue(link);
+    const {SettingsShell} = await import('./page-objects.js');
+    const shell = new SettingsShell(pageObject as never);
+
+    await shell.goto('workspace-1', tab);
+
+    expect(pageObject.goto).toHaveBeenCalledWith(settingsPath('workspace-1', tab));
+    expect(expectMock).toHaveBeenCalledWith(pageObject);
+    expect(toHaveURL).toHaveBeenCalledWith(
+      new RegExp(`${settingsPath('workspace-1', tab)}/?$`, 'u'),
+    );
+    expect(nav.getByRole).toHaveBeenCalledWith('link', {name: label});
+    expect(toHaveAttribute).toHaveBeenCalledWith('aria-current', 'page');
+  });
+
+  it('scopes table row lookups to the parent locator', async () => {
+    const parent = locator('table');
+    const row = locator('row');
+    const cells = locator('cells');
+    const cell = locator('cell');
+    parent.locator.mockReturnValue(row);
+    row.locator.mockReturnValue(cells);
+    cells.nth.mockReturnValue(cell);
+    const {DataTableRow} = await import('./page-objects.js');
+
+    const tableRow = new DataTableRow(parent as never, 'API_TOKEN');
+    tableRow.cell(2);
+    tableRow.actionMenuButton('Actions for API_TOKEN');
+
+    expect(parent.locator).toHaveBeenCalledWith('tr', {hasText: 'API_TOKEN'});
+    expect(row.locator).toHaveBeenCalledWith('td');
+    expect(cells.nth).toHaveBeenCalledWith(2);
+    expect(row.getByRole).toHaveBeenCalledWith('button', {name: 'Actions for API_TOKEN'});
+  });
+});

--- a/e2e/kit/src/ui/page-objects.ts
+++ b/e2e/kit/src/ui/page-objects.ts
@@ -1,0 +1,178 @@
+import {expect, type Page} from '@shipfox/playwright';
+
+type AppLocator = ReturnType<Page['locator']>;
+
+export type SettingsTab =
+  | 'members'
+  | 'runners'
+  | 'provisioners'
+  | 'model-providers'
+  | 'secrets'
+  | 'variables'
+  | 'integrations'
+  | 'events';
+
+export const SETTINGS_TAB_LABELS: Record<SettingsTab, string> = {
+  members: 'Members',
+  runners: 'Runners',
+  provisioners: 'Runner provisioners',
+  'model-providers': 'Model providers',
+  secrets: 'Secrets',
+  variables: 'Variables',
+  integrations: 'Integrations',
+  events: 'Events',
+};
+
+export function settingsPath(workspaceId: string, tab: SettingsTab): string {
+  return `/workspaces/${workspaceId}/settings/${tab}`;
+}
+
+export class TopNav {
+  constructor(private readonly page: Page) {}
+
+  currentWorkspace(name: string): AppLocator {
+    return this.page.getByRole('link', {name, exact: true});
+  }
+
+  workspaceSwitcherTrigger(): AppLocator {
+    return this.page.getByLabel('Switch workspace');
+  }
+
+  projectSwitcherTrigger(): AppLocator {
+    return this.page.getByLabel('Switch project');
+  }
+
+  userMenuTrigger(): AppLocator {
+    return this.page.getByLabel('User menu');
+  }
+}
+
+export class WorkspaceSwitcher {
+  private readonly topNav: TopNav;
+
+  constructor(private readonly page: Page) {
+    this.topNav = new TopNav(page);
+  }
+
+  async open(): Promise<void> {
+    await this.topNav.workspaceSwitcherTrigger().click();
+  }
+
+  searchInput(): AppLocator {
+    return this.page.getByPlaceholder('Search workspaces...');
+  }
+
+  async search(query: string): Promise<void> {
+    await this.searchInput().fill(query);
+  }
+
+  workspaceOption(name: string): AppLocator {
+    return this.page.getByRole('option', {name});
+  }
+
+  async pickWorkspace(name: string): Promise<void> {
+    await this.workspaceOption(name).click();
+  }
+
+  createWorkspaceOption(): AppLocator {
+    return this.page.getByRole('option', {name: 'Create workspace'});
+  }
+
+  async clickCreateWorkspace(): Promise<void> {
+    await this.createWorkspaceOption().click();
+  }
+}
+
+export class SettingsShell {
+  constructor(private readonly page: Page) {}
+
+  async goto(workspaceId: string, tab: SettingsTab): Promise<void> {
+    await this.page.goto(settingsPath(workspaceId, tab));
+    await expect(this.page).toHaveURL(new RegExp(`${settingsPath(workspaceId, tab)}/?$`, 'u'));
+    await expect(this.heading()).toBeVisible();
+    await expect(this.activeNavLink(tab)).toHaveAttribute('aria-current', 'page');
+  }
+
+  heading(): AppLocator {
+    return this.page.getByRole('heading', {name: 'Workspace settings'});
+  }
+
+  nav(): AppLocator {
+    return this.page.getByRole('navigation', {name: 'Workspace settings'});
+  }
+
+  activeNavLink(tab: SettingsTab): AppLocator {
+    return this.nav().getByRole('link', {name: SETTINGS_TAB_LABELS[tab]});
+  }
+}
+
+export class Dialog {
+  constructor(
+    private readonly page: Page,
+    private readonly name: string | RegExp,
+  ) {}
+
+  locator(): AppLocator {
+    return this.page.getByRole('dialog', {name: this.name});
+  }
+
+  field(label: string | RegExp): AppLocator {
+    return this.locator().getByLabel(label);
+  }
+
+  async fill(label: string | RegExp, value: string): Promise<void> {
+    await this.field(label).fill(value);
+  }
+
+  confirmButton(name: string | RegExp): AppLocator {
+    return this.locator().getByRole('button', {name});
+  }
+
+  async confirm(name: string | RegExp): Promise<void> {
+    await this.confirmButton(name).click();
+  }
+
+  async expectVisible(): Promise<void> {
+    await expect(this.locator()).toBeVisible();
+  }
+
+  async expectClosed(): Promise<void> {
+    await expect(this.locator()).toBeHidden();
+  }
+}
+
+export class Toast {
+  constructor(private readonly page: Page) {}
+
+  message(text: string | RegExp): AppLocator {
+    return this.page.getByText(text);
+  }
+
+  async expectVisible(text: string | RegExp): Promise<void> {
+    await expect(this.message(text)).toBeVisible();
+  }
+}
+
+export class DataTableRow {
+  readonly row: AppLocator;
+
+  constructor(parent: AppLocator, text: string | RegExp) {
+    this.row = parent.locator('tr', {hasText: text});
+  }
+
+  cell(index: number): AppLocator {
+    return this.row.locator('td').nth(index);
+  }
+
+  async cellText(index: number): Promise<string> {
+    return await this.cell(index).innerText();
+  }
+
+  actionMenuButton(name: string | RegExp): AppLocator {
+    return this.row.getByRole('button', {name});
+  }
+
+  async openActionMenu(name: string | RegExp): Promise<void> {
+    await this.actionMenuButton(name).click();
+  }
+}

--- a/e2e/kit/src/ui/stable-screenshot.test.ts
+++ b/e2e/kit/src/ui/stable-screenshot.test.ts
@@ -33,18 +33,26 @@ class FakeElement {
 }
 
 class FakeLocator {
-  constructor(private readonly elements: FakeElement[]) {}
+  constructor(
+    private readonly elements: FakeElement[],
+    private readonly failingIndexes = new Set<number>(),
+    private readonly index?: number,
+  ) {}
 
   count(): Promise<number> {
     return Promise.resolve(this.elements.length);
   }
 
   nth(index: number): FakeLocator {
-    return new FakeLocator([this.elements[index] as FakeElement]);
+    return new FakeLocator(this.elements, this.failingIndexes, index);
   }
 
   evaluate<T, A>(callback: (element: FakeElement, arg: A) => T, arg: A): Promise<T> {
-    return Promise.resolve(callback(this.elements[0] as FakeElement, arg));
+    const index = this.index ?? 0;
+    if (this.failingIndexes.has(index)) {
+      return Promise.reject(new Error(`evaluate failed for ${index}`));
+    }
+    return Promise.resolve(callback(this.elements[index] as FakeElement, arg));
   }
 }
 
@@ -99,6 +107,22 @@ describe('stableScreenshot', () => {
 
     await expect(result).rejects.toBe(error);
     expect(element.textContent).toBe('before');
+  });
+
+  it('restores completed replacements when a later replacement fails', async () => {
+    const first = new FakeElement({text: 'first-before'});
+    const second = new FakeElement({text: 'second-before'});
+    const locator = new FakeLocator([first, second], new Set([1]));
+    const {stableScreenshot} = await import('./stable-screenshot.js');
+
+    const result = stableScreenshot({} as never, 'partial-failure', [
+      {locator: locator as never, text: 'during'},
+    ]);
+
+    await expect(result).rejects.toThrow('evaluate failed for 1');
+    expect(argosScreenshot).not.toHaveBeenCalled();
+    expect(first.textContent).toBe('first-before');
+    expect(second.textContent).toBe('second-before');
   });
 
   it('throws clearly when locator counts drift before restore', async () => {

--- a/e2e/kit/src/ui/stable-screenshot.test.ts
+++ b/e2e/kit/src/ui/stable-screenshot.test.ts
@@ -1,0 +1,120 @@
+import {beforeEach, describe, expect, it, vi} from '@shipfox/vitest/vi';
+
+const argosScreenshot = vi.fn();
+
+class FakeElement {
+  textContent: string | null;
+  value?: string;
+  private readonly attributes = new Map<string, string>();
+
+  constructor(params: {
+    text?: string | null;
+    value?: string;
+    attributes?: Record<string, string>;
+  }) {
+    this.textContent = params.text ?? null;
+    if (params.value !== undefined) this.value = params.value;
+    for (const [name, value] of Object.entries(params.attributes ?? {})) {
+      this.attributes.set(name, value);
+    }
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+}
+
+class FakeLocator {
+  constructor(private readonly elements: FakeElement[]) {}
+
+  count(): Promise<number> {
+    return Promise.resolve(this.elements.length);
+  }
+
+  nth(index: number): FakeLocator {
+    return new FakeLocator([this.elements[index] as FakeElement]);
+  }
+
+  evaluate<T, A>(callback: (element: FakeElement, arg: A) => T, arg: A): Promise<T> {
+    return Promise.resolve(callback(this.elements[0] as FakeElement, arg));
+  }
+}
+
+describe('stableScreenshot', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    argosScreenshot.mockReset();
+    argosScreenshot.mockResolvedValue(undefined);
+    vi.doMock('@shipfox/playwright', () => ({
+      argosScreenshot,
+    }));
+  });
+
+  it('applies text, value, and attribute replacements then restores them', async () => {
+    const page = {};
+    const first = new FakeElement({
+      text: 'raw-token',
+      value: 'raw-value',
+      attributes: {'data-token': 'raw'},
+    });
+    const second = new FakeElement({text: 'raw-second'});
+    const locator = new FakeLocator([first, second]);
+    const {stableScreenshot} = await import('./stable-screenshot.js');
+
+    await stableScreenshot(page as never, 'normalized', [
+      {
+        locator: locator as never,
+        text: 'stable-token',
+        value: 'stable-value',
+        attributes: {'data-token': 'stable', 'data-added': 'stable-added'},
+      },
+    ]);
+
+    expect(argosScreenshot).toHaveBeenCalledWith(page, 'normalized');
+    expect(first.textContent).toBe('raw-token');
+    expect(first.value).toBe('raw-value');
+    expect(first.getAttribute('data-token')).toBe('raw');
+    expect(first.getAttribute('data-added')).toBeNull();
+    expect(second.textContent).toBe('raw-second');
+  });
+
+  it('restores replacements when argosScreenshot fails', async () => {
+    const error = new Error('argos failed');
+    argosScreenshot.mockRejectedValueOnce(error);
+    const element = new FakeElement({text: 'before'});
+    const locator = new FakeLocator([element]);
+    const {stableScreenshot} = await import('./stable-screenshot.js');
+
+    const result = stableScreenshot({} as never, 'failure', [
+      {locator: locator as never, text: 'during'},
+    ]);
+
+    await expect(result).rejects.toBe(error);
+    expect(element.textContent).toBe('before');
+  });
+
+  it('throws clearly when locator counts drift before restore', async () => {
+    const elements = [new FakeElement({text: 'before'})];
+    const locator = new FakeLocator(elements);
+    argosScreenshot.mockImplementationOnce(() => {
+      elements.push(new FakeElement({text: 'new'}));
+    });
+    const {stableScreenshot} = await import('./stable-screenshot.js');
+
+    const result = stableScreenshot({} as never, 'drift', [
+      {locator: locator as never, text: 'during'},
+    ]);
+
+    await expect(result).rejects.toThrow(
+      'Cannot restore stable screenshot replacements: locator matched 2 elements after capture, but matched 1 before capture.',
+    );
+  });
+});

--- a/e2e/kit/src/ui/stable-screenshot.ts
+++ b/e2e/kit/src/ui/stable-screenshot.ts
@@ -34,21 +34,28 @@ export async function stableScreenshot(
   name: string,
   replacements: StableReplacement[] = [],
 ): Promise<void> {
-  const snapshots = await applyReplacements(replacements);
+  const snapshots: LocatorSnapshot[] = [];
 
   try {
+    await applyReplacements(replacements, snapshots);
     await argosScreenshot(page, name);
   } finally {
-    await restoreSnapshots(snapshots);
+    if (snapshots.length > 0) await restoreSnapshots(snapshots);
   }
 }
 
-async function applyReplacements(replacements: StableReplacement[]): Promise<LocatorSnapshot[]> {
-  const snapshots: LocatorSnapshot[] = [];
-
+async function applyReplacements(
+  replacements: StableReplacement[],
+  snapshots: LocatorSnapshot[],
+): Promise<void> {
   for (const replacement of replacements) {
     const count = await replacement.locator.count();
-    const elements: ElementSnapshot[] = [];
+    const locatorSnapshot: LocatorSnapshot = {
+      locator: replacement.locator,
+      count,
+      elements: [],
+    };
+    snapshots.push(locatorSnapshot);
 
     for (let index = 0; index < count; index += 1) {
       const locator = replacement.locator.nth(index);
@@ -85,6 +92,7 @@ async function applyReplacements(replacements: StableReplacement[]): Promise<Loc
           valueReplacement: replacement.value,
         },
       );
+      locatorSnapshot.elements.push(snapshot);
 
       if (replacement.attributes) {
         await locator.evaluate((element: MutableElement, attributes: Record<string, string>) => {
@@ -93,14 +101,8 @@ async function applyReplacements(replacements: StableReplacement[]): Promise<Loc
           }
         }, replacement.attributes);
       }
-
-      elements.push(snapshot);
     }
-
-    snapshots.push({locator: replacement.locator, count, elements});
   }
-
-  return snapshots;
 }
 
 async function restoreSnapshots(snapshots: LocatorSnapshot[]): Promise<void> {
@@ -112,7 +114,7 @@ async function restoreSnapshots(snapshots: LocatorSnapshot[]): Promise<void> {
       );
     }
 
-    for (let index = 0; index < snapshot.count; index += 1) {
+    for (let index = 0; index < snapshot.elements.length; index += 1) {
       await snapshot.locator
         .nth(index)
         .evaluate((element: MutableElement, previous: ElementSnapshot) => {

--- a/e2e/kit/src/ui/stable-screenshot.ts
+++ b/e2e/kit/src/ui/stable-screenshot.ts
@@ -1,0 +1,129 @@
+import {argosScreenshot, type Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+
+interface MutableElement {
+  textContent: string | null;
+  value?: string;
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+}
+
+export interface StableReplacement {
+  locator: Locator;
+  text?: string;
+  attributes?: Record<string, string>;
+  value?: string;
+}
+
+interface ElementSnapshot {
+  text?: string | null;
+  value?: string;
+  attributes: Record<string, string | null>;
+}
+
+interface LocatorSnapshot {
+  locator: Locator;
+  count: number;
+  elements: ElementSnapshot[];
+}
+
+export async function stableScreenshot(
+  page: Page,
+  name: string,
+  replacements: StableReplacement[] = [],
+): Promise<void> {
+  const snapshots = await applyReplacements(replacements);
+
+  try {
+    await argosScreenshot(page, name);
+  } finally {
+    await restoreSnapshots(snapshots);
+  }
+}
+
+async function applyReplacements(replacements: StableReplacement[]): Promise<LocatorSnapshot[]> {
+  const snapshots: LocatorSnapshot[] = [];
+
+  for (const replacement of replacements) {
+    const count = await replacement.locator.count();
+    const elements: ElementSnapshot[] = [];
+
+    for (let index = 0; index < count; index += 1) {
+      const locator = replacement.locator.nth(index);
+      const snapshot = await locator.evaluate(
+        (
+          element: MutableElement,
+          options: {
+            textReplacement: string | undefined;
+            attributeNames: string[];
+            valueReplacement: string | undefined;
+          },
+        ): ElementSnapshot => {
+          const previous: ElementSnapshot = {
+            attributes: Object.fromEntries(
+              options.attributeNames.map((name) => [name, element.getAttribute(name)]),
+            ),
+          };
+          if (options.textReplacement !== undefined) previous.text = element.textContent;
+          if (options.valueReplacement !== undefined && 'value' in element) {
+            const currentValue = element.value;
+            if (currentValue !== undefined) previous.value = currentValue;
+          }
+
+          if (options.textReplacement !== undefined) element.textContent = options.textReplacement;
+          if (options.valueReplacement !== undefined && 'value' in element) {
+            element.value = options.valueReplacement;
+          }
+
+          return previous;
+        },
+        {
+          textReplacement: replacement.text,
+          attributeNames: Object.keys(replacement.attributes ?? {}),
+          valueReplacement: replacement.value,
+        },
+      );
+
+      if (replacement.attributes) {
+        await locator.evaluate((element: MutableElement, attributes: Record<string, string>) => {
+          for (const [name, value] of Object.entries(attributes)) {
+            element.setAttribute(name, value);
+          }
+        }, replacement.attributes);
+      }
+
+      elements.push(snapshot);
+    }
+
+    snapshots.push({locator: replacement.locator, count, elements});
+  }
+
+  return snapshots;
+}
+
+async function restoreSnapshots(snapshots: LocatorSnapshot[]): Promise<void> {
+  for (const snapshot of [...snapshots].reverse()) {
+    const currentCount = await snapshot.locator.count();
+    if (currentCount !== snapshot.count) {
+      throw new Error(
+        `Cannot restore stable screenshot replacements: locator matched ${currentCount} elements after capture, but matched ${snapshot.count} before capture.`,
+      );
+    }
+
+    for (let index = 0; index < snapshot.count; index += 1) {
+      await snapshot.locator
+        .nth(index)
+        .evaluate((element: MutableElement, previous: ElementSnapshot) => {
+          if (previous.text !== undefined) element.textContent = previous.text;
+          if (previous.value !== undefined && 'value' in element) element.value = previous.value;
+
+          for (const [name, value] of Object.entries(previous.attributes)) {
+            if (value === null) element.removeAttribute(name);
+            else element.setAttribute(name, value);
+          }
+        }, snapshot.elements[index] as ElementSnapshot);
+    }
+  }
+}

--- a/e2e/kit/tsconfig.test.json
+++ b/e2e/kit/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src", "test", "vitest.config.ts", "node_modules/@shipfox/vitest/globals.d.ts"],
+  "exclude": []
+}

--- a/e2e/kit/vitest.config.ts
+++ b/e2e/kit/vitest.config.ts
@@ -1,0 +1,3 @@
+import {defineConfig, type UserConfigExport} from '@shipfox/vitest';
+
+export default defineConfig({}, import.meta.url) as UserConfigExport;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -801,6 +801,9 @@ importers:
       '@shipfox/typescript':
         specifier: workspace:*
         version: link:../../tools/typescript
+      '@shipfox/vitest':
+        specifier: workspace:*
+        version: link:../../tools/vitest
 
   e2e/platform/workflows:
     devDependencies:


### PR DESCRIPTION
Add shared E2E kit UI helpers for app-shell interactions, ready workspace setup, and stable visual capture normalization.

The client E2E suites were carrying copied ready-workspace setup and ad hoc DOM normalization. This moves ready-workspace setup into `@shipfox/e2e-kit/fixtures`, adds cross-cutting page objects under `@shipfox/e2e-kit/ui`, and introduces one `stableScreenshot` helper that restores DOM changes after Argos capture.

The agent, runners, and secrets suites now consume the shared fixture directly. The new kit tests cover fixture composition, selector contracts, successful screenshot restoration, failure restoration, and locator-count drift.

Closes ENG-813

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes E2E workspace setup and adds shared UI helpers for app-shell navigation and stable visual captures. Implements ENG-813 by refactoring client suites to use a shared ready-workspace fixture and providing deterministic screenshot tooling.

- **New Features**
  - `@shipfox/e2e-kit/fixtures`: `createReadyWorkspace` fixture creates a user, workspace, project, session, logs in, and returns IDs plus `sessionToken`.
  - `@shipfox/e2e-kit/ui`: reusable page objects (`TopNav`, `WorkspaceSwitcher`, `SettingsShell`, `Dialog`, `Toast`, `DataTableRow`) plus `SETTINGS_TAB_LABELS` and `settingsPath`.
  - `stableScreenshot(page, name, replacements)`: normalizes text/values/attributes per locator for Argos, then restores; detects locator-count drift. Added kit tests and `@shipfox/vitest` setup.

- **Bug Fixes**
  - Restores completed DOM replacements even if a later replacement fails before Argos capture, so pages aren’t left mutated.
  - Fixed Playwright fixture registration for `createReadyWorkspace` by destructuring dependencies in `readyWorkspaceFixtures`, so downstream E2E packages can register `workspaceFixtures`.

<sup>Written for commit e61e34ca7cabeccb7856330b39e74637196b231d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

