### PR TITLE
[api/integration] Enable cron provider by default

### DIFF
--- a/libs/api/integration/core/src/config.test.ts
+++ b/libs/api/integration/core/src/config.test.ts
@@ -1,0 +1,24 @@
+describe('integration provider config', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('enables built-in cron and webhook providers by default', async () => {
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.INTEGRATIONS_ENABLE_CRON_PROVIDER).toBe(true);
+    expect(config.INTEGRATIONS_ENABLE_WEBHOOK_PROVIDER).toBe(true);
+  });
+
+  it('allows disabling the built-in cron provider', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_CRON_PROVIDER', 'false');
+    vi.resetModules();
+
+    const {config} = await import('#config.js');
+
+    expect(config.INTEGRATIONS_ENABLE_CRON_PROVIDER).toBe(false);
+  });
+});

--- a/libs/api/integration/core/src/config.ts
+++ b/libs/api/integration/core/src/config.ts
@@ -1,6 +1,10 @@
 import {bool, createConfig} from '@shipfox/config';
 
 export const config = createConfig({
+  INTEGRATIONS_ENABLE_CRON_PROVIDER: bool({
+    desc: 'Enables the cron integration provider so workflow schedules can use the built-in cron source. It is enabled by default because it does not require provider setup.',
+    default: true,
+  }),
   INTEGRATIONS_ENABLE_GITEA_PROVIDER: bool({
     desc: 'Enables the Gitea integration provider so users can connect a Gitea instance.',
     default: false,

--- a/libs/api/integration/core/src/providers/cron.ts
+++ b/libs/api/integration/core/src/providers/cron.ts
@@ -1,0 +1,13 @@
+import {config} from '#config.js';
+import type {IntegrationProviderModule} from '#providers/types.js';
+
+export const cronProviderModule: IntegrationProviderModule = {
+  id: 'cron',
+  enabled: config.INTEGRATIONS_ENABLE_CRON_PROVIDER,
+  load: async () => ({
+    provider: {
+      provider: 'cron',
+      displayName: 'Cron',
+    },
+  }),
+};

--- a/libs/api/integration/core/src/providers/modules.test.ts
+++ b/libs/api/integration/core/src/providers/modules.test.ts
@@ -1,0 +1,25 @@
+describe('loadEnabledProviderModules', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('loads cron alongside webhook by default', async () => {
+    vi.resetModules();
+
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules();
+
+    expect(parts.map((part) => part.provider.provider)).toEqual(['cron', 'webhook']);
+  });
+
+  it('does not load cron when the provider is disabled', async () => {
+    vi.stubEnv('INTEGRATIONS_ENABLE_CRON_PROVIDER', 'false');
+    vi.resetModules();
+
+    const {loadEnabledProviderModules} = await import('#providers/modules.js');
+    const parts = await loadEnabledProviderModules();
+
+    expect(parts.map((part) => part.provider.provider)).toEqual(['webhook']);
+  });
+});

--- a/libs/api/integration/core/src/providers/modules.ts
+++ b/libs/api/integration/core/src/providers/modules.ts
@@ -1,3 +1,4 @@
+import {cronProviderModule} from '#providers/cron.js';
 import {giteaProviderModule} from '#providers/gitea.js';
 import {githubProviderModule} from '#providers/github.js';
 import {sentryProviderModule} from '#providers/sentry.js';
@@ -10,6 +11,7 @@ const providerModules = [
   githubProviderModule,
   sentryProviderModule,
   giteaProviderModule,
+  cronProviderModule,
   webhookProviderModule,
 ];
 


### PR DESCRIPTION
Enable the built-in cron integration provider by default.

Cron is a platform trigger source like webhook: it does not require external provider setup, so new environments should expose it without an opt-in flag. This adds a config switch for cron that defaults on, registers a lightweight provider entry alongside webhook, and covers both the default and disabled cases in integration-core tests.

No changeset is included because the affected package is private and would be ignored by release tooling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the built-in `cron` integration provider by default so new environments can run scheduled workflows without setup. It still can be turned off via an env flag.

- **New Features**
  - Added `INTEGRATIONS_ENABLE_CRON_PROVIDER` (default: `true`) to control the cron provider.
  - Registered the `cron` provider module and load it alongside `webhook`.
  - Added tests for default enablement and for the disabled case.

<sup>Written for commit 7b7c6d3cbfe6f3ba7addd6f51526c1271fd95839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

