### PR TITLE
Tune CI test worker sharing

### DIFF
--- a/.changeset/steady-workers-share.md
+++ b/.changeset/steady-workers-share.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/vitest": patch
+---
+
+Lets package Vitest configs override the shared CI worker cap so small suites can default to one worker while heavier suites keep targeted parallelism.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
-      SHIPFOX_TURBO_CONCURRENCY: "2"
-      SHIPFOX_VITEST_MAX_WORKERS: "2"
+      SHIPFOX_TURBO_CONCURRENCY: "4"
+      SHIPFOX_VITEST_MAX_WORKERS: "1"
 
     steps:
       - name: Check out repository

--- a/libs/api/workflows/vitest.config.ts
+++ b/libs/api/workflows/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig(
   {
     test: {
       globalSetup: ['test/globalSetup.ts'],
+      maxWorkers: 2,
       setupFiles: ['test/setup.ts'],
     },
   },

--- a/libs/shared/react/ui/vitest.config.ts
+++ b/libs/shared/react/ui/vitest.config.ts
@@ -57,6 +57,8 @@ export default defineConfig(
               provider: playwright(),
               instances: [{browser: 'chromium'}],
             },
+            maxWorkers: 2,
+            sequence: {groupOrder: 1},
           },
         },
       ],

--- a/tools/vitest/src/config.ts
+++ b/tools/vitest/src/config.ts
@@ -30,7 +30,7 @@ type MergeableConfigInput = ConfigInput & {
 };
 
 const maxWorkers = parseMaxWorkers(process.env.SHIPFOX_VITEST_MAX_WORKERS);
-const workerPoolConfig = maxWorkers === undefined ? {} : {maxWorkers};
+const workerPoolDefaults = maxWorkers === undefined ? {} : {maxWorkers};
 
 function parseMaxWorkers(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -46,6 +46,7 @@ function parseMaxWorkers(value: string | undefined): number | undefined {
 function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): ConfigInput {
   const mergeableConfig = resolvedConfig as MergeableConfigInput;
   const existingPlugins = mergeableConfig.plugins || [];
+  const existingTestConfig = mergeableConfig.test || {};
   const merged = {
     ...resolvedConfig,
     plugins: [...existingPlugins],
@@ -60,15 +61,15 @@ function createMergedConfig(resolvedConfig: ConfigInput, projectRoot?: string): 
       },
     },
     test: {
-      ...(mergeableConfig.test || {}),
+      ...workerPoolDefaults,
+      ...existingTestConfig,
       globals: true,
-      ...workerPoolConfig,
       exclude: [
         '**/node_modules/**',
         '**/dist/**',
         '**/build/**',
         '**/out/**',
-        ...(mergeableConfig.test?.exclude || []),
+        ...(existingTestConfig.exclude || []),
       ],
     },
   };


### PR DESCRIPTION
Tune CI unit-test scheduling so the `isolate:false` suites can actually reuse module graphs on CI.

The previous CI setup used `SHIPFOX_VITEST_MAX_WORKERS=2` and Turbo concurrency 2. That avoided runner starvation, but it meant many small packages still split files across workers and only partially benefited from shared Vitest isolation. This makes the shared Vitest cap a default instead of a hard override, sets the CI test default to one worker, and raises Turbo test concurrency to 4 so cross-package parallelism replaces the within-package parallelism small suites give up.

Heavy packages keep explicit overrides where serialization would be expensive: `@shipfox/api-workflows` keeps two workers, and the `@shipfox/react-ui` Storybook browser project keeps two workers with a separate Vitest sequence group. `@shipfox/api-runners` keeps its existing one-worker pin from the shared-module DB test rollout.

Review the shared `@shipfox/vitest` merge order carefully: package-level `test.maxWorkers` now intentionally wins over `SHIPFOX_VITEST_MAX_WORKERS`.

Closes ENG-758

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tune CI test scheduling so small `isolate:false` suites default to one worker and reuse a single module graph, while heavy projects keep targeted parallelism. Increases cross-package parallelism by raising Turbo concurrency. Addresses ENG-758.

- **Refactors**
  - CI env: `SHIPFOX_TURBO_CONCURRENCY=4`, `SHIPFOX_VITEST_MAX_WORKERS=1`.
  - `@shipfox/vitest`: env maxWorkers is now a default; package `test.maxWorkers` overrides it.
  - Package overrides: `@shipfox/api-workflows` set to 2 workers; `@shipfox/react-ui` Storybook browser project set to 2 workers with a sequence group.

<sup>Written for commit a90e2f4b0cf588e29a19e25aae4efcf8dcbbd940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

