### PR TITLE
[runner] Cover split-secret tee redaction

### DIFF
--- a/libs/runner/execution/src/core/run-step.test.ts
+++ b/libs/runner/execution/src/core/run-step.test.ts
@@ -415,10 +415,12 @@ describe('executeRunStep', () => {
   });
 
   it('redacts a secret split across runner stdout tee chunks', async () => {
-    const secret = 'runtime-secret-value';
+    const secret = 'sf_mrt_SPLITTEE_SECRET_12345';
+    const firstFragment = secret.slice(0, 14);
+    const secondFragment = secret.slice(14);
     const script = [
-      `process.stdout.write(${JSON.stringify(secret.slice(0, 8))});`,
-      `setTimeout(() => process.stdout.end(${JSON.stringify(`${secret.slice(8)}\n`)}), 20);`,
+      `process.stdout.write(${JSON.stringify(firstFragment)});`,
+      `setTimeout(() => process.stdout.end(${JSON.stringify(`${secondFragment}\n`)}), 20);`,
     ].join('');
     const step = buildStep({config: {run: `node -e ${JSON.stringify(script)}`}});
     const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true as never);
@@ -429,6 +431,29 @@ describe('executeRunStep', () => {
     expect(result.success).toBe(true);
     expect(stdout).toContain('***');
     expect(stdout).not.toContain(secret);
+    expect(stdout).not.toContain(firstFragment);
+    expect(stdout).not.toContain(secondFragment);
+  });
+
+  it('redacts a secret split across runner stderr tee chunks', async () => {
+    const secret = 'sf_mrt_SPLITTEE_SECRET_67890';
+    const firstFragment = secret.slice(0, 14);
+    const secondFragment = secret.slice(14);
+    const script = [
+      `process.stderr.write(${JSON.stringify(firstFragment)});`,
+      `setTimeout(() => process.stderr.end(${JSON.stringify(`${secondFragment}\n`)}), 20);`,
+    ].join('');
+    const step = buildStep({config: {run: `node -e ${JSON.stringify(script)}`}});
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true as never);
+
+    const result = await executeRunStep(step, {secretValues: [secret]});
+
+    const stderr = stderrWrite.mock.calls.map((call) => String(call[0])).join('');
+    expect(result.success).toBe(true);
+    expect(stderr).toContain('***');
+    expect(stderr).not.toContain(secret);
+    expect(stderr).not.toContain(firstFragment);
+    expect(stderr).not.toContain(secondFragment);
   });
 
   it('returns failure for unsupported step type with the reason on error.message', async () => {


### PR DESCRIPTION
Add regression coverage for runner operational stdout/stderr tee redaction when a registered secret is split across child pipe chunks.

The stdout test now asserts neither side of the raw split secret escapes to the runner tee, and stderr gets matching coverage. This guards the stateful tee redactor behavior required for operational logs, where durable step logs already had split-secret lookbehind.

Closes ENG-790

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests to ensure the runner’s stdout/stderr tee redacts secrets even when split across chunks. Confirms only "***" is emitted and neither the full secret nor fragments appear in operational logs (ENG-790).

<sup>Written for commit 82424d5efa7ae7dc991e30452b06b0b039fc8656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

