### PR TITLE
Add E2E domain screen packages

### DIFF
--- a/e2e/client/agent/package.json
+++ b/e2e/client/agent/package.json
@@ -28,6 +28,7 @@
     "@shipfox/e2e-helper-projects": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
+    "@shipfox/e2e-screens-agent": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
+++ b/e2e/client/agent/tests/custom-model-provider-settings.e2e.ts
@@ -1,5 +1,4 @@
 import {type AgentHelper, ollamaConfig} from '@shipfox/e2e-helper-agent';
-import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const OLLAMA = ollamaConfig();
@@ -12,25 +11,6 @@ const EDITED_PROVIDER_NAME = 'Local Ollama Edited';
 const DELETE_PROVIDER_ID = 'local-ollama-delete';
 const DELETE_PROVIDER_NAME = 'Local Ollama Delete';
 const PROVIDER_SAVE_TIMEOUT_MS = 75_000;
-
-async function gotoModelProviders(page: Page, workspaceId: string) {
-  await page.goto(`/workspaces/${workspaceId}/settings/model-providers`);
-  await expect(page).toHaveURL(
-    new RegExp(`/workspaces/${workspaceId}/settings/model-providers/?$`, 'u'),
-  );
-  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
-  await expect(page.getByRole('heading', {name: 'Configured providers'})).toBeVisible();
-}
-
-function configuredProvidersSection(page: Page): ReturnType<Page['locator']> {
-  return page.locator('section[aria-label="Configured providers"]');
-}
-
-function configuredProviderRow(page: Page, label: string): ReturnType<Page['locator']> {
-  return configuredProvidersSection(page)
-    .locator('li')
-    .filter({has: page.getByText(label, {exact: true})});
-}
 
 async function expectProviderInApi(params: {
   agent: AgentHelper;
@@ -56,35 +36,34 @@ async function expectProviderInApi(params: {
 test('creates a custom model provider backed by local Ollama', async ({
   page,
   agent,
+  customModelProviders,
   createReadyWorkspace,
 }) => {
   const {workspaceId, sessionToken} = await createReadyWorkspace({
     name: 'Agent Provider Create Workspace',
   });
 
-  await gotoModelProviders(page, workspaceId);
-  await page.getByRole('button', {name: 'Configure custom provider'}).click();
-  const dialog = page.getByRole('dialog', {name: 'Add custom provider'});
-  await expect(dialog).toBeVisible();
+  await customModelProviders.goto(workspaceId);
+  const dialog = await customModelProviders.openCreateDialog();
 
-  await dialog.getByLabel('Display name').fill(CREATE_PROVIDER_NAME);
-  await dialog.getByLabel('Provider ID').fill(CREATE_PROVIDER_ID);
-  await dialog.getByLabel('Base URL').fill(OLLAMA.openAiBaseUrl);
+  await customModelProviders.fillProviderIdentity(dialog, {
+    displayName: CREATE_PROVIDER_NAME,
+    providerId: CREATE_PROVIDER_ID,
+    baseUrl: OLLAMA.openAiBaseUrl,
+  });
   const discoveryResponse = page.waitForResponse(
     (response) =>
       response.url().includes('/agent/custom-model-providers/discover-models') &&
       response.request().method() === 'POST',
   );
-  await dialog.getByRole('button', {name: 'Fetch models'}).click();
+  await customModelProviders.fetchModels(dialog);
   expect((await discoveryResponse).ok()).toBe(true);
 
-  const defaultModelField = dialog.getByLabel('Default model');
-  const discoveredModelOption = defaultModelField.locator('option').filter({
-    hasText: OLLAMA_MODEL_ID,
-  });
+  const defaultModelField = customModelProviders.defaultModelField(dialog);
+  const discoveredModelOption = customModelProviders.discoveredModelOption(dialog, OLLAMA_MODEL_ID);
   if ((await discoveredModelOption.count()) === 0) {
-    await dialog.getByLabel('Model id').first().fill(OLLAMA_MODEL_ID);
-    await dialog.getByLabel('Label').first().fill(OLLAMA_MODEL_ID);
+    await customModelProviders.firstModelIdField(dialog).fill(OLLAMA_MODEL_ID);
+    await customModelProviders.firstModelLabelField(dialog).fill(OLLAMA_MODEL_ID);
   }
   await expect(defaultModelField).toContainText(OLLAMA_MODEL_ID);
 
@@ -96,11 +75,11 @@ test('creates a custom model provider backed by local Ollama', async ({
       !response.url().includes('/discover-models'),
     {timeout: PROVIDER_SAVE_TIMEOUT_MS},
   );
-  await dialog.getByRole('button', {name: 'Test & save'}).click();
+  await customModelProviders.save(dialog);
   expect((await saveResponse).ok()).toBe(true);
 
-  await expect(page.getByText('Custom provider saved')).toBeVisible();
-  await expect(configuredProviderRow(page, CREATE_PROVIDER_NAME)).toBeVisible();
+  await customModelProviders.expectSavedToast('Custom provider saved');
+  await expect(customModelProviders.configuredProviderRow(CREATE_PROVIDER_NAME)).toBeVisible();
   await expectProviderInApi({
     agent,
     workspaceId,
@@ -113,6 +92,7 @@ test('creates a custom model provider backed by local Ollama', async ({
 test('edits an existing custom model provider and validates with local Ollama', async ({
   page,
   agent,
+  customModelProviders,
   createReadyWorkspace,
 }) => {
   const {workspaceId, sessionToken} = await createReadyWorkspace({
@@ -125,27 +105,25 @@ test('edits an existing custom model provider and validates with local Ollama', 
     displayName: EDIT_PROVIDER_NAME,
   });
 
-  await gotoModelProviders(page, workspaceId);
-  const row = configuredProviderRow(page, EDIT_PROVIDER_NAME);
+  await customModelProviders.goto(workspaceId);
+  const row = customModelProviders.configuredProviderRow(EDIT_PROVIDER_NAME);
   await expect(row).toBeVisible();
-  await row.getByRole('button', {name: `Open ${EDIT_PROVIDER_NAME} provider actions`}).click();
-  await page.getByRole('menuitem', {name: 'Edit'}).click();
-  const dialog = page.getByRole('dialog', {name: `Edit ${EDIT_PROVIDER_NAME}`});
-  await expect(dialog.getByLabel('Provider ID')).toBeDisabled();
+  const dialog = await customModelProviders.openEditDialog(EDIT_PROVIDER_NAME);
+  await expect(dialog.field('Provider ID')).toBeDisabled();
 
-  await dialog.getByLabel('Display name').fill(EDITED_PROVIDER_NAME);
+  await dialog.field('Display name').fill(EDITED_PROVIDER_NAME);
   const saveResponse = page.waitForResponse(
     (response) =>
       response.url().includes(`/agent/custom-model-providers/${EDIT_PROVIDER_ID}`) &&
       response.request().method() === 'PUT',
     {timeout: PROVIDER_SAVE_TIMEOUT_MS},
   );
-  await dialog.getByRole('button', {name: 'Test & save'}).click();
+  await customModelProviders.save(dialog);
   expect((await saveResponse).ok()).toBe(true);
 
-  await expect(page.getByText(`${EDIT_PROVIDER_NAME} saved`)).toBeVisible();
-  await expect(configuredProviderRow(page, EDITED_PROVIDER_NAME)).toBeVisible();
-  await expect(configuredProviderRow(page, EDIT_PROVIDER_NAME)).toHaveCount(0);
+  await customModelProviders.expectSavedToast(`${EDIT_PROVIDER_NAME} saved`);
+  await expect(customModelProviders.configuredProviderRow(EDITED_PROVIDER_NAME)).toBeVisible();
+  await expect(customModelProviders.configuredProviderRow(EDIT_PROVIDER_NAME)).toHaveCount(0);
   await expectProviderInApi({
     agent,
     workspaceId,
@@ -155,7 +133,11 @@ test('edits an existing custom model provider and validates with local Ollama', 
   });
 });
 
-test('deletes an existing custom model provider', async ({page, agent, createReadyWorkspace}) => {
+test('deletes an existing custom model provider', async ({
+  agent,
+  customModelProviders,
+  createReadyWorkspace,
+}) => {
   const {workspaceId, sessionToken} = await createReadyWorkspace({
     name: 'Agent Provider Delete Workspace',
   });
@@ -166,15 +148,13 @@ test('deletes an existing custom model provider', async ({page, agent, createRea
     displayName: DELETE_PROVIDER_NAME,
   });
 
-  await gotoModelProviders(page, workspaceId);
-  const row = configuredProviderRow(page, DELETE_PROVIDER_NAME);
+  await customModelProviders.goto(workspaceId);
+  const row = customModelProviders.configuredProviderRow(DELETE_PROVIDER_NAME);
   await expect(row).toBeVisible();
-  await row.getByRole('button', {name: `Open ${DELETE_PROVIDER_NAME} provider actions`}).click();
-  await page.getByRole('menuitem', {name: 'Delete'}).click();
-  const dialog = page.getByRole('dialog', {name: 'Delete model provider'});
-  await dialog.getByRole('button', {name: 'Delete'}).click();
+  const dialog = await customModelProviders.openDeleteDialog(DELETE_PROVIDER_NAME);
+  await dialog.confirm('Delete');
 
-  await expect(page.getByText(`${DELETE_PROVIDER_NAME} deleted`)).toBeVisible();
+  await customModelProviders.expectSavedToast(`${DELETE_PROVIDER_NAME} deleted`);
   await expect(row).toHaveCount(0);
   const configs = await agent.listModelProviderConfigs({workspaceId, sessionToken});
   expect(configs.configs.map((config) => config.provider_id)).not.toContain(DELETE_PROVIDER_ID);

--- a/e2e/client/agent/tests/test.ts
+++ b/e2e/client/agent/tests/test.ts
@@ -1,9 +1,11 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AgentFixtures, agentHelper} from '@shipfox/e2e-helper-agent';
 import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
+import {type AgentScreenFixtures, agentScreens} from '@shipfox/e2e-screens-agent';
 
-export const test = base.extend<WorkspaceFixtures & AgentFixtures>({
+export const test = base.extend<WorkspaceFixtures & AgentFixtures & AgentScreenFixtures>({
   ...workspaceFixtures,
   ...agentHelper,
+  ...agentScreens,
 });
 export {expect};

--- a/e2e/client/auth/package.json
+++ b/e2e/client/auth/package.json
@@ -22,6 +22,7 @@
     "@shipfox/client-auth": "workspace:*",
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
+    "@shipfox/e2e-screens-auth": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/auth/tests/auth-client.e2e.ts
+++ b/e2e/client/auth/tests/auth-client.e2e.ts
@@ -1,5 +1,5 @@
 import {randomUUID} from 'node:crypto';
-import {argosScreenshot} from '@shipfox/playwright';
+import {stableScreenshot} from '@shipfox/e2e-kit/ui';
 import {expect, test} from './test.js';
 
 const LOGIN_URL_RE = /\/auth\/login$/u;
@@ -11,29 +11,33 @@ function workspaceUrlRe(wid: string): RegExp {
   return new RegExp(`/workspaces/${wid}(/|$)`, 'u');
 }
 
-test('redirects guests from the app root to login', async ({page}) => {
-  await page.goto('/');
+test('redirects guests from the app root to login', async ({page, guestRedirects, login}) => {
+  await guestRedirects.goto('/');
 
   await expect(page).toHaveURL(LOGIN_URL_RE);
-  await expect(page.getByRole('heading', {name: 'Connect to Shipfox'})).toBeVisible();
-  await argosScreenshot(page, 'auth/login');
+  await expect(login.heading()).toBeVisible();
+  await stableScreenshot(page, 'auth/login');
 });
 
-test('logs in through the UI with an E2E-created verified user', async ({page, auth}) => {
+test('logs in through the UI with an E2E-created verified user', async ({
+  page,
+  auth,
+  guestRedirects,
+  login,
+}) => {
   const user = await auth.createUser();
 
-  await page.goto('/auth/login');
-  await page.getByLabel('Email').fill(user.email);
-  await page.getByLabel('Password').fill(user.password);
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await login.goto();
+  await login.submit(user.email, user.password);
 
-  await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
-  await argosScreenshot(page, 'auth/post-login-workspace');
+  await expect(guestRedirects.onboardingHeading()).toBeVisible();
+  await stableScreenshot(page, 'auth/post-login-workspace');
 });
 
 test('form login routes a user with workspaces straight to /workspaces/$wid', async ({
   page,
   auth,
+  login,
   workspaces,
 }) => {
   const user = await auth.createUser();
@@ -49,10 +53,8 @@ test('form login routes a user with workspaces straight to /workspaces/$wid', as
     }
   });
 
-  await page.goto('/auth/login');
-  await page.getByLabel('Email').fill(user.email);
-  await page.getByLabel('Password').fill(user.password);
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await login.goto();
+  await login.submit(user.email, user.password);
 
   await expect(page).toHaveURL(workspaceUrlRe(wsA.id));
 
@@ -66,18 +68,25 @@ test('form login routes a user with workspaces straight to /workspaces/$wid', as
 test('hydrates an E2E browser session from the refresh cookie after reload', async ({
   page,
   auth,
+  guestRedirects,
 }) => {
   const user = await auth.createUser();
   await auth.loginAs(page, user);
 
-  await page.goto('/');
-  await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
+  await guestRedirects.goto('/');
+  await expect(guestRedirects.onboardingHeading()).toBeVisible();
 
   await page.reload();
-  await expect(page.getByRole('heading', {name: 'Create your workspace'})).toBeVisible();
+  await expect(guestRedirects.onboardingHeading()).toBeVisible();
 });
 
-test('restores a nested deep link after login', async ({page, auth, workspaces}) => {
+test('restores a nested deep link after login', async ({
+  page,
+  auth,
+  guestRedirects,
+  login,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   const ws = await workspaces.create({userId: user.user.id, name: `DL ${randomUUID()}`});
   // Fresh E2E workspaces have no source connections, so WorkspaceSetupGuard
@@ -92,15 +101,15 @@ test('restores a nested deep link after login', async ({page, auth, workspaces})
     }
   });
 
-  await page.goto(target);
+  await guestRedirects.goto(target);
   await expect(page).toHaveURL(LOGIN_WITH_REDIRECT_URL_RE);
 
-  await page.getByLabel('Email').fill(user.email);
-  await page.getByLabel('Password').fill(user.password);
+  await login.emailField().fill(user.email);
+  await login.passwordField().fill(user.password);
   // Snapshot the navigation log before submit so the assertion ignores the
   // pre-login visit to `target` and only proves the post-login restore.
   const preLoginCount = urlsSeen.length;
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await login.submitButton().click();
 
   await expect(page).toHaveURL(workspaceUrlRe(ws.id));
 
@@ -114,7 +123,13 @@ test('restores a nested deep link after login', async ({page, auth, workspaces})
   ).toBe(true);
 });
 
-test('preserves search and hash in the deep link after login', async ({page, auth, workspaces}) => {
+test('preserves search and hash in the deep link after login', async ({
+  page,
+  auth,
+  guestRedirects,
+  login,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   const ws = await workspaces.create({userId: user.user.id, name: `DL ${randomUUID()}`});
   // WorkspaceSetupGuard at /workspaces/$wid redirects fresh workspaces to
@@ -130,15 +145,15 @@ test('preserves search and hash in the deep link after login', async ({page, aut
     }
   });
 
-  await page.goto(target);
+  await guestRedirects.goto(target);
   await expect(page).toHaveURL(LOGIN_WITH_REDIRECT_URL_RE);
 
-  await page.getByLabel('Email').fill(user.email);
-  await page.getByLabel('Password').fill(user.password);
+  await login.emailField().fill(user.email);
+  await login.passwordField().fill(user.password);
   // Snapshot the navigation log before submit so the assertion ignores the
   // pre-login visit to `target` and only proves the post-login restore.
   const preLoginCount = urlsSeen.length;
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await login.submitButton().click();
 
   await expect(page).toHaveURL(workspaceUrlRe(ws.id));
 
@@ -155,14 +170,17 @@ test('preserves search and hash in the deep link after login', async ({page, aut
   ).toBe(true);
 });
 
-test('blocks open-redirect to a cross-origin URL after login', async ({page, auth, workspaces}) => {
+test('blocks open-redirect to a cross-origin URL after login', async ({
+  page,
+  auth,
+  login,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   await workspaces.create({userId: user.user.id, name: `Block ${randomUUID()}`});
 
-  await page.goto('/auth/login?redirect=//evil.com');
-  await page.getByLabel('Email').fill(user.email);
-  await page.getByLabel('Password').fill(user.password);
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await login.gotoRawRedirect('//evil.com');
+  await login.submit(user.email, user.password);
 
   await expect(page).toHaveURL(ANY_WORKSPACE_URL_RE);
   expect(page.url()).not.toContain('evil.com');
@@ -171,27 +189,31 @@ test('blocks open-redirect to a cross-origin URL after login', async ({page, aut
 test('routes an already-authenticated visitor of /auth/login?redirect= straight to the deep link', async ({
   page,
   auth,
+  login,
   workspaces,
 }) => {
   const user = await auth.createUser();
   const ws = await workspaces.create({userId: user.user.id, name: `Auth ${randomUUID()}`});
   await auth.loginAs(page, user);
 
-  await page.goto(`/auth/login?redirect=/workspaces/${ws.id}`);
+  await login.goto(`/workspaces/${ws.id}`);
 
   await expect(page).toHaveURL(workspaceUrlRe(ws.id));
-  await expect(page.getByRole('heading', {name: 'Connect to Shipfox'})).not.toBeVisible();
+  await expect(login.heading()).not.toBeVisible();
 });
 
-test('restores a /setup deep link for a workspace-less user after login', async ({page, auth}) => {
+test('restores a /setup deep link for a workspace-less user after login', async ({
+  page,
+  auth,
+  guestRedirects,
+  login,
+}) => {
   const user = await auth.createUser();
 
-  await page.goto('/setup/workspaces/new');
+  await guestRedirects.goto('/setup/workspaces/new');
   await expect(page).toHaveURL(LOGIN_WITH_REDIRECT_URL_RE);
 
-  await page.getByLabel('Email').fill(user.email);
-  await page.getByLabel('Password').fill(user.password);
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await login.submit(user.email, user.password);
 
   await expect(page).toHaveURL(ONBOARDING_URL_RE);
 });

--- a/e2e/client/auth/tests/test.ts
+++ b/e2e/client/auth/tests/test.ts
@@ -1,5 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type AuthWorkspaceFixtures, authWorkspaceFixtures} from '@shipfox/e2e-kit/fixtures';
+import {type AuthScreenFixtures, authScreens} from '@shipfox/e2e-screens-auth';
 
-export const test = base.extend<AuthWorkspaceFixtures>(authWorkspaceFixtures);
+export const test = base.extend<AuthWorkspaceFixtures & AuthScreenFixtures>({
+  ...authWorkspaceFixtures,
+  ...authScreens,
+});
 export {expect};

--- a/e2e/client/integrations/package.json
+++ b/e2e/client/integrations/package.json
@@ -25,6 +25,7 @@
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-integrations-gitea": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
+    "@shipfox/e2e-screens-integrations": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/integrations/tests/integration-flows.e2e.ts
+++ b/e2e/client/integrations/tests/integration-flows.e2e.ts
@@ -1,31 +1,19 @@
-import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const WORKSPACE_INTEGRATIONS_URL_RE = /\/workspaces\/[^/]+\/integrations\/?$/u;
 const GITEA_INSTALL_URL_RE = /\/workspaces\/[^/]+\/integrations\/gitea\/?$/u;
 const SETUP_NAVIGATION_TIMEOUT_MS = 15_000;
 
-function modelProviderUrlRe(wid: string): RegExp {
-  return new RegExp(`/workspaces/${wid}/model-provider/?$`, 'u');
-}
-
-async function expectSetupNavigationHidden(page: Page): Promise<void> {
-  await expect(page.getByRole('tab', {name: 'Projects'})).toHaveCount(0);
-  await expect(page.getByRole('tab', {name: 'Settings'})).toHaveCount(0);
-  await expect(page.getByLabel('Switch project')).toHaveCount(0);
-  await expect(page.getByLabel('Switch workspace')).toBeVisible();
-}
-
-async function expectModelProviderSetup(page: Page, wid: string): Promise<void> {
-  await expect(page).toHaveURL(modelProviderUrlRe(wid));
-  await expect(page.getByRole('heading', {name: 'Configure model provider'})).toBeVisible();
-  await expectSetupNavigationHidden(page);
+function modelProviderUrlRe(workspaceId: string): RegExp {
+  return new RegExp(`/workspaces/${workspaceId}/model-provider/?$`, 'u');
 }
 
 test('connecting Gitea from source-control setup opens model-provider setup', async ({
   page,
   auth,
   gitea,
+  providerInstall,
+  sourceControlSetup,
   workspaces,
 }) => {
   const user = await auth.createUser();
@@ -34,20 +22,27 @@ test('connecting Gitea from source-control setup opens model-provider setup', as
 
   const org = await gitea.createOrg();
 
-  await page.goto('/');
+  await sourceControlSetup.gotoRoot();
   await expect(page).toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
   await expect(page).toHaveURL(new RegExp(`/workspaces/${workspace.id}/integrations/?$`, 'u'));
-  await expect(page.getByRole('heading', {name: 'Install source control'})).toBeVisible();
-  await expectSetupNavigationHidden(page);
+  await expect(sourceControlSetup.heading()).toBeVisible();
+  await expect(sourceControlSetup.projectTab()).toHaveCount(0);
+  await expect(sourceControlSetup.settingsTab()).toHaveCount(0);
+  await expect(sourceControlSetup.projectSwitcher()).toHaveCount(0);
+  await expect(sourceControlSetup.workspaceSwitcher()).toBeVisible();
 
-  await page.locator(`a[href$="/workspaces/${workspace.id}/integrations/gitea"]`).click();
-  await page.getByLabel('Organization').fill(org.org);
-  await page.getByRole('button', {name: 'Install'}).click();
+  await sourceControlSetup.providerLink(workspace.id, 'gitea').click();
+  await providerInstall.installOrganization(org.org);
 
   await expect(page).toHaveURL(modelProviderUrlRe(workspace.id), {
     timeout: SETUP_NAVIGATION_TIMEOUT_MS,
   });
   await expect(page).not.toHaveURL(GITEA_INSTALL_URL_RE);
   await expect(page).not.toHaveURL(WORKSPACE_INTEGRATIONS_URL_RE);
-  await expectModelProviderSetup(page, workspace.id);
+  await expect(page).toHaveURL(modelProviderUrlRe(workspace.id));
+  await expect(sourceControlSetup.modelProviderHeading()).toBeVisible();
+  await expect(sourceControlSetup.projectTab()).toHaveCount(0);
+  await expect(sourceControlSetup.settingsTab()).toHaveCount(0);
+  await expect(sourceControlSetup.projectSwitcher()).toHaveCount(0);
+  await expect(sourceControlSetup.workspaceSwitcher()).toBeVisible();
 });

--- a/e2e/client/integrations/tests/sentry-callback.e2e.ts
+++ b/e2e/client/integrations/tests/sentry-callback.e2e.ts
@@ -1,5 +1,6 @@
 import type {SentryConnectResponseDto} from '@shipfox/api-integration-sentry-dto';
-import {argosScreenshot, type Page} from '@shipfox/playwright';
+import {stableScreenshot} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const CALLBACK_URL =
@@ -35,44 +36,53 @@ async function stubConnect(page: Page, response: {status: number; body: unknown}
 }
 
 test('Sentry callback shows an error when required params are missing', async ({
-  page,
   auth,
+  page,
+  sentryCallback,
   workspaces,
 }) => {
   const user = await auth.createUser();
   await workspaces.create({userId: user.user.id});
   await auth.loginAs(page, user);
 
-  await page.goto('/integrations/sentry/callback');
+  await sentryCallback.goto('/integrations/sentry/callback');
 
   await expect(
-    page.getByText(
+    sentryCallback.message(
       'This Sentry link is missing required parameters. Start the install again from your workspace settings.',
     ),
   ).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Back to Shipfox'})).toBeVisible();
+  await expect(sentryCallback.backToShipfoxLink()).toBeVisible();
 
-  await argosScreenshot(page, 'integrations/sentry-callback-missing-params');
+  await stableScreenshot(page, 'integrations/sentry-callback-missing-params');
 });
 
-test('Sentry callback shows the workspace picker', async ({page, auth, workspaces}) => {
+test('Sentry callback shows the workspace picker', async ({
+  page,
+  auth,
+  sentryCallback,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   await workspaces.create({userId: user.user.id, name: 'Sentry Picker Workspace'});
   await auth.loginAs(page, user);
 
-  await page.goto(CALLBACK_URL);
+  await sentryCallback.goto(CALLBACK_URL);
 
-  await expect(page.getByRole('heading', {name: 'Install Sentry'})).toBeVisible();
-  await expect(page.getByText('Install the Sentry org "acme" in a workspace.')).toBeVisible();
-  await expect(page.getByRole('button', {name: 'Install'})).toBeVisible();
+  await expect(sentryCallback.heading()).toBeVisible();
+  await expect(
+    sentryCallback.message('Install the Sentry org "acme" in a workspace.'),
+  ).toBeVisible();
+  await expect(sentryCallback.installButton()).toBeVisible();
 
-  await argosScreenshot(page, 'integrations/sentry-callback-pick-workspace');
+  await stableScreenshot(page, 'integrations/sentry-callback-pick-workspace');
 });
 
 test('Sentry callback installs to a workspace on success', async ({
   page,
   auth,
   projects,
+  sentryCallback,
   workspaces,
 }) => {
   const user = await auth.createUser();
@@ -85,13 +95,13 @@ test('Sentry callback installs to a workspace on success', async ({
 
   await stubConnect(page, {status: 200, body: sentryConnectionFixture(workspace.id)});
 
-  await page.goto(CALLBACK_URL);
-  await expect(page.getByRole('heading', {name: 'Install Sentry'})).toBeVisible();
-  await page.getByRole('button', {name: 'Install'}).click();
+  await sentryCallback.goto(CALLBACK_URL);
+  await expect(sentryCallback.heading()).toBeVisible();
+  await sentryCallback.installButton().click();
 
   // The stub never persisted a connection, so we assert only the success toast
   // and the redirect target — not that Sentry appears in the gallery.
-  await expect(page.getByText('Sentry installed.')).toBeVisible();
+  await expect(sentryCallback.message('Sentry installed.')).toBeVisible();
   await expect(page).toHaveURL(
     new RegExp(`/workspaces/${workspace.id}/settings/integrations/?$`, 'u'),
   );
@@ -100,6 +110,7 @@ test('Sentry callback installs to a workspace on success', async ({
 test('Sentry callback offers Start over on a terminal failure', async ({
   page,
   auth,
+  sentryCallback,
   workspaces,
 }) => {
   const user = await auth.createUser();
@@ -116,20 +127,25 @@ test('Sentry callback offers Start over on a terminal failure', async ({
     },
   });
 
-  await page.goto(
+  await sentryCallback.goto(
     '/integrations/sentry/callback?code=spent-code&installation_id=test-install&org_slug=acme',
   );
-  await page.getByRole('button', {name: 'Install'}).click();
+  await sentryCallback.installButton().click();
 
   await expect(
-    page.getByText('This Sentry link could not be completed. Start the install again.'),
+    sentryCallback.message('This Sentry link could not be completed. Start the install again.'),
   ).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Start over'})).toBeVisible();
+  await expect(sentryCallback.startOverLink()).toBeVisible();
 
-  await argosScreenshot(page, 'integrations/sentry-callback-terminal');
+  await stableScreenshot(page, 'integrations/sentry-callback-terminal');
 });
 
-test('Sentry callback offers Retry on a retryable failure', async ({page, auth, workspaces}) => {
+test('Sentry callback offers Retry on a retryable failure', async ({
+  page,
+  auth,
+  sentryCallback,
+  workspaces,
+}) => {
   const user = await auth.createUser();
   await workspaces.create({userId: user.user.id, name: 'Sentry Retry Workspace'});
   await auth.loginAs(page, user);
@@ -141,13 +157,13 @@ test('Sentry callback offers Retry on a retryable failure', async ({page, auth, 
     body: {message: 'Sentry is rate limiting requests.', code: 'rate-limited'},
   });
 
-  await page.goto(CALLBACK_URL);
-  await page.getByRole('button', {name: 'Install'}).click();
+  await sentryCallback.goto(CALLBACK_URL);
+  await sentryCallback.installButton().click();
 
   await expect(
-    page.getByText('Sentry is rate limiting requests. Try again in a moment.'),
+    sentryCallback.message('Sentry is rate limiting requests. Try again in a moment.'),
   ).toBeVisible();
-  await expect(page.getByRole('button', {name: 'Retry'})).toBeVisible();
+  await expect(sentryCallback.retryButton()).toBeVisible();
 
-  await argosScreenshot(page, 'integrations/sentry-callback-retryable');
+  await stableScreenshot(page, 'integrations/sentry-callback-retryable');
 });

--- a/e2e/client/integrations/tests/settings-catalogue.e2e.ts
+++ b/e2e/client/integrations/tests/settings-catalogue.e2e.ts
@@ -1,5 +1,6 @@
 import type {ListIntegrationProvidersResponseDto} from '@shipfox/api-integration-core-dto';
-import {argosScreenshot, type Page} from '@shipfox/playwright';
+import {stableScreenshot} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const ADDED_DATE_RE = /^Added /u;
@@ -31,73 +32,56 @@ async function stubProviders(page: Page): Promise<void> {
 
 test('settings catalogue lists available providers with an empty installed state', async ({
   page,
-  auth,
-  projects,
-  workspaces,
+  integrationsCatalogue,
+  createReadyWorkspace,
 }) => {
-  const user = await auth.createUser();
-  const workspace = await workspaces.create({
-    userId: user.user.id,
+  const {workspaceId} = await createReadyWorkspace({
     name: 'Integrations Settings Workspace',
   });
-  await projects.createProject({workspaceId: workspace.id});
-  await auth.loginAs(page, user);
 
   await stubProviders(page);
 
-  await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
+  await integrationsCatalogue.goto(workspaceId);
 
-  await expect(page.getByRole('heading', {name: 'Available integrations'})).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Install GitHub'})).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Install Sentry'})).toBeVisible();
-  await expect(page.getByRole('link', {name: 'Install Gitea'})).toBeVisible();
-  await expect(page.getByText('No integrations installed yet')).toBeVisible();
+  await expect(integrationsCatalogue.availableHeading()).toBeVisible();
+  await expect(integrationsCatalogue.installLink('GitHub')).toBeVisible();
+  await expect(integrationsCatalogue.installLink('Sentry')).toBeVisible();
+  await expect(integrationsCatalogue.installLink('Gitea')).toBeVisible();
+  await expect(integrationsCatalogue.emptyInstalledState()).toBeVisible();
 
-  await argosScreenshot(page, 'integrations/settings-empty');
+  await stableScreenshot(page, 'integrations/settings-empty');
 });
 
 test('settings catalogue shows an installed provider after Gitea install', async ({
   page,
-  auth,
   gitea,
-  projects,
-  workspaces,
+  integrationsCatalogue,
+  providerInstall,
+  createReadyWorkspace,
 }) => {
-  const user = await auth.createUser();
-  const workspace = await workspaces.create({
-    userId: user.user.id,
+  const {workspaceId} = await createReadyWorkspace({
     name: 'Integrations Installed Workspace',
   });
-  await projects.createProject({workspaceId: workspace.id});
-  await auth.loginAs(page, user);
 
   const org = await gitea.createOrg();
 
-  await page.goto(`/workspaces/${workspace.id}/integrations/gitea`);
-  await page.getByLabel('Organization').fill(org.org);
-  await page.getByRole('button', {name: 'Install'}).click();
-  await expect(page.getByText('Gitea organization installed.')).toBeVisible();
+  await providerInstall.goto(workspaceId, 'gitea');
+  await providerInstall.installOrganization(org.org);
+  await providerInstall.expectInstalled('Gitea organization installed.');
 
-  await page.goto(`/workspaces/${workspace.id}/settings/integrations`);
+  await integrationsCatalogue.goto(workspaceId);
 
-  const installed = page.locator('section[aria-label="Installed integrations"]');
-  const installedName = installed.getByText(`Gitea ${org.org}`, {exact: true});
+  const installedName = integrationsCatalogue.installedProviderName(`Gitea ${org.org}`);
   await expect(installedName).toBeVisible();
-  await expect(installed.getByText('Connected')).toHaveCount(0);
-  await expect(installed.getByText(ADDED_DATE_RE)).toBeVisible();
+  await expect(integrationsCatalogue.installedStatus('Connected')).toHaveCount(0);
+  await expect(integrationsCatalogue.installedStatus(ADDED_DATE_RE)).toBeVisible();
 
-  await installedName.evaluate((element, text) => {
-    element.textContent = text;
-  }, VISUAL_GITEA_CONNECTION_NAME);
-  await installed.getByText(ADDED_DATE_RE).evaluate((element, text) => {
-    element.textContent = text;
-  }, VISUAL_ADDED_DATE);
-
-  await installed
-    .getByLabel(`Open Gitea ${org.org} integration actions`)
-    .evaluate((element, text) => {
-      element.setAttribute('aria-label', `Open ${text} integration actions`);
-    }, VISUAL_GITEA_CONNECTION_NAME);
-
-  await argosScreenshot(page, 'integrations/settings-installed');
+  await stableScreenshot(page, 'integrations/settings-installed', [
+    {locator: installedName, text: VISUAL_GITEA_CONNECTION_NAME},
+    {locator: integrationsCatalogue.installedStatus(ADDED_DATE_RE), text: VISUAL_ADDED_DATE},
+    {
+      locator: integrationsCatalogue.installedActionsButton(`Gitea ${org.org}`),
+      attributes: {'aria-label': `Open ${VISUAL_GITEA_CONNECTION_NAME} integration actions`},
+    },
+  ]);
 });

--- a/e2e/client/integrations/tests/test.ts
+++ b/e2e/client/integrations/tests/test.ts
@@ -1,9 +1,14 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type GiteaFixtures, giteaHelper} from '@shipfox/e2e-helper-integrations-gitea';
 import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
+import {
+  type IntegrationsScreenFixtures,
+  integrationsScreens,
+} from '@shipfox/e2e-screens-integrations';
 
-export const test = base.extend<WorkspaceFixtures & GiteaFixtures>({
+export const test = base.extend<WorkspaceFixtures & GiteaFixtures & IntegrationsScreenFixtures>({
   ...workspaceFixtures,
   ...giteaHelper,
+  ...integrationsScreens,
 });
 export {expect};

--- a/e2e/client/runners/package.json
+++ b/e2e/client/runners/package.json
@@ -29,6 +29,7 @@
     "@shipfox/e2e-helper-runners": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
+    "@shipfox/e2e-screens-runners": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/regex": "workspace:*",
     "@shipfox/ts-config": "workspace:*",

--- a/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
+++ b/e2e/client/runners/tests/manual-registration-token-flows.e2e.ts
@@ -1,6 +1,5 @@
 import {mintManualRegistrationToken, mintProvisionerToken} from '@shipfox/e2e-helper-runners';
-import type {Page} from '@shipfox/playwright';
-import {argosScreenshot} from '@shipfox/playwright';
+import {stableScreenshot} from '@shipfox/e2e-kit/ui';
 import {createShipfoxTokenPrefixRegexes} from '@shipfox/regex';
 import {expect, test} from './test.js';
 
@@ -14,66 +13,9 @@ const VISUAL_TEST_PROVISIONER_TOKEN = 'sf_pt_visual_regression_token';
 const VISUAL_TEST_CREATED_AT = 'Jan 15, 2026, 12:00 PM';
 const VISUAL_TEST_EXPIRES_AT = 'Jan 16, 2026, 12:00 PM';
 
-function manualTokensSection(page: Page) {
-  return page.locator('section', {hasText: 'Runner registration tokens'});
-}
-
-function provisionerTokensSection(page: Page) {
-  return page.locator('section', {hasText: 'Runner provisioner registration tokens'});
-}
-
-function rowByName(section: ReturnType<typeof manualTokensSection>, name: string) {
-  return section.locator('tr', {hasText: name});
-}
-
-async function gotoManualTokensSettings(page: Page, workspaceId: string) {
-  await page.goto(`/workspaces/${workspaceId}/settings/runners`);
-  await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/settings/runners/?$`, 'u'));
-  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
-}
-
-async function gotoProvisionerTokensSettings(page: Page, workspaceId: string) {
-  await page.goto(`/workspaces/${workspaceId}/settings/provisioners`);
-  await expect(page).toHaveURL(
-    new RegExp(`/workspaces/${workspaceId}/settings/provisioners/?$`, 'u'),
-  );
-  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
-}
-
-async function normalizeManualTokenRowForVisuals(
-  row: ReturnType<typeof rowByName>,
-  params: {prefix: string; expiresAt: string; createdAt: string},
-) {
-  const cells = row.locator('td');
-  await cells.nth(1).evaluate((element: Element, prefix) => {
-    element.textContent = prefix;
-  }, params.prefix);
-  await cells.nth(2).evaluate((element: Element, expiresAt) => {
-    element.textContent = expiresAt;
-  }, params.expiresAt);
-  await cells.nth(3).evaluate((element: Element, createdAt) => {
-    element.textContent = createdAt;
-  }, params.createdAt);
-}
-
-async function normalizeProvisionerTokenRowForVisuals(
-  row: ReturnType<typeof rowByName>,
-  params: {prefix: string; expiresAt: string; createdAt: string},
-) {
-  const cells = row.locator('td');
-  await cells.nth(1).evaluate((element: Element, prefix) => {
-    element.textContent = prefix;
-  }, params.prefix);
-  await cells.nth(3).evaluate((element: Element, expiresAt) => {
-    element.textContent = expiresAt;
-  }, params.expiresAt);
-  await cells.nth(4).evaluate((element: Element, createdAt) => {
-    element.textContent = createdAt;
-  }, params.createdAt);
-}
-
 test('creates a manual runner registration token from settings', async ({
   page,
+  runnerTokens,
   createReadyWorkspace,
 }) => {
   test.setTimeout(60_000);
@@ -83,43 +25,37 @@ test('creates a manual runner registration token from settings', async ({
     name: 'Manual Token Create Workspace',
   });
 
-  await gotoManualTokensSettings(page, workspaceId);
-  const section = manualTokensSection(page);
-  await expect(section.getByText('No usable manual registration tokens')).toBeVisible();
-  await argosScreenshot(page, 'runners/settings-runners-empty');
+  await runnerTokens.gotoManualTokens(workspaceId);
+  await expect(runnerTokens.manualEmptyState()).toBeVisible();
+  await stableScreenshot(page, 'runners/settings-runners-empty');
 
-  await section.getByRole('button', {name: 'Create token'}).click();
-  const createTokenDialog = page.getByRole('dialog', {name: 'Create manual registration token'});
-  await expect(createTokenDialog).toBeVisible();
-  await expect(createTokenDialog.getByLabel('Token name')).toBeVisible();
-  await expect(createTokenDialog.getByRole('button', {name: 'Create token'})).toBeVisible();
-  await argosScreenshot(page, 'runners/settings-runners-create-token-form');
+  const createTokenDialog = await runnerTokens.openManualCreateDialog();
+  await expect(createTokenDialog.field('Token name')).toBeVisible();
+  await expect(createTokenDialog.confirmButton('Create token')).toBeVisible();
+  await stableScreenshot(page, 'runners/settings-runners-create-token-form');
 
-  await createTokenDialog.getByLabel('Token name').fill('E2E manual runner');
-  await createTokenDialog.getByRole('button', {name: 'Create token'}).click();
+  await runnerTokens.createTokenFromDialog(createTokenDialog, 'E2E manual runner');
 
-  await expect(createTokenDialog.getByText('Token created')).toBeVisible();
-  const rawToken = createTokenDialog
-    .locator('p.font-code')
-    .filter({hasText: MANUAL_REGISTRATION_TOKEN_PREFIX_RE});
+  await expect(createTokenDialog.locator().getByText('Token created')).toBeVisible();
+  const rawToken = runnerTokens.rawToken(createTokenDialog, MANUAL_REGISTRATION_TOKEN_PREFIX_RE);
   await expect(rawToken).toBeVisible();
-  await rawToken.evaluate((element: Element, token) => {
-    element.textContent = token;
-  }, VISUAL_TEST_MANUAL_TOKEN);
-  await expect(createTokenDialog.getByText(VISUAL_TEST_MANUAL_TOKEN)).toBeVisible();
 
-  const row = rowByName(section, 'E2E manual runner');
+  const row = runnerTokens.manualTokenRow('E2E manual runner');
   await expect(row).toBeVisible();
-  await normalizeManualTokenRowForVisuals(row, {
-    prefix: VISUAL_TEST_MANUAL_TOKEN_PREFIX,
-    expiresAt: VISUAL_TEST_EXPIRES_AT,
-    createdAt: VISUAL_TEST_CREATED_AT,
-  });
-  await argosScreenshot(page, 'runners/settings-runners-create-token-success');
+  await stableScreenshot(page, 'runners/settings-runners-create-token-success', [
+    {locator: rawToken, text: VISUAL_TEST_MANUAL_TOKEN},
+    {
+      locator: runnerTokens.manualTokenCell('E2E manual runner', 1),
+      text: VISUAL_TEST_MANUAL_TOKEN_PREFIX,
+    },
+    {locator: runnerTokens.manualTokenCell('E2E manual runner', 2), text: VISUAL_TEST_EXPIRES_AT},
+    {locator: runnerTokens.manualTokenCell('E2E manual runner', 3), text: VISUAL_TEST_CREATED_AT},
+  ]);
 });
 
 test('revokes a manual runner registration token from settings', async ({
   page,
+  runnerTokens,
   createReadyWorkspace,
 }) => {
   const {sessionToken: userToken, workspaceId} = await createReadyWorkspace({
@@ -132,17 +68,11 @@ test('revokes a manual runner registration token from settings', async ({
     ttlSeconds: 3600,
   });
 
-  await gotoManualTokensSettings(page, workspaceId);
-  const section = manualTokensSection(page);
-  const row = rowByName(section, 'E2E manual revoke runner');
+  await runnerTokens.gotoManualTokens(workspaceId);
+  const row = runnerTokens.manualTokenRow('E2E manual revoke runner');
   await expect(row).toBeVisible();
 
-  await row
-    .getByRole('button', {name: 'Open E2E manual revoke runner registration token actions'})
-    .click();
-  await page.getByRole('menuitem', {name: 'Revoke token'}).click();
-  const revokeDialog = page.getByRole('dialog', {name: 'Revoke token'});
-  await expect(revokeDialog).toBeVisible();
+  const revokeDialog = await runnerTokens.openManualRevokeDialog('E2E manual revoke runner');
   await Promise.all([
     page.waitForResponse(
       (response) =>
@@ -150,16 +80,17 @@ test('revokes a manual runner registration token from settings', async ({
         response.url().endsWith('/revoke') &&
         response.status() === 200,
     ),
-    revokeDialog.getByRole('button', {name: 'Revoke', exact: true}).click(),
+    revokeDialog.locator().getByRole('button', {name: 'Revoke', exact: true}).click(),
   ]);
-  await expect(revokeDialog).toBeHidden();
+  await revokeDialog.expectClosed();
 
   await expect(row).toHaveCount(0);
-  await expect(section.getByText('No usable manual registration tokens')).toBeVisible();
+  await expect(runnerTokens.manualEmptyState()).toBeVisible();
 });
 
 test('creates a provisioner registration token from settings', async ({
   page,
+  runnerTokens,
   createReadyWorkspace,
 }) => {
   test.setTimeout(60_000);
@@ -169,45 +100,43 @@ test('creates a provisioner registration token from settings', async ({
     name: 'Provisioner Token Create Workspace',
   });
 
-  await gotoProvisionerTokensSettings(page, workspaceId);
-  const section = provisionerTokensSection(page);
-  await expect(section.getByText('No usable provisioner registration tokens')).toBeVisible();
-  await argosScreenshot(page, 'runners/settings-provisioners-empty');
+  await runnerTokens.gotoProvisionerTokens(workspaceId);
+  await expect(runnerTokens.provisionerEmptyState()).toBeVisible();
+  await stableScreenshot(page, 'runners/settings-provisioners-empty');
 
-  await section.getByRole('button', {name: 'Create token'}).click();
-  const createTokenDialog = page.getByRole('dialog', {
-    name: 'Create provisioner registration token',
-  });
-  await expect(createTokenDialog).toBeVisible();
-  await expect(createTokenDialog.getByLabel('Token name')).toBeVisible();
-  await expect(createTokenDialog.getByRole('button', {name: 'Create token'})).toBeVisible();
-  await argosScreenshot(page, 'runners/settings-provisioners-create-token-form');
+  const createTokenDialog = await runnerTokens.openProvisionerCreateDialog();
+  await expect(createTokenDialog.field('Token name')).toBeVisible();
+  await expect(createTokenDialog.confirmButton('Create token')).toBeVisible();
+  await stableScreenshot(page, 'runners/settings-provisioners-create-token-form');
 
-  await createTokenDialog.getByLabel('Token name').fill('E2E provisioner');
-  await createTokenDialog.getByRole('button', {name: 'Create token'}).click();
+  await runnerTokens.createTokenFromDialog(createTokenDialog, 'E2E provisioner');
 
-  await expect(createTokenDialog.getByText('Token created')).toBeVisible();
-  const rawToken = createTokenDialog.locator('p.font-code').filter({
-    hasText: PROVISIONER_TOKEN_PREFIX_RE,
-  });
+  await expect(createTokenDialog.locator().getByText('Token created')).toBeVisible();
+  const rawToken = runnerTokens.rawToken(createTokenDialog, PROVISIONER_TOKEN_PREFIX_RE);
   await expect(rawToken).toBeVisible();
-  await rawToken.evaluate((element: Element, token) => {
-    element.textContent = token;
-  }, VISUAL_TEST_PROVISIONER_TOKEN);
-  await expect(createTokenDialog.getByText(VISUAL_TEST_PROVISIONER_TOKEN)).toBeVisible();
 
-  const row = rowByName(section, 'E2E provisioner');
+  const row = runnerTokens.provisionerTokenRow('E2E provisioner');
   await expect(row).toBeVisible();
-  await normalizeProvisionerTokenRowForVisuals(row, {
-    prefix: VISUAL_TEST_PROVISIONER_TOKEN_PREFIX,
-    expiresAt: VISUAL_TEST_EXPIRES_AT,
-    createdAt: VISUAL_TEST_CREATED_AT,
-  });
-  await argosScreenshot(page, 'runners/settings-provisioners-create-token-success');
+  await stableScreenshot(page, 'runners/settings-provisioners-create-token-success', [
+    {locator: rawToken, text: VISUAL_TEST_PROVISIONER_TOKEN},
+    {
+      locator: runnerTokens.provisionerTokenCell('E2E provisioner', 1),
+      text: VISUAL_TEST_PROVISIONER_TOKEN_PREFIX,
+    },
+    {
+      locator: runnerTokens.provisionerTokenCell('E2E provisioner', 3),
+      text: VISUAL_TEST_EXPIRES_AT,
+    },
+    {
+      locator: runnerTokens.provisionerTokenCell('E2E provisioner', 4),
+      text: VISUAL_TEST_CREATED_AT,
+    },
+  ]);
 });
 
 test('revokes a provisioner registration token from settings', async ({
   page,
+  runnerTokens,
   createReadyWorkspace,
 }) => {
   const {sessionToken: userToken, workspaceId} = await createReadyWorkspace({
@@ -220,15 +149,11 @@ test('revokes a provisioner registration token from settings', async ({
     ttlSeconds: 3600,
   });
 
-  await gotoProvisionerTokensSettings(page, workspaceId);
-  const section = provisionerTokensSection(page);
-  const row = rowByName(section, 'E2E revoke provisioner');
+  await runnerTokens.gotoProvisionerTokens(workspaceId);
+  const row = runnerTokens.provisionerTokenRow('E2E revoke provisioner');
   await expect(row).toBeVisible();
 
-  await row.getByRole('button', {name: 'Open E2E revoke provisioner token actions'}).click();
-  await page.getByRole('menuitem', {name: 'Revoke token'}).click();
-  const revokeDialog = page.getByRole('dialog', {name: 'Revoke token'});
-  await expect(revokeDialog).toBeVisible();
+  const revokeDialog = await runnerTokens.openProvisionerRevokeDialog('E2E revoke provisioner');
   await Promise.all([
     page.waitForResponse(
       (response) =>
@@ -236,10 +161,10 @@ test('revokes a provisioner registration token from settings', async ({
         response.url().endsWith('/revoke') &&
         response.status() === 200,
     ),
-    revokeDialog.getByRole('button', {name: 'Revoke', exact: true}).click(),
+    revokeDialog.locator().getByRole('button', {name: 'Revoke', exact: true}).click(),
   ]);
-  await expect(revokeDialog).toBeHidden();
+  await revokeDialog.expectClosed();
 
   await expect(row).toHaveCount(0);
-  await expect(section.getByText('No usable provisioner registration tokens')).toBeVisible();
+  await expect(runnerTokens.provisionerEmptyState()).toBeVisible();
 });

--- a/e2e/client/runners/tests/test.ts
+++ b/e2e/client/runners/tests/test.ts
@@ -1,5 +1,9 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
+import {type RunnerScreenFixtures, runnerScreens} from '@shipfox/e2e-screens-runners';
 
-export const test = base.extend<WorkspaceFixtures>(workspaceFixtures);
+export const test = base.extend<WorkspaceFixtures & RunnerScreenFixtures>({
+  ...workspaceFixtures,
+  ...runnerScreens,
+});
 export {expect};

--- a/e2e/client/secrets/package.json
+++ b/e2e/client/secrets/package.json
@@ -29,6 +29,7 @@
     "@shipfox/e2e-helper-secrets": "workspace:*",
     "@shipfox/e2e-helper-workspaces": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
+    "@shipfox/e2e-screens-secrets": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/secrets/tests/secrets-settings.e2e.ts
+++ b/e2e/client/secrets/tests/secrets-settings.e2e.ts
@@ -1,4 +1,3 @@
-import type {Page} from '@shipfox/playwright';
 import {expect, test} from './test.js';
 
 const SECRET_CREATE_KEY = 'E2E_SECRET_CREATE';
@@ -8,74 +7,25 @@ const VARIABLE_CREATE_KEY = 'E2E_VARIABLE_CREATE';
 const VARIABLE_EDIT_KEY = 'E2E_VARIABLE_EDIT';
 const VARIABLE_DELETE_KEY = 'E2E_VARIABLE_DELETE';
 
-function secretsSection(page: Page) {
-  return page.locator('section[aria-label="Secrets"]');
-}
-
-function variablesSection(page: Page) {
-  return page.locator('section[aria-label="Variables"]');
-}
-
-function rowByKey(section: ReturnType<typeof secretsSection>, key: string) {
-  return section.locator('tr', {hasText: key});
-}
-
-async function gotoSecrets(page: Page, workspaceId: string) {
-  await page.goto(`/workspaces/${workspaceId}/settings/secrets`);
-  await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/settings/secrets/?$`, 'u'));
-  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
-}
-
-async function gotoVariables(page: Page, workspaceId: string) {
-  await page.goto(`/workspaces/${workspaceId}/settings/variables`);
-  await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/settings/variables/?$`, 'u'));
-  await expect(page.getByRole('heading', {name: 'Workspace settings'})).toBeVisible();
-}
-
-async function createSecretFromSettings(page: Page, key: string, value: string) {
-  const section = secretsSection(page);
-  await section.getByRole('button', {name: 'Create secret'}).first().click();
-  const dialog = page.getByRole('dialog', {name: 'Create secret'});
-  await expect(dialog).toBeVisible();
-
-  await dialog.getByLabel('Name').fill(key);
-  await dialog.getByRole('textbox', {name: 'Value'}).fill(value);
-  await dialog.getByRole('button', {name: 'Create secret'}).click();
-
-  await expect(page.getByText('Secret created')).toBeVisible();
-  await expect(rowByKey(section, key)).toBeVisible();
-}
-
-async function createVariableFromSettings(page: Page, key: string, value: string) {
-  const section = variablesSection(page);
-  await section.getByRole('button', {name: 'Create variable'}).first().click();
-  const dialog = page.getByRole('dialog', {name: 'Create variable'});
-  await expect(dialog).toBeVisible();
-
-  await dialog.getByLabel('Name').fill(key);
-  await dialog.getByRole('textbox', {name: 'Value'}).fill(value);
-  await dialog.getByRole('button', {name: 'Create variable'}).click();
-
-  await expect(page.getByText('Variable created')).toBeVisible();
-  await expect(rowByKey(section, key)).toBeVisible();
-}
-
-test('creates a workspace secret from settings', async ({page, createReadyWorkspace}) => {
+test('creates a workspace secret from settings', async ({secretsScreen, createReadyWorkspace}) => {
   const {workspaceId} = await createReadyWorkspace({
     name: 'Secrets Create Workspace',
   });
   const value = 'secret-create-value-e2e';
 
-  await gotoSecrets(page, workspaceId);
-  await expect(secretsSection(page).getByText('No secrets yet')).toBeVisible();
-  await createSecretFromSettings(page, SECRET_CREATE_KEY, value);
+  await secretsScreen.goto(workspaceId);
+  await expect(secretsScreen.emptyState()).toBeVisible();
+  await secretsScreen.createSecret(SECRET_CREATE_KEY, value);
 
-  const row = rowByKey(secretsSection(page), SECRET_CREATE_KEY);
-  await expect(row.getByLabel('Value hidden')).toBeVisible();
-  await expect(secretsSection(page)).not.toContainText(value);
+  await expect(secretsScreen.valueHidden(SECRET_CREATE_KEY)).toBeVisible();
+  await expect(secretsScreen.section()).not.toContainText(value);
 });
 
-test('edits a workspace secret from settings', async ({page, secrets, createReadyWorkspace}) => {
+test('edits a workspace secret from settings', async ({
+  secrets,
+  secretsScreen,
+  createReadyWorkspace,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     name: 'Secrets Edit Workspace',
   });
@@ -88,24 +38,25 @@ test('edits a workspace secret from settings', async ({page, secrets, createRead
     value: oldValue,
   });
 
-  await gotoSecrets(page, workspaceId);
-  const row = rowByKey(secretsSection(page), SECRET_EDIT_KEY);
-  await row.getByRole('button', {name: `Actions for ${SECRET_EDIT_KEY}`}).click();
-  await page.getByRole('menuitem', {name: 'Edit value'}).click();
-  const dialog = page.getByRole('dialog', {name: 'Update secret'});
-  await expect(dialog.getByLabel('Name')).toBeDisabled();
-  await expect(dialog.getByLabel('Name')).toHaveValue(SECRET_EDIT_KEY);
+  await secretsScreen.goto(workspaceId);
+  const dialog = await secretsScreen.openUpdateDialog(SECRET_EDIT_KEY);
+  await expect(dialog.field('Name')).toBeDisabled();
+  await expect(dialog.field('Name')).toHaveValue(SECRET_EDIT_KEY);
 
-  await dialog.getByRole('textbox', {name: 'Value'}).fill(newValue);
-  await dialog.getByRole('button', {name: 'Update secret'}).click();
+  await dialog.locator().getByRole('textbox', {name: 'Value'}).fill(newValue);
+  await dialog.confirm('Update secret');
 
-  await expect(page.getByText('Secret updated')).toBeVisible();
-  await expect(row).toBeVisible();
-  await expect(secretsSection(page)).not.toContainText(oldValue);
-  await expect(secretsSection(page)).not.toContainText(newValue);
+  await expect(secretsScreen.toastMessage('Secret updated')).toBeVisible();
+  await expect(secretsScreen.rowByKey(SECRET_EDIT_KEY)).toBeVisible();
+  await expect(secretsScreen.section()).not.toContainText(oldValue);
+  await expect(secretsScreen.section()).not.toContainText(newValue);
 });
 
-test('deletes a workspace secret from settings', async ({page, secrets, createReadyWorkspace}) => {
+test('deletes a workspace secret from settings', async ({
+  secrets,
+  secretsScreen,
+  createReadyWorkspace,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     name: 'Secrets Delete Workspace',
   });
@@ -116,34 +67,37 @@ test('deletes a workspace secret from settings', async ({page, secrets, createRe
     value: 'secret-delete-value-e2e',
   });
 
-  await gotoSecrets(page, workspaceId);
-  const section = secretsSection(page);
-  const row = rowByKey(section, SECRET_DELETE_KEY);
-  await row.getByRole('button', {name: `Actions for ${SECRET_DELETE_KEY}`}).click();
-  await page.getByRole('menuitem', {name: 'Delete'}).click();
-  const dialog = page.getByRole('dialog', {name: new RegExp(`Delete ${SECRET_DELETE_KEY}`, 'u')});
-  await dialog.getByRole('button', {name: 'Delete'}).click();
+  await secretsScreen.goto(workspaceId);
+  const row = secretsScreen.rowByKey(SECRET_DELETE_KEY);
+  await secretsScreen.deleteSecret(SECRET_DELETE_KEY);
 
-  await expect(page.getByText('Secret deleted')).toBeVisible();
   await expect(row).toHaveCount(0);
-  await expect(section.getByText('No secrets yet')).toBeVisible();
+  await expect(secretsScreen.emptyState()).toBeVisible();
 });
 
-test('creates a workspace variable from settings', async ({page, createReadyWorkspace}) => {
+test('creates a workspace variable from settings', async ({
+  variablesScreen,
+  createReadyWorkspace,
+}) => {
   const {workspaceId} = await createReadyWorkspace({
     name: 'Variables Create Workspace',
   });
   const value = 'debug';
 
-  await gotoVariables(page, workspaceId);
-  await expect(variablesSection(page).getByText('No variables yet')).toBeVisible();
-  await createVariableFromSettings(page, VARIABLE_CREATE_KEY, value);
+  await variablesScreen.goto(workspaceId);
+  await expect(variablesScreen.emptyState()).toBeVisible();
+  await variablesScreen.createVariable(VARIABLE_CREATE_KEY, value);
 
-  const row = rowByKey(variablesSection(page), VARIABLE_CREATE_KEY);
-  await expect(row.getByText(value, {exact: true})).toBeVisible();
+  await expect(
+    variablesScreen.rowByKey(VARIABLE_CREATE_KEY).getByText(value, {exact: true}),
+  ).toBeVisible();
 });
 
-test('edits a workspace variable from settings', async ({page, secrets, createReadyWorkspace}) => {
+test('edits a workspace variable from settings', async ({
+  secrets,
+  variablesScreen,
+  createReadyWorkspace,
+}) => {
   const {userId, workspaceId} = await createReadyWorkspace({
     name: 'Variables Edit Workspace',
   });
@@ -156,27 +110,24 @@ test('edits a workspace variable from settings', async ({page, secrets, createRe
     value: oldValue,
   });
 
-  await gotoVariables(page, workspaceId);
-  const section = variablesSection(page);
-  const row = rowByKey(section, VARIABLE_EDIT_KEY);
+  await variablesScreen.goto(workspaceId);
+  const row = variablesScreen.rowByKey(VARIABLE_EDIT_KEY);
   await expect(row.getByText(oldValue, {exact: true})).toBeVisible();
-  await row.getByRole('button', {name: `Actions for ${VARIABLE_EDIT_KEY}`}).click();
-  await page.getByRole('menuitem', {name: 'Edit value'}).click();
-  const dialog = page.getByRole('dialog', {name: 'Update variable'});
-  await expect(dialog.getByLabel('Name')).toBeDisabled();
-  await expect(dialog.getByLabel('Name')).toHaveValue(VARIABLE_EDIT_KEY);
+  const dialog = await variablesScreen.openUpdateDialog(VARIABLE_EDIT_KEY);
+  await expect(dialog.field('Name')).toBeDisabled();
+  await expect(dialog.field('Name')).toHaveValue(VARIABLE_EDIT_KEY);
 
-  await dialog.getByRole('textbox', {name: 'Value'}).fill(newValue);
-  await dialog.getByRole('button', {name: 'Update variable'}).click();
+  await dialog.locator().getByRole('textbox', {name: 'Value'}).fill(newValue);
+  await dialog.confirm('Update variable');
 
-  await expect(page.getByText('Variable updated')).toBeVisible();
+  await expect(variablesScreen.toastMessage('Variable updated')).toBeVisible();
   await expect(row.getByText(newValue, {exact: true})).toBeVisible();
   await expect(row).not.toContainText(oldValue);
 });
 
 test('deletes a workspace variable from settings', async ({
-  page,
   secrets,
+  variablesScreen,
   createReadyWorkspace,
 }) => {
   const {userId, workspaceId} = await createReadyWorkspace({
@@ -189,17 +140,10 @@ test('deletes a workspace variable from settings', async ({
     value: 'trace',
   });
 
-  await gotoVariables(page, workspaceId);
-  const section = variablesSection(page);
-  const row = rowByKey(section, VARIABLE_DELETE_KEY);
-  await row.getByRole('button', {name: `Actions for ${VARIABLE_DELETE_KEY}`}).click();
-  await page.getByRole('menuitem', {name: 'Delete'}).click();
-  const dialog = page.getByRole('dialog', {
-    name: new RegExp(`Delete ${VARIABLE_DELETE_KEY}`, 'u'),
-  });
-  await dialog.getByRole('button', {name: 'Delete'}).click();
+  await variablesScreen.goto(workspaceId);
+  const row = variablesScreen.rowByKey(VARIABLE_DELETE_KEY);
+  await variablesScreen.deleteVariable(VARIABLE_DELETE_KEY);
 
-  await expect(page.getByText('Variable deleted')).toBeVisible();
   await expect(row).toHaveCount(0);
-  await expect(section.getByText('No variables yet')).toBeVisible();
+  await expect(variablesScreen.emptyState()).toBeVisible();
 });

--- a/e2e/client/secrets/tests/test.ts
+++ b/e2e/client/secrets/tests/test.ts
@@ -1,9 +1,11 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type SecretsFixtures, secretsHelper} from '@shipfox/e2e-helper-secrets';
 import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
+import {type SecretsScreenFixtures, secretsScreens} from '@shipfox/e2e-screens-secrets';
 
-export const test = base.extend<WorkspaceFixtures & SecretsFixtures>({
+export const test = base.extend<WorkspaceFixtures & SecretsFixtures & SecretsScreenFixtures>({
   ...workspaceFixtures,
   ...secretsHelper,
+  ...secretsScreens,
 });
 export {expect};

--- a/e2e/client/workspaces/package.json
+++ b/e2e/client/workspaces/package.json
@@ -24,6 +24,7 @@
     "@shipfox/e2e-core": "workspace:*",
     "@shipfox/e2e-helper-integrations-gitea": "workspace:*",
     "@shipfox/e2e-kit": "workspace:*",
+    "@shipfox/e2e-screens-workspaces": "workspace:*",
     "@shipfox/playwright": "workspace:*",
     "@shipfox/ts-config": "workspace:*",
     "@shipfox/typescript": "workspace:*"

--- a/e2e/client/workspaces/tests/invitations-members.e2e.ts
+++ b/e2e/client/workspaces/tests/invitations-members.e2e.ts
@@ -1,5 +1,5 @@
 import {randomUUID} from 'node:crypto';
-import {argosScreenshot, type Page} from '@shipfox/playwright';
+import {stableScreenshot} from '@shipfox/e2e-kit/ui';
 import {expect, test} from './test.js';
 
 const PENDING_INVITATION_RE = /open invitation already exists/u;
@@ -17,113 +17,11 @@ function textRe(text: string): RegExp {
   return new RegExp(text.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&'), 'u');
 }
 
-async function stableArgosScreenshot(
-  page: Page,
-  name: string,
-  replacements: ReadonlyArray<readonly [string, string]> = [],
-): Promise<void> {
-  await argosScreenshot(page, name, {
-    beforeScreenshot: async () => {
-      await page.evaluate((visualReplacements) => {
-        type RestoreEntry =
-          | {kind: 'attribute'; target: Element; attribute: string; value: string}
-          | {kind: 'text'; target: Text; value: string}
-          | {kind: 'value'; target: HTMLInputElement | HTMLTextAreaElement; value: string};
-        const visualWindow = window as Window & {
-          __shipfoxVisualRestore?: RestoreEntry[];
-          __shipfoxToasterDisplay?: string;
-        };
-        const restoreEntries: RestoreEntry[] = [];
-
-        // A prior action's success toast auto-dismisses after a few seconds, so whether
-        // it lingers into a later snapshot is a timing race. Hide the toaster region for
-        // the capture; afterScreenshot restores it so later toast assertions still see it.
-        const toaster = document.querySelector('[data-sonner-toaster]');
-        if (toaster instanceof HTMLElement) {
-          visualWindow.__shipfoxToasterDisplay = toaster.style.display;
-          toaster.style.display = 'none';
-        }
-
-        const replaceValue = (value: string): string =>
-          visualReplacements.reduce(
-            (current, [source, replacement]) => current.split(source).join(replacement),
-            value,
-          );
-
-        const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-        let node = walker.nextNode();
-        while (node) {
-          const textNode = node as Text;
-          const nextValue = replaceValue(textNode.data);
-          if (nextValue !== textNode.data) {
-            restoreEntries.push({kind: 'text', target: textNode, value: textNode.data});
-            textNode.data = nextValue;
-          }
-          node = walker.nextNode();
-        }
-
-        for (const element of document.querySelectorAll('input, textarea')) {
-          if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
-            const nextValue = replaceValue(element.value);
-            if (nextValue !== element.value) {
-              restoreEntries.push({kind: 'value', target: element, value: element.value});
-              element.value = nextValue;
-            }
-          }
-        }
-
-        for (const element of document.querySelectorAll('[aria-label], [placeholder], [title]')) {
-          for (const attribute of ['aria-label', 'placeholder', 'title']) {
-            const value = element.getAttribute(attribute);
-            if (value == null) continue;
-            const nextValue = replaceValue(value);
-            if (nextValue !== value) {
-              restoreEntries.push({kind: 'attribute', target: element, attribute, value});
-              element.setAttribute(attribute, nextValue);
-            }
-          }
-        }
-
-        visualWindow.__shipfoxVisualRestore = restoreEntries;
-      }, replacements);
-    },
-    afterScreenshot: async () => {
-      await page.evaluate(() => {
-        type RestoreEntry =
-          | {kind: 'attribute'; target: Element; attribute: string; value: string}
-          | {kind: 'text'; target: Text; value: string}
-          | {kind: 'value'; target: HTMLInputElement | HTMLTextAreaElement; value: string};
-        const visualWindow = window as Window & {
-          __shipfoxVisualRestore?: RestoreEntry[];
-          __shipfoxToasterDisplay?: string;
-        };
-        const restoreEntries = visualWindow.__shipfoxVisualRestore ?? [];
-
-        for (const entry of restoreEntries.reverse()) {
-          if (entry.kind === 'text') {
-            entry.target.data = entry.value;
-          } else if (entry.kind === 'value') {
-            entry.target.value = entry.value;
-          } else {
-            entry.target.setAttribute(entry.attribute, entry.value);
-          }
-        }
-
-        const toaster = document.querySelector('[data-sonner-toaster]');
-        if (toaster instanceof HTMLElement && visualWindow.__shipfoxToasterDisplay !== undefined) {
-          toaster.style.display = visualWindow.__shipfoxToasterDisplay;
-        }
-        delete visualWindow.__shipfoxToasterDisplay;
-
-        delete visualWindow.__shipfoxVisualRestore;
-      });
-    },
-  });
-}
-
 test('accepts an invitation from the public landing page via login', async ({
   page,
   auth,
+  invitationAccept,
+  membersSettings,
   projects,
   workspaces,
 }) => {
@@ -144,60 +42,64 @@ test('accepts an invitation from the public landing page via login', async ({
     invitedByDisplay: 'Owner User',
   });
 
-  await page.goto(`/invitations/accept?token=${encodeURIComponent(invitation.raw_token)}`);
-  await expect(page.getByRole('heading', {name: 'Invitation Flow Workspace'})).toBeVisible();
-  await expect(page.getByText(`Invited by Owner User to join as ${invitee.email}.`)).toBeVisible();
-  await stableArgosScreenshot(page, 'invitations/pending-unauth', [
-    [owner.email, VISUAL_OWNER_EMAIL],
-    [invitee.email, VISUAL_INVITEE_EMAIL],
-  ]);
+  await invitationAccept.goto(invitation.raw_token);
+  await expect(invitationAccept.heading('Invitation Flow Workspace')).toBeVisible();
+  await expect(
+    invitationAccept.message(`Invited by Owner User to join as ${invitee.email}.`),
+  ).toBeVisible();
+  await stableScreenshot(page, 'invitations/pending-unauth', {
+    textReplacements: [
+      [owner.email, VISUAL_OWNER_EMAIL],
+      [invitee.email, VISUAL_INVITEE_EMAIL],
+    ],
+    hideToaster: true,
+  });
 
-  await page.getByRole('link', {name: 'I already have an account'}).click();
-  await expect(page.getByRole('heading', {name: 'Join Invitation Flow Workspace'})).toBeVisible();
-  const emailInput = page.getByLabel('Email');
+  await invitationAccept.link('I already have an account').click();
+  await expect(invitationAccept.heading('Join Invitation Flow Workspace')).toBeVisible();
+  const emailInput = invitationAccept.field('Email');
   await expect(emailInput).toHaveValue(invitee.email);
   await expect(emailInput).toHaveJSProperty('readOnly', true);
-  await expect(page.getByText('Joining Invitation Flow Workspace.')).toBeHidden();
+  await expect(invitationAccept.message('Joining Invitation Flow Workspace.')).toBeHidden();
 
-  await page.getByRole('link', {name: 'Create an account'}).click();
-  await expect(page.getByRole('heading', {name: 'Join Invitation Flow Workspace'})).toBeVisible();
-  const signupEmailInput = page.getByLabel('Email');
+  await invitationAccept.link('Create an account').click();
+  await expect(invitationAccept.heading('Join Invitation Flow Workspace')).toBeVisible();
+  const signupEmailInput = invitationAccept.field('Email');
   await expect(signupEmailInput).toHaveValue(invitee.email);
   await expect(signupEmailInput).toHaveJSProperty('readOnly', true);
 
-  await page.getByRole('link', {name: 'Log in'}).click();
-  await expect(page.getByRole('heading', {name: 'Join Invitation Flow Workspace'})).toBeVisible();
-  await expect(page.getByLabel('Email')).toHaveValue(invitee.email);
+  await invitationAccept.link('Log in').click();
+  await expect(invitationAccept.heading('Join Invitation Flow Workspace')).toBeVisible();
+  await expect(invitationAccept.field('Email')).toHaveValue(invitee.email);
 
-  await page.getByLabel('Password').fill(invitee.password);
+  await invitationAccept.field('Password').fill(invitee.password);
   await projects.createProject({workspaceId: workspace.id});
-  await page.getByRole('button', {name: 'Log in'}).click();
+  await invitationAccept.button('Log in').click();
 
   await expect(page).toHaveURL(workspaceUrlRe(workspace.id));
-  await expect(page.getByText('You joined Invitation Flow Workspace.')).toBeVisible();
+  await expect(invitationAccept.message('You joined Invitation Flow Workspace.')).toBeVisible();
 
-  await page.goto(`/workspaces/${workspace.id}/settings/members`);
-  await expect(page.getByRole('heading', {name: 'Members'})).toBeVisible();
-  await expect(page.getByText(owner.email)).toBeVisible();
-  await expect(page.getByText(invitee.email)).toBeVisible();
-  await expect(page.getByText('No pending invitations.')).toBeVisible();
-  const memberJoinedText = (
-    await page
-      .getByRole('row', {name: textRe(invitee.email)})
-      .getByRole('cell')
-      .nth(2)
-      .innerText()
-  ).trim();
-  await stableArgosScreenshot(page, 'members/populated-with-empty-invitations', [
-    [owner.email, VISUAL_OWNER_EMAIL],
-    [invitee.email, VISUAL_INVITEE_EMAIL],
-    [memberJoinedText, VISUAL_JOINED_DATE],
-  ]);
+  await membersSettings.goto(workspace.id);
+  await expect(membersSettings.heading()).toBeVisible();
+  await expect(membersSettings.memberText(owner.email)).toBeVisible();
+  await expect(membersSettings.memberText(invitee.email)).toBeVisible();
+  await expect(membersSettings.emptyPendingInvitations()).toBeVisible();
+  const memberJoinedText = await membersSettings.memberCellText(textRe(invitee.email), 2);
+  await stableScreenshot(page, 'members/populated-with-empty-invitations', {
+    textReplacements: [
+      [owner.email, VISUAL_OWNER_EMAIL],
+      [invitee.email, VISUAL_INVITEE_EMAIL],
+      [memberJoinedText, VISUAL_JOINED_DATE],
+    ],
+    hideToaster: true,
+  });
 });
 
 test('creates an account from an invitation with the email locked', async ({
   page,
   auth,
+  invitationAccept,
+  membersSettings,
   projects,
   workspaces,
 }) => {
@@ -216,31 +118,32 @@ test('creates an account from an invitation with the email locked', async ({
     invitedByDisplay: 'Signup Owner',
   });
 
-  await page.goto(`/invitations/accept?token=${encodeURIComponent(invitation.raw_token)}`);
-  await page.getByRole('link', {name: 'Create account'}).click();
+  await invitationAccept.goto(invitation.raw_token);
+  await invitationAccept.link('Create account').click();
 
-  await expect(page.getByRole('heading', {name: 'Join Invitation Signup Workspace'})).toBeVisible();
-  const emailInput = page.getByLabel('Email');
+  await expect(invitationAccept.heading('Join Invitation Signup Workspace')).toBeVisible();
+  const emailInput = invitationAccept.field('Email');
   await expect(emailInput).toHaveValue(inviteeEmail);
   await expect(emailInput).toHaveJSProperty('readOnly', true);
-  await expect(page.getByText('Joining Invitation Signup Workspace.')).toBeHidden();
+  await expect(invitationAccept.message('Joining Invitation Signup Workspace.')).toBeHidden();
 
-  await page.getByLabel('Name').fill('Signup Invitee');
-  await page.getByLabel('Password').fill('correct horse battery staple');
+  await invitationAccept.field('Name').fill('Signup Invitee');
+  await invitationAccept.field('Password').fill('correct horse battery staple');
   await projects.createProject({workspaceId: workspace.id});
-  await page.getByRole('button', {name: 'Create account'}).click();
+  await invitationAccept.button('Create account').click();
 
   await expect(page).toHaveURL(workspaceUrlRe(workspace.id));
-  await expect(page.getByText('You joined Invitation Signup Workspace.')).toBeVisible();
+  await expect(invitationAccept.message('You joined Invitation Signup Workspace.')).toBeVisible();
 
-  await page.goto(`/workspaces/${workspace.id}/settings/members`);
-  await expect(page.getByText(inviteeEmail)).toBeVisible();
-  await expect(page.getByText('Signup Invitee')).toBeVisible();
+  await membersSettings.goto(workspace.id);
+  await expect(membersSettings.memberText(inviteeEmail)).toBeVisible();
+  await expect(membersSettings.memberText('Signup Invitee')).toBeVisible();
 });
 
 test('creates, rejects duplicate, and revokes a pending invitation from members settings', async ({
   page,
   auth,
+  membersSettings,
   projects,
   workspaces,
 }) => {
@@ -255,70 +158,75 @@ test('creates, rejects duplicate, and revokes a pending invitation from members 
   await projects.createProject({workspaceId: workspace.id});
   await auth.loginAs(page, owner);
 
-  await page.goto(`/workspaces/${workspace.id}/settings/members`);
-  await expect(page.getByRole('heading', {name: 'Pending invitations'})).toBeVisible();
-  await expect(page.getByText('No pending invitations.')).toBeVisible();
-  const ownerJoinedText = (
-    await page
-      .getByRole('row', {name: textRe(owner.email)})
-      .getByRole('cell')
-      .nth(2)
-      .innerText()
-  ).trim();
+  await membersSettings.goto(workspace.id);
+  await expect(membersSettings.pendingInvitationsHeading()).toBeVisible();
+  await expect(membersSettings.emptyPendingInvitations()).toBeVisible();
+  const ownerJoinedText = await membersSettings.memberCellText(textRe(owner.email), 2);
   const ownerRowReplacements = [
     [owner.email, VISUAL_OWNER_EMAIL],
     [ownerJoinedText, VISUAL_JOINED_DATE],
   ] as const;
-  await stableArgosScreenshot(page, 'members/pending-invitations-empty', ownerRowReplacements);
+  await stableScreenshot(page, 'members/pending-invitations-empty', {
+    textReplacements: ownerRowReplacements,
+    hideToaster: true,
+  });
 
-  await page.getByRole('button', {name: 'Invite member'}).click();
-  await expect(page.getByRole('heading', {name: 'Invite a member'})).toBeVisible();
-  await expect(page.getByLabel('Email')).toBeFocused();
-  await stableArgosScreenshot(page, 'members/invite-member-modal-idle', ownerRowReplacements);
+  const firstInviteDialog = await membersSettings.openInviteDialog();
+  await expect(firstInviteDialog.locator()).toBeVisible();
+  await expect(firstInviteDialog.field('Email')).toBeFocused();
+  await stableScreenshot(page, 'members/invite-member-modal-idle', {
+    textReplacements: ownerRowReplacements,
+    hideToaster: true,
+  });
 
-  await page.getByLabel('Email').fill(pendingEmail);
-  await page.getByRole('button', {name: 'Send invitation'}).click();
-  await expect(page.getByText(`Invitation sent to ${pendingEmail}.`)).toBeVisible();
-  const pendingInvitationRow = page.getByRole('row', {name: textRe(pendingEmail)});
+  await firstInviteDialog.field('Email').fill(pendingEmail);
+  await firstInviteDialog.confirm('Send invitation');
+  await expect(membersSettings.memberText(`Invitation sent to ${pendingEmail}.`)).toBeVisible();
+  const pendingInvitationRow = membersSettings.pendingInvitationRow(textRe(pendingEmail));
   await expect(pendingInvitationRow).toBeVisible();
-  const pendingExpiresText = (
-    await pendingInvitationRow.getByRole('cell').nth(2).innerText()
-  ).trim();
+  const pendingExpiresText = await membersSettings.pendingInvitationExpiresText(
+    textRe(pendingEmail),
+  );
   const pendingRowReplacements = [
     [owner.email, VISUAL_OWNER_EMAIL],
     [pendingEmail, VISUAL_PENDING_EMAIL],
     [ownerJoinedText, VISUAL_JOINED_DATE],
     [pendingExpiresText, VISUAL_EXPIRES_DATE],
   ] as const;
-  await stableArgosScreenshot(
-    page,
-    'members/pending-invitations-populated',
-    pendingRowReplacements,
-  );
+  await stableScreenshot(page, 'members/pending-invitations-populated', {
+    textReplacements: pendingRowReplacements,
+    hideToaster: true,
+  });
 
-  await page.getByRole('button', {name: 'Invite member'}).click();
-  await expect(page.getByRole('heading', {name: 'Invite a member'})).toBeVisible();
-  await expect(page.getByLabel('Email')).toBeFocused();
-  await page.getByLabel('Email').fill(pendingEmail);
-  await page.getByRole('button', {name: 'Send invitation'}).click();
-  await expect(page.getByText(PENDING_INVITATION_RE)).toBeVisible();
-  await stableArgosScreenshot(page, 'members/invite-member-modal-conflict', pendingRowReplacements);
+  const conflictDialog = await membersSettings.openInviteDialog();
+  await expect(conflictDialog.locator()).toBeVisible();
+  await expect(conflictDialog.field('Email')).toBeFocused();
+  await conflictDialog.field('Email').fill(pendingEmail);
+  await conflictDialog.confirm('Send invitation');
+  await expect(membersSettings.memberText(PENDING_INVITATION_RE)).toBeVisible();
+  await stableScreenshot(page, 'members/invite-member-modal-conflict', {
+    textReplacements: pendingRowReplacements,
+    hideToaster: true,
+  });
   await page.keyboard.press('Escape');
 
   await pendingInvitationRow.hover();
-  await page.getByRole('button', {name: 'Revoke invitation'}).click();
-  await expect(page.getByText(`Revoke invitation to ${pendingEmail}?`)).toBeVisible();
-  await stableArgosScreenshot(page, 'members/revoke-invitation-confirm', pendingRowReplacements);
-  await page.getByRole('button', {name: 'Revoke'}).click();
+  await membersSettings.revokeInvitationButton().click();
+  await expect(membersSettings.memberText(`Revoke invitation to ${pendingEmail}?`)).toBeVisible();
+  await stableScreenshot(page, 'members/revoke-invitation-confirm', {
+    textReplacements: pendingRowReplacements,
+    hideToaster: true,
+  });
+  await membersSettings.confirmRevokeButton().click();
 
-  await expect(page.getByText(`Invitation to ${pendingEmail} revoked.`)).toBeVisible();
+  await expect(membersSettings.memberText(`Invitation to ${pendingEmail} revoked.`)).toBeVisible();
   await expect(pendingInvitationRow).toBeHidden();
 });
 
-test('renders terminal public invitation states', async ({page}) => {
-  await page.goto('/invitations/accept');
-  await expect(page.getByRole('heading', {name: 'Invalid link'})).toBeVisible();
-  await argosScreenshot(page, 'invitations/missing-token');
+test('renders terminal public invitation states', async ({page, invitationAccept}) => {
+  await invitationAccept.goto();
+  await expect(invitationAccept.heading('Invalid link')).toBeVisible();
+  await stableScreenshot(page, 'invitations/missing-token');
 
   await page.route('**/invitations/preview?**', async (route) => {
     await route.fulfill({
@@ -327,9 +235,9 @@ test('renders terminal public invitation states', async ({page}) => {
       body: JSON.stringify({status: 'invalid'}),
     });
   });
-  await page.goto(`/invitations/accept?token=${encodeURIComponent(`invalid-${randomUUID()}`)}`);
-  await expect(page.getByRole('heading', {name: 'Invalid invitation'})).toBeVisible();
-  await argosScreenshot(page, 'invitations/invalid');
+  await invitationAccept.goto(`invalid-${randomUUID()}`);
+  await expect(invitationAccept.heading('Invalid invitation')).toBeVisible();
+  await stableScreenshot(page, 'invitations/invalid');
 
   await page.unroute('**/invitations/preview?**');
   await page.route('**/invitations/preview?**', async (route) => {
@@ -343,7 +251,7 @@ test('renders terminal public invitation states', async ({page}) => {
       }),
     });
   });
-  await page.goto(`/invitations/accept?token=${encodeURIComponent(`expired-${randomUUID()}`)}`);
-  await expect(page.getByRole('heading', {name: 'Invitation expired'})).toBeVisible();
-  await argosScreenshot(page, 'invitations/expired');
+  await invitationAccept.goto(`expired-${randomUUID()}`);
+  await expect(invitationAccept.heading('Invitation expired')).toBeVisible();
+  await stableScreenshot(page, 'invitations/expired');
 });

--- a/e2e/client/workspaces/tests/test.ts
+++ b/e2e/client/workspaces/tests/test.ts
@@ -1,9 +1,11 @@
 import {test as base, expect} from '@shipfox/e2e-core/playwright';
 import {type GiteaFixtures, giteaHelper} from '@shipfox/e2e-helper-integrations-gitea';
 import {type WorkspaceFixtures, workspaceFixtures} from '@shipfox/e2e-kit/fixtures';
+import {type WorkspacesScreenFixtures, workspacesScreens} from '@shipfox/e2e-screens-workspaces';
 
-export const test = base.extend<WorkspaceFixtures & GiteaFixtures>({
+export const test = base.extend<WorkspaceFixtures & GiteaFixtures & WorkspacesScreenFixtures>({
   ...workspaceFixtures,
   ...giteaHelper,
+  ...workspacesScreens,
 });
 export {expect};

--- a/e2e/kit/src/ui/index.ts
+++ b/e2e/kit/src/ui/index.ts
@@ -9,4 +9,8 @@ export {
   TopNav,
   WorkspaceSwitcher,
 } from './page-objects.js';
-export {type StableReplacement, stableScreenshot} from './stable-screenshot.js';
+export {
+  type StableReplacement,
+  type StableScreenshotOptions,
+  stableScreenshot,
+} from './stable-screenshot.js';

--- a/e2e/kit/src/ui/stable-screenshot.test.ts
+++ b/e2e/kit/src/ui/stable-screenshot.test.ts
@@ -32,27 +32,49 @@ class FakeElement {
   }
 }
 
+class FakeElementHandle {
+  constructor(
+    private readonly element: FakeElement,
+    private readonly shouldFail = false,
+  ) {}
+
+  evaluate<T, A>(callback: (element: FakeElement, arg: A) => T, arg: A): Promise<T> {
+    if (this.shouldFail) {
+      return Promise.reject(new Error('evaluate failed'));
+    }
+    return Promise.resolve(callback(this.element, arg));
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
 class FakeLocator {
   constructor(
     private readonly elements: FakeElement[],
     private readonly failingIndexes = new Set<number>(),
+    private readonly predicate: (element: FakeElement) => boolean = () => true,
     private readonly index?: number,
   ) {}
 
   count(): Promise<number> {
-    return Promise.resolve(this.elements.length);
+    return Promise.resolve(this.matchedElements().length);
   }
 
   nth(index: number): FakeLocator {
-    return new FakeLocator(this.elements, this.failingIndexes, index);
+    return new FakeLocator(this.elements, this.failingIndexes, this.predicate, index);
   }
 
-  evaluate<T, A>(callback: (element: FakeElement, arg: A) => T, arg: A): Promise<T> {
+  elementHandle(): Promise<FakeElementHandle | null> {
     const index = this.index ?? 0;
-    if (this.failingIndexes.has(index)) {
-      return Promise.reject(new Error(`evaluate failed for ${index}`));
-    }
-    return Promise.resolve(callback(this.elements[index] as FakeElement, arg));
+    const element = this.matchedElements()[index];
+    if (!element) return Promise.resolve(null);
+    return Promise.resolve(new FakeElementHandle(element, this.failingIndexes.has(index)));
+  }
+
+  private matchedElements(): FakeElement[] {
+    return this.elements.filter(this.predicate);
   }
 }
 
@@ -119,13 +141,13 @@ describe('stableScreenshot', () => {
       {locator: locator as never, text: 'during'},
     ]);
 
-    await expect(result).rejects.toThrow('evaluate failed for 1');
+    await expect(result).rejects.toThrow('evaluate failed');
     expect(argosScreenshot).not.toHaveBeenCalled();
     expect(first.textContent).toBe('first-before');
     expect(second.textContent).toBe('second-before');
   });
 
-  it('throws clearly when locator counts drift before restore', async () => {
+  it('restores captured elements when locator counts drift before restore', async () => {
     const elements = [new FakeElement({text: 'before'})];
     const locator = new FakeLocator(elements);
     argosScreenshot.mockImplementationOnce(() => {
@@ -137,8 +159,24 @@ describe('stableScreenshot', () => {
       {locator: locator as never, text: 'during'},
     ]);
 
-    await expect(result).rejects.toThrow(
-      'Cannot restore stable screenshot replacements: locator matched 2 elements after capture, but matched 1 before capture.',
+    await expect(result).resolves.toBeUndefined();
+    expect(elements[0]?.textContent).toBe('before');
+    expect(elements[1]?.textContent).toBe('new');
+  });
+
+  it('restores text-based locators after replacement changes the matched text', async () => {
+    const element = new FakeElement({text: 'Gitea dynamic-org'});
+    const locator = new FakeLocator(
+      [element],
+      new Set(),
+      (element) => element.textContent === 'Gitea dynamic-org',
     );
+    const {stableScreenshot} = await import('./stable-screenshot.js');
+
+    await stableScreenshot({} as never, 'text-based', [
+      {locator: locator as never, text: 'Gitea visual-test-org'},
+    ]);
+
+    expect(element.textContent).toBe('Gitea dynamic-org');
   });
 });

--- a/e2e/kit/src/ui/stable-screenshot.test.ts
+++ b/e2e/kit/src/ui/stable-screenshot.test.ts
@@ -33,6 +33,8 @@ class FakeElement {
 }
 
 class FakeElementHandle {
+  disposed = false;
+
   constructor(
     private readonly element: FakeElement,
     private readonly shouldFail = false,
@@ -46,6 +48,7 @@ class FakeElementHandle {
   }
 
   dispose(): Promise<void> {
+    this.disposed = true;
     return Promise.resolve();
   }
 }
@@ -55,6 +58,7 @@ class FakeLocator {
     private readonly elements: FakeElement[],
     private readonly failingIndexes = new Set<number>(),
     private readonly predicate: (element: FakeElement) => boolean = () => true,
+    readonly handles: FakeElementHandle[] = [],
     private readonly index?: number,
   ) {}
 
@@ -63,14 +67,16 @@ class FakeLocator {
   }
 
   nth(index: number): FakeLocator {
-    return new FakeLocator(this.elements, this.failingIndexes, this.predicate, index);
+    return new FakeLocator(this.elements, this.failingIndexes, this.predicate, this.handles, index);
   }
 
   elementHandle(): Promise<FakeElementHandle | null> {
     const index = this.index ?? 0;
     const element = this.matchedElements()[index];
     if (!element) return Promise.resolve(null);
-    return Promise.resolve(new FakeElementHandle(element, this.failingIndexes.has(index)));
+    const handle = new FakeElementHandle(element, this.failingIndexes.has(index));
+    this.handles.push(handle);
+    return Promise.resolve(handle);
   }
 
   private matchedElements(): FakeElement[] {
@@ -145,6 +151,8 @@ describe('stableScreenshot', () => {
     expect(argosScreenshot).not.toHaveBeenCalled();
     expect(first.textContent).toBe('first-before');
     expect(second.textContent).toBe('second-before');
+    expect(locator.handles).toHaveLength(2);
+    expect(locator.handles.every((handle) => handle.disposed)).toBe(true);
   });
 
   it('restores captured elements when locator counts drift before restore', async () => {

--- a/e2e/kit/src/ui/stable-screenshot.ts
+++ b/e2e/kit/src/ui/stable-screenshot.ts
@@ -1,6 +1,7 @@
 import {argosScreenshot, type Page} from '@shipfox/playwright';
 
 type Locator = ReturnType<Page['locator']>;
+type ElementHandle = NonNullable<Awaited<ReturnType<Locator['elementHandle']>>>;
 
 interface MutableElement {
   textContent: string | null;
@@ -24,14 +25,13 @@ export interface StableScreenshotOptions {
 }
 
 interface ElementSnapshot {
+  handle: ElementHandle;
   text?: string | null;
   value?: string;
   attributes: Record<string, string | null>;
 }
 
 interface LocatorSnapshot {
-  locator: Locator;
-  count: number;
   elements: ElementSnapshot[];
 }
 
@@ -181,26 +181,31 @@ async function applyReplacements(
   for (const replacement of replacements) {
     const count = await replacement.locator.count();
     const locatorSnapshot: LocatorSnapshot = {
-      locator: replacement.locator,
-      count,
       elements: [],
     };
     snapshots.push(locatorSnapshot);
 
     for (let index = 0; index < count; index += 1) {
       const locator = replacement.locator.nth(index);
-      const snapshot = await locator.evaluate(
+      const handle = await locator.elementHandle();
+      if (!handle) {
+        throw new Error(
+          'Cannot apply stable screenshot replacements: locator element disappeared before capture.',
+        );
+      }
+
+      const snapshot = await handle.evaluate(
         (
           element: MutableElement,
           options: {
             textReplacement: string | undefined;
-            attributeNames: string[];
+            attributes: Record<string, string>;
             valueReplacement: string | undefined;
           },
-        ): ElementSnapshot => {
-          const previous: ElementSnapshot = {
+        ): Omit<ElementSnapshot, 'handle'> => {
+          const previous: Omit<ElementSnapshot, 'handle'> = {
             attributes: Object.fromEntries(
-              options.attributeNames.map((name) => [name, element.getAttribute(name)]),
+              Object.keys(options.attributes).map((name) => [name, element.getAttribute(name)]),
             ),
           };
           if (options.textReplacement !== undefined) previous.text = element.textContent;
@@ -214,48 +219,53 @@ async function applyReplacements(
             element.value = options.valueReplacement;
           }
 
+          for (const [name, value] of Object.entries(options.attributes)) {
+            element.setAttribute(name, value);
+          }
+
           return previous;
         },
         {
           textReplacement: replacement.text,
-          attributeNames: Object.keys(replacement.attributes ?? {}),
+          attributes: replacement.attributes ?? {},
           valueReplacement: replacement.value,
         },
       );
-      locatorSnapshot.elements.push(snapshot);
-
-      if (replacement.attributes) {
-        await locator.evaluate((element: MutableElement, attributes: Record<string, string>) => {
-          for (const [name, value] of Object.entries(attributes)) {
-            element.setAttribute(name, value);
-          }
-        }, replacement.attributes);
-      }
+      locatorSnapshot.elements.push({...snapshot, handle});
     }
   }
 }
 
 async function restoreSnapshots(snapshots: LocatorSnapshot[]): Promise<void> {
+  let restoreError: unknown;
+
   for (const snapshot of [...snapshots].reverse()) {
-    const currentCount = await snapshot.locator.count();
-    if (currentCount !== snapshot.count) {
-      throw new Error(
-        `Cannot restore stable screenshot replacements: locator matched ${currentCount} elements after capture, but matched ${snapshot.count} before capture.`,
-      );
-    }
+    for (const elementSnapshot of [...snapshot.elements].reverse()) {
+      try {
+        const previous: Omit<ElementSnapshot, 'handle'> = {
+          attributes: elementSnapshot.attributes,
+        };
+        if (elementSnapshot.text !== undefined) previous.text = elementSnapshot.text;
+        if (elementSnapshot.value !== undefined) previous.value = elementSnapshot.value;
+        await elementSnapshot.handle.evaluate(
+          (element: MutableElement, previous: Omit<ElementSnapshot, 'handle'>) => {
+            if (previous.text !== undefined) element.textContent = previous.text;
+            if (previous.value !== undefined && 'value' in element) element.value = previous.value;
 
-    for (let index = 0; index < snapshot.elements.length; index += 1) {
-      await snapshot.locator
-        .nth(index)
-        .evaluate((element: MutableElement, previous: ElementSnapshot) => {
-          if (previous.text !== undefined) element.textContent = previous.text;
-          if (previous.value !== undefined && 'value' in element) element.value = previous.value;
-
-          for (const [name, value] of Object.entries(previous.attributes)) {
-            if (value === null) element.removeAttribute(name);
-            else element.setAttribute(name, value);
-          }
-        }, snapshot.elements[index] as ElementSnapshot);
+            for (const [name, value] of Object.entries(previous.attributes)) {
+              if (value === null) element.removeAttribute(name);
+              else element.setAttribute(name, value);
+            }
+          },
+          previous,
+        );
+      } catch (error) {
+        restoreError ??= error;
+      } finally {
+        await elementSnapshot.handle.dispose();
+      }
     }
   }
+
+  if (restoreError) throw restoreError;
 }

--- a/e2e/kit/src/ui/stable-screenshot.ts
+++ b/e2e/kit/src/ui/stable-screenshot.ts
@@ -17,6 +17,12 @@ export interface StableReplacement {
   value?: string;
 }
 
+export interface StableScreenshotOptions {
+  replacements?: StableReplacement[];
+  textReplacements?: ReadonlyArray<readonly [string, string]>;
+  hideToaster?: boolean;
+}
+
 interface ElementSnapshot {
   text?: string | null;
   value?: string;
@@ -32,16 +38,140 @@ interface LocatorSnapshot {
 export async function stableScreenshot(
   page: Page,
   name: string,
-  replacements: StableReplacement[] = [],
+  replacementsOrOptions: StableReplacement[] | StableScreenshotOptions = [],
 ): Promise<void> {
+  const options = Array.isArray(replacementsOrOptions)
+    ? {replacements: replacementsOrOptions}
+    : replacementsOrOptions;
   const snapshots: LocatorSnapshot[] = [];
+  let pageWideReplacementsApplied = false;
+  let operationError: unknown;
 
   try {
-    await applyReplacements(replacements, snapshots);
+    if (options.textReplacements || options.hideToaster) {
+      await applyPageWideReplacements(page, {
+        textReplacements: options.textReplacements ?? [],
+        hideToaster: options.hideToaster ?? false,
+      });
+      pageWideReplacementsApplied = true;
+    }
+    await applyReplacements(options.replacements ?? [], snapshots);
     await argosScreenshot(page, name);
-  } finally {
-    if (snapshots.length > 0) await restoreSnapshots(snapshots);
+  } catch (error) {
+    operationError = error;
   }
+
+  let restoreError: unknown;
+  try {
+    if (snapshots.length > 0) await restoreSnapshots(snapshots);
+  } catch (error) {
+    restoreError = error;
+  }
+  if (pageWideReplacementsApplied) await restorePageWideReplacements(page);
+  if (restoreError) throw restoreError;
+  if (operationError) throw operationError;
+}
+
+async function applyPageWideReplacements(
+  page: Page,
+  options: {
+    textReplacements: ReadonlyArray<readonly [string, string]>;
+    hideToaster: boolean;
+  },
+): Promise<void> {
+  await page.evaluate((input) => {
+    type RestoreEntry =
+      | {kind: 'attribute'; target: Element; attribute: string; value: string}
+      | {kind: 'text'; target: Text; value: string}
+      | {kind: 'value'; target: HTMLInputElement | HTMLTextAreaElement; value: string};
+    const visualWindow = window as Window & {
+      __shipfoxVisualRestore?: RestoreEntry[];
+      __shipfoxToasterDisplay?: string;
+    };
+    const restoreEntries: RestoreEntry[] = [];
+
+    if (input.hideToaster) {
+      const toaster = document.querySelector('[data-sonner-toaster]');
+      if (toaster instanceof HTMLElement) {
+        visualWindow.__shipfoxToasterDisplay = toaster.style.display;
+        toaster.style.display = 'none';
+      }
+    }
+
+    const replaceValue = (value: string): string =>
+      input.textReplacements.reduce(
+        (current, [source, replacement]) => current.split(source).join(replacement),
+        value,
+      );
+
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let node = walker.nextNode();
+    while (node) {
+      const textNode = node as Text;
+      const nextValue = replaceValue(textNode.data);
+      if (nextValue !== textNode.data) {
+        restoreEntries.push({kind: 'text', target: textNode, value: textNode.data});
+        textNode.data = nextValue;
+      }
+      node = walker.nextNode();
+    }
+
+    for (const element of document.querySelectorAll('input, textarea')) {
+      if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+        const nextValue = replaceValue(element.value);
+        if (nextValue !== element.value) {
+          restoreEntries.push({kind: 'value', target: element, value: element.value});
+          element.value = nextValue;
+        }
+      }
+    }
+
+    for (const element of document.querySelectorAll('[aria-label], [placeholder], [title]')) {
+      for (const attribute of ['aria-label', 'placeholder', 'title']) {
+        const value = element.getAttribute(attribute);
+        if (value == null) continue;
+        const nextValue = replaceValue(value);
+        if (nextValue !== value) {
+          restoreEntries.push({kind: 'attribute', target: element, attribute, value});
+          element.setAttribute(attribute, nextValue);
+        }
+      }
+    }
+
+    visualWindow.__shipfoxVisualRestore = restoreEntries;
+  }, options);
+}
+
+async function restorePageWideReplacements(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type RestoreEntry =
+      | {kind: 'attribute'; target: Element; attribute: string; value: string}
+      | {kind: 'text'; target: Text; value: string}
+      | {kind: 'value'; target: HTMLInputElement | HTMLTextAreaElement; value: string};
+    const visualWindow = window as Window & {
+      __shipfoxVisualRestore?: RestoreEntry[];
+      __shipfoxToasterDisplay?: string;
+    };
+    const restoreEntries = visualWindow.__shipfoxVisualRestore ?? [];
+
+    for (const entry of restoreEntries.reverse()) {
+      if (entry.kind === 'text') {
+        entry.target.data = entry.value;
+      } else if (entry.kind === 'value') {
+        entry.target.value = entry.value;
+      } else {
+        entry.target.setAttribute(entry.attribute, entry.value);
+      }
+    }
+
+    const toaster = document.querySelector('[data-sonner-toaster]');
+    if (toaster instanceof HTMLElement && visualWindow.__shipfoxToasterDisplay !== undefined) {
+      toaster.style.display = visualWindow.__shipfoxToasterDisplay;
+    }
+
+    delete visualWindow.__shipfoxToasterDisplay;
+    delete visualWindow.__shipfoxVisualRestore;
+  });
 }
 
 async function applyReplacements(

--- a/e2e/kit/src/ui/stable-screenshot.ts
+++ b/e2e/kit/src/ui/stable-screenshot.ts
@@ -194,44 +194,51 @@ async function applyReplacements(
         );
       }
 
-      const snapshot = await handle.evaluate(
-        (
-          element: MutableElement,
-          options: {
-            textReplacement: string | undefined;
-            attributes: Record<string, string>;
-            valueReplacement: string | undefined;
+      let shouldDisposeHandle = true;
+      try {
+        const snapshot = await handle.evaluate(
+          (
+            element: MutableElement,
+            options: {
+              textReplacement: string | undefined;
+              attributes: Record<string, string>;
+              valueReplacement: string | undefined;
+            },
+          ): Omit<ElementSnapshot, 'handle'> => {
+            const previous: Omit<ElementSnapshot, 'handle'> = {
+              attributes: Object.fromEntries(
+                Object.keys(options.attributes).map((name) => [name, element.getAttribute(name)]),
+              ),
+            };
+            if (options.textReplacement !== undefined) previous.text = element.textContent;
+            if (options.valueReplacement !== undefined && 'value' in element) {
+              const currentValue = element.value;
+              if (currentValue !== undefined) previous.value = currentValue;
+            }
+
+            if (options.textReplacement !== undefined)
+              element.textContent = options.textReplacement;
+            if (options.valueReplacement !== undefined && 'value' in element) {
+              element.value = options.valueReplacement;
+            }
+
+            for (const [name, value] of Object.entries(options.attributes)) {
+              element.setAttribute(name, value);
+            }
+
+            return previous;
           },
-        ): Omit<ElementSnapshot, 'handle'> => {
-          const previous: Omit<ElementSnapshot, 'handle'> = {
-            attributes: Object.fromEntries(
-              Object.keys(options.attributes).map((name) => [name, element.getAttribute(name)]),
-            ),
-          };
-          if (options.textReplacement !== undefined) previous.text = element.textContent;
-          if (options.valueReplacement !== undefined && 'value' in element) {
-            const currentValue = element.value;
-            if (currentValue !== undefined) previous.value = currentValue;
-          }
-
-          if (options.textReplacement !== undefined) element.textContent = options.textReplacement;
-          if (options.valueReplacement !== undefined && 'value' in element) {
-            element.value = options.valueReplacement;
-          }
-
-          for (const [name, value] of Object.entries(options.attributes)) {
-            element.setAttribute(name, value);
-          }
-
-          return previous;
-        },
-        {
-          textReplacement: replacement.text,
-          attributes: replacement.attributes ?? {},
-          valueReplacement: replacement.value,
-        },
-      );
-      locatorSnapshot.elements.push({...snapshot, handle});
+          {
+            textReplacement: replacement.text,
+            attributes: replacement.attributes ?? {},
+            valueReplacement: replacement.value,
+          },
+        );
+        locatorSnapshot.elements.push({...snapshot, handle});
+        shouldDisposeHandle = false;
+      } finally {
+        if (shouldDisposeHandle) await handle.dispose();
+      }
     }
   }
 }

--- a/e2e/screens/agent/package.json
+++ b/e2e/screens/agent/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-screens-agent",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/screens/agent"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/screens/agent/src/index.ts
+++ b/e2e/screens/agent/src/index.ts
@@ -1,0 +1,106 @@
+import {Dialog, SettingsShell, Toast} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+type FixtureUse<T> = (fixture: T) => Promise<void>;
+
+export class CustomModelProviderScreen {
+  private readonly shell: SettingsShell;
+  private readonly toast: Toast;
+
+  constructor(private readonly page: Page) {
+    this.shell = new SettingsShell(page);
+    this.toast = new Toast(page);
+  }
+
+  async goto(workspaceId: string): Promise<void> {
+    await this.shell.goto(workspaceId, 'model-providers');
+  }
+
+  configuredProvidersSection(): Locator {
+    return this.page.locator('section[aria-label="Configured providers"]');
+  }
+
+  configuredProviderRow(label: string): Locator {
+    return this.configuredProvidersSection()
+      .locator('li')
+      .filter({has: this.page.getByText(label, {exact: true})});
+  }
+
+  async openCreateDialog(): Promise<Dialog> {
+    await this.page.getByRole('button', {name: 'Configure custom provider'}).click();
+    const dialog = new Dialog(this.page, 'Add custom provider');
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  async fillProviderIdentity(
+    dialog: Dialog,
+    params: {displayName: string; providerId: string; baseUrl: string},
+  ): Promise<void> {
+    await dialog.fill('Display name', params.displayName);
+    await dialog.fill('Provider ID', params.providerId);
+    await dialog.fill('Base URL', params.baseUrl);
+  }
+
+  async fetchModels(dialog: Dialog): Promise<void> {
+    await dialog.confirm('Fetch models');
+  }
+
+  defaultModelField(dialog: Dialog): Locator {
+    return dialog.field('Default model');
+  }
+
+  discoveredModelOption(dialog: Dialog, modelId: string): Locator {
+    return this.defaultModelField(dialog).locator('option').filter({hasText: modelId});
+  }
+
+  firstModelIdField(dialog: Dialog): Locator {
+    return dialog.field('Model id').first();
+  }
+
+  firstModelLabelField(dialog: Dialog): Locator {
+    return dialog.field('Label').first();
+  }
+
+  async save(dialog: Dialog): Promise<void> {
+    await dialog.confirm('Test & save');
+  }
+
+  async expectSavedToast(text: string | RegExp): Promise<void> {
+    await this.toast.expectVisible(text);
+  }
+
+  async openEditDialog(displayName: string): Promise<Dialog> {
+    await this.configuredProviderRow(displayName)
+      .getByRole('button', {name: `Open ${displayName} provider actions`})
+      .click();
+    await this.page.getByRole('menuitem', {name: 'Edit'}).click();
+    const dialog = new Dialog(this.page, `Edit ${displayName}`);
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  async openDeleteDialog(displayName: string): Promise<Dialog> {
+    await this.configuredProviderRow(displayName)
+      .getByRole('button', {name: `Open ${displayName} provider actions`})
+      .click();
+    await this.page.getByRole('menuitem', {name: 'Delete'}).click();
+    const dialog = new Dialog(this.page, 'Delete model provider');
+    await dialog.expectVisible();
+    return dialog;
+  }
+}
+
+export interface AgentScreenFixtures {
+  customModelProviders: CustomModelProviderScreen;
+}
+
+export const agentScreens = {
+  customModelProviders: async (
+    {page}: {page: Page},
+    use: FixtureUse<CustomModelProviderScreen>,
+  ) => {
+    await use(new CustomModelProviderScreen(page));
+  },
+};

--- a/e2e/screens/agent/tsconfig.build.json
+++ b/e2e/screens/agent/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "@shipfox/ts-config/node",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/screens/agent/tsconfig.json
+++ b/e2e/screens/agent/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/screens/auth/package.json
+++ b/e2e/screens/auth/package.json
@@ -32,9 +32,6 @@
     "type": "shipfox-tsc-check",
     "type:emit": "shipfox-tsc-emit"
   },
-  "dependencies": {
-    "@shipfox/e2e-kit": "workspace:*"
-  },
   "peerDependencies": {
     "@shipfox/playwright": "workspace:*"
   },

--- a/e2e/screens/auth/package.json
+++ b/e2e/screens/auth/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-screens-auth",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/screens/auth"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/screens/auth/src/index.ts
+++ b/e2e/screens/auth/src/index.ts
@@ -1,0 +1,69 @@
+import type {Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+type FixtureUse<T> = (fixture: T) => Promise<void>;
+
+export class LoginScreen {
+  constructor(private readonly page: Page) {}
+
+  async goto(redirect?: string): Promise<void> {
+    const suffix = redirect === undefined ? '' : `?redirect=${redirect}`;
+    await this.page.goto(`/auth/login${suffix}`);
+  }
+
+  async gotoRawRedirect(redirect: string): Promise<void> {
+    await this.page.goto(`/auth/login?redirect=${redirect}`);
+  }
+
+  heading(): Locator {
+    return this.page.getByRole('heading', {name: 'Connect to Shipfox'});
+  }
+
+  emailField(): Locator {
+    return this.page.getByLabel('Email');
+  }
+
+  passwordField(): Locator {
+    return this.page.getByLabel('Password');
+  }
+
+  submitButton(): Locator {
+    return this.page.getByRole('button', {name: 'Log in'});
+  }
+
+  async submit(email: string, password: string): Promise<void> {
+    await this.emailField().fill(email);
+    await this.passwordField().fill(password);
+    await this.submitButton().click();
+  }
+}
+
+export class GuestRedirectScreen {
+  constructor(private readonly page: Page) {}
+
+  async goto(path: string): Promise<void> {
+    await this.page.goto(path);
+  }
+
+  onboardingHeading(): Locator {
+    return this.page.getByRole('heading', {name: 'Create your workspace'});
+  }
+
+  workspaceNameField(): Locator {
+    return this.page.getByLabel('Workspace name');
+  }
+}
+
+export interface AuthScreenFixtures {
+  guestRedirects: GuestRedirectScreen;
+  login: LoginScreen;
+}
+
+export const authScreens = {
+  guestRedirects: async ({page}: {page: Page}, use: FixtureUse<GuestRedirectScreen>) => {
+    await use(new GuestRedirectScreen(page));
+  },
+  login: async ({page}: {page: Page}, use: FixtureUse<LoginScreen>) => {
+    await use(new LoginScreen(page));
+  },
+};

--- a/e2e/screens/auth/tsconfig.build.json
+++ b/e2e/screens/auth/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "@shipfox/ts-config/node",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/screens/auth/tsconfig.json
+++ b/e2e/screens/auth/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/screens/integrations/package.json
+++ b/e2e/screens/integrations/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-screens-integrations",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/screens/integrations"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/screens/integrations/src/index.ts
+++ b/e2e/screens/integrations/src/index.ts
@@ -1,0 +1,167 @@
+import {SettingsShell, Toast} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+type FixtureUse<T> = (fixture: T) => Promise<void>;
+
+export class IntegrationsCatalogueScreen {
+  private readonly shell: SettingsShell;
+
+  constructor(private readonly page: Page) {
+    this.shell = new SettingsShell(page);
+  }
+
+  async goto(workspaceId: string): Promise<void> {
+    await this.shell.goto(workspaceId, 'integrations');
+  }
+
+  availableHeading(): Locator {
+    return this.page.getByRole('heading', {name: 'Available integrations'});
+  }
+
+  installLink(name: string): Locator {
+    return this.page.getByRole('link', {name: `Install ${name}`});
+  }
+
+  emptyInstalledState(): Locator {
+    return this.page.getByText('No integrations installed yet');
+  }
+
+  installedSection(): Locator {
+    return this.page.locator('section[aria-label="Installed integrations"]');
+  }
+
+  installedProviderName(name: string): Locator {
+    return this.installedSection().getByText(name, {exact: true});
+  }
+
+  installedStatus(text: string | RegExp): Locator {
+    return this.installedSection().getByText(text);
+  }
+
+  installedActionsButton(name: string): Locator {
+    return this.installedSection().getByLabel(`Open ${name} integration actions`);
+  }
+}
+
+export class SourceControlSetupScreen {
+  constructor(private readonly page: Page) {}
+
+  async gotoRoot(): Promise<void> {
+    await this.page.goto('/');
+  }
+
+  async goto(workspaceId: string): Promise<void> {
+    await this.page.goto(`/workspaces/${workspaceId}/integrations`);
+  }
+
+  heading(): Locator {
+    return this.page.getByRole('heading', {name: 'Install source control'});
+  }
+
+  modelProviderHeading(): Locator {
+    return this.page.getByRole('heading', {name: 'Configure model provider'});
+  }
+
+  providerLink(workspaceId: string, provider: string): Locator {
+    return this.page.locator(`a[href$="/workspaces/${workspaceId}/integrations/${provider}"]`);
+  }
+
+  projectTab(): Locator {
+    return this.page.getByRole('tab', {name: 'Projects'});
+  }
+
+  settingsTab(): Locator {
+    return this.page.getByRole('tab', {name: 'Settings'});
+  }
+
+  projectSwitcher(): Locator {
+    return this.page.getByLabel('Switch project');
+  }
+
+  workspaceSwitcher(): Locator {
+    return this.page.getByLabel('Switch workspace');
+  }
+}
+
+export class ProviderInstallScreen {
+  private readonly toast: Toast;
+
+  constructor(private readonly page: Page) {
+    this.toast = new Toast(page);
+  }
+
+  async goto(workspaceId: string, provider: string): Promise<void> {
+    await this.page.goto(`/workspaces/${workspaceId}/integrations/${provider}`);
+  }
+
+  organizationField(): Locator {
+    return this.page.getByLabel('Organization');
+  }
+
+  async installOrganization(name: string): Promise<void> {
+    await this.organizationField().fill(name);
+    await this.page.getByRole('button', {name: 'Install'}).click();
+  }
+
+  async expectInstalled(message: string): Promise<void> {
+    await this.toast.expectVisible(message);
+  }
+}
+
+export class SentryCallbackScreen {
+  constructor(private readonly page: Page) {}
+
+  async goto(url: string): Promise<void> {
+    await this.page.goto(url);
+  }
+
+  heading(): Locator {
+    return this.page.getByRole('heading', {name: 'Install Sentry'});
+  }
+
+  message(text: string | RegExp): Locator {
+    return this.page.getByText(text);
+  }
+
+  installButton(): Locator {
+    return this.page.getByRole('button', {name: 'Install'});
+  }
+
+  retryButton(): Locator {
+    return this.page.getByRole('button', {name: 'Retry'});
+  }
+
+  backToShipfoxLink(): Locator {
+    return this.page.getByRole('link', {name: 'Back to Shipfox'});
+  }
+
+  startOverLink(): Locator {
+    return this.page.getByRole('link', {name: 'Start over'});
+  }
+}
+
+export interface IntegrationsScreenFixtures {
+  integrationsCatalogue: IntegrationsCatalogueScreen;
+  providerInstall: ProviderInstallScreen;
+  sentryCallback: SentryCallbackScreen;
+  sourceControlSetup: SourceControlSetupScreen;
+}
+
+export const integrationsScreens = {
+  integrationsCatalogue: async (
+    {page}: {page: Page},
+    use: FixtureUse<IntegrationsCatalogueScreen>,
+  ) => {
+    await use(new IntegrationsCatalogueScreen(page));
+  },
+  providerInstall: async ({page}: {page: Page}, use: FixtureUse<ProviderInstallScreen>) => {
+    await use(new ProviderInstallScreen(page));
+  },
+  sentryCallback: async ({page}: {page: Page}, use: FixtureUse<SentryCallbackScreen>) => {
+    await use(new SentryCallbackScreen(page));
+  },
+  sourceControlSetup: async ({page}: {page: Page}, use: FixtureUse<SourceControlSetupScreen>) => {
+    await use(new SourceControlSetupScreen(page));
+  },
+};

--- a/e2e/screens/integrations/tsconfig.build.json
+++ b/e2e/screens/integrations/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "@shipfox/ts-config/node",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/screens/integrations/tsconfig.json
+++ b/e2e/screens/integrations/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/screens/runners/package.json
+++ b/e2e/screens/runners/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-screens-runners",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/screens/runners"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/screens/runners/src/index.ts
+++ b/e2e/screens/runners/src/index.ts
@@ -1,0 +1,106 @@
+import {DataTableRow, Dialog, SettingsShell} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+type FixtureUse<T> = (fixture: T) => Promise<void>;
+
+export class RunnerTokensScreen {
+  private readonly shell: SettingsShell;
+
+  constructor(private readonly page: Page) {
+    this.shell = new SettingsShell(page);
+  }
+
+  async gotoManualTokens(workspaceId: string): Promise<void> {
+    await this.shell.goto(workspaceId, 'runners');
+  }
+
+  async gotoProvisionerTokens(workspaceId: string): Promise<void> {
+    await this.shell.goto(workspaceId, 'provisioners');
+  }
+
+  manualTokensSection(): Locator {
+    return this.page.locator('section', {hasText: 'Runner registration tokens'});
+  }
+
+  provisionerTokensSection(): Locator {
+    return this.page.locator('section', {hasText: 'Runner provisioner registration tokens'});
+  }
+
+  manualTokenRow(name: string): Locator {
+    return new DataTableRow(this.manualTokensSection(), name).row;
+  }
+
+  provisionerTokenRow(name: string): Locator {
+    return new DataTableRow(this.provisionerTokensSection(), name).row;
+  }
+
+  manualTokenCell(name: string, index: number): Locator {
+    return new DataTableRow(this.manualTokensSection(), name).cell(index);
+  }
+
+  provisionerTokenCell(name: string, index: number): Locator {
+    return new DataTableRow(this.provisionerTokensSection(), name).cell(index);
+  }
+
+  manualEmptyState(): Locator {
+    return this.manualTokensSection().getByText('No usable manual registration tokens');
+  }
+
+  provisionerEmptyState(): Locator {
+    return this.provisionerTokensSection().getByText('No usable provisioner registration tokens');
+  }
+
+  async openManualCreateDialog(): Promise<Dialog> {
+    await this.manualTokensSection().getByRole('button', {name: 'Create token'}).click();
+    const dialog = new Dialog(this.page, 'Create manual registration token');
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  async openProvisionerCreateDialog(): Promise<Dialog> {
+    await this.provisionerTokensSection().getByRole('button', {name: 'Create token'}).click();
+    const dialog = new Dialog(this.page, 'Create provisioner registration token');
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  rawToken(dialog: Dialog, tokenPrefix: RegExp): Locator {
+    return dialog.locator().locator('p.font-code').filter({hasText: tokenPrefix});
+  }
+
+  async createTokenFromDialog(dialog: Dialog, name: string): Promise<void> {
+    await dialog.fill('Token name', name);
+    await dialog.confirm('Create token');
+  }
+
+  async openManualRevokeDialog(name: string): Promise<Dialog> {
+    await this.manualTokenRow(name)
+      .getByRole('button', {name: `Open ${name} registration token actions`})
+      .click();
+    await this.page.getByRole('menuitem', {name: 'Revoke token'}).click();
+    const dialog = new Dialog(this.page, 'Revoke token');
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  async openProvisionerRevokeDialog(name: string): Promise<Dialog> {
+    await this.provisionerTokenRow(name)
+      .getByRole('button', {name: `Open ${name} token actions`})
+      .click();
+    await this.page.getByRole('menuitem', {name: 'Revoke token'}).click();
+    const dialog = new Dialog(this.page, 'Revoke token');
+    await dialog.expectVisible();
+    return dialog;
+  }
+}
+
+export interface RunnerScreenFixtures {
+  runnerTokens: RunnerTokensScreen;
+}
+
+export const runnerScreens = {
+  runnerTokens: async ({page}: {page: Page}, use: FixtureUse<RunnerTokensScreen>) => {
+    await use(new RunnerTokensScreen(page));
+  },
+};

--- a/e2e/screens/runners/tsconfig.build.json
+++ b/e2e/screens/runners/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "@shipfox/ts-config/node",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/screens/runners/tsconfig.json
+++ b/e2e/screens/runners/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/screens/secrets/package.json
+++ b/e2e/screens/secrets/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-screens-secrets",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/screens/secrets"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/screens/secrets/src/index.ts
+++ b/e2e/screens/secrets/src/index.ts
@@ -1,0 +1,172 @@
+import {DataTableRow, Dialog, SettingsShell, Toast} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+type FixtureUse<T> = (fixture: T) => Promise<void>;
+
+abstract class KeyValueSettingsScreen {
+  protected readonly shell: SettingsShell;
+  protected readonly toast: Toast;
+
+  constructor(
+    protected readonly page: Page,
+    private readonly tab: 'secrets' | 'variables',
+    private readonly sectionLabel: string,
+    private readonly createButtonName: string,
+    private readonly createDialogName: string,
+    private readonly updateDialogName: string,
+    private readonly createdToast: string,
+    private readonly updatedToast: string,
+    private readonly deletedToast: string,
+    private readonly emptyText: string,
+  ) {
+    this.shell = new SettingsShell(page);
+    this.toast = new Toast(page);
+  }
+
+  async goto(workspaceId: string): Promise<void> {
+    await this.shell.goto(workspaceId, this.tab);
+  }
+
+  section(): Locator {
+    return this.page.locator(`section[aria-label="${this.sectionLabel}"]`);
+  }
+
+  emptyState(): Locator {
+    return this.section().getByText(this.emptyText);
+  }
+
+  rowByKey(key: string): Locator {
+    return new DataTableRow(this.section(), key).row;
+  }
+
+  toastMessage(text: string | RegExp): Locator {
+    return this.toast.message(text);
+  }
+
+  async openRowActions(key: string): Promise<void> {
+    await this.rowByKey(key)
+      .getByRole('button', {name: `Actions for ${key}`})
+      .click();
+  }
+
+  async openCreateDialog(): Promise<Dialog> {
+    await this.section().getByRole('button', {name: this.createButtonName}).first().click();
+    const dialog = new Dialog(this.page, this.createDialogName);
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  async create(key: string, value: string): Promise<void> {
+    const dialog = await this.openCreateDialog();
+
+    await dialog.fill('Name', key);
+    await dialog.locator().getByRole('textbox', {name: 'Value'}).fill(value);
+    await dialog.confirm(this.createButtonName);
+
+    await this.toast.expectVisible(this.createdToast);
+  }
+
+  async openUpdateDialog(key: string): Promise<Dialog> {
+    await this.openRowActions(key);
+    await this.page.getByRole('menuitem', {name: 'Edit value'}).click();
+    const dialog = new Dialog(this.page, this.updateDialogName);
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  async updateValue(key: string, value: string): Promise<void> {
+    const dialog = await this.openUpdateDialog(key);
+
+    await dialog.locator().getByRole('textbox', {name: 'Value'}).fill(value);
+    await dialog.confirm(this.updateDialogName);
+
+    await this.toast.expectVisible(this.updatedToast);
+  }
+
+  async delete(key: string): Promise<void> {
+    await this.openRowActions(key);
+    await this.page.getByRole('menuitem', {name: 'Delete'}).click();
+    const dialog = new Dialog(this.page, new RegExp(`Delete ${key}`, 'u'));
+
+    await dialog.confirm('Delete');
+
+    await this.toast.expectVisible(this.deletedToast);
+  }
+}
+
+export class SecretsSettingsScreen extends KeyValueSettingsScreen {
+  constructor(page: Page) {
+    super(
+      page,
+      'secrets',
+      'Secrets',
+      'Create secret',
+      'Create secret',
+      'Update secret',
+      'Secret created',
+      'Secret updated',
+      'Secret deleted',
+      'No secrets yet',
+    );
+  }
+
+  async createSecret(key: string, value: string): Promise<void> {
+    await this.create(key, value);
+  }
+
+  async updateSecretValue(key: string, value: string): Promise<void> {
+    await this.updateValue(key, value);
+  }
+
+  async deleteSecret(key: string): Promise<void> {
+    await this.delete(key);
+  }
+
+  valueHidden(key: string): Locator {
+    return this.rowByKey(key).getByLabel('Value hidden');
+  }
+}
+
+export class VariablesSettingsScreen extends KeyValueSettingsScreen {
+  constructor(page: Page) {
+    super(
+      page,
+      'variables',
+      'Variables',
+      'Create variable',
+      'Create variable',
+      'Update variable',
+      'Variable created',
+      'Variable updated',
+      'Variable deleted',
+      'No variables yet',
+    );
+  }
+
+  async createVariable(key: string, value: string): Promise<void> {
+    await this.create(key, value);
+  }
+
+  async updateVariableValue(key: string, value: string): Promise<void> {
+    await this.updateValue(key, value);
+  }
+
+  async deleteVariable(key: string): Promise<void> {
+    await this.delete(key);
+  }
+}
+
+export interface SecretsScreenFixtures {
+  secretsScreen: SecretsSettingsScreen;
+  variablesScreen: VariablesSettingsScreen;
+}
+
+export const secretsScreens = {
+  secretsScreen: async ({page}: {page: Page}, use: FixtureUse<SecretsSettingsScreen>) => {
+    await use(new SecretsSettingsScreen(page));
+  },
+  variablesScreen: async ({page}: {page: Page}, use: FixtureUse<VariablesSettingsScreen>) => {
+    await use(new VariablesSettingsScreen(page));
+  },
+};

--- a/e2e/screens/secrets/tsconfig.build.json
+++ b/e2e/screens/secrets/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "@shipfox/ts-config/node",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/screens/secrets/tsconfig.json
+++ b/e2e/screens/secrets/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/e2e/screens/workspaces/package.json
+++ b/e2e/screens/workspaces/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@shipfox/e2e-screens-workspaces",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShipfoxHQ/shipfox.git",
+    "directory": "e2e/screens/workspaces"
+  },
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "imports": {
+    "#*": "./src/*"
+  },
+  "exports": {
+    ".": {
+      "development": {
+        "types": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "default": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "shipfox-swc",
+    "check": "shipfox-biome-check",
+    "check:fix": "shipfox-biome-check --write",
+    "type": "shipfox-tsc-check",
+    "type:emit": "shipfox-tsc-emit"
+  },
+  "dependencies": {
+    "@shipfox/e2e-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@shipfox/playwright": "workspace:*"
+  },
+  "devDependencies": {
+    "@shipfox/biome": "workspace:*",
+    "@shipfox/playwright": "workspace:*",
+    "@shipfox/swc": "workspace:*",
+    "@shipfox/ts-config": "workspace:*",
+    "@shipfox/typescript": "workspace:*"
+  }
+}

--- a/e2e/screens/workspaces/src/index.ts
+++ b/e2e/screens/workspaces/src/index.ts
@@ -1,0 +1,111 @@
+import {Dialog, SettingsShell} from '@shipfox/e2e-kit/ui';
+import type {Page} from '@shipfox/playwright';
+
+type Locator = ReturnType<Page['locator']>;
+type FixtureUse<T> = (fixture: T) => Promise<void>;
+
+export class MembersSettingsScreen {
+  private readonly shell: SettingsShell;
+
+  constructor(private readonly page: Page) {
+    this.shell = new SettingsShell(page);
+  }
+
+  async goto(workspaceId: string): Promise<void> {
+    await this.shell.goto(workspaceId, 'members');
+  }
+
+  heading(): Locator {
+    return this.page.getByRole('heading', {name: 'Members'});
+  }
+
+  pendingInvitationsHeading(): Locator {
+    return this.page.getByRole('heading', {name: 'Pending invitations'});
+  }
+
+  emptyPendingInvitations(): Locator {
+    return this.page.getByText('No pending invitations.');
+  }
+
+  memberText(text: string | RegExp): Locator {
+    return this.page.getByText(text);
+  }
+
+  memberRow(text: string | RegExp): Locator {
+    return this.page.getByRole('row', {name: text});
+  }
+
+  async memberCellText(rowName: string | RegExp, index: number): Promise<string> {
+    return (await this.memberRow(rowName).getByRole('cell').nth(index).innerText()).trim();
+  }
+
+  inviteButton(): Locator {
+    return this.page.getByRole('button', {name: 'Invite member'});
+  }
+
+  async openInviteDialog(): Promise<Dialog> {
+    await this.inviteButton().click();
+    const dialog = new Dialog(this.page, 'Invite a member');
+    await dialog.expectVisible();
+    return dialog;
+  }
+
+  pendingInvitationRow(email: string | RegExp): Locator {
+    return this.page.getByRole('row', {name: email});
+  }
+
+  async pendingInvitationExpiresText(email: string | RegExp): Promise<string> {
+    return (await this.pendingInvitationRow(email).getByRole('cell').nth(2).innerText()).trim();
+  }
+
+  revokeInvitationButton(): Locator {
+    return this.page.getByRole('button', {name: 'Revoke invitation'});
+  }
+
+  confirmRevokeButton(): Locator {
+    return this.page.getByRole('button', {name: 'Revoke'});
+  }
+}
+
+export class InvitationAcceptScreen {
+  constructor(private readonly page: Page) {}
+
+  async goto(rawToken?: string): Promise<void> {
+    const suffix = rawToken === undefined ? '' : `?token=${encodeURIComponent(rawToken)}`;
+    await this.page.goto(`/invitations/accept${suffix}`);
+  }
+
+  heading(name: string | RegExp): Locator {
+    return this.page.getByRole('heading', {name});
+  }
+
+  message(text: string | RegExp): Locator {
+    return this.page.getByText(text);
+  }
+
+  link(name: string | RegExp): Locator {
+    return this.page.getByRole('link', {name});
+  }
+
+  field(name: string | RegExp): Locator {
+    return this.page.getByLabel(name);
+  }
+
+  button(name: string | RegExp): Locator {
+    return this.page.getByRole('button', {name});
+  }
+}
+
+export interface WorkspacesScreenFixtures {
+  invitationAccept: InvitationAcceptScreen;
+  membersSettings: MembersSettingsScreen;
+}
+
+export const workspacesScreens = {
+  invitationAccept: async ({page}: {page: Page}, use: FixtureUse<InvitationAcceptScreen>) => {
+    await use(new InvitationAcceptScreen(page));
+  },
+  membersSettings: async ({page}: {page: Page}, use: FixtureUse<MembersSettingsScreen>) => {
+    await use(new MembersSettingsScreen(page));
+  },
+};

--- a/e2e/screens/workspaces/tsconfig.build.json
+++ b/e2e/screens/workspaces/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "@shipfox/ts-config/node",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "outDir": "dist"
   },
   "include": ["src"]
 }

--- a/e2e/screens/workspaces/tsconfig.json
+++ b/e2e/screens/workspaces/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "tsconfig.build.json" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../kit
+      '@shipfox/e2e-screens-agent':
+        specifier: workspace:*
+        version: link:../../screens/agent
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -315,6 +318,9 @@ importers:
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../kit
+      '@shipfox/e2e-screens-auth':
+        specifier: workspace:*
+        version: link:../../screens/auth
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -348,6 +354,9 @@ importers:
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../kit
+      '@shipfox/e2e-screens-integrations':
+        specifier: workspace:*
+        version: link:../../screens/integrations
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -393,6 +402,9 @@ importers:
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../kit
+      '@shipfox/e2e-screens-runners':
+        specifier: workspace:*
+        version: link:../../screens/runners
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -441,6 +453,9 @@ importers:
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../kit
+      '@shipfox/e2e-screens-secrets':
+        specifier: workspace:*
+        version: link:../../screens/secrets
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -471,6 +486,9 @@ importers:
       '@shipfox/e2e-kit':
         specifier: workspace:*
         version: link:../../kit
+      '@shipfox/e2e-screens-workspaces':
+        specifier: workspace:*
+        version: link:../../screens/workspaces
       '@shipfox/playwright':
         specifier: workspace:*
         version: link:../../../tools/playwright
@@ -876,6 +894,138 @@ importers:
       zod:
         specifier: ^4.4.3
         version: 4.4.3
+
+  e2e/screens/agent:
+    dependencies:
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/screens/auth:
+    dependencies:
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/screens/integrations:
+    dependencies:
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/screens/runners:
+    dependencies:
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/screens/secrets:
+    dependencies:
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
+
+  e2e/screens/workspaces:
+    dependencies:
+      '@shipfox/e2e-kit':
+        specifier: workspace:*
+        version: link:../../kit
+    devDependencies:
+      '@shipfox/biome':
+        specifier: workspace:*
+        version: link:../../../tools/biome
+      '@shipfox/playwright':
+        specifier: workspace:*
+        version: link:../../../tools/playwright
+      '@shipfox/swc':
+        specifier: workspace:*
+        version: link:../../../tools/swc
+      '@shipfox/ts-config':
+        specifier: workspace:*
+        version: link:../../../tools/ts-config
+      '@shipfox/typescript':
+        specifier: workspace:*
+        version: link:../../../tools/typescript
 
   libs/api/agent:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,10 +918,6 @@ importers:
         version: link:../../../tools/typescript
 
   e2e/screens/auth:
-    dependencies:
-      '@shipfox/e2e-kit':
-        specifier: workspace:*
-        version: link:../../kit
     devDependencies:
       '@shipfox/biome':
         specifier: workspace:*


### PR DESCRIPTION
Add per-domain E2E screen packages for the browser suites.

The E2E client specs were carrying route navigation, locators, dialog flows, and visual normalization inline. This extracts those browser-domain surfaces into reusable `@shipfox/e2e-screens-*` packages so specs can compose fixtures and stay focused on behavior.

This also extends `@shipfox/e2e-kit/ui`'s `stableScreenshot` so dynamic visual captures can use one shared restore path, including page-wide text/value/attribute replacement and toaster hiding. That replaces suite-local DOM mutation helpers in the migrated specs.

Areas worth careful review: the screen-vs-kit split for auth/workspaces surfaces, and the expanded `stableScreenshot` restore behavior.

Closes ENG-815

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted per-domain E2E screen packages and migrated client specs to use them, and expanded and hardened `stableScreenshot` for consistent, reliable visual captures. Implements ENG-815 by moving navigation/locators into reusable screens and stabilizing visual diffs.

- **New Features**
  - Added reusable screen packages: `@shipfox/e2e-screens-{agent,auth,integrations,runners,secrets,workspaces}` with fixtures consumed by client suites.
  - Extended `@shipfox/e2e-kit/ui` `stableScreenshot` to accept `replacements`, `textReplacements`, and `hideToaster`; exported `StableScreenshotOptions`. Replaced direct `argosScreenshot` usage in specs.

- **Bug Fixes**
  - Made `stableScreenshot` restoration robust with element handles and a single restore path, reliably restoring text/value/attributes and toaster visibility; added tests and DOM lib typing to prevent flakiness.

<sup>Written for commit 5fefcc951a77e7227506208efb2ed700b1a9e265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

