### PR TITLE
[api-triggers] Add cron firing engine and observability

### DIFF
--- a/.changeset/steady-crons-fire.md
+++ b/.changeset/steady-crons-fire.md
@@ -1,0 +1,6 @@
+---
+"@shipfox/api-triggers": patch
+"@shipfox/api-triggers-dto": patch
+---
+
+Adds the cron firing engine: a once-per-minute tick fans out bounded drain activities that claim due schedules (FOR UPDATE SKIP LOCKED), advance their next fire time, and fire the workflow deduplicated and crash-safe, recorded in trigger history with a `cron` origin and surfaced through cron fire and backlog metrics.

--- a/libs/api/triggers-dto/src/schemas/trigger-events.ts
+++ b/libs/api/triggers-dto/src/schemas/trigger-events.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 
-export const triggerEventOriginSchema = z.enum(['integration', 'manual']);
+export const triggerEventOriginSchema = z.enum(['integration', 'manual', 'cron']);
 export type TriggerEventOriginDto = z.infer<typeof triggerEventOriginSchema>;
 
 export const triggerEventOutcomeSchema = z.enum([

--- a/libs/api/triggers/src/config.ts
+++ b/libs/api/triggers/src/config.ts
@@ -9,6 +9,14 @@ export const config = createConfig({
     desc: 'Maximum number of seconds added as deterministic jitter to a cron trigger fire time. Use 0 to disable jitter. Values below about 60 seconds are usually no-ops when cron ticking runs at minute resolution; multi-minute windows spread large schedule herds.',
     default: 0,
   }),
+  TRIGGER_CRON_FANOUT: num({
+    desc: 'How many drain activities the once-per-minute cron tick runs in parallel. Each activity claims and fires one bounded batch, so the per-minute ceiling is TRIGGER_CRON_FANOUT times TRIGGER_CRON_CLAIM_BATCH runs. Raise it (and pod count) to fire more schedules per minute. Must be at least 1. Defaults to 2.',
+    default: 2,
+  }),
+  TRIGGER_CRON_CLAIM_BATCH: num({
+    desc: 'How many due cron schedules a single drain activity claims and fires per tick. Bounds the load a cron burst can put on the database and the run-creation path. Must be at least 1. Defaults to 100.',
+    default: 100,
+  }),
 });
 
 export function assertRetentionDaysWithinBounds(days: number): void {
@@ -30,3 +38,16 @@ export function assertCronConfigWithinBounds(jitterWindowSeconds: number): void 
 }
 
 assertCronConfigWithinBounds(config.TRIGGER_CRON_JITTER_WINDOW_SECONDS);
+
+export function assertCronThroughputWithinBounds(fanout: number, claimBatch: number): void {
+  if (!Number.isInteger(fanout) || fanout < 1) {
+    throw new Error(`TRIGGER_CRON_FANOUT must be an integer of at least 1, received ${fanout}.`);
+  }
+  if (!Number.isInteger(claimBatch) || claimBatch < 1) {
+    throw new Error(
+      `TRIGGER_CRON_CLAIM_BATCH must be an integer of at least 1, received ${claimBatch}.`,
+    );
+  }
+}
+
+assertCronThroughputWithinBounds(config.TRIGGER_CRON_FANOUT, config.TRIGGER_CRON_CLAIM_BATCH);

--- a/libs/api/triggers/src/core/drain-cron-schedules.test.ts
+++ b/libs/api/triggers/src/core/drain-cron-schedules.test.ts
@@ -1,0 +1,265 @@
+import {eq} from 'drizzle-orm';
+import type {CronSchedule} from '#core/entities/cron-schedule.js';
+import type {TriggerSubscription} from '#core/entities/subscription.js';
+import {countDueCronSchedules} from '#db/cron-schedules.js';
+import {db} from '#db/db.js';
+import {triggersCronSchedules} from '#db/schema/cron-schedules.js';
+import {triggersDecisions} from '#db/schema/decisions.js';
+import {triggersReceivedEvents} from '#db/schema/received-events.js';
+import {cronScheduleFactory, triggerSubscriptionFactory} from '#test/index.js';
+
+const runWorkflow = vi.fn();
+
+vi.mock('@shipfox/api-workflows', () => {
+  class DefinitionNotFoundError extends Error {
+    constructor(definitionId: string) {
+      super(`Definition not found: ${definitionId}`);
+      this.name = 'DefinitionNotFoundError';
+    }
+  }
+  return {
+    runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+    DefinitionNotFoundError,
+    isPermanentRunWorkflowError: (error: unknown) => error instanceof DefinitionNotFoundError,
+  };
+});
+
+import {DefinitionNotFoundError} from '@shipfox/api-workflows';
+
+// Import after mocks so the function under test sees the spy.
+const {drainDueCronSchedules} = await import('./drain-cron-schedules.js');
+
+const MINUTE_MS = 60 * 1000;
+
+// The drain claim is global over a shared test DB, so assertions target the specific
+// subscriptions each test creates (via the deterministic idempotency key) and use
+// lower bounds for any global count, mirroring the prune activity test.
+interface DueCron {
+  subscription: TriggerSubscription;
+  schedule: CronSchedule;
+  key: string;
+}
+
+async function createCronSchedule(params: {
+  nextFireAt: Date;
+  cronExpression?: string;
+  config?: Record<string, unknown>;
+}): Promise<DueCron> {
+  const subscription = await triggerSubscriptionFactory.create({
+    source: 'cron',
+    event: 'tick',
+    config: params.config ?? {},
+  });
+  const schedule = await cronScheduleFactory.create({
+    subscriptionId: subscription.id,
+    workspaceId: subscription.workspaceId,
+    cronExpression: params.cronExpression ?? '*/5 * * * *',
+    timezone: 'UTC',
+    nextFireAt: params.nextFireAt,
+  });
+  return {subscription, schedule, key: `${subscription.id}:${schedule.nextFireAt.toISOString()}`};
+}
+
+function callsWithKey(key: string) {
+  return runWorkflow.mock.calls.filter(
+    ([params]) => (params as {triggerIdempotencyKey?: string}).triggerIdempotencyKey === key,
+  );
+}
+
+async function reload(subscriptionId: string) {
+  const [row] = await db()
+    .select()
+    .from(triggersCronSchedules)
+    .where(eq(triggersCronSchedules.subscriptionId, subscriptionId));
+  if (!row) throw new Error('cron schedule row not found');
+  return row;
+}
+
+describe('drainDueCronSchedules', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+  });
+
+  test('fires a due schedule exactly once, records cron history, and advances next_fire_at', async () => {
+    const {subscription, schedule, key} = await createCronSchedule({
+      nextFireAt: new Date(Date.now() - MINUTE_MS),
+    });
+    const run = {id: crypto.randomUUID(), name: 'Cron run'};
+    runWorkflow.mockResolvedValue(run);
+
+    const summary = await drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0});
+
+    expect(callsWithKey(key)).toHaveLength(1);
+    expect(summary.fired).toBeGreaterThanOrEqual(1);
+    const [event] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, key));
+    if (!event) throw new Error('received event not found');
+    expect(event.origin).toBe('cron');
+    expect(event.outcome).toBe('routed');
+    const decisions = await db()
+      .select()
+      .from(triggersDecisions)
+      .where(eq(triggersDecisions.receivedEventId, event.id));
+    expect(decisions[0]?.decision).toBe('triggered');
+    expect(decisions[0]?.runId).toBe(run.id);
+    const row = await reload(subscription.id);
+    expect(row.nextFireAt.getTime()).toBeGreaterThan(Date.now());
+    expect(row.lastFiredAt?.getTime()).toBe(schedule.nextFireAt.getTime());
+  });
+
+  test('does not claim a schedule whose next fire time is still in the future', async () => {
+    const future = new Date(Date.now() + 60 * MINUTE_MS);
+    const {subscription, key} = await createCronSchedule({nextFireAt: future});
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'r'});
+
+    await drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0});
+
+    expect(callsWithKey(key)).toHaveLength(0);
+    const row = await reload(subscription.id);
+    expect(row.nextFireAt.getTime()).toBe(future.getTime());
+    expect(row.lastFiredAt).toBeNull();
+  });
+
+  test('overdue schedule fires once and skips the intermediate windows', async () => {
+    const {subscription, key} = await createCronSchedule({
+      nextFireAt: new Date(Date.now() - 60 * MINUTE_MS),
+      cronExpression: '*/5 * * * *',
+    });
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'r'});
+
+    await drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0});
+
+    expect(callsWithKey(key)).toHaveLength(1);
+    const row = await reload(subscription.id);
+    const now = Date.now();
+    expect(row.nextFireAt.getTime()).toBeGreaterThan(now);
+    expect(row.nextFireAt.getTime()).toBeLessThan(now + 6 * MINUTE_MS);
+  });
+
+  test('passes the deterministic idempotency key and the subscription inputs to runWorkflow', async () => {
+    const {subscription, key} = await createCronSchedule({
+      nextFireAt: new Date(Date.now() - MINUTE_MS),
+      config: {with: {environment: 'staging'}},
+    });
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'r'});
+
+    await drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0});
+
+    const [params] = callsWithKey(key)[0] as [Record<string, unknown>];
+    expect(params.triggerIdempotencyKey).toBe(key);
+    expect(params.inputs).toEqual({environment: 'staging'});
+    expect(params.triggerPayload).toEqual({
+      provider: 'cron',
+      source: 'cron',
+      event: 'tick',
+      scheduleId: subscription.id,
+    });
+  });
+
+  test('records an errored decision and still advances on a permanent runWorkflow failure', async () => {
+    const {subscription, key} = await createCronSchedule({
+      nextFireAt: new Date(Date.now() - MINUTE_MS),
+    });
+    runWorkflow.mockRejectedValue(new DefinitionNotFoundError('def-gone'));
+
+    await drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0});
+
+    const [event] = await db()
+      .select()
+      .from(triggersReceivedEvents)
+      .where(eq(triggersReceivedEvents.eventRef, key));
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    const decisions = await db()
+      .select()
+      .from(triggersDecisions)
+      .where(eq(triggersDecisions.receivedEventId, event.id));
+    expect(decisions[0]?.decision).toBe('errored');
+    const row = await reload(subscription.id);
+    expect(row.nextFireAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test('leaves the schedule due and unfired on a transient runWorkflow failure', async () => {
+    const {subscription, schedule} = await createCronSchedule({
+      nextFireAt: new Date(Date.now() - MINUTE_MS),
+    });
+    runWorkflow.mockRejectedValue(new Error('database unavailable'));
+
+    await drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0});
+
+    const row = await reload(subscription.id);
+    expect(row.nextFireAt.getTime()).toBe(schedule.nextFireAt.getTime());
+    expect(row.lastFiredAt).toBeNull();
+  });
+
+  test('invokes the liveness callback once per claimed schedule', async () => {
+    await createCronSchedule({nextFireAt: new Date(Date.now() - MINUTE_MS)});
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'r'});
+    const onScheduleProcessed = vi.fn();
+
+    const summary = await drainDueCronSchedules({
+      batchSize: 1000,
+      jitterWindowSeconds: 0,
+      onScheduleProcessed,
+    });
+
+    expect(summary.claimed).toBeGreaterThanOrEqual(1);
+    expect(onScheduleProcessed).toHaveBeenCalledTimes(summary.claimed);
+  });
+
+  test('claims at most batchSize schedules per drain and leaves the rest due', async () => {
+    const mine: DueCron[] = [];
+    for (let index = 0; index < 5; index += 1) {
+      mine.push(await createCronSchedule({nextFireAt: new Date(Date.now() - MINUTE_MS)}));
+    }
+    runWorkflow.mockResolvedValue({id: crypto.randomUUID(), name: 'r'});
+
+    const summary = await drainDueCronSchedules({batchSize: 3, jitterWindowSeconds: 0});
+
+    expect(summary.claimed).toBe(3);
+    expect(runWorkflow).toHaveBeenCalledTimes(3);
+    // The capped drain advanced at most 3 rows total, so at least 2 of my 5 stay due.
+    let stillDue = 0;
+    for (const {subscription} of mine) {
+      const row = await reload(subscription.id);
+      if (row.nextFireAt.getTime() <= Date.now()) stillDue += 1;
+    }
+    expect(stillDue).toBeGreaterThanOrEqual(2);
+  });
+
+  test('two concurrent drains fire each due schedule exactly once (SKIP LOCKED)', async () => {
+    const mine: DueCron[] = [];
+    for (let index = 0; index < 4; index += 1) {
+      mine.push(await createCronSchedule({nextFireAt: new Date(Date.now() - MINUTE_MS)}));
+    }
+    // Hold the batch locks briefly so both drains are in flight while claiming.
+    runWorkflow.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return {id: crypto.randomUUID(), name: 'r'};
+    });
+
+    await Promise.all([
+      drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0}),
+      drainDueCronSchedules({batchSize: 1000, jitterWindowSeconds: 0}),
+    ]);
+
+    for (const {subscription, schedule, key} of mine) {
+      expect(callsWithKey(key)).toHaveLength(1);
+      const row = await reload(subscription.id);
+      expect(row.lastFiredAt?.getTime()).toBe(schedule.nextFireAt.getTime());
+      expect(row.nextFireAt.getTime()).toBeGreaterThan(Date.now());
+    }
+  });
+});
+
+describe('countDueCronSchedules (backlog gauge source)', () => {
+  test('counts a schedule whose next fire time is due', async () => {
+    await createCronSchedule({nextFireAt: new Date(Date.now() - MINUTE_MS)});
+
+    const due = await countDueCronSchedules();
+
+    expect(due).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/libs/api/triggers/src/core/drain-cron-schedules.ts
+++ b/libs/api/triggers/src/core/drain-cron-schedules.ts
@@ -1,0 +1,87 @@
+import {logger} from '@shipfox/node-opentelemetry';
+import {advanceCronSchedule, claimDueCronSchedules} from '#db/cron-schedules.js';
+import {db} from '#db/db.js';
+import {computeNextFireAt} from './compute-next-fire-at.js';
+import {fireCronSubscription} from './fire-cron.js';
+
+export interface DrainDueCronSchedulesParams {
+  readonly batchSize: number;
+  readonly jitterWindowSeconds: number;
+  /**
+   * Liveness signal invoked once per processed schedule (e.g. the Temporal activity
+   * heartbeat), so a batch stuck on a slow `runWorkflow` is visible rather than
+   * looking hung until the start-to-close timeout fires.
+   */
+  readonly onScheduleProcessed?: (() => void) | undefined;
+}
+
+export interface CronDrainSummary {
+  readonly claimed: number;
+  readonly fired: number;
+  readonly errored: number;
+  readonly retried: number;
+}
+
+/**
+ * Claims one bounded batch of due cron schedules and, per row, advances the schedule
+ * and fires the workflow. There is no internal drain loop, so the per-activity ceiling
+ * stays a hard `batchSize`.
+ *
+ * The batch is claimed and processed inside a single transaction, so its `FOR UPDATE
+ * SKIP LOCKED` locks are held until commit and concurrent activities/pods claim disjoint
+ * rows. Each row runs in a nested savepoint that advances `next_fire_at` before firing:
+ * on a transient failure the savepoint rolls back only that row's advance, leaving it due
+ * for retry, without blocking the rest of the batch. Firing before the advance commits
+ * makes a crash between the two re-fire the (idempotent) occurrence rather than skip it.
+ */
+export async function drainDueCronSchedules(
+  params: DrainDueCronSchedulesParams,
+): Promise<CronDrainSummary> {
+  let claimed = 0;
+  let fired = 0;
+  let errored = 0;
+  let retried = 0;
+
+  await db().transaction(async (tx) => {
+    const due = await claimDueCronSchedules({tx, limit: params.batchSize});
+    claimed = due.length;
+
+    for (const schedule of due) {
+      const scheduledSlot = schedule.nextFireAt;
+      try {
+        const result = await tx.transaction(async (rowTx) => {
+          const nextFireAt = computeNextFireAt({
+            cronExpression: schedule.cronExpression,
+            timezone: schedule.timezone,
+            from: new Date(),
+            subscriptionId: schedule.subscriptionId,
+            jitterWindowSeconds: params.jitterWindowSeconds,
+          });
+          await advanceCronSchedule({
+            tx: rowTx,
+            subscriptionId: schedule.subscriptionId,
+            nextFireAt,
+            lastFiredAt: scheduledSlot,
+          });
+          return await fireCronSubscription({
+            subscriptionId: schedule.subscriptionId,
+            scheduledSlot,
+          });
+        });
+        if (result.outcome === 'fired') fired += 1;
+        else errored += 1;
+      } catch (error) {
+        // Transient failure: the savepoint rolled back the advance, so the schedule
+        // stays due and the next tick (or an activity retry) re-claims it.
+        retried += 1;
+        logger().warn(
+          {err: error, subscriptionId: schedule.subscriptionId},
+          'cron drain: transient fire failure; schedule left due for retry',
+        );
+      }
+      params.onScheduleProcessed?.();
+    }
+  });
+
+  return {claimed, fired, errored, retried};
+}

--- a/libs/api/triggers/src/core/drain-cron-schedules.ts
+++ b/libs/api/triggers/src/core/drain-cron-schedules.ts
@@ -1,5 +1,5 @@
 import {logger} from '@shipfox/node-opentelemetry';
-import {advanceCronSchedule, claimDueCronSchedules} from '#db/cron-schedules.js';
+import {advanceCronSchedule, claimDueCronSchedules, selectDbNow} from '#db/cron-schedules.js';
 import {db} from '#db/db.js';
 import {computeNextFireAt} from './compute-next-fire-at.js';
 import {fireCronSubscription} from './fire-cron.js';
@@ -43,7 +43,10 @@ export async function drainDueCronSchedules(
   let retried = 0;
 
   await db().transaction(async (tx) => {
-    const due = await claimDueCronSchedules({tx, limit: params.batchSize});
+    // One database-clock reading shared by the due check and every advance, so the two
+    // never disagree under application/database clock skew.
+    const now = await selectDbNow(tx);
+    const due = await claimDueCronSchedules({tx, limit: params.batchSize, now});
     claimed = due.length;
 
     for (const schedule of due) {
@@ -53,7 +56,7 @@ export async function drainDueCronSchedules(
           const nextFireAt = computeNextFireAt({
             cronExpression: schedule.cronExpression,
             timezone: schedule.timezone,
-            from: new Date(),
+            from: now,
             subscriptionId: schedule.subscriptionId,
             jitterWindowSeconds: params.jitterWindowSeconds,
           });

--- a/libs/api/triggers/src/core/entities/received-event.ts
+++ b/libs/api/triggers/src/core/entities/received-event.ts
@@ -1,4 +1,4 @@
-export const triggerEventOrigins = ['integration', 'manual'] as const;
+export const triggerEventOrigins = ['integration', 'manual', 'cron'] as const;
 export type TriggerEventOrigin = (typeof triggerEventOrigins)[number];
 
 export const triggerEventOutcomes = [

--- a/libs/api/triggers/src/core/errors.ts
+++ b/libs/api/triggers/src/core/errors.ts
@@ -32,6 +32,20 @@ export class TriggerSubscriptionNotManualError extends Error {
   }
 }
 
+export class TriggerSubscriptionNotCronError extends Error {
+  readonly subscriptionId: string;
+  readonly source: string;
+
+  constructor(subscriptionId: string, source: string) {
+    super(
+      `Trigger subscription ${subscriptionId} has source '${source}', expected 'cron' for cron fire`,
+    );
+    this.name = 'TriggerSubscriptionNotCronError';
+    this.subscriptionId = subscriptionId;
+    this.source = source;
+  }
+}
+
 export class TriggerWorkspaceMismatchError extends Error {
   readonly subscriptionId: string;
   readonly subscriptionWorkspaceId: string;

--- a/libs/api/triggers/src/core/fire-cron.test.ts
+++ b/libs/api/triggers/src/core/fire-cron.test.ts
@@ -1,0 +1,146 @@
+import {eq} from 'drizzle-orm';
+import {db} from '#db/db.js';
+import {triggersDecisions} from '#db/schema/decisions.js';
+import {triggersReceivedEvents} from '#db/schema/received-events.js';
+import {triggerSubscriptionFactory} from '#test/index.js';
+import {TriggerSubscriptionNotCronError} from './errors.js';
+
+const runWorkflow = vi.fn();
+
+// Keep a real-enough permanent-error class + the classifier so the cron path's
+// permanent/transient branching is exercised without loading the workflows module graph.
+vi.mock('@shipfox/api-workflows', () => {
+  class DefinitionNotFoundError extends Error {
+    constructor(definitionId: string) {
+      super(`Definition not found: ${definitionId}`);
+      this.name = 'DefinitionNotFoundError';
+    }
+  }
+  return {
+    runWorkflow: (...args: unknown[]) => runWorkflow(...args),
+    DefinitionNotFoundError,
+    isPermanentRunWorkflowError: (error: unknown) => error instanceof DefinitionNotFoundError,
+  };
+});
+
+import {DefinitionNotFoundError} from '@shipfox/api-workflows';
+
+// Import after mocks so the function under test sees the spy.
+const {fireCronSubscription} = await import('./fire-cron.js');
+
+const SLOT = new Date('2026-07-05T02:00:00.000Z');
+
+function eventsForWorkspace(workspaceId: string) {
+  return db()
+    .select()
+    .from(triggersReceivedEvents)
+    .where(eq(triggersReceivedEvents.workspaceId, workspaceId));
+}
+
+function decisionsForEvent(receivedEventId: string) {
+  return db()
+    .select()
+    .from(triggersDecisions)
+    .where(eq(triggersDecisions.receivedEventId, receivedEventId));
+}
+
+describe('fireCronSubscription', () => {
+  beforeEach(() => {
+    runWorkflow.mockReset();
+  });
+
+  test('records a routed cron event and a triggered decision on success', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'cron',
+      event: 'tick',
+      config: {with: {environment: 'staging'}},
+    });
+    const run = {id: crypto.randomUUID(), name: 'Cron run'};
+    runWorkflow.mockResolvedValue(run);
+
+    const result = await fireCronSubscription({
+      subscriptionId: subscription.id,
+      scheduledSlot: SLOT,
+    });
+
+    expect(result).toEqual({outcome: 'fired', run});
+    const [payload] = runWorkflow.mock.calls[0] as [Record<string, unknown>];
+    expect(payload.triggerPayload).toEqual({
+      provider: 'cron',
+      source: 'cron',
+      event: 'tick',
+      scheduleId: subscription.id,
+    });
+    expect(payload.inputs).toEqual({environment: 'staging'});
+    expect(payload.triggerIdempotencyKey).toBe(`${subscription.id}:${SLOT.toISOString()}`);
+    const [event] = await eventsForWorkspace(subscription.workspaceId);
+    if (!event) throw new Error('received event not found');
+    expect(event.origin).toBe('cron');
+    expect(event.source).toBe('cron');
+    expect(event.provider).toBeNull();
+    expect(event.outcome).toBe('routed');
+    expect(event.eventRef).toBe(`${subscription.id}:${SLOT.toISOString()}`);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.decision).toBe('triggered');
+    expect(decisions[0]?.runId).toBe(run.id);
+  });
+
+  test('returns errored (terminal) and records an errored decision on a permanent failure', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'cron',
+      event: 'tick',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(new DefinitionNotFoundError('def-gone'));
+
+    const result = await fireCronSubscription({
+      subscriptionId: subscription.id,
+      scheduledSlot: SLOT,
+    });
+
+    expect(result).toEqual({outcome: 'errored'});
+    const [event] = await eventsForWorkspace(subscription.workspaceId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('errored');
+    expect(event.processedAt).toBeInstanceOf(Date);
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions[0]?.decision).toBe('errored');
+    expect(decisions[0]?.reason).toContain('Definition not found');
+  });
+
+  test('re-throws and leaves the event non-terminal on a transient failure', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'cron',
+      event: 'tick',
+      config: {},
+    });
+    runWorkflow.mockRejectedValue(new Error('cron boom'));
+
+    await expect(
+      fireCronSubscription({subscriptionId: subscription.id, scheduledSlot: SLOT}),
+    ).rejects.toThrow('cron boom');
+
+    const [event] = await eventsForWorkspace(subscription.workspaceId);
+    if (!event) throw new Error('received event not found');
+    expect(event.outcome).toBe('failed');
+    expect(event.processedAt).toBeNull();
+    const decisions = await decisionsForEvent(event.id);
+    expect(decisions[0]?.decision).toBe('errored');
+  });
+
+  test('throws and records nothing when the subscription is not a cron trigger', async () => {
+    const subscription = await triggerSubscriptionFactory.create({
+      source: 'manual',
+      event: 'fire',
+      config: {},
+    });
+
+    await expect(
+      fireCronSubscription({subscriptionId: subscription.id, scheduledSlot: SLOT}),
+    ).rejects.toThrow(TriggerSubscriptionNotCronError);
+
+    expect(await eventsForWorkspace(subscription.workspaceId)).toHaveLength(0);
+    expect(runWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/libs/api/triggers/src/core/fire-cron.ts
+++ b/libs/api/triggers/src/core/fire-cron.ts
@@ -1,0 +1,98 @@
+import {isPermanentRunWorkflowError, runWorkflow, type WorkflowRun} from '@shipfox/api-workflows';
+import {getTriggerSubscriptionById} from '#db/subscriptions.js';
+import {cronFiredCount, cronFireLag} from '#metrics/instance.js';
+import {readConfigInputs} from './config.js';
+import {TriggerSubscriptionNotCronError, TriggerSubscriptionNotFoundError} from './errors.js';
+import {beginTriggerHistory, toReason} from './record-trigger-history.js';
+
+export interface FireCronSubscriptionParams {
+  subscriptionId: string;
+  /**
+   * The `next_fire_at` value the schedule held when it was claimed. Anchoring the
+   * idempotency key and history `event_ref` on this slot, rather than wall-clock
+   * time, makes a retry of the same occurrence a deterministic no-op.
+   */
+  scheduledSlot: Date;
+}
+
+export type FireCronSubscriptionResult =
+  | {outcome: 'fired'; run: WorkflowRun}
+  | {outcome: 'errored'};
+
+/**
+ * Fires one cron schedule occurrence. Mirrors `fireManualSubscription`, but is driven
+ * by the drain activity rather than an HTTP route, and reports the outcome instead of
+ * throwing on a permanent failure so the caller can advance the schedule past a
+ * permanently broken definition:
+ *
+ * - `{outcome: 'fired'}` on success (or an idempotent replay of an already-created run),
+ * - `{outcome: 'errored'}` on a permanent `runWorkflow` failure (recorded, schedule advances),
+ * - throws on a transient failure so the caller rolls back the advance and retries.
+ */
+export async function fireCronSubscription(
+  params: FireCronSubscriptionParams,
+): Promise<FireCronSubscriptionResult> {
+  const subscription = await getTriggerSubscriptionById(params.subscriptionId);
+  if (!subscription) throw new TriggerSubscriptionNotFoundError(params.subscriptionId);
+  if (subscription.source !== 'cron') {
+    throw new TriggerSubscriptionNotCronError(params.subscriptionId, subscription.source);
+  }
+
+  // Deterministic per-occurrence identity: unique across (subscription, slot), stable
+  // across retries. Used for both the run idempotency key and the received-event ref.
+  const eventRef = `${subscription.id}:${params.scheduledSlot.toISOString()}`;
+  const historyBase = {
+    origin: 'cron' as const,
+    workspaceId: subscription.workspaceId,
+    provider: null,
+    source: subscription.source,
+    event: subscription.event,
+    deliveryId: null,
+    connectionId: null,
+    connectionName: null,
+    payload: null,
+    // The scheduled occurrence is the logical arrival time of the tick event.
+    receivedAt: params.scheduledSlot,
+    eventRef,
+  };
+
+  let run: WorkflowRun;
+  try {
+    run = await runWorkflow({
+      workspaceId: subscription.workspaceId,
+      projectId: subscription.projectId,
+      definitionId: subscription.workflowDefinitionId,
+      triggerPayload: {
+        provider: 'cron',
+        source: 'cron',
+        event: 'tick',
+        scheduleId: subscription.id,
+      },
+      inputs: readConfigInputs(subscription),
+      triggerIdempotencyKey: eventRef,
+    });
+  } catch (error) {
+    const failure = await beginTriggerHistory(historyBase);
+    await failure.errored(subscription, toReason(error));
+    if (isPermanentRunWorkflowError(error)) {
+      recordFire('errored', params.scheduledSlot);
+      await failure.allErrored(1);
+      return {outcome: 'errored'};
+    }
+    // Transient: leave the event non-terminal and re-throw so the caller rolls back
+    // the advance and the schedule stays due for the next tick.
+    await failure.failed(1);
+    throw error;
+  }
+
+  const history = await beginTriggerHistory(historyBase);
+  await history.triggered(subscription, run);
+  recordFire('fired', params.scheduledSlot);
+  await history.routed(1);
+  return {outcome: 'fired', run};
+}
+
+function recordFire(outcome: 'fired' | 'errored', scheduledSlot: Date): void {
+  cronFiredCount.add(1, {outcome});
+  cronFireLag.record(Math.max(0, Date.now() - scheduledSlot.getTime()));
+}

--- a/libs/api/triggers/src/core/index.ts
+++ b/libs/api/triggers/src/core/index.ts
@@ -7,14 +7,25 @@ export {
   type DispatchIntegrationEventParams,
   dispatchIntegrationEvent,
 } from './dispatch-integration-event.js';
+export {
+  type CronDrainSummary,
+  type DrainDueCronSchedulesParams,
+  drainDueCronSchedules,
+} from './drain-cron-schedules.js';
 export type {CronSchedule} from './entities/cron-schedule.js';
 export type {TriggerSubscription} from './entities/subscription.js';
 export {
   ManualTriggerNotFoundError,
+  TriggerSubscriptionNotCronError,
   TriggerSubscriptionNotFoundError,
   TriggerSubscriptionNotManualError,
   TriggerWorkspaceMismatchError,
 } from './errors.js';
+export {
+  type FireCronSubscriptionParams,
+  type FireCronSubscriptionResult,
+  fireCronSubscription,
+} from './fire-cron.js';
 export {type FireManualSubscriptionParams, fireManualSubscription} from './fire-manual.js';
 export {
   type RouteEventToJobListenersParams,

--- a/libs/api/triggers/src/db/cron-schedules.ts
+++ b/libs/api/triggers/src/db/cron-schedules.ts
@@ -1,6 +1,6 @@
 import {logger} from '@shipfox/node-opentelemetry';
 import {triggerSourceConfigSchemas} from '@shipfox/workflow-document';
-import {eq, sql} from 'drizzle-orm';
+import {eq, lte, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import {computeNextFireAt} from '#core/compute-next-fire-at.js';
 import type {CronSchedule} from '#core/entities/cron-schedule.js';
@@ -79,6 +79,55 @@ export async function deleteCronScheduleForSubscription(
   await params.tx
     .delete(triggersCronSchedules)
     .where(eq(triggersCronSchedules.subscriptionId, params.subscriptionId));
+}
+
+export interface ClaimDueCronSchedulesParams {
+  readonly tx: Tx;
+  readonly limit: number;
+}
+
+/**
+ * Uses the database clock for due checks and holds `FOR UPDATE SKIP LOCKED` locks
+ * until the caller's transaction ends, so concurrent drains partition due rows
+ * instead of double-claiming them.
+ */
+export async function claimDueCronSchedules(
+  params: ClaimDueCronSchedulesParams,
+): Promise<CronSchedule[]> {
+  const rows = await params.tx
+    .select()
+    .from(triggersCronSchedules)
+    .where(lte(triggersCronSchedules.nextFireAt, sql`now()`))
+    .orderBy(triggersCronSchedules.nextFireAt)
+    .limit(params.limit)
+    .for('update', {skipLocked: true});
+  return rows.map(toCronSchedule);
+}
+
+export interface AdvanceCronScheduleParams {
+  readonly tx: Tx;
+  readonly subscriptionId: string;
+  readonly nextFireAt: Date;
+  readonly lastFiredAt: Date;
+}
+
+export async function advanceCronSchedule(params: AdvanceCronScheduleParams): Promise<void> {
+  await params.tx
+    .update(triggersCronSchedules)
+    .set({
+      nextFireAt: params.nextFireAt,
+      lastFiredAt: params.lastFiredAt,
+      updatedAt: new Date(),
+    })
+    .where(eq(triggersCronSchedules.subscriptionId, params.subscriptionId));
+}
+
+export async function countDueCronSchedules(): Promise<number> {
+  const [row] = await db()
+    .select({count: sql<number>`count(*)::int`})
+    .from(triggersCronSchedules)
+    .where(lte(triggersCronSchedules.nextFireAt, sql`now()`));
+  return row?.count ?? 0;
 }
 
 export async function getCronScheduleBySubscriptionId(

--- a/libs/api/triggers/src/db/cron-schedules.ts
+++ b/libs/api/triggers/src/db/cron-schedules.ts
@@ -4,7 +4,7 @@ import {eq, lte, sql} from 'drizzle-orm';
 import {config} from '#config.js';
 import {computeNextFireAt} from '#core/compute-next-fire-at.js';
 import type {CronSchedule} from '#core/entities/cron-schedule.js';
-import {db, type Tx} from './db.js';
+import {db, type Executor, type Tx} from './db.js';
 import {toCronSchedule, triggersCronSchedules} from './schema/cron-schedules.js';
 
 const defaultCronTimezone = 'UTC';
@@ -81,15 +81,25 @@ export async function deleteCronScheduleForSubscription(
     .where(eq(triggersCronSchedules.subscriptionId, params.subscriptionId));
 }
 
+// Reads the database clock so a tick's due check and its next-fire computation share
+// one time reference, immune to application/database clock skew.
+export async function selectDbNow(executor: Executor): Promise<Date> {
+  const result = await executor.execute<{now: Date | string}>(sql`select now() as now`);
+  const raw = result.rows[0]?.now;
+  if (raw === undefined) throw new Error('Failed to read the database clock');
+  return raw instanceof Date ? raw : new Date(raw);
+}
+
 export interface ClaimDueCronSchedulesParams {
   readonly tx: Tx;
   readonly limit: number;
+  readonly now: Date;
 }
 
 /**
- * Uses the database clock for due checks and holds `FOR UPDATE SKIP LOCKED` locks
- * until the caller's transaction ends, so concurrent drains partition due rows
- * instead of double-claiming them.
+ * Claims schedules due as of `now` (the shared database clock captured for this tick)
+ * and holds `FOR UPDATE SKIP LOCKED` locks until the caller's transaction ends, so
+ * concurrent drains partition due rows instead of double-claiming them.
  */
 export async function claimDueCronSchedules(
   params: ClaimDueCronSchedulesParams,
@@ -97,7 +107,7 @@ export async function claimDueCronSchedules(
   const rows = await params.tx
     .select()
     .from(triggersCronSchedules)
-    .where(lte(triggersCronSchedules.nextFireAt, sql`now()`))
+    .where(lte(triggersCronSchedules.nextFireAt, params.now))
     .orderBy(triggersCronSchedules.nextFireAt)
     .limit(params.limit)
     .for('update', {skipLocked: true});

--- a/libs/api/triggers/src/db/index.ts
+++ b/libs/api/triggers/src/db/index.ts
@@ -2,6 +2,9 @@ import {dirname, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 export {
+  advanceCronSchedule,
+  claimDueCronSchedules,
+  countDueCronSchedules,
   deleteCronScheduleForSubscription,
   getCronScheduleBySubscriptionId,
   syncCronSchedule,

--- a/libs/api/triggers/src/index.ts
+++ b/libs/api/triggers/src/index.ts
@@ -16,6 +16,7 @@ import {
 } from '@shipfox/api-workflows-dto';
 import {type ShipfoxModule, subscriberFactory} from '@shipfox/node-module';
 import {db, migrationsPath, triggersOutbox} from '#db/index.js';
+import {registerTriggersServiceMetrics} from '#metrics/index.js';
 import {routes} from '#presentation/index.js';
 import {
   onDefinitionDeleted,
@@ -24,8 +25,11 @@ import {
   onJobActivated,
   onJobTerminated,
 } from '#presentation/subscribers/index.js';
-import {createTriggersMaintenanceActivities} from '#temporal/activities/index.js';
-import {TRIGGERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
+import {
+  createTriggersCronActivities,
+  createTriggersMaintenanceActivities,
+} from '#temporal/activities/index.js';
+import {TRIGGERS_CRON_TASK_QUEUE, TRIGGERS_MAINTENANCE_TASK_QUEUE} from '#temporal/constants.js';
 
 export type {
   JobListenerMatcherKind,
@@ -33,8 +37,10 @@ export type {
 } from '#core/entities/job-listener-subscription.js';
 export type {TriggerSubscription} from '#core/entities/subscription.js';
 export {
+  fireCronSubscription,
   fireManualSubscription,
   ManualTriggerNotFoundError,
+  TriggerSubscriptionNotCronError,
   TriggerSubscriptionNotFoundError,
   TriggerSubscriptionNotManualError,
   TriggerWorkspaceMismatchError,
@@ -54,7 +60,7 @@ export {
 } from '#db/index.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const maintenanceWorkflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
+const temporalWorkflowsPath = resolve(packageRoot, 'dist/temporal/workflows/index.js');
 
 const subscriber = subscriberFactory<
   DefinitionsEventMap & IntegrationsEventMap & WorkflowsEventMapDto
@@ -64,6 +70,7 @@ export const triggersModule: ShipfoxModule = {
   name: 'triggers',
   database: {db, migrationsPath},
   routes,
+  metrics: registerTriggersServiceMetrics,
   publishers: [{name: 'triggers', table: triggersOutbox, db}],
   subscribers: [
     subscriber(DEFINITION_RESOLVED, onDefinitionResolved),
@@ -75,13 +82,25 @@ export const triggersModule: ShipfoxModule = {
   workers: [
     {
       taskQueue: TRIGGERS_MAINTENANCE_TASK_QUEUE,
-      workflowsPath: maintenanceWorkflowsPath,
+      workflowsPath: temporalWorkflowsPath,
       activities: createTriggersMaintenanceActivities,
       workflows: [
         {
           name: 'pruneTriggerEventsCron',
           id: 'triggers-prune-trigger-events',
           cronSchedule: '0 * * * *',
+        },
+      ],
+    },
+    {
+      taskQueue: TRIGGERS_CRON_TASK_QUEUE,
+      workflowsPath: temporalWorkflowsPath,
+      activities: createTriggersCronActivities,
+      workflows: [
+        {
+          name: 'cronTickCron',
+          id: 'triggers-cron-tick',
+          cronSchedule: '* * * * *',
         },
       ],
     },

--- a/libs/api/triggers/src/metrics/index.ts
+++ b/libs/api/triggers/src/metrics/index.ts
@@ -1,1 +1,8 @@
-export {eventOutcomeCount, eventReceivedCount, subscriptionTriggeredCount} from './instance.js';
+export {
+  cronFiredCount,
+  cronFireLag,
+  eventOutcomeCount,
+  eventReceivedCount,
+  subscriptionTriggeredCount,
+} from './instance.js';
+export {registerTriggersServiceMetrics} from './service.js';

--- a/libs/api/triggers/src/metrics/instance.ts
+++ b/libs/api/triggers/src/metrics/instance.ts
@@ -20,3 +20,14 @@ export const eventOutcomeCount = meter.createCounter<{
 }>('triggers_event_outcome', {
   description: 'Final outcomes of trigger events by provider and outcome',
 });
+
+export const cronFiredCount = meter.createCounter<{outcome: 'fired' | 'errored'}>(
+  'triggers_cron_fired',
+  {description: 'Cron schedule slots consumed by the tick, by fire outcome'},
+);
+
+export const cronFireLag = meter.createHistogram<Record<string, never>>('triggers_cron_fire_lag', {
+  description: 'Delay between a cron scheduled slot and when the tick actually fired it',
+  unit: 'ms',
+  advice: {explicitBucketBoundaries: [0, 100, 500, 1000, 5000, 15000, 60000, 300000]},
+});

--- a/libs/api/triggers/src/metrics/service.ts
+++ b/libs/api/triggers/src/metrics/service.ts
@@ -1,0 +1,18 @@
+import {getServiceMetricsProvider} from '@shipfox/node-opentelemetry';
+import {countDueCronSchedules} from '#db/cron-schedules.js';
+
+export function registerTriggersServiceMetrics(): void {
+  const meter = getServiceMetricsProvider().getMeter('triggers');
+
+  const cronBacklog = meter.createObservableGauge('triggers_cron_backlog', {
+    description:
+      'Cron schedules past their next fire time and still pending a fire (including any a drain is mid-flight on). A sustained nonzero value means the minute tick is falling behind; raise TRIGGER_CRON_FANOUT, TRIGGER_CRON_CLAIM_BATCH, or pod count.',
+  });
+
+  meter.addBatchObservableCallback(
+    async (observer) => {
+      observer.observe(cronBacklog, await countDueCronSchedules());
+    },
+    [cronBacklog],
+  );
+}

--- a/libs/api/triggers/src/temporal/activities/drain-cron-batch.ts
+++ b/libs/api/triggers/src/temporal/activities/drain-cron-batch.ts
@@ -1,0 +1,20 @@
+import {Context} from '@temporalio/activity';
+import {config} from '#config.js';
+import {type CronDrainSummary, drainDueCronSchedules} from '#core/drain-cron-schedules.js';
+
+export async function drainCronBatchActivity(): Promise<CronDrainSummary> {
+  const ctx = Context.current();
+  return await drainDueCronSchedules({
+    batchSize: config.TRIGGER_CRON_CLAIM_BATCH,
+    jitterWindowSeconds: config.TRIGGER_CRON_JITTER_WINDOW_SECONDS,
+    onScheduleProcessed: () => ctx.heartbeat(),
+  });
+}
+
+// Read at runtime rather than baked into the cron workflow's start args: a start arg
+// would freeze fanout at first launch (a restart re-skips the already-running workflow),
+// so an activity read lets a config change take effect on the next tick after a worker
+// restart, consistent with how TRIGGER_CRON_CLAIM_BATCH is read in the drain activity.
+export function readCronFanoutActivity(): Promise<number> {
+  return Promise.resolve(config.TRIGGER_CRON_FANOUT);
+}

--- a/libs/api/triggers/src/temporal/activities/index.ts
+++ b/libs/api/triggers/src/temporal/activities/index.ts
@@ -1,7 +1,15 @@
+import {drainCronBatchActivity, readCronFanoutActivity} from './drain-cron-batch.js';
 import {pruneTriggerEventsActivity} from './prune-trigger-events.js';
 
 export function createTriggersMaintenanceActivities() {
   return {
     pruneTriggerEventsActivity,
+  };
+}
+
+export function createTriggersCronActivities() {
+  return {
+    drainCronBatchActivity,
+    readCronFanoutActivity,
   };
 }

--- a/libs/api/triggers/src/temporal/constants.ts
+++ b/libs/api/triggers/src/temporal/constants.ts
@@ -1,1 +1,7 @@
 export const TRIGGERS_MAINTENANCE_TASK_QUEUE = 'triggers-maintenance';
+
+/**
+ * Dedicated queue for the minute cron tick, so bursty cron-fire load and hourly
+ * maintenance load scale independently.
+ */
+export const TRIGGERS_CRON_TASK_QUEUE = 'triggers-cron';

--- a/libs/api/triggers/src/temporal/workflows/cron-tick-cron.ts
+++ b/libs/api/triggers/src/temporal/workflows/cron-tick-cron.ts
@@ -1,0 +1,39 @@
+import {log, proxyActivities} from '@temporalio/workflow';
+import type {createTriggersCronActivities} from '../activities/index.js';
+
+const {drainCronBatchActivity, readCronFanoutActivity} = proxyActivities<
+  ReturnType<typeof createTriggersCronActivities>
+>({
+  // Throughput is governed by fanout and claim batch, not a per-tick time budget, so
+  // give the batch drain plenty of room.
+  startToCloseTimeout: '5 minutes',
+  // No activity retry: the drain is not batch-idempotent across retries. A retry after a
+  // committed advance would claim a fresh due batch and fire beyond the
+  // fanout * TRIGGER_CRON_CLAIM_BATCH per-tick ceiling. Whole-activity failures roll the
+  // batch back (rows stay due) and the once-per-minute cron schedule is the retry.
+  retry: {maximumAttempts: 1},
+});
+
+/**
+ * Fires once a minute (Temporal never overlaps a cron workflow with itself, so a slow
+ * tick delays the next rather than doubling it). Reads the current fanout and runs that
+ * many drain activities; Temporal spreads them across the worker fleet, and `SKIP LOCKED`
+ * keeps their claims disjoint. The per-tick fire ceiling is
+ * `fanout * TRIGGER_CRON_CLAIM_BATCH`.
+ */
+export async function cronTickCron(): Promise<void> {
+  const fanout = await readCronFanoutActivity();
+  const parallelism = Number.isInteger(fanout) && fanout > 0 ? fanout : 1;
+
+  const summaries = await Promise.all(
+    Array.from({length: parallelism}, () => drainCronBatchActivity()),
+  );
+
+  const fired = summaries.reduce((total, summary) => total + summary.fired, 0);
+  const errored = summaries.reduce((total, summary) => total + summary.errored, 0);
+  const retried = summaries.reduce((total, summary) => total + summary.retried, 0);
+
+  if (fired > 0 || errored > 0 || retried > 0) {
+    log.info('Cron tick drained schedules', {fired, errored, retried});
+  }
+}

--- a/libs/api/triggers/src/temporal/workflows/cron-tick-cron.ts
+++ b/libs/api/triggers/src/temporal/workflows/cron-tick-cron.ts
@@ -1,12 +1,22 @@
 import {log, proxyActivities} from '@temporalio/workflow';
 import type {createTriggersCronActivities} from '../activities/index.js';
 
+// Upper bound on per-tick parallelism. A misconfigured TRIGGER_CRON_FANOUT (e.g. a
+// pasted large number) is clamped to this rather than spawning an unbounded fan-out
+// that could stall the tick, so one config mistake cannot stop cron firing.
+const MAX_CRON_FANOUT = 32;
+
 const {drainCronBatchActivity, readCronFanoutActivity} = proxyActivities<
   ReturnType<typeof createTriggersCronActivities>
 >({
   // Throughput is governed by fanout and claim batch, not a per-tick time budget, so
   // give the batch drain plenty of room.
   startToCloseTimeout: '5 minutes',
+  // The drain heartbeats once per processed schedule, so a hung run stops heartbeating
+  // well before the start-to-close timeout. Fail it within a minute (rather than after
+  // five) so its FOR UPDATE SKIP LOCKED locks release and the next tick re-claims those
+  // rows.
+  heartbeatTimeout: '1 minute',
   // No activity retry: the drain is not batch-idempotent across retries. A retry after a
   // committed advance would claim a fresh due batch and fire beyond the
   // fanout * TRIGGER_CRON_CLAIM_BATCH per-tick ceiling. Whole-activity failures roll the
@@ -23,7 +33,14 @@ const {drainCronBatchActivity, readCronFanoutActivity} = proxyActivities<
  */
 export async function cronTickCron(): Promise<void> {
   const fanout = await readCronFanoutActivity();
-  const parallelism = Number.isInteger(fanout) && fanout > 0 ? fanout : 1;
+  const requested = Number.isInteger(fanout) && fanout > 0 ? fanout : 1;
+  const parallelism = Math.min(requested, MAX_CRON_FANOUT);
+  if (parallelism < requested) {
+    log.warn('Cron tick fanout exceeds the maximum; clamping', {
+      requested,
+      max: MAX_CRON_FANOUT,
+    });
+  }
 
   const summaries = await Promise.all(
     Array.from({length: parallelism}, () => drainCronBatchActivity()),

--- a/libs/api/triggers/src/temporal/workflows/index.ts
+++ b/libs/api/triggers/src/temporal/workflows/index.ts
@@ -1,1 +1,2 @@
+export {cronTickCron} from './cron-tick-cron.js';
 export {pruneTriggerEventsCron} from './prune-trigger-events-cron.js';

--- a/libs/api/triggers/test/factories/cron-schedule.ts
+++ b/libs/api/triggers/test/factories/cron-schedule.ts
@@ -1,0 +1,34 @@
+import {Factory} from 'fishery';
+import type {CronSchedule} from '#core/entities/cron-schedule.js';
+import {db} from '#db/db.js';
+import {toCronSchedule, triggersCronSchedules} from '#db/schema/cron-schedules.js';
+
+export const cronScheduleFactory = Factory.define<CronSchedule>(({onCreate}) => {
+  onCreate(async (schedule) => {
+    const [row] = await db()
+      .insert(triggersCronSchedules)
+      .values({
+        subscriptionId: schedule.subscriptionId,
+        workspaceId: schedule.workspaceId,
+        cronExpression: schedule.cronExpression,
+        timezone: schedule.timezone,
+        nextFireAt: schedule.nextFireAt,
+        lastFiredAt: schedule.lastFiredAt,
+      })
+      .returning();
+    if (!row) throw new Error('Insert returned no rows');
+    return toCronSchedule(row);
+  });
+
+  return {
+    subscriptionId: crypto.randomUUID(),
+    workspaceId: crypto.randomUUID(),
+    cronExpression: '0 2 * * *',
+    timezone: 'UTC',
+    // Default well into the future so a schedule is only "due" when a test says so.
+    nextFireAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    lastFiredAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+});

--- a/libs/api/triggers/test/index.ts
+++ b/libs/api/triggers/test/index.ts
@@ -1,3 +1,4 @@
+export {cronScheduleFactory} from './factories/cron-schedule.js';
 export {decisionFactory} from './factories/decision.js';
 export {jobListenerSubscriptionFactory} from './factories/job-listener-subscription.js';
 export {receivedEventFactory} from './factories/received-event.js';


### PR DESCRIPTION
Adds the firing engine that makes cron triggers actually run: a once-per-minute Temporal cron tick claims due schedules, fires their workflows, and records each fire, building on the schedule persistence and next-fire helper from ENG-677.

## Why

The cron trigger model already carried a `{source: 'cron', event: 'tick', scheduleId}` payload and a `triggers_cron_schedules` table, but nothing ticked them. This wires up the scheduler with a scale-first design: a single global minute tick over an indexed due-time queue with bounded fan-out, rather than one durable scheduler object per schedule, so cost per minute is proportional to schedules due that minute, not the total.

## What

- **Firing path** (`fireCronSubscription`): mirrors `fireManualSubscription` but is driven by the drain, not an HTTP route. It reports an outcome (`fired`/`errored`) instead of throwing on a permanent failure, so the schedule advances past a broken definition, and re-throws on a transient failure so the advance rolls back for retry.
- **Engine**: a dedicated `triggers-cron` task queue and worker; `cronTickCron` (`* * * * *`) fans out `TRIGGER_CRON_FANOUT` `drainCronBatch` activities. Each claims one bounded batch (`next_fire_at <= now() ORDER BY next_fire_at FOR UPDATE SKIP LOCKED LIMIT TRIGGER_CRON_CLAIM_BATCH`) and, per row in a savepoint, advances `next_fire_at` and fires. Firing before the advance commits keeps a crash re-firing the idempotent occurrence rather than skipping it; a deterministic `subscriptionId:scheduledSlot` key deduplicates both the run and the history event.
- **Observability**: `'cron'` origin in trigger history, a `triggers_cron_fired{outcome}` counter, a `triggers_cron_fire_lag` histogram, and a `triggers_cron_backlog` service gauge.
- **Config**: `TRIGGER_CRON_FANOUT` (default 2) and `TRIGGER_CRON_CLAIM_BATCH` (default 100).

## Review notes

Two review findings shaped the final design and are worth a careful look:

- **The drain activity runs with `maximumAttempts: 1`.** The batch drain is not batch-idempotent across activity retries: a retry after a committed advance would claim a *fresh* due batch and fire beyond the `fanout * claimBatch` ceiling. Per-row transient failures are already isolated by the savepoint, and the once-per-minute cron is the natural retry, so no activity retry keeps the per-tick ceiling a hard cap.
- **Fanout is read at runtime via an activity, not frozen as a workflow start arg.** `startModuleWorkers` skips an already-running cron workflow, so a start arg could never be updated. Reading it (like the claim batch) lets a config change take effect on the next tick after a worker restart.

The drain holds its batch transaction open across `runWorkflow`, so raising `TRIGGER_CRON_FANOUT` at scale should be matched by a larger `POSTGRES_MAX_CONNECTIONS` (as the spec's scalability section documents). No migration is needed: the `cron_schedules` table shipped in ENG-677 and `origin` is a plain text column.

Closes ENG-678

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cron firing engine that runs every minute to claim due schedules and fire their workflows at scale, recording history and emitting metrics. Closes ENG-678.

- **New Features**
  - Adds `cron` origin to trigger events and a new `fireCronSubscription` path with per-occurrence idempotency (`subscriptionId:ISO-slot`).
  - Introduces a dedicated `triggers-cron` task queue and `cronTickCron` workflow that reads fanout at runtime and runs `drainCronBatchActivity` in parallel.
  - Drain claims due rows with `FOR UPDATE SKIP LOCKED` (ordered, bounded by `TRIGGER_CRON_CLAIM_BATCH`), advances `next_fire_at`, then fires in a per-row savepoint.
  - Permanent `runWorkflow` failures record an errored decision and still advance; transient failures roll back only that row, leaving it due for the next tick.
  - Config: `TRIGGER_CRON_FANOUT` (default 2) and `TRIGGER_CRON_CLAIM_BATCH` (default 100) with bounds checks; drain activity uses `maximumAttempts: 1` to keep the per-minute cap hard.
  - Metrics: `triggers_cron_fired` (by outcome), `triggers_cron_fire_lag` histogram, and a `triggers_cron_backlog` service gauge.
  - Hardening: clamp per‑tick fanout to a max of 32, add a 1‑minute activity heartbeat timeout to release locks on hangs, and read a single DB clock per tick for due checks and advances.

<sup>Written for commit c93d383579f65b5d32efc71997e791160d9e31e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

