### PR TITLE
Add typed workflow step output coercion

### DIFF
--- a/.changeset/steady-outputs-coerce.md
+++ b/.changeset/steady-outputs-coerce.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds typed step output coercion helpers for validating reported workflow outputs against declarations.

--- a/e2e/platform/workflows/src/expect.ts
+++ b/e2e/platform/workflows/src/expect.ts
@@ -49,6 +49,7 @@ const stepErrorReasonSchema = z.enum([
   'workspace_prep_failed',
   'setup_aborted',
   'config_unresolvable',
+  'output_invalid',
   'agent_config_invalid',
   'agent_invocation_failed',
 ]);

--- a/libs/api/workflows-dto/src/schemas/step.test.ts
+++ b/libs/api/workflows-dto/src/schemas/step.test.ts
@@ -45,6 +45,20 @@ describe('stepErrorDtoSchema', () => {
     });
   });
 
+  it('accepts typed output validation failures', () => {
+    const result = stepErrorDtoSchema.parse({
+      message: 'Output "count" must be a finite number or numeric string.',
+      reason: 'output_invalid',
+      field: 'outputs.count',
+    });
+
+    expect(result).toEqual({
+      message: 'Output "count" must be a finite number or numeric string.',
+      reason: 'output_invalid',
+      field: 'outputs.count',
+    });
+  });
+
   it('rejects unknown agent config issues', () => {
     const result = stepErrorDtoSchema.safeParse({
       message: 'Model provider credentials are not configured',

--- a/libs/api/workflows-dto/src/schemas/step.ts
+++ b/libs/api/workflows-dto/src/schemas/step.ts
@@ -16,6 +16,7 @@ export const stepErrorReasonSchema = z.enum([
   'workspace_prep_failed',
   'setup_aborted',
   'config_unresolvable',
+  'output_invalid',
   'agent_config_invalid',
   'agent_invocation_failed',
 ]);

--- a/libs/api/workflows/src/core/job-execution.test.ts
+++ b/libs/api/workflows/src/core/job-execution.test.ts
@@ -461,6 +461,136 @@ describe('recordStepResult', () => {
     expect(after[2]?.status).toBe('cancelled');
     expect(await jobStepsSettledEvents(jobId)).toHaveLength(1);
   });
+
+  test('coerces declared output before persisting and filling later step config', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(2);
+    const producer = steps[0];
+    const consumer = steps[1];
+    if (!producer || !consumer) throw new Error('Expected arranged steps');
+    const countPlan = stepOutputField('build', 'count');
+    await db()
+      .update(stepsTable)
+      .set({
+        key: 'build',
+        config: {run: 'build', outputs: {count: {type: 'number'}}},
+      })
+      .where(eq(stepsTable.id, producer.id));
+    await db()
+      .update(stepsTable)
+      .set({
+        key: 'deploy',
+        config: {run: 'deploy'},
+        configPlan: {env: {COUNT: countPlan}},
+      })
+      .where(eq(stepsTable.id, consumer.id));
+    await nextStepForJob(jobId);
+
+    await recordStepResult({
+      jobId,
+      stepId: producer.id,
+      status: 'succeeded',
+      output: {count: '42'},
+    });
+    const next = await nextStepForJob(jobId);
+
+    const attempts = await getStepAttempts(jobId);
+    expect(attempts.find((attempt) => attempt.stepId === producer.id)).toMatchObject({
+      status: 'succeeded',
+      output: {count: 42},
+    });
+    expect(next).toEqual({
+      kind: 'step',
+      step: expect.objectContaining({
+        id: consumer.id,
+        config: {run: 'deploy', env: {COUNT: '42'}},
+      }),
+    });
+  });
+
+  test('coerces JSON output against its declared schema', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await db()
+      .update(stepsTable)
+      .set({
+        config: {
+          run: 'build',
+          outputs: {
+            meta: {
+              type: 'json',
+              schema: {
+                type: 'object',
+                properties: {
+                  registry: {type: 'string'},
+                  size_bytes: {type: 'integer'},
+                },
+                required: ['registry', 'size_bytes'],
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      })
+      .where(eq(stepsTable.id, stepId));
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'succeeded',
+      output: {meta: '{"registry":"ghcr.io","size_bytes":"42"}'},
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.output).toEqual({meta: {registry: 'ghcr.io', size_bytes: 42}});
+  });
+
+  it.each([
+    ['missing declared key', {}, 'outputs.count'],
+    ['undeclared emitted key', {count: '1', extra: 'nope'}, 'outputs.extra'],
+    ['non-parsing scalar', {count: 'nope'}, 'outputs.count'],
+  ])('fails declared output report for %s', async (_label, output, field) => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await db()
+      .update(stepsTable)
+      .set({config: {run: 'build', outputs: {count: {type: 'number'}}}})
+      .where(eq(stepsTable.id, stepId));
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({jobId, stepId, status: 'succeeded', output});
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after[0]).toMatchObject({
+      status: 'failed',
+      error: {reason: 'output_invalid', field},
+    });
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt).toMatchObject({
+      status: 'failed',
+      output: null,
+      error: {reason: 'output_invalid', field},
+    });
+  });
+
+  test('keeps untyped steps open to arbitrary output keys', async () => {
+    const {jobId, steps} = await arrangeJobWithSteps(1);
+    const stepId = steps[0]?.id as string;
+    await nextStepForJob(jobId);
+
+    const outcome = await recordStepResult({
+      jobId,
+      stepId,
+      status: 'succeeded',
+      output: {count: 'not typed', extra: 'allowed'},
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'succeeded'});
+    const [attempt] = await getStepAttempts(jobId);
+    expect(attempt?.output).toEqual({count: 'not typed', extra: 'allowed'});
+  });
 });
 
 describe('nextStepForJob concurrency', () => {
@@ -956,6 +1086,7 @@ describe('durable gate restart', () => {
   // producer (named) → reviewer (gated `success: step.exit_code == 0`, on_failure restart_from producer)
   async function arrangeGatedJob(params: {
     source: string;
+    outputs?: Record<string, unknown>;
     feedback?: string;
     feedbackTemplate?: ReturnType<typeof plannedField>;
   }): Promise<{jobId: string; producer: string; reviewer: string}> {
@@ -968,6 +1099,7 @@ describe('durable gate restart', () => {
       .set({
         config: {
           run: 'review',
+          ...(params.outputs === undefined ? {} : {outputs: params.outputs}),
           gate: {
             success: {language: 'cel', check: 'syntax', source: params.source},
             on_failure: {
@@ -1014,6 +1146,39 @@ describe('durable gate restart', () => {
     const reviewerAttempt = attempts.find((a) => a.stepId === reviewer && a.attempt === 1);
     expect(reviewerAttempt?.status).toBe('failed');
     expect(reviewerAttempt?.restartFeedback).toBeTruthy();
+  });
+
+  test('output coercion failure bypasses gate restart evaluation', async () => {
+    const {jobId, producer, reviewer} = await arrangeGatedJob({
+      source: 'step.outputs.pass == true',
+      outputs: {pass: {type: 'boolean'}},
+    });
+
+    await runStep(jobId, producer, 0);
+    await nextStepForJob(jobId);
+    const outcome = await recordStepResult({
+      jobId,
+      stepId: reviewer,
+      status: 'succeeded',
+      output: {pass: 'not-a-boolean'},
+      exitCode: 0,
+    });
+
+    expect(outcome).toEqual({jobFinished: true, status: 'failed'});
+    const after = await getStepsByJobId(jobId);
+    expect(after.map((step) => step.status)).toEqual(['succeeded', 'failed']);
+    expect(after.every((step) => step.currentAttempt === 1)).toBe(true);
+    expect(after.find((step) => step.id === reviewer)?.error).toMatchObject({
+      reason: 'output_invalid',
+      field: 'outputs.pass',
+    });
+    expect(await restartEventCount(jobId)).toBe(0);
+    const attempts = await getStepAttempts(jobId);
+    expect(attempts.find((attempt) => attempt.stepId === reviewer)).toMatchObject({
+      gateResult: null,
+      output: null,
+      error: {reason: 'output_invalid'},
+    });
   });
 
   test('restart event identifies the failed gate attempt and restart target', async () => {

--- a/libs/api/workflows/src/core/job-execution.ts
+++ b/libs/api/workflows/src/core/job-execution.ts
@@ -1,5 +1,6 @@
 import {catalogDefaultAgentResolver} from '@shipfox/api-agent/core/resolve-agent-config';
 import type {LogOutcomeDto} from '@shipfox/api-workflows-dto';
+import {coerceStepOutputs, type StepOutputCoercionError} from '@shipfox/expression';
 import {type Tx, withTransaction} from '#db/db.js';
 import {
   countStepAttempts,
@@ -48,9 +49,17 @@ import {
   gateResultPayload,
   readStepGate,
 } from './step-transition/evaluate-gate.js';
+import {readStepOutputs} from './step-transition/read-step-outputs.js';
 import type {RuntimeCompletionStatus} from './workflow-scheduling/runtime-dag.js';
 
 type CompletionStatus = RuntimeCompletionStatus;
+
+type ReportedStepResult = {
+  readonly status: 'succeeded' | 'failed';
+  readonly error: Record<string, unknown> | null;
+  readonly output: Record<string, unknown> | null;
+  readonly exitCode: number | null;
+};
 
 export type NextStep = {kind: 'step'; step: Step} | {kind: 'done'; status: CompletionStatus};
 
@@ -320,16 +329,30 @@ async function recordStepResultInTransaction(
     tx,
   );
 
-  const result = {
+  let result: ReportedStepResult = {
     status: params.status,
     error: params.error ?? null,
     output: params.output ?? null,
     exitCode: params.exitCode ?? null,
   };
+  const outputCoercion = coerceReportedStepOutput(target.config, result);
+  if (outputCoercion.kind === 'coerced') {
+    result = {...result, output: outputCoercion.output};
+  }
+  if (outputCoercion.kind === 'failed') {
+    result = {
+      status: 'failed',
+      error: outputInvalidError(outputCoercion.error),
+      output: null,
+      exitCode: result.exitCode,
+    };
+  }
+
   // Evaluate the gate (if any) at the service boundary — the only place the CEL
   // engine runs — and pass the precomputed outcome into the pure decision.
-  const gate = readStepGate(target.config);
-  const gateOutcome = evaluateGate(gate, result);
+  const shouldEvaluateGate = outputCoercion.kind !== 'failed';
+  const gate = shouldEvaluateGate ? readStepGate(target.config) : undefined;
+  const gateOutcome = shouldEvaluateGate ? evaluateGate(gate, result) : {kind: 'no-gate' as const};
   const hasRestartPolicy = gate?.onFailure?.restartFrom !== undefined;
   // The restart cap is bounded on the gating step's OWN attempts, not its
   // current_attempt (which a rewind inflates for downstream steps).
@@ -365,15 +388,41 @@ async function recordStepResultInTransaction(
   );
 }
 
+type OutputCoercionResult =
+  | {kind: 'not-applicable'}
+  | {kind: 'coerced'; output: Record<string, unknown>}
+  | {kind: 'failed'; error: StepOutputCoercionError};
+
+function coerceReportedStepOutput(
+  config: Record<string, unknown>,
+  result: ReportedStepResult,
+): OutputCoercionResult {
+  if (result.status !== 'succeeded') return {kind: 'not-applicable'};
+
+  const declarations = readStepOutputs(config);
+  if (declarations === undefined) return {kind: 'not-applicable'};
+
+  const coerced = coerceStepOutputs({declarations, output: result.output});
+  if (!coerced.ok) return {kind: 'failed', error: coerced.error};
+  return {kind: 'coerced', output: coerced.output};
+}
+
+function outputInvalidError(error: StepOutputCoercionError): Record<string, unknown> {
+  return {
+    message: error.message,
+    reason: 'output_invalid',
+    field: `outputs.${error.key}`,
+    outputKey: error.key,
+    issue: error.reason,
+    ...(error.expectedType === undefined ? {} : {expectedType: error.expectedType}),
+    ...(error.schemaError === undefined ? {} : {schemaError: error.schemaError}),
+  };
+}
+
 function resolveRestartFeedback(params: {
   decision: StepTransitionDecision;
   gate: ReturnType<typeof readStepGate>;
-  result: {
-    status: 'succeeded' | 'failed';
-    error: Record<string, unknown> | null;
-    output: Record<string, unknown> | null;
-    exitCode: number | null;
-  };
+  result: ReportedStepResult;
   definitionId: string;
 }): StepTransitionDecision {
   if (params.decision.kind !== 'restart-job-from-step') return params.decision;

--- a/libs/api/workflows/src/core/step-config/resolve-step-config.ts
+++ b/libs/api/workflows/src/core/step-config/resolve-step-config.ts
@@ -77,13 +77,14 @@ function buildStepConfig(
   params: Omit<BuildStepConfigParams, 'context'> & {readonly context: WorkflowEvaluationContext},
 ): BuiltStepConfig {
   const gate = gateConfigForStep(params.step);
+  const outputs = outputsConfigForStep(params.step);
   const runStep = runStepOrNull(params.step);
   const isRunStep = runStep !== null;
 
   if (isRunStep) {
     const run = resolveRunStepConfig({...params, step: runStep});
     return {
-      config: {...run.config, ...gate},
+      config: {...run.config, ...gate, ...outputs},
       configPlan: run.configPlan,
       diagnostics: run.diagnostics,
       trace: run.trace,
@@ -96,7 +97,7 @@ function buildStepConfig(
 
   const agent = resolveAgentStepConfig({...params, step: agentStep});
   return {
-    config: {...agent.config, ...gate},
+    config: {...agent.config, ...gate, ...outputs},
     configPlan: agent.configPlan,
     diagnostics: agent.diagnostics,
     trace: agent.trace,
@@ -124,6 +125,11 @@ function agentStepOrNull(step: WorkflowModelStep): WorkflowModelAgentStep | null
 function gateConfigForStep(step: WorkflowModelStep): Record<string, unknown> {
   const hasGate = step.gate !== undefined;
   return hasGate ? {gate: stepGateConfig(step.gate)} : {};
+}
+
+function outputsConfigForStep(step: WorkflowModelStep): Record<string, unknown> {
+  const hasOutputs = step.outputs !== undefined;
+  return hasOutputs ? {outputs: step.outputs} : {};
 }
 
 function resolveStepName(

--- a/libs/api/workflows/src/core/step-transition/read-step-outputs.ts
+++ b/libs/api/workflows/src/core/step-transition/read-step-outputs.ts
@@ -1,0 +1,27 @@
+import {type OutputDeclarations, outputTypes} from '@shipfox/expression';
+
+const outputTypeSet = new Set<string>(outputTypes);
+
+export function readStepOutputs(config: Record<string, unknown>): OutputDeclarations | undefined {
+  const outputs = config.outputs;
+  if (!isRecord(outputs)) return undefined;
+
+  const declarations: Record<string, {type: (typeof outputTypes)[number]; schema?: unknown}> =
+    Object.create(null) as Record<string, {type: (typeof outputTypes)[number]; schema?: unknown}>;
+
+  for (const [key, declaration] of Object.entries(outputs)) {
+    if (!isRecord(declaration)) return undefined;
+    const type = declaration.type;
+    if (typeof type !== 'string' || !outputTypeSet.has(type)) return undefined;
+    declarations[key] = {
+      type: type as (typeof outputTypes)[number],
+      ...(!Object.hasOwn(declaration, 'schema') ? {} : {schema: declaration.schema}),
+    };
+  }
+
+  return declarations;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -30,6 +30,8 @@ export type {
   WorkflowExpressionCheckOptions,
 } from './expression/workflow-expression.js';
 export {
+  type CoerceStepOutputsResult,
+  coerceStepOutputs,
   type JsonSchemaValidationResult,
   jsonSchemaToExpressionType,
   type OutputDeclarations,
@@ -38,6 +40,8 @@ export {
   outputDeclarationsToExpressionFields,
   outputDeclarationToExpressionType,
   outputTypes,
+  type StepOutputCoercionError,
+  type StepOutputCoercionErrorReason,
   validateJsonSchema,
 } from './outputs/index.js';
 export {isBareContextReference} from './plan/bare-reference.js';

--- a/libs/shared/expression/src/outputs/index.ts
+++ b/libs/shared/expression/src/outputs/index.ts
@@ -1,4 +1,6 @@
 export {
+  type CoerceStepOutputsResult,
+  coerceStepOutputs,
   type JsonSchemaValidationResult,
   jsonSchemaToExpressionType,
   type OutputDeclarations,
@@ -7,5 +9,7 @@ export {
   outputDeclarationsToExpressionFields,
   outputDeclarationToExpressionType,
   outputTypes,
+  type StepOutputCoercionError,
+  type StepOutputCoercionErrorReason,
   validateJsonSchema,
 } from './output-declarations.js';

--- a/libs/shared/expression/src/outputs/output-declarations.test.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.test.ts
@@ -241,4 +241,34 @@ describe('coerceStepOutputs', () => {
     expect(compileSpy).toHaveBeenCalledTimes(1);
     compileSpy.mockRestore();
   });
+
+  it('does not collide when different JSON Schemas reuse the same schema id', () => {
+    const first = coerceStepOutputs({
+      declarations: {
+        payload: {
+          type: 'json',
+          schema: {$id: 'https://shipfox.dev/schemas/output', type: 'integer'},
+        },
+      },
+      output: {payload: '1'},
+    });
+    const second = coerceStepOutputs({
+      declarations: {
+        payload: {
+          type: 'json',
+          schema: {
+            $id: 'https://shipfox.dev/schemas/output',
+            type: 'object',
+            properties: {name: {type: 'string'}},
+            required: ['name'],
+            additionalProperties: false,
+          },
+        },
+      },
+      output: {payload: '{"name":"artifact"}'},
+    });
+
+    expect(first).toEqual({ok: true, output: {payload: 1}});
+    expect(second).toEqual({ok: true, output: {payload: {name: 'artifact'}}});
+  });
 });

--- a/libs/shared/expression/src/outputs/output-declarations.test.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.test.ts
@@ -1,4 +1,6 @@
+import {Ajv} from 'ajv';
 import {
+  coerceStepOutputs,
   jsonSchemaToExpressionType,
   outputDeclarationToExpressionType,
   validateJsonSchema,
@@ -102,5 +104,141 @@ describe('validateJsonSchema', () => {
     const result = validateJsonSchema({type: 'definitely-not-a-json-schema-type'});
 
     expect(result).toMatchObject({ok: false});
+  });
+});
+
+describe('coerceStepOutputs', () => {
+  it('coerces declared scalar output values', () => {
+    const result = coerceStepOutputs({
+      declarations: {
+        count: {type: 'number'},
+        ready: {type: 'boolean'},
+        sha: {type: 'string'},
+      },
+      output: {count: '42', ready: 'true', sha: 'abc123'},
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {count: 42, ready: true, sha: 'abc123'},
+    });
+  });
+
+  it('coerces JSON string output through its schema', () => {
+    const result = coerceStepOutputs({
+      declarations: {
+        payload: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {
+              size: {type: 'integer'},
+              ready: {type: 'boolean'},
+            },
+            required: ['size', 'ready'],
+            additionalProperties: false,
+          },
+        },
+      },
+      output: {payload: '{"size":"42","ready":"false"}'},
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      output: {payload: {size: 42, ready: false}},
+    });
+  });
+
+  it('coerces a copied JSON value without mutating the reported output object', () => {
+    const payload = {size: '42'};
+
+    const result = coerceStepOutputs({
+      declarations: {
+        payload: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {size: {type: 'integer'}},
+            required: ['size'],
+            additionalProperties: false,
+          },
+        },
+      },
+      output: {payload},
+    });
+
+    expect(result).toEqual({ok: true, output: {payload: {size: 42}}});
+    expect(payload).toEqual({size: '42'});
+  });
+
+  it.each([
+    ['missing declared key', {count: {type: 'number'}}, {}, {key: 'count', reason: 'missing'}],
+    [
+      'undeclared emitted key',
+      {count: {type: 'number'}},
+      {count: '1', extra: 'nope'},
+      {key: 'extra', reason: 'undeclared'},
+    ],
+    [
+      'invalid scalar',
+      {count: {type: 'number'}},
+      {count: 'not-a-number'},
+      {key: 'count', reason: 'invalid_type'},
+    ],
+    [
+      'invalid JSON',
+      {payload: {type: 'json'}},
+      {payload: '{not-json'},
+      {key: 'payload', reason: 'invalid_json'},
+    ],
+    [
+      'schema validation failure',
+      {
+        payload: {
+          type: 'json',
+          schema: {
+            type: 'object',
+            properties: {size: {type: 'integer'}},
+            required: ['size'],
+            additionalProperties: false,
+          },
+        },
+      },
+      {payload: '{"size":"not-an-int"}'},
+      {key: 'payload', reason: 'schema_invalid'},
+    ],
+  ] as const)('fails for %s', (_label, declarations, output, expectedError) => {
+    const result = coerceStepOutputs({declarations, output});
+
+    expect(result).toMatchObject({ok: false, error: expectedError});
+  });
+
+  it('reuses compiled JSON Schema validators by stable schema content', () => {
+    const compileSpy = vi.spyOn(Ajv.prototype, 'compile');
+    compileSpy.mockClear();
+
+    const first = coerceStepOutputs({
+      declarations: {
+        payload: {
+          type: 'json',
+          schema: {title: 'cache-test-schema', type: 'integer'},
+        },
+      },
+      output: {payload: '1'},
+    });
+    const second = coerceStepOutputs({
+      declarations: {
+        payload: {
+          type: 'json',
+          schema: {type: 'integer', title: 'cache-test-schema'},
+        },
+      },
+      output: {payload: '2'},
+    });
+
+    expect(first).toEqual({ok: true, output: {payload: 1}});
+    expect(second).toEqual({ok: true, output: {payload: 2}});
+    expect(compileSpy).toHaveBeenCalledTimes(1);
+    compileSpy.mockRestore();
   });
 });

--- a/libs/shared/expression/src/outputs/output-declarations.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.ts
@@ -2,7 +2,7 @@ import {
   type WorkflowDocumentStepOutputType,
   workflowDocumentStepOutputTypes,
 } from '@shipfox/workflow-document';
-import {Ajv, type AnySchema} from 'ajv';
+import {Ajv, type AnySchema, type ValidateFunction} from 'ajv';
 import type {ExpressionType} from '../expression/workflow-expression.js';
 
 export type OutputType = WorkflowDocumentStepOutputType;
@@ -18,7 +18,28 @@ export type JsonSchemaValidationResult =
   | {readonly ok: true}
   | {readonly ok: false; readonly reason: string};
 
+export type StepOutputCoercionErrorReason =
+  | 'missing'
+  | 'undeclared'
+  | 'invalid_type'
+  | 'invalid_json'
+  | 'schema_invalid';
+
+export interface StepOutputCoercionError {
+  readonly key: string;
+  readonly reason: StepOutputCoercionErrorReason;
+  readonly expectedType?: OutputType;
+  readonly message: string;
+  readonly schemaError?: string;
+}
+
+export type CoerceStepOutputsResult =
+  | {readonly ok: true; readonly output: Record<string, unknown>}
+  | {readonly ok: false; readonly error: StepOutputCoercionError};
+
 const ajv = new Ajv({strict: false});
+const coercingAjv = new Ajv({strict: false, coerceTypes: true, allErrors: true});
+const jsonOutputValidatorCache = new Map<string, ValidateFunction>();
 const fallbackJsonType = {kind: 'map'} as const satisfies ExpressionType;
 
 export {workflowDocumentStepOutputTypes as outputTypes};
@@ -91,6 +112,175 @@ export function validateJsonSchema(schema: unknown): JsonSchemaValidationResult 
   };
 }
 
+export function coerceStepOutputs(params: {
+  readonly declarations: OutputDeclarations;
+  readonly output: Record<string, unknown> | null | undefined;
+}): CoerceStepOutputsResult {
+  const declaredKeys = Object.keys(params.declarations);
+  const output = params.output ?? {};
+
+  for (const key of declaredKeys) {
+    if (Object.hasOwn(output, key)) continue;
+    const declaration = params.declarations[key];
+    return {
+      ok: false,
+      error: {
+        key,
+        reason: 'missing',
+        ...(declaration === undefined ? {} : {expectedType: declaration.type}),
+        message: `Output "${key}" is required by the step output declaration.`,
+      },
+    };
+  }
+
+  for (const key of Object.keys(output)) {
+    if (Object.hasOwn(params.declarations, key)) continue;
+    return {
+      ok: false,
+      error: {
+        key,
+        reason: 'undeclared',
+        message: `Output "${key}" is not declared by the step output schema.`,
+      },
+    };
+  }
+
+  const coerced: Record<string, unknown> = {};
+  for (const [key, declaration] of Object.entries(params.declarations)) {
+    const value = output[key];
+    const result = coerceStepOutputValue(key, declaration, value);
+    if (!result.ok) return result;
+    coerced[key] = result.value;
+  }
+
+  return {ok: true, output: coerced};
+}
+
+type CoerceStepOutputValueResult =
+  | {readonly ok: true; readonly value: unknown}
+  | {readonly ok: false; readonly error: StepOutputCoercionError};
+
+function coerceStepOutputValue(
+  key: string,
+  declaration: OutputTypeDeclaration,
+  value: unknown,
+): CoerceStepOutputValueResult {
+  switch (declaration.type) {
+    case 'string':
+      return coerceStringOutput(key, value);
+    case 'number':
+      return coerceNumberOutput(key, value);
+    case 'boolean':
+      return coerceBooleanOutput(key, value);
+    case 'json':
+      return coerceJsonOutput(key, declaration, value);
+  }
+}
+
+function coerceStringOutput(key: string, value: unknown): CoerceStepOutputValueResult {
+  if (typeof value === 'string') return {ok: true, value};
+  return invalidTypeError(key, 'string', 'must be a string');
+}
+
+function coerceNumberOutput(key: string, value: unknown): CoerceStepOutputValueResult {
+  if (typeof value === 'number' && Number.isFinite(value)) return {ok: true, value};
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed !== '') {
+      const number = Number(trimmed);
+      if (Number.isFinite(number)) return {ok: true, value: number};
+    }
+  }
+
+  return invalidTypeError(key, 'number', 'must be a finite number or numeric string');
+}
+
+function coerceBooleanOutput(key: string, value: unknown): CoerceStepOutputValueResult {
+  if (typeof value === 'boolean') return {ok: true, value};
+  if (value === 'true') return {ok: true, value: true};
+  if (value === 'false') return {ok: true, value: false};
+  return invalidTypeError(key, 'boolean', 'must be a boolean or the string "true" or "false"');
+}
+
+function coerceJsonOutput(
+  key: string,
+  declaration: OutputTypeDeclaration,
+  value: unknown,
+): CoerceStepOutputValueResult {
+  const parsed = parseJsonOutputValue(key, value);
+  if (!parsed.ok) return parsed;
+
+  if (declaration.schema === undefined) return {ok: true, value: parsed.value};
+
+  const data = {value: cloneJsonValue(parsed.value)};
+  const validate = validatorForJsonOutputSchema(declaration.schema);
+  if (validate(data)) return {ok: true, value: data.value};
+
+  return {
+    ok: false,
+    error: {
+      key,
+      reason: 'schema_invalid',
+      expectedType: 'json',
+      message: `Output "${key}" does not match its JSON Schema.`,
+      schemaError: coercingAjv.errorsText(validate.errors, {separator: '; '}),
+    },
+  };
+}
+
+function parseJsonOutputValue(key: string, value: unknown): CoerceStepOutputValueResult {
+  if (typeof value !== 'string') return {ok: true, value};
+
+  try {
+    return {ok: true, value: JSON.parse(value) as unknown};
+  } catch {
+    if (looksLikeJsonContainer(value)) {
+      return {
+        ok: false,
+        error: {
+          key,
+          reason: 'invalid_json',
+          expectedType: 'json',
+          message: `Output "${key}" must be valid JSON.`,
+        },
+      };
+    }
+    return {ok: true, value};
+  }
+}
+
+function invalidTypeError(
+  key: string,
+  expectedType: OutputType,
+  detail: string,
+): CoerceStepOutputValueResult {
+  return {
+    ok: false,
+    error: {
+      key,
+      reason: 'invalid_type',
+      expectedType,
+      message: `Output "${key}" ${detail}.`,
+    },
+  };
+}
+
+function validatorForJsonOutputSchema(schema: unknown): ValidateFunction {
+  const key = stableJsonStringify(schema);
+  const cached = jsonOutputValidatorCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const validate = coercingAjv.compile({
+    type: 'object',
+    properties: {value: schema},
+    required: ['value'],
+    additionalProperties: false,
+  });
+  jsonOutputValidatorCache.set(key, validate);
+  return validate;
+}
+
 function closedObjectJsonSchemaToExpressionType(
   schema: Readonly<Record<string, unknown>>,
 ): ExpressionType {
@@ -135,4 +325,31 @@ function hasUnsupportedCombinator(schema: Readonly<Record<string, unknown>>): bo
 
 function isPlainRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cloneJsonValue(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) return value;
+  return JSON.parse(serialized) as unknown;
+}
+
+function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(canonicalJson(value));
+}
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!isPlainRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonicalJson(value[key])]),
+  );
+}
+
+function looksLikeJsonContainer(value: string): boolean {
+  const trimmed = value.trimStart();
+  return trimmed.startsWith('{') || trimmed.startsWith('[');
 }

--- a/libs/shared/expression/src/outputs/output-declarations.ts
+++ b/libs/shared/expression/src/outputs/output-declarations.ts
@@ -38,7 +38,12 @@ export type CoerceStepOutputsResult =
   | {readonly ok: false; readonly error: StepOutputCoercionError};
 
 const ajv = new Ajv({strict: false});
-const coercingAjv = new Ajv({strict: false, coerceTypes: true, allErrors: true});
+const coercingAjv = new Ajv({
+  strict: false,
+  coerceTypes: true,
+  allErrors: true,
+  addUsedSchema: false,
+});
 const jsonOutputValidatorCache = new Map<string, ValidateFunction>();
 const fallbackJsonType = {kind: 'map'} as const satisfies ExpressionType;
 


### PR DESCRIPTION
Add typed step output coercion at the server report boundary.

Typed output declarations are now carried into the materialized step config and enforced per succeeded step attempt before gate evaluation. Valid output reports are persisted as typed values, while missing declared keys, undeclared keys, scalar coercion failures, and JSON Schema validation failures fail the attempt with output_invalid and skip gate/restart handling.

This keeps the runner schema-free and centralizes coercion in @shipfox/expression with stable cached JSON Schema validators so reports do not recompile equivalent schemas after config reloads.

Reviewers should look closely at the report-step ordering in job-execution.ts and the JSON output coercion/cache behavior in @shipfox/expression.

Closes ENG-820

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed step output coercion at the API boundary so declared outputs are validated and converted before gate evaluation. Invalid reports fail with `output_invalid` and skip gate/restart; JSON schema validators are cached by schema content to avoid `$id` collisions. Implements ENG-820.

- **New Features**
  - Enforce step `outputs` in materialized config; untyped steps stay permissive.
  - Coerce scalars and parse/validate JSON; persist typed outputs; bypass gate on `output_invalid`.

- **Dependencies**
  - `@shipfox/expression`: add `coerceStepOutputs`, typed coercion errors, and AJV validators cached by canonical schema (avoid `$id` collisions).
  - DTO: add `output_invalid` to step error reasons.

<sup>Written for commit 06ba907bad3163e1ff1c7746911b5cbb1e95ac2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

