### PR TITLE
Parallelize CI setup phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Start test services
+        id: test-services
+        run: |
+          docker compose up --wait -d postgres temporal garage
+          docker compose run --rm garage-init
+        background: true
+
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
@@ -67,10 +74,8 @@ jobs:
       - name: Set up Playwright
         uses: ./.github/actions/setup-playwright
 
-      - name: Start test services
-        run: |
-          docker compose up --wait -d postgres temporal garage
-          docker compose run --rm garage-init
+      - name: Wait for test services
+        wait: test-services
 
       - name: Run tests
         env:
@@ -88,8 +93,23 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
+      - name: Start test services
+        id: test-services
+        env:
+          SHIPFOX_GITEA_HTTP_HOST: 0.0.0.0
+        run: |
+          docker compose up --wait -d postgres temporal garage gitea
+          docker compose run --rm garage-init
+          docker compose run --rm gitea-init
+        background: true
+
       - name: Set up mise
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+
+      - name: Start Ollama
+        id: ollama
+        run: mise run ollama:up
+        background: true
 
       - name: Set up pnpm
         uses: ./.github/actions/setup-pnpm
@@ -97,24 +117,13 @@ jobs:
       - name: Set up Playwright
         uses: ./.github/actions/setup-playwright
 
-      - name: Start test services
-        env:
-          SHIPFOX_GITEA_HTTP_HOST: 0.0.0.0
-        run: |
-          docker compose up --wait -d postgres temporal garage gitea
-          docker compose run --rm garage-init
-          docker compose run --rm gitea-init
-
-      - name: Install Playwright browsers
-        run: pnpm --filter=@shipfox/playwright exec playwright install --with-deps chromium
-
       # E2E dev servers still depend on dist/ for Temporal workflow bundles and
       # the shared vite-dev bin.
       - name: Build dev server dependencies
         run: turbo build --filter @shipfox/api --filter @shipfox/vite
 
-      - name: Start Ollama
-        run: mise run ollama:up
+      - name: Wait for test services and Ollama
+        wait: [test-services, ollama]
 
       - name: Run E2E tests
         id: e2e


### PR DESCRIPTION
Parallelize independent setup work in the CI test jobs.

The test and E2E jobs spent serial time starting Docker services before moving on to tool and dependency setup. GitHub Actions now supports background steps with explicit waits, so this moves Docker service startup earlier and waits only before the test commands need those services. The E2E job also starts Ollama in the background after mise is available, overlapping it with pnpm, Playwright setup, and dev-server dependency builds.

The E2E workflow no longer repeats the raw Playwright browser install because the shared setup-playwright action already installs Chromium.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized CI setup in test and E2E jobs to cut idle time by running services/tools in the background with explicit waits. Also removed a redundant Playwright browser install.

- **Refactors**
  - Start Docker services earlier in background; wait only before running tests.
  - In E2E, start `ollama` in background after `jdx/mise-action`, overlapping with `./.github/actions/setup-pnpm`, `./.github/actions/setup-playwright`, and dev-server dependency builds.
  - Remove manual `playwright install` step; rely on shared `./.github/actions/setup-playwright` to install Chromium.
  - Add `wait` steps to synchronize on `test-services` and `ollama`.

<sup>Written for commit d2c541e9beeee1f38e9510a97ff5b01bebd5c29a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

