### PR TITLE
[api-workflows] Guard listener history growth

### DIFF
--- a/libs/api/workflows/src/temporal/workflows/job-listener-orchestration-continuation.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-listener-orchestration-continuation.test.ts
@@ -1,0 +1,93 @@
+const workflowMocks = vi.hoisted(() => ({
+  cancelScope: vi.fn(),
+  condition: vi.fn(),
+  continueAsNew: vi.fn(),
+  executeChild: vi.fn(),
+  proxyActivities: vi.fn(() => ({})),
+  setHandler: vi.fn(),
+  workflowInfo: vi.fn(() => ({continueAsNewSuggested: false})),
+}));
+
+vi.mock('@temporalio/workflow', () => ({
+  CancellationScope: class {
+    run<T>(fn: () => T): T {
+      return fn();
+    }
+    cancel = workflowMocks.cancelScope;
+  },
+  condition: workflowMocks.condition,
+  continueAsNew: workflowMocks.continueAsNew,
+  defineSignal: vi.fn((name: string) => name),
+  executeChild: workflowMocks.executeChild,
+  log: {warn: vi.fn()},
+  ParentClosePolicy: {TERMINATE: 'TERMINATE'},
+  proxyActivities: workflowMocks.proxyActivities,
+  setHandler: workflowMocks.setHandler,
+  workflowInfo: workflowMocks.workflowInfo,
+}));
+
+import {
+  type JobListenerOrchestrationInput,
+  LISTENER_CONTINUE_AS_NEW_FIRING_LIMIT,
+  listenerContinuationInput,
+  shouldContinueListenerAsNew,
+} from './job-listener-orchestration.js';
+
+describe('listener continue-as-new guard', () => {
+  it('continues when Temporal suggests it', () => {
+    const shouldContinue = shouldContinueListenerAsNew({
+      firingsInCurrentRun: 0,
+      continueAsNewSuggested: true,
+    });
+
+    expect(shouldContinue).toBe(true);
+  });
+
+  it('continues when the bounded firing count is reached', () => {
+    const shouldContinue = shouldContinueListenerAsNew({
+      firingsInCurrentRun: LISTENER_CONTINUE_AS_NEW_FIRING_LIMIT,
+      continueAsNewSuggested: false,
+    });
+
+    expect(shouldContinue).toBe(true);
+  });
+
+  it('keeps looping below the history guard thresholds', () => {
+    const shouldContinue = shouldContinueListenerAsNew({
+      firingsInCurrentRun: LISTENER_CONTINUE_AS_NEW_FIRING_LIMIT - 1,
+      continueAsNewSuggested: false,
+    });
+
+    expect(shouldContinue).toBe(false);
+  });
+
+  it('carries listener loop state into the continued run', () => {
+    const input: JobListenerOrchestrationInput = {
+      workspaceId: 'workspace-1',
+      workflowRunId: 'run-1',
+      projectId: 'project-1',
+      runAttemptId: 'attempt-1',
+      jobId: 'job-1',
+      jobVersion: 3,
+      requiredLabels: ['ubuntu22'],
+      listeningTimeoutMs: 30_000,
+      maxExecutions: 10,
+      onResolve: 'finish',
+    };
+
+    const continued = listenerContinuationInput(input, {
+      nextSequence: 7,
+      latchedReason: 'until',
+      listenerDeadline: 1_725_000_000_000,
+    });
+
+    expect(continued).toEqual({
+      ...input,
+      continuation: {
+        nextSequence: 7,
+        latchedReason: 'until',
+        listenerDeadline: 1_725_000_000_000,
+      },
+    });
+  });
+});

--- a/libs/api/workflows/src/temporal/workflows/job-listener-orchestration.test.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-listener-orchestration.test.ts
@@ -5,6 +5,7 @@ import {
   LISTENER_EVENTS_AVAILABLE_SIGNAL,
   LISTENER_RESOLVE_SIGNAL,
 } from '../constants.js';
+import type {ListenerContinuationState} from './job-listener-orchestration.js';
 import {
   callsNamed,
   listenerFiringOutcomeCalls,
@@ -43,6 +44,7 @@ interface ListenerInputOverrides {
   batchDebounceMs?: number | null;
   batchMaxSize?: number | null;
   batchMaxWaitMs?: number | null;
+  continuation?: ListenerContinuationState;
 }
 
 function listenerInput(overrides: ListenerInputOverrides = {}) {
@@ -67,6 +69,7 @@ function listenerInput(overrides: ListenerInputOverrides = {}) {
       : {batchDebounceMs: overrides.batchDebounceMs}),
     ...(overrides.batchMaxSize === undefined ? {} : {batchMaxSize: overrides.batchMaxSize}),
     ...(overrides.batchMaxWaitMs === undefined ? {} : {batchMaxWaitMs: overrides.batchMaxWaitMs}),
+    ...(overrides.continuation === undefined ? {} : {continuation: overrides.continuation}),
   };
 }
 
@@ -130,6 +133,28 @@ describe('jobListenerOrchestration', () => {
       expect(result).toEqual({status: expected, jobVersion: 7});
       expect(callsNamed('drainListenerEventsActivity')).toHaveLength(0);
       expect(resolveJobListenerCalls()).toHaveLength(0);
+    });
+
+    test('continued listeners skip activation and resume at the carried sequence', async () => {
+      setCfg({
+        dag: makeDag([]),
+        jobResults: new Map(),
+        drainResults: [firingDrain(7, 'pending')],
+        listenerResolved: {status: 'succeeded', jobVersion: 9},
+      });
+
+      const result = await runListener({
+        maxExecutions: 7,
+        continuation: {nextSequence: 7},
+      });
+
+      expect(callsNamed('activateJobListenerActivity')).toHaveLength(0);
+      expect(callsNamed('drainListenerEventsActivity').map((c) => c.params)).toEqual([
+        {jobId, expectedSequence: 7},
+      ]);
+      expect(listenerFiringOutcomeCalls().map((c) => c.params.outcome)).toEqual(['succeeded']);
+      expect(resolveJobListenerCalls().map((c) => c.params.reason)).toEqual(['max_executions']);
+      expect(result).toEqual({status: 'succeeded', jobVersion: 9});
     });
   });
 

--- a/libs/api/workflows/src/temporal/workflows/job-listener-orchestration.ts
+++ b/libs/api/workflows/src/temporal/workflows/job-listener-orchestration.ts
@@ -1,12 +1,14 @@
 import {
   CancellationScope,
   condition,
+  continueAsNew,
   defineSignal,
   executeChild,
   log,
   ParentClosePolicy,
   proxyActivities,
   setHandler,
+  workflowInfo,
 } from '@temporalio/workflow';
 import type {ResolutionReason} from '#core/entities/job.js';
 import {runtimeStatusForTerminalJobExecutionStatus} from '#core/job-execution-orchestration.js';
@@ -45,6 +47,7 @@ export interface JobListenerOrchestrationInput {
   batchDebounceMs?: number | null | undefined;
   batchMaxSize?: number | null | undefined;
   batchMaxWaitMs?: number | null | undefined;
+  continuation?: ListenerContinuationState | undefined;
 }
 
 export interface JobListenerOrchestrationResult {
@@ -54,6 +57,14 @@ export interface JobListenerOrchestrationResult {
 
 type ResolutionLatch = Exclude<ResolutionReason, 'cancelled'> | undefined;
 type BatchFiringDecision = 'fire' | 'resolve' | 'deadline';
+
+export interface ListenerContinuationState {
+  nextSequence: number;
+  latchedReason?: ResolutionLatch;
+  listenerDeadline?: number | undefined;
+}
+
+export const LISTENER_CONTINUE_AS_NEW_FIRING_LIMIT = 500;
 
 interface ListenerBatchConfig {
   debounceMs?: number | undefined;
@@ -81,7 +92,7 @@ export async function jobListenerOrchestration(
   input: JobListenerOrchestrationInput,
 ): Promise<JobListenerOrchestrationResult> {
   let eventsAvailable = false;
-  let latchedReason: ResolutionLatch;
+  let latchedReason = input.continuation?.latchedReason;
 
   setHandler(listenerEventsAvailableSignal, () => {
     eventsAvailable = true;
@@ -90,31 +101,48 @@ export async function jobListenerOrchestration(
     latchedReason = 'until';
   });
 
-  const listenerDeadline =
-    input.listeningTimeoutMs === undefined || input.listeningTimeoutMs === null
-      ? undefined
-      : Date.now() + input.listeningTimeoutMs;
+  const listenerDeadline = input.continuation?.listenerDeadline ?? initialListenerDeadline(input);
 
-  const activated = await activateJobListenerActivity({
-    jobId: input.jobId,
-    expectedVersion: input.jobVersion,
-  });
-  if (activated.status === 'terminal') {
-    return {
-      status: runtimeStatusForTerminalJobExecutionStatus(activated.jobStatus),
-      jobVersion: activated.jobVersion,
-    };
+  let nextSequence: number;
+  if (input.continuation) {
+    nextSequence = input.continuation.nextSequence;
+  } else {
+    const activated = await activateJobListenerActivity({
+      jobId: input.jobId,
+      expectedVersion: input.jobVersion,
+    });
+    if (activated.status === 'terminal') {
+      return {
+        status: runtimeStatusForTerminalJobExecutionStatus(activated.jobStatus),
+        jobVersion: activated.jobVersion,
+      };
+    }
+    nextSequence = activated.executionCount + 1;
   }
 
-  let nextSequence = activated.executionCount + 1;
+  let firingsInCurrentRun = 0;
   const maxExecutions = input.maxExecutions ?? undefined;
   const batchConfig = listenerBatchConfig(input);
   while (true) {
     if (deadlineReached(listenerDeadline)) latchedReason ??= 'timeout';
+    await continueListenerAsNewIfNeeded({
+      input,
+      nextSequence,
+      latchedReason,
+      listenerDeadline,
+      firingsInCurrentRun,
+    });
     if (latchedReason !== undefined) break;
     if (maxExecutions !== undefined) {
       if (nextSequence > maxExecutions) {
         latchedReason = 'max_executions';
+        await continueListenerAsNewIfNeeded({
+          input,
+          nextSequence,
+          latchedReason,
+          listenerDeadline,
+          firingsInCurrentRun,
+        });
         break;
       }
     }
@@ -164,6 +192,7 @@ export async function jobListenerOrchestration(
     if (drained.status === 'failed') {
       await recordListenerFiringOutcomeActivity({outcome: 'failed'});
       nextSequence = drained.sequence + 1;
+      firingsInCurrentRun += 1;
       if (maxExecutions !== undefined && drained.sequence >= maxExecutions) {
         latchedReason = 'max_executions';
       }
@@ -187,6 +216,7 @@ export async function jobListenerOrchestration(
 
     if (deadlineReached(listenerDeadline)) latchedReason ??= 'timeout';
     nextSequence = drained.sequence + 1;
+    firingsInCurrentRun += 1;
     if (maxExecutions !== undefined && drained.sequence >= maxExecutions) {
       latchedReason = 'max_executions';
     }
@@ -195,6 +225,54 @@ export async function jobListenerOrchestration(
   const reason = latchedReason ?? 'timeout';
   const resolved = await resolveJobListenerActivity({jobId: input.jobId, reason});
   return {status: resolved.status, jobVersion: resolved.jobVersion};
+}
+
+function initialListenerDeadline(input: JobListenerOrchestrationInput): number | undefined {
+  return input.listeningTimeoutMs === undefined || input.listeningTimeoutMs === null
+    ? undefined
+    : Date.now() + input.listeningTimeoutMs;
+}
+
+async function continueListenerAsNewIfNeeded(params: {
+  input: JobListenerOrchestrationInput;
+  nextSequence: number;
+  latchedReason: ResolutionLatch;
+  listenerDeadline: number | undefined;
+  firingsInCurrentRun: number;
+}): Promise<void> {
+  if (
+    !shouldContinueListenerAsNew({
+      firingsInCurrentRun: params.firingsInCurrentRun,
+      continueAsNewSuggested: workflowInfo().continueAsNewSuggested,
+    })
+  ) {
+    return;
+  }
+
+  await continueAsNew<typeof jobListenerOrchestration>(
+    listenerContinuationInput(params.input, {
+      nextSequence: params.nextSequence,
+      latchedReason: params.latchedReason,
+      listenerDeadline: params.listenerDeadline,
+    }),
+  );
+}
+
+export function shouldContinueListenerAsNew(params: {
+  firingsInCurrentRun: number;
+  continueAsNewSuggested: boolean;
+}): boolean {
+  return (
+    params.continueAsNewSuggested ||
+    params.firingsInCurrentRun >= LISTENER_CONTINUE_AS_NEW_FIRING_LIMIT
+  );
+}
+
+export function listenerContinuationInput(
+  input: JobListenerOrchestrationInput,
+  continuation: ListenerContinuationState,
+): JobListenerOrchestrationInput {
+  return {...input, continuation};
 }
 
 function listenerBatchConfig(


### PR DESCRIPTION
Guard listener orchestration history growth with Temporal continue-as-new.

Long-lived listening jobs can drain and run many event firings inside one child workflow, which grows Temporal history until the workflow risks hitting event-count or size limits. This carries listener loop state into a fresh workflow run when Temporal suggests continuing as new, or after a bounded number of firings as a fallback.

The continued run resumes with the next sequence, any latched resolution reason, and the original listener deadline. That keeps the existing drain idempotency, resolution ladder, and finish/cancel semantics intact across the boundary.

No changeset is included because the touched package is private.

Closes ENG-780

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard listener orchestration history growth by continuing the workflow as new when suggested or after a bounded number of firings. Prevents long-lived jobs from hitting Temporal history limits while preserving sequence, resolution, and deadlines. Closes ENG-780.

- **New Features**
  - Use `continueAsNew` from `@temporalio/workflow` when `workflowInfo().continueAsNewSuggested` is true or after 500 firings.
  - Carry state into the next run: next sequence, latched resolution reason, and listener deadline; continued runs skip activation and resume draining at the carried sequence.
  - Add tests for continuation input and the continue-as-new guard, including resume-at-sequence behavior.

<sup>Written for commit e0777980795ec4b6e58daf11e8ef59fd82b1ad8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

