### PR TITLE
Add filter predicate foundations

### DIFF
--- a/.changeset/bright-fields-shape.md
+++ b/.changeset/bright-fields-shape.md
@@ -1,0 +1,5 @@
+---
+"@shipfox/expression": minor
+---
+
+Adds ingest-time predicate foundations with filter predicate fields and boolean-shape detection.

--- a/libs/api/definitions/src/core/workflow-model/validate-job-references.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-job-references.ts
@@ -80,6 +80,12 @@ function fieldLabel(field: WorkflowInterpolationField | WorkflowPredicateField):
       return 'Step feedback';
     case 'job.success':
       return 'Job success';
+    case 'trigger.filter':
+      return 'Trigger filter';
+    case 'listener.on':
+      return 'Listener on filter';
+    case 'listener.until':
+      return 'Listener until filter';
     default:
       return assertNever(field);
   }

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
@@ -1,0 +1,159 @@
+import type {ExpressionTypeEnvironment} from '@shipfox/expression';
+import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
+import {validatePredicateExpression} from './validate-predicate-expression.js';
+
+function validate(params: {
+  source: string;
+  field: Parameters<typeof validatePredicateExpression>[0]['field'];
+  site: Parameters<typeof validatePredicateExpression>[0]['site'];
+  allowedJobReferences?: ReadonlySet<string>;
+  typeOverlay?: ExpressionTypeEnvironment;
+}): {
+  readonly expression: ReturnType<typeof validatePredicateExpression>;
+  readonly issues: WorkflowModelValidationIssue[];
+} {
+  const issues: WorkflowModelValidationIssue[] = [];
+  const expression = validatePredicateExpression({
+    field: params.field,
+    source: params.source,
+    site: params.site,
+    path: ['predicate'],
+    invalidCode: 'invalid-job-success',
+    invalidMessage: 'Predicate must be a valid CEL boolean expression.',
+    issues,
+    ...(params.allowedJobReferences === undefined
+      ? {}
+      : {allowedJobReferences: params.allowedJobReferences}),
+    ...(params.typeOverlay === undefined ? {} : {typeOverlay: params.typeOverlay}),
+  });
+
+  return {expression, issues};
+}
+
+describe('validatePredicateExpression', () => {
+  it.each([
+    ['event.ref == "refs/heads/main"', 'syntax'],
+    ['trigger.event == "push"', 'typed'],
+  ] as const)('accepts trigger filters at ingest: %s', (source, check) => {
+    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+
+    expect(result.issues).toEqual([]);
+    expect(result.expression).toMatchObject({source, check});
+  });
+
+  it.each([
+    ['event.ref', 'Predicate source must be boolean-shaped.'],
+    ['trigger.event', 'must return bool'],
+  ])('rejects non-boolean trigger filters: %s', (source, reason) => {
+    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid-job-success',
+        details: expect.objectContaining({
+          source,
+          reason: expect.stringContaining(reason),
+        }),
+      }),
+    ]);
+  });
+
+  it.each([
+    'run.id == "run-1"',
+    'inputs.env == "prod"',
+    'jobs.build.status == "succeeded"',
+  ])('rejects trigger filter roots that are unavailable at ingest: %s', (source) => {
+    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'context-unavailable-at-predicate-site',
+        details: expect.objectContaining({field: 'trigger.filter', source, site: 'ingest'}),
+      }),
+    ]);
+  });
+
+  it.each([
+    ['runner.os == "linux"', 'runner-context-in-server-predicate'],
+    ['vars.ENV == "prod"', 'vars-context-in-server-predicate'],
+  ])('rejects forbidden server predicate roots: %s', (source, code) => {
+    const result = validate({field: 'trigger.filter', source, site: 'ingest'});
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code,
+        details: expect.objectContaining({field: 'trigger.filter', source}),
+      }),
+    ]);
+  });
+
+  it.each([
+    ['listener.on', 'event.action == "created"', undefined],
+    ['listener.on', 'run.id == "run-1"', undefined],
+    ['listener.until', 'inputs.target == event.issue.number', undefined],
+    ['listener.until', 'job.key == "await-review"', undefined],
+    ['listener.on', 'executions.all(execution, execution.status != "")', undefined],
+    ['listener.until', 'execution.status == "waiting"', undefined],
+    ['listener.on', 'matrix.os == "linux"', undefined],
+    ['listener.until', 'jobs.build.outputs.pr_number == event.issue.number', new Set(['build'])],
+  ] as const)('accepts listener filters at job activation: %s %s', (field, source, allowedJobs) => {
+    const result = validate({
+      field,
+      source,
+      site: 'job-activation',
+      ...(allowedJobs === undefined ? {} : {allowedJobReferences: allowedJobs}),
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.expression).toMatchObject({source});
+  });
+
+  it.each([
+    'step.status == "succeeded"',
+    'steps.build.outputs.sha == "abc"',
+  ])('rejects listener roots that are unavailable at job activation: %s', (source) => {
+    const result = validate({field: 'listener.on', source, site: 'job-activation'});
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'context-unavailable-at-predicate-site',
+        details: expect.objectContaining({field: 'listener.on', source, site: 'job-activation'}),
+      }),
+    ]);
+  });
+
+  it('rejects listener job references without a direct needs edge', () => {
+    const result = validate({
+      field: 'listener.on',
+      source: 'jobs.build.outputs.pr_number == event.issue.number',
+      site: 'job-activation',
+      allowedJobReferences: new Set(['test']),
+    });
+
+    expect(result.expression).toBeUndefined();
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'missing-job-needs-edge',
+        details: expect.objectContaining({field: 'listener.on', job: 'build'}),
+      }),
+    ]);
+  });
+
+  it('keeps existing job success syntax-only behavior unchanged', () => {
+    const result = validate({
+      field: 'job.success',
+      source: 'jobs.build.outputs.ready',
+      site: 'job-resolution',
+    });
+
+    expect(result.issues).toEqual([]);
+    expect(result.expression).toMatchObject({
+      source: 'jobs.build.outputs.ready',
+      check: 'syntax',
+    });
+  });
+});

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.test.ts
@@ -34,6 +34,7 @@ describe('validatePredicateExpression', () => {
   it.each([
     ['event.ref == "refs/heads/main"', 'syntax'],
     ['trigger.event == "push"', 'typed'],
+    ['has(event.ref)', 'syntax'],
   ] as const)('accepts trigger filters at ingest: %s', (source, check) => {
     const result = validate({field: 'trigger.filter', source, site: 'ingest'});
 
@@ -99,6 +100,7 @@ describe('validatePredicateExpression', () => {
     ['listener.until', 'execution.status == "waiting"', undefined],
     ['listener.on', 'matrix.os == "linux"', undefined],
     ['listener.until', 'jobs.build.outputs.pr_number == event.issue.number', new Set(['build'])],
+    ['listener.until', 'has(jobs.build.outputs.pr_number)', new Set(['build'])],
   ] as const)('accepts listener filters at job activation: %s %s', (field, source, allowedJobs) => {
     const result = validate({
       field,

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -7,6 +7,7 @@ import {
   getWorkflowContextDefinition,
   getWorkflowContextTypeEnvironment,
   InvalidWorkflowExpressionError,
+  predicateSourceIsBooleanShaped,
   resolveContextRootAvailability,
   resolveContextRootHost,
   validateServerEvaluable,
@@ -90,6 +91,20 @@ export function validatePredicateExpression(params: {
   }
 
   if (params.typeOverlay === undefined && knownRoots.some((root) => hasSyntaxOnlyCheckMode(root))) {
+    if (
+      isWorkflowFilterPredicateField(params.field) &&
+      !predicateSourceIsBooleanShaped(syntaxExpression.source)
+    ) {
+      params.issues.push(
+        invalidPredicateIssue({
+          ...params,
+          contextRoots,
+          reason: 'Predicate source must be boolean-shaped.',
+        }),
+      );
+      return undefined;
+    }
+
     return syntaxExpression;
   }
 
@@ -264,6 +279,7 @@ function unavailableRootAvailabilityMessage(root: string): string {
 }
 
 function hasSyntaxOnlyCheckMode(root: string): boolean {
+  if (!isWorkflowContextName(root)) return resolveContextRootHost(root) === 'server';
   return isWorkflowContextName(root) && getWorkflowContextDefinition(root).checkMode === 'syntax';
 }
 
@@ -301,8 +317,29 @@ function isWorkflowContextName(root: string): root is WorkflowContextName {
   return (workflowContextNames as readonly string[]).includes(root);
 }
 
+function isWorkflowFilterPredicateField(field: WorkflowPredicateField): boolean {
+  return field === 'trigger.filter' || field === 'listener.on' || field === 'listener.until';
+}
+
 function fieldLabel(field: WorkflowPredicateField): string {
-  return field === 'step.success' ? 'Step gate success' : 'Job success';
+  switch (field) {
+    case 'step.success':
+      return 'Step gate success';
+    case 'job.success':
+      return 'Job success';
+    case 'trigger.filter':
+      return 'Trigger filter';
+    case 'listener.on':
+      return 'Listener on filter';
+    case 'listener.until':
+      return 'Listener until filter';
+    default:
+      return assertNever(field);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled workflow predicate field: ${value}`);
 }
 
 function contextNoun(roots: readonly string[]): 'context' | 'contexts' {

--- a/libs/api/workflows/src/db/workflow-runs.test.ts
+++ b/libs/api/workflows/src/db/workflow-runs.test.ts
@@ -547,7 +547,7 @@ describe('workflow run queries', () => {
           {
             expression: 'event.ref',
             roots: ['event'],
-            fillTarget: 'run-creation',
+            fillTarget: 'ingest',
             evaluatedAt: 'execution-creation',
             value: 'refs/heads/main',
             field: 'job.name',

--- a/libs/shared/expression/src/index.ts
+++ b/libs/shared/expression/src/index.ts
@@ -85,6 +85,7 @@ export {
   type PlanViolation,
   planInterpolationField,
 } from './plan/plan-field.js';
+export {predicateSourceIsBooleanShaped} from './plan/predicate-shape.js';
 export type {
   ResolvedField,
   ResolvedFieldDeferredSegment,

--- a/libs/shared/expression/src/plan/plan-field.test.ts
+++ b/libs/shared/expression/src/plan/plan-field.test.ts
@@ -84,7 +84,7 @@ describe('planInterpolationField', () => {
           segments: [
             {kind: 'deferred', roots: ['run'], fillTarget: 'run-creation'},
             {kind: 'literal', value: '-'},
-            {kind: 'deferred', roots: ['trigger'], fillTarget: 'run-creation'},
+            {kind: 'deferred', roots: ['trigger'], fillTarget: 'ingest'},
           ],
         },
       },

--- a/libs/shared/expression/src/plan/predicate-shape.test.ts
+++ b/libs/shared/expression/src/plan/predicate-shape.test.ts
@@ -14,6 +14,8 @@ describe('predicateSourceIsBooleanShaped', () => {
     'event.labels.exists(label, label == "bug")',
     'event.labels.all(label, label != "")',
     'event.labels.exists_one(label, label == "bug")',
+    'has(event.ref)',
+    'has(jobs.build.outputs.pr_number)',
     'event.ref.matches("^refs/heads/")',
     'event.ref.startsWith("refs/")',
     'event.ref.endsWith("/main")',

--- a/libs/shared/expression/src/plan/predicate-shape.test.ts
+++ b/libs/shared/expression/src/plan/predicate-shape.test.ts
@@ -1,0 +1,47 @@
+import {predicateSourceIsBooleanShaped} from './predicate-shape.js';
+
+describe('predicateSourceIsBooleanShaped', () => {
+  it.each([
+    'event.ref == "refs/heads/main"',
+    'event.ref != "refs/heads/main"',
+    'event.count > 0',
+    '"admin" in event.labels',
+    'event.ref == "main" && trigger.event == "push"',
+    'event.ref == "main" || trigger.event == "push"',
+    '!event.deleted',
+    'true',
+    'false',
+    'event.labels.exists(label, label == "bug")',
+    'event.labels.all(label, label != "")',
+    'event.labels.exists_one(label, label == "bug")',
+    'event.ref.matches("^refs/heads/")',
+    'event.ref.startsWith("refs/")',
+    'event.ref.endsWith("/main")',
+    'event.ref.contains("main")',
+    'contains(event.ref, "main")',
+    'event.ready ? true : event.ref == "main"',
+  ])('accepts boolean-shaped predicates: %s', (source) => {
+    const result = predicateSourceIsBooleanShaped(source);
+
+    expect(result).toBe(true);
+  });
+
+  it.each([
+    'event.ref',
+    'trigger.event',
+    '"main"',
+    '1',
+    'null',
+    'event.count + 1',
+    '{ref: event.ref}',
+    '[event.ref]',
+    'event.labels.map(label, label)',
+    'event.ready ? 1 : 2',
+    'event.ready ? event.ref == "main" : event.ref',
+    'event.',
+  ])('rejects non-boolean-shaped predicates: %s', (source) => {
+    const result = predicateSourceIsBooleanShaped(source);
+
+    expect(result).toBe(false);
+  });
+});

--- a/libs/shared/expression/src/plan/predicate-shape.ts
+++ b/libs/shared/expression/src/plan/predicate-shape.ts
@@ -1,0 +1,38 @@
+import {type ASTNode, type BinaryOperator, parse as parseCel} from '@marcbachmann/cel-js';
+
+const comparisonOperators = new Set<BinaryOperator>(['!=', '==', 'in', '<', '<=', '>', '>=']);
+const booleanReturningCalls = new Set([
+  'all',
+  'contains',
+  'endsWith',
+  'exists',
+  'exists_one',
+  'matches',
+  'startsWith',
+]);
+
+export function predicateSourceIsBooleanShaped(source: string): boolean {
+  try {
+    return nodeIsBooleanShaped(parseCel(source).ast);
+  } catch {
+    return false;
+  }
+}
+
+function nodeIsBooleanShaped(node: ASTNode): boolean {
+  if (comparisonOperators.has(node.op as BinaryOperator)) return true;
+  if (node.op === '&&' || node.op === '||' || node.op === '!_') return true;
+
+  switch (node.op) {
+    case 'value':
+      return typeof node.args === 'boolean';
+    case 'call':
+      return booleanReturningCalls.has(node.args[0]);
+    case 'rcall':
+      return booleanReturningCalls.has(node.args[0]);
+    case '?:':
+      return nodeIsBooleanShaped(node.args[1]) && nodeIsBooleanShaped(node.args[2]);
+    default:
+      return false;
+  }
+}

--- a/libs/shared/expression/src/plan/predicate-shape.ts
+++ b/libs/shared/expression/src/plan/predicate-shape.ts
@@ -7,6 +7,7 @@ const booleanReturningCalls = new Set([
   'endsWith',
   'exists',
   'exists_one',
+  'has',
   'matches',
   'startsWith',
 ]);

--- a/libs/shared/expression/src/plan/predicate-shape.ts
+++ b/libs/shared/expression/src/plan/predicate-shape.ts
@@ -1,6 +1,6 @@
-import {type ASTNode, type BinaryOperator, parse as parseCel} from '@marcbachmann/cel-js';
+import {type ASTNode, parse as parseCel} from '@marcbachmann/cel-js';
 
-const comparisonOperators = new Set<BinaryOperator>(['!=', '==', 'in', '<', '<=', '>', '>=']);
+const comparisonOperators = new Set<string>(['!=', '==', 'in', '<', '<=', '>', '>=']);
 const booleanReturningCalls = new Set([
   'all',
   'contains',
@@ -20,7 +20,7 @@ export function predicateSourceIsBooleanShaped(source: string): boolean {
 }
 
 function nodeIsBooleanShaped(node: ASTNode): boolean {
-  if (comparisonOperators.has(node.op as BinaryOperator)) return true;
+  if (comparisonOperators.has(node.op)) return true;
   if (node.op === '&&' || node.op === '||' || node.op === '!_') return true;
 
   switch (node.op) {

--- a/libs/shared/expression/src/plan/route-expression.test.ts
+++ b/libs/shared/expression/src/plan/route-expression.test.ts
@@ -9,6 +9,8 @@ import {routeExpression} from './route-expression.js';
 describe('routeExpression', () => {
   it.each([
     ['1 + 1', [], [], 'ingest'],
+    ['trigger.event', ['trigger'], [], 'ingest'],
+    ['event.ref', ['event'], [], 'ingest'],
     ['run.id', ['run'], [], 'run-creation'],
     ['run.id + execution.name', ['execution', 'run'], [], 'execution-creation'],
     ['jobs.build.outputs.sha', ['jobs'], [], 'job-activation'],

--- a/libs/shared/expression/src/workflow-context/workflow-context.test.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.test.ts
@@ -94,6 +94,7 @@ describe('workflow context registry', () => {
       checkMode: 'typed',
     });
     expect(workflowContextDefinitions.trigger).toMatchObject({
+      availability: 'ingest',
       shape: 'known',
       checkMode: 'typed',
     });
@@ -131,6 +132,7 @@ describe('workflow context registry', () => {
       checkMode: 'syntax',
     });
     expect(workflowContextDefinitions.event).toMatchObject({
+      availability: 'ingest',
       shape: 'open',
       checkMode: 'syntax',
     });
@@ -332,7 +334,7 @@ describe('workflow context registry', () => {
   });
 
   it('returns the roots available at each availability site', () => {
-    expect(rootsAvailableAt('ingest')).toEqual([]);
+    expect(rootsAvailableAt('ingest')).toEqual(['trigger', 'event']);
     expect(rootsAvailableAt('run-creation')).toEqual([
       'run',
       'trigger',
@@ -579,7 +581,13 @@ describe('workflow context registry', () => {
     });
 
     it('declares predicate fields as fail-closed', () => {
-      expect(workflowPredicateFields).toEqual(['step.success', 'job.success']);
+      expect(workflowPredicateFields).toEqual([
+        'step.success',
+        'job.success',
+        'trigger.filter',
+        'listener.on',
+        'listener.until',
+      ]);
       expect(workflowPredicateFieldFailurePolicy).toBe('fail-closed');
     });
   });

--- a/libs/shared/expression/src/workflow-context/workflow-context.ts
+++ b/libs/shared/expression/src/workflow-context/workflow-context.ts
@@ -260,7 +260,7 @@ export const workflowContextDefinitions = {
     typeEnvironment: runTypeEnvironment,
   },
   trigger: {
-    availability: 'run-creation',
+    availability: 'ingest',
     trustTier: 'trusted',
     sensitivity: 'persistable',
     host: 'server',
@@ -269,7 +269,7 @@ export const workflowContextDefinitions = {
     typeEnvironment: triggerTypeEnvironment,
   },
   event: {
-    availability: 'run-creation',
+    availability: 'ingest',
     trustTier: 'untrusted',
     sensitivity: 'persistable',
     host: 'server',
@@ -462,7 +462,13 @@ export const workflowInterpolationFields = Object.keys(
   workflowInterpolationFieldPolicies,
 ) as readonly WorkflowInterpolationField[];
 
-export const workflowPredicateFields = ['step.success', 'job.success'] as const;
+export const workflowPredicateFields = [
+  'step.success',
+  'job.success',
+  'trigger.filter',
+  'listener.on',
+  'listener.until',
+] as const;
 export type WorkflowPredicateField = (typeof workflowPredicateFields)[number];
 
 export const workflowPredicateFieldFailurePolicy =


### PR DESCRIPTION
Add the expression-engine foundations needed for trigger and listener filters.

Filters need `event` and `trigger` to be valid at ingest before later issues can wire authoring validation and runtime evaluation. This lowers those context roots to ingest, adds the filter predicate field names, and exposes a small CEL AST shape helper so syntax-only filter predicates can reject common non-boolean mistakes like `event.ref`.

This deliberately stops short of wiring trigger/listener filter validation or evaluation; those follow in ENG-822 through ENG-827.

Closes ENG-821

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ingest-time foundations for trigger and listener filters so authors can catch non-boolean predicates early. Makes `event` and `trigger` available at ingest and adds stricter boolean-shape checks, including support for `has(...)`. Fixes ENG-821.

- **New Features**
  - New predicate fields: `trigger.filter`, `listener.on`, `listener.until`.
  - Syntax-only boolean-shape validation for filter predicates via CEL AST; exports `predicateSourceIsBooleanShaped` from `@shipfox/expression`.
  - Lowers `event` and `trigger` context availability to `ingest` and updates routing/fill targets.

- **Bug Fixes**
  - Tightened predicate-shape operator checks to avoid false positives when parsing CEL AST.
  - Treats CEL `has(...)` calls as boolean-shaped so existence-only filters pass validation.

<sup>Written for commit 4d0f05da2a2f8bd70b46595ffecf7aaa1214e35a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

