### PR TITLE
[api-definitions] Validate trigger filters at authoring

### DIFF
--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -13,6 +13,7 @@ export type WorkflowModelValidationIssueCode =
   | 'invalid-cron-schedule'
   | 'invalid-cron-timezone'
   | 'invalid-provider'
+  | 'invalid-trigger-filter'
   | 'invalid-interpolation-expression'
   | 'invalid-interpolation-template'
   | 'invalid-duration'

--- a/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-triggers.ts
@@ -6,10 +6,12 @@ import type {
 import {cronTriggerDefaultTimezone, validateCronTrigger} from './cron-trigger.js';
 import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
 import {stableId} from './stable-id.js';
+import {validatePredicateExpression} from './validate-predicate-expression.js';
 import {issue} from './validation-issue.js';
 
 const manualTriggerSource = 'manual';
 const cronTriggerSource = 'cron';
+type WorkflowDocumentTrigger = NonNullable<WorkflowDocument['triggers']>[string];
 
 export function normalizeTriggers(
   document: WorkflowDocument,
@@ -48,6 +50,8 @@ export function normalizeTriggers(
     }
     usedTriggerIds.set(id, sourceKey);
 
+    validateTriggerFilter({sourceKey, trigger, issues});
+
     const normalizedTrigger = normalizeTriggerEntry(trigger);
     if (trigger.source !== cronTriggerSource) {
       return [
@@ -76,6 +80,38 @@ export function normalizeTriggers(
         config: normalizedCronConfig,
       },
     ];
+  });
+}
+
+function validateTriggerFilter(params: {
+  sourceKey: string;
+  trigger: WorkflowDocumentTrigger;
+  issues: WorkflowModelValidationIssue[];
+}): void {
+  const {sourceKey, trigger, issues} = params;
+  if (trigger.filter === undefined) return;
+
+  const path = ['triggers', sourceKey, 'filter'] as const;
+  if (trigger.source === manualTriggerSource || trigger.source === cronTriggerSource) {
+    issues.push(
+      issue({
+        code: 'invalid-trigger-filter',
+        message: `A ${trigger.source} trigger cannot define a filter because it does not receive an event payload.`,
+        path,
+        details: {source: trigger.filter, triggerSource: trigger.source},
+      }),
+    );
+    return;
+  }
+
+  validatePredicateExpression({
+    field: 'trigger.filter',
+    source: trigger.filter,
+    site: 'ingest',
+    path,
+    invalidCode: 'invalid-trigger-filter',
+    invalidMessage: 'Trigger filter must be a valid boolean predicate.',
+    issues,
   });
 }
 

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -2083,14 +2083,14 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
-  it('keeps trigger filters as source strings until event typed expressions are introduced', () => {
+  it('validates trigger filters while preserving their source strings', () => {
     const document: WorkflowDocument = {
-      name: 'deferred trigger filter',
+      name: 'validated trigger filter',
       triggers: {
         main: {
           source: 'github',
           event: 'push',
-          filter: 'event.conclsion == "success"',
+          filter: 'event.ref == "refs/heads/main" && trigger.source == "github"',
         },
       },
       jobs: {
@@ -2108,7 +2108,125 @@ describe('normalizeWorkflowDocument', () => {
         key: 'main',
         source: 'github',
         event: 'push',
-        filter: 'event.conclsion == "success"',
+        filter: 'event.ref == "refs/heads/main" && trigger.source == "github"',
+      },
+    ]);
+  });
+
+  it.each([
+    [
+      'jobs root',
+      'jobs.build.outputs.result == "ok"',
+      'context-unavailable-at-predicate-site',
+      {
+        field: 'trigger.filter',
+        source: 'jobs.build.outputs.result == "ok"',
+        contextRoots: ['jobs'],
+        unavailableRoots: ['jobs'],
+        site: 'ingest',
+      },
+    ],
+    [
+      'run root',
+      'run.id == "run-1"',
+      'context-unavailable-at-predicate-site',
+      {
+        field: 'trigger.filter',
+        source: 'run.id == "run-1"',
+        contextRoots: ['run'],
+        unavailableRoots: ['run'],
+        site: 'ingest',
+      },
+    ],
+    [
+      'runner root',
+      'runner.os == "linux"',
+      'runner-context-in-server-predicate',
+      {
+        field: 'trigger.filter',
+        source: 'runner.os == "linux"',
+        contextRoots: ['runner'],
+        runnerRoots: ['runner'],
+        site: 'ingest',
+      },
+    ],
+    [
+      'vars root',
+      'vars.environment == "prod"',
+      'vars-context-in-server-predicate',
+      {
+        field: 'trigger.filter',
+        source: 'vars.environment == "prod"',
+        contextRoots: ['vars'],
+        rejectedRoots: ['vars'],
+        site: 'ingest',
+      },
+    ],
+    [
+      'non-boolean shape',
+      'event.ref',
+      'invalid-trigger-filter',
+      {
+        source: 'event.ref',
+        contextRoots: ['event'],
+        reason: 'Predicate source must be boolean-shaped.',
+      },
+    ],
+  ] as const)('rejects trigger filters with %s', (_label, filter, code, details) => {
+    const document: WorkflowDocument = {
+      name: 'invalid trigger filter',
+      triggers: {
+        main: {
+          source: 'github',
+          event: 'push',
+          filter,
+        },
+      },
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code,
+        message: expect.any(String),
+        path: ['triggers', 'main', 'filter'],
+        details,
+      },
+    ]);
+  });
+
+  it.each(['manual', 'cron'] as const)('rejects filters on %s triggers', (source) => {
+    const document: WorkflowDocument = {
+      name: 'unsupported trigger filter',
+      triggers: {
+        main: {
+          source,
+          event: source === 'cron' ? 'tick' : 'fire',
+          filter: 'event.ref == "refs/heads/main"',
+          ...(source === 'cron' ? {config: {schedule: '0 2 * * *'}} : {}),
+        },
+      },
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      {
+        code: 'invalid-trigger-filter',
+        message: `A ${source} trigger cannot define a filter because it does not receive an event payload.`,
+        path: ['triggers', 'main', 'filter'],
+        details: {source: 'event.ref == "refs/heads/main"', triggerSource: source},
       },
     ]);
   });


### PR DESCRIPTION
Validate workflow trigger filters during definition normalization.

Trigger filters were previously preserved as source strings without authoring validation, so invalid predicates could reach subscription creation and fail later. This wires the existing predicate validator into trigger normalization at the ingest site and rejects filters on manual or cron triggers, where no event payload exists.

The rejection paths use workflow-model validation issues with field-specific paths so definition resolution fails with actionable errors.

No changeset is included because `@shipfox/api-definitions` is private.

Closes ENG-822

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate workflow trigger filters during normalization in `@shipfox/api-definitions` so invalid predicates fail at authoring and never reach subscription creation. Also block filters on `manual` and `cron` triggers, which do not receive an event payload. Closes ENG-822.

- **New Features**
  - Validate `trigger.filter` with the existing predicate validator during normalization while keeping the source string.
  - Reject filters on `manual` and `cron` triggers; emit `invalid-trigger-filter` with a precise field path.
  - Added test coverage for valid filters, common invalid cases, and manual/cron rejection.

- **Migration**
  - Remove `filter` from `manual` and `cron` triggers.
  - Fix non-boolean or unsupported-context predicates in `trigger.filter`.

<sup>Written for commit 8522d4dca44aacce9c95083852e47a7925eae5b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

