### PR TITLE
[api-definitions] Validate listener matcher filters

### DIFF
--- a/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
+++ b/libs/api/definitions/src/core/workflow-model/invalid-workflow-model-error.ts
@@ -16,6 +16,7 @@ export type WorkflowModelValidationIssueCode =
   | 'invalid-interpolation-expression'
   | 'invalid-interpolation-template'
   | 'invalid-duration'
+  | 'invalid-listener-filter'
   | 'invalid-job-output'
   | 'invalid-job-success'
   | 'invalid-output-schema'

--- a/libs/api/definitions/src/core/workflow-model/normalize-job-listening.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-job-listening.ts
@@ -4,12 +4,14 @@ import {DEFAULT_RUN_TIMEOUT_MS} from './constants.js';
 import type {WorkflowModelValidationIssue} from './invalid-workflow-model-error.js';
 import {normalizeTriggerEntry} from './normalize-triggers.js';
 import {parseDurationMs} from './parse-duration-ms.js';
+import {validatePredicateExpression} from './validate-predicate-expression.js';
 import {issue} from './validation-issue.js';
 
 export function normalizeJobListening(params: {
   job: WorkflowDocumentJob;
   sourceName: string;
   issues: WorkflowModelValidationIssue[];
+  allowedJobReferences: ReadonlySet<string>;
 }): WorkflowModelJobListening | undefined {
   const path = ['jobs', params.sourceName] as const;
   const listening = params.job.listening;
@@ -61,11 +63,59 @@ export function normalizeJobListening(params: {
         };
 
   return {
-    on: listening.on.map(normalizeTriggerEntry),
-    ...(listening.until === undefined ? {} : {until: listening.until.map(normalizeTriggerEntry)}),
+    on: listening.on.map((trigger, index) =>
+      normalizeListeningTrigger({
+        trigger,
+        field: 'listener.on',
+        path: [...path, 'listening', 'on', index, 'filter'],
+        issues: params.issues,
+        allowedJobReferences: params.allowedJobReferences,
+      }),
+    ),
+    ...(listening.until === undefined
+      ? {}
+      : {
+          until: listening.until.map((trigger, index) =>
+            normalizeListeningTrigger({
+              trigger,
+              field: 'listener.until',
+              path: [...path, 'listening', 'until', index, 'filter'],
+              issues: params.issues,
+              allowedJobReferences: params.allowedJobReferences,
+            }),
+          ),
+        }),
     ...(timeoutMs === undefined ? {} : {timeoutMs}),
     ...(listening.max_executions === undefined ? {} : {maxExecutions: listening.max_executions}),
     ...(batch === undefined ? {} : {batch}),
     onResolve: listening.on_resolve ?? 'finish',
   };
+}
+
+function normalizeListeningTrigger(params: {
+  trigger: {
+    readonly source: string;
+    readonly event: string;
+    readonly with?: Readonly<Record<string, unknown>> | undefined;
+    readonly filter?: string | undefined;
+  };
+  field: 'listener.on' | 'listener.until';
+  path: readonly (string | number)[];
+  issues: WorkflowModelValidationIssue[];
+  allowedJobReferences: ReadonlySet<string>;
+}): WorkflowModelJobListening['on'][number] {
+  if (params.trigger.filter !== undefined) {
+    validatePredicateExpression({
+      field: params.field,
+      source: params.trigger.filter,
+      site: 'job-activation',
+      path: params.path,
+      invalidCode: 'invalid-listener-filter',
+      invalidMessage: `${params.field === 'listener.on' ? 'Listener on' : 'Listener until'} filter must be a valid CEL boolean expression.`,
+      issues: params.issues,
+      allowedJobReferences: params.allowedJobReferences,
+    });
+  }
+
+  return normalizeTriggerEntry(params.trigger);
 }

--- a/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-jobs.ts
@@ -214,6 +214,7 @@ function normalizeJob(params: {
     job: params.job,
     sourceName: params.sourceName,
     issues: params.issues,
+    allowedJobReferences,
   });
   const name =
     params.job.name === undefined

--- a/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
+++ b/libs/api/definitions/src/core/workflow-model/normalize-workflow-document.test.ts
@@ -400,6 +400,152 @@ describe('normalizeWorkflowDocument', () => {
     ]);
   });
 
+  it('validates listener filters against job-activation roots', () => {
+    const document: WorkflowDocument = {
+      name: 'listener filter roots',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+        review: {
+          needs: ['build'],
+          listening: {
+            on: [
+              {
+                source: 'github',
+                event: 'pull_request_review',
+                filter:
+                  'run.id != "" && inputs.target == event.issue.number && job.key == "review" && executions.all(execution, execution.status != "") && matrix.os == "linux" && jobs.build.outputs.pr_number == event.issue.number',
+              },
+            ],
+            until: [
+              {
+                source: 'github',
+                event: 'pull_request',
+                filter: 'event.action == "closed"',
+              },
+            ],
+          },
+          steps: [{run: 'echo ok'}],
+        },
+      },
+    };
+
+    const model = normalizeWorkflowDocument(document);
+
+    expect(model.jobs[1]?.listening?.on[0]?.filter).toBe(
+      'run.id != "" && inputs.target == event.issue.number && job.key == "review" && executions.all(execution, execution.status != "") && matrix.os == "linux" && jobs.build.outputs.pr_number == event.issue.number',
+    );
+    expect(model.jobs[1]?.listening?.until?.[0]?.filter).toBe('event.action == "closed"');
+  });
+
+  it.each([
+    ['step root', 'step.status == "succeeded"', 'context-unavailable-at-predicate-site'],
+    ['steps root', 'steps.build.outputs.sha == "abc"', 'context-unavailable-at-predicate-site'],
+    ['runner root', 'runner.os == "linux"', 'runner-context-in-server-predicate'],
+    ['non-boolean source', 'event.action', 'invalid-listener-filter'],
+  ] as const)('reports invalid listener on filters for %s', (_label, filter, code) => {
+    const document: WorkflowDocument = {
+      name: 'invalid listener filter',
+      jobs: {
+        review: {
+          listening: {
+            on: [{source: 'github', event: 'pull_request_review', filter}],
+            max_executions: 1,
+          },
+          steps: [{run: 'echo ok'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code,
+        path: ['jobs', 'review', 'listening', 'on', 0, 'filter'],
+        details: expect.objectContaining({
+          field: 'listener.on',
+          source: filter,
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects listener filters that reference jobs without a direct needs edge', () => {
+    const document: WorkflowDocument = {
+      name: 'listener missing needs',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+        review: {
+          listening: {
+            on: [
+              {
+                source: 'github',
+                event: 'pull_request_review',
+                filter: 'jobs.build.outputs.pr_number == event.issue.number',
+              },
+            ],
+            max_executions: 1,
+          },
+          steps: [{run: 'echo ok'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'missing-job-needs-edge',
+        path: ['jobs', 'review', 'listening', 'on', 0, 'filter'],
+        details: expect.objectContaining({
+          field: 'listener.on',
+          job: 'build',
+        }),
+      }),
+    ]);
+  });
+
+  it('rejects computed job keys in listener until filters', () => {
+    const document: WorkflowDocument = {
+      name: 'computed listener job key',
+      jobs: {
+        build: {
+          steps: [{run: 'npm run build'}],
+        },
+        review: {
+          needs: ['build'],
+          listening: {
+            on: [{source: 'github', event: 'pull_request_review'}],
+            until: [
+              {
+                source: 'github',
+                event: 'pull_request',
+                filter: 'jobs[event.job].outputs.sha == "abc"',
+              },
+            ],
+          },
+          steps: [{run: 'echo ok'}],
+        },
+      },
+    };
+
+    const error = expectInvalid(document);
+
+    expect(error.issues).toEqual([
+      expect.objectContaining({
+        code: 'computed-context-key',
+        path: ['jobs', 'review', 'listening', 'until', 0, 'filter'],
+        details: expect.objectContaining({
+          field: 'listener.until',
+        }),
+      }),
+    ]);
+  });
+
   it('preserves explicit model ids even when the seed catalog only knows provider defaults', () => {
     const document: WorkflowDocument = {
       name: 'agent build',

--- a/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
+++ b/libs/api/definitions/src/core/workflow-model/validate-predicate-expression.ts
@@ -135,6 +135,7 @@ export function validatePredicateExpression(params: {
 }
 
 function createSyntaxExpression(params: {
+  field: WorkflowPredicateField;
   source: string;
   path: readonly WorkflowModelValidationIssuePathSegment[];
   invalidCode: WorkflowModelValidationIssueCode;
@@ -162,6 +163,7 @@ function createSyntaxExpression(params: {
 }
 
 function invalidPredicateIssue(params: {
+  field: WorkflowPredicateField;
   source: string;
   path: readonly WorkflowModelValidationIssuePathSegment[];
   invalidCode: WorkflowModelValidationIssueCode;
@@ -174,6 +176,7 @@ function invalidPredicateIssue(params: {
     message: params.invalidMessage,
     path: params.path,
     details: {
+      field: params.field,
       source: params.source,
       contextRoots: params.contextRoots,
       reason: params.reason ?? 'Expression source did not parse or type-check.',


### PR DESCRIPTION
Validate listener `on:` and `until:` matcher filters during workflow definition normalization.

Listener matcher filters previously stayed as unchecked source strings, so invalid roots, non-boolean predicates, computed `jobs[...]` keys, and missing direct `needs` edges could pass authoring and fail later. This runs those filters through the shared predicate validation path at the `job-activation` site, using the listening job's direct dependencies as the allowed job references.

`@shipfox/api-definitions` is private, so this does not include a release changeset.

Closes ENG-824

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `listener.on` and `listener.until` filters during workflow normalization in `@shipfox/api-definitions` so only valid boolean CEL expressions with allowed job references are accepted. This fails bad filters at authoring time and satisfies ENG-824.

- **Bug Fixes**
  - Validate listener filters via the shared predicate validator at the job-activation site.
  - Enforce boolean type and allowed roots; reject runner/step roots server-side.
  - Require direct `needs` edges for `jobs.<key>` references; disallow computed keys.
  - Add `invalid-listener-filter` issue code and include `field` in predicate error details.
  - Add tests for valid filters and for invalid roots, non-boolean expressions, missing needs edges, and computed job keys.

<sup>Written for commit 4c31fbd217c453564e1f162e66b330dfc899dece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

