### PR TITLE
Add listener filter snapshots

### DIFF
--- a/.changeset/quiet-roots-snapshot.md
+++ b/.changeset/quiet-roots-snapshot.md
@@ -1,0 +1,7 @@
+---
+"@shipfox/api-workflows-dto": patch
+"@shipfox/api-workflows": patch
+"@shipfox/api-triggers": patch
+---
+
+Adds listener filter snapshots to job activation events and persists them on listener subscriptions.

--- a/libs/api/triggers/src/db/job-listener-subscriptions.test.ts
+++ b/libs/api/triggers/src/db/job-listener-subscriptions.test.ts
@@ -121,6 +121,77 @@ describe('job listener subscriptions', () => {
     ).toBe(true);
   });
 
+  it('persists listener filter snapshots verbatim in matcher config', async () => {
+    const filterSnapshot = {jobs: {build: {outputs: {pr_number: 42}}}};
+    const payload = buildActivatedPayload({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request_review',
+          filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+          filter_snapshot: filterSnapshot,
+        },
+      ],
+      until: null,
+    });
+
+    await onJobActivated(payload);
+
+    const rows = await listJobSubscriptions(payload.jobId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.config).toEqual({
+      filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+      filter_snapshot: filterSnapshot,
+    });
+  });
+
+  it('omits filter snapshots from matcher config when absent', async () => {
+    const payload = buildActivatedPayload({
+      on: [{source: 'github', event: 'pull_request_review', filter: 'event.action == "created"'}],
+      until: null,
+    });
+
+    await onJobActivated(payload);
+
+    const rows = await listJobSubscriptions(payload.jobId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.config).toEqual({filter: 'event.action == "created"'});
+  });
+
+  it('updates existing matcher ordinals with replacement filter snapshots', async () => {
+    const payload = buildActivatedPayload({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request_review',
+          filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+          filter_snapshot: {jobs: {build: {outputs: {pr_number: 42}}}},
+        },
+      ],
+      until: null,
+    });
+
+    await onJobActivated(payload);
+    await onJobActivated({
+      ...payload,
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request_review',
+          filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+          filter_snapshot: {jobs: {build: {outputs: {pr_number: 43}}}},
+        },
+      ],
+    });
+
+    const rows = await listJobSubscriptions(payload.jobId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.config).toEqual({
+      filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+      filter_snapshot: {jobs: {build: {outputs: {pr_number: 43}}}},
+    });
+  });
+
   it('deletes all subscriptions for a terminated job', async () => {
     const jobId = crypto.randomUUID();
     await jobListenerSubscriptionFactory.create({jobId, kind: 'on', matcherOrdinal: 0});

--- a/libs/api/triggers/src/db/job-listener-subscriptions.ts
+++ b/libs/api/triggers/src/db/job-listener-subscriptions.ts
@@ -16,6 +16,7 @@ export interface ListenerMatcher {
   event: string;
   inputs?: Readonly<Record<string, unknown>> | undefined;
   filter?: string | undefined;
+  filter_snapshot?: Readonly<Record<string, unknown>> | undefined;
 }
 
 export interface ProjectJobListenerSubscriptionsParams {
@@ -41,6 +42,7 @@ export async function projectJobListenerSubscriptions(
         const config: Record<string, unknown> = {};
         if (matcher.inputs !== undefined) config.inputs = matcher.inputs;
         if (matcher.filter !== undefined) config.filter = matcher.filter;
+        if (matcher.filter_snapshot !== undefined) config.filter_snapshot = matcher.filter_snapshot;
 
         await tx
           .insert(jobListenerSubscriptions)

--- a/libs/api/workflows-dto/src/events.test.ts
+++ b/libs/api/workflows-dto/src/events.test.ts
@@ -216,6 +216,44 @@ describe('workflowsJobActivatedSchema', () => {
 
     expect(result).toEqual(payload);
   });
+
+  it('retains resolved listener filter snapshots on job-activated matchers', () => {
+    const payload = {
+      ...validJobActivated,
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request_review',
+          filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+          filter_snapshot: {jobs: {build: {outputs: {pr_number: 42}}}},
+        },
+      ],
+      until: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.build.outputs.pr_number == event.pull_request.number',
+          filter_snapshot: {jobs: {build: {outputs: {pr_number: 42}}}},
+        },
+      ],
+    };
+
+    const result = workflowsJobActivatedSchema.parse(payload);
+
+    expect(result).toEqual(payload);
+  });
+
+  it('keeps authoring-shaped matchers compatible when no snapshot is present', () => {
+    const payload = {
+      ...validJobActivated,
+      on: [{source: 'github', event: 'pull_request_review', filter: 'event.action == "opened"'}],
+      until: [{source: 'github', event: 'pull_request'}],
+    };
+
+    const result = workflowsJobActivatedSchema.parse(payload);
+
+    expect(result).toEqual(payload);
+  });
 });
 
 describe('workflowsStepRestartEnqueuedSchema', () => {

--- a/libs/api/workflows-dto/src/events.ts
+++ b/libs/api/workflows-dto/src/events.ts
@@ -80,16 +80,20 @@ const workflowsJobActivatedBaseSchema = z.object({
   workspaceId: nonEmptyStringSchema,
 });
 
+const resolvedListeningTriggerSchema = listeningTriggerSchema.extend({
+  filter_snapshot: z.record(z.string(), z.unknown()).optional(),
+});
+
 export const workflowsJobActivatedSchema = z.discriminatedUnion('mode', [
   workflowsJobActivatedBaseSchema.extend({
     mode: z.literal('one_shot'),
-    on: z.array(listeningTriggerSchema).nullable().optional(),
-    until: z.array(listeningTriggerSchema).nullable().optional(),
+    on: z.array(resolvedListeningTriggerSchema).nullable().optional(),
+    until: z.array(resolvedListeningTriggerSchema).nullable().optional(),
   }),
   workflowsJobActivatedBaseSchema.extend({
     mode: z.literal('listening'),
-    on: z.array(listeningTriggerSchema).nonempty(),
-    until: z.array(listeningTriggerSchema).nullable(),
+    on: z.array(resolvedListeningTriggerSchema).nonempty(),
+    until: z.array(resolvedListeningTriggerSchema).nullable(),
   }),
 ]);
 export type WorkflowsJobActivatedEventDto = z.infer<typeof workflowsJobActivatedSchema>;

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -1,6 +1,9 @@
-import {WORKFLOWS_JOB_ACTIVATED} from '@shipfox/api-workflows-dto';
+import {
+  WORKFLOWS_JOB_ACTIVATED,
+  type WorkflowsJobActivatedEventDto,
+} from '@shipfox/api-workflows-dto';
 import {and, asc, eq, isNull} from 'drizzle-orm';
-import type {JobStatus} from '#core/entities/job.js';
+import type {JobListeningTrigger, JobStatus} from '#core/entities/job.js';
 import type {JobExecutionStatus} from '#core/entities/job-execution.js';
 import {nextStepForJob, recordStepResult} from '#core/job-execution.js';
 import {db} from '#db/db.js';
@@ -101,6 +104,98 @@ function readJob(jobId: string) {
     .then((rows) => rows[0]);
 }
 
+async function activatedPayload(jobId: string): Promise<WorkflowsJobActivatedEventDto> {
+  const rows = await db()
+    .select({payload: workflowsOutbox.payload})
+    .from(workflowsOutbox)
+    .where(eq(workflowsOutbox.eventType, WORKFLOWS_JOB_ACTIVATED));
+  const payload = rows
+    .map((row) => row.payload as WorkflowsJobActivatedEventDto)
+    .find((candidate) => candidate.jobId === jobId);
+  if (!payload) throw new Error(`No activated payload for job ${jobId}`);
+  return payload;
+}
+
+function expectListeningPayload(
+  payload: WorkflowsJobActivatedEventDto,
+): asserts payload is Extract<WorkflowsJobActivatedEventDto, {mode: 'listening'}> {
+  expect(payload.mode).toBe('listening');
+}
+
+async function createInactiveListeningJobWithMatchers(params: {
+  readonly on: readonly JobListeningTrigger[];
+  readonly until?: readonly JobListeningTrigger[] | null;
+}) {
+  const job = await createListeningJob({
+    key: 'await',
+    status: 'pending',
+    listenerStatus: 'inactive',
+  });
+  await db()
+    .update(jobs)
+    .set({listeningOn: [...params.on], listeningUntil: params.until ? [...params.until] : null})
+    .where(eq(jobs.id, job.id));
+  const updated = await readJob(job.id);
+  if (!updated) throw new Error('Expected inactive listener job');
+  return updated;
+}
+
+async function createListenerWithDependencies(params: {
+  readonly on: readonly JobListeningTrigger[];
+}) {
+  const run = await workflowRunFactory.create(
+    {
+      inputs: {environment: 'prod'},
+      triggerPayload: {
+        source: 'github',
+        event: 'pull_request',
+        deliveryId: 'delivery-1',
+        data: {action: 'opened'},
+      },
+    },
+    {
+      transient: {
+        model: workflowModel({
+          jobs: {
+            build: {steps: [{run: 'echo build'}]},
+            review: {steps: [{run: 'echo review'}]},
+            await: {needs: ['build', 'review'], steps: [{run: 'echo await'}]},
+          },
+        }),
+      },
+    },
+  );
+  const runJobs = await getJobsByWorkflowRunId(run.id);
+  const build = runJobs.find((job) => job.key === 'build');
+  const review = runJobs.find((job) => job.key === 'review');
+  const listener = runJobs.find((job) => job.key === 'await');
+  if (!build || !review || !listener) throw new Error('Expected dependency fixture jobs');
+
+  await db()
+    .update(jobs)
+    .set({status: 'succeeded', outputs: {pr_number: 42}})
+    .where(eq(jobs.id, build.id));
+  await db()
+    .update(jobs)
+    .set({status: 'succeeded', outputs: {pr_number: 99}})
+    .where(eq(jobs.id, review.id));
+  await db()
+    .update(jobs)
+    .set({
+      mode: 'listening',
+      status: 'pending',
+      listenerStatus: 'inactive',
+      listeningOn: [...params.on],
+      listeningUntil: null,
+    })
+    .where(eq(jobs.id, listener.id));
+  await db().delete(jobExecutions).where(eq(jobExecutions.jobId, listener.id));
+
+  const updated = await readJob(listener.id);
+  if (!updated) throw new Error('Expected listener fixture job');
+  return updated;
+}
+
 function template(source: string): string {
   return `\${{ ${source} }}`;
 }
@@ -151,6 +246,93 @@ describe('activateJobListener', () => {
     const result = await activateJobListener({jobId: job.id, expectedVersion: job.version});
 
     expect(result.executionCount).toBe(2);
+  });
+
+  it('omits filter snapshots for matchers without non-event roots', async () => {
+    const job = await createInactiveListeningJobWithMatchers({
+      on: [{source: 'github', event: 'pull_request'}],
+      until: [{source: 'github', event: 'pull_request', filter: 'event.action == "closed"'}],
+    });
+
+    await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expectListeningPayload(payload);
+    expect(payload.on[0]).toEqual({source: 'github', event: 'pull_request'});
+    expect(payload.until?.[0]).toEqual({
+      source: 'github',
+      event: 'pull_request',
+      filter: 'event.action == "closed"',
+    });
+  });
+
+  it('snapshots only referenced activation roots for listener filters', async () => {
+    const job = await createListenerWithDependencies({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter:
+            'jobs.build.outputs.pr_number == event.pull_request.number && inputs.environment == "prod" && trigger.event == "pull_request" && run.id != "" && job.key == "await"',
+        },
+      ],
+    });
+
+    await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expectListeningPayload(payload);
+    const snapshot = payload.on[0]?.filter_snapshot;
+    expect(snapshot).toEqual({
+      run: expect.objectContaining({id: expect.any(String), name: 'Test Workflow'}),
+      trigger: {source: 'github', event: 'pull_request'},
+      inputs: {environment: 'prod'},
+      job: {key: 'await'},
+      jobs: {
+        build: expect.objectContaining({
+          status: 'succeeded',
+          outputs: {pr_number: 42},
+          executions: expect.any(Array),
+        }),
+      },
+    });
+    expect(snapshot).not.toHaveProperty('event');
+    expect(snapshot?.jobs).not.toHaveProperty('review');
+  });
+
+  it('omits snapshots when referenced job keys are absent', async () => {
+    const job = await createListenerWithDependencies({
+      on: [
+        {
+          source: 'github',
+          event: 'pull_request',
+          filter: 'jobs.missing.outputs.pr_number == event.pull_request.number',
+        },
+      ],
+    });
+
+    await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expectListeningPayload(payload);
+    expect(payload.on[0]).toEqual({
+      source: 'github',
+      event: 'pull_request',
+      filter: 'jobs.missing.outputs.pr_number == event.pull_request.number',
+    });
+  });
+
+  it('keeps listener activation total when filter root extraction fails', async () => {
+    const job = await createInactiveListeningJobWithMatchers({
+      on: [{source: 'github', event: 'pull_request', filter: 'event.'}],
+    });
+
+    const result = await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expect(result.status).toBe('running');
+    expectListeningPayload(payload);
+    expect(payload.on[0]).toEqual({source: 'github', event: 'pull_request', filter: 'event.'});
   });
 });
 

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -266,6 +266,22 @@ describe('activateJobListener', () => {
     });
   });
 
+  it('omits filter snapshots for reserved roots without concrete activation data', async () => {
+    const job = await createInactiveListeningJobWithMatchers({
+      on: [{source: 'github', event: 'pull_request', filter: 'matrix.os == "linux"'}],
+    });
+
+    await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expectListeningPayload(payload);
+    expect(payload.on[0]).toEqual({
+      source: 'github',
+      event: 'pull_request',
+      filter: 'matrix.os == "linux"',
+    });
+  });
+
   it('snapshots only referenced activation roots for listener filters', async () => {
     const job = await createListenerWithDependencies({
       on: [

--- a/libs/api/workflows/src/db/job-listeners.test.ts
+++ b/libs/api/workflows/src/db/job-listeners.test.ts
@@ -282,6 +282,23 @@ describe('activateJobListener', () => {
     });
   });
 
+  it('snapshots null run inputs when listener filters reference inputs', async () => {
+    const job = await createInactiveListeningJobWithMatchers({
+      on: [{source: 'github', event: 'pull_request', filter: 'inputs == null'}],
+    });
+
+    await activateJobListener({jobId: job.id, expectedVersion: job.version});
+
+    const payload = await activatedPayload(job.id);
+    expectListeningPayload(payload);
+    expect(payload.on[0]).toEqual({
+      source: 'github',
+      event: 'pull_request',
+      filter: 'inputs == null',
+      filter_snapshot: {inputs: null},
+    });
+  });
+
   it('snapshots only referenced activation roots for listener filters', async () => {
     const job = await createListenerWithDependencies({
       on: [

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -69,7 +69,7 @@ type JobActivatedListenerMatcher = Extract<
   {mode: 'listening'}
 >['on'][number];
 
-type SnapshotRoot = 'run' | 'trigger' | 'inputs' | 'job' | 'jobs' | 'matrix';
+type SnapshotRoot = 'run' | 'trigger' | 'inputs' | 'job' | 'jobs';
 
 interface MatcherSnapshotPlan {
   readonly matcher: JobListeningTrigger;
@@ -216,12 +216,7 @@ function planMatcherFilterSnapshot(
 
 function isSnapshotRoot(root: string): root is SnapshotRoot {
   return (
-    root === 'run' ||
-    root === 'trigger' ||
-    root === 'inputs' ||
-    root === 'job' ||
-    root === 'jobs' ||
-    root === 'matrix'
+    root === 'run' || root === 'trigger' || root === 'inputs' || root === 'job' || root === 'jobs'
   );
 }
 

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -2,15 +2,28 @@ import {
   type AgentDefaultsResolver,
   catalogDefaultAgentResolver,
 } from '@shipfox/api-agent/core/resolve-agent-config';
-import {WORKFLOWS_JOB_ACTIVATED} from '@shipfox/api-workflows-dto';
+import {
+  WORKFLOWS_JOB_ACTIVATED,
+  type WorkflowsJobActivatedEventDto,
+} from '@shipfox/api-workflows-dto';
+import {
+  analyzeContextRootKeyAccess,
+  extractExactContextRoots,
+  type WorkflowExpressionEvaluationContext,
+} from '@shipfox/expression';
 import {and, asc, count, eq, inArray, isNull, notInArray, sql} from 'drizzle-orm';
-import type {JobStatus, ResolutionReason} from '#core/entities/job.js';
+import type {JobListeningTrigger, JobStatus, ResolutionReason} from '#core/entities/job.js';
 import type {JobExecutionStatus, WorkflowExecutionEvent} from '#core/entities/job-execution.js';
 import {
   AgentConfigUnresolvableError,
   InterpolationUnresolvableError,
   InvalidJobRunnerLabelsError,
 } from '#core/errors.js';
+import {
+  assembleJobsContext,
+  assembleWorkflowRunContext,
+  type JobContextInput,
+} from '#core/step-config/assemble-run-context.js';
 import {
   assembleExecutionCreationContext,
   materializeJobExecutionSteps,
@@ -33,6 +46,7 @@ import {toWorkflowRun, workflowRuns} from './schema/workflow-runs.js';
 import {
   bulkUpdateStepStatuses,
   evaluateJobSuccess,
+  getDirectDependencyJobContexts,
   updateJobStatusAtVersion,
 } from './workflow-runs.js';
 
@@ -48,6 +62,26 @@ export interface ActivateJobListenerResult {
   jobStatus: JobStatus;
   jobVersion: number;
   executionCount: number;
+}
+
+type JobActivatedListenerMatcher = Extract<
+  WorkflowsJobActivatedEventDto,
+  {mode: 'listening'}
+>['on'][number];
+
+type SnapshotRoot = 'run' | 'trigger' | 'inputs' | 'job' | 'jobs' | 'matrix';
+
+interface MatcherSnapshotPlan {
+  readonly matcher: JobListeningTrigger;
+  readonly roots: ReadonlySet<SnapshotRoot>;
+  readonly jobKeys: ReadonlySet<string>;
+}
+
+interface ListenerSnapshotPlan {
+  readonly on: readonly MatcherSnapshotPlan[];
+  readonly until: readonly MatcherSnapshotPlan[];
+  readonly roots: ReadonlySet<SnapshotRoot>;
+  readonly jobKeys: ReadonlySet<string>;
 }
 
 export async function activateJobListener(
@@ -105,6 +139,17 @@ export async function activateJobListener(
       .returning();
 
     if (listenerRows[0]) {
+      const matchers = {
+        on: target.job.listeningOn ?? [],
+        until: target.job.listeningUntil ?? null,
+      };
+      const snapshotPlan = planListenerFilterSnapshots(matchers);
+      const snapshotContext = await assembleListenerSnapshotContext(tx, {
+        job: toJob(target.job),
+        run: toWorkflowRun(target.run),
+        plan: snapshotPlan,
+      });
+
       await writeWorkflowsOutboxEvent(tx, {
         type: WORKFLOWS_JOB_ACTIVATED,
         payload: {
@@ -112,14 +157,161 @@ export async function activateJobListener(
           workflowRunId: target.run.id,
           workspaceId: target.run.workspaceId,
           mode: 'listening',
-          on: target.job.listeningOn ?? [],
-          until: target.job.listeningUntil ?? null,
+          on: applyFilterSnapshots(snapshotPlan.on, snapshotContext),
+          until:
+            matchers.until === null
+              ? null
+              : applyFilterSnapshots(snapshotPlan.until, snapshotContext),
         },
       });
     }
 
     return {status: 'running', jobStatus: job.status, jobVersion: job.version, executionCount};
   });
+}
+
+function planListenerFilterSnapshots(params: {
+  readonly on: readonly JobListeningTrigger[];
+  readonly until: readonly JobListeningTrigger[] | null;
+}): ListenerSnapshotPlan {
+  const roots = new Set<SnapshotRoot>();
+  const jobKeys = new Set<string>();
+  const on = params.on.map((matcher) => planMatcherFilterSnapshot(matcher, roots, jobKeys));
+  const until = (params.until ?? []).map((matcher) =>
+    planMatcherFilterSnapshot(matcher, roots, jobKeys),
+  );
+  return {on, until, roots, jobKeys};
+}
+
+function planMatcherFilterSnapshot(
+  matcher: JobListeningTrigger,
+  allRoots: Set<SnapshotRoot>,
+  allJobKeys: Set<string>,
+): MatcherSnapshotPlan {
+  if (matcher.filter === undefined) return {matcher, roots: new Set(), jobKeys: new Set()};
+
+  let roots: SnapshotRoot[];
+  try {
+    roots = extractExactContextRoots(matcher.filter)
+      .filter((root) => root !== 'event')
+      .filter(isSnapshotRoot);
+  } catch {
+    return {matcher, roots: new Set(), jobKeys: new Set()};
+  }
+
+  if (roots.length === 0) return {matcher, roots: new Set(), jobKeys: new Set()};
+
+  const jobKeys =
+    roots.includes('jobs') && matcher.filter !== undefined
+      ? new Set(
+          analyzeContextRootKeyAccess(matcher.filter, ['jobs']).references.map(
+            (reference) => reference.key,
+          ),
+        )
+      : new Set<string>();
+  for (const root of roots) allRoots.add(root);
+  for (const key of jobKeys) allJobKeys.add(key);
+  return {matcher, roots: new Set(roots), jobKeys};
+}
+
+function isSnapshotRoot(root: string): root is SnapshotRoot {
+  return (
+    root === 'run' ||
+    root === 'trigger' ||
+    root === 'inputs' ||
+    root === 'job' ||
+    root === 'jobs' ||
+    root === 'matrix'
+  );
+}
+
+async function assembleListenerSnapshotContext(
+  tx: Tx,
+  params: {
+    readonly job: ReturnType<typeof toJob>;
+    readonly run: ReturnType<typeof toWorkflowRun>;
+    readonly plan: ListenerSnapshotPlan;
+  },
+): Promise<WorkflowExpressionEvaluationContext> {
+  const context: Record<string, unknown> = {};
+  if (params.plan.roots.has('run') || params.plan.roots.has('trigger')) {
+    const runContext = assembleWorkflowRunContext({
+      run: params.run,
+      triggerPayload: params.run.triggerPayload,
+      inputs: params.run.inputs,
+    });
+    if (params.plan.roots.has('run')) context.run = runContext.run;
+    if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
+  }
+
+  if (params.plan.roots.has('inputs') && params.run.inputs !== null) {
+    context.inputs = params.run.inputs;
+  }
+  if (params.plan.roots.has('job')) {
+    context.job = {key: params.job.key};
+  }
+  if (params.plan.roots.has('jobs') && params.plan.jobKeys.size > 0) {
+    const dependencyJobs = await getDirectDependencyJobContexts(params.job.id, tx);
+    const jobsContext = requestedJobsContext(dependencyJobs, params.plan.jobKeys);
+    if (jobsContext !== undefined) context.jobs = jobsContext;
+  }
+
+  return context;
+}
+
+function requestedJobsContext(
+  dependencyJobs: readonly JobContextInput[],
+  jobKeys: ReadonlySet<string>,
+): unknown {
+  const filtered = dependencyJobs.filter(({job}) => jobKeys.has(job.key));
+  if (filtered.length === 0) return undefined;
+
+  return assembleJobsContext(filtered).jobs;
+}
+
+function applyFilterSnapshots(
+  plans: readonly MatcherSnapshotPlan[],
+  context: WorkflowExpressionEvaluationContext,
+): JobActivatedListenerMatcher[] {
+  return plans.map((plan) => {
+    const filterSnapshot = filterSnapshotForPlan(plan, context);
+    if (filterSnapshot === undefined) return plan.matcher;
+
+    return {...plan.matcher, filter_snapshot: filterSnapshot};
+  });
+}
+
+function filterSnapshotForPlan(
+  plan: MatcherSnapshotPlan,
+  context: WorkflowExpressionEvaluationContext,
+): Record<string, unknown> | undefined {
+  const snapshot: Record<string, unknown> = {};
+  for (const root of plan.roots) {
+    if (root === 'jobs') {
+      const jobsSnapshot = jobsSnapshotForPlan(plan, context);
+      if (jobsSnapshot !== undefined) snapshot.jobs = jobsSnapshot;
+      continue;
+    }
+
+    if (root in context) snapshot[root] = context[root];
+  }
+
+  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
+}
+
+function jobsSnapshotForPlan(
+  plan: MatcherSnapshotPlan,
+  context: WorkflowExpressionEvaluationContext,
+): Record<string, unknown> | undefined {
+  if (plan.jobKeys.size === 0 || typeof context.jobs !== 'object' || context.jobs === null) {
+    return undefined;
+  }
+
+  const jobsContext = context.jobs as Record<string, unknown>;
+  const snapshot = Object.fromEntries(
+    [...plan.jobKeys].flatMap((key) => (key in jobsContext ? [[key, jobsContext[key]]] : [])),
+  );
+  return Object.keys(snapshot).length === 0 ? undefined : snapshot;
 }
 
 export type DrainListenerEventsResult =

--- a/libs/api/workflows/src/db/job-listeners.ts
+++ b/libs/api/workflows/src/db/job-listeners.ts
@@ -239,7 +239,7 @@ async function assembleListenerSnapshotContext(
     if (params.plan.roots.has('trigger')) context.trigger = runContext.trigger;
   }
 
-  if (params.plan.roots.has('inputs') && params.run.inputs !== null) {
+  if (params.plan.roots.has('inputs')) {
     context.inputs = params.run.inputs;
   }
   if (params.plan.roots.has('job')) {


### PR DESCRIPTION
Add listener filter snapshots to the job activation event and persist them on listener subscriptions.

Listener filter evaluation will run in the triggers module, but the non-event data it can reference is owned by workflows. This freezes the concrete activation roots once when a listening job activates, narrows `jobs` snapshots to literal referenced dependency keys, and carries the resulting `filter_snapshot` through to trigger subscription config. Root extraction is total: invalid or event-only filters activate normally and simply omit the snapshot.

This deliberately does not define `execution` or `executions` as activation roots; ENG-825 now has a Linear clarification comment for that scope boundary.

Closes ENG-825

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes listener filter context at job activation and stores it as a snapshot on the job-activated event and listener subscription config. This lets triggers evaluate filters without extra workflow DB lookups and keeps activation deterministic.

- **New Features**
  - Adds optional `filter_snapshot` to `WORKFLOWS_JOB_ACTIVATED` `on`/`until` matchers in `@shipfox/api-workflows-dto`; remains compatible when absent.
  - Builds snapshots in `@shipfox/api-workflows` from only referenced roots (run, trigger, inputs, job, jobs); preserves null `inputs`; narrows `jobs` to referenced dependency keys; skips snapshots for event-only filters, matrix-only filters, unknown job keys, or parse errors; excludes `execution/executions` (ENG-825).
  - Persists snapshots verbatim in listener subscription config in `@shipfox/api-triggers` (extends `ListenerMatcher` and write path); updates replace existing snapshots.

<sup>Written for commit 9c87911138a5273f8bad3becd443cf41e47d1258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ShipfoxHQ/shipfox/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

